### PR TITLE
Add Gpu support in the sandboxes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# AerolVM — Claude Code Instructions
+
+## Documentation rules
+
+- **Never use raw HTTP / curl examples in docs or in any md file.** All code examples must use one of the five SDK languages (TypeScript, Python, Go, Rust, Java) shown in `<Tabs syncKey="lang">` blocks. curl is only acceptable in `getting-started.md` for the initial server-install one-liners, not for sandbox API calls.
+- When adding a new top-level feature to the docs (GPU sandboxes, a new runtime, a new resource type, etc.), create a **new `.mdx` file** rather than appending a subsection to an existing page. Register the new page in the sidebar config at `docs/src/content/config.ts`.
+- Every new docs page must cover all five SDK languages with synced tab keys (`syncKey="lang"`).

--- a/docs/src/content/config.ts
+++ b/docs/src/content/config.ts
@@ -64,6 +64,12 @@ const getDocsSidebarConfig = (): NavigationGroup[] => [
       },
       {
         type: 'link',
+        href: '/gpu-sandboxes',
+        label: 'GPU Sandboxes',
+        description: 'Attach NVIDIA, AMD, or Apple Silicon GPUs to a sandbox.',
+      },
+      {
+        type: 'link',
         href: '/environment',
         label: 'Environment',
         description: 'Docker image, env vars, resource limits, and idle lifecycle.',

--- a/docs/src/content/config.ts
+++ b/docs/src/content/config.ts
@@ -236,7 +236,7 @@ const getUseCasesSidebarConfig = (): NavigationGroup[] => [
           },
           {
             type: 'link',
-            href: '/use-cases/customer-facing-product-experiences/live-preview-urls',
+            href: '/use-cases/customer-facing-product-experiences/spawn-postgres',
             label: 'Deploy your own Supabase',
             description: 'Run a dedicated Postgres instance in a sandbox and expose an HTTP admin surface on a public URL.',
           },

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -110,6 +110,43 @@ export SB_CONTAINER_RUNTIME=gvisor
 - Incompatible with `--privileged` containers.
 - `disk_gb` quota is silently ignored (CPU and memory caps still apply).
 - Requires cgroupv2 + systemd on the host.
+- **GPU access is not supported** - gVisor's user-space kernel cannot pass through host GPU drivers. Use the `docker` runtime for GPU workloads.
+
+## GPU Support
+
+AerolVM supports GPU-accelerated sandboxes for NVIDIA, AMD, and Apple Silicon hardware. Most competing sandbox platforms (E2B, Daytona) do not offer GPU passthrough - you get dedicated GPU access per sandbox with no shared-tenancy limitations.
+
+| Vendor | Installer flag | Notes |
+|---|---|---|
+| NVIDIA | `--with-nvidia-gpu` | Installs `nvidia-container-toolkit` and registers the `nvidia` OCI runtime in Docker. NVIDIA drivers must already be present on the host (`nvidia-smi` must work). |
+| AMD | `--with-amd-gpu` | Installs AMD ROCm and exposes `/dev/kfd` and `/dev/dri` to containers. x86_64 only. The `amdgpu` kernel module must be loaded. |
+| Apple Silicon | No flag needed | The installer is Linux-only, so there is nothing to install. Apple GPU access works automatically through Docker Desktop on macOS - Docker Desktop ships with built-in Metal GPU support. Just pass `vendor: "apple"` in the create request. |
+
+**GPU is not compatible with the gVisor runtime.** If you set `gpus` and `runtime: "gvisor"` in the same request, the API returns an error immediately.
+
+### Install with GPU support
+
+**NVIDIA:**
+```bash
+curl -fsSL https://github.com/aerol-ai/microvm/releases/latest/download/install.sh | sudo bash -s -- \
+    --domain sandbox.example.com \
+    --pat-token your-secret-pat \
+    --with-nvidia-gpu
+```
+
+**AMD:**
+```bash
+curl -fsSL https://github.com/aerol-ai/microvm/releases/latest/download/install.sh | sudo bash -s -- \
+    --domain sandbox.example.com \
+    --pat-token your-secret-pat \
+    --with-amd-gpu
+```
+
+Both flags can be combined with `--with-gvisor` if needed (gVisor and GPU run under separate containers, so they don't conflict at the host level - you just can't use both in the same sandbox).
+
+### Create a GPU sandbox
+
+See [GPU Sandboxes](/gpu-sandboxes) for code examples in all SDK languages.
 
 ## Local Development
 

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -148,6 +148,8 @@ Both flags can be combined with `--with-gvisor` if needed (gVisor and GPU run un
 
 See [GPU Sandboxes](/gpu-sandboxes) for code examples in all SDK languages.
 
+---
+
 ## Local Development
 
 To run the server locally without the installer:

--- a/docs/src/content/docs/gpu-sandboxes.mdx
+++ b/docs/src/content/docs/gpu-sandboxes.mdx
@@ -1,0 +1,301 @@
+---
+title: GPU Sandboxes
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+GPU sandboxes give each container direct, dedicated access to host GPU hardware. Unlike most competing platforms (E2B, Daytona), AerolVM passes the full GPU through to the container - no shared tenancy, no synthetic limits.
+
+GPU access requires `runtime: "docker"` (the default). It is **not compatible with gVisor** - the API returns an error if both `gpus` and `runtime: "gvisor"` are set in the same request.
+
+See [Server Setup](/getting-started#gpu-support) for host installation (`--with-nvidia-gpu` / `--with-amd-gpu` installer flags).
+
+## Vendors
+
+| Vendor | Host requirement |
+|---|---|
+| `nvidia` | `nvidia-container-toolkit` installed + NVIDIA drivers present. Install with `--with-nvidia-gpu`. |
+| `amd` | AMD ROCm installed + `amdgpu` kernel module loaded. Install with `--with-amd-gpu`. x86_64 only. |
+| `apple` | Docker Desktop on macOS. No setup needed - Metal GPU support is built into Docker Desktop. |
+
+## NVIDIA
+
+Allocate one GPU:
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    const sandbox = await client.create({
+      image: 'nvidia/cuda:12.2.0-base-ubuntu22.04',
+      gpus: { vendor: 'nvidia', count: 1 },
+    })
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    sandbox = client.create({
+        'image': 'nvidia/cuda:12.2.0-base-ubuntu22.04',
+        'gpus': {'vendor': 'nvidia', 'count': 1},
+    })
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    sandbox, err := client.Create(ctx, sdktypes.CreateSandboxOptions{
+        Image: "nvidia/cuda:12.2.0-base-ubuntu22.04",
+        GPUs: &sdktypes.GPURequest{
+            Vendor: sdktypes.GPUVendorNVIDIA,
+            Count:  1,
+        },
+    })
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let sandbox = client.create(CreateOptions {
+        image: "nvidia/cuda:12.2.0-base-ubuntu22.04".to_string(),
+        gpus: Some(GPUOptions {
+            vendor: GPUVendor::Nvidia,
+            count: Some(1),
+            device_ids: None,
+        }),
+        ..Default::default()
+    })?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    Sandbox sandbox = client.create(
+        new CreateOptions()
+            .setImage("nvidia/cuda:12.2.0-base-ubuntu22.04")
+            .setGpus(new GpuOptions().setVendor("nvidia").setCount(1))
+    );
+    ```
+  </TabItem>
+</Tabs>
+
+Request all GPUs on the host (`count: -1`):
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    const sandbox = await client.create({
+      image: 'nvidia/cuda:12.2.0-base-ubuntu22.04',
+      gpus: { vendor: 'nvidia', count: -1 },
+    })
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    sandbox = client.create({
+        'image': 'nvidia/cuda:12.2.0-base-ubuntu22.04',
+        'gpus': {'vendor': 'nvidia', 'count': -1},
+    })
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    sandbox, err := client.Create(ctx, sdktypes.CreateSandboxOptions{
+        Image: "nvidia/cuda:12.2.0-base-ubuntu22.04",
+        GPUs: &sdktypes.GPURequest{
+            Vendor: sdktypes.GPUVendorNVIDIA,
+            Count:  -1,
+        },
+    })
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let sandbox = client.create(CreateOptions {
+        image: "nvidia/cuda:12.2.0-base-ubuntu22.04".to_string(),
+        gpus: Some(GPUOptions {
+            vendor: GPUVendor::Nvidia,
+            count: Some(-1),
+            device_ids: None,
+        }),
+        ..Default::default()
+    })?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    Sandbox sandbox = client.create(
+        new CreateOptions()
+            .setImage("nvidia/cuda:12.2.0-base-ubuntu22.04")
+            .setGpus(new GpuOptions().setVendor("nvidia").setCount(-1))
+    );
+    ```
+  </TabItem>
+</Tabs>
+
+Pin specific GPUs by device index or UUID:
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    const sandbox = await client.create({
+      image: 'nvidia/cuda:12.2.0-base-ubuntu22.04',
+      gpus: {
+        vendor: 'nvidia',
+        count: 2,
+        deviceIDs: ['GPU-abc123', 'GPU-def456'],
+      },
+    })
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    sandbox = client.create({
+        'image': 'nvidia/cuda:12.2.0-base-ubuntu22.04',
+        'gpus': {
+            'vendor': 'nvidia',
+            'count': 2,
+            'deviceIDs': ['GPU-abc123', 'GPU-def456'],
+        },
+    })
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    sandbox, err := client.Create(ctx, sdktypes.CreateSandboxOptions{
+        Image: "nvidia/cuda:12.2.0-base-ubuntu22.04",
+        GPUs: &sdktypes.GPURequest{
+            Vendor:    sdktypes.GPUVendorNVIDIA,
+            Count:     2,
+            DeviceIDs: []string{"GPU-abc123", "GPU-def456"},
+        },
+    })
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let sandbox = client.create(CreateOptions {
+        image: "nvidia/cuda:12.2.0-base-ubuntu22.04".to_string(),
+        gpus: Some(GPUOptions {
+            vendor: GPUVendor::Nvidia,
+            count: Some(2),
+            device_ids: Some(vec!["GPU-abc123".to_string(), "GPU-def456".to_string()]),
+        }),
+        ..Default::default()
+    })?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    Sandbox sandbox = client.create(
+        new CreateOptions()
+            .setImage("nvidia/cuda:12.2.0-base-ubuntu22.04")
+            .setGpus(new GpuOptions()
+                .setVendor("nvidia")
+                .setCount(2)
+                .setDeviceIds(List.of("GPU-abc123", "GPU-def456")))
+    );
+    ```
+  </TabItem>
+</Tabs>
+
+## AMD
+
+All AMD GPUs on the host are exposed via `/dev/kfd` (compute) and `/dev/dri` (render nodes). The `count` and `deviceIDs` fields are ignored for AMD.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    const sandbox = await client.create({
+      image: 'rocm/rocm-terminal',
+      gpus: { vendor: 'amd' },
+    })
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    sandbox = client.create({
+        'image': 'rocm/rocm-terminal',
+        'gpus': {'vendor': 'amd'},
+    })
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    sandbox, err := client.Create(ctx, sdktypes.CreateSandboxOptions{
+        Image: "rocm/rocm-terminal",
+        GPUs: &sdktypes.GPURequest{Vendor: sdktypes.GPUVendorAMD},
+    })
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let sandbox = client.create(CreateOptions {
+        image: "rocm/rocm-terminal".to_string(),
+        gpus: Some(GPUOptions {
+            vendor: GPUVendor::Amd,
+            count: None,
+            device_ids: None,
+        }),
+        ..Default::default()
+    })?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    Sandbox sandbox = client.create(
+        new CreateOptions()
+            .setImage("rocm/rocm-terminal")
+            .setGpus(new GpuOptions().setVendor("amd"))
+    );
+    ```
+  </TabItem>
+</Tabs>
+
+## Apple Silicon
+
+Requires Docker Desktop on macOS. Metal GPU support is built into Docker Desktop - no additional host setup.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    const sandbox = await client.create({
+      image: 'ubuntu:22.04',
+      gpus: { vendor: 'apple' },
+    })
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    sandbox = client.create({
+        'image': 'ubuntu:22.04',
+        'gpus': {'vendor': 'apple'},
+    })
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    sandbox, err := client.Create(ctx, sdktypes.CreateSandboxOptions{
+        Image: "ubuntu:22.04",
+        GPUs: &sdktypes.GPURequest{Vendor: sdktypes.GPUVendorApple},
+    })
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let sandbox = client.create(CreateOptions {
+        image: "ubuntu:22.04".to_string(),
+        gpus: Some(GPUOptions {
+            vendor: GPUVendor::Apple,
+            count: None,
+            device_ids: None,
+        }),
+        ..Default::default()
+    })?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    Sandbox sandbox = client.create(
+        new CreateOptions()
+            .setImage("ubuntu:22.04")
+            .setGpus(new GpuOptions().setVendor("apple"))
+    );
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/src/content/docs/quick-start.md
+++ b/docs/src/content/docs/quick-start.md
@@ -45,6 +45,7 @@ Today, sandboxes run on Docker. GVisor, Kata, and WebAssembly support are on the
 | **Persistent stop/start** | ✅ | ✗ | ✅ |
 | **Sandbox Lifecycle** | Infinite | 1 day | Infinite |
 | **External storage** | S3, NFS, SSHFS, rclone | ✗ | ✗ |
+| **GPU Support** | ✅ | ✗ | ✗ |
 | **SSH access** | ✅ | ✗ | ✅ |
 | **Per-sandbox egress control** | ✅ | ✗ | ✗ |
 | **SDK languages** | TS, Python, Go, Rust, Java | TS, Python | TS, Python |

--- a/docs/src/content/docs/sandboxes.mdx
+++ b/docs/src/content/docs/sandboxes.mdx
@@ -64,6 +64,10 @@ The default runtime is `docker`. Pass `runtime: 'gvisor'` in the create request 
   </TabItem>
 </Tabs>
 
+### Create a GPU Sandbox
+
+See [GPU Sandboxes](/gpu-sandboxes) for full examples covering NVIDIA, AMD, and Apple Silicon.
+
 ## Lifecycle States
 
 ```

--- a/docs/src/content/docs/use-cases/customer-facing-product-experiences/spawn-postgres.mdx
+++ b/docs/src/content/docs/use-cases/customer-facing-product-experiences/spawn-postgres.mdx
@@ -3,8 +3,6 @@ title: Deploy Your Own Postgres
 description: Run a dedicated Postgres instance inside an AerolVM sandbox, keep credentials in env vars, and publish an HTTP admin endpoint on a public URL.
 ---
 
-## What you are building
-
 This workflow boots a dedicated Postgres instance inside an AerolVM sandbox, initializes it from environment variables, and keeps the database alive in a long-running session. It also starts a tiny HTTP admin endpoint that checks the database and can be exposed on a public URL.
 
 This is the Postgres foundation, not the full Supabase control plane. If you want a Supabase-style stack, add PostgREST, GoTrue, storage, realtime, and pooling on top of this database runtime.

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -104,6 +104,12 @@ func (s *Service) CreateSandbox(ctx context.Context, req models.CreateSandboxReq
 		lifecycle = *req.Lifecycle
 	}
 
+	if req.GPUs != nil {
+		if err := req.GPUs.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid gpu request: %w", err)
+		}
+	}
+
 	sealedMounts, err := s.sealMounts(req.Mounts)
 	if err != nil {
 		return nil, err
@@ -185,6 +191,7 @@ func (s *Service) CreateSandbox(ctx context.Context, req models.CreateSandboxReq
 		ContainerCommand: req.ContainerCommand,
 		Lifecycle:        lifecycle,
 		Runtime:          chosenRuntime,
+		GPUs:             req.GPUs,
 	}
 
 	if err := s.caddy.UpsertSandboxRoute(ctx, sandbox.ID, sandbox.ContainerIP, s.cfg.ToolboxPort); err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -109,6 +109,9 @@ func Open(path string) (*Store, error) {
 		// always store the resolved value so the choice cannot drift across
 		// host restarts.
 		`ALTER TABLE sandboxes ADD COLUMN runtime TEXT NOT NULL DEFAULT '';`,
+		// GPU configuration as a JSON blob. Empty string means no GPU was
+		// requested. Stored as JSON to avoid schema churn as GPU options grow.
+		`ALTER TABLE sandboxes ADD COLUMN gpus_json TEXT NOT NULL DEFAULT '';`,
 	}
 	for _, stmt := range migrations {
 		if _, err := db.Exec(stmt); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
@@ -149,6 +152,10 @@ func (s *Store) Create(ctx context.Context, sandbox *models.Sandbox) error {
 	if err != nil {
 		return err
 	}
+	gpusJSON, err := marshalGPUs(sandbox.GPUs)
+	if err != nil {
+		return err
+	}
 
 	_, err = s.db.ExecContext(ctx, `
 		INSERT INTO sandboxes (
@@ -156,8 +163,8 @@ func (s *Store) Create(ctx context.Context, sandbox *models.Sandbox) error {
 			os_user, env_json, network_block_all, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
-			runtime
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			runtime, gpus_json
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		sandbox.ID,
 		sandbox.Image,
@@ -184,6 +191,7 @@ func (s *Store) Create(ctx context.Context, sandbox *models.Sandbox) error {
 		int64(sandbox.Lifecycle.StopAtAge),
 		int64(sandbox.Lifecycle.DestroyAtAge),
 		sandbox.Runtime,
+		gpusJSON,
 	)
 	if err != nil {
 		return fmt.Errorf("insert sandbox: %w", err)
@@ -200,6 +208,10 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 	if err != nil {
 		return err
 	}
+	gpusJSON, err := marshalGPUs(sandbox.GPUs)
+	if err != nil {
+		return err
+	}
 
 	_, err = s.db.ExecContext(ctx, `
 		INSERT INTO sandboxes (
@@ -207,8 +219,8 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 			os_user, env_json, network_block_all, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
-			runtime
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			runtime, gpus_json
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			image = excluded.image,
 			status = excluded.status,
@@ -232,7 +244,8 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 			destroy_if_idle_for_ns = excluded.destroy_if_idle_for_ns,
 			stop_at_age_ns = excluded.stop_at_age_ns,
 			destroy_at_age_ns = excluded.destroy_at_age_ns,
-			runtime = excluded.runtime
+			runtime = excluded.runtime,
+			gpus_json = excluded.gpus_json
 	`,
 		sandbox.ID,
 		sandbox.Image,
@@ -259,6 +272,7 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 		int64(sandbox.Lifecycle.StopAtAge),
 		int64(sandbox.Lifecycle.DestroyAtAge),
 		sandbox.Runtime,
+		gpusJSON,
 	)
 	if err != nil {
 		return fmt.Errorf("upsert sandbox: %w", err)
@@ -272,7 +286,7 @@ func (s *Store) Get(ctx context.Context, id string) (*models.Sandbox, error) {
 			os_user, env_json, network_block_all, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
-			runtime
+			runtime, gpus_json
 		FROM sandboxes
 		WHERE id = ?
 	`, id)
@@ -300,7 +314,7 @@ func (s *Store) List(ctx context.Context) ([]*models.Sandbox, error) {
 			os_user, env_json, network_block_all, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
-			runtime
+			runtime, gpus_json
 		FROM sandboxes
 		ORDER BY created_at DESC
 	`)
@@ -568,6 +582,7 @@ func scanSandbox(scanner interface {
 	var networkBlocked int
 	var toolboxEnabled int
 	var commandJSON string
+	var gpusJSON string
 	var stopIfIdleNs, destroyIfIdleNs, stopAtAgeNs, destroyAtAgeNs int64
 
 	err := scanner.Scan(
@@ -596,6 +611,7 @@ func scanSandbox(scanner interface {
 		&stopAtAgeNs,
 		&destroyAtAgeNs,
 		&sandbox.Runtime,
+		&gpusJSON,
 	)
 	if err != nil {
 		return nil, err
@@ -610,6 +626,13 @@ func scanSandbox(scanner interface {
 		if err := json.Unmarshal([]byte(commandJSON), &sandbox.ContainerCommand); err != nil {
 			return nil, fmt.Errorf("decode container command: %w", err)
 		}
+	}
+	if gpusJSON != "" {
+		var gpu models.GPURequest
+		if err := json.Unmarshal([]byte(gpusJSON), &gpu); err != nil {
+			return nil, fmt.Errorf("decode sandbox gpus: %w", err)
+		}
+		sandbox.GPUs = &gpu
 	}
 
 	sandbox.NetworkBlockAll = networkBlocked == 1
@@ -631,6 +654,19 @@ func marshalJSON(value any, fallback string) (string, error) {
 	encoded, err := json.Marshal(value)
 	if err != nil {
 		return "", fmt.Errorf("marshal json: %w", err)
+	}
+	return string(encoded), nil
+}
+
+// marshalGPUs serializes a GPURequest pointer. Nil (no GPU) returns an empty
+// string, which the column default also holds for pre-GPU rows.
+func marshalGPUs(g *models.GPURequest) (string, error) {
+	if g == nil {
+		return "", nil
+	}
+	encoded, err := json.Marshal(g)
+	if err != nil {
+		return "", fmt.Errorf("marshal gpus: %w", err)
 	}
 	return string(encoded), nil
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -600,7 +600,7 @@ func TestStoreHelperCases(t *testing.T) {
 		row := sqlRowStub{values: []any{
 			"sb-bad", "image", models.SandboxStatusStarted, "https://example.com", "container", "10.0.0.1",
 			float64(1), 1024, 10, "root", "{bad json", 0, 1, "", "", "", "[]", time.Now(), time.Now(), time.Now(),
-			int64(0), int64(0), int64(0), int64(0), "",
+			int64(0), int64(0), int64(0), int64(0), "", "",
 		}}
 		_, err := scanSandbox(row)
 		if err == nil {

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -140,6 +140,15 @@ func (c *Client) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 	if effectiveRuntime == models.RuntimeGvisor && c.privileged {
 		return nil, fmt.Errorf("runtime %q is incompatible with privileged containers", effectiveRuntime)
 	}
+	// gVisor's user-space kernel cannot pass through host GPU drivers. Fail
+	// before any image pull so the error is immediate and actionable.
+	if req.GPUs != nil && effectiveRuntime == models.RuntimeGvisor {
+		return nil, fmt.Errorf(
+			"GPU access is not supported with the %q runtime: gVisor's user-space kernel "+
+				"cannot safely pass through host GPU drivers; use the %q runtime for GPU workloads",
+			models.RuntimeGvisor, models.RuntimeDocker,
+		)
+	}
 	// Translate user-facing name to the OCI runtime binary Docker actually
 	// looks up in /etc/docker/daemon.json. ResolveOCIRuntime returns "" for
 	// "docker" (let Docker use its compiled-in default) and "runsc" for
@@ -203,6 +212,11 @@ func (c *Client) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 		}
 		binds = append(binds, entry)
 	}
+	// AMD ROCm exposes render nodes as a directory (/dev/dri). Bind-mount it
+	// before hostConfig captures the slice; /dev/kfd is added via Devices later.
+	if req.GPUs != nil && req.GPUs.Vendor == models.GPUVendorAMD {
+		binds = append(binds, "/dev/dri:/dev/dri")
+	}
 
 	hostConfig := map[string]any{
 		"Privileged": c.privileged,
@@ -247,6 +261,46 @@ func (c *Client) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 		}
 		hostConfig["Resources"] = resources
 	}
+
+	if req.GPUs != nil {
+		count := req.GPUs.Count
+		if count == 0 {
+			count = 1
+		}
+		switch req.GPUs.Vendor {
+		case models.GPUVendorNVIDIA:
+			// Standard Docker GPU interface for NVIDIA. Requires
+			// nvidia-container-toolkit on the host.
+			hostConfig["DeviceRequests"] = []map[string]any{{
+				"Driver":       "nvidia",
+				"Count":        count,
+				"DeviceIDs":    req.GPUs.DeviceIDs,
+				"Capabilities": [][]string{{"gpu"}},
+				"Options":      map[string]string{},
+			}}
+		case models.GPUVendorAMD:
+			// AMD ROCm: /dev/kfd is the compute driver added as a cgroup device
+			// so Docker sets the correct cgroup permissions. /dev/dri (render
+			// nodes) is already in Binds above. Non-privileged containers also
+			// need the container user in the "video" and "render" groups.
+			hostConfig["Devices"] = []map[string]any{{
+				"PathOnHost":        "/dev/kfd",
+				"PathInContainer":   "/dev/kfd",
+				"CgroupPermissions": "mrw",
+			}}
+		case models.GPUVendorApple:
+			// Apple Metal GPU via Docker Desktop's experimental Metal support.
+			// Only functional on macOS with Docker Desktop; a Linux Docker host
+			// will receive a daemon error at container creation time.
+			hostConfig["DeviceRequests"] = []map[string]any{{
+				"Driver":       "apple",
+				"Count":        count,
+				"Capabilities": [][]string{{"gpu"}},
+				"Options":      map[string]string{},
+			}}
+		}
+	}
+
 	createRequest["HostConfig"] = hostConfig
 
 	var created struct {

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -64,6 +64,54 @@ const (
 // an actionable error instead of a generic 500.
 var ErrRuntimeNotImplemented = errors.New("runtime not yet implemented on this build")
 
+// GPUVendor identifies the GPU hardware vendor for sandbox GPU allocation.
+type GPUVendor string
+
+const (
+	// GPUVendorNVIDIA selects NVIDIA GPUs via nvidia-container-runtime.
+	// Requires nvidia-container-toolkit installed on the host.
+	GPUVendorNVIDIA GPUVendor = "nvidia"
+	// GPUVendorAMD selects AMD GPUs via ROCm device bind-mounts (/dev/kfd,
+	// /dev/dri). Requires ROCm drivers on the host.
+	GPUVendorAMD GPUVendor = "amd"
+	// GPUVendorApple selects Apple Silicon GPU via Docker Desktop's
+	// experimental Metal support. Only functional on macOS with Docker Desktop;
+	// Linux hosts will receive a Docker daemon error at container creation.
+	GPUVendorApple GPUVendor = "apple"
+)
+
+// GPURequest describes the GPU resources to attach to a sandbox. The parent
+// CreateSandboxRequest.GPUs field is a pointer, so omitting it entirely means
+// no GPU — this struct only appears when the caller explicitly opts in.
+type GPURequest struct {
+	// Vendor is required. Allowed values: "nvidia", "amd", "apple".
+	Vendor GPUVendor `json:"vendor"`
+	// Count is the number of GPUs to allocate. Use -1 to request all GPUs on
+	// the host. Zero is treated as 1 (default). Ignored for AMD (all AMD GPUs
+	// on the host are exposed via /dev/kfd and /dev/dri).
+	Count int `json:"count,omitempty"`
+	// DeviceIDs pins the sandbox to specific GPU device indices or UUIDs.
+	// For NVIDIA: GPU indices ("0", "1") or UUIDs ("GPU-abc123...").
+	// For AMD and Apple: ignored.
+	DeviceIDs []string `json:"device_ids,omitempty"`
+}
+
+// Validate checks GPURequest fields for consistency.
+func (g *GPURequest) Validate() error {
+	if g == nil {
+		return nil
+	}
+	switch g.Vendor {
+	case GPUVendorNVIDIA, GPUVendorAMD, GPUVendorApple:
+	default:
+		return fmt.Errorf("unsupported GPU vendor %q (allowed: %s, %s, %s)", g.Vendor, GPUVendorNVIDIA, GPUVendorAMD, GPUVendorApple)
+	}
+	if g.Count < -1 {
+		return fmt.Errorf("gpu count must be -1 (all), 0 (default 1), or a positive integer")
+	}
+	return nil
+}
+
 // ValidRuntime normalizes and validates a user-facing runtime identifier.
 // Empty input passes through unchanged so the caller can substitute the host
 // default; any other value must be one of the recognized names. The intent
@@ -192,6 +240,10 @@ type CreateSandboxRequest struct {
 	// userspace kernel — use for untrusted workloads), or "kata" (reserved,
 	// not yet implemented).
 	Runtime string `json:"runtime,omitempty"`
+	// GPUs attaches GPU resources to the sandbox. Nil means no GPU. GPU access
+	// is not supported with the gVisor runtime — the API returns an error if
+	// both GPUs and runtime="gvisor" are set.
+	GPUs *GPURequest `json:"gpus,omitempty"`
 }
 
 type ResizeSandboxRequest struct {
@@ -228,6 +280,9 @@ type Sandbox struct {
 	// host default at start time; new sandboxes always store the resolved
 	// value so the choice cannot drift across host restarts.
 	Runtime string `json:"runtime"`
+	// GPUs is the GPU configuration this sandbox was created with. Nil means
+	// no GPU was requested.
+	GPUs *GPURequest `json:"gpus,omitempty"`
 }
 
 // CreateSandboxResponse is what the API returns from POST /v1/sandboxes.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,8 @@ DNS_API_TOKEN=""
 CADDY_BUILD_URL_BASE="https://caddyserver.com/api/download"
 WITH_GVISOR="false"
 RUNSC_PATH=""
+WITH_NVIDIA_GPU="false"
+WITH_AMD_GPU="false"
 
 usage() {
 	cat <<'EOF'
@@ -56,6 +58,19 @@ Options:
                                Skips the download step and registers this
                                binary instead. Only consulted with
                                --with-gvisor.
+  --with-nvidia-gpu            Install nvidia-container-toolkit and register
+                               the nvidia OCI runtime in daemon.json. Requires
+                               NVIDIA drivers already installed on the host
+                               (nvidia-smi must be present). Downloads the
+                               toolkit from the official NVIDIA package repo
+                               and runs nvidia-ctk to configure Docker.
+                               Restarts Docker on completion.
+  --with-amd-gpu               Install AMD ROCm from the official AMD package
+                               repository so containers can access AMD GPUs via
+                               /dev/kfd and /dev/dri. Only supported on x86_64.
+                               Requires the amdgpu kernel module loaded on the
+                               host (the GPU must already be recognized by the
+                               OS — /dev/kfd must exist).
   --help                       Show this help
 
 Examples:
@@ -207,6 +222,14 @@ while [[ $# -gt 0 ]]; do
 		--runsc-path)
 			RUNSC_PATH="$2"
 			shift 2
+			;;
+		--with-nvidia-gpu)
+			WITH_NVIDIA_GPU="true"
+			shift
+			;;
+		--with-amd-gpu)
+			WITH_AMD_GPU="true"
+			shift
 			;;
 		--help)
 			usage
@@ -643,6 +666,106 @@ WantedBy=timers.target
 EOF
 }
 
+install_nvidia_gpu() {
+	# Install nvidia-container-toolkit from the official NVIDIA repo and wire it
+	# into Docker via nvidia-ctk. The host NVIDIA driver (and nvidia-smi) must
+	# already be present — the toolkit only provides the container integration
+	# layer on top of the driver. We warn but continue when nvidia-smi is absent
+	# so pre-staging the toolkit before driver installation is also possible.
+	if ! command -v nvidia-smi >/dev/null 2>&1; then
+		echo "Warning: nvidia-smi not found — NVIDIA drivers may not be installed." >&2
+		echo "  Install the NVIDIA drivers first (https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)," >&2
+		echo "  then re-run with --with-nvidia-gpu, or continue if drivers will be installed separately." >&2
+	fi
+
+	case "$(uname -m)" in
+		x86_64|amd64|aarch64|arm64) ;;
+		*)
+			echo "--with-nvidia-gpu: unsupported architecture $(uname -m)" >&2
+			exit 1
+			;;
+	esac
+
+	local keyring="/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg"
+	if [[ ! -f "$keyring" ]]; then
+		curl -fsSL "https://nvidia.github.io/libnvidia-container/gpgkey" \
+			| gpg --dearmor -o "$keyring"
+	fi
+
+	# nvidia-container-toolkit.list uses plain https:// refs; rewrite to
+	# include the signed-by pointer so apt can verify the packages.
+	if [[ ! -f /etc/apt/sources.list.d/nvidia-container-toolkit.list ]]; then
+		curl -fsSL "https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list" \
+			| sed "s#deb https://#deb [signed-by=${keyring}] https://#g" \
+			> /etc/apt/sources.list.d/nvidia-container-toolkit.list
+		apt-get update
+	fi
+
+	apt-get install -y nvidia-container-toolkit
+
+	# nvidia-ctk handles the daemon.json merge and sets the default runtime
+	# field so docker run --gpus just works out of the box.
+	nvidia-ctk runtime configure --runtime=docker
+
+	systemctl restart docker
+	echo "NVIDIA container toolkit installed. Docker restarted."
+	echo "Verify GPU access inside a container: docker run --rm --gpus all nvidia/cuda:12.2.0-base-ubuntu22.04 nvidia-smi"
+}
+
+install_amd_gpu() {
+	# Install AMD ROCm so containers can access AMD GPUs via /dev/kfd
+	# (compute) and /dev/dri (render nodes). No Docker daemon.json changes
+	# are needed — sandboxd uses device bind-mounts for AMD, not a custom OCI
+	# runtime. Only x86_64 is supported by the ROCm stack.
+	case "$(uname -m)" in
+		x86_64|amd64) ;;
+		*)
+			echo "--with-amd-gpu: ROCm only supports x86_64; $(uname -m) is not supported" >&2
+			exit 1
+			;;
+	esac
+
+	if [[ ! -e /dev/kfd ]]; then
+		echo "Warning: /dev/kfd not found — amdgpu kernel module may not be loaded." >&2
+		echo "  Make sure the GPU is present and 'modprobe amdgpu' has run (or the" >&2
+		echo "  driver is loaded automatically via /etc/modules-load.d/)." >&2
+		echo "  Continuing; /dev/kfd will appear after the driver loads." >&2
+	fi
+
+	local dist_codename
+	dist_codename="$(lsb_release -cs 2>/dev/null || echo "jammy")"
+
+	# Try the amdgpu-install convenience package first — it's the approach AMD
+	# documents and handles kernel module + ROCm library installation together.
+	local tmp_deb
+	tmp_deb="$(mktemp --suffix=.deb)"
+	if curl -fsSL \
+		"https://repo.radeon.com/amdgpu-install/latest/ubuntu/${dist_codename}/amdgpu-install_latest_all.deb" \
+		-o "$tmp_deb" 2>/dev/null; then
+		apt-get install -y "$tmp_deb"
+		rm -f "$tmp_deb"
+		# --usecase=rocm installs the ROCm compute stack.
+		# --no-dkms skips recompiling kernel modules (existing amdgpu driver is enough).
+		amdgpu-install -y --usecase=rocm --no-dkms
+	else
+		rm -f "$tmp_deb"
+		echo "amdgpu-install package unavailable for '${dist_codename}'; falling back to direct ROCm apt repo" >&2
+		local keyring="/usr/share/keyrings/rocm-archive-keyring.gpg"
+		curl -fsSL "https://repo.radeon.com/rocm/rocm.gpg.key" | gpg --dearmor -o "$keyring"
+		echo "deb [arch=amd64 signed-by=${keyring}] https://repo.radeon.com/rocm/apt/latest ${dist_codename} main" \
+			> /etc/apt/sources.list.d/rocm.list
+		apt-get update
+		apt-get install -y rocm-hip-sdk || apt-get install -y rocm
+	fi
+
+	# Ensure the render group exists and add current user if running interactively.
+	groupadd -f render
+	groupadd -f video
+	echo "AMD ROCm installed."
+	echo "Note: container users need 'video' and 'render' group membership to access GPU devices."
+	echo "Verify with: rocm-smi"
+}
+
 install_runsc_binary() {
 	# Download the latest runsc release from gVisor's official storage bucket
 	# and install it to /usr/local/bin. The bucket layout is:
@@ -757,6 +880,12 @@ PY
 install_packages
 if [[ "$WITH_GVISOR" == "true" ]]; then
 	register_gvisor_runtime
+fi
+if [[ "$WITH_NVIDIA_GPU" == "true" ]]; then
+	install_nvidia_gpu
+fi
+if [[ "$WITH_AMD_GPU" == "true" ]]; then
+	install_amd_gpu
 fi
 if [[ -n "$DNS_PROVIDER" ]]; then
 	install_caddy_dns_plugin "$DNS_PROVIDER"

--- a/sdk/go/pkg/types/types.go
+++ b/sdk/go/pkg/types/types.go
@@ -37,3 +37,12 @@ const (
 	RuntimeGvisor = models.RuntimeGvisor
 	RuntimeKata   = models.RuntimeKata
 )
+
+type GPURequest = models.GPURequest
+type GPUVendor = models.GPUVendor
+
+const (
+	GPUVendorNVIDIA = models.GPUVendorNVIDIA
+	GPUVendorAMD    = models.GPUVendorAMD
+	GPUVendorApple  = models.GPUVendorApple
+)

--- a/sdk/java/src/main/java/ai/aerol/microvm/model/CreateOptions.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/model/CreateOptions.java
@@ -22,6 +22,8 @@ public class CreateOptions {
     public List<MountSpec> mounts;
     public Lifecycle lifecycle;
     public String runtime;
+    /** Attach GPU resources to the sandbox. Null means no GPU (CPU-only). */
+    public GpuOptions gpus;
 
     public CreateOptions setImage(String image) {
         this.image = image;
@@ -80,6 +82,11 @@ public class CreateOptions {
 
     public CreateOptions setRuntime(String runtime) {
         this.runtime = runtime;
+        return this;
+    }
+
+    public CreateOptions setGpus(GpuOptions gpus) {
+        this.gpus = gpus;
         return this;
     }
 }

--- a/sdk/java/src/main/java/ai/aerol/microvm/model/GpuOptions.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/model/GpuOptions.java
@@ -1,0 +1,63 @@
+package ai.aerol.microvm.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * GPU resources to attach to a sandbox at creation time. Not compatible with
+ * runtime="gvisor" — the API returns an error if both gpus and
+ * runtime="gvisor" are set.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GpuOptions {
+    /**
+     * GPU hardware vendor. Required. Allowed values:
+     * <ul>
+     *   <li>"nvidia" — NVIDIA GPUs via nvidia-container-runtime. Requires
+     *       nvidia-container-toolkit on the host.</li>
+     *   <li>"amd" — AMD GPUs via ROCm (/dev/kfd + /dev/dri). Requires ROCm
+     *       drivers on the host.</li>
+     *   <li>"apple" — Apple Silicon GPU via Docker Desktop's experimental Metal
+     *       support. Only functional on macOS with Docker Desktop.</li>
+     * </ul>
+     */
+    public String vendor;
+
+    /**
+     * Number of GPUs to allocate. Use -1 to request all GPUs on the host.
+     * Omit or set 0 for the default (1 GPU). Ignored for AMD (all AMD GPUs on
+     * the host are exposed via /dev/kfd and /dev/dri).
+     */
+    public Integer count;
+
+    /**
+     * Pin the sandbox to specific GPU device indices or UUIDs. For NVIDIA:
+     * indices ("0", "1") or UUIDs ("GPU-abc123..."). For AMD and Apple: ignored.
+     */
+    @JsonProperty("device_ids")
+    public List<String> deviceIds;
+
+    public GpuOptions setVendor(String vendor) {
+        this.vendor = vendor;
+        return this;
+    }
+
+    public GpuOptions setCount(Integer count) {
+        this.count = count;
+        return this;
+    }
+
+    public GpuOptions setDeviceIds(List<String> deviceIds) {
+        this.deviceIds = deviceIds;
+        return this;
+    }
+
+    public GpuOptions copy() {
+        return new GpuOptions()
+            .setVendor(vendor)
+            .setCount(count)
+            .setDeviceIds(deviceIds == null ? null : new java.util.ArrayList<>(deviceIds));
+    }
+}

--- a/sdk/java/src/main/java/ai/aerol/microvm/model/SandboxData.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/model/SandboxData.java
@@ -37,6 +37,8 @@ public class SandboxData {
     public List<String> containerCommand;
     public Lifecycle lifecycle = new Lifecycle();
     public String runtime = "";
+    /** GPU configuration this sandbox was created with. Null means no GPU. */
+    public GpuOptions gpus;
 
     public SandboxData copy() {
         SandboxData copy = new SandboxData();
@@ -71,5 +73,6 @@ public class SandboxData {
         containerCommand = other.containerCommand == null ? null : new ArrayList<>(other.containerCommand);
         lifecycle = other.lifecycle == null ? new Lifecycle() : other.lifecycle.copy();
         runtime = other.runtime == null ? "" : other.runtime;
+        gpus = other.gpus == null ? null : other.gpus.copy();
     }
 }

--- a/sdk/python/microvm/types.py
+++ b/sdk/python/microvm/types.py
@@ -41,6 +41,32 @@ class Lifecycle(TypedDict, total=False):
 UpdateLifecycleOptions = Lifecycle
 
 
+GPUVendor = Literal["nvidia", "amd", "apple"]
+
+
+class GPUOptions(TypedDict, total=False):
+    """GPU resources to attach to a sandbox at creation time.
+
+    Not compatible with runtime="gvisor" — the API returns an error if both
+    gpus and runtime="gvisor" are set.
+
+    vendor values:
+    - "nvidia": NVIDIA GPUs via nvidia-container-runtime. Requires
+      nvidia-container-toolkit on the host.
+    - "amd": AMD GPUs via ROCm (/dev/kfd + /dev/dri). Requires ROCm
+      drivers on the host.
+    - "apple": Apple Silicon GPU via Docker Desktop's experimental Metal
+      support. Only functional on macOS with Docker Desktop.
+    """
+    vendor: GPUVendor
+    # Number of GPUs. -1 = all available. 0/omit = default (1).
+    # Ignored for AMD (all AMD GPUs on the host are exposed).
+    count: int
+    # For NVIDIA: indices ("0", "1") or UUIDs ("GPU-abc123...").
+    # For AMD and Apple: ignored.
+    deviceIDs: List[str]
+
+
 class CreateOptions(TypedDict, total=False):
     image: str
     # cpu accepts fractional cores: 0.5 = half a core, 1.5 = one and a half.
@@ -57,8 +83,11 @@ class CreateOptions(TypedDict, total=False):
     # Container runtime to use for this sandbox. Omit to inherit the host
     # default (SB_CONTAINER_RUNTIME). Use "gvisor" for runsc-backed isolation
     # when running untrusted workloads. "kata" is reserved and rejected by the
-    # API today.
+    # API today. Not compatible with gpus.
     runtime: Literal["docker", "gvisor", "kata"]
+    # Attach GPU resources to the sandbox. Omit for CPU-only workloads.
+    # Not compatible with runtime="gvisor".
+    gpus: GPUOptions
 
 
 class ResizeOptions(TypedDict, total=False):
@@ -178,6 +207,8 @@ class SandboxData(TypedDict, total=False):
     # Container runtime this sandbox is running under. Empty string indicates
     # a pre-migration row that resolves to the host default at start time.
     runtime: Literal["", "docker", "gvisor", "kata"]
+    # GPU configuration this sandbox was created with. Absent means no GPU.
+    gpus: GPUOptions
 
 
 class HealthStatus(TypedDict):

--- a/sdk/rust/src/types.rs
+++ b/sdk/rust/src/types.rs
@@ -48,6 +48,37 @@ pub struct MountSpecRedacted {
     pub has_credentials: bool,
 }
 
+/// GPU hardware vendor for sandbox GPU allocation.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum GPUVendor {
+    /// NVIDIA GPUs via nvidia-container-runtime. Requires
+    /// nvidia-container-toolkit on the host.
+    Nvidia,
+    /// AMD GPUs via ROCm (/dev/kfd + /dev/dri). Requires ROCm drivers
+    /// on the host.
+    Amd,
+    /// Apple Silicon GPU via Docker Desktop's experimental Metal support.
+    /// Only functional on macOS with Docker Desktop.
+    Apple,
+}
+
+/// GPU resources to attach to a sandbox at creation time. Not compatible
+/// with runtime `"gvisor"`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GPUOptions {
+    /// GPU hardware vendor. Required.
+    pub vendor: GPUVendor,
+    /// Number of GPUs. `-1` = all available, `0`/omit = default (1).
+    /// Ignored for AMD (all AMD GPUs on the host are exposed).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub count: Option<i32>,
+    /// For NVIDIA: GPU indices (`"0"`, `"1"`) or UUIDs (`"GPU-abc123..."`).
+    /// For AMD and Apple: ignored.
+    #[serde(rename = "device_ids", skip_serializing_if = "Option::is_none")]
+    pub device_ids: Option<Vec<String>>,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CreateOptions {
     pub image: String,
@@ -74,9 +105,13 @@ pub struct CreateOptions {
     /// Container runtime for this sandbox. Omit to inherit the host default
     /// (SB_CONTAINER_RUNTIME). Use `"gvisor"` for runsc-backed isolation when
     /// running untrusted workloads. `"kata"` is reserved and rejected by the
-    /// API today.
+    /// API today. Not compatible with `gpus`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime: Option<String>,
+    /// Attach GPU resources to the sandbox. Omit for CPU-only workloads.
+    /// Not compatible with `runtime = "gvisor"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gpus: Option<GPUOptions>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
@@ -157,6 +192,10 @@ pub struct Sandbox {
     /// a pre-migration row that resolves to the host default at start time.
     #[serde(default)]
     pub runtime: String,
+    /// GPU configuration this sandbox was created with. `None` means no GPU
+    /// was requested.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gpus: Option<GPUOptions>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -39,6 +39,36 @@ export interface Lifecycle {
 
 export type UpdateLifecycleOptions = Lifecycle;
 
+export type GPUVendor = "nvidia" | "amd" | "apple";
+
+export interface GPUOptions {
+  /**
+   * GPU hardware vendor. Required when gpus is set.
+   * - "nvidia": NVIDIA GPUs via nvidia-container-runtime. Requires
+   *   nvidia-container-toolkit on the host.
+   * - "amd": AMD GPUs via ROCm (/dev/kfd + /dev/dri). Requires ROCm
+   *   drivers on the host.
+   * - "apple": Apple Silicon GPU via Docker Desktop's experimental Metal
+   *   support. Only functional on macOS with Docker Desktop.
+   *
+   * GPU access is not supported with runtime="gvisor" — the API returns
+   * an error if both gpus and runtime="gvisor" are set.
+   */
+  vendor: GPUVendor;
+  /**
+   * Number of GPUs to allocate. Use -1 to request all GPUs on the host.
+   * Defaults to 1 when omitted. Ignored for AMD (all AMD GPUs are exposed
+   * via /dev/kfd and /dev/dri).
+   */
+  count?: number;
+  /**
+   * Pin the sandbox to specific GPU device indices or UUIDs.
+   * For NVIDIA: indices ("0", "1") or UUIDs ("GPU-abc123...").
+   * For AMD and Apple: ignored.
+   */
+  deviceIDs?: string[];
+}
+
 export interface CreateOptions {
   image: string;
   /** Number of CPU cores to allocate. Fractional values are supported (e.g. 0.5 = half a core). */
@@ -59,8 +89,15 @@ export interface CreateOptions {
    * privileged containers and ignores per-sandbox disk quotas. `"kata"` is
    * reserved for future Kata Containers support and is rejected by the API
    * today.
+   *
+   * GPU access is not supported with `"gvisor"`.
    */
   runtime?: "docker" | "gvisor" | "kata";
+  /**
+   * Attach GPU resources to the sandbox. Omit for CPU-only workloads.
+   * Not compatible with runtime="gvisor".
+   */
+  gpus?: GPUOptions;
 }
 
 export interface ResizeOptions {
@@ -135,6 +172,8 @@ export interface Sandbox {
    * a pre-migration row that resolves to the host default at start time.
    */
   runtime: "" | "docker" | "gvisor" | "kata";
+  /** GPU configuration this sandbox was created with. Absent means no GPU. */
+  gpus?: GPUOptions;
 }
 
 export interface ExecRequest {


### PR DESCRIPTION
This pull request adds first-class GPU support to AerolVM sandboxes, enabling users to request dedicated NVIDIA, AMD, or Apple Silicon GPUs for their workloads. It updates the service, storage, and documentation layers to support GPU configuration, validation, and usage across all SDK languages. Additionally, it introduces a new documentation page with comprehensive GPU usage examples, and updates the sidebar navigation to surface this new feature.

**GPU Support Implementation and Storage:**
- Added a `gpus_json` column to the `sandboxes` table to store GPU configuration as a JSON blob, and updated all relevant database queries and migration logic to handle this new field. [[1]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daR112-R114) [[2]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daR155-R167) [[3]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daR194) [[4]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daR211-R223) [[5]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daL235-R248) [[6]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daR275) [[7]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daL275-R289) [[8]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daL303-R317) [[9]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daR585) [[10]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daR614)
- Service layer now validates GPU requests and passes them through to the sandbox model for creation. [[1]](diffhunk://#diff-e977aef3a61407d38b134a73df7978004343a347ee0b5c8cc69a57b31624e2d0R107-R112) [[2]](diffhunk://#diff-e977aef3a61407d38b134a73df7978004343a347ee0b5c8cc69a57b31624e2d0R194)

**Documentation and User Guidance:**
- Added a new page, `gpu-sandboxes.mdx`, with detailed examples for requesting GPUs in TypeScript, Python, Go, Rust, and Java, covering NVIDIA, AMD, and Apple Silicon.
- Updated the "Getting Started" and "Sandboxes" docs to explain GPU support, installation flags, and compatibility notes, and linked to the new GPU documentation. [[1]](diffhunk://#diff-1262f479864911329a61ff3084b548b82ed08aef6815b0cd04f006b176283b59R113-R151) [[2]](diffhunk://#diff-3dc0b4484404c0d8f2614489015b8ce36ce46a4f69d825af2e2cfcc1c5d87da3R67-R70)
- Updated the quick-start feature matrix to indicate GPU support.

**Navigation and Docs Structure:**
- Added "GPU Sandboxes" as a sidebar link in the documentation navigation for easier discovery.
- Added documentation rules to ensure all new features are documented in all SDK languages and that new top-level features get their own pages.

**Minor Adjustments:**
- Updated a use-case sidebar link and renamed a use-case doc for clarity. [[1]](diffhunk://#diff-9de6dde6792a780b33723ce43337db38d9c0ad8ba77e084444b27cbf6faca23bL239-R245) [[2]](diffhunk://#diff-11ed935ded5d1532342c7c46bd9370705060dddc2df6a8fdeca9ed9e60dd5055L6-L7)

**References:**  
[[1]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daR112-R114) [[2]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daR155-R167) [[3]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daR194) [[4]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daR211-R223) [[5]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daL235-R248) [[6]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daR275) [[7]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daL275-R289) [[8]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daL303-R317) [[9]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daR585) [[10]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daR614) [[11]](diffhunk://#diff-e977aef3a61407d38b134a73df7978004343a347ee0b5c8cc69a57b31624e2d0R107-R112) [[12]](diffhunk://#diff-e977aef3a61407d38b134a73df7978004343a347ee0b5c8cc69a57b31624e2d0R194) [[13]](diffhunk://#diff-0f609422b4f8689d8ea5fb67036cfadede8f83c59a622a0ff8e7076ac721e86cR1-R301) [[14]](diffhunk://#diff-1262f479864911329a61ff3084b548b82ed08aef6815b0cd04f006b176283b59R113-R151) [[15]](diffhunk://#diff-3dc0b4484404c0d8f2614489015b8ce36ce46a4f69d825af2e2cfcc1c5d87da3R67-R70) [[16]](diffhunk://#diff-0e6808cbb18eb7cc27fa9190a120de7649720ba2e91d23451ae184937b602974R48) [[17]](diffhunk://#diff-9de6dde6792a780b33723ce43337db38d9c0ad8ba77e084444b27cbf6faca23bR65-R70) [[18]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R1-R7) [[19]](diffhunk://#diff-9de6dde6792a780b33723ce43337db38d9c0ad8ba77e084444b27cbf6faca23bL239-R245) [[20]](diffhunk://#diff-11ed935ded5d1532342c7c46bd9370705060dddc2df6a8fdeca9ed9e60dd5055L6-L7)