### PR TITLE
feat: refactor Docker event handling to improve sandbox destruction l…

### DIFF
--- a/internal/service/events.go
+++ b/internal/service/events.go
@@ -102,9 +102,9 @@ func (s *Service) handleDockerEvent(ctx context.Context, event docker.DockerEven
 
 	switch event.Action {
 	case "die", "stop", "oom":
-		return s.markSandboxStopped(ctx, sandbox, event, models.SandboxStatusStopped)
+		return s.markSandboxStopped(ctx, sandbox, event)
 	case "destroy":
-		return s.markSandboxStopped(ctx, sandbox, event, models.SandboxStatusDestroyed)
+		return s.handleDestroyEvent(ctx, sandbox)
 	case "start":
 		return s.handleStartEvent(ctx, sandbox)
 	default:
@@ -112,14 +112,16 @@ func (s *Service) handleDockerEvent(ctx context.Context, event docker.DockerEven
 	}
 }
 
-func (s *Service) markSandboxStopped(ctx context.Context, sandbox *models.Sandbox, event docker.DockerEvent, status models.SandboxStatus) error {
+// markSandboxStopped handles die/stop/oom events: the container exited but the
+// sandbox row stays — Start can resurrect it, the image is still needed, and
+// the capacity reservation is legitimately held. Routes are torn down and
+// per-IP netrules cleared so a stopped sandbox doesn't leave dangling Caddy
+// upstreams pointing at an IP Docker may reassign on the next start.
+func (s *Service) markSandboxStopped(ctx context.Context, sandbox *models.Sandbox, event docker.DockerEvent) error {
 	previousIP := sandbox.ContainerIP
 
-	sandbox.Status = status
+	sandbox.Status = models.SandboxStatusStopped
 	sandbox.UpdatedAt = time.Now().UTC()
-	if status == models.SandboxStatusDestroyed {
-		sandbox.ContainerIP = ""
-	}
 	if event.Action == "oom" {
 		sandbox.LastError = "container killed by OOM"
 	} else if event.Action == "die" && event.ExitCode != 0 {
@@ -152,18 +154,60 @@ func (s *Service) markSandboxStopped(ctx context.Context, sandbox *models.Sandbo
 		"exit_code", event.ExitCode,
 		"status", string(sandbox.Status),
 	)
+	return nil
+}
 
-	// Image GC and admitter release: only on destroy. die/stop transition to
-	// stopped, where the image is still needed for a future Start and the
-	// reservation is still legitimately held. The store row above has already
-	// been updated to destroyed, so the GC helper's predicate will skip this
-	// sandbox correctly.
-	if status == models.SandboxStatusDestroyed {
-		if s.admitter != nil {
-			s.admitter.Release(sandbox.ID)
-		}
-		s.maybeRemoveImage(ctx, sandbox.Image)
+// handleDestroyEvent fires when Docker emits a destroy for a container we own
+// — typically `docker rm -f <id>` outside the API, OOM-then-autoremove, or a
+// daemon-side cleanup. Semantically equivalent to API DestroySandbox and the
+// reconcile destroyed-branch: delete the row, cascading exposed_ports and
+// freeing any L4 host_port reservation immediately. Without this, the row
+// would sit at status=destroyed until the next reconcile pass picked it up,
+// holding its host_port slot in the unique-index pool the entire time. With
+// SB_AUTO_RECONCILE=false or a stalled reconcile loop, that slot would be
+// stuck indefinitely.
+func (s *Service) handleDestroyEvent(ctx context.Context, sandbox *models.Sandbox) error {
+	previousIP := sandbox.ContainerIP
+
+	// Best-effort teardown. Order matches DestroySandbox (caddy → mounts →
+	// store.Delete → admitter → maybeRemoveImage); container destroy is
+	// skipped because the event itself means the container is already gone.
+	// Failures here are picked up by gcZombieCaddyEntries / mounts.Sweep on
+	// the next reconcile pass.
+	if err := s.caddy.DeleteSandboxRoute(ctx, sandbox.ID); err != nil {
+		s.logger.Warn("delete sandbox route failed", "sandbox_id", sandbox.ID, "error", err)
 	}
+	for _, port := range sandbox.ExposedPorts {
+		if err := s.deleteExposedPortRoute(ctx, sandbox, port); err != nil {
+			s.logger.Warn("delete port route failed", "sandbox_id", sandbox.ID, "port", port.Port, "protocol", port.Protocol, "error", err)
+		}
+	}
+	if err := s.mounts.UnmountAll(sandbox.ID); err != nil {
+		s.logger.Warn("unmount on destroy event failed", "sandbox_id", sandbox.ID, "error", err)
+	}
+	if previousIP != "" {
+		if err := s.docker.ClearNetworkRules(previousIP); err != nil {
+			s.logger.Warn("clear network rules failed", "sandbox_id", sandbox.ID, "ip", previousIP, "error", err)
+		}
+	}
+
+	// store.Delete must happen BEFORE maybeRemoveImage: HasActiveImageRef
+	// queries the sandboxes table and treats any non-destroyed row as a live
+	// reference. Deleting first lets the image GC see the correct state.
+	// ErrNotFound is benign — the API-driven destroy path may have raced us.
+	if err := s.store.Delete(ctx, sandbox.ID); err != nil && !errors.Is(err, store.ErrNotFound) {
+		return fmt.Errorf("delete sandbox: %w", err)
+	}
+
+	if s.admitter != nil {
+		s.admitter.Release(sandbox.ID)
+	}
+	s.maybeRemoveImage(ctx, sandbox.Image)
+
+	s.logger.Info("audit sandbox destroyed via docker event",
+		"sandbox_id", sandbox.ID,
+		"image", sandbox.Image,
+	)
 	return nil
 }
 

--- a/internal/service/reconcile_destroy_test.go
+++ b/internal/service/reconcile_destroy_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aerol-ai/microvm/internal/store"
 	"github.com/aerol-ai/microvm/pkg/caddy"
 	"github.com/aerol-ai/microvm/pkg/capacity"
+	"github.com/aerol-ai/microvm/pkg/docker"
 	"github.com/aerol-ai/microvm/pkg/models"
 	"github.com/aerol-ai/microvm/pkg/mounts"
 )
@@ -202,5 +203,210 @@ func TestReconcileDestroyedRowFreesHostPort(t *testing.T) {
 	// Image GC was attempted exactly once — no other sandbox referenced it.
 	if got := rt.removeImageHits.Load(); got != 1 {
 		t.Fatalf("RemoveImage hits = %d, want 1", got)
+	}
+}
+
+// TestDestroyEventFreesHostPort covers the second cleanup path — the Docker
+// /events stream's "destroy" action. Pre-fix, the event handler called
+// markSandboxStopped which Upserted status=destroyed and left exposed_ports
+// rows behind; the host_port reservation would then sit in the unique-index
+// pool until the next reconcile tick (or forever, if SB_AUTO_RECONCILE=false
+// or reconcile was failing). Post-fix, handleDestroyEvent deletes the row in
+// the same handler call, matching DestroySandbox and the reconcile branch.
+func TestDestroyEventFreesHostPort(t *testing.T) {
+	ctx := context.Background()
+
+	dbPath := filepath.Join(t.TempDir(), "state.db")
+	st, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	mgr, err := mounts.New(slog.New(slog.NewTextHandler(io.Discard, nil)), mounts.Config{
+		RootDir:     filepath.Join(t.TempDir(), "mounts"),
+		CredDir:     filepath.Join(t.TempDir(), "cred"),
+		WaitTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("mounts.New: %v", err)
+	}
+	t.Cleanup(mgr.Close)
+
+	caddyClient := caddy.New(config.Config{
+		EnableCaddy:       false,
+		HTTPClientTimeout: time.Second,
+	})
+	admitter := capacity.New(
+		capacity.HostInfo{CPUCores: 8, MemoryTotalMB: 16384},
+		capacity.Limits{CPUReservationRatio: 1, MemoryReservationRatio: 1},
+		nil,
+	)
+	rt := &fakeReconcileRuntime{managed: map[string]*models.SandboxRuntimeState{}}
+
+	svc := &Service{
+		cfg:      config.Config{},
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		store:    st,
+		docker:   rt,
+		caddy:    caddyClient,
+		mounts:   mgr,
+		admitter: admitter,
+	}
+
+	const (
+		sandboxID = "sb-event-doomed"
+		image     = "ubuntu:22.04"
+		hostPort  = 22501
+		container = 6379
+	)
+
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{
+		ID:           sandboxID,
+		Image:        image,
+		Status:       models.SandboxStatusStarted,
+		ContainerID:  "ctr-event-doomed",
+		ContainerIP:  "10.0.0.99",
+		CPU:          1,
+		MemoryMB:     512,
+		Runtime:      models.RuntimeDocker,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		LastActiveAt: now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+	if res, err := st.TryReserveHostPort(ctx, sandboxID, container, hostPort, models.ExposedPortProtocolTCP, "", now); err != nil || !res.Reserved {
+		t.Fatalf("seed exposed port: reserved=%v err=%v", res.Reserved, err)
+	}
+	admitter.Reserve(sandboxID, capacity.Request{CPU: 1, MemoryMB: 512})
+
+	// Simulate `docker rm -f <container>` — the daemon emits a destroy event
+	// for our managed container, which the event monitor would route to
+	// handleDockerEvent. Bypass the stream and invoke the handler directly so
+	// the test is hermetic.
+	event := docker.DockerEvent{
+		ContainerID: "ctr-event-doomed",
+		SandboxID:   sandboxID,
+		Action:      "destroy",
+		Time:        time.Now().UTC(),
+	}
+	if err := svc.handleDockerEvent(ctx, event); err != nil {
+		t.Fatalf("handleDockerEvent destroy: %v", err)
+	}
+
+	// Sandbox row deleted in the same handler call — no waiting for reconcile.
+	if _, err := st.Get(ctx, sandboxID); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("sandbox row should be deleted by destroy event, got err=%v", err)
+	}
+
+	// host_port reusable. Pre-fix this would have failed: the row sat at
+	// status=destroyed and the unique index doesn't filter on status.
+	const successorID = "sb-event-successor"
+	if err := st.Create(ctx, &models.Sandbox{
+		ID:           successorID,
+		Image:        image,
+		Status:       models.SandboxStatusStarted,
+		Runtime:      models.RuntimeDocker,
+		CreatedAt:    time.Now().UTC(),
+		UpdatedAt:    time.Now().UTC(),
+		LastActiveAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("create successor: %v", err)
+	}
+	probe, err := st.TryReserveHostPort(ctx, successorID, container, hostPort, models.ExposedPortProtocolTCP, "", time.Now().UTC())
+	if err != nil {
+		t.Fatalf("re-reserve host_port: %v", err)
+	}
+	if !probe.Reserved {
+		t.Fatalf("host_port %d still held after destroy event (existing=%+v)", hostPort, probe.Existing)
+	}
+
+	if snap := admitter.Snapshot(); snap.SandboxesActive != 0 {
+		t.Fatalf("admitter not released: %+v", snap)
+	}
+	if got := rt.removeImageHits.Load(); got != 1 {
+		t.Fatalf("RemoveImage hits = %d, want 1", got)
+	}
+}
+
+// TestDieEventDoesNotDeleteRow verifies the symmetry: die/stop/oom must
+// preserve the sandbox row so a future Start can resurrect it. Only destroy
+// is allowed to delete. A regression that funnelled die through the new
+// delete path would silently lose all stopped sandboxes — this test exists
+// to make that failure loud.
+func TestDieEventDoesNotDeleteRow(t *testing.T) {
+	ctx := context.Background()
+
+	dbPath := filepath.Join(t.TempDir(), "state.db")
+	st, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	mgr, err := mounts.New(slog.New(slog.NewTextHandler(io.Discard, nil)), mounts.Config{
+		RootDir:     filepath.Join(t.TempDir(), "mounts"),
+		CredDir:     filepath.Join(t.TempDir(), "cred"),
+		WaitTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("mounts.New: %v", err)
+	}
+	t.Cleanup(mgr.Close)
+
+	rt := &fakeReconcileRuntime{managed: map[string]*models.SandboxRuntimeState{}}
+	svc := &Service{
+		cfg:    config.Config{},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		store:  st,
+		docker: rt,
+		caddy: caddy.New(config.Config{
+			EnableCaddy:       false,
+			HTTPClientTimeout: time.Second,
+		}),
+		mounts: mgr,
+		admitter: capacity.New(
+			capacity.HostInfo{CPUCores: 8, MemoryTotalMB: 16384},
+			capacity.Limits{CPUReservationRatio: 1, MemoryReservationRatio: 1},
+			nil,
+		),
+	}
+
+	const sandboxID = "sb-stoppable"
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{
+		ID:           sandboxID,
+		Image:        "ubuntu:22.04",
+		Status:       models.SandboxStatusStarted,
+		ContainerID:  "ctr-stoppable",
+		ContainerIP:  "10.0.0.7",
+		Runtime:      models.RuntimeDocker,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		LastActiveAt: now,
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := svc.handleDockerEvent(ctx, docker.DockerEvent{
+		SandboxID: sandboxID,
+		Action:    "die",
+		ExitCode:  137,
+		Time:      time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("handleDockerEvent die: %v", err)
+	}
+
+	got, err := st.Get(ctx, sandboxID)
+	if err != nil {
+		t.Fatalf("die must preserve the row, got err=%v", err)
+	}
+	if got.Status != models.SandboxStatusStopped {
+		t.Fatalf("status after die: got %q, want %q", got.Status, models.SandboxStatusStopped)
+	}
+	if rt.removeImageHits.Load() != 0 {
+		t.Fatalf("die must not GC image, got %d hits", rt.removeImageHits.Load())
 	}
 }


### PR DESCRIPTION
This pull request refactors how Docker "destroy" events are handled for sandboxes, ensuring immediate cleanup of resources and preventing resource leaks. It introduces a dedicated handler for "destroy" events that deletes the sandbox row and frees associated resources right away, rather than waiting for a periodic reconcile. The changes also add comprehensive tests to verify correct behavior for both "destroy" and "die/stop/oom" events.

**Event handling improvements:**

* Refactored the `handleDockerEvent` method in `internal/service/events.go` to route "destroy" events to a new `handleDestroyEvent` function, which deletes the sandbox row and cleans up resources immediately, instead of just marking the sandbox as destroyed. This prevents host port leaks and matches the behavior of the API-driven destroy path. [[1]](diffhunk://#diff-bf702c7fa4c39ba053dc54097edcd8a79d531cbed5c1f86e2bcee84ad2c898eeL105-L122) [[2]](diffhunk://#diff-bf702c7fa4c39ba053dc54097edcd8a79d531cbed5c1f86e2bcee84ad2c898eeR157-R210)

**Testing enhancements:**

* Added `TestDestroyEventFreesHostPort` in `internal/service/reconcile_destroy_test.go` to verify that a "destroy" event fully deletes the sandbox and releases the host port for immediate reuse.
* Added `TestDieEventDoesNotDeleteRow` to ensure that "die/stop/oom" events do not delete the sandbox row, preserving the ability to restart the sandbox.

**Dependency updates:**

* Imported the `docker` package in the test file to support the new event simulation.…ogic

<!--
GitHub auto-fills new PR descriptions with this template. Fill in EVERY
section below. "N/A — <one-line reason>" is a valid answer; an empty answer
is not. See pr-review.md at the repo root for what each section is asking.
-->

