### PR TITLE
feat: enhance WebSocket error handling and diagnostics across multiple SDKs

### DIFF
--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -4,7 +4,7 @@ import LanguageSelect from './LanguageSelect.astro'
 import ThemeSelect from './ThemeSelect.astro'
 
 const currentPath = Astro.url.pathname
-const version = import.meta.env.VERSION || '0.1.2'
+const version = import.meta.env.VERSION || '0.1.3'
 
 const navLinks = [
 ]

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1,9 +1,11 @@
 package api
 
 import (
+	"bufio"
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -312,9 +314,83 @@ func (s *Server) proxyToToolbox(w http.ResponseWriter, r *http.Request, path str
 func loggingMiddleware(logger *slog.Logger, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
-		next.ServeHTTP(w, r)
-		logger.Info("request complete", "method", r.Method, "path", r.URL.Path, "duration", time.Since(start))
+		// Wrap the writer so we can record the status code and whether the
+		// connection was hijacked (i.e. WebSocket upgrade succeeded). The
+		// wrapper proxies http.Hijacker / http.Flusher so the toolbox proxy
+		// can still upgrade through this middleware.
+		rec := &statusRecorder{ResponseWriter: w}
+		next.ServeHTTP(rec, r)
+		fields := []any{
+			"method", r.Method,
+			"path", r.URL.Path,
+			"duration", time.Since(start),
+			"status", rec.statusCode(),
+		}
+		if rec.hijacked {
+			fields = append(fields, "hijacked", true)
+		}
+		if upgrade := r.Header.Get("Upgrade"); upgrade != "" {
+			fields = append(fields, "upgrade", upgrade)
+		}
+		logger.Info("request complete", fields...)
 	})
+}
+
+// statusRecorder records the status the handler wrote (default 200, mirroring
+// net/http) and whether the connection was hijacked. The Hijack/Flush passthrough
+// is the load-bearing bit for WebSocket upgrades — the gorilla/websocket-style
+// proxy in handleToolboxProxy needs the underlying ResponseWriter to satisfy
+// http.Hijacker, and a wrapper that doesn't forward Hijack would silently break
+// every WS request flowing through this middleware.
+type statusRecorder struct {
+	http.ResponseWriter
+	status   int
+	wrote    bool
+	hijacked bool
+}
+
+func (s *statusRecorder) WriteHeader(code int) {
+	if !s.wrote {
+		s.status = code
+		s.wrote = true
+	}
+	s.ResponseWriter.WriteHeader(code)
+}
+
+func (s *statusRecorder) Write(b []byte) (int, error) {
+	if !s.wrote {
+		s.status = http.StatusOK
+		s.wrote = true
+	}
+	return s.ResponseWriter.Write(b)
+}
+
+func (s *statusRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hj, ok := s.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, errors.New("response writer does not implement http.Hijacker")
+	}
+	conn, rw, err := hj.Hijack()
+	if err == nil {
+		s.hijacked = true
+	}
+	return conn, rw, err
+}
+
+func (s *statusRecorder) Flush() {
+	if f, ok := s.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (s *statusRecorder) statusCode() int {
+	if s.hijacked {
+		return http.StatusSwitchingProtocols
+	}
+	if !s.wrote {
+		return http.StatusOK
+	}
+	return s.status
 }
 
 func writeJSON(w http.ResponseWriter, status int, value any) {

--- a/sdk/go/internal/apiclient/exec_stream.go
+++ b/sdk/go/internal/apiclient/exec_stream.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -66,9 +67,9 @@ func (c *Client) ExecStream(ctx context.Context, id string, options ExecStreamOp
 		requestHeader.Set("Authorization", "Bearer "+c.patToken)
 	}
 
-	conn, _, err := websocket.DefaultDialer.DialContext(ctx, wsURL, requestHeader)
+	conn, resp, err := websocket.DefaultDialer.DialContext(ctx, wsURL, requestHeader)
 	if err != nil {
-		return nil, err
+		return nil, decorateHandshakeError("exec stream", wsURL, resp, err)
 	}
 
 	handle := &ExecStreamHandle{
@@ -140,7 +141,7 @@ func (h *ExecStreamHandle) readLoop(options ExecStreamOptions) {
 	for {
 		messageType, payload, err := h.conn.ReadMessage()
 		if err != nil {
-			h.finish(ExecExitInfo{}, fmt.Errorf("stream closed before exit: %w", err))
+			h.finish(ExecExitInfo{}, fmt.Errorf("stream closed before exit: %w", describeReadErr(err)))
 			return
 		}
 
@@ -204,6 +205,45 @@ func (h *ExecStreamHandle) finish(info ExecExitInfo, err error) {
 		h.resultMu.Unlock()
 		close(h.done)
 	})
+}
+
+// describeReadErr annotates a gorilla/websocket read error with the close
+// code/text when the peer sent one. Plain `err.Error()` says only "websocket:
+// close 1006 (abnormal closure)"; with this we surface the toolboxd-supplied
+// text frame too when present.
+func describeReadErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	if ce, ok := err.(*websocket.CloseError); ok {
+		if ce.Text == "" {
+			return fmt.Errorf("close code=%d", ce.Code)
+		}
+		return fmt.Errorf("close code=%d text=%q", ce.Code, ce.Text)
+	}
+	return err
+}
+
+// decorateHandshakeError annotates a gorilla/websocket Dial error with the
+// HTTP status and body the server returned. On a non-101 response the dialer
+// surfaces only "websocket: bad handshake", which is useless for diagnosing
+// 401s ("auth dropped"), 404s ("route mismatch"), 502s ("toolbox unavailable"),
+// or 5xx from upstream. Caller passes the *http.Response the dialer also
+// returned (may be nil on transport-level errors).
+func decorateHandshakeError(label, wsURL string, resp *http.Response, err error) error {
+	if err == nil {
+		return nil
+	}
+	if resp == nil {
+		return fmt.Errorf("%s websocket dial %s: %w", label, wsURL, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4*1024))
+	trimmed := strings.TrimSpace(string(body))
+	if trimmed == "" {
+		return fmt.Errorf("%s websocket dial %s: %w (status=%d)", label, wsURL, err, resp.StatusCode)
+	}
+	return fmt.Errorf("%s websocket dial %s: %w (status=%d, body=%q)", label, wsURL, err, resp.StatusCode, trimmed)
 }
 
 func websocketURL(baseURL, path string) (string, error) {

--- a/sdk/go/internal/apiclient/sessions.go
+++ b/sdk/go/internal/apiclient/sessions.go
@@ -154,9 +154,9 @@ func (c *Client) AttachSession(ctx context.Context, sandboxID, sessionID string,
 	if c.patToken != "" {
 		requestHeader.Set("Authorization", "Bearer "+c.patToken)
 	}
-	conn, _, err := websocket.DefaultDialer.DialContext(ctx, wsURL, requestHeader)
+	conn, resp, err := websocket.DefaultDialer.DialContext(ctx, wsURL, requestHeader)
 	if err != nil {
-		return nil, err
+		return nil, decorateHandshakeError("session attach", wsURL, resp, err)
 	}
 
 	handle := &SessionAttachHandle{
@@ -217,7 +217,7 @@ func (h *SessionAttachHandle) readLoop(options SessionAttachOptions) {
 	for {
 		messageType, payload, err := h.conn.ReadMessage()
 		if err != nil {
-			h.finish(0, "", fmt.Errorf("session stream closed: %w", err))
+			h.finish(0, "", fmt.Errorf("session stream closed: %w", describeReadErr(err)))
 			return
 		}
 		switch messageType {

--- a/sdk/java/README.md
+++ b/sdk/java/README.md
@@ -24,7 +24,7 @@ The release workflow publishes the package to GitHub Packages as `ai.aerol:aerol
   <dependency>
     <groupId>ai.aerol</groupId>
     <artifactId>aerolvm-sdk</artifactId>
-    <version>0.1.2</version>
+    <version>0.1.3</version>
   </dependency>
 </dependencies>
 ```

--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>ai.aerol</groupId>
   <artifactId>aerolvm-sdk</artifactId>
-  <version>0.1.2</version>
+  <version>0.1.3</version>
   <name>Aerol.ai MicroVM Java SDK</name>
   <description>A Java client for the Aerol.ai MicroVM sandbox API.</description>
   <url>https://github.com/aerol-ai/microvm</url>

--- a/sdk/java/src/main/java/ai/aerol/microvm/internal/JavaNetWebSocketConnector.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/internal/JavaNetWebSocketConnector.java
@@ -3,7 +3,9 @@ package ai.aerol.microvm.internal;
 import java.io.ByteArrayOutputStream;
 import java.net.URI;
 import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
 import java.net.http.WebSocket;
+import java.net.http.WebSocketHandshakeException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -30,8 +32,39 @@ public final class JavaNetWebSocketConnector implements WebSocketConnector {
             WebSocket webSocket = builder.buildAsync(uri, new AdapterListener(listener)).join();
             return new AdapterSocket(webSocket);
         } catch (CompletionException ex) {
-            throw new MicroVMException("failed to connect websocket", resolveCause(ex));
+            Throwable cause = resolveCause(ex);
+            throw new MicroVMException(describeConnectFailure(uri, cause), cause);
         }
+    }
+
+    // describeConnectFailure pulls HTTP status / body off WebSocketHandshakeException
+    // so callers see "websocket connect to <uri> failed: status=502 body='toolbox unavailable'"
+    // instead of just "failed to connect websocket".
+    private static String describeConnectFailure(URI uri, Throwable cause) {
+        if (cause instanceof WebSocketHandshakeException) {
+            WebSocketHandshakeException handshake = (WebSocketHandshakeException) cause;
+            HttpResponse<?> response = handshake.getResponse();
+            int status = response == null ? -1 : response.statusCode();
+            String body = "";
+            if (response != null) {
+                Object rawBody = response.body();
+                if (rawBody instanceof byte[]) {
+                    body = new String((byte[]) rawBody).trim();
+                } else if (rawBody != null) {
+                    body = rawBody.toString().trim();
+                }
+            }
+            StringBuilder sb = new StringBuilder("websocket connect to ").append(uri).append(" failed");
+            if (status > 0) {
+                sb.append(": status=").append(status);
+            }
+            if (!body.isEmpty()) {
+                sb.append(" body=").append(body);
+            }
+            return sb.toString();
+        }
+        String message = cause == null || cause.getMessage() == null ? "" : ": " + cause.getMessage();
+        return "websocket connect to " + uri + " failed" + message;
     }
 
     private static final class AdapterSocket implements StreamingWebSocket {

--- a/sdk/python/microvm/client.py
+++ b/sdk/python/microvm/client.py
@@ -401,11 +401,8 @@ class MicroVM:
             raise MicroVMError("command is required")
 
         websocket_module = _load_websocket_module()
-        ws = websocket_module.create_connection(
-            _to_websocket_url(self.api_url, f"/v1/sandboxes/{urllib.parse.quote(sandbox_id, safe='')}/toolbox/process/exec/stream"),
-            header=[f"Authorization: Bearer {self.pat_token}"],
-            enable_multithread=True,
-        )
+        ws_url = _to_websocket_url(self.api_url, f"/v1/sandboxes/{urllib.parse.quote(sandbox_id, safe='')}/toolbox/process/exec/stream")
+        ws = _connect_websocket(websocket_module, ws_url, self.pat_token, "exec stream")
         ws.send(json.dumps(_to_api_exec_stream_request(options)))
         return ExecStreamHandle(websocket_module, ws, options)
 
@@ -447,14 +444,11 @@ class MicroVM:
     ) -> SessionAttachHandle:
         attach_options: SessionAttachOptions = options or {}
         websocket_module = _load_websocket_module()
-        ws = websocket_module.create_connection(
-            _to_websocket_url(
-                self.api_url,
-                f"/v1/sandboxes/{urllib.parse.quote(sandbox_id, safe='')}/sessions/{urllib.parse.quote(session_id, safe='')}/attach",
-            ),
-            header=[f"Authorization: Bearer {self.pat_token}"],
-            enable_multithread=True,
+        ws_url = _to_websocket_url(
+            self.api_url,
+            f"/v1/sandboxes/{urllib.parse.quote(sandbox_id, safe='')}/sessions/{urllib.parse.quote(session_id, safe='')}/attach",
         )
+        ws = _connect_websocket(websocket_module, ws_url, self.pat_token, "session attach")
 
         cols = _first_of(attach_options, "cols")
         rows = _first_of(attach_options, "rows")
@@ -547,6 +541,35 @@ class MicroVM:
 
 def _load_websocket_module() -> Any:
     return importlib.import_module("websocket")
+
+
+def _connect_websocket(websocket_module: Any, ws_url: str, pat_token: str, label: str) -> Any:
+    """create_connection wrapper that surfaces HTTP status/body on bad
+    handshake. websocket-client raises WebSocketBadStatusException for non-101
+    responses, which carries .status_code and .resp_body but stringifies as
+    "Handshake status 401 Unauthorized" — we want the body too so 502s from
+    the toolbox proxy ("toolbox unavailable") and 401s with JSON error bodies
+    are decipherable without a packet capture.
+    """
+    try:
+        return websocket_module.create_connection(
+            ws_url,
+            header=[f"Authorization: Bearer {pat_token}"],
+            enable_multithread=True,
+        )
+    except Exception as exc:
+        status = getattr(exc, "status_code", None)
+        body = getattr(exc, "resp_body", None)
+        if isinstance(body, (bytes, bytearray)):
+            body = body.decode("utf-8", errors="replace").strip()
+        elif isinstance(body, str):
+            body = body.strip()
+        parts = [f"{label} websocket connect to {ws_url} failed: {exc}"]
+        if status is not None:
+            parts.append(f"status={status}")
+        if body:
+            parts.append(f"body={body!r}")
+        raise MicroVMError(" | ".join(parts)) from exc
 
 
 def _to_websocket_url(base_url: str, path: str) -> str:

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aerolvm-sdk"
-version = "0.1.2"
+version = "0.1.3"
 description = "A Python client for the Aerol.ai MicroVM sandbox API."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aerolvm-sdk"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["Aerol AI"]
 description = "A Rust SDK for the Aerol.ai MicroVM sandbox API"

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -627,7 +627,9 @@ async fn run_exec_stream(
             .map_err(|err| Error::Api(format!("invalid auth header: {}", err)))?,
     );
 
-    let (stream, _) = connect_async(request).await?;
+    let (stream, _) = connect_async(request)
+        .await
+        .map_err(|err| decorate_ws_handshake("exec stream", err))?;
     let (mut write, mut read) = stream.split();
 
     let start = ExecStreamStartRequest {
@@ -718,7 +720,9 @@ async fn run_session_attach(
             .map_err(|err| Error::Api(format!("invalid auth header: {}", err)))?,
     );
 
-    let (stream, _) = connect_async(request).await?;
+    let (stream, _) = connect_async(request)
+        .await
+        .map_err(|err| decorate_ws_handshake("session attach", err))?;
     let (mut write, mut read) = stream.split();
 
     if let (Some(cols), Some(rows)) = (options.cols, options.rows) {
@@ -789,6 +793,30 @@ async fn run_session_attach(
                 }
             }
         }
+    }
+}
+
+// decorate_ws_handshake unwraps tungstenite's Http error variant so the
+// caller sees the actual status + body the server returned (e.g.
+// "status=502, body=\"toolbox unavailable\"") instead of just
+// "Http error: 502 Bad Gateway".
+fn decorate_ws_handshake(label: &str, err: WebSocketError) -> Error {
+    match err {
+        WebSocketError::Http(response) => {
+            let status = response.status();
+            let body = response.into_body().unwrap_or_default();
+            let body_str = String::from_utf8_lossy(&body);
+            let trimmed = body_str.trim();
+            if trimmed.is_empty() {
+                Error::Api(format!("{} websocket handshake failed: status={}", label, status))
+            } else {
+                Error::Api(format!(
+                    "{} websocket handshake failed: status={}, body={:?}",
+                    label, status, trimmed
+                ))
+            }
+        }
+        other => Error::WebSocket(other),
     }
 }
 

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aerol-ai/aerolvm-sdk",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aerol-ai/aerolvm-sdk",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "devDependencies": {
         "@types/node": "^22.15.17",
         "tsx": "^4.21.0",

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aerol-ai/aerolvm-sdk",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aerol-ai/aerolvm-sdk",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "devDependencies": {
         "@types/node": "^22.15.17",
         "tsx": "^4.21.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerol-ai/aerolvm-sdk",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": false,
   "type": "module",
   "main": "./dist/index.js",

--- a/sdk/typescript/src/examples/createSandbox.ts
+++ b/sdk/typescript/src/examples/createSandbox.ts
@@ -290,16 +290,33 @@ async function startExpressServer(
 		publicURL: options.publicURL,
 	}, null, 2));
 
-	const handle = sandbox.execStream({
+	// Background servers should run as sessions so we can detach cleanly after
+	// readiness checks instead of keeping an exec stream transport open.
+	const session = await sandbox.createSession({
+		name: `express-server-${options.port}`,
 		command: "npm start",
-		workdir: options.workDir,
+		workDir: options.workDir,
 		env: options.env,
+	});
+	const handle = sandbox.attachSession(session.id, {
 		onStdout: (chunk) => stdoutLogger.write(chunk),
 		onStderr: (chunk) => stderrLogger.write(chunk),
 		onError: (message) => {
 			console.error(`[${actionName}:error] ${message}`);
-			rejectReady?.(new Error(message));
+			if (!ready) {
+				rejectReady?.(new Error(message));
+			}
 		},
+	});
+	let detached = false;
+	void handle.done.then((exit) => {
+		if (!ready) {
+			rejectReady?.(new Error(`${actionName} exited before it became ready (${formatExecExit(exit)})`));
+		}
+	}).catch((error: unknown) => {
+		if (!detached && !ready) {
+			rejectReady?.(error instanceof Error ? error : new Error(String(error)));
+		}
 	});
 
 	const healthURL = new URL("/health", options.publicURL).toString();
@@ -326,12 +343,22 @@ async function startExpressServer(
 			name: actionName,
 			status: "ready",
 			publicURL: options.publicURL,
+			sessionID: session.id,
 		}, null, 2));
 	} catch (error: unknown) {
-		handle.signal("TERM");
+		try {
+			await sandbox.deleteSession(session.id);
+		} catch {
+			// Best-effort cleanup. The original startup error is more useful.
+		}
 		throw error;
 	} finally {
-		handle.close();
+		detached = true;
+		try {
+			handle.close();
+		} catch {
+			// The attach stream may already be closed if startup failed early.
+		}
 		stdoutLogger.flush();
 		stderrLogger.flush();
 	}
@@ -417,6 +444,13 @@ function timeoutAfter(ms: number, message: string): Promise<never> {
 			reject(new Error(message));
 		}, ms);
 	});
+}
+
+function formatExecExit(exit: { code: number; signal?: string }): string {
+	if (exit.signal) {
+		return `signal ${exit.signal}`;
+	}
+	return `exit code ${exit.code}`;
 }
 
 function delay(ms: number): Promise<void> {

--- a/sdk/typescript/src/internal/client.test.ts
+++ b/sdk/typescript/src/internal/client.test.ts
@@ -358,6 +358,70 @@ test("internal client execStream rejects when stream closes before exit", async 
   }
 });
 
+test("internal client attachSession close detaches transport", async () => {
+  const originalWebSocket = globalThis.WebSocket;
+
+  class FakeWebSocket {
+    static instances: FakeWebSocket[] = [];
+
+    readonly url: string;
+    readonly protocols: string[];
+    binaryType = "blob";
+    sent: Array<string | Uint8Array> = [];
+    closed = false;
+    private readonly listeners = new Map<string, Array<(event?: unknown) => void>>();
+
+    constructor(url: string, protocols?: string | string[]) {
+      this.url = url;
+      this.protocols = Array.isArray(protocols) ? protocols : protocols ? [protocols] : [];
+      FakeWebSocket.instances.push(this);
+    }
+
+    addEventListener(name: string, listener: (event?: unknown) => void): void {
+      const listeners = this.listeners.get(name) ?? [];
+      listeners.push(listener);
+      this.listeners.set(name, listeners);
+    }
+
+    send(data: string | Uint8Array): void {
+      this.sent.push(data);
+    }
+
+    close(): void {
+      this.closed = true;
+    }
+
+    emit(name: string, event?: unknown): void {
+      for (const listener of this.listeners.get(name) ?? []) {
+        listener(event);
+      }
+    }
+  }
+
+  try {
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+
+    const client = new APIClient({
+      baseURL: "https://api.example.com",
+      patToken: "pat-token",
+    });
+
+    const handle = client.attachSession("sb-stream", "ses-1");
+    const ws = FakeWebSocket.instances[0];
+    assert.ok(ws);
+
+    ws.emit("open");
+    handle.close();
+
+    assert.equal(ws.url, "wss://api.example.com/v1/sandboxes/sb-stream/sessions/ses-1/attach");
+    assert.deepEqual(ws.protocols, ["sandbox.bearer", "pat-token"]);
+    assert.equal(ws.sent[0], JSON.stringify({ type: "close" }));
+    assert.equal(ws.closed, true);
+  } finally {
+    globalThis.WebSocket = originalWebSocket;
+  }
+});
+
 test("internal client create forwards runtime selector and parses response", async () => {
   let seenRequest: Request | undefined;
   const client = new APIClient({

--- a/sdk/typescript/src/internal/client.ts
+++ b/sdk/typescript/src/internal/client.ts
@@ -676,6 +676,29 @@ async function decodeError(response: Response): Promise<Error> {
 const STREAM_PREFIX_STDOUT = 0x01;
 const STREAM_PREFIX_STDERR = 0x02;
 
+// Pull whatever diagnostic detail the runtime gave us off a WebSocket "error"
+// event. Node 22's native WebSocket fires an ErrorEvent with `.error` /
+// `.message`; browsers' base WebSocket fires a bare Event. Returns "" when
+// nothing useful is there so callers can fall back to a generic label.
+function describeWSError(event: unknown): string {
+  if (!event || typeof event !== "object") return "";
+  const e = event as { error?: unknown; message?: unknown };
+  if (e.error instanceof Error && e.error.message) return e.error.message;
+  if (typeof e.error === "string" && e.error !== "") return e.error;
+  if (typeof e.message === "string" && e.message !== "") return e.message;
+  return "";
+}
+
+function describeWSClose(event: unknown): string {
+  if (!event || typeof event !== "object") return "";
+  const e = event as { code?: unknown; reason?: unknown; wasClean?: unknown };
+  const parts: string[] = [];
+  if (typeof e.code === "number") parts.push(`code=${e.code}`);
+  if (typeof e.reason === "string" && e.reason !== "") parts.push(`reason=${JSON.stringify(e.reason)}`);
+  if (typeof e.wasClean === "boolean") parts.push(`wasClean=${e.wasClean}`);
+  return parts.join(" ");
+}
+
 function openExecStream(baseURL: string, patToken: string, sandboxID: string, options: ExecStreamOptions): ExecStreamHandle {
   const wsURL = baseURL.replace(/^http/, "ws") + `/v1/sandboxes/${encodeURIComponent(sandboxID)}/toolbox/process/exec/stream`;
 
@@ -689,6 +712,11 @@ function openExecStream(baseURL: string, patToken: string, sandboxID: string, op
   // `sandbox.bearer, <token>`.
   const ws = new WS(wsURL, ["sandbox.bearer", patToken]);
   ws.binaryType = "arraybuffer";
+
+  // Captured by the "error" listener and consumed by "close" so we report the
+  // root cause (e.g. "Unexpected server response: 502") rather than the
+  // generic "stream closed before exit" that would otherwise win the race.
+  let lastErrorDetail = "";
 
   let exitResolve: ((info: ExecExitInfo) => void) | undefined;
   let exitReject: ((err: Error) => void) | undefined;
@@ -748,12 +776,20 @@ function openExecStream(baseURL: string, patToken: string, sandboxID: string, op
     }
   });
 
-  ws.addEventListener("close", () => {
-    failWith("stream closed before exit");
+  ws.addEventListener("close", (event) => {
+    const closeDetail = describeWSClose(event);
+    const parts = [lastErrorDetail, closeDetail].filter((s) => s !== "");
+    const suffix = parts.length > 0 ? ` (${parts.join("; ")})` : "";
+    failWith(`stream closed before exit${suffix}`);
   });
 
-  ws.addEventListener("error", () => {
-    failWith("websocket error");
+  ws.addEventListener("error", (event) => {
+    const detail = describeWSError(event);
+    if (detail !== "") {
+      lastErrorDetail = detail;
+    }
+    options.onError?.(detail !== "" ? detail : "websocket error");
+    failWith(detail !== "" ? `websocket error: ${detail}` : "websocket error");
   });
 
   const sendBinary = (data: Uint8Array | string) => {
@@ -801,6 +837,7 @@ function openSessionAttach(
   });
 
   let settled = false;
+  let lastErrorDetail = "";
   const finishWith = (info: ExecExitInfo) => {
     if (settled) return;
     settled = true;
@@ -850,14 +887,22 @@ function openSessionAttach(
     }
   });
 
-  ws.addEventListener("close", () => {
+  ws.addEventListener("close", (event) => {
     if (!settled) {
-      failWith("session stream closed before exit");
+      const closeDetail = describeWSClose(event);
+      const parts = [lastErrorDetail, closeDetail].filter((s) => s !== "");
+      const suffix = parts.length > 0 ? ` (${parts.join("; ")})` : "";
+      failWith(`session stream closed before exit${suffix}`);
     }
   });
 
-  ws.addEventListener("error", () => {
-    failWith("websocket error");
+  ws.addEventListener("error", (event) => {
+    const detail = describeWSError(event);
+    if (detail !== "") {
+      lastErrorDetail = detail;
+    }
+    options.onError?.(detail !== "" ? detail : "websocket error");
+    failWith(detail !== "" ? `websocket error: ${detail}` : "websocket error");
   });
 
   const sendBinary = (data: Uint8Array | string) => {


### PR DESCRIPTION
This pull request improves error handling and diagnostics for WebSocket connections across the Go, Python, Java, Rust, and TypeScript SDKs, as well as enhances logging in the Go API server. The main focus is to ensure that when a WebSocket handshake fails, clients receive detailed error messages including HTTP status codes and response bodies, making debugging much easier. Additionally, the TypeScript example for starting an Express server is updated to use sessions for better lifecycle management.

**Enhanced WebSocket error reporting and diagnostics:**

* Go SDK (`sdk/go/internal/apiclient/exec_stream.go`, `sdk/go/internal/apiclient/sessions.go`):
  - Added helper functions (`decorateHandshakeError`, `describeReadErr`) to surface HTTP status codes and response bodies on WebSocket handshake and read errors, improving error messages for failed connections. [[1]](diffhunk://#diff-95c75081bae0cc9617dcaa7c53440713ee22bb2f9cf514f726d486b0d9c3bd52L69-R72) [[2]](diffhunk://#diff-95c75081bae0cc9617dcaa7c53440713ee22bb2f9cf514f726d486b0d9c3bd52L143-R144) [[3]](diffhunk://#diff-95c75081bae0cc9617dcaa7c53440713ee22bb2f9cf514f726d486b0d9c3bd52R210-R248) [[4]](diffhunk://#diff-0ea5bdfec477ff8393b6ecfc19a279debc89887b0d0b5b980552a5eef488c2b1L157-R159) [[5]](diffhunk://#diff-0ea5bdfec477ff8393b6ecfc19a279debc89887b0d0b5b980552a5eef488c2b1L220-R220)
* Python SDK (`sdk/python/microvm/client.py`):
  - Introduced `_connect_websocket` to wrap connection attempts and raise errors that include HTTP status and body when the handshake fails. Updated `exec_stream` and `attach_session` to use this function. [[1]](diffhunk://#diff-ddd402048684d5e8a7d4ac680f2524448dea8cee2dfffb6bb03efb9f73bd7518L404-R405) [[2]](diffhunk://#diff-ddd402048684d5e8a7d4ac680f2524448dea8cee2dfffb6bb03efb9f73bd7518L450-R451) [[3]](diffhunk://#diff-ddd402048684d5e8a7d4ac680f2524448dea8cee2dfffb6bb03efb9f73bd7518R546-R574)
* Java SDK (`sdk/java/src/main/java/ai/aerol/microvm/internal/JavaNetWebSocketConnector.java`):
  - Added `describeConnectFailure` to extract and report HTTP status and body from `WebSocketHandshakeException`, providing more informative error messages on connection failure. [[1]](diffhunk://#diff-1913baf93d1f39bb1518ee57c205a1f9264c93542e4167840580436dd2447fa0R6-R8) [[2]](diffhunk://#diff-1913baf93d1f39bb1518ee57c205a1f9264c93542e4167840580436dd2447fa0L33-R69)
* Rust SDK (`sdk/rust/src/lib.rs`):
  - Implemented `decorate_ws_handshake` to unwrap handshake errors and include HTTP status and response body in error messages for both exec stream and session attach flows. [[1]](diffhunk://#diff-a8b4e080c431607355115562b733433d32abb3b89141f0a09e136c7703a0a820L630-R632) [[2]](diffhunk://#diff-a8b4e080c431607355115562b733433d32abb3b89141f0a09e136c7703a0a820L721-R725) [[3]](diffhunk://#diff-a8b4e080c431607355115562b733433d32abb3b89141f0a09e136c7703a0a820R799-R822)

**API server logging improvements:**

* Go API server (`pkg/api/server.go`):
  - Enhanced logging middleware to record HTTP status codes and WebSocket upgrade events, using a new `statusRecorder` wrapper to capture hijack/flush events for accurate logging of WebSocket requests. [[1]](diffhunk://#diff-734f9c34b34af099d24da13054e167f7df72706dc733edf21c61c0cc1548224aR4-R8) [[2]](diffhunk://#diff-734f9c34b34af099d24da13054e167f7df72706dc733edf21c61c0cc1548224aL315-R395)

**TypeScript SDK and example improvements:**

* TypeScript SDK example (`sdk/typescript/src/examples/createSandbox.ts`):
  - Updated the Express server example to use sessions instead of exec streams for background servers, enabling cleaner detachment and resource management. Improved error handling and logging for session lifecycle. [[1]](diffhunk://#diff-6efb712e5ba189a6628daa489c75be02f4e812f2056a27c3674816cffcc9173fL293-R320) [[2]](diffhunk://#diff-6efb712e5ba189a6628daa489c75be02f4e812f2056a27c3674816cffcc9173fR346-R361) [[3]](diffhunk://#diff-6efb712e5ba189a6628daa489c75be02f4e812f2056a27c3674816cffcc9173fR449-R455)
* Version bump:
  - Updated TypeScript SDK version in `package-lock.json`.