### PR TITLE
fix: update import paths from aerovm_sdk to aerolvm_sdk in Rust SDK documentation and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,17 +109,17 @@ Publishing a GitHub Release, or pushing a tag that starts with `v`, also trigger
 That workflow publishes:
 
 - the Java SDK in `sdk/java` to GitHub Packages as `ai.aerol:aerolvm-sdk`
-- the TypeScript SDK in `sdk/typescript` to npm as `@aerol-ai/microvm-sdk`
-- the Python SDK in `sdk/python` to PyPI as `aerol-ai-microvm-sdk`
-- the Rust SDK in `sdk/rust` to crates.io as `microvm-sdk`
+- the TypeScript SDK in `sdk/typescript` to npm as `@aerol-ai/aerolvm-sdk`
+- the Python SDK in `sdk/python` to PyPI as `aerolvm-sdk`
+- the Rust SDK in `sdk/rust` to crates.io as `aerolvm-sdk`
 
 The workflow requires the SDK versions to match the git tag without the leading `v`. For example, tag `v0.1.0` publishes SDK packages whose manifest version is `0.1.0`.
 
 Required GitHub Actions repository secrets:
 
-- `NPM_TOKEN`: npm automation token with publish access to `@aerol-ai/microvm-sdk`
-- `PYPI_API_TOKEN`: PyPI API token for `aerol-ai-microvm-sdk`
-- `CARGO_REGISTRY_TOKEN`: crates.io API token for `microvm-sdk`
+- `NPM_TOKEN`: npm automation token with publish access to `@aerol-ai/aerolvm-sdk`
+- `PYPI_API_TOKEN`: PyPI API token for `aerolvm-sdk`
+- `CARGO_REGISTRY_TOKEN`: crates.io API token for `aerolvm-sdk`
 
 The Java publish job deploys to GitHub Packages with the workflow's built-in `GITHUB_TOKEN`, so it does not require an additional repository secret. The workflow must keep `packages: write` permission enabled.
 
@@ -335,7 +335,7 @@ MicroVMClient client = new MicroVMClient(
 TypeScript:
 
 ```ts
-import { MicroVM } from "@aerol-ai/microvm-sdk";
+import { MicroVM } from "@aerol-ai/aerolvm-sdk";
 
 const client = new MicroVM({
 	apiUrl: "https://sandbox.example.com",

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ client = MicroVM(api_url="https://sandbox.example.com", pat_token="${SB_PAT_TOKE
 Rust:
 
 ```rust
-use microvm_sdk::Client;
+use aerolvm_sdk::Client;
 
 let client = Client::new(Some("https://sandbox.example.com"), Some("your_token"))?;
 ```

--- a/docs/src/content/docs/python-sdk.md
+++ b/docs/src/content/docs/python-sdk.md
@@ -3,12 +3,12 @@ title: Python SDK
 description: Use the Python client for synchronous sandbox lifecycle, exec streaming, file transfer, and sessions.
 ---
 
-The Python SDK lives under `sdk/python`, publishes as `aerol-ai-microvm-sdk`, and is imported as `microvm`.
+The Python SDK lives under `sdk/python`, publishes as `aerolvm-sdk`, and is imported as `microvm`.
 
 ## Install
 
 ```bash
-pip install aerol-ai-microvm-sdk
+pip install aerolvm-sdk
 ```
 
 For local development from this repository, `cd sdk/python && pip install .` also works.

--- a/docs/src/content/docs/rust-sdk.md
+++ b/docs/src/content/docs/rust-sdk.md
@@ -3,7 +3,7 @@ title: Rust SDK
 description: Use the Rust client for blocking API calls plus WebSocket-based exec and session attachment.
 ---
 
-The Rust SDK lives under `sdk/rust`, publishes as `aerolvm-sdk`, and is imported in code as `aerovm_sdk`.
+The Rust SDK lives under `sdk/rust`, publishes as `aerolvm-sdk`, and is imported in code as `aerolvm_sdk`.
 
 ## Install
 
@@ -14,7 +14,7 @@ cargo add aerolvm-sdk
 ## Create A Client
 
 ```rust
-use aerovm_sdk::Client;
+use aerolvm_sdk::Client;
 
 let client = Client::new(
     Some("https://sandbox.example.com"),
@@ -27,7 +27,7 @@ If you pass `None`, the client falls back to `SB_API_URL`, `SB_PAT_TOKEN`, and t
 ## Create And Use A Sandbox
 
 ```rust
-use aerovm_sdk::{Client, CreateOptions, Lifecycle};
+use aerolvm_sdk::{Client, CreateOptions, Lifecycle};
 
 let client = Client::new(Some("https://sandbox.example.com"), Some("your-token"))?;
 
@@ -49,7 +49,7 @@ let mut sandbox = client.create(CreateOptions {
     }),
 })?;
 
-let result = sandbox.exec(aerovm_sdk::ExecRequest {
+let result = sandbox.exec(aerolvm_sdk::ExecRequest {
     command: "echo hello from rust".to_string(),
     work_dir: None,
     env: None,
@@ -69,7 +69,7 @@ The Rust wrapper stores the API record on `sandbox.data`, while the create-only 
 ```rust
 use std::sync::Arc;
 
-let handle = sandbox.exec_stream(aerovm_sdk::ExecStreamOptions {
+let handle = sandbox.exec_stream(aerolvm_sdk::ExecStreamOptions {
     command: "bash".to_string(),
     tty: true,
     cols: Some(120),
@@ -85,7 +85,7 @@ println!("{:?}", handle.wait()?);
 ```
 
 ```rust
-let session = sandbox.create_session(aerovm_sdk::CreateSessionOptions {
+let session = sandbox.create_session(aerolvm_sdk::CreateSessionOptions {
     name: Some("shell".to_string()),
     command: Some("bash".to_string()),
     work_dir: Some("/workspace".to_string()),
@@ -95,7 +95,7 @@ let session = sandbox.create_session(aerovm_sdk::CreateSessionOptions {
     ..Default::default()
 })?;
 
-let attached = sandbox.attach_session(&session.id, aerovm_sdk::SessionAttachOptions {
+let attached = sandbox.attach_session(&session.id, aerolvm_sdk::SessionAttachOptions {
     cols: Some(120),
     rows: Some(40),
     on_stdout: Some(Arc::new(|chunk| {

--- a/docs/src/content/docs/rust-sdk.md
+++ b/docs/src/content/docs/rust-sdk.md
@@ -3,18 +3,18 @@ title: Rust SDK
 description: Use the Rust client for blocking API calls plus WebSocket-based exec and session attachment.
 ---
 
-The Rust SDK lives under `sdk/rust`, publishes as `microvm-sdk`, and is imported in code as `microvm_sdk`.
+The Rust SDK lives under `sdk/rust`, publishes as `aerolvm-sdk`, and is imported in code as `aerovm_sdk`.
 
 ## Install
 
 ```bash
-cargo add microvm-sdk
+cargo add aerolvm-sdk
 ```
 
 ## Create A Client
 
 ```rust
-use microvm_sdk::Client;
+use aerovm_sdk::Client;
 
 let client = Client::new(
     Some("https://sandbox.example.com"),
@@ -27,7 +27,7 @@ If you pass `None`, the client falls back to `SB_API_URL`, `SB_PAT_TOKEN`, and t
 ## Create And Use A Sandbox
 
 ```rust
-use microvm_sdk::{Client, CreateOptions, Lifecycle};
+use aerovm_sdk::{Client, CreateOptions, Lifecycle};
 
 let client = Client::new(Some("https://sandbox.example.com"), Some("your-token"))?;
 
@@ -49,7 +49,7 @@ let mut sandbox = client.create(CreateOptions {
     }),
 })?;
 
-let result = sandbox.exec(microvm_sdk::ExecRequest {
+let result = sandbox.exec(aerovm_sdk::ExecRequest {
     command: "echo hello from rust".to_string(),
     work_dir: None,
     env: None,
@@ -69,7 +69,7 @@ The Rust wrapper stores the API record on `sandbox.data`, while the create-only 
 ```rust
 use std::sync::Arc;
 
-let handle = sandbox.exec_stream(microvm_sdk::ExecStreamOptions {
+let handle = sandbox.exec_stream(aerovm_sdk::ExecStreamOptions {
     command: "bash".to_string(),
     tty: true,
     cols: Some(120),
@@ -85,7 +85,7 @@ println!("{:?}", handle.wait()?);
 ```
 
 ```rust
-let session = sandbox.create_session(microvm_sdk::CreateSessionOptions {
+let session = sandbox.create_session(aerovm_sdk::CreateSessionOptions {
     name: Some("shell".to_string()),
     command: Some("bash".to_string()),
     work_dir: Some("/workspace".to_string()),
@@ -95,7 +95,7 @@ let session = sandbox.create_session(microvm_sdk::CreateSessionOptions {
     ..Default::default()
 })?;
 
-let attached = sandbox.attach_session(&session.id, microvm_sdk::SessionAttachOptions {
+let attached = sandbox.attach_session(&session.id, aerovm_sdk::SessionAttachOptions {
     cols: Some(120),
     rows: Some(40),
     on_stdout: Some(Arc::new(|chunk| {

--- a/docs/src/content/docs/sdk-clients.md
+++ b/docs/src/content/docs/sdk-clients.md
@@ -87,7 +87,7 @@ client = MicroVM(api_url='https://sandbox.example.com', pat_token='your-token')
 ### Rust
 
 ```rust
-use aerovm_sdk::Client;
+use aerolvm_sdk::Client;
 
 let client = Client::new(Some("https://sandbox.example.com"), Some("your-token"))?;
 ```

--- a/docs/src/content/docs/sdk-clients.md
+++ b/docs/src/content/docs/sdk-clients.md
@@ -10,9 +10,9 @@ This docs section mirrors the Daytona docs layout, but the content here is taken
 | Language | Package | Install |
 | --- | --- | --- |
 | Go | `github.com/aerol-ai/microvm/sdk/go/pkg/microvm` | `go get github.com/aerol-ai/microvm/sdk/go/pkg/microvm@latest` |
-| TypeScript | `@aerol-ai/microvm-sdk` | `npm install @aerol-ai/microvm-sdk` |
-| Python | `aerol-ai-microvm-sdk` | `pip install aerol-ai-microvm-sdk` |
-| Rust | `microvm-sdk` | `cargo add microvm-sdk` |
+| TypeScript | `@aerol-ai/aerolvm-sdk` | `npm install @aerol-ai/aerolvm-sdk` |
+| Python | `aerolvm-sdk` | `pip install aerolvm-sdk` |
+| Rust | `aerolvm-sdk` | `cargo add aerolvm-sdk` |
 
 If you are working directly from this repository, each SDK can also be installed from its matching `sdk/<language>` directory.
 
@@ -68,7 +68,7 @@ client, err := microvm.NewClientWithConfig(&sdktypes.MicroVMConfig{
 ### TypeScript
 
 ```ts
-import { MicroVM } from '@aerol-ai/microvm-sdk'
+import { MicroVM } from '@aerol-ai/aerolvm-sdk'
 
 const client = new MicroVM({
   apiUrl: process.env.SB_API_URL,
@@ -87,7 +87,7 @@ client = MicroVM(api_url='https://sandbox.example.com', pat_token='your-token')
 ### Rust
 
 ```rust
-use microvm_sdk::Client;
+use aerovm_sdk::Client;
 
 let client = Client::new(Some("https://sandbox.example.com"), Some("your-token"))?;
 ```

--- a/docs/src/content/docs/typescript-sdk.md
+++ b/docs/src/content/docs/typescript-sdk.md
@@ -3,18 +3,18 @@ title: TypeScript SDK
 description: Use the TypeScript client from Node.js or other fetch-compatible runtimes to control sandboxes.
 ---
 
-The TypeScript SDK lives under `sdk/typescript` and publishes as `@aerol-ai/microvm-sdk`.
+The TypeScript SDK lives under `sdk/typescript` and publishes as `@aerol-ai/aerolvm-sdk`.
 
 ## Install
 
 ```bash
-npm install @aerol-ai/microvm-sdk
+npm install @aerol-ai/aerolvm-sdk
 ```
 
 ## Create A Client
 
 ```ts
-import { MicroVM } from '@aerol-ai/microvm-sdk'
+import { MicroVM } from '@aerol-ai/aerolvm-sdk'
 
 const client = new MicroVM({
   apiUrl: process.env.SB_API_URL,

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -5,6 +5,12 @@ A lightweight Python SDK for the Aerol.ai MicroVM sandbox API.
 ## Install
 
 ```bash
+pip install aerolvm-sdk
+```
+
+For local development from this repository:
+
+```bash
 cd sdk/python
 pip install .
 ```

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "aerol-ai-microvm-sdk"
+name = "aerolvm-sdk"
 version = "0.1.0"
 description = "A Python client for the Aerol.ai MicroVM sandbox API."
 readme = "README.md"

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -2,10 +2,16 @@
 
 A Rust client for the Aerol.ai MicroVM sandbox API.
 
+## Install
+
+```bash
+cargo add aerolvm-sdk
+```
+
 ## Usage
 
 ```rust
-use microvm_sdk::{Client, CreateOptions, Lifecycle};
+use aerovm_sdk::{Client, CreateOptions, Lifecycle};
 
 let client = Client::new(Some("http://127.0.0.1:8080"), Some("your-pat-token"))?;
 let health = client.health()?;
@@ -51,7 +57,7 @@ cargo run --example create_sandbox -- http://127.0.0.1:8080 your-pat-token ghcr.
 ```rust
 use std::sync::Arc;
 
-let handle = sandbox.exec_stream(microvm_sdk::ExecStreamOptions {
+let handle = sandbox.exec_stream(aerovm_sdk::ExecStreamOptions {
 	command: "bash".to_string(),
 	tty: true,
 	cols: Some(120),
@@ -70,7 +76,7 @@ println!("{:?}", result);
 ```rust
 use std::sync::Arc;
 
-let session = sandbox.create_session(microvm_sdk::CreateSessionOptions {
+let session = sandbox.create_session(aerovm_sdk::CreateSessionOptions {
 	name: Some("shell".to_string()),
 	command: Some("bash".to_string()),
 	work_dir: Some("/workspace".to_string()),
@@ -84,7 +90,7 @@ println!("session = {:?}", session);
 println!("sessions = {:?}", sandbox.list_sessions()?);
 println!("log = {}", String::from_utf8_lossy(&sandbox.session_log(&session.id)?));
 
-let handle = sandbox.attach_session(&session.id, microvm_sdk::SessionAttachOptions {
+let handle = sandbox.attach_session(&session.id, aerovm_sdk::SessionAttachOptions {
 	cols: Some(120),
 	rows: Some(40),
 	on_stdout: Some(Arc::new(|chunk| print!("{}", String::from_utf8_lossy(&chunk)))),

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -11,7 +11,7 @@ cargo add aerolvm-sdk
 ## Usage
 
 ```rust
-use aerovm_sdk::{Client, CreateOptions, Lifecycle};
+use aerolvm_sdk::{Client, CreateOptions, Lifecycle};
 
 let client = Client::new(Some("http://127.0.0.1:8080"), Some("your-pat-token"))?;
 let health = client.health()?;
@@ -57,7 +57,7 @@ cargo run --example create_sandbox -- http://127.0.0.1:8080 your-pat-token ghcr.
 ```rust
 use std::sync::Arc;
 
-let handle = sandbox.exec_stream(aerovm_sdk::ExecStreamOptions {
+let handle = sandbox.exec_stream(aerolvm_sdk::ExecStreamOptions {
 	command: "bash".to_string(),
 	tty: true,
 	cols: Some(120),
@@ -76,7 +76,7 @@ println!("{:?}", result);
 ```rust
 use std::sync::Arc;
 
-let session = sandbox.create_session(aerovm_sdk::CreateSessionOptions {
+let session = sandbox.create_session(aerolvm_sdk::CreateSessionOptions {
 	name: Some("shell".to_string()),
 	command: Some("bash".to_string()),
 	work_dir: Some("/workspace".to_string()),
@@ -90,7 +90,7 @@ println!("session = {:?}", session);
 println!("sessions = {:?}", sandbox.list_sessions()?);
 println!("log = {}", String::from_utf8_lossy(&sandbox.session_log(&session.id)?));
 
-let handle = sandbox.attach_session(&session.id, aerovm_sdk::SessionAttachOptions {
+let handle = sandbox.attach_session(&session.id, aerolvm_sdk::SessionAttachOptions {
 	cols: Some(120),
 	rows: Some(40),
 	on_stdout: Some(Arc::new(|chunk| print!("{}", String::from_utf8_lossy(&chunk)))),

--- a/sdk/rust/examples/create_sandbox.rs
+++ b/sdk/rust/examples/create_sandbox.rs
@@ -1,4 +1,4 @@
-use microvm_sdk::{Client, CreateOptions};
+use aerovm_sdk::{Client, CreateOptions};
 use std::env;
 
 fn main() {

--- a/sdk/rust/examples/create_sandbox.rs
+++ b/sdk/rust/examples/create_sandbox.rs
@@ -1,4 +1,4 @@
-use aerovm_sdk::{Client, CreateOptions};
+use aerolvm_sdk::{Client, CreateOptions};
 use std::env;
 
 fn main() {

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@aerol-ai/microvm-sdk",
+  "name": "@aerol-ai/aerolvm-sdk",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@aerol-ai/microvm-sdk",
+      "name": "@aerol-ai/aerolvm-sdk",
       "version": "0.1.0",
       "devDependencies": {
         "@types/node": "^22.15.17",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aerol-ai/microvm-sdk",
+  "name": "@aerol-ai/aerolvm-sdk",
   "version": "0.1.0",
   "private": false,
   "type": "module",


### PR DESCRIPTION
This pull request updates the package names and import paths for the TypeScript, Python, and Rust SDKs to use the new unified `aerolvm-sdk` naming convention. The changes affect documentation, installation instructions, code samples, and package metadata to ensure consistency across all SDKs and published packages.

**SDK Package Renaming and Import Path Updates**

* Updated all references to the TypeScript SDK from `@aerol-ai/microvm-sdk` to `@aerol-ai/aerolvm-sdk` in documentation, code samples, and package metadata (`README.md`, `docs/src/content/docs/typescript-sdk.md`, `docs/src/content/docs/sdk-clients.md`, `sdk/typescript/package.json`, `sdk/typescript/package-lock.json`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L112-R122) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L338-R338) [[3]](diffhunk://#diff-a7c6687a475649b9f97e169ff64a970e95913a5867c3a3964cf2e2caa806929cL13-R15) [[4]](diffhunk://#diff-a7c6687a475649b9f97e169ff64a970e95913a5867c3a3964cf2e2caa806929cL71-R71) [[5]](diffhunk://#diff-d8e84008a052ecdf6758cf169704a44bb53cc11403ec8e98ecacc0cf414e2c60L6-R17) [[6]](diffhunk://#diff-1097377c78d22400c9189626a6f2d209142a89cc652ea050fb577aa1087634e0L2-R2) [[7]](diffhunk://#diff-d7577e6d0cb74d2181c950723039aebc7137c2572828dda945e9be535843cd3bL2-R8)

* Changed all references to the Python SDK from `aerol-ai-microvm-sdk` to `aerolvm-sdk` in documentation, installation instructions, and package metadata (`README.md`, `docs/src/content/docs/python-sdk.md`, `docs/src/content/docs/sdk-clients.md`, `sdk/python/README.md`, `sdk/python/pyproject.toml`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L112-R122) [[2]](diffhunk://#diff-b7f4c284515f95489b30601d2b4175ca89d4488618ee6f91b48f2147a7b22847L6-R11) [[3]](diffhunk://#diff-a7c6687a475649b9f97e169ff64a970e95913a5867c3a3964cf2e2caa806929cL13-R15) [[4]](diffhunk://#diff-73be8f6fa2dd9e669bfdfa8a5732ce9aede74f50a230b04fa9bda67ac5930e46R7-R12) [[5]](diffhunk://#diff-0cba00bc8967d0c3e4a42244a5c9d5112d5d9580d645572cda9ccf4af64c732fL2-R2)

* Updated all references to the Rust SDK from `microvm-sdk` to `aerolvm-sdk` in documentation, installation instructions, code samples, and package metadata (`README.md`, `docs/src/content/docs/rust-sdk.md`, `docs/src/content/docs/sdk-clients.md`, `sdk/rust/README.md`, `sdk/rust/examples/create_sandbox.rs`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L112-R122) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L357-R357) [[3]](diffhunk://#diff-a7c6687a475649b9f97e169ff64a970e95913a5867c3a3964cf2e2caa806929cL13-R15) [[4]](diffhunk://#diff-a7c6687a475649b9f97e169ff64a970e95913a5867c3a3964cf2e2caa806929cL90-R90) [[5]](diffhunk://#diff-3b50f66ab5e0e425244af91ba8376cb9740a40d7b4de25e369681ed38a443252L6-R17) [[6]](diffhunk://#diff-3b50f66ab5e0e425244af91ba8376cb9740a40d7b4de25e369681ed38a443252L30-R30) [[7]](diffhunk://#diff-3b50f66ab5e0e425244af91ba8376cb9740a40d7b4de25e369681ed38a443252L52-R52) [[8]](diffhunk://#diff-3b50f66ab5e0e425244af91ba8376cb9740a40d7b4de25e369681ed38a443252L72-R72) [[9]](diffhunk://#diff-3b50f66ab5e0e425244af91ba8376cb9740a40d7b4de25e369681ed38a443252L88-R88) [[10]](diffhunk://#diff-3b50f66ab5e0e425244af91ba8376cb9740a40d7b4de25e369681ed38a443252L98-R98) [[11]](diffhunk://#diff-336c860403fc16f6f3be19d2e1b770ff761b4cdfcbb702bb923d9fd371b17dfaR5-R14) [[12]](diffhunk://#diff-336c860403fc16f6f3be19d2e1b770ff761b4cdfcbb702bb923d9fd371b17dfaL54-R60) [[13]](diffhunk://#diff-336c860403fc16f6f3be19d2e1b770ff761b4cdfcbb702bb923d9fd371b17dfaL73-R79) [[14]](diffhunk://#diff-336c860403fc16f6f3be19d2e1b770ff761b4cdfcbb702bb923d9fd371b17dfaL87-R93) [[15]](diffhunk://#diff-2b8ca1bb2a1587a1e28f717b21aec9032577d4775b0bc89c013ec28cbd4d9bd0L1-R1)

**Repository Secret and Publishing Workflow Updates**

* Adjusted documentation for repository secrets and publishing workflows to reference the new package names and tokens for npm, PyPI, and crates.io (`README.md`).

These changes ensure a consistent naming convention for all SDKs, simplifying installation and usage for developers.Revise SDK names and installation instructions across documentation and examples to reflect the new naming convention, ensuring clarity and consistency in the Rust SDK documentation. Update import paths from `aerovm_sdk` to `aerolvm_sdk`.