### PR TITLE
feat: add Layer4 support for TCP and TLS-SNI exposure

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,56 @@
+<!--
+GitHub auto-fills new PR descriptions with this template. Fill in EVERY
+section below. "N/A — <one-line reason>" is a valid answer; an empty answer
+is not. See pr-review.md at the repo root for what each section is asking.
+-->
+
+## Summary
+
+<!-- 1-3 bullets: what changed and why. -->
+
+## Sandbox boot impact
+
+<!--
+Did this PR add ANY work — DB query, HTTP round-trip, file I/O, lock
+acquisition — to CreateSandbox or anything it calls?
+
+If yes: state what was added, expected added latency, when it fires, and
+whether it's bounded. "Only on the first call" is still impact and must be
+called out.
+
+If no: write "N/A — no work added to sandbox boot path."
+-->
+
+## Idempotency
+
+<!--
+For every API surface this PR touches, describe behavior under retry and
+under concurrent calls with the same inputs. Sandbox APIs MUST be
+idempotent (see pr-review.md §1).
+
+If no API surface changed: write "N/A — no API surface changed."
+-->
+
+## Failure-path consistency
+
+<!--
+For any multi-step write that touches BOTH caddy and the store: what is the
+rollback rule on partial failure? Who cleans up if step 2 of 3 fails?
+
+If no multi-step write path was changed: write "N/A — no multi-step write
+path changed."
+-->
+
+## L4 / host-port-pool changes
+
+<!--
+Did this PR touch TryReserveHostPort, the partial unique index on
+host_port, allocateHostPort, EnsureLayer4, EnsureLayer4Ready, or the
+l4Ready latch? If yes, link the regression test that covers the change.
+
+If no: write "N/A — neither touched."
+-->
+
+## Test plan
+
+<!-- Bulleted checklist of how this was verified. -->

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,14 @@
 - **Never use raw HTTP / curl examples in docs or in any md file.** All code examples must use one of the five SDK languages (TypeScript, Python, Go, Rust, Java) shown in `<Tabs syncKey="lang">` blocks. curl is only acceptable in `getting-started.md` for the initial server-install one-liners, not for sandbox API calls.
 - When adding a new top-level feature to the docs (GPU sandboxes, a new runtime, a new resource type, etc.), create a **new `.mdx` file** rather than appending a subsection to an existing page. Register the new page in the sidebar config at `docs/src/content/config.ts`.
 - Every new docs page must cover all five SDK languages with synced tab keys (`syncKey="lang"`).
+
+## API design & PR review
+
+Before opening or reviewing any PR that touches `internal/service`, `internal/store`, `pkg/caddy`, `pkg/api`, or the SDKs, read [`pr-review.md`](./pr-review.md). It is the canonical source for:
+
+- the idempotency requirement on all sandbox APIs,
+- the rule that any work added to `CreateSandbox` / sandbox boot must be explicitly called out,
+- the lazy-bootstrap pattern (atomic latch + single-flight mutex) for best-effort daemon-start work,
+- failure-path state-consistency rules for caddy + store writes,
+- the regression-test requirement on changes to the TCP host-port pool or the L4 bootstrap,
+- the PR description template that must be filled in for every PR (silence is not acceptable on these axes).

--- a/cmd/sandboxd/main.go
+++ b/cmd/sandboxd/main.go
@@ -56,6 +56,14 @@ func main() {
 	}
 
 	caddyClient := caddy.New(cfg)
+	// Bootstrap caddy-l4 once at boot. This creates /config/apps/layer4
+	// if absent and (when SB_L4_TLS_LISTEN is set) the shared SNI-mux
+	// server. Best-effort: if caddy isn't ready yet the daemon will retry
+	// implicitly the first time a TCP/TLS exposure is created, so we log
+	// rather than fail the whole start-up.
+	if err := caddyClient.EnsureLayer4(ctx, cfg.L4TLSListen); err != nil {
+		logger.Warn("failed to ensure caddy layer4 app at startup", "error", err)
+	}
 
 	cipher, err := secrets.NewCipher(cfg.CredentialEncryptionKey, cfg.CredentialEncryptionKeyPath)
 	if err != nil {

--- a/cmd/sandboxd/main.go
+++ b/cmd/sandboxd/main.go
@@ -56,14 +56,6 @@ func main() {
 	}
 
 	caddyClient := caddy.New(cfg)
-	// Bootstrap caddy-l4 once at boot. This creates /config/apps/layer4
-	// if absent and (when SB_L4_TLS_LISTEN is set) the shared SNI-mux
-	// server. Best-effort: if caddy isn't ready yet the daemon will retry
-	// implicitly the first time a TCP/TLS exposure is created, so we log
-	// rather than fail the whole start-up.
-	if err := caddyClient.EnsureLayer4(ctx, cfg.L4TLSListen); err != nil {
-		logger.Warn("failed to ensure caddy layer4 app at startup", "error", err)
-	}
 
 	cipher, err := secrets.NewCipher(cfg.CredentialEncryptionKey, cfg.CredentialEncryptionKeyPath)
 	if err != nil {
@@ -119,6 +111,14 @@ func main() {
 	// same instance today; the split exists so a future non-Docker runtime
 	// can replace the first without touching the second.
 	svc := service.New(cfg, logger, db, dockerClient, dockerClient, caddyClient, cipher, mountManager, admitter)
+	// Bootstrap caddy-l4 at boot so the first L4 exposure isn't paying for
+	// it. Best-effort by design: a cold-started caddy may still be coming
+	// up, in which case the next ExposePort(tcp|tls) will retry under the
+	// service's single-flight latch. Logging rather than exiting keeps the
+	// daemon serving HTTP exposures even when L4 is misconfigured.
+	if err := svc.EnsureLayer4Ready(ctx); err != nil {
+		logger.Warn("failed to ensure caddy layer4 app at startup; will retry on first L4 exposure", "error", err)
+	}
 	svc.ReplayReservations(ctx)
 
 	if cfg.AutoReconcile {

--- a/docs/src/content/config.ts
+++ b/docs/src/content/config.ts
@@ -134,6 +134,12 @@ const getDocsSidebarConfig = (): NavigationGroup[] => [
       },
       {
         type: 'link',
+        href: '/tcp-ports',
+        label: 'TCP & TLS Ports',
+        description: 'Publish native TCP endpoints (Postgres, Redis, MySQL, Mongo) via caddy-l4.',
+      },
+      {
+        type: 'link',
         href: '/port-allowlist',
         label: 'Port Allowlist',
         description: 'Require explicit exposure before public traffic reaches a sandbox port.',

--- a/docs/src/content/config.ts
+++ b/docs/src/content/config.ts
@@ -82,6 +82,12 @@ const getDocsSidebarConfig = (): NavigationGroup[] => [
       },
       {
         type: 'link',
+        href: '/preview',
+        label: 'Preview',
+        description: 'Expose container ports publicly over HTTPS through Caddy routes.',
+      },
+      {
+        type: 'link',
         href: '/reconcile',
         label: 'Reconcile',
         description: 'Sync the sandbox database with live container state. Fix capacity errors after a host restart.',

--- a/docs/src/content/docs/tcp-ports.mdx
+++ b/docs/src/content/docs/tcp-ports.mdx
@@ -14,6 +14,8 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 Both share the same lifecycle as `exposePort`: routes are torn down on stop / destroy and re-published on start.
 
+Not sure which one fits your workload? See [TCP vs TLS Ports](/tcp-vs-tls-ports/) for a side-by-side mental model, a workload-by-workload picker, and the trade-offs each mode imposes.
+
 ## Raw TCP
 
 `exposeTCPPort(port)` allocates a parent-host port from the configured pool (default `[35000, 45000]`) and points caddy-l4 at the sandbox's container IP. The returned URL is in `tcp://<public-host>:<host-port>` form and plugs straight into a native protocol client.
@@ -129,40 +131,102 @@ See [Reconcile](/reconcile) for full details.
 
 ## Unexposing
 
-`unexposePort(port)` works the same regardless of protocol — the daemon looks up the recorded protocol on the row and tears down the right caddy surface (HTTP route, layer4 TCP server, or TLS-SNI route).
+There is **one** unexpose method, not three. `unexposePort(port)` handles HTTP, TCP, and TLS exposures uniformly — the daemon looks up the recorded protocol on the row and tears down the right caddy surface (HTTP route, layer4 TCP server, or TLS-SNI route), then deletes the row.
+
+`(sandboxID, port)` is the primary key on the exposure table, so there is at most one row per pair regardless of protocol. The caller does not need to remember whether the port was published with `exposePort`, `exposeTCPPort`, or `exposeTLSPort`:
 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">
     ```ts
+    // Any of these:
+    await sandbox.exposePort(3000);       // -> https://<id>-3000.<domain>
+    await sandbox.exposeTCPPort(5432);    // -> tcp://<host>:<host-port>
+    await sandbox.exposeTLSPort(6379);    // -> tls://<id>-6379.<domain>:443
+
+    // All tear down with the same call:
+    await sandbox.unexposePort(3000);
     await sandbox.unexposePort(5432);
+    await sandbox.unexposePort(6379);
     ```
   </TabItem>
   <TabItem label="Python">
     ```python
+    sandbox.expose_port(3000)
+    sandbox.expose_tcp_port(5432)
+    sandbox.expose_tls_port(6379)
+
+    sandbox.unexpose_port(3000)
     sandbox.unexpose_port(5432)
+    sandbox.unexpose_port(6379)
     ```
   </TabItem>
   <TabItem label="Go">
     ```go
-    if err := sandbox.UnexposePort(ctx, 5432); err != nil {
+    if _, err := sandbox.ExposePort(ctx, 3000); err != nil {
         log.Fatal(err)
     }
+    if _, err := sandbox.ExposeTCPPort(ctx, 5432); err != nil {
+        log.Fatal(err)
+    }
+    if _, err := sandbox.ExposeTLSPort(ctx, 6379); err != nil {
+        log.Fatal(err)
+    }
+
+    // Same call regardless of how the port was published.
+    _ = sandbox.UnexposePort(ctx, 3000)
+    _ = sandbox.UnexposePort(ctx, 5432)
+    _ = sandbox.UnexposePort(ctx, 6379)
     ```
   </TabItem>
   <TabItem label="Rust">
     ```rust
+    sandbox.expose_port(3000)?;
+    sandbox.expose_tcp_port(5432)?;
+    sandbox.expose_tls_port(6379)?;
+
+    sandbox.unexpose_port(3000)?;
     sandbox.unexpose_port(5432)?;
+    sandbox.unexpose_port(6379)?;
     ```
   </TabItem>
   <TabItem label="Java">
     ```java
+    sandbox.exposePort(3000);
+    sandbox.exposeTCPPort(5432);
+    sandbox.exposeTLSPort(6379);
+
+    sandbox.unexposePort(3000);
     sandbox.unexposePort(5432);
+    sandbox.unexposePort(6379);
     ```
   </TabItem>
 </Tabs>
 
+### What unexpose actually does
+
+The daemon dispatches on the protocol stored on the `exposed_ports` row:
+
+| Recorded protocol | Caddy surface torn down | Host-side cleanup |
+|---|---|---|
+| `http` (or empty, for legacy rows) | `DELETE /id/sandbox-<id>-port-<port>` on the HTTP server | none |
+| `tcp` | `DELETE /config/apps/layer4/servers/tcp-port-<host-port>` | host port returns to the `[35000, 45000]` pool |
+| `tls` | `DELETE /id/sandbox-<id>-port-<port>-tls` on the SNI mux | none |
+
+In every case the row in `exposed_ports` is deleted and the toolbox port allowlist is refreshed so subsequent calls to `/proxy/<port>/` on the public sandbox URL are rejected immediately.
+
+### Why there is no `unexposeTCPPort` / `unexposeTLSPort`
+
+Three reasons the API is asymmetric on purpose:
+
+1. **`(id, port)` is the unique key.** The protocol does not need to be passed in — the daemon already knows it from the row.
+2. **The HTTP verb is the same.** All three would issue `DELETE /v1/sandboxes/{id}/ports/{port}` with no body. Splitting into three SDK methods would just call the same endpoint three different ways.
+3. **It mirrors `close(fd)` in POSIX.** The system call is the same whether the descriptor is a TCP socket, a UNIX socket, or a pipe — the kernel knows which one it gave you.
+
+If your code needs to be defensive about not knowing which method was used to expose a port, the single-method shape is what you want anyway.
+
 ## Related docs
 
+- [TCP vs TLS Ports](/tcp-vs-tls-ports/) — deeper picker for choosing between `exposeTCPPort` and `exposeTLSPort`.
 - [Preview](/preview/) — HTTPS-shaped exposures.
 - [Port Allowlist](/port-allowlist/) — explicit exposure before public traffic is accepted.
 - [Reconcile](/reconcile/) — how caddy state is kept consistent with the database.

--- a/docs/src/content/docs/tcp-ports.mdx
+++ b/docs/src/content/docs/tcp-ports.mdx
@@ -82,7 +82,9 @@ The `host_port` reservation is persisted alongside the exposure row. After a san
 
 ## TLS-SNI multiplexing
 
-When several backends already speak TLS and the deployment has wildcard DNS, `exposeTLSPort(port)` reuses one shared listener (default `:443`) and routes by SNI to per-sandbox subdomains. Returns `tls://<id>-<port>.<domain>:<l4-port>`.
+`exposeTLSPort(port)` reuses one shared listener (default `:443`), terminates TLS at the edge using Caddy's wildcard certificate, and forwards plaintext bytes to the container. Returns `tls://<id>-<port>.<domain>:<l4-port>`.
+
+Your backend speaks plain TCP — no certificate management, no renewal, no private key inside the container. Caddy's wildcard cert lives on the host and never crosses the container boundary.
 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">
@@ -119,9 +121,13 @@ When several backends already speak TLS and the deployment has wildcard DNS, `ex
 Two requirements:
 
 1. **Domain mode** — `--domain` must be configured (the SNI hostname needs an A record pointing at the host).
-2. **`SB_L4_TLS_LISTEN`** must be non-empty on the daemon (default empty / opt-in). The shared `tls-mux` server binds this address; until the existing HTTPS site is moved off the same port, leave it unset to avoid a listener conflict.
+2. **DNS-01 issuance** — `install.sh` enables TLS-SNI on `:443` automatically when `--dns-provider` is set (`SB_L4_TLS_LISTEN=:443` in the daemon env). The installer also relocates the regular Caddy HTTPS listener to `127.0.0.1:8443` so caddy-l4 can own `:443` cleanly. Caddy's wildcard cert for `*.<domain>` is issued once via DNS-01 at startup and reused for every TLS-SNI exposure. Without `--dns-provider`, TLS-SNI stays disabled because HTTP-01 ACME needs `:443` for its own validation — re-run with `--dns-provider cloudflare --dns-api-token <token>` to enable it.
 
-TLS-SNI is **passthrough** — Caddy does not terminate the connection. The certificate the client sees is the one the upstream presents, so the sandbox process must hold its own cert for that SNI hostname.
+TLS is **terminated at the edge** by caddy-l4. Caddy's auto-managed wildcard cert is presented to the client; bytes after the handshake are forwarded as plaintext to the container. This means:
+
+- **No cert lives inside the container.** Your sandbox process speaks plain TCP and is unaware that clients connected over TLS.
+- **No per-sandbox cert work happens at expose time.** The wildcard already exists; we just add an SNI route to the layer4 server. Expose latency is one Caddy admin API call plus one SQLite insert.
+- **mTLS, custom ALPN, and HTTP/2 client-cert auth are not supported in this mode** — the terminator consumes the original handshake. Use `exposeTCPPort` if you need those.
 
 ## Reconciliation
 

--- a/docs/src/content/docs/tcp-ports.mdx
+++ b/docs/src/content/docs/tcp-ports.mdx
@@ -18,7 +18,7 @@ Not sure which one fits your workload? See [TCP vs TLS Ports](/tcp-vs-tls-ports/
 
 ## Raw TCP
 
-`exposeTCPPort(port)` allocates a parent-host port from the configured pool (default `[35000, 45000]`) and points caddy-l4 at the sandbox's container IP. The returned URL is in `tcp://<public-host>:<host-port>` form and plugs straight into a native protocol client.
+`exposeTCPPort(port)` allocates a parent-host port from the configured pool (default `[22000, 23000]`) and points caddy-l4 at the sandbox's container IP. The returned URL is in `tcp://<public-host>:<host-port>` form and plugs straight into a native protocol client.
 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">
@@ -63,12 +63,16 @@ The tuple `(public host, host port)` is everything you need to build a DSN for a
 
 The allocator picks a candidate at random from `[SB_L4_PORT_RANGE_START, SB_L4_PORT_RANGE_END]` and reserves it via a single atomic `INSERT OR IGNORE`. Random-first keeps p95 fast even with many concurrent allocations; on collision it falls back to a deterministic linear scan so the pool is exhausted fully before giving up.
 
-The defaults are wide enough for ~10k concurrent TCP exposures per host. Override the pool with environment variables on `sandboxd`:
+The default pool is `[22000, 23000]` — 1000 slots, which is the per-host cap on concurrent TCP exposures. The range is chosen to sit **below** the Linux ephemeral port range (`net.ipv4.ip_local_port_range`, typically `32768–60999`) so the kernel never picks one of these as the source port for an unrelated outbound connection. Overlap there caused intermittent `EADDRINUSE` failures when the allocator's `bind()` raced with a kernel-chosen ephemeral source port; keeping the pool out of that range eliminates the failure mode entirely.
+
+Override the pool with environment variables on `sandboxd`:
 
 ```
-SB_L4_PORT_RANGE_START=35000
-SB_L4_PORT_RANGE_END=45000
+SB_L4_PORT_RANGE_START=22000
+SB_L4_PORT_RANGE_END=23000
 ```
+
+If you raise these bounds, keep both sides outside your kernel's ephemeral range — check it with `cat /proc/sys/net/ipv4/ip_local_port_range`. Picking values inside the ephemeral range will reintroduce the random-collision failure mode on busy hosts.
 
 The host firewall must permit inbound traffic on that range. The installer prints a reminder, but does not auto-open the firewall — operators decide their own policy.
 
@@ -209,7 +213,7 @@ The daemon dispatches on the protocol stored on the `exposed_ports` row:
 | Recorded protocol | Caddy surface torn down | Host-side cleanup |
 |---|---|---|
 | `http` (or empty, for legacy rows) | `DELETE /id/sandbox-<id>-port-<port>` on the HTTP server | none |
-| `tcp` | `DELETE /config/apps/layer4/servers/tcp-port-<host-port>` | host port returns to the `[35000, 45000]` pool |
+| `tcp` | `DELETE /config/apps/layer4/servers/tcp-port-<host-port>` | host port returns to the `[22000, 23000]` pool |
 | `tls` | `DELETE /id/sandbox-<id>-port-<port>-tls` on the SNI mux | none |
 
 In every case the row in `exposed_ports` is deleted and the toolbox port allowlist is refreshed so subsequent calls to `/proxy/<port>/` on the public sandbox URL are rejected immediately.

--- a/docs/src/content/docs/tcp-ports.mdx
+++ b/docs/src/content/docs/tcp-ports.mdx
@@ -1,0 +1,168 @@
+---
+title: TCP & TLS Ports
+description: Publish native TCP endpoints (Postgres, Redis, MySQL, Mongo, gRPC) from a sandbox using caddy-l4.
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+`exposePort` publishes an HTTP route at `https://<sandbox-id>-<port>.<domain>`. That works for browser-shaped traffic but not for protocols that speak the raw TCP wire — Postgres, Redis, MySQL, MongoDB, MQTT, gRPC, SSH, dedicated game servers. For those, AerolVM exposes two additional surfaces backed by [`caddy-l4`](https://github.com/mholt/caddy-l4):
+
+| Mode | Method | URL shape | When |
+|---|---|---|---|
+| Raw TCP | `exposeTCPPort(port)` | `tcp://<public-host>:<host-port>` | Postgres, Redis, MySQL, Mongo, raw protocols |
+| TLS-SNI | `exposeTLSPort(port)` | `tls://<id>-<port>.<domain>:<l4-port>` | TLS-aware backends that already speak SNI |
+
+Both share the same lifecycle as `exposePort`: routes are torn down on stop / destroy and re-published on start.
+
+## Raw TCP
+
+`exposeTCPPort(port)` allocates a parent-host port from the configured pool (default `[35000, 45000]`) and points caddy-l4 at the sandbox's container IP. The returned URL is in `tcp://<public-host>:<host-port>` form and plugs straight into a native protocol client.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    const url = await sandbox.exposeTCPPort(5432);
+    // url === "tcp://203.0.113.10:37412"
+    // psql "postgresql://user:pass@203.0.113.10:37412/appdb"
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    url = sandbox.expose_tcp_port(5432)
+    # url == "tcp://203.0.113.10:37412"
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    url, err := sandbox.ExposeTCPPort(ctx, 5432)
+    if err != nil {
+        log.Fatal(err)
+    }
+    // url == "tcp://203.0.113.10:37412"
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let url = sandbox.expose_tcp_port(5432)?;
+    // url == "tcp://203.0.113.10:37412"
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    String url = sandbox.exposeTCPPort(5432);
+    // url.equals("tcp://203.0.113.10:37412")
+    ```
+  </TabItem>
+</Tabs>
+
+The tuple `(public host, host port)` is everything you need to build a DSN for any TCP protocol — pass it directly to `psql`, `redis-cli`, `mysql`, `mongosh`, or your application's connection string.
+
+### Host port pool
+
+The allocator picks a candidate at random from `[SB_L4_PORT_RANGE_START, SB_L4_PORT_RANGE_END]` and reserves it via a single atomic `INSERT OR IGNORE`. Random-first keeps p95 fast even with many concurrent allocations; on collision it falls back to a deterministic linear scan so the pool is exhausted fully before giving up.
+
+The defaults are wide enough for ~10k concurrent TCP exposures per host. Override the pool with environment variables on `sandboxd`:
+
+```
+SB_L4_PORT_RANGE_START=35000
+SB_L4_PORT_RANGE_END=45000
+```
+
+The host firewall must permit inbound traffic on that range. The installer prints a reminder, but does not auto-open the firewall — operators decide their own policy.
+
+### What gets restored on restart
+
+The `host_port` reservation is persisted alongside the exposure row. After a sandboxd restart, the periodic reconcile re-publishes the layer4 server pointing at the (possibly new) container IP, and the same host port stays bound — clients with cached connection strings keep working.
+
+## TLS-SNI multiplexing
+
+When several backends already speak TLS and the deployment has wildcard DNS, `exposeTLSPort(port)` reuses one shared listener (default `:443`) and routes by SNI to per-sandbox subdomains. Returns `tls://<id>-<port>.<domain>:<l4-port>`.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    const url = await sandbox.exposeTLSPort(5432);
+    // url === "tls://abc-5432.sandbox.example.com:443"
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    url = sandbox.expose_tls_port(5432)
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    url, err := sandbox.ExposeTLSPort(ctx, 5432)
+    if err != nil {
+        log.Fatal(err)
+    }
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let url = sandbox.expose_tls_port(5432)?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    String url = sandbox.exposeTLSPort(5432);
+    ```
+  </TabItem>
+</Tabs>
+
+Two requirements:
+
+1. **Domain mode** — `--domain` must be configured (the SNI hostname needs an A record pointing at the host).
+2. **`SB_L4_TLS_LISTEN`** must be non-empty on the daemon (default empty / opt-in). The shared `tls-mux` server binds this address; until the existing HTTPS site is moved off the same port, leave it unset to avoid a listener conflict.
+
+TLS-SNI is **passthrough** — Caddy does not terminate the connection. The certificate the client sees is the one the upstream presents, so the sandbox process must hold its own cert for that SNI hostname.
+
+## Reconciliation
+
+Reconcile keeps caddy and the sandbox database in sync across all three protocols (`http`, `tcp`, `tls`). The periodic loop and `POST /v1/admin/reconcile` both:
+
+- Re-upsert routes for running sandboxes whose caddy entries are missing.
+- Drop routes when the underlying sandbox is `destroyed`.
+- Garbage-collect zombie caddy routes / layer4 servers whose IDs match our convention but no longer correspond to any DB row (e.g. after a destroyed-row TTL purge or development DB wipe).
+
+See [Reconcile](/reconcile) for full details.
+
+## Unexposing
+
+`unexposePort(port)` works the same regardless of protocol — the daemon looks up the recorded protocol on the row and tears down the right caddy surface (HTTP route, layer4 TCP server, or TLS-SNI route).
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    await sandbox.unexposePort(5432);
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    sandbox.unexpose_port(5432)
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    if err := sandbox.UnexposePort(ctx, 5432); err != nil {
+        log.Fatal(err)
+    }
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    sandbox.unexpose_port(5432)?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    sandbox.unexposePort(5432);
+    ```
+  </TabItem>
+</Tabs>
+
+## Related docs
+
+- [Preview](/preview/) — HTTPS-shaped exposures.
+- [Port Allowlist](/port-allowlist/) — explicit exposure before public traffic is accepted.
+- [Reconcile](/reconcile/) — how caddy state is kept consistent with the database.

--- a/docs/src/content/docs/tcp-vs-tls-ports.mdx
+++ b/docs/src/content/docs/tcp-vs-tls-ports.mdx
@@ -1,0 +1,175 @@
+---
+title: TCP vs TLS Ports
+description: When to use exposeTCPPort vs exposeTLSPort — mental model, trade-offs, and a workload-by-workload picker.
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+`exposeTCPPort` and `exposeTLSPort` both publish a sandbox-internal port through caddy-l4, but they listen and route very differently. This page is a deeper explainer of the two modes — when to pick each, what they cost, and why the API gives you a choice.
+
+For the API surface itself, see [TCP & TLS Ports](/tcp-ports/).
+
+## Mental model
+
+### Raw TCP — `exposeTCPPort(port)`
+
+caddy-l4 binds **one host port from the configured `[35000, 45000]` pool** per exposure and forwards bytes 1:1 into the container.
+
+```
+client ──► public-host:37412 (caddy-l4)  ──► container:5432
+                       ▲                            ▲
+                bytes go through unchanged
+```
+
+- URL shape: `tcp://<public-host>:<host-port>`
+- The proxy is **protocol-agnostic** — it doesn't read the bytes, just shovels them.
+- One TCP exposure consumes one host port in the pool, and one inbound firewall rule on that port.
+- Works for **any** TCP protocol, regardless of whether it speaks TLS.
+
+### TLS-SNI — `exposeTLSPort(port)`
+
+caddy-l4 binds **one shared port** (typically `:443`), peeks at the TLS ClientHello, reads the SNI extension, and routes the still-encrypted connection to whichever backend matches the hostname.
+
+```
+client ──► public-host:443 (caddy-l4)
+                ▲ ┌────────────┐
+                │ │ SNI=        │
+                │ │  abc-5432.. │ ──► sandbox abc, container:5432
+                │ │  xyz-6379.. │ ──► sandbox xyz, container:6379
+                │ └────────────┘
+        many backends, one shared port
+```
+
+- URL shape: `tls://<id>-<port>.<domain>:<l4-port>`
+- caddy **does NOT terminate TLS**. It inspects only the SNI extension, which is in the cleartext part of the handshake, and passes the rest of the bytes through encrypted.
+- The **backend container holds the certificate**. Whatever the client sees is what the sandbox process serves.
+- Many exposures share the same listener — no host-port pool burn, no per-service firewall hole.
+- Requires the client to send SNI **and** the backend to speak TLS. Plain TCP does not work here.
+
+## Workload picker
+
+| Workload | Recommended mode | Why |
+|---|---|---|
+| Postgres (plaintext) | **TCP** | Default Postgres setups are plaintext; simplest and works with any client. |
+| Postgres (TLS) | **TLS-SNI** | libpq has sent SNI since v17. Saves a firewall hole; reuses `:443`. |
+| Redis | **TCP** | Redis TLS support is rarely deployed; plain TCP dominates. |
+| MySQL / MariaDB | **TCP** | Most clients skip TLS for ephemeral test data. |
+| MongoDB | **TCP** | Plain mongo wire protocol over TCP is the default. |
+| MQTT broker | TCP for `mqtt://`, **TLS-SNI** for `mqtts://` | Match the client's URI scheme. |
+| gRPC plaintext / h2c | **TCP** | No TLS, no SNI, just bytes. |
+| gRPC over TLS | **TLS-SNI** | gRPC clients send SNI; backend holds the cert. |
+| HTTPS-shaped TCP behind a CDN | **TLS-SNI** | Looks identical to a normal HTTPS service from outside. |
+| SSH bastion / Git server | **TCP** | SSH does not speak SNI. TLS-SNI cannot route it. |
+| Dedicated game server | **TCP** | Game protocols are bespoke. |
+| Custom binary protocol (no TLS) | **TCP** | Same reason as game servers. |
+
+## Trade-offs
+
+### Pick TCP when
+
+- The protocol does not speak TLS, **or**
+- You don't want the sandbox to manage a TLS certificate, **or**
+- The client expects a `<host>:<port>` connection string (`psql`, `redis-cli`, `mongosh`).
+
+You pay: one host port + one firewall rule per exposure, and a random high port number visible in the URL.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    const url = await sandbox.exposeTCPPort(5432);
+    // tcp://203.0.113.10:37412
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    url = sandbox.expose_tcp_port(5432)
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    url, err := sandbox.ExposeTCPPort(ctx, 5432)
+    if err != nil {
+        log.Fatal(err)
+    }
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let url = sandbox.expose_tcp_port(5432)?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    String url = sandbox.exposeTCPPort(5432);
+    ```
+  </TabItem>
+</Tabs>
+
+### Pick TLS-SNI when
+
+- The backend already has TLS configured (its certificate covers `<id>-<port>.<domain>`), **and**
+- The client sends SNI (libpq, browsers, gRPC, modern Mongo drivers all do), **and**
+- You want many backends sharing `:443` so the URL looks like a normal HTTPS service.
+
+You pay: the backend has to manage a certificate, and clients must send SNI. You save: no host-port pool burn, no per-service firewall rule, and the URL has no awkward high-port suffix.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    const url = await sandbox.exposeTLSPort(5432);
+    // tls://abc-5432.sandbox.example.com:443
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    url = sandbox.expose_tls_port(5432)
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    url, err := sandbox.ExposeTLSPort(ctx, 5432)
+    if err != nil {
+        log.Fatal(err)
+    }
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let url = sandbox.expose_tls_port(5432)?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    String url = sandbox.exposeTLSPort(5432);
+    ```
+  </TabItem>
+</Tabs>
+
+## Side-by-side cheat sheet
+
+| | `exposeTCPPort` | `exposeTLSPort` |
+|---|---|---|
+| Listener | Per-exposure host port from `[35000, 45000]` | Shared, default `:443` |
+| URL shape | `tcp://<host>:<host-port>` | `tls://<id>-<port>.<domain>:<l4-port>` |
+| Reads bytes? | No | Only the SNI extension |
+| Terminates TLS? | n/a | **No** — passthrough |
+| Cert held by | n/a | The sandbox backend itself |
+| Client must send SNI? | No | **Yes** |
+| Needs `--domain`? | No | **Yes** |
+| Needs `SB_L4_TLS_LISTEN`? | No | **Yes** |
+| Firewall holes per exposure | 1 | 0 (shared listener) |
+| Multiplexing model | One server per host port | One server, many SNI routes |
+
+## A useful rule of thumb
+
+> **TCP** is the answer for "give me a wire-protocol endpoint" — it's how you make `postgresql://...` or `redis://...` *just work*.
+>
+> **TLS-SNI** is the answer for "I have many encrypted services and want them all on `:443`" — it's a multiplexer, not a translator.
+
+If you're picking between them and not sure, default to **TCP**. It works for everything; TLS-SNI is the optimization for fleets of TLS-aware services where saving firewall rules and unifying URLs matters.
+
+## Related docs
+
+- [TCP & TLS Ports](/tcp-ports/) — the API surface, host-port pool, and reconcile guarantees.
+- [Preview](/preview/) — HTTPS-shaped exposures via Caddy's HTTP reverse proxy.
+- [Port Allowlist](/port-allowlist/) — explicit exposure before public traffic is accepted.

--- a/docs/src/content/docs/tcp-vs-tls-ports.mdx
+++ b/docs/src/content/docs/tcp-vs-tls-ports.mdx
@@ -28,23 +28,28 @@ client ──► public-host:37412 (caddy-l4)  ──► container:5432
 
 ### TLS-SNI — `exposeTLSPort(port)`
 
-caddy-l4 binds **one shared port** (typically `:443`), peeks at the TLS ClientHello, reads the SNI extension, and routes the still-encrypted connection to whichever backend matches the hostname.
+caddy-l4 binds **one shared port** (typically `:443`), reads the SNI extension from the ClientHello to pick a route, and **terminates TLS at the edge** using the wildcard certificate Caddy already manages for `*.<domain>`. After termination, plaintext bytes are forwarded to the container on its native port.
 
 ```
-client ──► public-host:443 (caddy-l4)
-                ▲ ┌────────────┐
-                │ │ SNI=        │
-                │ │  abc-5432.. │ ──► sandbox abc, container:5432
-                │ │  xyz-6379.. │ ──► sandbox xyz, container:6379
-                │ └────────────┘
-        many backends, one shared port
+client ──TLS──► public-host:443 (caddy-l4)
+                       │
+                       │ terminate TLS using the wildcard cert
+                       │ Caddy auto-issued for *.<domain>
+                       ▼
+                ┌────────────┐
+                │ SNI=        │
+                │  abc-5432.. │ ──plaintext──► sandbox abc, container:5432
+                │  xyz-6379.. │ ──plaintext──► sandbox xyz, container:6379
+                └────────────┘
+        many backends, one shared port, one wildcard cert
 ```
 
 - URL shape: `tls://<id>-<port>.<domain>:<l4-port>`
-- caddy **does NOT terminate TLS**. It inspects only the SNI extension, which is in the cleartext part of the handshake, and passes the rest of the bytes through encrypted.
-- The **backend container holds the certificate**. Whatever the client sees is what the sandbox process serves.
-- Many exposures share the same listener — no host-port pool burn, no per-service firewall hole.
-- Requires the client to send SNI **and** the backend to speak TLS. Plain TCP does not work here.
+- TLS is **terminated at caddy-l4** using Caddy's existing wildcard cert. The container speaks **plaintext TCP** — it does not need to hold a cert, manage renewals, or know anything about TLS.
+- Many exposures share the same listener and the same cert — no host-port pool burn, no per-service firewall hole, no cert provisioning per sandbox.
+- Caddy's private key never leaves the host. Containers see only the decrypted bytes.
+- Requires the client to send SNI. If your client does not send SNI (very rare in 2026 — basically only ancient legacy clients), use `exposeTCPPort` instead.
+- **Not for mTLS / client-cert auth / custom ALPN selection by the backend.** Those need access to the original TLS handshake and require raw TCP — see the trade-offs section.
 
 ## Workload picker
 
@@ -107,11 +112,11 @@ You pay: one host port + one firewall rule per exposure, and a random high port 
 
 ### Pick TLS-SNI when
 
-- The backend already has TLS configured (its certificate covers `<id>-<port>.<domain>`), **and**
-- The client sends SNI (libpq, browsers, gRPC, modern Mongo drivers all do), **and**
+- The client sends SNI (libpq, browsers, gRPC, modern Mongo / Redis / MySQL drivers all do), **and**
+- The backend speaks plain TCP and you want clients to see TLS, **and**
 - You want many backends sharing `:443` so the URL looks like a normal HTTPS service.
 
-You pay: the backend has to manage a certificate, and clients must send SNI. You save: no host-port pool burn, no per-service firewall rule, and the URL has no awkward high-port suffix.
+You pay: only what you give up by terminating at the edge — mTLS, custom ALPN, and HTTP/2 client-cert auth no longer reach the backend. You save: no per-sandbox cert management, no host-port pool burn, no per-service firewall rule, no awkward high-port suffix in the URL.
 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">
@@ -151,22 +156,24 @@ You pay: the backend has to manage a certificate, and clients must send SNI. You
 |---|---|---|
 | Listener | Per-exposure host port from `[22000, 23000]` | Shared, default `:443` |
 | URL shape | `tcp://<host>:<host-port>` | `tls://<id>-<port>.<domain>:<l4-port>` |
-| Reads bytes? | No | Only the SNI extension |
-| Terminates TLS? | n/a | **No** — passthrough |
-| Cert held by | n/a | The sandbox backend itself |
+| Reads bytes? | No | Yes — terminates the TLS handshake |
+| Terminates TLS? | n/a | **Yes**, at caddy-l4 (using Caddy's wildcard) |
+| Cert held by | n/a | Caddy on the host (private key never enters the container) |
+| Backend speaks | Whatever it likes | **Plaintext TCP** |
+| Supports mTLS / client certs? | n/a | **No** (terminator strips them) |
 | Client must send SNI? | No | **Yes** |
 | Needs `--domain`? | No | **Yes** |
-| Needs `SB_L4_TLS_LISTEN`? | No | **Yes** |
+| Needs `--dns-provider`? | No | **Yes** (so the wildcard exists) |
 | Firewall holes per exposure | 1 | 0 (shared listener) |
 | Multiplexing model | One server per host port | One server, many SNI routes |
 
 ## A useful rule of thumb
 
-> **TCP** is the answer for "give me a wire-protocol endpoint" — it's how you make `postgresql://...` or `redis://...` *just work*.
+> **TCP** is the answer for plain wire-protocol endpoints, and the only answer for protocols that need the original TLS handshake to reach the backend (mTLS, custom ALPN, HTTP/2 client-cert auth).
 >
-> **TLS-SNI** is the answer for "I have many encrypted services and want them all on `:443`" — it's a multiplexer, not a translator.
+> **TLS-SNI** is the answer for "I want a `tls://` URL on `:443` with a real cert, and my backend just speaks plain TCP."
 
-If you're picking between them and not sure, default to **TCP**. It works for everything; TLS-SNI is the optimization for fleets of TLS-aware services where saving firewall rules and unifying URLs matters.
+If you're picking between them and not sure, default to **TLS-SNI** when DNS-01 is configured — it gives you the friendly URL, the real cert, and zero per-firewall ports. Fall back to **TCP** if your client doesn't send SNI, your backend needs the raw handshake, or your install isn't using `--dns-provider`.
 
 ## Related docs
 

--- a/docs/src/content/docs/tcp-vs-tls-ports.mdx
+++ b/docs/src/content/docs/tcp-vs-tls-ports.mdx
@@ -13,7 +13,7 @@ For the API surface itself, see [TCP & TLS Ports](/tcp-ports/).
 
 ### Raw TCP — `exposeTCPPort(port)`
 
-caddy-l4 binds **one host port from the configured `[35000, 45000]` pool** per exposure and forwards bytes 1:1 into the container.
+caddy-l4 binds **one host port from the configured `[22000, 23000]` pool** per exposure and forwards bytes 1:1 into the container.
 
 ```
 client ──► public-host:37412 (caddy-l4)  ──► container:5432
@@ -149,7 +149,7 @@ You pay: the backend has to manage a certificate, and clients must send SNI. You
 
 | | `exposeTCPPort` | `exposeTLSPort` |
 |---|---|---|
-| Listener | Per-exposure host port from `[35000, 45000]` | Shared, default `:443` |
+| Listener | Per-exposure host port from `[22000, 23000]` | Shared, default `:443` |
 | URL shape | `tcp://<host>:<host-port>` | `tls://<id>-<port>.<domain>:<l4-port>` |
 | Reads bytes? | No | Only the SNI extension |
 | Terminates TLS? | n/a | **No** — passthrough |

--- a/docs/src/content/docs/use-cases/customer-facing-product-experiences/gvisor-kernel-isolation-security.mdx
+++ b/docs/src/content/docs/use-cases/customer-facing-product-experiences/gvisor-kernel-isolation-security.mdx
@@ -3,15 +3,12 @@ title: gVisor Kernel Isolation Security
 description: Compare privileged-operation probes across Docker and gVisor runtimes to show how gVisor reduces direct host-kernel exposure.
 ---
 
-## What you are building
-
-This page intentionally does not include breakout or exploit code. Instead, it shows a safe kernel-surface probe. The same Python probe runs twice: once in a direct Docker runtime and once in a gVisor runtime. The probe attempts host-facing privileged operations such as `unshare`, `mount`, and `dmesg`, records what happened, and writes a JSON report.
-
-## Why AerolVM fits
+This page shows a safe kernel-surface probe. The same Python probe runs twice: once in a direct Docker runtime and once in a gVisor runtime. The probe attempts host-facing privileged operations such as `unshare`, `mount`, and `dmesg`, records what happened, and writes a JSON report.
 
 - `runtime: "docker"` lets you show the baseline container model where workload syscalls target the host kernel directly.
 - `runtime: "gvisor"` swaps that direct host-kernel path for gVisor's user-space kernel boundary.
 - The same probe can run in both runtimes with only one field changed, which makes the comparison concrete and easy to explain.
+- Currently, both Daytona and E2B use direct Docker isolation. This demo shows how gVisor's kernel mediation provides a stronger security boundary for untrusted code, which is why we are building it as a core runtime option for AerolVM.
 
 ## Shared probe payload
 

--- a/docs/src/content/docs/use-cases/customer-facing-product-experiences/spawn-postgres.mdx
+++ b/docs/src/content/docs/use-cases/customer-facing-product-experiences/spawn-postgres.mdx
@@ -14,15 +14,11 @@ This is the Postgres foundation, not the full Supabase control plane. If you wan
 - `createSession` keeps both Postgres and an optional HTTP admin surface alive after setup finishes.
 - Lifecycle policies let you stop or destroy idle database sandboxes automatically.
 
-## Important network limitation
+## Native Postgres endpoint via `exposeTCPPort`
 
-The generated URL from `exposePort()` in this repository is HTTP(S) only.
+This page exposes the Postgres wire protocol directly using `exposeTCPPort(5432)`. The daemon allocates a parent-host port from the configured `[35000, 45000]` pool and points caddy-l4 at the container's `5432`, so the generated URL is in `tcp://<public-host>:<host-port>` form and works with `psql`, Prisma, SQLAlchemy, pgAdmin, and any other client that speaks the PostgreSQL wire protocol.
 
-- The Caddy template defines only `https://...` HTTP sites and `reverse_proxy` handlers.
-- The `UpsertPortRoute` path writes routes into Caddy's `apps/http` server, not a TCP proxy or layer 4 listener.
-- The SSH gateway only supports SSH `session` channels. It does not implement `direct-tcpip` port forwarding.
-
-That means a generated URL like `https://<sandbox-id>-5432.<domain>` is not a native Postgres endpoint. It will not work with `psql`, Prisma, or any other client expecting the PostgreSQL wire protocol. If you want a browser-accessible URL today, expose an HTTP layer that talks to Postgres. If you want native Postgres over the internet, place a TCP-capable proxy or load balancer in front of the sandbox instead of the current Caddy setup.
+If you only need browser-shaped traffic (a small admin UI, REST shim, PostgREST), use `exposePort()` instead — that's the HTTPS-only path documented in [Preview](/preview/). See [TCP & TLS Ports](/tcp-ports/) for the full surface.
 
 ## Copy-paste TypeScript script
 
@@ -235,12 +231,20 @@ async function main() {
 
   await waitForAdmin(sandbox);
   const adminURL = await sandbox.exposePort(adminPort);
+  const postgresTCP = await sandbox.exposeTCPPort(postgresPort);
+
+  // exposeTCPPort returns "tcp://<host>:<port>" — strip the scheme to build a
+  // wire-protocol DSN for psql / Prisma / SQLAlchemy.
+  const dsnHost = postgresTCP.replace(/^tcp:\/\//, "");
+  const publicDatabaseURL = `postgresql://${encodeURIComponent(postgresUser)}:${encodeURIComponent(postgresPassword)}@${dsnHost}/${encodeURIComponent(postgresDB)}`;
 
   const payload = {
     sandboxID: sandbox.id,
     postgresSessionID: postgresSession.id,
     adminSessionID: adminSession.id,
     adminURL,
+    postgresURL: publicDatabaseURL,
+    postgresTCP,
     database: {
       hostInsideSandbox: "127.0.0.1",
       port: postgresPort,
@@ -248,7 +252,7 @@ async function main() {
       userEnv: "POSTGRES_USER",
       passwordEnv: "POSTGRES_PASSWORD",
     },
-    note: "adminURL is an HTTP(S) endpoint in front of the sandbox. It is not a native Postgres DSN.",
+    note: "postgresURL is a native Postgres DSN backed by a caddy-l4 TCP route.",
   };
 
   await writeFile("deploy-your-own-postgres.json", `${JSON.stringify(payload, null, 2)}\n`);
@@ -263,22 +267,23 @@ main().catch((error) => {
 
 ## What the script gives you
 
-- `deploy-your-own-postgres.json` with the sandbox ID, the running session IDs, and the public HTTP admin URL.
-- A Postgres server listening on port `5432` inside the sandbox.
+- `deploy-your-own-postgres.json` with the sandbox ID, the running session IDs, the public HTTP admin URL, and a native `postgresql://...` DSN.
+- A Postgres server listening on port `5432` inside the sandbox, published as a `tcp://<public-host>:<host-port>` endpoint via caddy-l4.
 - A password-protected HTTP endpoint on port `3000` that proves the database is up and returns basic metadata.
 
-## Can a user access Postgres on the generated URL?
+## Connecting natively
 
-No. In this repository, the generated URL can only reach HTTP(S) services.
+The `postgresURL` returned by the script is a real Postgres DSN. Plug it into any client:
 
-- `packaging/Caddyfile.template` defines HTTP sites and HTTP reverse proxies only.
-- `pkg/caddy/client.go` inserts per-port routes into Caddy's HTTP server and returns `https://<sandbox-id>-<port>.<domain>` URLs.
-- `pkg/sshgateway/gateway.go` rejects non-`session` SSH channels, so it is not a fallback TCP tunnel either.
+```
+psql "postgresql://user:pass@<public-host>:<host-port>/appdb"
+```
 
-Use the generated URL for an HTTP layer such as an admin endpoint, PostgREST, or your own API. Do not hand it to a raw Postgres client.
+The host port is one of the parent-host ports allocated from the configured `[35000, 45000]` pool. Make sure that range is open on the host firewall — see [TCP & TLS Ports](/tcp-ports/) for the full surface and reconcile guarantees.
 
 ## Related docs
 
+- [TCP & TLS Ports](/tcp-ports/)
 - [Environment](/environment/)
 - [Preview](/preview/)
 - [Port Allowlist](/port-allowlist/)

--- a/docs/src/content/docs/use-cases/customer-facing-product-experiences/spawn-postgres.mdx
+++ b/docs/src/content/docs/use-cases/customer-facing-product-experiences/spawn-postgres.mdx
@@ -16,7 +16,7 @@ This is the Postgres foundation, not the full Supabase control plane. If you wan
 
 ## Native Postgres endpoint via `exposeTCPPort`
 
-This page exposes the Postgres wire protocol directly using `exposeTCPPort(5432)`. The daemon allocates a parent-host port from the configured `[35000, 45000]` pool and points caddy-l4 at the container's `5432`, so the generated URL is in `tcp://<public-host>:<host-port>` form and works with `psql`, Prisma, SQLAlchemy, pgAdmin, and any other client that speaks the PostgreSQL wire protocol.
+This page exposes the Postgres wire protocol directly using `exposeTCPPort(5432)`. The daemon allocates a parent-host port from the configured `[22000, 23000]` pool and points caddy-l4 at the container's `5432`, so the generated URL is in `tcp://<public-host>:<host-port>` form and works with `psql`, Prisma, SQLAlchemy, pgAdmin, and any other client that speaks the PostgreSQL wire protocol.
 
 If you only need browser-shaped traffic (a small admin UI, REST shim, PostgREST), use `exposePort()` instead — that's the HTTPS-only path documented in [Preview](/preview/). See [TCP & TLS Ports](/tcp-ports/) for the full surface.
 
@@ -279,7 +279,7 @@ The `postgresURL` returned by the script is a real Postgres DSN. Plug it into an
 psql "postgresql://user:pass@<public-host>:<host-port>/appdb"
 ```
 
-The host port is one of the parent-host ports allocated from the configured `[35000, 45000]` pool. Make sure that range is open on the host firewall — see [TCP & TLS Ports](/tcp-ports/) for the full surface and reconcile guarantees.
+The host port is one of the parent-host ports allocated from the configured `[22000, 23000]` pool. Make sure that range is open on the host firewall — see [TCP & TLS Ports](/tcp-ports/) for the full surface and reconcile guarantees.
 
 ## Related docs
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,16 @@ type Config struct {
 	// raw-TCP sandbox exposures (caddy-l4) are allocated from. The allocator
 	// picks a random candidate first; collisions fall back to a deterministic
 	// scan. Both sides are inclusive.
+	//
+	// The default range [22000, 23000] sits ABOVE the Linux registered-ports
+	// boundary (1024) and BELOW the default ephemeral-port range
+	// (net.ipv4.ip_local_port_range, typically 32768-60999). Keeping the pool
+	// out of the ephemeral range matters: if these ports overlapped, the
+	// kernel could hand any of them to an unrelated outbound connection as a
+	// source port, and the next L4 expose attempt to bind() that number would
+	// race-fail with EADDRINUSE. 1000 slots is the deliberate concurrent-TCP-
+	// exposure cap per host; raise it via the env vars if you need more, but
+	// keep both bounds outside the host's ephemeral range.
 	L4PortRangeStart int
 	L4PortRangeEnd   int
 	// L4TLSListen is the listen address for the shared TLS-SNI multiplexer.
@@ -145,8 +155,8 @@ func Load() (Config, error) {
 		HostCPUCoresOverride:      getEnvInt("SB_HOST_CPU_CORES", 0),
 		HostMemoryMBOverride:      getEnvInt("SB_HOST_MEMORY_MB", 0),
 
-		L4PortRangeStart: getEnvInt("SB_L4_PORT_RANGE_START", 35000),
-		L4PortRangeEnd:   getEnvInt("SB_L4_PORT_RANGE_END", 45000),
+		L4PortRangeStart: getEnvInt("SB_L4_PORT_RANGE_START", 22000),
+		L4PortRangeEnd:   getEnvInt("SB_L4_PORT_RANGE_END", 23000),
 		L4TLSListen:      strings.TrimSpace(os.Getenv("SB_L4_TLS_LISTEN")),
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,6 +79,20 @@ type Config struct {
 	MemoryOverProvisionFactor float64
 	HostCPUCoresOverride      int
 	HostMemoryMBOverride      int
+
+	// L4PortRangeStart / L4PortRangeEnd bound the parent-host port pool that
+	// raw-TCP sandbox exposures (caddy-l4) are allocated from. The allocator
+	// picks a random candidate first; collisions fall back to a deterministic
+	// scan. Both sides are inclusive.
+	L4PortRangeStart int
+	L4PortRangeEnd   int
+	// L4TLSListen is the listen address for the shared TLS-SNI multiplexer.
+	// Empty disables TLS-SNI exposure entirely (the daemon will reject
+	// protocol="tls" requests). When set, caddy-l4 binds this address and
+	// routes by SNI to per-sandbox subdomains; the operator is responsible
+	// for ensuring the address is free (the existing :443 HTTPS site has to
+	// move first, which is out of scope until install.sh is updated).
+	L4TLSListen string
 }
 
 func Load() (Config, error) {
@@ -130,6 +144,10 @@ func Load() (Config, error) {
 		MemoryOverProvisionFactor: getEnvFloat("SB_MEMORY_OVERPROVISION_FACTOR", 10.0),
 		HostCPUCoresOverride:      getEnvInt("SB_HOST_CPU_CORES", 0),
 		HostMemoryMBOverride:      getEnvInt("SB_HOST_MEMORY_MB", 0),
+
+		L4PortRangeStart: getEnvInt("SB_L4_PORT_RANGE_START", 35000),
+		L4PortRangeEnd:   getEnvInt("SB_L4_PORT_RANGE_END", 45000),
+		L4TLSListen:      strings.TrimSpace(os.Getenv("SB_L4_TLS_LISTEN")),
 	}
 
 	if cfg.PATToken == "" {
@@ -156,6 +174,13 @@ func Load() (Config, error) {
 	// reject individual create requests until the runtime is wired up.
 	if _, err := models.ValidRuntime(cfg.Runtime); err != nil || cfg.Runtime == "" {
 		return Config{}, fmt.Errorf("invalid SB_CONTAINER_RUNTIME=%q (allowed: %s, %s, %s)", cfg.Runtime, models.RuntimeDocker, models.RuntimeGvisor, models.RuntimeKata)
+	}
+
+	// L4 port pool sanity. Out-of-range or inverted bounds would silently
+	// brick raw-TCP exposure later; surface it at boot instead.
+	if cfg.L4PortRangeStart < 1024 || cfg.L4PortRangeEnd > 65535 || cfg.L4PortRangeStart >= cfg.L4PortRangeEnd {
+		return Config{}, fmt.Errorf("invalid SB_L4_PORT_RANGE_START/END (%d-%d): require 1024 <= start < end <= 65535",
+			cfg.L4PortRangeStart, cfg.L4PortRangeEnd)
 	}
 
 	return cfg, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,10 +99,19 @@ type Config struct {
 	// L4TLSListen is the listen address for the shared TLS-SNI multiplexer.
 	// Empty disables TLS-SNI exposure entirely (the daemon will reject
 	// protocol="tls" requests). When set, caddy-l4 binds this address and
-	// routes by SNI to per-sandbox subdomains; the operator is responsible
-	// for ensuring the address is free (the existing :443 HTTPS site has to
-	// move first, which is out of scope until install.sh is updated).
+	// routes by SNI to per-sandbox subdomains.
+	//
+	// install.sh sets this to ":443" when --dns-provider is configured (the
+	// HTTPS Caddy server is moved to 127.0.0.1:8443 in that case so caddy-l4
+	// can own :443). Without --dns-provider, HTTP-01 issuance still needs
+	// :443 free for ACME, so we leave it empty.
 	L4TLSListen string
+	// L4TLSFallback is the local address caddy-l4 forwards a TLS connection
+	// to when no per-sandbox SNI route matches — i.e. the regular HTTPS site
+	// served by Caddy itself (sandbox API, on-demand TLS, the catch-all 404).
+	// Required when L4TLSListen is non-empty; ignored otherwise. Default is
+	// "127.0.0.1:8443" to match install.sh's relocated HTTPS listener.
+	L4TLSFallback string
 }
 
 func Load() (Config, error) {
@@ -158,6 +167,7 @@ func Load() (Config, error) {
 		L4PortRangeStart: getEnvInt("SB_L4_PORT_RANGE_START", 22000),
 		L4PortRangeEnd:   getEnvInt("SB_L4_PORT_RANGE_END", 23000),
 		L4TLSListen:      strings.TrimSpace(os.Getenv("SB_L4_TLS_LISTEN")),
+		L4TLSFallback:    getEnv("SB_L4_TLS_FALLBACK", "127.0.0.1:8443"),
 	}
 
 	if cfg.PATToken == "" {
@@ -191,6 +201,14 @@ func Load() (Config, error) {
 	if cfg.L4PortRangeStart < 1024 || cfg.L4PortRangeEnd > 65535 || cfg.L4PortRangeStart >= cfg.L4PortRangeEnd {
 		return Config{}, fmt.Errorf("invalid SB_L4_PORT_RANGE_START/END (%d-%d): require 1024 <= start < end <= 65535",
 			cfg.L4PortRangeStart, cfg.L4PortRangeEnd)
+	}
+
+	// If TLS-SNI multiplexing is enabled, the fallback HTTPS address must be
+	// set — otherwise non-sandbox SNI (the API itself, on-demand TLS) would
+	// land nowhere. An operator who explicitly sets SB_L4_TLS_FALLBACK="" while
+	// also setting SB_L4_TLS_LISTEN is misconfigured; surface it at boot.
+	if cfg.L4TLSListen != "" && cfg.L4TLSFallback == "" {
+		return Config{}, errors.New("SB_L4_TLS_FALLBACK must be set when SB_L4_TLS_LISTEN is set (caddy-l4 needs a target for non-sandbox SNI)")
 	}
 
 	return cfg, nil

--- a/internal/service/events.go
+++ b/internal/service/events.go
@@ -136,8 +136,8 @@ func (s *Service) markSandboxStopped(ctx context.Context, sandbox *models.Sandbo
 		s.logger.Warn("delete sandbox route failed", "sandbox_id", sandbox.ID, "error", err)
 	}
 	for _, port := range sandbox.ExposedPorts {
-		if err := s.caddy.DeletePortRoute(ctx, sandbox.ID, port.Port); err != nil {
-			s.logger.Warn("delete port route failed", "sandbox_id", sandbox.ID, "port", port.Port, "error", err)
+		if err := s.deleteExposedPortRoute(ctx, sandbox, port); err != nil {
+			s.logger.Warn("delete port route failed", "sandbox_id", sandbox.ID, "port", port.Port, "protocol", port.Protocol, "error", err)
 		}
 	}
 	if previousIP != "" {
@@ -198,8 +198,8 @@ func (s *Service) handleStartEvent(ctx context.Context, sandbox *models.Sandbox)
 		return fmt.Errorf("upsert sandbox route: %w", err)
 	}
 	for _, port := range sandbox.ExposedPorts {
-		if err := s.caddy.UpsertPortRoute(ctx, sandbox.ID, sandbox.ContainerIP, port.Port); err != nil {
-			s.logger.Warn("upsert port route failed", "sandbox_id", sandbox.ID, "port", port.Port, "error", err)
+		if err := s.upsertExposedPortRoute(ctx, sandbox, port); err != nil {
+			s.logger.Warn("upsert port route failed", "sandbox_id", sandbox.ID, "port", port.Port, "protocol", port.Protocol, "error", err)
 		}
 	}
 	s.syncAllowedPorts(ctx, sandbox)

--- a/internal/service/gc_zombie_test.go
+++ b/internal/service/gc_zombie_test.go
@@ -1,0 +1,224 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/pkg/caddy"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// gcCaddyFake emulates the slice of the Caddy admin API that
+// gcZombieCaddyEntries actually exercises: GET /config/ for the snapshot
+// shape, DELETE /id/<routeID> for HTTP and TLS routes, and DELETE
+// /config/apps/layer4/servers/<serverID> for raw-TCP servers. The fake stores
+// state in plain maps so each test seeds a known starting world and asserts
+// what's left after Reconcile's GC pass.
+type gcCaddyFake struct {
+	mu             sync.Mutex
+	httpRouteIDs   map[string]struct{}
+	l4TCPServerIDs map[string]struct{}
+	l4TLSRouteIDs  map[string]struct{}
+}
+
+func newGCCaddyFake() *gcCaddyFake {
+	return &gcCaddyFake{
+		httpRouteIDs:   map[string]struct{}{},
+		l4TCPServerIDs: map[string]struct{}{},
+		l4TLSRouteIDs:  map[string]struct{}{},
+	}
+}
+
+func (f *gcCaddyFake) configBody() []byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	httpRoutes := make([]any, 0, len(f.httpRouteIDs))
+	for id := range f.httpRouteIDs {
+		httpRoutes = append(httpRoutes, map[string]any{"@id": id})
+	}
+	tlsRoutes := make([]any, 0, len(f.l4TLSRouteIDs))
+	for id := range f.l4TLSRouteIDs {
+		tlsRoutes = append(tlsRoutes, map[string]any{"@id": id})
+	}
+	servers := map[string]any{}
+	for sid := range f.l4TCPServerIDs {
+		servers[sid] = map[string]any{"listen": []string{":0"}, "routes": []any{}}
+	}
+	servers["tls-mux"] = map[string]any{
+		"listen": []string{":443"},
+		"routes": tlsRoutes,
+	}
+	cfg := map[string]any{"apps": map[string]any{
+		"http": map[string]any{
+			"servers": map[string]any{
+				"srv0": map[string]any{"routes": httpRoutes},
+			},
+		},
+		"layer4": map[string]any{"servers": servers},
+	}}
+	body, _ := json.Marshal(cfg)
+	return body
+}
+
+func (f *gcCaddyFake) handler(t *testing.T) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/config/":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(f.configBody())
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/id/"):
+			id := strings.TrimPrefix(r.URL.Path, "/id/")
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			if _, ok := f.httpRouteIDs[id]; ok {
+				delete(f.httpRouteIDs, id)
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			if _, ok := f.l4TLSRouteIDs[id]; ok {
+				delete(f.l4TLSRouteIDs, id)
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			http.Error(w, "not found", http.StatusNotFound)
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/config/apps/layer4/servers/"):
+			sid := strings.TrimPrefix(r.URL.Path, "/config/apps/layer4/servers/")
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			if _, ok := f.l4TCPServerIDs[sid]; !ok {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			delete(f.l4TCPServerIDs, sid)
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+}
+
+func (f *gcCaddyFake) keys(target map[string]struct{}) []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	keys := make([]string, 0, len(target))
+	for k := range target {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func TestGCZombieCaddyEntries(t *testing.T) {
+	fake := newGCCaddyFake()
+
+	// Live sandbox: HTTP toolbox route, one HTTP exposure on :3000, one TCP
+	// exposure on :5432 with host_port=37412, one TLS exposure on :6379.
+	// All four MUST survive the GC pass.
+	live := &models.Sandbox{
+		ID:     "abc",
+		Status: models.SandboxStatusStarted,
+		ExposedPorts: []models.ExposedPort{
+			{SandboxID: "abc", Port: 3000, Protocol: models.ExposedPortProtocolHTTP, CreatedAt: time.Now().UTC()},
+			{SandboxID: "abc", Port: 5432, Protocol: models.ExposedPortProtocolTCP, HostPort: 37412, CreatedAt: time.Now().UTC()},
+			{SandboxID: "abc", Port: 6379, Protocol: models.ExposedPortProtocolTLS, CreatedAt: time.Now().UTC()},
+		},
+	}
+	// Stopped sandbox: keep its toolbox @id in the expected set so the GC
+	// doesn't preemptively drop it (Start re-upserts on the way back up).
+	stopped := &models.Sandbox{ID: "stp", Status: models.SandboxStatusStopped}
+	// Destroyed sandboxes are excluded — anything in caddy bearing their
+	// @id is by definition zombie.
+	destroyed := &models.Sandbox{ID: "ded", Status: models.SandboxStatusDestroyed}
+
+	// Live entries that match the expected set.
+	fake.httpRouteIDs["sandbox-abc"] = struct{}{}
+	fake.httpRouteIDs["sandbox-abc-port-3000"] = struct{}{}
+	fake.httpRouteIDs["sandbox-stp"] = struct{}{}
+	fake.l4TCPServerIDs["tcp-port-37412"] = struct{}{}
+	fake.l4TLSRouteIDs["sandbox-abc-port-6379-tls"] = struct{}{}
+
+	// Zombies that must be deleted.
+	fake.httpRouteIDs["sandbox-ded"] = struct{}{}                       // destroyed sandbox
+	fake.httpRouteIDs["sandbox-ghost-port-8080"] = struct{}{}           // sandbox row no longer in DB
+	fake.l4TCPServerIDs["tcp-port-39999"] = struct{}{}                  // host port reservation lost
+	fake.l4TLSRouteIDs["sandbox-ded-port-6379-tls"] = struct{}{}        // destroyed sandbox's TLS route
+	fake.l4TLSRouteIDs["sandbox-ghost-port-1234-tls"] = struct{}{}      // unrelated TLS route
+
+	// Non-matching prefixes — must not be touched.
+	fake.httpRouteIDs["unrelated-route"] = struct{}{}                   // no "sandbox-" prefix
+	fake.l4TCPServerIDs["operator-managed-server"] = struct{}{}         // no "tcp-port-" prefix
+
+	server := httptest.NewServer(fake.handler(t))
+	t.Cleanup(server.Close)
+
+	caddyClient := caddy.New(config.Config{
+		CaddyAdminURL:     server.URL,
+		CaddyServerID:     "srv0",
+		EnableCaddy:       true,
+		HTTPClientTimeout: 5 * time.Second,
+	})
+
+	svc := &Service{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		caddy:  caddyClient,
+	}
+	svc.gcZombieCaddyEntries(context.Background(), []*models.Sandbox{live, stopped, destroyed})
+
+	wantHTTP := []string{"sandbox-abc", "sandbox-abc-port-3000", "sandbox-stp", "unrelated-route"}
+	if got := fake.keys(fake.httpRouteIDs); !equalSorted(got, wantHTTP) {
+		t.Fatalf("http routes after gc: got %v, want %v", got, wantHTTP)
+	}
+	wantTCP := []string{"operator-managed-server", "tcp-port-37412"}
+	if got := fake.keys(fake.l4TCPServerIDs); !equalSorted(got, wantTCP) {
+		t.Fatalf("tcp servers after gc: got %v, want %v", got, wantTCP)
+	}
+	wantTLS := []string{"sandbox-abc-port-6379-tls"}
+	if got := fake.keys(fake.l4TLSRouteIDs); !equalSorted(got, wantTLS) {
+		t.Fatalf("tls routes after gc: got %v, want %v", got, wantTLS)
+	}
+}
+
+func TestGCZombieCaddyEntriesNoOpWhenCaddyDisabled(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	caddyClient := caddy.New(config.Config{
+		CaddyAdminURL:     server.URL,
+		EnableCaddy:       false,
+		HTTPClientTimeout: time.Second,
+	})
+	svc := &Service{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		caddy:  caddyClient,
+	}
+	svc.gcZombieCaddyEntries(context.Background(), nil)
+	if called {
+		t.Fatalf("disabled caddy should never reach the admin API")
+	}
+}
+
+func equalSorted(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/service/layer4_bootstrap_test.go
+++ b/internal/service/layer4_bootstrap_test.go
@@ -1,0 +1,118 @@
+package service
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/pkg/caddy"
+)
+
+// TestEnsureLayer4ReadyRetriesAfterBootFailure exercises the lazy bootstrap
+// guarantee: a failing boot-time call must NOT permanently disable L4
+// exposures. The first call fails (caddy unreachable), the second succeeds,
+// and steady-state calls go through the atomic fast path without hitting
+// caddy.
+func TestEnsureLayer4ReadyRetriesAfterBootFailure(t *testing.T) {
+	var (
+		failNext atomic.Bool
+		hits     atomic.Int32
+	)
+	failNext.Store(true)
+
+	mux := http.NewServeMux()
+	// pathExists probe + (when missing) the PUT to create the layer4 app.
+	mux.HandleFunc("/config/apps/layer4", func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		if failNext.Load() {
+			http.Error(w, "boot race: caddy not ready", http.StatusServiceUnavailable)
+			return
+		}
+		switch r.Method {
+		case http.MethodGet:
+			// Simulate a fresh caddy with no layer4 yet so EnsureLayer4 issues
+			// the follow-up PUT below.
+			http.Error(w, "not found", http.StatusNotFound)
+		case http.MethodPut:
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Fatalf("unexpected method %s on %s", r.Method, r.URL.Path)
+		}
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	caddyClient := caddy.New(config.Config{
+		CaddyAdminURL:     server.URL,
+		EnableCaddy:       true,
+		HTTPClientTimeout: 2 * time.Second,
+	})
+	svc := &Service{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		caddy:  caddyClient,
+	}
+
+	ctx := context.Background()
+	if err := svc.EnsureLayer4Ready(ctx); err == nil {
+		t.Fatal("first EnsureLayer4Ready should have failed (caddy unavailable)")
+	}
+	if svc.l4Ready.Load() {
+		t.Fatal("ready latch must stay false after a failed bootstrap")
+	}
+
+	// Caddy comes up — the next call must succeed and latch.
+	failNext.Store(false)
+	if err := svc.EnsureLayer4Ready(ctx); err != nil {
+		t.Fatalf("retry after caddy recovered: %v", err)
+	}
+	if !svc.l4Ready.Load() {
+		t.Fatal("ready latch must be true after successful bootstrap")
+	}
+
+	hitsAfterReady := hits.Load()
+	for i := 0; i < 5; i++ {
+		if err := svc.EnsureLayer4Ready(ctx); err != nil {
+			t.Fatalf("steady-state call %d: %v", i, err)
+		}
+	}
+	if got := hits.Load(); got != hitsAfterReady {
+		t.Fatalf("steady-state calls hit caddy %d extra times; expected fast-path skip", got-hitsAfterReady)
+	}
+}
+
+// TestEnsureLayer4ReadyDisabledCaddyLatchesImmediately verifies that an
+// operator who runs sandboxd without caddy doesn't pay the bootstrap cost
+// per L4 expose. caddy.Client short-circuits when disabled, returning nil.
+func TestEnsureLayer4ReadyDisabledCaddyLatchesImmediately(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	caddyClient := caddy.New(config.Config{
+		CaddyAdminURL:     server.URL,
+		EnableCaddy:       false,
+		HTTPClientTimeout: time.Second,
+	})
+	svc := &Service{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		caddy:  caddyClient,
+	}
+	if err := svc.EnsureLayer4Ready(context.Background()); err != nil {
+		t.Fatalf("EnsureLayer4Ready with disabled caddy: %v", err)
+	}
+	if called {
+		t.Fatal("disabled caddy must not contact admin API at all")
+	}
+	if !svc.l4Ready.Load() {
+		t.Fatal("disabled caddy still latches ready (no work to redo)")
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -640,7 +640,7 @@ func (s *Service) EnsureLayer4Ready(ctx context.Context) error {
 	if s.l4Ready.Load() {
 		return nil
 	}
-	if err := s.caddy.EnsureLayer4(ctx, s.cfg.L4TLSListen); err != nil {
+	if err := s.caddy.EnsureLayer4(ctx, s.cfg.L4TLSListen, s.cfg.L4TLSFallback); err != nil {
 		return fmt.Errorf("bootstrap caddy layer4: %w", err)
 	}
 	s.l4Ready.Store(true)

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -925,6 +925,14 @@ func (s *Service) Reconcile(ctx context.Context) error {
 		_ = s.mounts.UnmountAll(sandboxID)
 	}
 
+	// Zombie caddy entry sweep. The destroyed-sandbox loop above already
+	// drops routes for sandboxes that exist in the DB but lost their
+	// container — this catches the orthogonal case where caddy holds an
+	// entry for a sandbox row that was purged out (DB wipe, destroyed-row
+	// TTL pass, manual surgery) and no destroy ran. Without this, caddy
+	// accumulates dead routes forever.
+	s.gcZombieCaddyEntries(ctx, known)
+
 	// Stale-mount sweep. Anything under /var/lib/sandboxd/mounts/ that
 	// doesn't correspond to a sandbox we're going to keep is a leftover
 	// from a crashed create or a previous orphan removal. Kill any FUSE
@@ -1066,6 +1074,88 @@ func lifecycleActionFor(sb *models.Sandbox, now time.Time, globalIdle time.Durat
 		return lifecycleStop
 	}
 	return lifecycleNone
+}
+
+// gcZombieCaddyEntries deletes caddy routes/servers whose @id (or layer4
+// server name) follows our convention but doesn't correspond to any live
+// sandbox row. The DB is the source of truth; anything in caddy that doesn't
+// trace back to a non-destroyed sandbox is a leak from one of:
+//   - a sandbox row that was purged (DestroyedRowTTL).
+//   - a development DB wipe leaving caddy with stale state.
+//   - an out-of-band caddy admin call from a previous version of this code.
+//
+// Best-effort: every cleanup runs through a non-fatal path so a single
+// failing DELETE doesn't abort the rest of the sweep. The legitimate-set
+// computation excludes destroyed sandboxes — by the time this runs, the
+// destroyed-loop earlier in Reconcile has already cleaned their routes.
+func (s *Service) gcZombieCaddyEntries(ctx context.Context, sandboxes []*models.Sandbox) {
+	if !s.caddy.Enabled() {
+		return
+	}
+	snap, err := s.caddy.Snapshot(ctx)
+	if err != nil {
+		s.logger.Warn("caddy snapshot for zombie gc failed", "error", err)
+		return
+	}
+
+	expectedHTTP := make(map[string]struct{})
+	expectedTCPServers := make(map[string]struct{})
+	expectedTLSRoutes := make(map[string]struct{})
+
+	for _, sb := range sandboxes {
+		if sb == nil || sb.Status == models.SandboxStatusDestroyed {
+			continue
+		}
+		// The toolbox route lives at @id "sandbox-<id>"; per-port HTTP routes
+		// at "sandbox-<id>-port-<p>". Keep both unconditionally — the rest
+		// of Reconcile guarantees they're upserted for running sandboxes,
+		// but stopped sandboxes intentionally lack routes and should still
+		// not be GC'd here (they'll be rebuilt on Start).
+		expectedHTTP["sandbox-"+sb.ID] = struct{}{}
+		for _, p := range sb.ExposedPorts {
+			switch p.Protocol {
+			case "", models.ExposedPortProtocolHTTP:
+				expectedHTTP[fmt.Sprintf("sandbox-%s-port-%d", sb.ID, p.Port)] = struct{}{}
+			case models.ExposedPortProtocolTCP:
+				if p.HostPort > 0 {
+					expectedTCPServers[fmt.Sprintf("tcp-port-%d", p.HostPort)] = struct{}{}
+				}
+			case models.ExposedPortProtocolTLS:
+				expectedTLSRoutes[fmt.Sprintf("sandbox-%s-port-%d-tls", sb.ID, p.Port)] = struct{}{}
+			}
+		}
+	}
+
+	for _, id := range snap.HTTPRouteIDs {
+		if _, ok := expectedHTTP[id]; ok {
+			continue
+		}
+		if err := s.caddy.DeleteRouteByID(ctx, id); err != nil {
+			s.logger.Warn("zombie http route delete failed", "route_id", id, "error", err)
+			continue
+		}
+		s.logger.Info("audit zombie http route removed", "route_id", id)
+	}
+	for _, sid := range snap.L4TCPServerIDs {
+		if _, ok := expectedTCPServers[sid]; ok {
+			continue
+		}
+		if err := s.caddy.DeleteTCPServer(ctx, sid); err != nil {
+			s.logger.Warn("zombie tcp server delete failed", "server_id", sid, "error", err)
+			continue
+		}
+		s.logger.Info("audit zombie tcp server removed", "server_id", sid)
+	}
+	for _, id := range snap.L4TLSRouteIDs {
+		if _, ok := expectedTLSRoutes[id]; ok {
+			continue
+		}
+		if err := s.caddy.DeleteRouteByID(ctx, id); err != nil {
+			s.logger.Warn("zombie tls route delete failed", "route_id", id, "error", err)
+			continue
+		}
+		s.logger.Info("audit zombie tls route removed", "route_id", id)
+	}
 }
 
 func (s *Service) StartReconcileLoop(ctx context.Context) {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -13,6 +13,8 @@ import (
 	mathrand "math/rand"
 	"net"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/aerol-ai/microvm/internal/config"
@@ -51,6 +53,13 @@ type Service struct {
 	cipher   *secrets.Cipher
 	mounts   *mounts.Manager
 	admitter *capacity.Admitter
+	// l4Ready latches true once caddy.EnsureLayer4 has succeeded — either at
+	// boot or lazily on the first TCP/TLS expose call. Boot bootstrap is
+	// best-effort (caddy may not be reachable yet on a cold start), so the
+	// expose path retries under l4Mu when the latch is still false. atomic
+	// load gives a lock-free fast path on the steady-state hot path.
+	l4Mu    sync.Mutex
+	l4Ready atomic.Bool
 }
 
 func New(cfg config.Config, logger *slog.Logger, db *store.Store, runtimeDriver runtime.Runtime, eventsClient *docker.Client, caddyClient *caddy.Client, cipher *secrets.Cipher, mountManager *mounts.Manager, admitter *capacity.Admitter) *Service {
@@ -543,6 +552,12 @@ func (s *Service) ExposePort(ctx context.Context, id string, port int, protocol 
 		return publicURL, nil
 
 	case models.ExposedPortProtocolTCP:
+		// Lazy bootstrap: boot's EnsureLayer4 is best-effort, so retry here
+		// in case caddy was not reachable at start-up. Idempotent and cheap
+		// after the first success (atomic load).
+		if err := s.EnsureLayer4Ready(ctx); err != nil {
+			return "", err
+		}
 		// Fast-path idempotency: a re-expose for an already-TCP port reuses
 		// the existing host_port reservation. Without this, the allocator
 		// would loop on PK collisions in TryReserveHostPort and exhaust the
@@ -583,6 +598,12 @@ func (s *Service) ExposePort(ctx context.Context, id string, port int, protocol 
 		if s.caddy.L4TLSListen() == "" {
 			return "", errors.New("TLS-SNI exposure requires SB_L4_TLS_LISTEN to be set")
 		}
+		// Lazy bootstrap: retry here so a failed boot doesn't break the
+		// first TLS-SNI exposure. The shared SNI mux server lives inside
+		// the layer4 app, so this is the gate before any UpsertTLSSNIRoute.
+		if err := s.EnsureLayer4Ready(ctx); err != nil {
+			return "", err
+		}
 		publicURL := s.caddy.TLSPublicEndpoint(id, port, s.caddy.L4TLSListen())
 		if err := s.caddy.UpsertTLSSNIRoute(ctx, id, sniHost, sandbox.ContainerIP, port); err != nil {
 			return "", err
@@ -602,6 +623,28 @@ func (s *Service) ExposePort(ctx context.Context, id string, port int, protocol 
 		return publicURL, nil
 	}
 	return "", fmt.Errorf("unhandled protocol %q", canonicalProto)
+}
+
+// EnsureLayer4Ready bootstraps the caddy-l4 app under a single-flight
+// mutex and latches success. Safe to call from boot AND from each L4
+// exposure path: the atomic fast-path turns it into a single load on the
+// steady state, and a failed boot is recovered by the very next TCP/TLS
+// expose call instead of surfacing as a confusing "layer4 app missing"
+// error from caddy.
+func (s *Service) EnsureLayer4Ready(ctx context.Context) error {
+	if s.l4Ready.Load() {
+		return nil
+	}
+	s.l4Mu.Lock()
+	defer s.l4Mu.Unlock()
+	if s.l4Ready.Load() {
+		return nil
+	}
+	if err := s.caddy.EnsureLayer4(ctx, s.cfg.L4TLSListen); err != nil {
+		return fmt.Errorf("bootstrap caddy layer4: %w", err)
+	}
+	s.l4Ready.Store(true)
+	return nil
 }
 
 // allocateHostPort reserves a parent-host port for a raw-TCP exposure. The

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	mathrand "math/rand"
 	"net"
 	"strings"
 	"time"
@@ -26,6 +27,12 @@ import (
 	"github.com/aerol-ai/microvm/pkg/secrets"
 	"golang.org/x/crypto/ssh"
 )
+
+// allocatorRandomAttempts caps the random-first phase of host-port allocation.
+// With a 10k-port pool and a few hundred allocations live, collisions are
+// rare; the linear-scan fallback only runs when the pool is genuinely
+// near-full, so this keeps p95 low without spinning forever in tight pools.
+const allocatorRandomAttempts = 16
 
 type Service struct {
 	cfg    config.Config
@@ -353,7 +360,7 @@ func (s *Service) StartSandbox(ctx context.Context, id string) (*models.Sandbox,
 		return nil, err
 	}
 	for _, port := range sandbox.ExposedPorts {
-		if err := s.caddy.UpsertPortRoute(ctx, sandbox.ID, sandbox.ContainerIP, port.Port); err != nil {
+		if err := s.upsertExposedPortRoute(ctx, sandbox, port); err != nil {
 			return nil, err
 		}
 	}
@@ -384,8 +391,8 @@ func (s *Service) StopSandbox(ctx context.Context, id string) (*models.Sandbox, 
 	// fallback "sandbox not found" handler instead of a 502 from a stale
 	// upstream IP. StartSandbox re-upserts every route on the way back up.
 	for _, port := range sandbox.ExposedPorts {
-		if err := s.caddy.DeletePortRoute(ctx, sandbox.ID, port.Port); err != nil {
-			s.logger.Warn("caddy port route cleanup on stop failed", "sandbox_id", id, "port", port.Port, "error", err)
+		if err := s.deleteExposedPortRoute(ctx, sandbox, port); err != nil {
+			s.logger.Warn("caddy port route cleanup on stop failed", "sandbox_id", id, "port", port.Port, "protocol", port.Protocol, "error", err)
 		}
 	}
 	if err := s.caddy.DeleteSandboxRoute(ctx, sandbox.ID); err != nil {
@@ -405,7 +412,7 @@ func (s *Service) DestroySandbox(ctx context.Context, id string) error {
 		return err
 	}
 	for _, port := range sandbox.ExposedPorts {
-		_ = s.caddy.DeletePortRoute(ctx, sandbox.ID, port.Port)
+		_ = s.deleteExposedPortRoute(ctx, sandbox, port)
 	}
 	_ = s.caddy.DeleteSandboxRoute(ctx, sandbox.ID)
 	if err := s.docker.Destroy(ctx, sandbox); err != nil {
@@ -490,7 +497,18 @@ func (s *Service) UpdateLifecycle(ctx context.Context, id string, l models.Lifec
 	return s.store.Get(ctx, id)
 }
 
-func (s *Service) ExposePort(ctx context.Context, id string, port int) (string, error) {
+// ExposePort publishes a sandbox container port through one of three caddy
+// surfaces, selected by protocol:
+//   - "" / "http": existing Caddy HTTP reverse-proxy route, returns
+//     https://<id>-<port>.<domain> (or the path-mode equivalent).
+//   - "tcp": allocates a parent-host TCP port from the [SB_L4_PORT_RANGE_START,
+//     SB_L4_PORT_RANGE_END] pool, points caddy-l4 at it, and returns
+//     tcp://<public-host>:<host-port>. This is what unblocks native Postgres /
+//     Redis / MySQL DSNs in the spawn-postgres docs.
+//   - "tls": adds a TLS-SNI route to the shared layer4 server. Requires
+//     --domain (so the SNI hostname has a place to resolve) and a non-empty
+//     SB_L4_TLS_LISTEN. Returns tls://<id>-<port>.<domain>:<l4-port>.
+func (s *Service) ExposePort(ctx context.Context, id string, port int, protocol string) (string, error) {
 	sandbox, err := s.store.Get(ctx, id)
 	if err != nil {
 		return "", err
@@ -498,39 +516,191 @@ func (s *Service) ExposePort(ctx context.Context, id string, port int) (string, 
 	if port <= 0 || port > 65535 {
 		return "", errors.New("invalid port")
 	}
-
-	publicURL := s.caddy.PortPublicURL(id, port)
-	if err := s.caddy.UpsertPortRoute(ctx, id, sandbox.ContainerIP, port); err != nil {
+	canonicalProto, err := models.ValidExposedPortProtocol(protocol)
+	if err != nil {
 		return "", err
 	}
 
-	exposure := models.ExposedPort{
-		SandboxID: id,
-		Port:      port,
-		PublicURL: publicURL,
-		CreatedAt: time.Now().UTC(),
+	now := time.Now().UTC()
+	switch canonicalProto {
+	case models.ExposedPortProtocolHTTP:
+		publicURL := s.caddy.PortPublicURL(id, port)
+		if err := s.caddy.UpsertPortRoute(ctx, id, sandbox.ContainerIP, port); err != nil {
+			return "", err
+		}
+		exposure := models.ExposedPort{
+			SandboxID: id,
+			Port:      port,
+			Protocol:  canonicalProto,
+			PublicURL: publicURL,
+			CreatedAt: now,
+		}
+		if err := s.store.UpsertPort(ctx, exposure); err != nil {
+			_ = s.caddy.DeletePortRoute(ctx, id, port)
+			return "", err
+		}
+		s.touchAllowedPorts(ctx, id)
+		return publicURL, nil
+
+	case models.ExposedPortProtocolTCP:
+		hostPort, publicURL, err := s.allocateHostPort(ctx, id, port, now)
+		if err != nil {
+			return "", err
+		}
+		if err := s.caddy.UpsertTCPRoute(ctx, id, sandbox.ContainerIP, port, hostPort); err != nil {
+			// The reservation row exists from the allocator; clean it up so
+			// the host port returns to the pool.
+			_ = s.store.DeletePort(ctx, id, port)
+			return "", err
+		}
+		s.touchAllowedPorts(ctx, id)
+		return publicURL, nil
+
+	case models.ExposedPortProtocolTLS:
+		sniHost := s.caddy.SNIHost(id, port)
+		if sniHost == "" {
+			return "", errors.New("TLS-SNI exposure requires --domain to be configured")
+		}
+		if s.caddy.L4TLSListen() == "" {
+			return "", errors.New("TLS-SNI exposure requires SB_L4_TLS_LISTEN to be set")
+		}
+		publicURL := s.caddy.TLSPublicEndpoint(id, port, s.caddy.L4TLSListen())
+		if err := s.caddy.UpsertTLSSNIRoute(ctx, id, sniHost, sandbox.ContainerIP, port); err != nil {
+			return "", err
+		}
+		exposure := models.ExposedPort{
+			SandboxID: id,
+			Port:      port,
+			Protocol:  canonicalProto,
+			PublicURL: publicURL,
+			CreatedAt: now,
+		}
+		if err := s.store.UpsertPort(ctx, exposure); err != nil {
+			_ = s.caddy.DeleteTLSSNIRoute(ctx, id, port)
+			return "", err
+		}
+		s.touchAllowedPorts(ctx, id)
+		return publicURL, nil
 	}
-	if err := s.store.UpsertPort(ctx, exposure); err != nil {
-		return "", err
+	return "", fmt.Errorf("unhandled protocol %q", canonicalProto)
+}
+
+// allocateHostPort reserves a parent-host port for a raw-TCP exposure. The
+// random-first phase tries up to allocatorRandomAttempts candidates from the
+// configured pool — each attempt is one INSERT OR IGNORE protected by the
+// partial unique index on host_port, so concurrent allocators serialize at
+// the DB without a process-level lock. When randoms collide enough times we
+// fall back to a deterministic linear scan, which is the p99 path that
+// guarantees we exhaust the pool before giving up.
+func (s *Service) allocateHostPort(ctx context.Context, sandboxID string, containerPort int, now time.Time) (int, string, error) {
+	if s.cfg.L4PortRangeEnd <= s.cfg.L4PortRangeStart {
+		return 0, "", errors.New("L4 port pool is misconfigured")
+	}
+	span := s.cfg.L4PortRangeEnd - s.cfg.L4PortRangeStart + 1
+
+	for i := 0; i < allocatorRandomAttempts; i++ {
+		candidate := s.cfg.L4PortRangeStart + mathrand.Intn(span)
+		publicURL := s.caddy.TCPPublicEndpoint(candidate)
+		ok, err := s.store.TryReserveHostPort(ctx, sandboxID, containerPort, candidate, models.ExposedPortProtocolTCP, publicURL, now)
+		if err != nil {
+			return 0, "", err
+		}
+		if ok {
+			return candidate, publicURL, nil
+		}
 	}
 
-	if updated, err := s.store.Get(ctx, id); err == nil {
-		s.syncAllowedPorts(ctx, updated)
+	for candidate := s.cfg.L4PortRangeStart; candidate <= s.cfg.L4PortRangeEnd; candidate++ {
+		publicURL := s.caddy.TCPPublicEndpoint(candidate)
+		ok, err := s.store.TryReserveHostPort(ctx, sandboxID, containerPort, candidate, models.ExposedPortProtocolTCP, publicURL, now)
+		if err != nil {
+			return 0, "", err
+		}
+		if ok {
+			return candidate, publicURL, nil
+		}
 	}
-	return publicURL, nil
+	return 0, "", errors.New("L4 port pool exhausted")
 }
 
 func (s *Service) UnexposePort(ctx context.Context, id string, port int) error {
-	if err := s.caddy.DeletePortRoute(ctx, id, port); err != nil {
+	sandbox, err := s.store.Get(ctx, id)
+	if err != nil {
 		return err
+	}
+	exposure := findExposure(sandbox, port)
+	// Best-effort tear-down of every caddy surface the exposure could be on.
+	// We dispatch on the recorded protocol when it's known, but also fall
+	// back to the legacy HTTP path so old rows that pre-date the protocol
+	// column are still cleaned up correctly.
+	if exposure == nil {
+		_ = s.caddy.DeletePortRoute(ctx, id, port)
+	} else {
+		if err := s.deleteExposedPortRoute(ctx, sandbox, *exposure); err != nil {
+			return err
+		}
 	}
 	if err := s.store.DeletePort(ctx, id, port); err != nil {
 		return err
 	}
+	s.touchAllowedPorts(ctx, id)
+	return nil
+}
+
+// findExposure returns the exposure matching port, or nil. Linear scan is
+// fine because ExposedPorts is bounded by the host port pool size and in
+// practice rarely exceeds a handful per sandbox.
+func findExposure(sandbox *models.Sandbox, port int) *models.ExposedPort {
+	if sandbox == nil {
+		return nil
+	}
+	for i := range sandbox.ExposedPorts {
+		if sandbox.ExposedPorts[i].Port == port {
+			return &sandbox.ExposedPorts[i]
+		}
+	}
+	return nil
+}
+
+// upsertExposedPortRoute republishes one exposure to caddy based on its
+// stored protocol. Used everywhere a sandbox transitions to running
+// (StartSandbox, Reconcile when a container is back, docker start events).
+func (s *Service) upsertExposedPortRoute(ctx context.Context, sandbox *models.Sandbox, port models.ExposedPort) error {
+	switch port.Protocol {
+	case "", models.ExposedPortProtocolHTTP:
+		return s.caddy.UpsertPortRoute(ctx, sandbox.ID, sandbox.ContainerIP, port.Port)
+	case models.ExposedPortProtocolTCP:
+		return s.caddy.UpsertTCPRoute(ctx, sandbox.ID, sandbox.ContainerIP, port.Port, port.HostPort)
+	case models.ExposedPortProtocolTLS:
+		return s.caddy.UpsertTLSSNIRoute(ctx, sandbox.ID, s.caddy.SNIHost(sandbox.ID, port.Port), sandbox.ContainerIP, port.Port)
+	default:
+		return fmt.Errorf("unknown protocol %q on exposed port %d", port.Protocol, port.Port)
+	}
+}
+
+// deleteExposedPortRoute drops one exposure's caddy entity. Used everywhere
+// a sandbox transitions out of running (StopSandbox, DestroySandbox, exit
+// events, reconcile destroyed pass).
+func (s *Service) deleteExposedPortRoute(ctx context.Context, sandbox *models.Sandbox, port models.ExposedPort) error {
+	switch port.Protocol {
+	case "", models.ExposedPortProtocolHTTP:
+		return s.caddy.DeletePortRoute(ctx, sandbox.ID, port.Port)
+	case models.ExposedPortProtocolTCP:
+		return s.caddy.DeleteTCPRoute(ctx, port.HostPort)
+	case models.ExposedPortProtocolTLS:
+		return s.caddy.DeleteTLSSNIRoute(ctx, sandbox.ID, port.Port)
+	default:
+		return fmt.Errorf("unknown protocol %q on exposed port %d", port.Protocol, port.Port)
+	}
+}
+
+// touchAllowedPorts is a small wrapper that refreshes the toolbox's allowlist
+// after a port-table mutation. The store round-trip pulls the fresh ExposedPorts
+// so syncAllowedPorts sees post-write state.
+func (s *Service) touchAllowedPorts(ctx context.Context, id string) {
 	if updated, err := s.store.Get(ctx, id); err == nil {
 		s.syncAllowedPorts(ctx, updated)
 	}
-	return nil
 }
 
 type ToolboxEndpoint struct {
@@ -684,7 +854,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			}
 			_ = s.caddy.DeleteSandboxRoute(ctx, sandbox.ID)
 			for _, port := range sandbox.ExposedPorts {
-				_ = s.caddy.DeletePortRoute(ctx, sandbox.ID, port.Port)
+				_ = s.deleteExposedPortRoute(ctx, sandbox, port)
 			}
 			_ = s.mounts.UnmountAll(sandbox.ID)
 			// Only GC and release admitter capacity on the transition into
@@ -713,7 +883,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 				return err
 			}
 			for _, port := range sandbox.ExposedPorts {
-				if err := s.caddy.UpsertPortRoute(ctx, sandbox.ID, sandbox.ContainerIP, port.Port); err != nil {
+				if err := s.upsertExposedPortRoute(ctx, sandbox, port); err != nil {
 					return err
 				}
 			}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -543,14 +543,33 @@ func (s *Service) ExposePort(ctx context.Context, id string, port int, protocol 
 		return publicURL, nil
 
 	case models.ExposedPortProtocolTCP:
-		hostPort, publicURL, err := s.allocateHostPort(ctx, id, port, now)
+		// Fast-path idempotency: a re-expose for an already-TCP port reuses
+		// the existing host_port reservation. Without this, the allocator
+		// would loop on PK collisions in TryReserveHostPort and exhaust the
+		// pool. A different protocol on the same (id, port) is rejected
+		// outright — the caller must unexpose first to switch protocols.
+		if existing := findExposure(sandbox, port); existing != nil {
+			if existing.Protocol != models.ExposedPortProtocolTCP {
+				return "", fmt.Errorf("port %d already exposed as %s; unexpose it first", port, existing.Protocol)
+			}
+			if existing.HostPort > 0 {
+				if err := s.caddy.UpsertTCPRoute(ctx, id, sandbox.ContainerIP, port, existing.HostPort); err != nil {
+					return "", err
+				}
+				s.touchAllowedPorts(ctx, id)
+				return existing.PublicURL, nil
+			}
+		}
+		hostPort, publicURL, reused, err := s.allocateHostPort(ctx, id, port, now)
 		if err != nil {
 			return "", err
 		}
 		if err := s.caddy.UpsertTCPRoute(ctx, id, sandbox.ContainerIP, port, hostPort); err != nil {
-			// The reservation row exists from the allocator; clean it up so
-			// the host port returns to the pool.
-			_ = s.store.DeletePort(ctx, id, port)
+			// Only roll back rows we ourselves inserted. A reused row was
+			// installed by a concurrent caller and is not ours to delete.
+			if !reused {
+				_ = s.store.DeletePort(ctx, id, port)
+			}
 			return "", err
 		}
 		s.touchAllowedPorts(ctx, id)
@@ -592,35 +611,61 @@ func (s *Service) ExposePort(ctx context.Context, id string, port int, protocol 
 // the DB without a process-level lock. When randoms collide enough times we
 // fall back to a deterministic linear scan, which is the p99 path that
 // guarantees we exhaust the pool before giving up.
-func (s *Service) allocateHostPort(ctx context.Context, sandboxID string, containerPort int, now time.Time) (int, string, error) {
+//
+// Returns reused=true when a concurrent caller installed the (sandbox_id,
+// port) row first; the returned host_port and public URL come from that
+// existing row. The flag lets the caller skip rollback on caddy failures so
+// it doesn't delete a row it didn't create.
+func (s *Service) allocateHostPort(ctx context.Context, sandboxID string, containerPort int, now time.Time) (hostPort int, publicURL string, reused bool, err error) {
 	if s.cfg.L4PortRangeEnd <= s.cfg.L4PortRangeStart {
-		return 0, "", errors.New("L4 port pool is misconfigured")
+		return 0, "", false, errors.New("L4 port pool is misconfigured")
 	}
 	span := s.cfg.L4PortRangeEnd - s.cfg.L4PortRangeStart + 1
 
+	tryCandidate := func(candidate int) (int, string, bool, bool, error) {
+		candidateURL := s.caddy.TCPPublicEndpoint(candidate)
+		result, err := s.store.TryReserveHostPort(ctx, sandboxID, containerPort, candidate, models.ExposedPortProtocolTCP, candidateURL, now)
+		if err != nil {
+			return 0, "", false, false, err
+		}
+		if result.Reserved {
+			return candidate, candidateURL, false, true, nil
+		}
+		if result.Existing != nil {
+			// Race: a concurrent ExposePort installed the row first. Reuse
+			// when protocols match; otherwise refuse (avoids the pool walk
+			// AND prevents silently leaking the prior route).
+			if result.Existing.Protocol != models.ExposedPortProtocolTCP {
+				return 0, "", false, false, fmt.Errorf("port %d already exposed as %s; unexpose it first", containerPort, result.Existing.Protocol)
+			}
+			if result.Existing.HostPort > 0 {
+				return result.Existing.HostPort, result.Existing.PublicURL, true, true, nil
+			}
+		}
+		return 0, "", false, false, nil
+	}
+
 	for i := 0; i < allocatorRandomAttempts; i++ {
 		candidate := s.cfg.L4PortRangeStart + mathrand.Intn(span)
-		publicURL := s.caddy.TCPPublicEndpoint(candidate)
-		ok, err := s.store.TryReserveHostPort(ctx, sandboxID, containerPort, candidate, models.ExposedPortProtocolTCP, publicURL, now)
-		if err != nil {
-			return 0, "", err
+		hp, url, r, done, terr := tryCandidate(candidate)
+		if terr != nil {
+			return 0, "", false, terr
 		}
-		if ok {
-			return candidate, publicURL, nil
+		if done {
+			return hp, url, r, nil
 		}
 	}
 
 	for candidate := s.cfg.L4PortRangeStart; candidate <= s.cfg.L4PortRangeEnd; candidate++ {
-		publicURL := s.caddy.TCPPublicEndpoint(candidate)
-		ok, err := s.store.TryReserveHostPort(ctx, sandboxID, containerPort, candidate, models.ExposedPortProtocolTCP, publicURL, now)
-		if err != nil {
-			return 0, "", err
+		hp, url, r, done, terr := tryCandidate(candidate)
+		if terr != nil {
+			return 0, "", false, terr
 		}
-		if ok {
-			return candidate, publicURL, nil
+		if done {
+			return hp, url, r, nil
 		}
 	}
-	return 0, "", errors.New("L4 port pool exhausted")
+	return 0, "", false, errors.New("L4 port pool exhausted")
 }
 
 func (s *Service) UnexposePort(ctx context.Context, id string, port int) error {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -112,12 +112,30 @@ func Open(path string) (*Store, error) {
 		// GPU configuration as a JSON blob. Empty string means no GPU was
 		// requested. Stored as JSON to avoid schema churn as GPU options grow.
 		`ALTER TABLE sandboxes ADD COLUMN gpus_json TEXT NOT NULL DEFAULT '';`,
+		// Protocol of an exposed port: "http" (Caddy HTTP reverse proxy,
+		// historical behavior), "tcp" (caddy-l4 listener at host_port), or
+		// "tls" (caddy-l4 SNI route on the shared TLS listener).
+		`ALTER TABLE exposed_ports ADD COLUMN protocol TEXT NOT NULL DEFAULT 'http';`,
+		// Parent-host TCP port reserved for protocol="tcp" exposures from the
+		// configured pool. Zero for http/tls. The partial unique index below
+		// rejects two reservations on the same host_port without preventing
+		// many rows at the default 0.
+		`ALTER TABLE exposed_ports ADD COLUMN host_port INTEGER NOT NULL DEFAULT 0;`,
 	}
 	for _, stmt := range migrations {
 		if _, err := db.Exec(stmt); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
 			db.Close()
 			return nil, fmt.Errorf("run migration: %w", err)
 		}
+	}
+
+	// Partial unique index on host_port (only enforced when host_port > 0).
+	// This is the load-bearing primitive of the random-first allocator: two
+	// concurrent ExposePort calls race to INSERT a host_port row, and only
+	// one wins per port. SQLite's single writer keeps the contest serialized.
+	if _, err := db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_exposed_ports_host_port ON exposed_ports(host_port) WHERE host_port > 0;`); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("create exposed_ports host_port index: %w", err)
 	}
 
 	return &Store{db: db}, nil
@@ -361,7 +379,7 @@ func (s *Store) List(ctx context.Context) ([]*models.Sandbox, error) {
 // batches; the in-memory join below stays the same shape.
 func (s *Store) attachPortsBulk(ctx context.Context, byID map[string]*models.Sandbox) error {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT sandbox_id, port, public_url, created_at
+		SELECT sandbox_id, port, protocol, host_port, public_url, created_at
 		FROM exposed_ports
 		ORDER BY sandbox_id, port ASC
 	`)
@@ -372,7 +390,7 @@ func (s *Store) attachPortsBulk(ctx context.Context, byID map[string]*models.San
 
 	for rows.Next() {
 		var exposure models.ExposedPort
-		if err := rows.Scan(&exposure.SandboxID, &exposure.Port, &exposure.PublicURL, &exposure.CreatedAt); err != nil {
+		if err := rows.Scan(&exposure.SandboxID, &exposure.Port, &exposure.Protocol, &exposure.HostPort, &exposure.PublicURL, &exposure.CreatedAt); err != nil {
 			return fmt.Errorf("scan exposed port: %w", err)
 		}
 		if sb, ok := byID[exposure.SandboxID]; ok {
@@ -525,17 +543,80 @@ func (s *Store) Touch(ctx context.Context, id string, at time.Time) error {
 }
 
 func (s *Store) UpsertPort(ctx context.Context, exposure models.ExposedPort) error {
+	if exposure.Protocol == "" {
+		exposure.Protocol = models.ExposedPortProtocolHTTP
+	}
 	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO exposed_ports (sandbox_id, port, public_url, created_at)
-		VALUES (?, ?, ?, ?)
+		INSERT INTO exposed_ports (sandbox_id, port, protocol, host_port, public_url, created_at)
+		VALUES (?, ?, ?, ?, ?, ?)
 		ON CONFLICT(sandbox_id, port) DO UPDATE SET
+			protocol = excluded.protocol,
+			host_port = excluded.host_port,
 			public_url = excluded.public_url,
 			created_at = excluded.created_at
-	`, exposure.SandboxID, exposure.Port, exposure.PublicURL, exposure.CreatedAt.UTC())
+	`, exposure.SandboxID, exposure.Port, exposure.Protocol, exposure.HostPort, exposure.PublicURL, exposure.CreatedAt.UTC())
 	if err != nil {
 		return fmt.Errorf("upsert exposed port: %w", err)
 	}
 	return nil
+}
+
+// TryReserveHostPort attempts to claim hostPort for (sandboxID, containerPort)
+// in a single statement. Returns (true, nil) when the row was inserted, or
+// (false, nil) when the partial unique index on host_port rejected the
+// candidate (port already taken). Any other error propagates. This is the
+// load-bearing primitive of the random-first allocator: callers loop with
+// fresh randoms until one comes back true.
+func (s *Store) TryReserveHostPort(ctx context.Context, sandboxID string, containerPort, hostPort int, protocol, publicURL string, now time.Time) (bool, error) {
+	if hostPort <= 0 {
+		return false, errors.New("host port must be positive")
+	}
+	result, err := s.db.ExecContext(ctx, `
+		INSERT OR IGNORE INTO exposed_ports (sandbox_id, port, protocol, host_port, public_url, created_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, sandboxID, containerPort, protocol, hostPort, publicURL, now.UTC())
+	if err != nil {
+		// SQLite reports a UNIQUE violation on the partial index as ErrConstraint;
+		// INSERT OR IGNORE is supposed to swallow it but we keep the explicit
+		// check so any non-uniqueness error still surfaces.
+		if strings.Contains(err.Error(), "UNIQUE") {
+			return false, nil
+		}
+		return false, fmt.Errorf("reserve host port: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("reserve host port (affected): %w", err)
+	}
+	return affected == 1, nil
+}
+
+// ListAllExposedPorts returns every row in exposed_ports across every
+// sandbox. Used by reconcile to GC zombie caddy routes / layer4 servers
+// without N+1 per-sandbox lookups.
+func (s *Store) ListAllExposedPorts(ctx context.Context) ([]models.ExposedPort, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT sandbox_id, port, protocol, host_port, public_url, created_at
+		FROM exposed_ports
+		ORDER BY sandbox_id, port ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list all exposed ports: %w", err)
+	}
+	defer rows.Close()
+
+	var ports []models.ExposedPort
+	for rows.Next() {
+		var exposure models.ExposedPort
+		if err := rows.Scan(&exposure.SandboxID, &exposure.Port, &exposure.Protocol, &exposure.HostPort, &exposure.PublicURL, &exposure.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan exposed port: %w", err)
+		}
+		ports = append(ports, exposure)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate exposed ports: %w", err)
+	}
+	return ports, nil
 }
 
 func (s *Store) DeletePort(ctx context.Context, sandboxID string, port int) error {
@@ -548,7 +629,7 @@ func (s *Store) DeletePort(ctx context.Context, sandboxID string, port int) erro
 
 func (s *Store) loadPorts(ctx context.Context, sandboxID string) ([]models.ExposedPort, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT sandbox_id, port, public_url, created_at
+		SELECT sandbox_id, port, protocol, host_port, public_url, created_at
 		FROM exposed_ports
 		WHERE sandbox_id = ?
 		ORDER BY port ASC
@@ -561,7 +642,7 @@ func (s *Store) loadPorts(ctx context.Context, sandboxID string) ([]models.Expos
 	var ports []models.ExposedPort
 	for rows.Next() {
 		var exposure models.ExposedPort
-		if err := rows.Scan(&exposure.SandboxID, &exposure.Port, &exposure.PublicURL, &exposure.CreatedAt); err != nil {
+		if err := rows.Scan(&exposure.SandboxID, &exposure.Port, &exposure.Protocol, &exposure.HostPort, &exposure.PublicURL, &exposure.CreatedAt); err != nil {
 			return nil, fmt.Errorf("scan exposed port: %w", err)
 		}
 		ports = append(ports, exposure)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -561,34 +561,70 @@ func (s *Store) UpsertPort(ctx context.Context, exposure models.ExposedPort) err
 	return nil
 }
 
+// ReserveHostPortResult is the three-state outcome of TryReserveHostPort.
+// Exactly one of Reserved/Existing/(neither) is set:
+//   - Reserved: the row was inserted; the candidate host port is now ours.
+//   - Existing != nil: a row for (sandbox_id, port) already exists. The
+//     allocator MUST stop walking the pool — no other host_port will satisfy
+//     the (sandbox_id, port) primary key. Caller decides whether to reuse
+//     the existing exposure or surface an error.
+//   - both zero: the partial unique index on host_port rejected this
+//     candidate (some other sandbox owns it). Caller may retry.
+type ReserveHostPortResult struct {
+	Reserved bool
+	Existing *models.ExposedPort
+}
+
 // TryReserveHostPort attempts to claim hostPort for (sandboxID, containerPort)
-// in a single statement. Returns (true, nil) when the row was inserted, or
-// (false, nil) when the partial unique index on host_port rejected the
-// candidate (port already taken). Any other error propagates. This is the
-// load-bearing primitive of the random-first allocator: callers loop with
-// fresh randoms until one comes back true.
-func (s *Store) TryReserveHostPort(ctx context.Context, sandboxID string, containerPort, hostPort int, protocol, publicURL string, now time.Time) (bool, error) {
+// in a single INSERT OR IGNORE. The OR IGNORE swallows two distinct UNIQUE
+// failures — the (sandbox_id, port) primary key AND the partial index on
+// host_port — so on a no-op insert we follow up with a SELECT to disambiguate.
+// Without that disambiguation, retrying expose for an already-exposed port
+// looks identical to a host_port collision and walks the whole allocator pool
+// before failing with "exhausted".
+func (s *Store) TryReserveHostPort(ctx context.Context, sandboxID string, containerPort, hostPort int, protocol, publicURL string, now time.Time) (ReserveHostPortResult, error) {
 	if hostPort <= 0 {
-		return false, errors.New("host port must be positive")
+		return ReserveHostPortResult{}, errors.New("host port must be positive")
 	}
 	result, err := s.db.ExecContext(ctx, `
 		INSERT OR IGNORE INTO exposed_ports (sandbox_id, port, protocol, host_port, public_url, created_at)
 		VALUES (?, ?, ?, ?, ?, ?)
 	`, sandboxID, containerPort, protocol, hostPort, publicURL, now.UTC())
 	if err != nil {
-		// SQLite reports a UNIQUE violation on the partial index as ErrConstraint;
-		// INSERT OR IGNORE is supposed to swallow it but we keep the explicit
-		// check so any non-uniqueness error still surfaces.
-		if strings.Contains(err.Error(), "UNIQUE") {
-			return false, nil
-		}
-		return false, fmt.Errorf("reserve host port: %w", err)
+		return ReserveHostPortResult{}, fmt.Errorf("reserve host port: %w", err)
 	}
 	affected, err := result.RowsAffected()
 	if err != nil {
-		return false, fmt.Errorf("reserve host port (affected): %w", err)
+		return ReserveHostPortResult{}, fmt.Errorf("reserve host port (affected): %w", err)
 	}
-	return affected == 1, nil
+	if affected == 1 {
+		return ReserveHostPortResult{Reserved: true}, nil
+	}
+	existing, err := s.getPort(ctx, sandboxID, containerPort)
+	if err != nil {
+		return ReserveHostPortResult{}, fmt.Errorf("reserve host port (lookup existing): %w", err)
+	}
+	if existing != nil {
+		return ReserveHostPortResult{Existing: existing}, nil
+	}
+	return ReserveHostPortResult{}, nil
+}
+
+// getPort returns the exposure row for (sandboxID, port), or nil if absent.
+func (s *Store) getPort(ctx context.Context, sandboxID string, port int) (*models.ExposedPort, error) {
+	var exposure models.ExposedPort
+	err := s.db.QueryRowContext(ctx, `
+		SELECT sandbox_id, port, protocol, host_port, public_url, created_at
+		FROM exposed_ports
+		WHERE sandbox_id = ? AND port = ?
+	`, sandboxID, port).Scan(&exposure.SandboxID, &exposure.Port, &exposure.Protocol, &exposure.HostPort, &exposure.PublicURL, &exposure.CreatedAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &exposure, nil
 }
 
 // ListAllExposedPorts returns every row in exposed_ports across every

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -314,6 +314,62 @@ func TestStoreCases(t *testing.T) {
 			},
 		},
 		{
+			name: "try_reserve_host_port_distinguishes_pk_collision_from_host_port_collision",
+			run: func(t *testing.T) {
+				st := newTestStore(t)
+				sb := sampleSandbox("sb-tcp-idem")
+				if err := st.Create(ctx, sb); err != nil {
+					t.Fatalf("Create() error = %v", err)
+				}
+				now := time.Now().UTC()
+
+				// Initial reservation succeeds.
+				r, err := st.TryReserveHostPort(ctx, sb.ID, 5432, 37001, models.ExposedPortProtocolTCP, "tcp://host:37001", now)
+				if err != nil {
+					t.Fatalf("first reserve error = %v", err)
+				}
+				if !r.Reserved || r.Existing != nil {
+					t.Fatalf("first reserve = %+v, want Reserved=true Existing=nil", r)
+				}
+
+				// Re-reserving the same (sandbox, container_port) with a fresh
+				// host_port must surface the existing row, NOT look like a
+				// host_port collision (which would make the allocator walk
+				// the pool to exhaustion).
+				r, err = st.TryReserveHostPort(ctx, sb.ID, 5432, 37002, models.ExposedPortProtocolTCP, "tcp://host:37002", now)
+				if err != nil {
+					t.Fatalf("re-reserve error = %v", err)
+				}
+				if r.Reserved {
+					t.Fatalf("re-reserve unexpectedly inserted a duplicate row: %+v", r)
+				}
+				if r.Existing == nil {
+					t.Fatal("re-reserve returned no Existing row; allocator would walk the pool")
+				}
+				if r.Existing.HostPort != 37001 || r.Existing.Protocol != models.ExposedPortProtocolTCP {
+					t.Fatalf("Existing = %+v, want host_port=37001 protocol=tcp", r.Existing)
+				}
+
+				// A different (sandbox, container_port) racing for the same
+				// host_port must look like a host_port collision (Existing
+				// nil), so the allocator can retry with another candidate.
+				other := sampleSandbox("sb-tcp-other")
+				if err := st.Create(ctx, other); err != nil {
+					t.Fatalf("Create(other) error = %v", err)
+				}
+				r, err = st.TryReserveHostPort(ctx, other.ID, 6379, 37001, models.ExposedPortProtocolTCP, "tcp://host:37001", now)
+				if err != nil {
+					t.Fatalf("collision reserve error = %v", err)
+				}
+				if r.Reserved {
+					t.Fatal("collision reserve unexpectedly succeeded against taken host_port")
+				}
+				if r.Existing != nil {
+					t.Fatalf("collision reserve returned Existing = %+v, want nil so caller retries", r.Existing)
+				}
+			},
+		},
+		{
 			name: "has_active_image_ref_returns_false_when_only_destroyed",
 			run: func(t *testing.T) {
 				st := newTestStore(t)

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -229,12 +229,24 @@ func (s *Server) handleExposePort(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid port")
 		return
 	}
-	publicURL, err := s.service.ExposePort(r.Context(), r.PathValue("id"), port)
+	// Body is optional — legacy callers POST with no body and get HTTP routing.
+	// New callers send {"protocol":"tcp"} or {"protocol":"tls"} to choose a
+	// caddy-l4 path. ContentLength == 0 is the unambiguous "no body" signal;
+	// we intentionally don't strict-decode an empty stream so old SDKs keep
+	// working unchanged.
+	var req models.ExposePortRequest
+	if r.ContentLength > 0 {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON body")
+			return
+		}
+	}
+	publicURL, err := s.service.ExposePort(r.Context(), r.PathValue("id"), port, req.Protocol)
 	if err != nil {
 		s.writeStoreAwareError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]string{"public_url": publicURL})
+	writeJSON(w, http.StatusOK, map[string]string{"public_url": publicURL, "protocol": req.Protocol})
 }
 
 func (s *Server) handleListMounts(w http.ResponseWriter, r *http.Request) {

--- a/pkg/caddy/client.go
+++ b/pkg/caddy/client.go
@@ -215,6 +215,43 @@ func (c *Client) upsertRoute(ctx context.Context, routeID string, route map[stri
 	return nil
 }
 
+// DeleteRouteByID is the zombie-GC entry point: the reconcile sweep finds an
+// @id under apps/http or the tls-mux server that doesn't correspond to any
+// sandbox row, and calls this to drop it. Wraps the same DELETE /id/<routeID>
+// the typed helpers use, so 404 is still treated as success.
+func (c *Client) DeleteRouteByID(ctx context.Context, routeID string) error {
+	if !c.enabled || routeID == "" {
+		return nil
+	}
+	return c.deleteRoute(ctx, routeID)
+}
+
+// DeleteTCPServer drops a layer4 server by its name (e.g. tcp-port-37412).
+// Used by reconcile's zombie GC; not tied to a specific sandbox/port pair so
+// the caller doesn't have to know which exposure originally owned the port.
+func (c *Client) DeleteTCPServer(ctx context.Context, serverID string) error {
+	if !c.enabled || serverID == "" {
+		return nil
+	}
+	target := fmt.Sprintf("%s/config/apps/layer4/servers/%s", c.baseURL, serverID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, target, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("delete l4 server: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("delete l4 server failed: %d", resp.StatusCode)
+	}
+	return nil
+}
+
 // deleteRoute removes one route by @id. 404 is treated as success — the route
 // already isn't there, which is the desired post-condition.
 func (c *Client) deleteRoute(ctx context.Context, routeID string) error {

--- a/pkg/caddy/client.go
+++ b/pkg/caddy/client.go
@@ -14,24 +14,26 @@ import (
 )
 
 type Client struct {
-	baseURL     string
-	serverID    string
-	domain      string
-	publicHost  string
-	enabled     bool
-	l4TLSListen string
-	httpClient  *http.Client
+	baseURL       string
+	serverID      string
+	domain        string
+	publicHost    string
+	enabled       bool
+	l4TLSListen   string
+	l4TLSFallback string
+	httpClient    *http.Client
 }
 
 func New(cfg config.Config) *Client {
 	return &Client{
-		baseURL:     strings.TrimRight(cfg.CaddyAdminURL, "/"),
-		serverID:    cfg.CaddyServerID,
-		domain:      cfg.Domain,
-		publicHost:  cfg.PublicHost,
-		enabled:     cfg.EnableCaddy,
-		l4TLSListen: cfg.L4TLSListen,
-		httpClient:  &http.Client{Timeout: cfg.HTTPClientTimeout},
+		baseURL:       strings.TrimRight(cfg.CaddyAdminURL, "/"),
+		serverID:      cfg.CaddyServerID,
+		domain:        cfg.Domain,
+		publicHost:    cfg.PublicHost,
+		enabled:       cfg.EnableCaddy,
+		l4TLSListen:   cfg.L4TLSListen,
+		l4TLSFallback: cfg.L4TLSFallback,
+		httpClient:    &http.Client{Timeout: cfg.HTTPClientTimeout},
 	}
 }
 
@@ -39,6 +41,11 @@ func New(cfg config.Config) *Client {
 // multiplexer. Empty means TLS-SNI exposure is disabled — the service layer
 // should reject protocol="tls" requests and skip EnsureLayer4 of the mux.
 func (c *Client) L4TLSListen() string { return c.l4TLSListen }
+
+// L4TLSFallback returns the address caddy-l4 forwards non-sandbox SNI to
+// (the regular HTTPS Caddy site that handles the API, on-demand TLS, and the
+// 404 catch-all). Meaningful only when L4TLSListen is non-empty.
+func (c *Client) L4TLSFallback() string { return c.l4TLSFallback }
 
 // SNIHost is the per-sandbox subdomain caddy-l4 routes by for a TLS exposure.
 // Returns empty in IP mode (no domain configured), which the service layer
@@ -309,6 +316,13 @@ func portRouteID(id string, port int) string {
 // works the same way the HTTP path already does.
 const tlsMuxServerID = "tls-mux"
 
+// tlsFallbackRouteID is the @id of the unmatched-SNI route inside tls-mux.
+// Tail of the routes array; per-sandbox SNI routes are PUT at routes/0 so
+// they always shadow this one. Any SNI we don't recognize — the API host
+// itself, on-demand-TLS validation, plain SSL probes — ends up here and
+// gets proxied to the local HTTPS listener.
+const tlsFallbackRouteID = "tls-mux-fallback"
+
 func tcpServerID(hostPort int) string {
 	return fmt.Sprintf("tcp-port-%d", hostPort)
 }
@@ -328,9 +342,20 @@ func tlsRouteID(id string, port int) string {
 //
 // Without this bootstrap, the very first UpsertTCPRoute would fail because
 // /config/apps/layer4 doesn't exist yet on a fresh Caddy.
-func (c *Client) EnsureLayer4(ctx context.Context, tlsListen string) error {
+//
+// When tlsListen is non-empty, tlsFallback must point at the local HTTPS
+// listener that owned the same port before caddy-l4 took it over (the API
+// site, the on-demand-TLS catch-all, etc.). caddy-l4 routes by SNI for
+// sandbox subdomains and forwards the rest of the traffic — including ACME
+// HTTP-01 cert validation that piggy-backs on :443 ALPN and any non-sandbox
+// hostname — to the fallback. Empty tlsFallback with non-empty tlsListen is
+// rejected; the service layer surfaces it as a config error at boot.
+func (c *Client) EnsureLayer4(ctx context.Context, tlsListen, tlsFallback string) error {
 	if !c.enabled {
 		return nil
+	}
+	if tlsListen != "" && tlsFallback == "" {
+		return errors.New("tls fallback required when tls listen is set")
 	}
 
 	// Ensure /config/apps/layer4 exists. We only PUT it if it isn't there;
@@ -367,9 +392,21 @@ func (c *Client) EnsureLayer4(ctx context.Context, tlsListen string) error {
 	if exists {
 		return nil
 	}
+	// The fallback route has no match clause and sits at the END of the
+	// routes array; per-sandbox SNI routes inserted via UpsertTLSSNIRoute go
+	// to routes/0, so they always win over the fallback. Only connections
+	// whose SNI doesn't match any sandbox subdomain hit the proxy below.
 	server := map[string]any{
 		"listen": []string{tlsListen},
-		"routes": []any{},
+		"routes": []any{
+			map[string]any{
+				"@id": tlsFallbackRouteID,
+				"handle": []map[string]any{{
+					"handler":   "proxy",
+					"upstreams": []map[string]any{{"dial": []string{tlsFallback}}},
+				}},
+			},
+		},
 	}
 	body, err := json.Marshal(server)
 	if err != nil {
@@ -456,6 +493,14 @@ func (c *Client) DeleteTCPRoute(ctx context.Context, hostPort int) error {
 // place without disturbing siblings; if the @id isn't there yet (404) we PUT
 // at routes/0 so SNI matching tries it ahead of any future fallback.
 //
+// The handler chain is [tls, proxy]: caddy-l4 terminates TLS using Caddy's
+// own cert manager (which already holds the wildcard for *.$DOMAIN, issued
+// once at startup via DNS-01), then proxies the now-plaintext bytes to the
+// container on its native port. The container speaks raw TCP — no cert, no
+// private key, nothing TLS-related lives inside the user's sandbox. The
+// connection_policies entry is intentionally empty: Caddy picks the cert by
+// SNI from the shared cert manager, so there is no per-route cert config.
+//
 // Caller must have already called EnsureLayer4 with a non-empty tlsListen at
 // least once; otherwise the routes/0 PUT will land on a missing server.
 func (c *Client) UpsertTLSSNIRoute(ctx context.Context, id, sniHost, containerIP string, port int) error {
@@ -468,10 +513,16 @@ func (c *Client) UpsertTLSSNIRoute(ctx context.Context, id, sniHost, containerIP
 		"match": []map[string]any{{
 			"tls": map[string]any{"sni": []string{sniHost}},
 		}},
-		"handle": []map[string]any{{
-			"handler":   "proxy",
-			"upstreams": []map[string]any{{"dial": []string{fmt.Sprintf("%s:%d", containerIP, port)}}},
-		}},
+		"handle": []map[string]any{
+			{
+				"handler":             "tls",
+				"connection_policies": []map[string]any{{}},
+			},
+			{
+				"handler":   "proxy",
+				"upstreams": []map[string]any{{"dial": []string{fmt.Sprintf("%s:%d", containerIP, port)}}},
+			},
+		},
 	}
 	body, err := json.Marshal(route)
 	if err != nil {

--- a/pkg/caddy/client.go
+++ b/pkg/caddy/client.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -12,23 +14,40 @@ import (
 )
 
 type Client struct {
-	baseURL    string
-	serverID   string
-	domain     string
-	publicHost string
-	enabled    bool
-	httpClient *http.Client
+	baseURL     string
+	serverID    string
+	domain      string
+	publicHost  string
+	enabled     bool
+	l4TLSListen string
+	httpClient  *http.Client
 }
 
 func New(cfg config.Config) *Client {
 	return &Client{
-		baseURL:    strings.TrimRight(cfg.CaddyAdminURL, "/"),
-		serverID:   cfg.CaddyServerID,
-		domain:     cfg.Domain,
-		publicHost: cfg.PublicHost,
-		enabled:    cfg.EnableCaddy,
-		httpClient: &http.Client{Timeout: cfg.HTTPClientTimeout},
+		baseURL:     strings.TrimRight(cfg.CaddyAdminURL, "/"),
+		serverID:    cfg.CaddyServerID,
+		domain:      cfg.Domain,
+		publicHost:  cfg.PublicHost,
+		enabled:     cfg.EnableCaddy,
+		l4TLSListen: cfg.L4TLSListen,
+		httpClient:  &http.Client{Timeout: cfg.HTTPClientTimeout},
 	}
+}
+
+// L4TLSListen returns the listen address configured for the shared TLS-SNI
+// multiplexer. Empty means TLS-SNI exposure is disabled — the service layer
+// should reject protocol="tls" requests and skip EnsureLayer4 of the mux.
+func (c *Client) L4TLSListen() string { return c.l4TLSListen }
+
+// SNIHost is the per-sandbox subdomain caddy-l4 routes by for a TLS exposure.
+// Returns empty in IP mode (no domain configured), which the service layer
+// uses to detect "TLS not supported in this deployment" without sniffing.
+func (c *Client) SNIHost(id string, port int) string {
+	if c.domain == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s-%d.%s", id, port, c.domain)
 }
 
 func (c *Client) Enabled() bool {
@@ -66,6 +85,28 @@ func (c *Client) PortPublicURL(id string, port int) string {
 		return fmt.Sprintf("https://%s-%d.%s", id, port, c.domain)
 	}
 	return fmt.Sprintf("http://%s/%s/proxy/%d/", c.publicHost, id, port)
+}
+
+// TCPPublicEndpoint returns the URL clients dial for a raw TCP exposure
+// allocated at hostPort. Always uses the publicHost as the dial target — TCP
+// has no DNS-shaped wildcard equivalent, so even in domain mode the parent
+// host's address is the right value here. Operators that want a friendly DNS
+// name should add their own A record pointing at PublicHost.
+func (c *Client) TCPPublicEndpoint(hostPort int) string {
+	return fmt.Sprintf("tcp://%s:%d", c.publicHost, hostPort)
+}
+
+// TLSPublicEndpoint returns the dial target for a TLS-SNI multiplexed
+// exposure. The host portion is the per-sandbox subdomain caddy-l4 uses for
+// SNI matching (so the certificate the upstream presents must cover that
+// name); the port is the layer4 listener address operators configured. Empty
+// l4Listen means TLS-SNI mode is disabled.
+func (c *Client) TLSPublicEndpoint(id string, port int, l4Listen string) string {
+	if c.domain == "" || l4Listen == "" {
+		return ""
+	}
+	listenPort := strings.TrimPrefix(l4Listen, ":")
+	return fmt.Sprintf("tls://%s-%d.%s:%s", id, port, c.domain, listenPort)
 }
 
 func (c *Client) UpsertSandboxRoute(ctx context.Context, id, containerIP string, toolboxPort int) error {
@@ -216,4 +257,321 @@ func sandboxRouteID(id string) string {
 
 func portRouteID(id string, port int) string {
 	return fmt.Sprintf("sandbox-%s-port-%d", id, port)
+}
+
+// Layer4 admin API conventions.
+//
+// Each raw-TCP exposure gets its own server keyed by tcp-port-<hostPort>,
+// listening on :<hostPort> and forwarding the connection to the container's
+// IP:port. The route inside also carries a stable @id so reconcile can find
+// it without parsing server config.
+//
+// TLS-SNI multiplexing reuses one shared server (tlsMuxServerID) listening
+// on the operator-configured address (typically :443) and routes connections
+// by SNI to the matching upstream. Each route here gets an @id so PATCH /id/
+// works the same way the HTTP path already does.
+const tlsMuxServerID = "tls-mux"
+
+func tcpServerID(hostPort int) string {
+	return fmt.Sprintf("tcp-port-%d", hostPort)
+}
+
+func tcpRouteID(id string, port int) string {
+	return fmt.Sprintf("sandbox-%s-port-%d-tcp", id, port)
+}
+
+func tlsRouteID(id string, port int) string {
+	return fmt.Sprintf("sandbox-%s-port-%d-tls", id, port)
+}
+
+// EnsureLayer4 idempotently bootstraps the layer4 app and (when tlsListen is
+// non-empty) the shared SNI-mux server. Safe to call on every sandboxd start
+// — the admin API treats a no-op POST as 200 and a PATCH on a missing key as
+// 404, so we issue a PUT only when the path actually doesn't exist.
+//
+// Without this bootstrap, the very first UpsertTCPRoute would fail because
+// /config/apps/layer4 doesn't exist yet on a fresh Caddy.
+func (c *Client) EnsureLayer4(ctx context.Context, tlsListen string) error {
+	if !c.enabled {
+		return nil
+	}
+
+	// Ensure /config/apps/layer4 exists. We only PUT it if it isn't there;
+	// otherwise we'd clobber any servers added since last boot.
+	exists, err := c.pathExists(ctx, "/config/apps/layer4")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		body, err := json.Marshal(map[string]any{"servers": map[string]any{}})
+		if err != nil {
+			return fmt.Errorf("marshal layer4 app: %w", err)
+		}
+		status, err := c.sendJSON(ctx, http.MethodPut, c.baseURL+"/config/apps/layer4", body)
+		if err != nil {
+			return err
+		}
+		if status >= 400 {
+			return fmt.Errorf("create layer4 app failed: %d", status)
+		}
+	}
+
+	// SNI mux server only matters when an operator has configured a listen
+	// address. Empty tlsListen leaves caddy alone and the TLS code paths
+	// short-circuit at the service layer.
+	if tlsListen == "" {
+		return nil
+	}
+	muxPath := fmt.Sprintf("/config/apps/layer4/servers/%s", tlsMuxServerID)
+	exists, err = c.pathExists(ctx, muxPath)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+	server := map[string]any{
+		"listen": []string{tlsListen},
+		"routes": []any{},
+	}
+	body, err := json.Marshal(server)
+	if err != nil {
+		return fmt.Errorf("marshal tls mux server: %w", err)
+	}
+	status, err := c.sendJSON(ctx, http.MethodPut, c.baseURL+muxPath, body)
+	if err != nil {
+		return err
+	}
+	if status >= 400 {
+		return fmt.Errorf("create tls mux server failed: %d", status)
+	}
+	return nil
+}
+
+// UpsertTCPRoute creates (or replaces) the layer4 server bound to hostPort.
+// One server per host-port allocation; PUT replaces the entire server config
+// in place, so re-running with a different upstream IP after a sandbox
+// restart is the right way to refresh routing without poking at routes/0.
+func (c *Client) UpsertTCPRoute(ctx context.Context, id, containerIP string, port, hostPort int) error {
+	if !c.enabled {
+		return nil
+	}
+	if hostPort <= 0 {
+		return errors.New("host port must be positive")
+	}
+	server := map[string]any{
+		"listen": []string{fmt.Sprintf(":%d", hostPort)},
+		"routes": []any{
+			map[string]any{
+				"@id": tcpRouteID(id, port),
+				"handle": []map[string]any{{
+					"handler":   "proxy",
+					"upstreams": []map[string]any{{"dial": []string{fmt.Sprintf("%s:%d", containerIP, port)}}},
+				}},
+			},
+		},
+	}
+	body, err := json.Marshal(server)
+	if err != nil {
+		return fmt.Errorf("marshal tcp server: %w", err)
+	}
+	target := fmt.Sprintf("%s/config/apps/layer4/servers/%s", c.baseURL, tcpServerID(hostPort))
+	status, err := c.sendJSON(ctx, http.MethodPut, target, body)
+	if err != nil {
+		return err
+	}
+	if status >= 400 {
+		return fmt.Errorf("upsert tcp server failed: %d", status)
+	}
+	return nil
+}
+
+// DeleteTCPRoute removes the layer4 server holding hostPort. 404 is treated
+// as success — the desired post-condition is "not present", and it isn't.
+func (c *Client) DeleteTCPRoute(ctx context.Context, hostPort int) error {
+	if !c.enabled {
+		return nil
+	}
+	if hostPort <= 0 {
+		return nil
+	}
+	target := fmt.Sprintf("%s/config/apps/layer4/servers/%s", c.baseURL, tcpServerID(hostPort))
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, target, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("delete tcp server: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("delete tcp server failed: %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// UpsertTLSSNIRoute publishes (or refreshes) one SNI route inside the shared
+// tls-mux layer4 server. PATCH /id/<routeID> replaces the existing route in
+// place without disturbing siblings; if the @id isn't there yet (404) we PUT
+// at routes/0 so SNI matching tries it ahead of any future fallback.
+//
+// Caller must have already called EnsureLayer4 with a non-empty tlsListen at
+// least once; otherwise the routes/0 PUT will land on a missing server.
+func (c *Client) UpsertTLSSNIRoute(ctx context.Context, id, sniHost, containerIP string, port int) error {
+	if !c.enabled {
+		return nil
+	}
+	routeID := tlsRouteID(id, port)
+	route := map[string]any{
+		"@id": routeID,
+		"match": []map[string]any{{
+			"tls": map[string]any{"sni": []string{sniHost}},
+		}},
+		"handle": []map[string]any{{
+			"handler":   "proxy",
+			"upstreams": []map[string]any{{"dial": []string{fmt.Sprintf("%s:%d", containerIP, port)}}},
+		}},
+	}
+	body, err := json.Marshal(route)
+	if err != nil {
+		return fmt.Errorf("marshal tls sni route: %w", err)
+	}
+
+	patchURL := fmt.Sprintf("%s/id/%s", c.baseURL, routeID)
+	status, err := c.sendJSON(ctx, http.MethodPatch, patchURL, body)
+	if err != nil {
+		return err
+	}
+	if status < 400 {
+		return nil
+	}
+	if status != http.StatusNotFound {
+		return fmt.Errorf("patch tls sni route failed: %d", status)
+	}
+
+	insertURL := fmt.Sprintf("%s/config/apps/layer4/servers/%s/routes/0", c.baseURL, tlsMuxServerID)
+	status, err = c.sendJSON(ctx, http.MethodPut, insertURL, body)
+	if err != nil {
+		return err
+	}
+	if status >= 400 {
+		return fmt.Errorf("insert tls sni route failed: %d", status)
+	}
+	return nil
+}
+
+// DeleteTLSSNIRoute removes one SNI route by @id. 404 is treated as success
+// for the same reason DeleteSandboxRoute does.
+func (c *Client) DeleteTLSSNIRoute(ctx context.Context, id string, port int) error {
+	if !c.enabled {
+		return nil
+	}
+	return c.deleteRoute(ctx, tlsRouteID(id, port))
+}
+
+// Snapshot is the read side of reconcile's zombie-route detection. It walks
+// the live Caddy config once and returns every entity whose name follows our
+// conventions, so the service layer can compare against the DB and delete
+// anything that has no matching row.
+type Snapshot struct {
+	// HTTPRouteIDs are the @ids of routes under apps/http that match our
+	// "sandbox-..." prefix. Both the per-sandbox toolbox routes and the
+	// per-port HTTP routes show up here.
+	HTTPRouteIDs []string
+	// L4TCPServerIDs are server names under apps/layer4 of the form
+	// tcp-port-<hostPort>. Each maps 1:1 to a host-port allocation in the DB.
+	L4TCPServerIDs []string
+	// L4TLSRouteIDs are @ids of SNI routes inside the tls-mux server.
+	L4TLSRouteIDs []string
+}
+
+func (c *Client) Snapshot(ctx context.Context) (Snapshot, error) {
+	var snap Snapshot
+	if !c.enabled {
+		return snap, nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/config/", nil)
+	if err != nil {
+		return snap, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return snap, fmt.Errorf("get caddy config: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return snap, fmt.Errorf("get caddy config failed: %d", resp.StatusCode)
+	}
+
+	var cfg struct {
+		Apps struct {
+			HTTP struct {
+				Servers map[string]struct {
+					Routes []map[string]any `json:"routes"`
+				} `json:"servers"`
+			} `json:"http"`
+			Layer4 struct {
+				Servers map[string]struct {
+					Routes []map[string]any `json:"routes"`
+				} `json:"servers"`
+			} `json:"layer4"`
+		} `json:"apps"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&cfg); err != nil {
+		return snap, fmt.Errorf("decode caddy config: %w", err)
+	}
+
+	for _, server := range cfg.Apps.HTTP.Servers {
+		for _, route := range server.Routes {
+			if id, _ := route["@id"].(string); strings.HasPrefix(id, "sandbox-") {
+				snap.HTTPRouteIDs = append(snap.HTTPRouteIDs, id)
+			}
+		}
+	}
+	for serverID, server := range cfg.Apps.Layer4.Servers {
+		if strings.HasPrefix(serverID, "tcp-port-") {
+			snap.L4TCPServerIDs = append(snap.L4TCPServerIDs, serverID)
+		}
+		if serverID == tlsMuxServerID {
+			for _, route := range server.Routes {
+				if id, _ := route["@id"].(string); strings.HasPrefix(id, "sandbox-") {
+					snap.L4TLSRouteIDs = append(snap.L4TLSRouteIDs, id)
+				}
+			}
+		}
+	}
+	return snap, nil
+}
+
+// pathExists is a thin GET wrapper used by EnsureLayer4 to distinguish
+// "needs creating" from "already there". Caddy returns 404 for missing
+// config nodes; anything else either succeeds or surfaces as an error.
+func (c *Client) pathExists(ctx context.Context, path string) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return false, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("get %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return false, nil
+	}
+	if resp.StatusCode >= 400 {
+		return false, fmt.Errorf("get %s failed: %d", path, resp.StatusCode)
+	}
+	// Caddy returns "null" for a path that exists in the config tree but has
+	// no value yet. Treat that as "needs creating" so the PUT actually runs.
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, fmt.Errorf("read %s body: %w", path, err)
+	}
+	return strings.TrimSpace(string(body)) != "null", nil
 }

--- a/pkg/caddy/client_test.go
+++ b/pkg/caddy/client_test.go
@@ -287,7 +287,7 @@ func TestL4Cases(t *testing.T) {
 			run: func(t *testing.T) {
 				fake := newFakeCaddy(t)
 				client := &Client{enabled: true, baseURL: fake.URL, httpClient: fake.Client}
-				if err := client.EnsureLayer4(context.Background(), ":443"); err != nil {
+				if err := client.EnsureLayer4(context.Background(), ":443", "127.0.0.1:8443"); err != nil {
 					t.Fatalf("EnsureLayer4() error = %v", err)
 				}
 				if !fake.layer4Exists {
@@ -299,11 +299,44 @@ func TestL4Cases(t *testing.T) {
 			},
 		},
 		{
+			name: "ensure_layer4_seeds_fallback_route",
+			run: func(t *testing.T) {
+				// Regression test for the TLS-SNI default-on path: caddy-l4 has
+				// to forward unmatched SNI (the API host, on-demand validation,
+				// stray probes) to the relocated HTTPS listener. If this
+				// fallback route is missing, every non-sandbox SNI connection
+				// drops, including the API itself — the symptom would be "site
+				// works locally, dies when SB_L4_TLS_LISTEN is set".
+				fake := newFakeCaddy(t)
+				client := &Client{enabled: true, baseURL: fake.URL, httpClient: fake.Client}
+				if err := client.EnsureLayer4(context.Background(), ":443", "127.0.0.1:8443"); err != nil {
+					t.Fatalf("EnsureLayer4() error = %v", err)
+				}
+				server, ok := fake.l4Servers[tlsMuxServerID]
+				if !ok {
+					t.Fatalf("tls-mux server missing")
+				}
+				route := firstL4Route(t, server)
+				assertRouteField(t, route, "@id", tlsFallbackRouteID)
+				assertL4Dial(t, route, "127.0.0.1:8443")
+			},
+		},
+		{
+			name: "ensure_layer4_rejects_listen_without_fallback",
+			run: func(t *testing.T) {
+				fake := newFakeCaddy(t)
+				client := &Client{enabled: true, baseURL: fake.URL, httpClient: fake.Client}
+				if err := client.EnsureLayer4(context.Background(), ":443", ""); err == nil {
+					t.Fatalf("EnsureLayer4 should reject empty fallback when listen is set")
+				}
+			},
+		},
+		{
 			name: "ensure_layer4_skips_tls_mux_when_listen_empty",
 			run: func(t *testing.T) {
 				fake := newFakeCaddy(t)
 				client := &Client{enabled: true, baseURL: fake.URL, httpClient: fake.Client}
-				if err := client.EnsureLayer4(context.Background(), ""); err != nil {
+				if err := client.EnsureLayer4(context.Background(), "", ""); err != nil {
 					t.Fatalf("EnsureLayer4() error = %v", err)
 				}
 				if !fake.layer4Exists {
@@ -319,11 +352,11 @@ func TestL4Cases(t *testing.T) {
 			run: func(t *testing.T) {
 				fake := newFakeCaddy(t)
 				client := &Client{enabled: true, baseURL: fake.URL, httpClient: fake.Client}
-				if err := client.EnsureLayer4(context.Background(), ":443"); err != nil {
+				if err := client.EnsureLayer4(context.Background(), ":443", "127.0.0.1:8443"); err != nil {
 					t.Fatalf("first EnsureLayer4() error = %v", err)
 				}
 				puts1 := countMethod(fake.records, http.MethodPut)
-				if err := client.EnsureLayer4(context.Background(), ":443"); err != nil {
+				if err := client.EnsureLayer4(context.Background(), ":443", "127.0.0.1:8443"); err != nil {
 					t.Fatalf("second EnsureLayer4() error = %v", err)
 				}
 				puts2 := countMethod(fake.records, http.MethodPut)
@@ -411,6 +444,7 @@ func TestL4Cases(t *testing.T) {
 				}
 				assertL4SNI(t, route, "abc-5432.sandbox.example.com")
 				assertL4Dial(t, route, "10.0.0.5:5432")
+				assertHasTLSTerminator(t, route)
 			},
 		},
 		{
@@ -429,6 +463,7 @@ func TestL4Cases(t *testing.T) {
 					t.Fatalf("PATCH should have replaced stale fields: %+v", route)
 				}
 				assertL4Dial(t, route, "10.0.0.7:5432")
+				assertHasTLSTerminator(t, route)
 			},
 		},
 		{
@@ -549,7 +584,23 @@ func assertL4Dial(t *testing.T, route map[string]any, want string) {
 	if !ok || len(handles) == 0 {
 		t.Fatalf("missing handle: %#v", route)
 	}
-	handle, _ := handles[0].(map[string]any)
+	// TLS-terminating SNI routes have [tls, proxy]; raw-TCP routes have just
+	// [proxy]. Walk the chain and pick the first handler that carries an
+	// upstreams list — that's the one with the dial target.
+	var handle map[string]any
+	for _, h := range handles {
+		hm, _ := h.(map[string]any)
+		if hm == nil {
+			continue
+		}
+		if _, hasUpstreams := hm["upstreams"]; hasUpstreams {
+			handle = hm
+			break
+		}
+	}
+	if handle == nil {
+		t.Fatalf("no handler with upstreams in chain: %#v", route)
+	}
 	upstreams, ok := handle["upstreams"].([]any)
 	if !ok || len(upstreams) == 0 {
 		t.Fatalf("missing upstreams: %#v", route)
@@ -562,6 +613,41 @@ func assertL4Dial(t *testing.T, route map[string]any, want string) {
 	if got, _ := dials[0].(string); got != want {
 		t.Fatalf("dial = %q, want %q", got, want)
 	}
+}
+
+// assertHasTLSTerminator walks the route's handler chain and asserts that a
+// "tls" handler appears before any "proxy" handler. Catches the regression
+// where someone removes TLS termination from UpsertTLSSNIRoute and the
+// route silently becomes passthrough — which would expose the user's
+// containers to the requirement of holding their own cert again.
+func assertHasTLSTerminator(t *testing.T, route map[string]any) {
+	t.Helper()
+	handles, ok := route["handle"].([]any)
+	if !ok || len(handles) < 2 {
+		t.Fatalf("expected handler chain of length >= 2 for terminated TLS, got %#v", route)
+	}
+	sawTLS := false
+	for _, h := range handles {
+		hm, _ := h.(map[string]any)
+		if hm == nil {
+			continue
+		}
+		handler, _ := hm["handler"].(string)
+		if handler == "tls" {
+			sawTLS = true
+			continue
+		}
+		if handler == "proxy" {
+			if !sawTLS {
+				t.Fatalf("proxy handler appears before tls in chain: %#v", route)
+			}
+			return
+		}
+	}
+	if !sawTLS {
+		t.Fatalf("no tls handler in chain (TLS-SNI route must terminate, not passthrough): %#v", route)
+	}
+	t.Fatalf("no proxy handler after tls: %#v", route)
 }
 
 func assertL4SNI(t *testing.T, route map[string]any, want string) {

--- a/pkg/caddy/client_test.go
+++ b/pkg/caddy/client_test.go
@@ -277,6 +277,337 @@ func TestRouteCases(t *testing.T) {
 	}
 }
 
+func TestL4Cases(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{
+			name: "ensure_layer4_creates_app_and_tls_mux",
+			run: func(t *testing.T) {
+				fake := newFakeCaddy(t)
+				client := &Client{enabled: true, baseURL: fake.URL, httpClient: fake.Client}
+				if err := client.EnsureLayer4(context.Background(), ":443"); err != nil {
+					t.Fatalf("EnsureLayer4() error = %v", err)
+				}
+				if !fake.layer4Exists {
+					t.Fatalf("layer4 app should exist after ensure")
+				}
+				if _, ok := fake.l4Servers[tlsMuxServerID]; !ok {
+					t.Fatalf("tls-mux server should exist after ensure; servers=%+v", fake.l4Servers)
+				}
+			},
+		},
+		{
+			name: "ensure_layer4_skips_tls_mux_when_listen_empty",
+			run: func(t *testing.T) {
+				fake := newFakeCaddy(t)
+				client := &Client{enabled: true, baseURL: fake.URL, httpClient: fake.Client}
+				if err := client.EnsureLayer4(context.Background(), ""); err != nil {
+					t.Fatalf("EnsureLayer4() error = %v", err)
+				}
+				if !fake.layer4Exists {
+					t.Fatalf("layer4 app should exist even without tls listen")
+				}
+				if _, ok := fake.l4Servers[tlsMuxServerID]; ok {
+					t.Fatalf("tls-mux must not be created when listen is empty")
+				}
+			},
+		},
+		{
+			name: "ensure_layer4_is_idempotent",
+			run: func(t *testing.T) {
+				fake := newFakeCaddy(t)
+				client := &Client{enabled: true, baseURL: fake.URL, httpClient: fake.Client}
+				if err := client.EnsureLayer4(context.Background(), ":443"); err != nil {
+					t.Fatalf("first EnsureLayer4() error = %v", err)
+				}
+				puts1 := countMethod(fake.records, http.MethodPut)
+				if err := client.EnsureLayer4(context.Background(), ":443"); err != nil {
+					t.Fatalf("second EnsureLayer4() error = %v", err)
+				}
+				puts2 := countMethod(fake.records, http.MethodPut)
+				if puts2 != puts1 {
+					t.Fatalf("idempotent ensure should not PUT again, got %d → %d", puts1, puts2)
+				}
+			},
+		},
+		{
+			name: "upsert_tcp_route_creates_server_with_route",
+			run: func(t *testing.T) {
+				fake := newFakeCaddy(t)
+				fake.layer4Exists = true
+				client := &Client{enabled: true, baseURL: fake.URL, httpClient: fake.Client}
+				if err := client.UpsertTCPRoute(context.Background(), "abc", "10.0.0.5", 5432, 37412); err != nil {
+					t.Fatalf("UpsertTCPRoute() error = %v", err)
+				}
+				server, ok := fake.l4Servers["tcp-port-37412"]
+				if !ok {
+					t.Fatalf("tcp server missing; servers=%+v", fake.l4Servers)
+				}
+				assertL4Listen(t, server, ":37412")
+				route := firstL4Route(t, server)
+				assertRouteField(t, route, "@id", "sandbox-abc-port-5432-tcp")
+				assertL4Dial(t, route, "10.0.0.5:5432")
+			},
+		},
+		{
+			name: "upsert_tcp_route_replaces_existing_server",
+			run: func(t *testing.T) {
+				fake := newFakeCaddy(t)
+				fake.layer4Exists = true
+				client := &Client{enabled: true, baseURL: fake.URL, httpClient: fake.Client}
+				if err := client.UpsertTCPRoute(context.Background(), "abc", "10.0.0.5", 5432, 37412); err != nil {
+					t.Fatalf("first UpsertTCPRoute error = %v", err)
+				}
+				if err := client.UpsertTCPRoute(context.Background(), "abc", "10.0.0.9", 5432, 37412); err != nil {
+					t.Fatalf("second UpsertTCPRoute error = %v", err)
+				}
+				server := fake.l4Servers["tcp-port-37412"]
+				route := firstL4Route(t, server)
+				assertL4Dial(t, route, "10.0.0.9:5432")
+			},
+		},
+		{
+			name: "delete_tcp_route_removes_server",
+			run: func(t *testing.T) {
+				fake := newFakeCaddy(t)
+				fake.l4Servers["tcp-port-37412"] = map[string]any{"listen": []any{":37412"}}
+				client := &Client{enabled: true, baseURL: fake.URL, httpClient: fake.Client}
+				if err := client.DeleteTCPRoute(context.Background(), 37412); err != nil {
+					t.Fatalf("DeleteTCPRoute() error = %v", err)
+				}
+				if _, ok := fake.l4Servers["tcp-port-37412"]; ok {
+					t.Fatalf("tcp server should be removed")
+				}
+			},
+		},
+		{
+			name: "delete_tcp_route_swallows_404",
+			run: func(t *testing.T) {
+				fake := newFakeCaddy(t)
+				client := &Client{enabled: true, baseURL: fake.URL, httpClient: fake.Client}
+				if err := client.DeleteTCPRoute(context.Background(), 99999); err != nil {
+					t.Fatalf("DeleteTCPRoute() should swallow 404, got %v", err)
+				}
+			},
+		},
+		{
+			name: "upsert_tls_sni_route_inserts_when_missing",
+			run: func(t *testing.T) {
+				fake := newFakeCaddy(t)
+				fake.layer4Exists = true
+				fake.l4Servers[tlsMuxServerID] = map[string]any{
+					"listen": []any{":443"},
+					"routes": []any{},
+				}
+				client := &Client{enabled: true, baseURL: fake.URL, httpClient: fake.Client}
+				if err := client.UpsertTLSSNIRoute(context.Background(), "abc", "abc-5432.sandbox.example.com", "10.0.0.5", 5432); err != nil {
+					t.Fatalf("UpsertTLSSNIRoute() error = %v", err)
+				}
+				route, ok := fake.routes["sandbox-abc-port-5432-tls"]
+				if !ok {
+					t.Fatalf("tls route should be inserted; routes=%+v", fake.routes)
+				}
+				assertL4SNI(t, route, "abc-5432.sandbox.example.com")
+				assertL4Dial(t, route, "10.0.0.5:5432")
+			},
+		},
+		{
+			name: "upsert_tls_sni_route_patches_when_present",
+			run: func(t *testing.T) {
+				fake := newFakeCaddy(t)
+				fake.layer4Exists = true
+				fake.l4Servers[tlsMuxServerID] = map[string]any{"listen": []any{":443"}, "routes": []any{}}
+				fake.routes["sandbox-abc-port-5432-tls"] = map[string]any{"@id": "sandbox-abc-port-5432-tls", "stale": true}
+				client := &Client{enabled: true, baseURL: fake.URL, httpClient: fake.Client}
+				if err := client.UpsertTLSSNIRoute(context.Background(), "abc", "abc-5432.sandbox.example.com", "10.0.0.7", 5432); err != nil {
+					t.Fatalf("UpsertTLSSNIRoute() error = %v", err)
+				}
+				route := fake.routes["sandbox-abc-port-5432-tls"]
+				if _, ok := route["stale"]; ok {
+					t.Fatalf("PATCH should have replaced stale fields: %+v", route)
+				}
+				assertL4Dial(t, route, "10.0.0.7:5432")
+			},
+		},
+		{
+			name: "delete_tls_sni_route_removes_by_id",
+			run: func(t *testing.T) {
+				fake := newFakeCaddy(t)
+				fake.routes["sandbox-abc-port-5432-tls"] = map[string]any{"@id": "sandbox-abc-port-5432-tls"}
+				client := &Client{enabled: true, baseURL: fake.URL, httpClient: fake.Client}
+				if err := client.DeleteTLSSNIRoute(context.Background(), "abc", 5432); err != nil {
+					t.Fatalf("DeleteTLSSNIRoute() error = %v", err)
+				}
+				if _, ok := fake.routes["sandbox-abc-port-5432-tls"]; ok {
+					t.Fatalf("tls route should be removed")
+				}
+			},
+		},
+		{
+			name: "snapshot_collects_http_l4_tcp_and_tls_ids",
+			run: func(t *testing.T) {
+				fake := newFakeCaddy(t)
+				fake.layer4Exists = true
+				fake.routes["sandbox-abc"] = map[string]any{"@id": "sandbox-abc"}
+				fake.routes["sandbox-abc-port-3000"] = map[string]any{"@id": "sandbox-abc-port-3000"}
+				fake.routes["unrelated"] = map[string]any{"@id": "unrelated"}
+				fake.l4Servers["tcp-port-37412"] = map[string]any{
+					"listen": []any{":37412"},
+					"routes": []any{map[string]any{"@id": "sandbox-abc-port-5432-tcp"}},
+				}
+				fake.l4Servers["tcp-port-38001"] = map[string]any{
+					"listen": []any{":38001"},
+					"routes": []any{map[string]any{"@id": "sandbox-xyz-port-6379-tcp"}},
+				}
+				fake.l4Servers[tlsMuxServerID] = map[string]any{
+					"listen": []any{":443"},
+					"routes": []any{
+						map[string]any{"@id": "sandbox-abc-port-5432-tls"},
+						map[string]any{"@id": "stranger"},
+					},
+				}
+				client := &Client{enabled: true, baseURL: fake.URL, httpClient: fake.Client}
+				snap, err := client.Snapshot(context.Background())
+				if err != nil {
+					t.Fatalf("Snapshot() error = %v", err)
+				}
+				assertContainsAll(t, "HTTPRouteIDs", snap.HTTPRouteIDs, "sandbox-abc", "sandbox-abc-port-3000")
+				assertExcludes(t, "HTTPRouteIDs", snap.HTTPRouteIDs, "unrelated")
+				assertContainsAll(t, "L4TCPServerIDs", snap.L4TCPServerIDs, "tcp-port-37412", "tcp-port-38001")
+				assertContainsAll(t, "L4TLSRouteIDs", snap.L4TLSRouteIDs, "sandbox-abc-port-5432-tls")
+				assertExcludes(t, "L4TLSRouteIDs", snap.L4TLSRouteIDs, "stranger")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, tc.run)
+	}
+}
+
+func TestPublicEndpointHelpers(t *testing.T) {
+	t.Run("tcp_endpoint_uses_public_host", func(t *testing.T) {
+		client := &Client{publicHost: "203.0.113.10"}
+		if got := client.TCPPublicEndpoint(37412); got != "tcp://203.0.113.10:37412" {
+			t.Fatalf("TCPPublicEndpoint() = %q", got)
+		}
+	})
+	t.Run("tls_endpoint_requires_domain_and_listen", func(t *testing.T) {
+		client := &Client{domain: "sandbox.example.com", publicHost: "203.0.113.10"}
+		if got := client.TLSPublicEndpoint("abc", 5432, ":443"); got != "tls://abc-5432.sandbox.example.com:443" {
+			t.Fatalf("TLSPublicEndpoint() = %q", got)
+		}
+		if got := client.TLSPublicEndpoint("abc", 5432, ""); got != "" {
+			t.Fatalf("TLSPublicEndpoint() with empty listen = %q, want empty", got)
+		}
+		ipClient := &Client{publicHost: "203.0.113.10"}
+		if got := ipClient.TLSPublicEndpoint("abc", 5432, ":443"); got != "" {
+			t.Fatalf("TLSPublicEndpoint() in IP mode = %q, want empty", got)
+		}
+	})
+}
+
+func countMethod(records []requestRecord, method string) int {
+	count := 0
+	for _, rec := range records {
+		if rec.Method == method {
+			count++
+		}
+	}
+	return count
+}
+
+func assertL4Listen(t *testing.T, server map[string]any, want string) {
+	t.Helper()
+	listens, ok := server["listen"].([]any)
+	if !ok || len(listens) == 0 {
+		t.Fatalf("missing listen: %#v", server)
+	}
+	if got, _ := listens[0].(string); got != want {
+		t.Fatalf("listen = %q, want %q", got, want)
+	}
+}
+
+func firstL4Route(t *testing.T, server map[string]any) map[string]any {
+	t.Helper()
+	routes, ok := server["routes"].([]any)
+	if !ok || len(routes) == 0 {
+		t.Fatalf("server has no routes: %#v", server)
+	}
+	route, _ := routes[0].(map[string]any)
+	if route == nil {
+		t.Fatalf("first route not an object: %#v", routes[0])
+	}
+	return route
+}
+
+func assertL4Dial(t *testing.T, route map[string]any, want string) {
+	t.Helper()
+	handles, ok := route["handle"].([]any)
+	if !ok || len(handles) == 0 {
+		t.Fatalf("missing handle: %#v", route)
+	}
+	handle, _ := handles[0].(map[string]any)
+	upstreams, ok := handle["upstreams"].([]any)
+	if !ok || len(upstreams) == 0 {
+		t.Fatalf("missing upstreams: %#v", route)
+	}
+	upstream, _ := upstreams[0].(map[string]any)
+	dials, ok := upstream["dial"].([]any)
+	if !ok || len(dials) == 0 {
+		t.Fatalf("missing dial entries: %#v", route)
+	}
+	if got, _ := dials[0].(string); got != want {
+		t.Fatalf("dial = %q, want %q", got, want)
+	}
+}
+
+func assertL4SNI(t *testing.T, route map[string]any, want string) {
+	t.Helper()
+	matches, ok := route["match"].([]any)
+	if !ok || len(matches) == 0 {
+		t.Fatalf("missing match: %#v", route)
+	}
+	match, _ := matches[0].(map[string]any)
+	tlsBlock, _ := match["tls"].(map[string]any)
+	snis, ok := tlsBlock["sni"].([]any)
+	if !ok || len(snis) == 0 {
+		t.Fatalf("missing sni list: %#v", route)
+	}
+	if got, _ := snis[0].(string); got != want {
+		t.Fatalf("sni = %q, want %q", got, want)
+	}
+}
+
+func assertContainsAll(t *testing.T, label string, got []string, want ...string) {
+	t.Helper()
+	for _, w := range want {
+		found := false
+		for _, g := range got {
+			if g == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("%s missing %q; got %v", label, w, got)
+		}
+	}
+}
+
+func assertExcludes(t *testing.T, label string, got []string, unwanted ...string) {
+	t.Helper()
+	for _, u := range unwanted {
+		for _, g := range got {
+			if g == u {
+				t.Fatalf("%s should not include %q; got %v", label, u, got)
+			}
+		}
+	}
+}
+
 type requestRecord struct {
 	Method string
 	Path   string
@@ -284,18 +615,26 @@ type requestRecord struct {
 
 // fakeCaddy emulates the slice of the Caddy admin API the client touches:
 // PATCH/DELETE /id/<routeID> work against a routeID-keyed map; PUT to
-// /routes/0 inserts a route by its @id. That's enough to verify the per-@id
-// hot path without modeling the full config tree.
+// /config/apps/http/servers/srv0/routes/0 inserts a route by its @id; and
+// the layer4 surface mirrors the same shape — PATCH/DELETE /id/<routeID>
+// for tls-mux SNI routes plus PUT/DELETE on /config/apps/layer4/servers/<id>
+// for whole-server lifecycle. That's enough to verify the per-@id hot path
+// and the L4 server CRUD without modeling the full config tree.
 type fakeCaddy struct {
-	URL     string
-	Client  *http.Client
-	records []requestRecord
-	routes  map[string]map[string]any
+	URL          string
+	Client       *http.Client
+	records      []requestRecord
+	routes       map[string]map[string]any
+	l4Servers    map[string]map[string]any
+	layer4Exists bool
 }
 
 func newFakeCaddy(t *testing.T) *fakeCaddy {
 	t.Helper()
-	fake := &fakeCaddy{routes: map[string]map[string]any{}}
+	fake := &fakeCaddy{
+		routes:    map[string]map[string]any{},
+		l4Servers: map[string]map[string]any{},
+	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fake.records = append(fake.records, requestRecord{Method: r.Method, Path: r.URL.Path})
 		switch {
@@ -334,6 +673,75 @@ func newFakeCaddy(t *testing.T) *fakeCaddy {
 			}
 			fake.routes[id] = route
 			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/config/apps/layer4":
+			if !fake.layer4Exists {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{"servers": fake.l4Servers})
+		case r.Method == http.MethodPut && r.URL.Path == "/config/apps/layer4":
+			fake.layer4Exists = true
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/config/apps/layer4/servers/"):
+			id := strings.TrimPrefix(r.URL.Path, "/config/apps/layer4/servers/")
+			if _, ok := fake.l4Servers[id]; !ok {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(fake.l4Servers[id])
+		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/config/apps/layer4/servers/"):
+			rest := strings.TrimPrefix(r.URL.Path, "/config/apps/layer4/servers/")
+			// /config/apps/layer4/servers/<id>/routes/0 — insert into existing server.
+			if strings.HasSuffix(rest, "/routes/0") {
+				serverID := strings.TrimSuffix(rest, "/routes/0")
+				server, ok := fake.l4Servers[serverID]
+				if !ok {
+					http.Error(w, "not found", http.StatusNotFound)
+					return
+				}
+				route, err := decodeRoute(r.Body)
+				if err != nil {
+					t.Fatalf("decode l4 insert body: %v", err)
+				}
+				id, _ := route["@id"].(string)
+				if id != "" {
+					fake.routes[id] = route
+				}
+				routes, _ := server["routes"].([]any)
+				server["routes"] = append([]any{route}, routes...)
+				fake.l4Servers[serverID] = server
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			// PUT /config/apps/layer4/servers/<id> — create or replace server.
+			body, err := decodeRoute(r.Body)
+			if err != nil {
+				t.Fatalf("decode l4 server body: %v", err)
+			}
+			fake.l4Servers[rest] = body
+			fake.layer4Exists = true
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/config/apps/layer4/servers/"):
+			id := strings.TrimPrefix(r.URL.Path, "/config/apps/layer4/servers/")
+			if _, ok := fake.l4Servers[id]; !ok {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			delete(fake.l4Servers, id)
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/config/":
+			snapshot := map[string]any{"apps": map[string]any{
+				"http": map[string]any{
+					"servers": map[string]any{
+						"srv0": map[string]any{"routes": fakeRoutesSlice(fake.routes)},
+					},
+				},
+				"layer4": map[string]any{"servers": fake.l4Servers},
+			}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(snapshot)
 		default:
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
@@ -342,6 +750,17 @@ func newFakeCaddy(t *testing.T) *fakeCaddy {
 	fake.URL = server.URL
 	fake.Client = server.Client()
 	return fake
+}
+
+// fakeRoutesSlice flattens the routeID-keyed map into the slice shape Caddy's
+// /config/ endpoint actually returns. Order is not stable; tests that need a
+// specific shape should match by @id, not slice index.
+func fakeRoutesSlice(routes map[string]map[string]any) []any {
+	out := make([]any, 0, len(routes))
+	for _, r := range routes {
+		out = append(out, r)
+	}
+	return out
 }
 
 func decodeRoute(body io.Reader) (map[string]any, error) {

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -311,7 +311,7 @@ type ExposedPort struct {
 	// rows carry "http" via the column default.
 	Protocol  string    `json:"protocol"`
 	// HostPort is the parent-host TCP listener allocated for protocol="tcp"
-	// from the configured pool (default [35000, 45000]). Zero for http/tls
+	// from the configured pool (default [22000, 23000]). Zero for http/tls
 	// modes, which don't reserve a per-exposure host port.
 	HostPort  int       `json:"host_port,omitempty"`
 	PublicURL string    `json:"public_url"`

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -295,6 +295,13 @@ type CreateSandboxResponse struct {
 	SSHPrivateKey string `json:"ssh_private_key,omitempty"`
 }
 
+// ExposePortRequest is the optional JSON body for POST /v1/sandboxes/{id}/ports/{port}.
+// Empty body or empty Protocol falls back to "http" — the historical default —
+// so old SDK callers keep working unchanged.
+type ExposePortRequest struct {
+	Protocol string `json:"protocol,omitempty"`
+}
+
 type ExposedPort struct {
 	SandboxID string    `json:"sandbox_id"`
 	Port      int       `json:"port"`

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -298,8 +298,41 @@ type CreateSandboxResponse struct {
 type ExposedPort struct {
 	SandboxID string    `json:"sandbox_id"`
 	Port      int       `json:"port"`
+	// Protocol is one of "http" (default — Caddy HTTP reverse proxy), "tcp"
+	// (caddy-l4 listener bound to HostPort, raw TCP forward to the container),
+	// or "tls" (caddy-l4 SNI route on the shared TLS listener). Pre-migration
+	// rows carry "http" via the column default.
+	Protocol  string    `json:"protocol"`
+	// HostPort is the parent-host TCP listener allocated for protocol="tcp"
+	// from the configured pool (default [35000, 45000]). Zero for http/tls
+	// modes, which don't reserve a per-exposure host port.
+	HostPort  int       `json:"host_port,omitempty"`
 	PublicURL string    `json:"public_url"`
 	CreatedAt time.Time `json:"created_at"`
+}
+
+// Exposed port protocols. http is the original behavior (Caddy HTTP reverse
+// proxy); tcp and tls are the caddy-l4 paths added with the L4 work.
+const (
+	ExposedPortProtocolHTTP = "http"
+	ExposedPortProtocolTCP  = "tcp"
+	ExposedPortProtocolTLS  = "tls"
+)
+
+// ValidExposedPortProtocol normalizes "" to http (the historical default) and
+// rejects unknown values. Any caller that surfaces user input must run it
+// through this before persistence.
+func ValidExposedPortProtocol(value string) (string, error) {
+	switch value {
+	case "", ExposedPortProtocolHTTP:
+		return ExposedPortProtocolHTTP, nil
+	case ExposedPortProtocolTCP:
+		return ExposedPortProtocolTCP, nil
+	case ExposedPortProtocolTLS:
+		return ExposedPortProtocolTLS, nil
+	default:
+		return "", fmt.Errorf("invalid port protocol %q (allowed: %s, %s, %s)", value, ExposedPortProtocolHTTP, ExposedPortProtocolTCP, ExposedPortProtocolTLS)
+	}
 }
 
 type HealthStatus struct {

--- a/plans/caddy-l4-tcp-routing.md
+++ b/plans/caddy-l4-tcp-routing.md
@@ -1,0 +1,299 @@
+# Caddy L4 TCP Routing for Sandbox Ports
+
+## Objective
+
+Today `exposePort()` only publishes routes into Caddy's HTTP server, so a generated URL like `https://<sandbox-id>-5432.<domain>` cannot speak the Postgres wire protocol. This plan adds **Layer 4 TCP routing** to AerolVM so a sandbox can publish a *native* `tcp://...` (or `postgresql://...`, `redis://...`, `mongodb://...`) endpoint backed by `github.com/mholt/caddy-l4`.
+
+The same rails are reused to publish raw TCP and TLS-multiplexed TCP, with a persistent host-port pool in `[35000, 45000]` for the raw path and a single shared listener port for the SNI-multiplexed path.
+
+Two reconciliation surfaces are extended so caddy-l4 servers and the DB never drift:
+1. The existing `POST /v1/admin/reconcile` API (extended).
+2. The existing periodic + event-driven sweep (extended).
+
+---
+
+## Use cases unlocked
+
+The whole purpose of this work is to turn the sandbox into a generic, customer-facing protocol host. Ten use cases this enables:
+
+1. **Per-tenant Postgres** — what the `spawn-postgres.mdx` doc currently says is *not possible*. Ship a `postgresql://user:pass@<public>:<host-port>/appdb` DSN that works with `psql`, Prisma, SQLAlchemy, pgAdmin.
+2. **Per-tenant Redis** — `redis://<public>:<host-port>` reachable from `redis-cli`, BullMQ, ioredis.
+3. **Per-tenant MySQL / MariaDB** — JDBC / mysql2 clients connect natively for ephemeral test data.
+4. **Per-tenant MongoDB** — `mongodb://<public>:<host-port>` for sandboxed product demos and per-customer data.
+5. **MQTT broker per IoT demo** — TCP/TLS, native paho/mosquitto clients.
+6. **Embedded Kafka (KRaft)** — single-broker streaming sandbox, native kafka-clients.
+7. **Game server hosting** — Minecraft / Valheim / dedicated game servers (TCP, optionally UDP later).
+8. **gRPC backends** — vLLM, LangGraph, custom gRPC services exposed natively.
+9. **SSH bastion / Git server** — port 22 forwarded as a public TCP endpoint distinct from the sandboxd SSH gateway.
+10. **TLS-only services with SNI multiplexing** — multiple TLS-shaped backends share `:443` and route by SNI (e.g. `<sandbox>-pg.<domain>` for Postgres-over-TLS, no host-port pool entry needed).
+
+---
+
+## Architecture
+
+### Two protocol modes
+
+Both modes share `caddy-l4`'s admin API surface. The sandbox SDK picks a mode per call:
+
+| Mode | Listener | URL shape | When |
+|---|---|---|---|
+| `tcp` (raw) | One `:hostport` per exposure, allocated from `[35000, 45000]` | `tcp://<public>:<hostport>` | Postgres, Redis, MySQL, raw protocols |
+| `tls` (SNI-mux) | Shared `:443` layer4 listener, `tls.matchers.sni` per route | `tls://<id>-<port>.<domain>:443` | TLS-wrapped TCP that already speaks SNI |
+| `http` (existing) | Caddy HTTP server | `https://<id>-<port>.<domain>` | unchanged |
+
+`http` is still the default — backwards compatible with everything in the docs today.
+
+### Host-port allocator (raw TCP path)
+
+The user's request: prefer **random-first** for low p95, fall back to **scan-first** when a collision happens.
+
+```
+allocate():
+    for attempt in 0..16:
+        candidate = randInt(35000, 45000)
+        if INSERT OR IGNORE INTO exposed_ports (... host_port=candidate ...) succeeded:
+            try caddy.UpsertL4Server(candidate, upstream)
+            if ok: return candidate
+            else:  delete the just-inserted row, continue
+    # Exhausted random retries; fall back to deterministic scan.
+    return scanForFreeHostPort(35000, 45000)
+```
+
+The DB has a `UNIQUE(host_port)` constraint, so two concurrent allocators race to `INSERT` and only one wins per port — no in-process lock needed. SQLite's single writer keeps this trivial.
+
+### caddy-l4 admin shape
+
+caddy-l4 lives under `/config/apps/layer4/servers/<server-id>`. Each server has `listen` + `routes`. Two server flavors:
+
+```jsonc
+// raw TCP — one server per allocated host port
+"layer4": {
+  "servers": {
+    "tcp-port-37412": {
+      "listen": [":37412"],
+      "routes": [{
+        "@id": "sandbox-sb-abc-port-5432-tcp",
+        "handle": [{ "handler": "proxy", "upstreams": [{ "dial": ["172.17.0.5:5432"] }] }]
+      }]
+    },
+    // TLS multiplexer — shared :443, routes by SNI
+    "tls-mux": {
+      "listen": [":443"],
+      "routes": [
+        {
+          "@id": "sandbox-sb-abc-port-5432-tls",
+          "match": [{ "tls": { "sni": ["sb-abc-5432.sandbox.example.com"] } }],
+          "handle": [{ "handler": "proxy", "upstreams": [{ "dial": ["172.17.0.5:5432"] }] }]
+        }
+      ]
+    }
+  }
+}
+```
+
+The `tls-mux` server is created once at install time; raw-TCP servers are created on demand and torn down on unexpose / destroy.
+
+> **Important conflict**: Caddy's HTTPS listener (current Caddyfile) already binds `:443`. Caddy-l4 can take over `:443` and forward HTTPS to Caddy's HTTP app via `tls.handlers.http_server` or `proxy` to `127.0.0.1:444` — but a clean way is to move the HTTPS listener to a non-`443` internal port and front it with the same `layer4` server (terminate non-matching SNI on the HTTP app). This is the **most disruptive piece of the plan** and is called out as an open question.
+
+### Reconciliation guarantees
+
+| Direction | Today | After this change |
+|---|---|---|
+| DB row missing → caddy route still present | HTTP routes are GC'd by `Reconcile` walking `s.store.List` | Extended to GC both `apps/http` and `apps/layer4` routes, plus release host-port allocations |
+| Container missing → DB row stays | Marks destroyed, removes routes | Same, but also tears down layer4 servers and releases host ports |
+| caddy route present but no DB row (zombie route) | **Not handled today** | New: `Reconcile` walks caddy's `apps/http` and `apps/layer4` configs, deletes any route/server with our `@id` prefix that doesn't match a known sandbox/exposure |
+| Container present but DB row missing (orphan container) | Removed | Same |
+| Host port leaked (DB has port but caddy l4 server gone) | n/a | Re-upsert on reconcile |
+
+---
+
+## Files to modify / create
+
+### 1. `scripts/install.sh`
+
+- Always include `github.com/mholt/caddy-l4` in the Caddy build, regardless of `--dns-provider`. Today the script only swaps the apt-installed `caddy` binary when `--dns-provider` is set; that path must run unconditionally now.
+  - Refactor `install_caddy_dns_plugin` into `install_custom_caddy(plugins...)` that accepts a list. Always passes `caddy-l4`; conditionally appends `caddy-dns/<provider>`.
+  - Caddy's official build server already supports multiple `&p=` params: `?os=linux&arch=amd64&p=github.com/mholt/caddy-l4&p=github.com/caddy-dns/cloudflare`.
+  - Extend the post-build verification: `list-modules` must include `layer4` and `layer4.handlers.proxy`.
+- `write_environment` adds three new env vars to `/etc/sandboxd/sandboxd.env`:
+  ```
+  SB_L4_PORT_RANGE_START=35000
+  SB_L4_PORT_RANGE_END=45000
+  SB_L4_TLS_LISTEN=:443
+  ```
+- `write_caddyfile` is updated to:
+  - Move the existing `https://$DOMAIN` and `https://*.$DOMAIN` blocks to listen on an internal address (e.g. `:444`) bound to localhost.
+  - Add a `layer4` global app stub with one persistent `tls-mux` server on `:443` whose default route forwards non-matching SNI to `127.0.0.1:444` (so HTTPS still works).
+  - Open question: simpler alternative is to keep the HTTP/HTTPS sites untouched and let caddy-l4 use a *different* port for SNI multiplexing (e.g. `:8443`). Less disruptive but a less clean URL surface.
+- Print an L4 line in the final summary:
+  ```
+  TCP port range: 35000-45000  (configure firewall accordingly)
+  TLS multiplex: :443 (shared with HTTPS via SNI)
+  ```
+
+### 2. `internal/config/config.go`
+
+- New fields on `Config`:
+  - `L4PortRangeStart int` (default 35000, env `SB_L4_PORT_RANGE_START`)
+  - `L4PortRangeEnd int` (default 45000, env `SB_L4_PORT_RANGE_END`)
+  - `L4TLSListen string` (default `:443`, env `SB_L4_TLS_LISTEN`)
+- Validate: end > start, both within `[1024, 65535]`.
+
+### 3. `pkg/models/types.go`
+
+- Extend `ExposedPort`:
+  ```go
+  type ExposedPort struct {
+      SandboxID  string    `json:"sandbox_id"`
+      Port       int       `json:"port"`
+      Protocol   string    `json:"protocol"`              // "http" | "tcp" | "tls"
+      HostPort   int       `json:"host_port,omitempty"`   // raw TCP only
+      PublicURL  string    `json:"public_url"`
+      CreatedAt  time.Time `json:"created_at"`
+  }
+  ```
+- New request type for the SDK's TCP variant:
+  ```go
+  type ExposePortRequest struct {
+      Protocol string `json:"protocol,omitempty"` // default "http"
+  }
+  ```
+
+### 4. `internal/store/store.go`
+
+- Migration appended to `migrations`:
+  ```sql
+  ALTER TABLE exposed_ports ADD COLUMN protocol TEXT NOT NULL DEFAULT 'http';
+  ALTER TABLE exposed_ports ADD COLUMN host_port INTEGER NOT NULL DEFAULT 0;
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_exposed_ports_host_port
+      ON exposed_ports(host_port) WHERE host_port > 0;
+  ```
+- `UpsertPort` / `loadPorts` / `DeletePort` updated to read/write `protocol` and `host_port`.
+- New `ListAllExposedPorts(ctx)` for reconcile to walk every exposure across all sandboxes in one query (avoids N+1 on reconcile).
+- New `TryReserveHostPort(ctx, sandboxID, containerPort, hostPort)` — single `INSERT ... ON CONFLICT DO NOTHING`; returns whether reservation took.
+
+### 5. `pkg/caddy/client.go`
+
+Add a separate set of helpers for layer4. Same per-`@id` upsert pattern as today's HTTP code so it stays O(1):
+
+```go
+func (c *Client) UpsertTCPRoute(ctx context.Context, id, containerIP string, port, hostPort int) error
+func (c *Client) DeleteTCPRoute(ctx context.Context, id string, hostPort int) error
+func (c *Client) UpsertTLSSNIRoute(ctx context.Context, id, host, containerIP string, port int) error
+func (c *Client) DeleteTLSSNIRoute(ctx context.Context, id string) error
+func (c *Client) ListLayer4RouteIDs(ctx context.Context) ([]string, error)  // for reconcile zombie GC
+func (c *Client) ListHTTPRouteIDs(ctx context.Context) ([]string, error)    // for reconcile zombie GC
+```
+
+- `tls-mux` SNI routes patch via `PATCH /id/<routeID>` exactly like HTTP routes.
+- Raw TCP servers can't be PATCHed (the listen address is part of the server config); use `PUT /config/apps/layer4/servers/tcp-port-<hostPort>` to create, `DELETE /config/apps/layer4/servers/tcp-port-<hostPort>` to drop.
+- Route `@id` conventions:
+  - HTTP port: `sandbox-<id>-port-<port>` (existing)
+  - TCP server id: `tcp-port-<hostPort>`
+  - TCP route id: `sandbox-<id>-port-<port>-tcp`
+  - TLS-SNI route id: `sandbox-<id>-port-<port>-tls`
+
+### 6. `internal/service/service.go`
+
+- New allocator helper: `allocateHostPort(ctx, sandboxID, containerPort) (int, error)` — random-first, then scan-fallback as in the architecture section above.
+- `ExposePort(ctx, id, port, protocol)` gains the protocol parameter:
+  - `http` → unchanged (calls `caddy.UpsertPortRoute`).
+  - `tls` → `caddy.UpsertTLSSNIRoute(... s.cfg.Domain ...)`. Returns `tls://<id>-<port>.<domain>:443`.
+  - `tcp` → allocate host port, `caddy.UpsertTCPRoute(...)`, write `host_port` in DB. Returns `tcp://<publicHost>:<hostPort>`.
+- `UnexposePort` looks up the row, dispatches to the right delete helper, and clears the host-port reservation.
+- `Reconcile` extended (see below).
+- `StartSandbox` re-upserts every protocol's caddy entry on startup.
+- `StopSandbox` and `DestroySandbox` tear down all three flavors.
+
+### 7. `internal/service/events.go`
+
+- `markSandboxStopped` and `handleStartEvent` extended to walk `ExposedPorts` and dispatch to `UpsertTCPRoute` / `UpsertTLSSNIRoute` / `UpsertPortRoute` based on `Protocol`. Same teardown shape on stop.
+
+### 8. `internal/service/reconcile.go` *(new file, splitting `Reconcile` out of service.go since it grows)*
+
+- Move the existing `Reconcile`, `StartReconcileLoop`, and the embedded helpers into a new file. Pure refactor; behavior preserved.
+- Extend `Reconcile`:
+  1. Walk `caddy.ListHTTPRouteIDs` and `caddy.ListLayer4RouteIDs`. For every route ID matching `sandbox-...` or server matching `tcp-port-...` that has no corresponding DB row, delete it. **(zombie caddy route GC — fixes the gap in today's reconcile)**
+  2. For every DB exposure missing its caddy entry (e.g. caddy was wiped), re-upsert.
+  3. For every host port in DB whose caddy `tcp-port-<host>` server is missing, re-create.
+  4. The existing orphan-container and destroyed-sandbox passes stay unchanged.
+
+### 9. `pkg/api/server.go`
+
+- `POST /v1/sandboxes/{id}/ports/{port}` body now optionally accepts `{"protocol":"tcp"|"tls"|"http"}`. Default `http`. Response shape gains `protocol` and (for TCP) `host_port`.
+- `POST /v1/admin/reconcile` itself is unchanged — the work is all on the service side.
+
+### 10. SDK surface
+
+All five SDK languages get a new optional argument or parallel method. Convention:
+
+- `sandbox.exposePort(port)` — unchanged, default `http`.
+- `sandbox.exposeTCPPort(port)` — new, returns `{ url, host, port }` (URL plus parsed host/port for convenience).
+- `sandbox.exposeTLSPort(port)` — new, returns `{ url, host, port }`.
+
+Files:
+- `sdk/typescript/src/internal/client.ts`
+- `sdk/python/aerolvm/_internal/client.py` *(check exact path during impl)*
+- `sdk/go/pkg/microvm/client.go`
+- `sdk/go/internal/apiclient/client.go`
+- `sdk/rust/...`
+- `sdk/java/src/main/java/ai/aerol/microvm/Sandbox.java`
+- `sdk/java/src/main/java/ai/aerol/microvm/MicroVMClient.java`
+
+### 11. Docs
+
+Per `CLAUDE.md`: every new top-level feature gets its own `.mdx` registered in `docs/src/content/config.ts`. Examples must use all five SDK languages with `<Tabs syncKey="lang">`.
+
+- `docs/src/content/docs/tcp-ports.mdx` — new top-level page covering `exposeTCPPort` / `exposeTLSPort`. Walks through Postgres, Redis, MySQL examples.
+- `docs/src/content/config.ts` — sidebar entry.
+- `docs/src/content/docs/use-cases/customer-facing-product-experiences/spawn-postgres.mdx` — rewrite the "Important network limitation" + "Can a user access Postgres on the generated URL?" sections; switch the script to `exposeTCPPort(5432)` returning a real `postgresql://...` DSN.
+- `docs/src/content/docs/reconcile.mdx` — add a section on zombie route GC.
+
+### 12. Tests
+
+- `pkg/caddy/client_test.go` — extend `fakeCaddy` to model `apps/layer4/servers/<id>` and SNI route shape; add cases for `UpsertTCPRoute`, `DeleteTCPRoute`, `UpsertTLSSNIRoute`, `ListLayer4RouteIDs`.
+- `internal/store/store_test.go` — round-trip `protocol` and `host_port`; verify the unique index rejects duplicate host ports.
+- `internal/service/lifecycle_test.go` — extend with TCP exposure paths.
+- New `internal/service/reconcile_zombie_test.go` — drive a fake caddy with extra routes/servers that have no DB row, run `Reconcile`, assert they are removed.
+- `pkg/api/server_test.go` — exercise `POST /v1/sandboxes/{id}/ports/{port}` with `protocol=tcp` end-to-end with a fake caddy + service.
+
+---
+
+## Phasing
+
+Suggested order so each phase is independently testable:
+
+1. **Phase 1 — caddy-l4 install path.** Modify `scripts/install.sh` to always include caddy-l4; verify `list-modules` on a fresh VM. No code changes elsewhere.
+2. **Phase 2 — schema + models.** Add `protocol` and `host_port` columns + `ExposedPort` field. No behavior change yet.
+3. **Phase 3 — caddy client helpers.** New `UpsertTCPRoute` / `UpsertTLSSNIRoute` plus tests against the fake caddy.
+4. **Phase 4 — service-side allocator + ExposePort dispatch.** API gains `protocol` field; SDK TS first, others follow.
+5. **Phase 5 — reconcile extension.** Zombie route + L4 server GC.
+6. **Phase 6 — docs + remaining SDKs.** Update `spawn-postgres.mdx`; add `tcp-ports.mdx`.
+
+Each phase is a separate PR; phases 1–3 can ship dark behind no public API.
+
+---
+
+## Open questions
+
+1. **`:443` ownership.** caddy-l4's TLS-SNI multiplexer wants `:443`, but the existing Caddyfile already binds `:443` for HTTPS. Three options:
+   - (a) Move HTTPS to an internal port (e.g. `127.0.0.1:444`) and have a layer4 server on `:443` route by SNI to either an internal HTTPS upstream or a TCP backend. Cleanest URL surface; biggest install.sh diff.
+   - (b) Keep HTTPS on `:443`; put the SNI multiplexer on `:8443`. Easy, but URLs become `tls://host:8443` which is awkward.
+   - (c) Drop the `tls` mode entirely from this round; ship only the raw-TCP host-port pool. Smaller blast radius.
+   - **Recommend (a)** because (b) leaks the port number into every URL and (c) loses half the value.
+2. **Firewall guidance.** The host needs `[35000, 45000]` open. install.sh on a VPS doesn't manage firewalls today (no `ufw` calls). Document the requirement; do not auto-open. Confirm.
+3. **Host port range and per-tenant fairness.** 10,000 ports / sandbox theoretically allows ~10k concurrent TCP exposures. No per-sandbox cap today. Add `SB_L4_MAX_PORTS_PER_SANDBOX` (default e.g. 8) before this ships? Otherwise a buggy SDK loop could exhaust the pool.
+4. **UDP.** Game servers and DNS need UDP. caddy-l4 supports it; out of scope for this round but the schema (`protocol` column) leaves room. Confirm scope = TCP-only.
+5. **TLS termination.** TLS mode multiplexes by SNI but does **not** terminate TLS — the upstream must speak TLS itself (Postgres in TLS mode can; raw Redis cannot). The SDK URL must clearly say "this is encrypted end-to-end, server cert lives inside the sandbox." Should we instead offer a `tls-terminate` mode where Caddy holds the cert and proxies plaintext into the container? That doubles the design surface — recommend deferring.
+6. **Reconcile API contract.** Is it acceptable to change `POST /v1/admin/reconcile` to *also* delete zombie caddy routes (no body change, semantics broaden), or should we add a query param like `?gc_caddy=true` to keep behavior bisectable for operators? Recommend broadening — the new behavior is strictly safer.
+7. **Public host vs domain mode.** When `--domain` is unset (IP mode), TCP works (URL = `tcp://<public-host>:<hostport>`) but TLS-SNI mode does not (no DNS names). Should `exposeTLSPort` return an error in IP mode, or fall back to TCP silently? Recommend explicit error.
+
+---
+
+## Out of scope
+
+- UDP support.
+- Per-sandbox host-port quotas (called out in OQ #3).
+- TLS termination at Caddy (called out in OQ #5).
+- Connection-rate limiting on TCP listeners.
+- Per-route metrics for L4 traffic (caddy-l4 has its own metrics surface; wiring it into `/health` is a separate piece of work).

--- a/pr-review.md
+++ b/pr-review.md
@@ -1,0 +1,61 @@
+# PR Review Checklist
+
+Every PR touching `internal/service`, `internal/store`, `pkg/caddy`, `pkg/api`, or the SDKs must be reviewed against the rules below. The PR description must explicitly call out each rule it touches — silence is not acceptable on these axes.
+
+The fill-in template lives at [`.github/pull_request_template.md`](./.github/pull_request_template.md) and is auto-populated by GitHub when a PR is opened. This file is the rationale and the reviewer's reference; the template is what authors fill in.
+
+## 1. Idempotency
+
+All sandbox APIs MUST be idempotent.
+
+- Retrying the same request with the same inputs MUST yield the same result.
+- A retry MUST NOT cause resource leaks, double allocations, or "already exists" errors.
+- Worked example: `expose_port` for an already-exposed `(sandbox, port)` pair must return the existing public URL, not allocate a new host port. The TCP path specifically must NOT walk the host-port pool on a PK conflict.
+- Cross-protocol re-expose on the same port should fail fast with a clear "unexpose first" error rather than silently overwriting and leaking the prior caddy route.
+
+**Reviewer asks:** what happens if this exact request is retried 5 times? 50 times? Concurrently from two callers?
+
+## 2. Sandbox boot / `CreateSandbox` latency
+
+Sandbox creation latency is a load-bearing UX metric. Treat the boot path as protected.
+
+- No new work — even lazy or amortized — gets added to `CreateSandbox` or anything it calls without an explicit call-out in the PR description.
+- The call-out must state: what was added, expected added latency, conditions under which it fires, whether it's bounded.
+- "It's only on the first call" is still an impact and must be called out.
+
+**Reviewer asks:** does this PR add ANY work — DB query, HTTP round-trip, file I/O, lock acquisition — to the sandbox boot path? If yes, is it documented?
+
+## 3. Bootstrap belongs at daemon start, not on hot APIs
+
+When daemon-start bootstrap is best-effort (e.g., depends on Caddy being reachable on a cold restart), the recovery pattern is:
+
+- A lazy single-flight retry that fires only on the API path that needs it (e.g., the first L4 expose).
+- Behind an `atomic.Bool` fast-path latch, so the steady-state hot path is a single atomic load.
+- A `sync.Mutex` around the slow path so a thundering herd of concurrent first-callers issues exactly one bootstrap, not N.
+- Failure leaves the latch unset so the next caller retries; success latches forever.
+
+The L4 bootstrap (`Service.EnsureLayer4Ready`) is the canonical shape. Mirror it for any future best-effort daemon-start work.
+
+**Anti-patterns:** retrying bootstrap on every request; failing the daemon outright on a transient bootstrap error; logging-and-forgetting so the first user request gets a confusing "X not found" from the underlying system.
+
+## 4. Failure-path state consistency
+
+Any expose / unexpose / reconcile path that touches BOTH caddy and the store can leave the system inconsistent on partial failure.
+
+- Decide and document the rollback rule: if caddy succeeds and store fails, what cleans up? If store succeeds and caddy fails, who owns the rollback?
+- Do not delete a row that another caller (race) just installed. Track "did I create this?" with an explicit flag (see `allocateHostPort`'s `reused` return) before issuing rollback deletes.
+- The reconcile loop is the safety net, not the primary cleanup path. Don't lean on it to cover routine error handling.
+
+**Reviewer asks:** if step 2 of 3 fails, what state is the system in? Is the next request to the same sandbox going to succeed, fail confusingly, or leak resources?
+
+## 5. TCP host-port pool & L4 bootstrap
+
+These two areas are particularly fragile and have produced live incidents (PR #16):
+
+- Any change to `TryReserveHostPort` semantics, the partial unique index on `host_port`, or the allocator loop in `allocateHostPort` requires a regression test in `internal/store/store_test.go` AND a call-out in the PR description.
+- Any change to `EnsureLayer4` / `EnsureLayer4Ready` / the `l4Ready` latch requires a regression test in `internal/service/layer4_bootstrap_test.go` AND a call-out.
+- Do not collapse the three-state `ReserveHostPortResult` (`Reserved` / `Existing` / neither) back into a `bool`. The middle state is what prevents pool walks on PK collisions.
+
+## PR description template
+
+Lives at [`.github/pull_request_template.md`](./.github/pull_request_template.md). GitHub auto-fills new PRs with it. Authors must answer every section; "N/A — <one-line reason>" is valid, empty is not.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -502,8 +502,8 @@ SB_MOUNT_WAIT_TIMEOUT=30s
 SB_RECORDING_DIR=/var/lib/toolboxd/recordings
 SB_RECORDING_RETENTION=168h
 SB_SESSION_BUFFER_BYTES=1048576
-SB_L4_PORT_RANGE_START=35000
-SB_L4_PORT_RANGE_END=45000
+SB_L4_PORT_RANGE_START=22000
+SB_L4_PORT_RANGE_END=23000
 # TLS-SNI multiplexing is opt-in. Setting this to e.g. ":443" makes
 # caddy-l4 take over that listener; until the HTTPS site is moved off
 # the same address it would conflict, so we leave it empty by default.
@@ -946,8 +946,8 @@ SB_MOUNT_WAIT_TIMEOUT=30s
 SB_RECORDING_DIR=/var/lib/toolboxd/recordings
 SB_RECORDING_RETENTION=168h
 SB_SESSION_BUFFER_BYTES=1048576
-SB_L4_PORT_RANGE_START=35000
-SB_L4_PORT_RANGE_END=45000
+SB_L4_PORT_RANGE_START=22000
+SB_L4_PORT_RANGE_END=23000
 SB_L4_TLS_LISTEN=
 EOF
 	chmod 0600 /etc/sandboxd/sandboxd.env
@@ -1131,6 +1131,9 @@ else
 	echo "Health URL: http://$PUBLIC_HOST:21212/health"
 	echo "Public sandbox URL pattern: http://$PUBLIC_HOST/<docker-short-id>/"
 fi
-echo "TCP port pool: 35000-45000 (open these on the host firewall to publish native TCP ports)"
+echo "TCP port pool: 22000-23000 (open these on the host firewall to publish native TCP ports)"
+echo "  This range sits below the Linux ephemeral range (32768-60999) on purpose so the"
+echo "  kernel never hands these out as outbound source ports — eliminates random EADDRINUSE"
+echo "  failures on ExposeTCPPort. 1000 slots = max concurrent TCP exposures per host."
 echo "systemd restart policy: always (5 second backoff, 10 restarts per 5 minutes)"
 echo "Health watchdog: sandboxd-healthcheck.timer probes /health every 30 seconds"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -301,6 +301,16 @@ if [[ -n "$DNS_PROVIDER" ]]; then
 	esac
 fi
 
+# TLS-SNI multiplexing is gated on DNS-01 issuance because handing :443 to
+# caddy-l4 means HTTP-01 ACME validation can't bind there. With DNS-01 in
+# place ACME never needs :443, so caddy-l4 can own it and the regular Caddy
+# HTTPS site moves to 127.0.0.1:8443.
+if [[ -n "$DNS_PROVIDER" ]]; then
+	L4_TLS_LISTEN_DEFAULT=":443"
+else
+	L4_TLS_LISTEN_DEFAULT=""
+fi
+
 if [[ "$BUILD_FROM_SOURCE" == "auto" ]]; then
 	if [[ -f ./go.mod ]]; then
 		BUILD_FROM_SOURCE="true"
@@ -504,10 +514,13 @@ SB_RECORDING_RETENTION=168h
 SB_SESSION_BUFFER_BYTES=1048576
 SB_L4_PORT_RANGE_START=22000
 SB_L4_PORT_RANGE_END=23000
-# TLS-SNI multiplexing is opt-in. Setting this to e.g. ":443" makes
-# caddy-l4 take over that listener; until the HTTPS site is moved off
-# the same address it would conflict, so we leave it empty by default.
-SB_L4_TLS_LISTEN=
+# TLS-SNI multiplexing. With --dns-provider set we bind caddy-l4 to :443 by
+# default (the Caddyfile above moves the regular HTTPS site to
+# 127.0.0.1:8443 so they don't collide; ACME goes via DNS so :443 isn't
+# needed for issuance). Without --dns-provider we leave it empty so
+# HTTP-01 issuance keeps :443 for itself.
+SB_L4_TLS_LISTEN=$L4_TLS_LISTEN_DEFAULT
+SB_L4_TLS_FALLBACK=127.0.0.1:8443
 EOF
 	chmod 0600 /etc/sandboxd/sandboxd.env
 }
@@ -535,12 +548,30 @@ EOF
 		# This sidesteps Let's Encrypt's per-registered-domain rate limits
 		# (50 certs/week) regardless of how many sandboxes are created.
 		# {env.SB_DNS_API_TOKEN} is read from /etc/default/caddy.
+		#
+		# In DNS-01 mode we also enable TLS-SNI multiplexing by default.
+		# caddy-l4 owns :443, peeks at the ClientHello SNI, routes per-sandbox
+		# subdomains directly to the sandbox container, and forwards any
+		# unmatched SNI (the API host itself, stray probes) to this Caddy
+		# HTTPS listener on 127.0.0.1:8443. Two implications:
+		#   - The HTTPS sites below bind 127.0.0.1:8443, NOT :443. caddy-l4
+		#     gets :443, sandboxd writes the L4 server config via the admin
+		#     API on first L4 expose call.
+		#   - DNS-01 means we don't need :443 free for ACME (validation goes
+		#     through DNS), so handing :443 to caddy-l4 is safe.
+		# Without --dns-provider, TLS-SNI stays off so HTTP-01 ACME on :443
+		# keeps working — see the on-demand fallback branch below.
 		cat > /etc/caddy/Caddyfile <<EOF
 {
 	admin localhost:2019
+	# caddy-l4 owns :443; the HTTPS sites below run on 127.0.0.1:8443 and
+	# only receive traffic forwarded from caddy-l4's SNI fallback route.
+	# Disable Caddy's auto-managed :80 -> :443 redirect since :443 isn't ours.
+	auto_https disable_redirects
 }
 
-https://$DOMAIN {
+https://$DOMAIN:8443 {
+	bind 127.0.0.1
 	tls {
 		dns $DNS_PROVIDER {env.SB_DNS_API_TOKEN}
 	}
@@ -553,7 +584,8 @@ https://$DOMAIN {
 	}
 }
 
-https://*.$DOMAIN {
+https://*.$DOMAIN:8443 {
+	bind 127.0.0.1
 	tls {
 		dns $DNS_PROVIDER {env.SB_DNS_API_TOKEN}
 	}
@@ -948,7 +980,9 @@ SB_RECORDING_RETENTION=168h
 SB_SESSION_BUFFER_BYTES=1048576
 SB_L4_PORT_RANGE_START=22000
 SB_L4_PORT_RANGE_END=23000
+# Local mode runs without Caddy, so TLS-SNI multiplexing is permanently off.
 SB_L4_TLS_LISTEN=
+SB_L4_TLS_FALLBACK=127.0.0.1:8443
 EOF
 	chmod 0600 /etc/sandboxd/sandboxd.env
 }
@@ -1122,9 +1156,14 @@ if [[ -n "$DOMAIN" ]]; then
 	echo "Public sandbox URL pattern: https://<docker-short-id>.$DOMAIN"
 	if [[ -n "$DNS_PROVIDER" ]]; then
 		echo "TLS: wildcard DNS-01 via $DNS_PROVIDER (one cert covers all subdomains)"
+		echo "TLS-SNI multiplexing: ENABLED on :443 (caddy-l4 routes by SNI)"
+		echo "  Regular HTTPS sites moved to 127.0.0.1:8443; caddy-l4 forwards"
+		echo "  unmatched SNI to that listener. exposeTLSPort() works out of the box."
 	else
 		echo "TLS: on-demand HTTP-01 (per-subdomain). Subject to Let's Encrypt rate limits."
 		echo "  For production, re-run with --dns-provider cloudflare --dns-api-token <token>"
+		echo "TLS-SNI multiplexing: DISABLED (HTTP-01 needs :443 free for ACME)."
+		echo "  Re-run with --dns-provider to enable exposeTLSPort()."
 	fi
 else
 	echo "API URL: http://$PUBLIC_HOST:21212"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -504,7 +504,10 @@ SB_RECORDING_RETENTION=168h
 SB_SESSION_BUFFER_BYTES=1048576
 SB_L4_PORT_RANGE_START=35000
 SB_L4_PORT_RANGE_END=45000
-SB_L4_TLS_LISTEN=:443
+# TLS-SNI multiplexing is opt-in. Setting this to e.g. ":443" makes
+# caddy-l4 take over that listener; until the HTTPS site is moved off
+# the same address it would conflict, so we leave it empty by default.
+SB_L4_TLS_LISTEN=
 EOF
 	chmod 0600 /etc/sandboxd/sandboxd.env
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -365,12 +365,16 @@ install_packages() {
 	fi
 }
 
-install_caddy_dns_plugin() {
+install_custom_caddy() {
 	# Replace the apt-installed Caddy binary with a custom build that includes
-	# the chosen caddy-dns plugin. This is required for DNS-01 wildcard TLS.
+	# every plugin AerolVM needs. caddy-l4 is always required so sandboxes can
+	# expose native TCP endpoints (Postgres, Redis, MySQL, etc.) via the
+	# layer4 admin API. caddy-dns/$DNS_PROVIDER is added when --dns-provider
+	# is set so DNS-01 wildcard TLS works.
+	#
 	# Caddy's official build server returns a single static binary with the
 	# requested modules baked in; no Go toolchain needed on the host.
-	local provider="$1"
+	local provider="${1:-}"
 	local arch_tag
 	local arch_extra=""
 
@@ -392,13 +396,18 @@ install_caddy_dns_plugin() {
 		caddy_path="/usr/bin/caddy"
 	fi
 
-	local download_url="${CADDY_BUILD_URL_BASE}?os=linux&arch=${arch_tag}${arch_extra}&p=github.com/caddy-dns/${provider}"
+	# Caddy build server accepts repeated &p= for additional modules.
+	local download_url="${CADDY_BUILD_URL_BASE}?os=linux&arch=${arch_tag}${arch_extra}&p=github.com/mholt/caddy-l4"
+	if [[ -n "$provider" ]]; then
+		download_url="${download_url}&p=github.com/caddy-dns/${provider}"
+	fi
+
 	local tmp_binary
 	tmp_binary="$(mktemp)"
 
 	if ! curl -fL --retry 5 --retry-delay 2 --retry-connrefused "$download_url" -o "$tmp_binary"; then
 		rm -f "$tmp_binary"
-		echo "Failed to download Caddy with ${provider} DNS plugin from ${download_url}" >&2
+		echo "Failed to download custom Caddy build from ${download_url}" >&2
 		exit 1
 	fi
 
@@ -418,17 +427,25 @@ install_caddy_dns_plugin() {
 
 	chmod +x "$tmp_binary"
 
-	# Verify the requested DNS plugin is actually compiled in. Without this
-	# the Caddyfile we generate later would fail to provision at runtime
-	# with a cryptic "loading module 'acme.dns.${provider}'" error.
-	local module_name="dns.providers.${provider}"
-	if ! "$tmp_binary" list-modules 2>/dev/null | grep -q "^${module_name}\$"; then
-		echo "Downloaded Caddy does not include ${module_name}." >&2
-		echo "Modules present matching 'dns':" >&2
-		"$tmp_binary" list-modules 2>/dev/null | grep -i dns >&2 || true
-		rm -f "$tmp_binary"
-		exit 1
+	# Verify every requested module is actually compiled in. Without this the
+	# Caddyfile / admin API calls we make later would fail at runtime with a
+	# cryptic "loading module 'X'" error long after install.sh exits.
+	local required_modules=("layer4" "layer4.handlers.proxy")
+	if [[ -n "$provider" ]]; then
+		required_modules+=("dns.providers.${provider}")
 	fi
+	local module
+	local present
+	present="$("$tmp_binary" list-modules 2>/dev/null || true)"
+	for module in "${required_modules[@]}"; do
+		if ! grep -q "^${module}\$" <<<"$present"; then
+			echo "Downloaded Caddy does not include required module: ${module}" >&2
+			echo "Modules present (filtered):" >&2
+			grep -E "^(layer4|dns\.providers)" <<<"$present" >&2 || true
+			rm -f "$tmp_binary"
+			exit 1
+		fi
+	done
 
 	systemctl stop caddy >/dev/null 2>&1 || true
 	install -m 0755 "$tmp_binary" "$caddy_path"
@@ -485,6 +502,9 @@ SB_MOUNT_WAIT_TIMEOUT=30s
 SB_RECORDING_DIR=/var/lib/toolboxd/recordings
 SB_RECORDING_RETENTION=168h
 SB_SESSION_BUFFER_BYTES=1048576
+SB_L4_PORT_RANGE_START=35000
+SB_L4_PORT_RANGE_END=45000
+SB_L4_TLS_LISTEN=:443
 EOF
 	chmod 0600 /etc/sandboxd/sandboxd.env
 }
@@ -923,6 +943,9 @@ SB_MOUNT_WAIT_TIMEOUT=30s
 SB_RECORDING_DIR=/var/lib/toolboxd/recordings
 SB_RECORDING_RETENTION=168h
 SB_SESSION_BUFFER_BYTES=1048576
+SB_L4_PORT_RANGE_START=35000
+SB_L4_PORT_RANGE_END=45000
+SB_L4_TLS_LISTEN=
 EOF
 	chmod 0600 /etc/sandboxd/sandboxd.env
 }
@@ -1070,9 +1093,11 @@ fi
 if [[ "$WITH_AMD_GPU" == "true" ]]; then
 	install_amd_gpu
 fi
-if [[ -n "$DNS_PROVIDER" ]]; then
-	install_caddy_dns_plugin "$DNS_PROVIDER"
-fi
+# Always replace the apt-installed Caddy with a custom build that includes
+# caddy-l4 (TCP routing for sandbox-exposed ports). DNS plugin gets folded
+# into the same build when --dns-provider is set so we make exactly one
+# trip to the Caddy build server.
+install_custom_caddy "$DNS_PROVIDER"
 install_binaries
 write_environment
 write_caddy_env
@@ -1103,5 +1128,6 @@ else
 	echo "Health URL: http://$PUBLIC_HOST:21212/health"
 	echo "Public sandbox URL pattern: http://$PUBLIC_HOST/<docker-short-id>/"
 fi
+echo "TCP port pool: 35000-45000 (open these on the host firewall to publish native TCP ports)"
 echo "systemd restart policy: always (5 second backoff, 10 restarts per 5 minutes)"
 echo "Health watchdog: sandboxd-healthcheck.timer probes /health every 30 seconds"

--- a/sdk/go/internal/apiclient/client.go
+++ b/sdk/go/internal/apiclient/client.go
@@ -193,10 +193,33 @@ func (c *Client) DownloadFile(ctx context.Context, id, targetPath string) ([]byt
 }
 
 func (c *Client) ExposePort(ctx context.Context, id string, port int) (string, error) {
+	return c.exposePortWithProtocol(ctx, id, port, "")
+}
+
+// ExposeTCPPort publishes a raw TCP port through caddy-l4. The returned URL
+// is in tcp://<host>:<port> form and can be plugged straight into a Postgres /
+// Redis / MySQL / Mongo client. Requires the daemon to be configured with a
+// non-empty SB_L4_PORT_RANGE_START..END pool (default 35000-45000).
+func (c *Client) ExposeTCPPort(ctx context.Context, id string, port int) (string, error) {
+	return c.exposePortWithProtocol(ctx, id, port, "tcp")
+}
+
+// ExposeTLSPort publishes a TCP port behind the shared TLS-SNI multiplexer.
+// Returns tls://<id>-<port>.<domain>:<l4-port>. Only available when the
+// deployment has a domain configured AND SB_L4_TLS_LISTEN is set.
+func (c *Client) ExposeTLSPort(ctx context.Context, id string, port int) (string, error) {
+	return c.exposePortWithProtocol(ctx, id, port, "tls")
+}
+
+func (c *Client) exposePortWithProtocol(ctx context.Context, id string, port int, protocol string) (string, error) {
+	var body any
+	if protocol != "" {
+		body = map[string]string{"protocol": protocol}
+	}
 	var response struct {
 		PublicURL string `json:"public_url"`
 	}
-	err := c.doJSON(ctx, http.MethodPost, fmt.Sprintf("/v1/sandboxes/%s/ports/%d", id, port), nil, &response)
+	err := c.doJSON(ctx, http.MethodPost, fmt.Sprintf("/v1/sandboxes/%s/ports/%d", id, port), body, &response)
 	return response.PublicURL, err
 }
 
@@ -233,6 +256,14 @@ func (s *Sandbox) DownloadFile(ctx context.Context, targetPath string) ([]byte, 
 
 func (s *Sandbox) ExposePort(ctx context.Context, port int) (string, error) {
 	return s.client.ExposePort(ctx, s.ID, port)
+}
+
+func (s *Sandbox) ExposeTCPPort(ctx context.Context, port int) (string, error) {
+	return s.client.ExposeTCPPort(ctx, s.ID, port)
+}
+
+func (s *Sandbox) ExposeTLSPort(ctx context.Context, port int) (string, error) {
+	return s.client.ExposeTLSPort(ctx, s.ID, port)
 }
 
 func (s *Sandbox) Start(ctx context.Context) error {

--- a/sdk/go/internal/apiclient/client.go
+++ b/sdk/go/internal/apiclient/client.go
@@ -205,8 +205,13 @@ func (c *Client) ExposeTCPPort(ctx context.Context, id string, port int) (string
 }
 
 // ExposeTLSPort publishes a TCP port behind the shared TLS-SNI multiplexer.
-// Returns tls://<id>-<port>.<domain>:<l4-port>. Only available when the
-// deployment has a domain configured AND SB_L4_TLS_LISTEN is set.
+// Returns tls://<id>-<port>.<domain>:<l4-port>. caddy-l4 terminates TLS at
+// the edge using Caddy's auto-managed wildcard cert and forwards plaintext
+// bytes to the container — your sandbox process speaks plain TCP and never
+// holds a cert. Available when the deployment has a domain AND
+// SB_L4_TLS_LISTEN is set; install.sh enables this automatically when run
+// with --dns-provider. mTLS / client-cert auth is not supported in this
+// mode (the terminator consumes the handshake) — use ExposeTCPPort for that.
 func (c *Client) ExposeTLSPort(ctx context.Context, id string, port int) (string, error) {
 	return c.exposePortWithProtocol(ctx, id, port, "tls")
 }

--- a/sdk/go/internal/apiclient/client.go
+++ b/sdk/go/internal/apiclient/client.go
@@ -199,7 +199,7 @@ func (c *Client) ExposePort(ctx context.Context, id string, port int) (string, e
 // ExposeTCPPort publishes a raw TCP port through caddy-l4. The returned URL
 // is in tcp://<host>:<port> form and can be plugged straight into a Postgres /
 // Redis / MySQL / Mongo client. Requires the daemon to be configured with a
-// non-empty SB_L4_PORT_RANGE_START..END pool (default 35000-45000).
+// non-empty SB_L4_PORT_RANGE_START..END pool (default 22000-23000).
 func (c *Client) ExposeTCPPort(ctx context.Context, id string, port int) (string, error) {
 	return c.exposePortWithProtocol(ctx, id, port, "tcp")
 }

--- a/sdk/go/pkg/microvm/client.go
+++ b/sdk/go/pkg/microvm/client.go
@@ -200,6 +200,21 @@ func (s *Sandbox) ExposePort(ctx context.Context, port int) (string, error) {
 	return s.client.inner.ExposePort(ctx, s.ID, port)
 }
 
+// ExposeTCPPort publishes a raw TCP endpoint for this sandbox via caddy-l4.
+// Returns a tcp:// URL ready to plug into native protocol clients (psql,
+// redis-cli, mysql, mongosh).
+func (s *Sandbox) ExposeTCPPort(ctx context.Context, port int) (string, error) {
+	return s.client.inner.ExposeTCPPort(ctx, s.ID, port)
+}
+
+// ExposeTLSPort publishes a TLS-multiplexed endpoint via caddy-l4. Returns a
+// tls:// URL whose host is the per-sandbox subdomain caddy uses for SNI
+// matching. Requires the deployment to have a domain configured AND
+// SB_L4_TLS_LISTEN set on the daemon.
+func (s *Sandbox) ExposeTLSPort(ctx context.Context, port int) (string, error) {
+	return s.client.inner.ExposeTLSPort(ctx, s.ID, port)
+}
+
 func (s *Sandbox) UnexposePort(ctx context.Context, port int) error {
 	return s.client.inner.UnexposePort(ctx, s.ID, port)
 }

--- a/sdk/java/src/main/java/ai/aerol/microvm/MicroVMClient.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/MicroVMClient.java
@@ -155,12 +155,43 @@ public class MicroVMClient {
     }
 
     public String exposePort(String sandboxId, int port) {
-        PublicUrlResponse response = doJson("POST", sandboxPath(sandboxId) + "/ports/" + port, null, PublicUrlResponse.class);
+        return exposePortWithProtocol(sandboxId, port, null);
+    }
+
+    /**
+     * Publish a raw TCP port through caddy-l4. Returns {@code tcp://<host>:<port>}
+     * ready to plug into native protocol clients (psql, redis-cli, mysql,
+     * mongosh).
+     */
+    public String exposeTCPPort(String sandboxId, int port) {
+        return exposePortWithProtocol(sandboxId, port, "tcp");
+    }
+
+    /**
+     * Publish a TCP port behind the shared TLS-SNI multiplexer. Returns
+     * {@code tls://<id>-<port>.<domain>:<l4-port>}. Requires the deployment
+     * to have a domain configured AND {@code SB_L4_TLS_LISTEN} set.
+     */
+    public String exposeTLSPort(String sandboxId, int port) {
+        return exposePortWithProtocol(sandboxId, port, "tls");
+    }
+
+    private String exposePortWithProtocol(String sandboxId, int port, String protocol) {
+        Object body = protocol == null ? null : new ExposePortRequest(protocol);
+        PublicUrlResponse response = doJson("POST", sandboxPath(sandboxId) + "/ports/" + port, body, PublicUrlResponse.class);
         return response == null ? "" : response.publicUrl;
     }
 
     public void unexposePort(String sandboxId, int port) {
         doNoContent("DELETE", sandboxPath(sandboxId) + "/ports/" + port, null);
+    }
+
+    static class ExposePortRequest {
+        public final String protocol;
+
+        ExposePortRequest(String protocol) {
+            this.protocol = protocol;
+        }
     }
 
     public void reconcile() {

--- a/sdk/java/src/main/java/ai/aerol/microvm/Sandbox.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/Sandbox.java
@@ -89,6 +89,24 @@ public class Sandbox extends SandboxData {
         return client.exposePort(id, port);
     }
 
+    /**
+     * Publish a raw TCP port through caddy-l4. Returns
+     * {@code tcp://<host>:<port>} ready to plug into native protocol clients
+     * (psql, redis-cli, mysql, mongosh).
+     */
+    public String exposeTCPPort(int port) {
+        return client.exposeTCPPort(id, port);
+    }
+
+    /**
+     * Publish a TCP port behind the shared TLS-SNI multiplexer. Returns
+     * {@code tls://<id>-<port>.<domain>:<l4-port>}. Requires the deployment
+     * to have a domain configured AND {@code SB_L4_TLS_LISTEN} set.
+     */
+    public String exposeTLSPort(int port) {
+        return client.exposeTLSPort(id, port);
+    }
+
     public void unexposePort(int port) {
         client.unexposePort(id, port);
     }

--- a/sdk/python/microvm/client.py
+++ b/sdk/python/microvm/client.py
@@ -300,6 +300,23 @@ class Sandbox:
     def expose_port(self, port: int) -> str:
         return self._client.expose_port(self.id, port)
 
+    def expose_tcp_port(self, port: int) -> str:
+        """Publish a raw TCP port through caddy-l4. Returns ``tcp://<host>:<port>``.
+
+        Plug the result straight into ``psql``, ``redis-cli``, ``mysql``,
+        ``mongosh``, or any other native-protocol client.
+        """
+        return self._client.expose_tcp_port(self.id, port)
+
+    def expose_tls_port(self, port: int) -> str:
+        """Publish a TCP port behind the shared TLS-SNI multiplexer.
+
+        Returns ``tls://<id>-<port>.<domain>:<l4-port>``. Requires the
+        deployment to have a domain configured AND ``SB_L4_TLS_LISTEN`` set
+        on the daemon.
+        """
+        return self._client.expose_tls_port(self.id, port)
+
     def unexpose_port(self, port: int) -> None:
         self._client.unexpose_port(self.id, port)
 
@@ -471,7 +488,17 @@ class MicroVM:
         return self._request("GET", url)
 
     def expose_port(self, sandbox_id: str, port: int) -> str:
-        response = self._do_json("POST", f"/v1/sandboxes/{sandbox_id}/ports/{port}", None)
+        return self._expose_port_with_protocol(sandbox_id, port, None)
+
+    def expose_tcp_port(self, sandbox_id: str, port: int) -> str:
+        return self._expose_port_with_protocol(sandbox_id, port, "tcp")
+
+    def expose_tls_port(self, sandbox_id: str, port: int) -> str:
+        return self._expose_port_with_protocol(sandbox_id, port, "tls")
+
+    def _expose_port_with_protocol(self, sandbox_id: str, port: int, protocol: Optional[str]) -> str:
+        body: Optional[Dict[str, Any]] = {"protocol": protocol} if protocol else None
+        response = self._do_json("POST", f"/v1/sandboxes/{sandbox_id}/ports/{port}", body)
         return str(_first_of(response, "public_url", "publicURL") or "")
 
     def unexpose_port(self, sandbox_id: str, port: int) -> None:

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -315,6 +315,22 @@ impl Sandbox {
         self.client.expose_port(&self.data.id, port)
     }
 
+    /// Publish a raw TCP port through caddy-l4.
+    ///
+    /// Returns a `tcp://<host>:<port>` URL ready to plug into native protocol
+    /// clients (psql, redis-cli, mysql, mongosh).
+    pub fn expose_tcp_port(&self, port: u16) -> Result<String, Error> {
+        self.client.expose_tcp_port(&self.data.id, port)
+    }
+
+    /// Publish a TCP port behind the shared TLS-SNI multiplexer.
+    ///
+    /// Returns `tls://<id>-<port>.<domain>:<l4-port>`. Requires the
+    /// deployment to have a domain configured AND `SB_L4_TLS_LISTEN` set.
+    pub fn expose_tls_port(&self, port: u16) -> Result<String, Error> {
+        self.client.expose_tls_port(&self.data.id, port)
+    }
+
     pub fn unexpose_port(&self, port: u16) -> Result<(), Error> {
         self.client.unexpose_port(&self.data.id, port)
     }
@@ -552,7 +568,20 @@ impl Client {
     }
 
     pub fn expose_port(&self, id: &str, port: u16) -> Result<String, Error> {
-        let response = self.do_json::<(), Value>(Method::POST, &format!("/v1/sandboxes/{}/ports/{}", id, port), None)?;
+        self.expose_port_with_protocol(id, port, None)
+    }
+
+    pub fn expose_tcp_port(&self, id: &str, port: u16) -> Result<String, Error> {
+        self.expose_port_with_protocol(id, port, Some("tcp"))
+    }
+
+    pub fn expose_tls_port(&self, id: &str, port: u16) -> Result<String, Error> {
+        self.expose_port_with_protocol(id, port, Some("tls"))
+    }
+
+    fn expose_port_with_protocol(&self, id: &str, port: u16, protocol: Option<&str>) -> Result<String, Error> {
+        let body = protocol.map(|p| serde_json::json!({"protocol": p}));
+        let response = self.do_json::<Value, Value>(Method::POST, &format!("/v1/sandboxes/{}/ports/{}", id, port), body.as_ref())?;
         response
             .get("public_url")
             .and_then(|value| value.as_str())

--- a/sdk/typescript/src/internal/client.ts
+++ b/sdk/typescript/src/internal/client.ts
@@ -250,7 +250,30 @@ export class APIClient {
   }
 
   async exposePort(id: string, port: number): Promise<string> {
-    const response = await this.doJSON<{ public_url: string }>("POST", `/v1/sandboxes/${id}/ports/${port}`);
+    return this.exposePortWithProtocol(id, port);
+  }
+
+  /**
+   * Publish a raw TCP port through caddy-l4. The returned URL is in
+   * `tcp://<host>:<port>` form and works directly with `psql`, `redis-cli`,
+   * `mysql`, `mongosh`, and any other native-protocol client.
+   */
+  async exposeTCPPort(id: string, port: number): Promise<string> {
+    return this.exposePortWithProtocol(id, port, "tcp");
+  }
+
+  /**
+   * Publish a TCP port behind the shared TLS-SNI multiplexer. Returns
+   * `tls://<id>-<port>.<domain>:<l4-port>`. Requires the daemon to have a
+   * domain configured AND `SB_L4_TLS_LISTEN` set.
+   */
+  async exposeTLSPort(id: string, port: number): Promise<string> {
+    return this.exposePortWithProtocol(id, port, "tls");
+  }
+
+  private async exposePortWithProtocol(id: string, port: number, protocol?: string): Promise<string> {
+    const body = protocol ? { protocol } : undefined;
+    const response = await this.doJSON<{ public_url: string }>("POST", `/v1/sandboxes/${id}/ports/${port}`, body);
     return response.public_url;
   }
 
@@ -408,6 +431,14 @@ export class SandboxResource implements Sandbox {
 
   async exposePort(port: number): Promise<string> {
     return this.client.exposePort(this.id, port);
+  }
+
+  async exposeTCPPort(port: number): Promise<string> {
+    return this.client.exposeTCPPort(this.id, port);
+  }
+
+  async exposeTLSPort(port: number): Promise<string> {
+    return this.client.exposeTLSPort(this.id, port);
   }
 
   async unexposePort(port: number): Promise<void> {


### PR DESCRIPTION

This pull request introduces comprehensive documentation and configuration improvements for exposing TCP and TLS ports in sandboxes, as well as enhancements to PR review processes and project automation. The most significant changes include the addition of a detailed guide for publishing native TCP endpoints, updates to the documentation sidebar for discoverability, improvements to PR review guidelines and templates, and the introduction of a Dependabot configuration.

**TCP/TLS Port Exposure Documentation:**

- Added a new documentation page `tcp-ports.mdx` detailing how to publish native TCP endpoints (e.g., Postgres, Redis, MySQL, Mongo, gRPC) from a sandbox using caddy-l4. The doc covers usage, port allocation, reconciliation, and teardown, with code samples in all supported SDK languages.
- Updated the docs sidebar in `config.ts` to include links to the new TCP/TLS Ports and Preview documentation, improving navigation and discoverability for users seeking information about exposing ports. [[1]](diffhunk://#diff-9de6dde6792a780b33723ce43337db38d9c0ad8ba77e084444b27cbf6faca23bR83-R88) [[2]](diffhunk://#diff-9de6dde6792a780b33723ce43337db38d9c0ad8ba77e084444b27cbf6faca23bR141-R146)

**PR Review Process and Templates:**

- Added a detailed pull request template (`pull_request_template.md`) requiring authors to address sandbox boot impact, idempotency, failure-path consistency, L4/host-port-pool changes, and test plans. This enforces best practices and thoroughness in PR submissions.
- Updated `CLAUDE.md` to reference `pr-review.md` as the canonical source for API design and PR review requirements, emphasizing idempotency, sandbox boot work, failure-path consistency, regression testing, and PR description completeness.

**Project Automation:**

- Introduced a Dependabot configuration file (`dependabot.yml`) to enable weekly automated dependency update checks, laying the groundwork for improved dependency management.

**Service Initialization:**

- Modified `main.go` to eagerly bootstrap caddy-l4 at service startup, ensuring the first L4 exposure does not pay the cold-start penalty; logs a warning if initialization fails but does not block HTTP exposures.