### PR TITLE
feat: add CPU and memory overprovision factors to capacity management

### DIFF
--- a/cmd/sandboxd/main.go
+++ b/cmd/sandboxd/main.go
@@ -89,9 +89,11 @@ func main() {
 		host.MemoryTotalMB = cfg.HostMemoryMBOverride
 	}
 	admitter := capacity.New(host, capacity.Limits{
-		CPUReservationRatio:    cfg.CPUReservationRatio,
-		MemoryReservationRatio: cfg.MemoryReservationRatio,
-		MemoryFloorRatio:       cfg.MemoryFloorRatio,
+		CPUReservationRatio:       cfg.CPUReservationRatio,
+		MemoryReservationRatio:    cfg.MemoryReservationRatio,
+		MemoryFloorRatio:          cfg.MemoryFloorRatio,
+		CPUOverProvisionFactor:    cfg.CPUOverProvisionFactor,
+		MemoryOverProvisionFactor: cfg.MemoryOverProvisionFactor,
 	}, capacity.NewProcMeminfoProbe())
 	logger.Info("capacity admission configured",
 		"host_cpu_cores", host.CPUCores,
@@ -99,6 +101,8 @@ func main() {
 		"cpu_reservation_ratio", cfg.CPUReservationRatio,
 		"memory_reservation_ratio", cfg.MemoryReservationRatio,
 		"memory_floor_ratio", cfg.MemoryFloorRatio,
+		"cpu_overprovision_factor", cfg.CPUOverProvisionFactor,
+		"memory_overprovision_factor", cfg.MemoryOverProvisionFactor,
 	)
 
 	// dockerClient is passed twice: as the runtime.Runtime driver (the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,8 +67,18 @@ type Config struct {
 	CPUReservationRatio    float64
 	MemoryReservationRatio float64
 	MemoryFloorRatio       float64
-	HostCPUCoresOverride   int
-	HostMemoryMBOverride   int
+	// CPUOverProvisionFactor and MemoryOverProvisionFactor multiply the
+	// reservation budgets above. Docker --cpus is a CFS cap (not a hard
+	// reservation) and Linux lazy-allocates memory pages, so a host with
+	// mostly-idle sandboxes can safely accept far more reservations than its
+	// nominal capacity. The live MemoryFloorRatio check is the backstop that
+	// catches real pressure when reservations and reality diverge. 0 or <1
+	// is clamped to 1.0 (no overcommit) — operators that want strict packing
+	// should lower the reservation ratios instead.
+	CPUOverProvisionFactor    float64
+	MemoryOverProvisionFactor float64
+	HostCPUCoresOverride      int
+	HostMemoryMBOverride      int
 }
 
 func Load() (Config, error) {
@@ -113,11 +123,13 @@ func Load() (Config, error) {
 		DestroyedRowTTL:          getEnvDuration("SB_DESTROYED_ROW_TTL", 0),
 		UploadMaxBytes:           int64(getEnvInt("SB_UPLOAD_MAX_BYTES", 256*1024*1024)),
 
-		CPUReservationRatio:    getEnvFloat("SB_CPU_RESERVATION_RATIO", 0.9),
-		MemoryReservationRatio: getEnvFloat("SB_MEMORY_RESERVATION_RATIO", 0.85),
-		MemoryFloorRatio:       getEnvFloat("SB_MEMORY_FLOOR_RATIO", 0.05),
-		HostCPUCoresOverride:   getEnvInt("SB_HOST_CPU_CORES", 0),
-		HostMemoryMBOverride:   getEnvInt("SB_HOST_MEMORY_MB", 0),
+		CPUReservationRatio:       getEnvFloat("SB_CPU_RESERVATION_RATIO", 0.9),
+		MemoryReservationRatio:    getEnvFloat("SB_MEMORY_RESERVATION_RATIO", 0.85),
+		MemoryFloorRatio:          getEnvFloat("SB_MEMORY_FLOOR_RATIO", 0.05),
+		CPUOverProvisionFactor:    getEnvFloat("SB_CPU_OVERPROVISION_FACTOR", 10.0),
+		MemoryOverProvisionFactor: getEnvFloat("SB_MEMORY_OVERPROVISION_FACTOR", 10.0),
+		HostCPUCoresOverride:      getEnvInt("SB_HOST_CPU_CORES", 0),
+		HostMemoryMBOverride:      getEnvInt("SB_HOST_MEMORY_MB", 0),
 	}
 
 	if cfg.PATToken == "" {

--- a/pkg/capacity/capacity.go
+++ b/pkg/capacity/capacity.go
@@ -44,6 +44,18 @@ type Limits struct {
 	// proportionally — a fixed MB floor would be either pointless on big
 	// hosts or starve small ones. 0 = no floor.
 	MemoryFloorRatio float64
+	// CPUOverProvisionFactor multiplies the CPU reservation budget. Docker
+	// --cpus is a CFS cap, not a hard reservation, so idle sandboxes share
+	// cores happily — a 10× default lets typical workloads pack densely.
+	// Values below 1.0 are clamped to 1.0 (no overcommit). 0 is treated as
+	// the default 1.0 so a zero-value Limits behaves as before.
+	CPUOverProvisionFactor float64
+	// MemoryOverProvisionFactor multiplies the memory reservation budget.
+	// Memory pressure is harder to recover from than CPU contention (OOM
+	// killer fires on hard limits), so the live MemoryFloorRatio check is
+	// the real backstop when this is set high. Same clamping as the CPU
+	// factor.
+	MemoryOverProvisionFactor float64
 }
 
 // Request is the per-sandbox resource ask, in normalized units. CPU is
@@ -64,12 +76,18 @@ type Snapshot struct {
 	SandboxesActive   int      `json:"sandboxes_active"`
 	CanAdmit          bool     `json:"can_admit"`
 	Reasons           []string `json:"reasons,omitempty"`
-	CPUReservationRatio    float64 `json:"cpu_reservation_ratio"`
-	MemoryReservationRatio float64 `json:"memory_reservation_ratio"`
-	MemoryFloorRatio       float64 `json:"memory_floor_ratio"`
+	CPUReservationRatio       float64 `json:"cpu_reservation_ratio"`
+	MemoryReservationRatio    float64 `json:"memory_reservation_ratio"`
+	MemoryFloorRatio          float64 `json:"memory_floor_ratio"`
+	CPUOverProvisionFactor    float64 `json:"cpu_overprovision_factor"`
+	MemoryOverProvisionFactor float64 `json:"memory_overprovision_factor"`
 	// MemoryFloorMB is the absolute floor derived from MemoryFloorRatio and
 	// host memory, exposed for operators reading /capacity.
 	MemoryFloorMB int `json:"memory_floor_mb"`
+	// CPUBudget and MemoryBudgetMB are the post-overcommit budgets actually
+	// used by Admit, exposed so operators can see the effective ceiling.
+	CPUBudget      float64 `json:"cpu_budget"`
+	MemoryBudgetMB int     `json:"memory_budget_mb"`
 }
 
 // MemProbe reports live free memory in MB. The default implementation reads
@@ -145,10 +163,7 @@ func (a *Admitter) Admit(sandboxID string, req Request) error {
 	var reasons []string
 
 	if a.limits.CPUReservationRatio > 0 && a.host.CPUCores > 0 {
-		cpuBudget := float64(a.host.CPUCores) * a.limits.CPUReservationRatio
-		if cpuBudget < 0.01 {
-			cpuBudget = 0.01
-		}
+		cpuBudget := a.cpuBudget()
 		if projectedCPU > cpuBudget {
 			reasons = append(reasons, fmt.Sprintf(
 				"cpu reservation exceeded (%.2f+%.2f > %.2f budget)",
@@ -158,7 +173,7 @@ func (a *Admitter) Admit(sandboxID string, req Request) error {
 	}
 
 	if a.limits.MemoryReservationRatio > 0 && a.host.MemoryTotalMB > 0 {
-		memBudget := int(float64(a.host.MemoryTotalMB) * a.limits.MemoryReservationRatio)
+		memBudget := a.memBudgetMB()
 		if projectedMem > memBudget {
 			reasons = append(reasons, fmt.Sprintf(
 				"memory reservation exceeded (%d+%d MB > %d MB budget)",
@@ -239,16 +254,20 @@ func (a *Admitter) Snapshot() Snapshot {
 	}
 
 	snap := Snapshot{
-		HostCPUCores:           a.host.CPUCores,
-		HostMemoryTotalMB:      a.host.MemoryTotalMB,
-		ReservedCPU:            totalCPU,
-		ReservedMemoryMB:       totalMem,
-		LiveMemoryFreeMB:       free,
-		SandboxesActive:        count,
-		CPUReservationRatio:    a.limits.CPUReservationRatio,
-		MemoryReservationRatio: a.limits.MemoryReservationRatio,
-		MemoryFloorRatio:       a.limits.MemoryFloorRatio,
-		MemoryFloorMB:          a.memoryFloorMB(),
+		HostCPUCores:              a.host.CPUCores,
+		HostMemoryTotalMB:         a.host.MemoryTotalMB,
+		ReservedCPU:               totalCPU,
+		ReservedMemoryMB:          totalMem,
+		LiveMemoryFreeMB:          free,
+		SandboxesActive:           count,
+		CPUReservationRatio:       a.limits.CPUReservationRatio,
+		MemoryReservationRatio:    a.limits.MemoryReservationRatio,
+		MemoryFloorRatio:          a.limits.MemoryFloorRatio,
+		CPUOverProvisionFactor:    a.cpuOverProvisionFactor(),
+		MemoryOverProvisionFactor: a.memOverProvisionFactor(),
+		MemoryFloorMB:             a.memoryFloorMB(),
+		CPUBudget:                 a.cpuBudget(),
+		MemoryBudgetMB:            a.memBudgetMB(),
 	}
 	// Use the smallest meaningful request (1 CPU, 1 MB) as the probe ask.
 	// We don't use 0/0 because that bypasses every check and would always
@@ -267,16 +286,13 @@ func (a *Admitter) dryRun(req Request) (bool, []string) {
 
 	var reasons []string
 	if a.limits.CPUReservationRatio > 0 && a.host.CPUCores > 0 {
-		cpuBudget := float64(a.host.CPUCores) * a.limits.CPUReservationRatio
-		if cpuBudget < 0.01 {
-			cpuBudget = 0.01
-		}
+		cpuBudget := a.cpuBudget()
 		if totalCPU+req.CPU > cpuBudget {
 			reasons = append(reasons, fmt.Sprintf("cpu reservation exceeded (%.2f/%.2f)", totalCPU, cpuBudget))
 		}
 	}
 	if a.limits.MemoryReservationRatio > 0 && a.host.MemoryTotalMB > 0 {
-		memBudget := int(float64(a.host.MemoryTotalMB) * a.limits.MemoryReservationRatio)
+		memBudget := a.memBudgetMB()
 		if totalMem+req.MemoryMB > memBudget {
 			reasons = append(reasons, fmt.Sprintf("memory reservation exceeded (%d MB/%d MB)", totalMem, memBudget))
 		}
@@ -296,4 +312,37 @@ func (a *Admitter) memoryFloorMB() int {
 		return 0
 	}
 	return int(float64(a.host.MemoryTotalMB) * a.limits.MemoryFloorRatio)
+}
+
+// cpuOverProvisionFactor returns the effective CPU overcommit multiplier.
+// 0 or any value <1 is clamped to 1.0 so callers that don't set the field
+// (and tests that predate it) keep their original "fits exactly to host"
+// semantics.
+func (a *Admitter) cpuOverProvisionFactor() float64 {
+	if a.limits.CPUOverProvisionFactor < 1 {
+		return 1
+	}
+	return a.limits.CPUOverProvisionFactor
+}
+
+func (a *Admitter) memOverProvisionFactor() float64 {
+	if a.limits.MemoryOverProvisionFactor < 1 {
+		return 1
+	}
+	return a.limits.MemoryOverProvisionFactor
+}
+
+// cpuBudget is the post-overcommit reservation ceiling: cores × ratio × factor.
+// Floored at 0.01 so a host with extreme ratios still admits the smallest
+// fractional ask we model.
+func (a *Admitter) cpuBudget() float64 {
+	budget := float64(a.host.CPUCores) * a.limits.CPUReservationRatio * a.cpuOverProvisionFactor()
+	if budget < 0.01 {
+		budget = 0.01
+	}
+	return budget
+}
+
+func (a *Admitter) memBudgetMB() int {
+	return int(float64(a.host.MemoryTotalMB) * a.limits.MemoryReservationRatio * a.memOverProvisionFactor())
 }

--- a/pkg/capacity/capacity_test.go
+++ b/pkg/capacity/capacity_test.go
@@ -103,6 +103,64 @@ func TestAdmitMemoryReservationRatio(t *testing.T) {
 	}
 }
 
+// TestAdmitCPUOverProvisionFactor verifies the factor multiplies the budget.
+// 4 cores × 1.0 ratio × 10× factor = 40 CPU budget — twenty 2-CPU sandboxes
+// must fit, the twenty-first overflows.
+func TestAdmitCPUOverProvisionFactor(t *testing.T) {
+	a := New(HostInfo{CPUCores: 4, MemoryTotalMB: 1_000_000}, Limits{
+		CPUReservationRatio:    1.0,
+		MemoryReservationRatio: 1.0,
+		CPUOverProvisionFactor: 10.0,
+	}, nil)
+
+	for i := range 20 {
+		id := fmt.Sprintf("s-%d", i)
+		if err := a.Admit(id, Request{CPU: 2, MemoryMB: 1}); err != nil {
+			t.Fatalf("admit %s: %v", id, err)
+		}
+	}
+	if err := a.Admit("overflow", Request{CPU: 0.1, MemoryMB: 1}); !errors.Is(err, ErrCapacityExceeded) {
+		t.Fatalf("expected overcommit ceiling, got %v", err)
+	}
+	snap := a.Snapshot()
+	if snap.CPUBudget != 40 {
+		t.Fatalf("CPUBudget = %v, want 40", snap.CPUBudget)
+	}
+	if snap.CPUOverProvisionFactor != 10.0 {
+		t.Fatalf("CPUOverProvisionFactor = %v, want 10", snap.CPUOverProvisionFactor)
+	}
+}
+
+// TestAdmitMemoryOverProvisionFactor mirrors the CPU test for memory.
+func TestAdmitMemoryOverProvisionFactor(t *testing.T) {
+	a := New(HostInfo{CPUCores: 1000, MemoryTotalMB: 1000}, Limits{
+		CPUReservationRatio:       1.0,
+		MemoryReservationRatio:    1.0,
+		MemoryOverProvisionFactor: 10.0,
+	}, nil)
+
+	mustAdmit(t, a, "a", Request{CPU: 1, MemoryMB: 9000})
+	mustAdmit(t, a, "b", Request{CPU: 1, MemoryMB: 1000})
+	if err := a.Admit("c", Request{CPU: 1, MemoryMB: 1}); !errors.Is(err, ErrCapacityExceeded) {
+		t.Fatalf("expected overcommit ceiling, got %v", err)
+	}
+}
+
+// TestOverProvisionFactorClampedToOne checks the zero/sub-1 clamp so existing
+// callers (and tests) that don't set the factor keep prior behaviour.
+func TestOverProvisionFactorClampedToOne(t *testing.T) {
+	a := New(HostInfo{CPUCores: 4, MemoryTotalMB: 1000}, Limits{
+		CPUReservationRatio:       1.0,
+		MemoryReservationRatio:    1.0,
+		CPUOverProvisionFactor:    0,   // unset
+		MemoryOverProvisionFactor: 0.5, // sub-1, must clamp up
+	}, nil)
+	snap := a.Snapshot()
+	if snap.CPUBudget != 4 || snap.MemoryBudgetMB != 1000 {
+		t.Fatalf("clamp failed: %+v", snap)
+	}
+}
+
 func TestAdmitMemoryFloorBlocks(t *testing.T) {
 	// 2000 MB floor on a 16384 MB host = 0.122 ratio.
 	a := New(HostInfo{CPUCores: 8, MemoryTotalMB: 16384}, Limits{


### PR DESCRIPTION
This pull request introduces support for CPU and memory overprovisioning in the resource admission logic, allowing the system to admit more sandbox reservations than the host's nominal capacity when workloads are mostly idle. This is achieved by adding configurable overprovision factors, updating the admission and snapshot logic to use these factors, and providing comprehensive tests for the new behavior.

**Resource overprovisioning support:**

* Added `CPUOverProvisionFactor` and `MemoryOverProvisionFactor` fields to the `Config` and `Limits` structs, with documentation explaining their purpose and clamping behavior. These factors multiply the reservation budgets, enabling controlled overcommit of CPU and memory resources. [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR70-R79) [[2]](diffhunk://#diff-3c5ff888e1655ac845fdcb818e147ea43a9fb00e5cd86397ace2be4fa0be8521R47-R58)
* Updated the configuration loader to support environment variables for the new overprovision factors, with sensible defaults.
* Modified the admission logic (`Admit`, `dryRun`) to calculate CPU and memory budgets using the new overprovision factors, ensuring backward compatibility by clamping factors below 1.0 to 1.0. [[1]](diffhunk://#diff-3c5ff888e1655ac845fdcb818e147ea43a9fb00e5cd86397ace2be4fa0be8521L148-R166) [[2]](diffhunk://#diff-3c5ff888e1655ac845fdcb818e147ea43a9fb00e5cd86397ace2be4fa0be8521L161-R176) [[3]](diffhunk://#diff-3c5ff888e1655ac845fdcb818e147ea43a9fb00e5cd86397ace2be4fa0be8521L270-R295) [[4]](diffhunk://#diff-3c5ff888e1655ac845fdcb818e147ea43a9fb00e5cd86397ace2be4fa0be8521R316-R348)
* Enhanced the `Snapshot` struct and method to expose the effective overprovision factors and post-overcommit budgets, so operators can observe the real admission ceilings. [[1]](diffhunk://#diff-3c5ff888e1655ac845fdcb818e147ea43a9fb00e5cd86397ace2be4fa0be8521R82-R90) [[2]](diffhunk://#diff-3c5ff888e1655ac845fdcb818e147ea43a9fb00e5cd86397ace2be4fa0be8521R266-R270)

**Testing improvements:**

* Added tests to verify that CPU and memory overprovisioning factors correctly multiply the admission budgets, and that clamping to 1.0 preserves legacy behavior when unset or set below 1.0.

**Integration and observability:**

* Updated `cmd/sandboxd/main.go` to wire the new configuration fields and log the overprovision factors at startup for operator visibility.