### PR TITLE
feat: add multi-architecture support in install script and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,11 @@ permissions:
   contents: write
 
 jobs:
-  release:
+  test:
+    name: Test
     runs-on: ubuntu-latest
     env:
       VERSION: ${{ github.event.release.tag_name }}
-      LDFLAGS: -X github.com/aerol-ai/microvm/internal/version.Version=${{ github.event.release.tag_name }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -33,16 +33,11 @@ jobs:
           cache: npm
           cache-dependency-path: sdk/typescript/package-lock.json
 
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential gcc-aarch64-linux-gnu
-
       - name: Install TypeScript SDK dependencies
         working-directory: sdk/typescript
         run: npm ci
 
-      - name: Run tests
+      - name: Run Go tests
         run: |
           go test -count=1 -coverprofile=coverage.out ./...
           go tool cover -func=coverage.out | tail -n 1
@@ -53,59 +48,203 @@ jobs:
           npm run build
           npm test
 
-      - name: Build release assets
-        shell: bash
+  build:
+    name: Build - ${{ matrix.name }}
+    needs: test
+    runs-on: ${{ matrix.runner }}
+    env:
+      VERSION: ${{ github.event.release.tag_name }}
+      LDFLAGS: -X github.com/aerol-ai/microvm/internal/version.Version=${{ github.event.release.tag_name }}
+    strategy:
+      matrix:
+        include:
+          # Linux — sandboxd (CGO) + toolboxd
+          - name: Linux x86_64
+            runner: ubuntu-latest
+            goos: linux
+            goarch: amd64
+            suffix: linux_amd64
+            cc: gcc
+            apt_pkgs: build-essential
+            goarm: ""
+
+          - name: Linux x86
+            runner: ubuntu-latest
+            goos: linux
+            goarch: "386"
+            suffix: linux_386
+            cc: gcc
+            apt_pkgs: "build-essential gcc-multilib"
+            goarm: ""
+
+          - name: Linux aarch64
+            runner: ubuntu-latest
+            goos: linux
+            goarch: arm64
+            suffix: linux_arm64
+            cc: aarch64-linux-gnu-gcc
+            apt_pkgs: "build-essential gcc-aarch64-linux-gnu"
+            goarm: ""
+
+          - name: Linux armv7hf
+            runner: ubuntu-latest
+            goos: linux
+            goarch: arm
+            suffix: linux_armv7
+            cc: arm-linux-gnueabihf-gcc
+            apt_pkgs: "build-essential gcc-arm-linux-gnueabihf"
+            goarm: "7"
+
+          - name: Linux armv6
+            runner: ubuntu-latest
+            goos: linux
+            goarch: arm
+            suffix: linux_armv6
+            cc: arm-linux-gnueabi-gcc
+            apt_pkgs: "build-essential gcc-arm-linux-gnueabi"
+            goarm: "6"
+
+          # FreeBSD — toolboxd only (CGO=0, no cross-compiler available)
+          - name: Freebsd x86_64
+            runner: ubuntu-latest
+            goos: freebsd
+            goarch: amd64
+            suffix: freebsd_amd64
+            cc: ""
+            apt_pkgs: ""
+            goarm: ""
+
+          - name: Freebsd x86
+            runner: ubuntu-latest
+            goos: freebsd
+            goarch: "386"
+            suffix: freebsd_386
+            cc: ""
+            apt_pkgs: ""
+            goarm: ""
+
+          # macOS — toolboxd only
+          - name: MacOS x86_64
+            runner: macos-13
+            goos: darwin
+            goarch: amd64
+            suffix: darwin_amd64
+            cc: ""
+            apt_pkgs: ""
+            goarm: ""
+
+          - name: MacOS aarch64
+            runner: macos-14
+            goos: darwin
+            goarch: arm64
+            suffix: darwin_arm64
+            cc: ""
+            apt_pkgs: ""
+            goarm: ""
+
+          # Windows — toolboxd only
+          - name: Windows x86_64
+            runner: windows-latest
+            goos: windows
+            goarch: amd64
+            suffix: windows_amd64
+            cc: ""
+            apt_pkgs: ""
+            goarm: ""
+
+          - name: Windows x86
+            runner: windows-latest
+            goos: windows
+            goarch: "386"
+            suffix: windows_386
+            cc: ""
+            apt_pkgs: ""
+            goarm: ""
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.VERSION }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install Linux build dependencies
+        if: runner.os == 'Linux' && matrix.apt_pkgs != ''
         run: |
-          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y ${{ matrix.apt_pkgs }}
 
+      - name: Build sandboxd (Linux only, CGO enabled)
+        if: matrix.goos == 'linux'
+        shell: bash
+        env:
+          CGO_ENABLED: "1"
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          GOARM: ${{ matrix.goarm }}
+          CC: ${{ matrix.cc }}
+        run: |
           mkdir -p dist
+          go build -trimpath -ldflags "$LDFLAGS" -o dist/sandboxd_${{ matrix.suffix }} ./cmd/sandboxd
+          chmod 0755 dist/sandboxd_${{ matrix.suffix }}
 
-          build_binary() {
-            local binary="$1"
-            local arch="$2"
-            local cgo_enabled="$3"
-            local cc="$4"
-            local output="dist/${binary}_linux_${arch}"
+      - name: Build toolboxd
+        shell: bash
+        env:
+          CGO_ENABLED: "0"
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          GOARM: ${{ matrix.goarm }}
+        run: |
+          mkdir -p dist
+          ext=""
+          [[ "${{ matrix.goos }}" == "windows" ]] && ext=".exe"
+          go build -trimpath -ldflags "$LDFLAGS" -o "dist/toolboxd_${{ matrix.suffix }}${ext}" ./cmd/toolboxd
+          [[ "${{ matrix.goos }}" != "windows" ]] && chmod 0755 "dist/toolboxd_${{ matrix.suffix }}${ext}"
 
-            if [[ "$cgo_enabled" == "1" ]]; then
-              CGO_ENABLED=1 GOOS=linux GOARCH="$arch" CC="$cc" \
-                go build -trimpath -ldflags "$LDFLAGS" -o "$output" "./cmd/${binary}"
-            else
-              CGO_ENABLED=0 GOOS=linux GOARCH="$arch" \
-                go build -trimpath -ldflags "$LDFLAGS" -o "$output" "./cmd/${binary}"
-            fi
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.suffix }}
+          path: dist/
 
-            chmod 0755 "$output"
-          }
+  release:
+    name: Publish release
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ github.event.release.tag_name }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.VERSION }}
 
-          build_binary sandboxd amd64 1 gcc
-          build_binary toolboxd amd64 0 gcc
-          build_binary sandboxd arm64 1 aarch64-linux-gnu-gcc
-          build_binary toolboxd arm64 0 gcc
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: dist-*
+          path: dist/
+          merge-multiple: true
 
+      - name: Copy install script
+        run: |
           cp scripts/install.sh dist/install.sh
           chmod 0755 dist/install.sh
 
-          (
-            cd dist
-            sha256sum \
-              sandboxd_linux_amd64 \
-              toolboxd_linux_amd64 \
-              sandboxd_linux_arm64 \
-              toolboxd_linux_arm64 \
-              install.sh \
-              > checksums.txt
-          )
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum * > checksums.txt
 
       - name: Publish GitHub release assets
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.VERSION }}
           generate_release_notes: true
-          files: |
-            dist/sandboxd_linux_amd64
-            dist/toolboxd_linux_amd64
-            dist/sandboxd_linux_arm64
-            dist/toolboxd_linux_arm64
-            dist/install.sh
-            dist/checksums.txt
+          files: dist/*

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -96,8 +96,17 @@ detect_platform() {
 		x86_64|amd64)
 			arch="amd64"
 			;;
+		i686|i386)
+			arch="386"
+			;;
 		aarch64|arm64)
 			arch="arm64"
+			;;
+		armv7l|armv7)
+			arch="armv7"
+			;;
+		armv6l|armv6)
+			arch="armv6"
 			;;
 		*)
 			echo "Unsupported architecture: $(uname -m)" >&2
@@ -352,10 +361,14 @@ install_caddy_dns_plugin() {
 	# requested modules baked in; no Go toolchain needed on the host.
 	local provider="$1"
 	local arch_tag
+	local arch_extra=""
 
 	case "$(uname -m)" in
-		x86_64|amd64) arch_tag="amd64" ;;
+		x86_64|amd64)  arch_tag="amd64" ;;
+		i686|i386)     arch_tag="386" ;;
 		aarch64|arm64) arch_tag="arm64" ;;
+		armv7l|armv7)  arch_tag="arm"; arch_extra="&arm=7" ;;
+		armv6l|armv6)  arch_tag="arm"; arch_extra="&arm=6" ;;
 		*)
 			echo "Unsupported architecture for custom Caddy build: $(uname -m)" >&2
 			exit 1
@@ -368,7 +381,7 @@ install_caddy_dns_plugin() {
 		caddy_path="/usr/bin/caddy"
 	fi
 
-	local download_url="${CADDY_BUILD_URL_BASE}?os=linux&arch=${arch_tag}&p=github.com/caddy-dns/${provider}"
+	local download_url="${CADDY_BUILD_URL_BASE}?os=linux&arch=${arch_tag}${arch_extra}&p=github.com/caddy-dns/${provider}"
 	local tmp_binary
 	tmp_binary="$(mktemp)"
 


### PR DESCRIPTION
This pull request significantly refactors the release workflow and improves architecture detection and handling in the install script. The most important changes are the introduction of a matrix-based build system for cross-platform releases, improved architecture support in the install script, and a more modular workflow structure.

**Workflow and Build Process Refactor:**

* The GitHub Actions workflow in `.github/workflows/release.yml` is restructured to use separate `test`, `build`, and `release` jobs, with the build step now running as a matrix to build and package binaries for multiple platforms (Linux, FreeBSD, macOS, Windows) and architectures (amd64, 386, arm64, armv7, armv6). This enables automated cross-platform releases and simplifies the addition of new targets. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L12-L16) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L56-R250)
* The build process is now more modular, with each platform/architecture combination handled individually in the matrix, and platform-specific dependencies installed only as needed.
* Artifacts from all builds are automatically collected and published as release assets, streamlining the release process.

**Install Script Improvements:**

* The `scripts/install.sh` script now detects additional architectures (`i686`, `i386`, `armv7l`, `armv7`, `armv6l`, `armv6`) and maps them to the appropriate Go architecture names, improving compatibility for users on a wider range of systems.
* The `install_caddy_dns_plugin` function in the install script is updated to handle new architectures, including passing the correct `arm` version to the Caddy build service via the `arch_extra` parameter. [[1]](diffhunk://#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09ccR364-R371) [[2]](diffhunk://#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09ccL371-R384)

These changes make the release process more robust and scalable, and improve the user experience for installation on diverse platforms.