### PR TITLE
feat: Add reconcile endpoint to sync sandbox database with live state

### DIFF
--- a/docs/src/content/config.ts
+++ b/docs/src/content/config.ts
@@ -73,6 +73,12 @@ export const getSidebarConfig = (): NavigationGroup[] => [
         label: 'Volumes',
         description: 'Mount S3, NFS, SSHFS, and rclone-backed storage into sandboxes.',
       },
+      {
+        type: 'link',
+        href: '/reconcile',
+        label: 'Reconcile',
+        description: 'Sync the sandbox database with live container state. Fix capacity errors after a host restart.',
+      },
     ],
   },
   {

--- a/docs/src/content/docs/reconcile.mdx
+++ b/docs/src/content/docs/reconcile.mdx
@@ -1,0 +1,123 @@
+---
+title: Reconcile
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+Reconciliation syncs the server's database with the actual state of running containers. It is the fix for situations where the sandbox count in the database is out of sync with what Docker reports — for example, after a host reboot, a crash, or a manual `docker rm`.
+
+## When reconciliation runs automatically
+
+The server reconciles on its own in three situations:
+
+| Trigger | When |
+|---|---|
+| **Startup** | Once at boot, before accepting traffic, if `AUTO_RECONCILE=true` (the default). |
+| **Periodic loop** | Every reconcile interval (default 30 s) while the server is running. |
+| **Docker events** | Whenever a container exits or is destroyed, the event monitor updates the affected sandbox immediately. |
+
+For most deployments automatic reconciliation is sufficient. The manual API is useful when you need the database to reflect reality right now — for example, immediately after clearing stuck containers so a new sandbox creation can succeed.
+
+## What reconciliation does
+
+For every sandbox row in the database, the server checks whether a matching Docker container exists:
+
+- **Container missing** — the sandbox is marked `destroyed`, its Caddy routes are removed, and any mounts are unmounted.
+- **Container present** — the sandbox's status, IP address, and Caddy routes are refreshed to match the live container state.
+
+Rows that were already `destroyed` before the pass are left unchanged.
+
+## Trigger reconciliation manually
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    await client.reconcile()
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    client.reconcile()
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    if err := client.Reconcile(ctx); err != nil {
+        log.Fatal(err)
+    }
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    client.reconcile()?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    client.reconcile();
+    ```
+  </TabItem>
+</Tabs>
+
+The call blocks until the full reconcile pass completes. On success it returns with no data. On failure it throws with the server-side error message.
+
+## HTTP API
+
+```http
+POST /v1/admin/reconcile
+Authorization: Bearer <pat-token>
+```
+
+**200 OK**
+```json
+{ "status": "ok" }
+```
+
+## Common scenario: capacity exceeded after a restart
+
+If the host was rebooted or containers were removed outside of the API, the database still counts those sandboxes against the CPU and memory budget. Creating a new sandbox fails with `host capacity exceeded`.
+
+Fix:
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    // Force the DB to reflect what Docker actually sees
+    await client.reconcile()
+
+    // Now create succeeds
+    const sandbox = await client.create({ image: 'ubuntu:22.04' })
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    client.reconcile()
+    sandbox = client.create({'image': 'ubuntu:22.04'})
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    if err := client.Reconcile(ctx); err != nil {
+        log.Fatal(err)
+    }
+    sandbox, err := client.Create(ctx, sdktypes.CreateSandboxOptions{
+        Image: "ubuntu:22.04",
+    })
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    client.reconcile()?;
+    let sandbox = client.create(CreateOptions {
+        image: "ubuntu:22.04".to_string(),
+        ..Default::default()
+    })?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    client.reconcile();
+    Sandbox sandbox = client.create(new CreateOptions().setImage("ubuntu:22.04"));
+    ```
+  </TabItem>
+</Tabs>

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -42,6 +42,7 @@ func (s *Server) Handler() http.Handler {
 func (s *Server) routes() {
 	s.mux.HandleFunc("GET /health", s.handleHealth)
 	s.mux.Handle("GET /v1/capacity", s.requireAuth(http.HandlerFunc(s.handleCapacity)))
+	s.mux.Handle("POST /v1/admin/reconcile", s.requireAuth(http.HandlerFunc(s.handleReconcile)))
 	s.mux.HandleFunc("GET /v1/tls-check", s.handleTLSCheck)
 
 	s.mux.Handle("POST /v1/sandboxes", s.requireAuth(http.HandlerFunc(s.handleCreateSandbox)))
@@ -105,6 +106,15 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, status)
+}
+
+func (s *Server) handleReconcile(w http.ResponseWriter, r *http.Request) {
+	if err := s.service.Reconcile(r.Context()); err != nil {
+		s.logger.Warn("reconcile failed", "error", err)
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"status": "ok"})
 }
 
 func (s *Server) handleCapacity(w http.ResponseWriter, r *http.Request) {

--- a/sdk/go/internal/apiclient/client.go
+++ b/sdk/go/internal/apiclient/client.go
@@ -99,6 +99,10 @@ func (c *Client) Destroy(ctx context.Context, id string) error {
 	return c.doJSON(ctx, http.MethodDelete, "/v1/sandboxes/"+id, nil, nil)
 }
 
+func (c *Client) Reconcile(ctx context.Context) error {
+	return c.doJSON(ctx, http.MethodPost, "/v1/admin/reconcile", nil, nil)
+}
+
 func (c *Client) Resize(ctx context.Context, id string, opts ResizeOptions) (*Sandbox, error) {
 	var response models.Sandbox
 	if err := c.doJSON(ctx, http.MethodPost, "/v1/sandboxes/"+id+"/resize", opts, &response); err != nil {

--- a/sdk/go/pkg/microvm/client.go
+++ b/sdk/go/pkg/microvm/client.go
@@ -151,6 +151,10 @@ func (c *Client) UpdateLifecycle(ctx context.Context, id string, lifecycle sdkty
 	return wrapSandbox(c, item), nil
 }
 
+func (c *Client) Reconcile(ctx context.Context) error {
+	return c.inner.Reconcile(ctx)
+}
+
 func (c *Client) Health(ctx context.Context) (sdktypes.HealthStatus, error) {
 	return c.inner.Health(ctx)
 }

--- a/sdk/java/src/main/java/ai/aerol/microvm/MicroVMClient.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/MicroVMClient.java
@@ -163,6 +163,10 @@ public class MicroVMClient {
         doNoContent("DELETE", sandboxPath(sandboxId) + "/ports/" + port, null);
     }
 
+    public void reconcile() {
+        doNoContent("POST", "/v1/admin/reconcile", null);
+    }
+
     public HealthStatus health() {
         return doJson("GET", "/health", null, HealthStatus.class);
     }

--- a/sdk/python/microvm/client.py
+++ b/sdk/python/microvm/client.py
@@ -378,6 +378,9 @@ class MicroVM:
         sandbox = self._do_json("PUT", f"/v1/sandboxes/{sandbox_id}/lifecycle", _to_api_lifecycle(lifecycle))
         return self._wrap_sandbox(sandbox)
 
+    def reconcile(self) -> None:
+        self._do_json("POST", "/v1/admin/reconcile", None)
+
     def health(self) -> HealthStatus:
         return _from_api_health_status(self._do_json("GET", "/health", None))
 

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -408,6 +408,10 @@ impl Client {
         Ok(Sandbox::new(self.clone(), raw))
     }
 
+    pub fn reconcile(&self) -> Result<(), Error> {
+        self.do_json::<(), serde_json::Value>(Method::POST, "/v1/admin/reconcile", None).map(|_| ())
+    }
+
     pub fn health(&self) -> Result<HealthStatus, Error> {
         self.do_json::<(), HealthStatus>(Method::GET, "/health", None)
     }

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -15,6 +15,8 @@
     "build": "tsc -p tsconfig.json",
     "example:create": "npm run build && node dist/examples/createSandbox.js",
     "example:create:src": "npx tsx src/examples/createSandbox.ts",
+    "example:delete": "npm run build && node dist/examples/deleteSandbox.js",
+    "example:delete:src": "npx tsx src/examples/deleteSandbox.ts",
     "test": "tsc -p tsconfig.test.json --outDir dist-test && node --test dist-test/*.test.js"
   },
   "devDependencies": {

--- a/sdk/typescript/src/MicroVM.ts
+++ b/sdk/typescript/src/MicroVM.ts
@@ -88,6 +88,10 @@ export class MicroVM {
     return this.wrap(sandbox.toJSON());
   }
 
+  async reconcile(): Promise<void> {
+    await this.client.reconcile();
+  }
+
   async health(): Promise<HealthStatus> {
     return this.client.health();
   }

--- a/sdk/typescript/src/examples/deleteSandbox.ts
+++ b/sdk/typescript/src/examples/deleteSandbox.ts
@@ -1,0 +1,56 @@
+/// <reference types="node" />
+
+import { MicroVM } from "../index.js";
+
+async function main(): Promise<void> {
+	const apiUrl = process.env.SB_API_URL ?? "https://sandbox.aerol.cloud";
+	const patToken = process.env.SB_PAT_TOKEN ?? "";
+	if (patToken === "") {
+		throw new Error("PAT token is required. Set SB_PAT_TOKEN.");
+	}
+
+	const sandboxID = process.argv[2];
+
+	const client = new MicroVM({ apiUrl, patToken });
+
+	if (!sandboxID) {
+		const sandboxes = await client.list();
+		if (sandboxes.length === 0) {
+			console.log("No sandboxes found.");
+			return;
+		}
+		console.log(`Found ${sandboxes.length} sandbox(es):\n`);
+		for (const sb of sandboxes) {
+			console.log(`  id=${sb.id}  status=${sb.status}  image=${sb.image}  created=${sb.createdAt}`);
+		}
+		console.log("\nUsage: npx tsx src/examples/deleteSandbox.ts <sandbox-id>");
+		console.log("       npx tsx src/examples/deleteSandbox.ts --all");
+		return;
+	}
+
+	if (sandboxID === "--all") {
+		const sandboxes = await client.list();
+		if (sandboxes.length === 0) {
+			console.log("No sandboxes to delete.");
+			return;
+		}
+		console.log(`Deleting ${sandboxes.length} sandbox(es)…`);
+		await Promise.all(
+			sandboxes.map(async (sb) => {
+				await client.destroy(sb.id);
+				console.log(`  deleted ${sb.id}`);
+			}),
+		);
+		console.log("Done.");
+		return;
+	}
+
+	await client.destroy(sandboxID);
+	console.log(`deleted ${sandboxID}`);
+}
+
+main().catch((error: unknown) => {
+	const message = error instanceof Error ? error.message : String(error);
+	console.error(message);
+	process.exitCode = 1;
+});

--- a/sdk/typescript/src/internal/client.ts
+++ b/sdk/typescript/src/internal/client.ts
@@ -258,6 +258,10 @@ export class APIClient {
     await this.doJSON<void>("DELETE", `/v1/sandboxes/${id}/ports/${port}`);
   }
 
+  async reconcile(): Promise<void> {
+    await this.doJSON<unknown>("POST", "/v1/admin/reconcile");
+  }
+
   async health(): Promise<HealthStatus> {
     const response = await this.doJSON<ApiHealthStatus>("GET", "/health");
     return fromApiHealthStatus(response);


### PR DESCRIPTION
This pull request introduces a new "Reconcile" feature to the API and SDKs, which synchronizes the sandbox database with the actual state of Docker containers. This is especially useful for resolving capacity errors after host restarts or manual container changes. The changes include backend API support, SDK bindings in all supported languages, updates to documentation, and a new TypeScript example for deleting sandboxes.

**Reconcile Feature Implementation**

* Added a new `POST /v1/admin/reconcile` API endpoint to trigger reconciliation, with server-side logic to sync the database to live container state. [[1]](diffhunk://#diff-734f9c34b34af099d24da13054e167f7df72706dc733edf21c61c0cc1548224aR45) [[2]](diffhunk://#diff-734f9c34b34af099d24da13054e167f7df72706dc733edf21c61c0cc1548224aR111-R119)
* Implemented `reconcile` methods in all SDKs (Go, Python, Rust, Java, TypeScript) to expose the new API to clients. [[1]](diffhunk://#diff-655f0769034c8c99a15b5fbdd98f7878b4b767638ae1202e2f7ddd9a44ecd0cbR102-R105) [[2]](diffhunk://#diff-d69c89a9451f43580822ad7a8bf11a04ed437ffd809aa46cd901d559152cefdeR154-R157) [[3]](diffhunk://#diff-ddd402048684d5e8a7d4ac680f2524448dea8cee2dfffb6bb03efb9f73bd7518R381-R383) [[4]](diffhunk://#diff-a8b4e080c431607355115562b733433d32abb3b89141f0a09e136c7703a0a820R411-R414) [[5]](diffhunk://#diff-41e3a009316f2b485a6bd94bdf4d8d22e8d6b0f3fb84a221df9763b538507a0cR91-R94) [[6]](diffhunk://#diff-31e4c7d01f0164972accfbd223d61527dc9c2ddd25dc49b6db26cba90f618328R261-R264)

**Documentation Updates**

* Added a new `reconcile.mdx` documentation page describing when and how reconciliation runs, its effects, API usage, and common scenarios.
* Updated the sidebar configuration to include a link to the new "Reconcile" documentation.

**TypeScript SDK Improvements**

* Added a new example script `deleteSandbox.ts` for deleting sandboxes via the TypeScript SDK, and updated `package.json` scripts to include this example. [[1]](diffhunk://#diff-ba0fdd9b14eb1dc6cdb849845a7646e9e6656eff6ba27fb9dab915442da477bfR1-R56) [[2]](diffhunk://#diff-1097377c78d22400c9189626a6f2d209142a89cc652ea050fb577aa1087634e0R18-R19)

These changes ensure users can easily recover from host restarts or out-of-band container deletions by manually or automatically reconciling the sandbox state.…se with live container state