### PR TITLE
feat: Improve process exit handling and add tests for ECHILD errors

### DIFF
--- a/cmd/toolboxd/exec_stream.go
+++ b/cmd/toolboxd/exec_stream.go
@@ -197,8 +197,11 @@ func (s *server) runWithPipes(conn *websocket.Conn, cmd *exec.Cmd) {
 				if err := json.Unmarshal(data, &ctrl); err != nil {
 					continue
 				}
-				if ctrl.Type == "signal" {
+				switch ctrl.Type {
+				case "signal":
 					sendSignalToCmd(cmd, ctrl.Signal)
+				case "close":
+					_ = stdinPipe.Close()
 				}
 			}
 		}
@@ -301,7 +304,10 @@ func writeStreamControl(conn *websocket.Conn, msg execStreamControlOut) {
 }
 
 func waitForCommand(cmd *exec.Cmd) (int, string) {
-	err := cmd.Wait()
+	return interpretWaitResult(cmd.Wait())
+}
+
+func interpretWaitResult(err error) (int, string) {
 	if err == nil {
 		return 0, ""
 	}
@@ -320,8 +326,7 @@ func waitForCommand(cmd *exec.Cmd) (int, string) {
 	// rare races this can cause the kernel to return ECHILD for our direct
 	// child before cmd.Wait() gets there. Since we only call this after all
 	// pipe I/O has completed (process definitely exited), treat ECHILD as 0.
-	var se *os.SyscallError
-	if errors.As(err, &se) && errors.Is(se.Err, syscall.ECHILD) {
+	if errors.Is(err, syscall.ECHILD) {
 		return 0, ""
 	}
 	return -1, err.Error()

--- a/cmd/toolboxd/exec_stream_test.go
+++ b/cmd/toolboxd/exec_stream_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+)
+
+func TestInterpretWaitResultTreatsWrappedECHILDAsSuccess(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "direct syscall error",
+			err:  &os.SyscallError{Syscall: "waitid", Err: syscall.ECHILD},
+		},
+		{
+			name: "wrapped syscall error",
+			err:  fmt.Errorf("wrapped: %w", &os.SyscallError{Syscall: "waitid", Err: syscall.ECHILD}),
+		},
+		{
+			name: "wrapped sentinel",
+			err:  fmt.Errorf("wrapped: %w", syscall.ECHILD),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			code, signal := interpretWaitResult(tc.err)
+			if code != 0 || signal != "" {
+				t.Fatalf("interpretWaitResult(%v) = (%d, %q), want (0, \"\")", tc.err, code, signal)
+			}
+		})
+	}
+}
+
+func TestInterpretWaitResultPreservesExitCode(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "exit 17")
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected non-zero exit error")
+	}
+
+	code, signal := interpretWaitResult(err)
+	if code != 17 || signal != "" {
+		t.Fatalf("interpretWaitResult(%v) = (%d, %q), want (17, \"\")", err, code, signal)
+	}
+}
+
+func TestInterpretWaitResultPreservesSignal(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "kill -TERM $$")
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected signal exit error")
+	}
+
+	code, signal := interpretWaitResult(err)
+	if code != -1 || signal != syscall.SIGTERM.String() {
+		t.Fatalf("interpretWaitResult(%v) = (%d, %q), want (-1, %q)", err, code, signal, syscall.SIGTERM.String())
+	}
+}

--- a/cmd/toolboxd/main.go
+++ b/cmd/toolboxd/main.go
@@ -368,8 +368,19 @@ func (s *server) handleExec(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	stdoutBytes, _ := io.ReadAll(stdout)
-	stderrBytes, _ := io.ReadAll(stderr)
+	var stdoutBytes []byte
+	var stderrBytes []byte
+	var readWG sync.WaitGroup
+	readWG.Add(2)
+	go func() {
+		defer readWG.Done()
+		stdoutBytes, _ = io.ReadAll(stdout)
+	}()
+	go func() {
+		defer readWG.Done()
+		stderrBytes, _ = io.ReadAll(stderr)
+	}()
+	readWG.Wait()
 	waitErr := cmd.Wait()
 
 	result := models.ExecResult{
@@ -378,16 +389,12 @@ func (s *server) handleExec(w http.ResponseWriter, r *http.Request) {
 		DurationMS: time.Since(start).Milliseconds(),
 	}
 
+	result.ExitCode, _ = interpretWaitResult(waitErr)
 	if waitErr != nil {
 		var exitErr *exec.ExitError
-		if errors.As(waitErr, &exitErr) {
-			result.ExitCode = exitErr.ExitCode()
-		} else {
-			result.ExitCode = -1
+		if !errors.As(waitErr, &exitErr) && !errors.Is(waitErr, syscall.ECHILD) {
 			result.Stderr = strings.TrimSpace(result.Stderr + "\n" + waitErr.Error())
 		}
-	} else {
-		result.ExitCode = 0
 	}
 
 	writeJSON(w, http.StatusOK, result)
@@ -597,4 +604,3 @@ func writeJSON(w http.ResponseWriter, status int, value any) {
 func writeError(w http.ResponseWriter, status int, message string) {
 	writeJSON(w, status, models.ErrorResponse{Error: message})
 }
-

--- a/cmd/toolboxd/sessions/session.go
+++ b/cmd/toolboxd/sessions/session.go
@@ -328,7 +328,10 @@ func (s *Session) shutdown() {
 // waitProcess returns (exit_code, signal_name). signal_name is empty if the
 // process exited normally.
 func waitProcess(cmd *exec.Cmd) (int, string) {
-	err := cmd.Wait()
+	return interpretWaitProcessResult(cmd.Wait())
+}
+
+func interpretWaitProcessResult(err error) (int, string) {
 	if err == nil {
 		return 0, ""
 	}
@@ -341,6 +344,9 @@ func waitProcess(cmd *exec.Cmd) (int, string) {
 			return status.ExitStatus(), ""
 		}
 		return ee.ExitCode(), ""
+	}
+	if errors.Is(err, syscall.ECHILD) {
+		return 0, ""
 	}
 	return -1, err.Error()
 }

--- a/cmd/toolboxd/sessions/session_test.go
+++ b/cmd/toolboxd/sessions/session_test.go
@@ -1,0 +1,64 @@
+package sessions
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+)
+
+func TestInterpretWaitProcessResultTreatsWrappedECHILDAsSuccess(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "direct syscall error",
+			err:  &os.SyscallError{Syscall: "waitid", Err: syscall.ECHILD},
+		},
+		{
+			name: "wrapped syscall error",
+			err:  fmt.Errorf("wrapped: %w", &os.SyscallError{Syscall: "waitid", Err: syscall.ECHILD}),
+		},
+		{
+			name: "wrapped sentinel",
+			err:  fmt.Errorf("wrapped: %w", syscall.ECHILD),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			code, signal := interpretWaitProcessResult(tc.err)
+			if code != 0 || signal != "" {
+				t.Fatalf("interpretWaitProcessResult(%v) = (%d, %q), want (0, \"\")", tc.err, code, signal)
+			}
+		})
+	}
+}
+
+func TestInterpretWaitProcessResultPreservesExitCode(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "exit 17")
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected non-zero exit error")
+	}
+
+	code, signal := interpretWaitProcessResult(err)
+	if code != 17 || signal != "" {
+		t.Fatalf("interpretWaitProcessResult(%v) = (%d, %q), want (17, \"\")", err, code, signal)
+	}
+}
+
+func TestInterpretWaitProcessResultPreservesSignal(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "kill -TERM $$")
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected signal exit error")
+	}
+
+	code, signal := interpretWaitProcessResult(err)
+	if code != -1 || signal != syscall.SIGTERM.String() {
+		t.Fatalf("interpretWaitProcessResult(%v) = (%d, %q), want (-1, %q)", err, code, signal, syscall.SIGTERM.String())
+	}
+}

--- a/sdk/typescript/src/internal/client.test.ts
+++ b/sdk/typescript/src/internal/client.test.ts
@@ -234,6 +234,130 @@ test("internal client execStream uses sandbox bearer subprotocol", async () => {
   }
 });
 
+test("internal client execStream close keeps waiting for exit", async () => {
+  const originalWebSocket = globalThis.WebSocket;
+
+  class FakeWebSocket {
+    static instances: FakeWebSocket[] = [];
+
+    readonly url: string;
+    readonly protocols: string[];
+    binaryType = "blob";
+    sent: Array<string | Uint8Array> = [];
+    closed = false;
+    private readonly listeners = new Map<string, Array<(event?: unknown) => void>>();
+
+    constructor(url: string, protocols?: string | string[]) {
+      this.url = url;
+      this.protocols = Array.isArray(protocols) ? protocols : protocols ? [protocols] : [];
+      FakeWebSocket.instances.push(this);
+    }
+
+    addEventListener(name: string, listener: (event?: unknown) => void): void {
+      const listeners = this.listeners.get(name) ?? [];
+      listeners.push(listener);
+      this.listeners.set(name, listeners);
+    }
+
+    send(data: string | Uint8Array): void {
+      this.sent.push(data);
+    }
+
+    close(): void {
+      this.closed = true;
+    }
+
+    emit(name: string, event?: unknown): void {
+      for (const listener of this.listeners.get(name) ?? []) {
+        listener(event);
+      }
+    }
+  }
+
+  try {
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+
+    const client = new APIClient({
+      baseURL: "https://api.example.com",
+      patToken: "pat-token",
+    });
+
+    const handle = client.execStream("sb-stream", { command: "npm install" });
+    const ws = FakeWebSocket.instances[0];
+    assert.ok(ws);
+
+    ws.emit("open");
+    handle.close();
+
+    assert.equal(ws.sent[1], JSON.stringify({ type: "close" }));
+    assert.equal(ws.closed, false);
+
+    ws.emit("message", { data: JSON.stringify({ type: "exit", code: 0 }) });
+    const result = await handle.done;
+    assert.equal(result.code, 0);
+  } finally {
+    globalThis.WebSocket = originalWebSocket;
+  }
+});
+
+test("internal client execStream rejects when stream closes before exit", async () => {
+  const originalWebSocket = globalThis.WebSocket;
+
+  class FakeWebSocket {
+    static instances: FakeWebSocket[] = [];
+
+    readonly url: string;
+    readonly protocols: string[];
+    binaryType = "blob";
+    sent: Array<string | Uint8Array> = [];
+    private readonly listeners = new Map<string, Array<(event?: unknown) => void>>();
+
+    constructor(url: string, protocols?: string | string[]) {
+      this.url = url;
+      this.protocols = Array.isArray(protocols) ? protocols : protocols ? [protocols] : [];
+      FakeWebSocket.instances.push(this);
+    }
+
+    addEventListener(name: string, listener: (event?: unknown) => void): void {
+      const listeners = this.listeners.get(name) ?? [];
+      listeners.push(listener);
+      this.listeners.set(name, listeners);
+    }
+
+    send(data: string | Uint8Array): void {
+      this.sent.push(data);
+    }
+
+    close(): void {}
+
+    emit(name: string, event?: unknown): void {
+      for (const listener of this.listeners.get(name) ?? []) {
+        listener(event);
+      }
+    }
+  }
+
+  try {
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+
+    const client = new APIClient({
+      baseURL: "https://api.example.com",
+      patToken: "pat-token",
+    });
+
+    const handle = client.execStream("sb-stream", { command: "npm install" });
+    const ws = FakeWebSocket.instances[0];
+    assert.ok(ws);
+
+    ws.emit("open");
+    ws.emit("close");
+
+    await assert.rejects(handle.done, /stream closed before exit/);
+  } finally {
+    globalThis.WebSocket = originalWebSocket;
+  }
+});
+
 test("internal client create forwards runtime selector and parses response", async () => {
   let seenRequest: Request | undefined;
   const client = new APIClient({

--- a/sdk/typescript/src/internal/client.ts
+++ b/sdk/typescript/src/internal/client.ts
@@ -745,7 +745,7 @@ function openExecStream(baseURL: string, patToken: string, sandboxID: string, op
   });
 
   ws.addEventListener("close", () => {
-    finishWith({ code: 0 });
+    failWith("stream closed before exit");
   });
 
   ws.addEventListener("error", () => {
@@ -767,7 +767,6 @@ function openExecStream(baseURL: string, patToken: string, sandboxID: string, op
     },
     close() {
       ws.send(JSON.stringify({ type: "close" }));
-      ws.close();
     },
     done,
   };


### PR DESCRIPTION
This pull request improves the handling and reporting of process exit codes and error conditions for exec streams and sessions, adds comprehensive tests for these behaviors, and refines the TypeScript SDK's execStream close semantics. The changes ensure that rare kernel errors (like `ECHILD`) are treated as successful exits, unify exit code extraction logic, and guarantee that the client waits for process exit even after a close request.

**Process exit handling improvements:**

* Introduced `interpretWaitResult` and `interpretWaitProcessResult` helpers to consistently interpret process exit errors, treating `ECHILD` (even when wrapped) as a successful exit and preserving exit codes and signals. Updated all relevant server and session code to use these helpers. [[1]](diffhunk://#diff-74812ddbb05e34feda634813f850e22fc7152de53cb1da38c0471b0bc7957047L304-R310) [[2]](diffhunk://#diff-74812ddbb05e34feda634813f850e22fc7152de53cb1da38c0471b0bc7957047L323-R329) [[3]](diffhunk://#diff-0ff23e6ccd60fa622dc1b4b0cfc829342b7a6c9831a5ee4e0c5e08820b75dddbL331-R334) [[4]](diffhunk://#diff-0ff23e6ccd60fa622dc1b4b0cfc829342b7a6c9831a5ee4e0c5e08820b75dddbR348-R350) [[5]](diffhunk://#diff-e91f7073ddf9918c24938a18fa5277d310676570cb3e30ec5b26cd08f4866db2R392-L390)
* Refactored `handleExec` to read `stdout` and `stderr` concurrently to avoid deadlocks and ensure all output is captured before waiting for process exit.

**Testing enhancements:**

* Added thorough unit tests for `interpretWaitResult` and `interpretWaitProcessResult` covering direct, wrapped, and sentinel `ECHILD` errors, as well as normal exit and signal cases (`cmd/toolboxd/exec_stream_test.go`, `cmd/toolboxd/sessions/session_test.go`). [[1]](diffhunk://#diff-20b8f6439ec6eb9c349308cef68df1a272f47076f0da7cedc6efde31861c789eR1-R64) [[2]](diffhunk://#diff-172591a81f5f29e9d8c53cd14630b7f43e6168a1fbb5870657f6dca28186ce86R1-R64)

**WebSocket execStream protocol and SDK changes:**

* Updated the Go server to handle a new `"close"` control message in execStream, closing the stdin pipe but not terminating the process, allowing for graceful shutdown.
* In the TypeScript SDK, changed `execStream.close()` to send a `"close"` message without closing the WebSocket, ensuring the client waits for the process exit event. If the WebSocket closes before an exit event, the promise is rejected with a clear error. [[1]](diffhunk://#diff-31e4c7d01f0164972accfbd223d61527dc9c2ddd25dc49b6db26cba90f618328L748-R748) [[2]](diffhunk://#diff-31e4c7d01f0164972accfbd223d61527dc9c2ddd25dc49b6db26cba90f618328L770)
* Added tests for the new execStream close semantics, verifying that the client waits for process exit and correctly handles premature stream closure (`sdk/typescript/src/internal/client.test.ts`).

These changes collectively make process termination handling more robust and predictable for both server and client code.…terpretation