### PR TITLE
feat: add ApplyNetworkBlockAll method for per-IP egress rule management

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -69,4 +69,11 @@ type Runtime interface {
 	// to a sandbox. Used by the event-driven path when a container exits or
 	// is destroyed out-of-band; Destroy() handles this during normal teardown.
 	ClearNetworkRules(containerIP string) error
+
+	// ApplyNetworkBlockAll installs the per-IP egress DROP rule for sandboxes
+	// created with NetworkBlockAll=true. Idempotent — safe to call on every
+	// Start and reconcile pass. Used to reapply the rule after Stop+Start
+	// cycles (which clear it on the stop event) and after host-side state
+	// loss (iptables flush, daemon restart that rebuilds chains).
+	ApplyNetworkBlockAll(containerIP string) error
 }

--- a/internal/service/reconcile_destroy_test.go
+++ b/internal/service/reconcile_destroy_test.go
@@ -69,6 +69,9 @@ func (f *fakeReconcileRuntime) PushAllowedPorts(context.Context, string, string,
 func (f *fakeReconcileRuntime) ClearNetworkRules(string) error {
 	return nil
 }
+func (f *fakeReconcileRuntime) ApplyNetworkBlockAll(string) error {
+	return nil
+}
 
 // TestReconcileDestroyedRowFreesHostPort is the regression test required by
 // pr-review.md §5: a destroyed sandbox must free its TCP host_port reservation

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -365,6 +365,19 @@ func (s *Service) StartSandbox(ctx context.Context, id string) (*models.Sandbox,
 	sandbox.UpdatedAt = time.Now().UTC()
 	sandbox.LastActiveAt = time.Now().UTC()
 
+	// Reapply the per-IP egress DROP rule. The stop event clears it (the IP
+	// can be reassigned to another container), so a Stop+Start cycle would
+	// otherwise come back without network isolation. Fail closed: if we can't
+	// reinstall the rule, stop the container and surface the error.
+	if sandbox.NetworkBlockAll {
+		if err := s.docker.ApplyNetworkBlockAll(sandbox.ContainerIP); err != nil {
+			_ = s.docker.Stop(ctx, sandboxContainerRef(sandbox))
+			_ = s.mounts.UnmountAll(id)
+			_ = s.store.UpdateStatus(ctx, id, models.SandboxStatusError, err.Error())
+			return nil, fmt.Errorf("apply network block on start: %w", err)
+		}
+	}
+
 	if err := s.caddy.UpsertSandboxRoute(ctx, sandbox.ID, sandbox.ContainerIP, s.cfg.ToolboxPort); err != nil {
 		return nil, err
 	}
@@ -977,6 +990,20 @@ func (s *Service) Reconcile(ctx context.Context) error {
 		sandbox.PublicURL = s.caddy.SandboxPublicURL(sandbox.ID)
 		sandbox.UpdatedAt = time.Now().UTC()
 		if state.Status == models.SandboxStatusStarted {
+			// Heal the per-IP egress DROP rule for sandboxes opted into
+			// NetworkBlockAll. Idempotent at the netrules layer (Exists check
+			// before insert), so this is safe to run on every reconcile pass.
+			// Catches host-side state loss: iptables flush, daemon restart
+			// rebuilding chains, or a missed Create/Start install.
+			if sandbox.NetworkBlockAll {
+				if err := s.docker.ApplyNetworkBlockAll(sandbox.ContainerIP); err != nil {
+					s.logger.Warn("reconcile reapply network block failed",
+						"sandbox_id", sandbox.ID,
+						"ip", sandbox.ContainerIP,
+						"error", err,
+					)
+				}
+			}
 			if err := s.caddy.UpsertSandboxRoute(ctx, sandbox.ID, sandbox.ContainerIP, s.cfg.ToolboxPort); err != nil {
 				return err
 			}

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -105,6 +105,18 @@ func (c *Client) ClearNetworkRules(containerIP string) error {
 	return c.networkRules.ClearBlockAllEgress(containerIP)
 }
 
+// ApplyNetworkBlockAll installs the per-IP egress DROP rule. Idempotent —
+// the underlying rule manager checks for an existing match before inserting.
+// Called on Create (initial install), StartSandbox (after a Stop+Start cycle
+// drops the rule on the stop event), and reconcile (to heal after host-side
+// state loss).
+func (c *Client) ApplyNetworkBlockAll(containerIP string) error {
+	if containerIP == "" {
+		return nil
+	}
+	return c.networkRules.BlockAllEgress(containerIP)
+}
+
 func (c *Client) Ping(ctx context.Context) error {
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://docker/_ping", nil)
 	if err != nil {
@@ -336,7 +348,13 @@ func (c *Client) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 
 	if req.NetworkBlockAll {
 		if err := c.networkRules.BlockAllEgress(runtime.ContainerIP); err != nil {
-			c.logger.Warn("failed to apply network rule", "sandbox_id", runtime.SandboxID, "error", err)
+			// Fail closed: the user opted into network isolation, so a sandbox
+			// that came up without the DROP rule must not be left running.
+			// Clear any partial state and tear the container down before
+			// returning the error.
+			_ = c.networkRules.ClearBlockAllEgress(runtime.ContainerIP)
+			_ = c.removeContainer(ctx, created.ID, true)
+			return nil, fmt.Errorf("apply network block: %w", err)
 		}
 	}
 

--- a/plans/issues.md
+++ b/plans/issues.md
@@ -1,0 +1,95 @@
+# Open security issues — deferred fixes
+
+Issues identified during the network-isolation hardening pass that were **not** fixed in the
+same change set. Each entry lists the symptom, the affected code, why it was deferred, and a
+proposed fix shape.
+
+---
+
+## 1. Boot-time race: workload runs before the egress DROP rule lands
+
+### Symptom
+
+A sandbox created with `network_block_all=true` can make outbound network calls during a
+short window between container start and the moment the host installs the per-IP DROP rule
+in the `DOCKER-USER` chain. A workload that issues its evil network call in its first few
+hundred milliseconds (crypto miner, post-install hook, exfil-on-startup) gets it through.
+
+### Affected code
+
+- `pkg/docker/client.go:326` — `POST /containers/<id>/start` is issued first.
+- `pkg/docker/client.go:331` — host then waits for the container IP via `waitForRuntime`.
+- `pkg/docker/client.go:337-341` — only after that does `BlockAllEgress` install the rule.
+- `cmd/toolboxd/main.go:91` — inside the container, toolboxd (PID 1) calls
+  `startUserCommand` immediately, *before* it starts listening on its HTTP port at
+  `main.go:105`. There is no synchronization with the host on whether the rule is in place.
+
+### Window
+
+Typically a few hundred ms; can stretch to seconds on a busy Docker daemon, on hosts with
+slow iptables-nft writes, or when many sandboxes are being created concurrently.
+
+### Why deferred
+
+Closing this race requires real coordination between the host and the in-container PID 1.
+Three viable shapes, each a non-trivial change:
+
+1. **Sentinel signal from host → container.** Host writes a sentinel file (or sets a
+   "rule-installed" flag readable via a control endpoint) after `BlockAllEgress` succeeds.
+   toolboxd blocks at startup until it observes the sentinel, then runs the user command.
+   Requires a writable shared bind mount or a host→toolbox API the workload cannot forge.
+2. **Create paused, unpause after rule install.** Use Docker's `--init`-style pause / a
+   create-without-start path: create the container, attach the rule against the assigned
+   IP (would need to inspect IP without starting), then start. Docker's create-then-attach-IP
+   ordering does not allow inspecting the IP pre-start on the bridge driver, so this needs
+   investigation and may require a custom network driver.
+3. **`network=none` at create, attach bridge after rule.** Create the container in
+   `network=none`, then `docker network connect` the bridge *after* installing the egress
+   rule against the IP that connect will assign. Cleanest model in principle, but needs
+   the IP to be predictable or to install the rule reactively on the connect event.
+
+All three are larger than a single-file fix and warrant a focused plan + tests.
+
+### Proposed fix shape (sketch — pick one in a follow-up plan)
+
+- **Short term (sentinel approach):**
+  - Host: after `BlockAllEgress` succeeds in `Create`, write
+    `/var/run/aerolvm/network-ready` inside the container via a tmpfs bind mount that the
+    workload cannot write to.
+  - toolboxd: at startup, before `startUserCommand`, block (with a bounded timeout, e.g.
+    5s) on the sentinel's existence. If `network_block_all` was requested but the sentinel
+    does not appear within the timeout, exit non-zero (fail closed).
+  - Pass `SB_NETWORK_BLOCK_REQUIRED=1` into the container env so toolboxd knows when to
+    enforce the wait vs. start immediately.
+- **Long term:** evaluate the `network=none` + reactive-attach model. Removes the race by
+  construction (no L3 connectivity exists until after the rule is in place).
+
+### Severity
+
+Medium-High. The control is sold as "no network." A determined adversary will hit this
+window reliably; opportunistic and accidental traffic mostly will not.
+
+### Test plan
+
+- Integration test that creates a sandbox with `network_block_all=true` whose entrypoint
+  is `sh -c 'curl -m 1 https://example.com; sleep 60'` and asserts the curl fails with a
+  network error (not a 200).
+- Stress variant: create N sandboxes concurrently and assert zero successful outbound
+  requests across all of them in their first 500 ms.
+
+---
+
+## What was fixed in the same pass (for context)
+
+- `pkg/docker/client.go` — `Create` now fails closed if `BlockAllEgress` errors (was a
+  warn-only fail-open).
+- `internal/runtime/runtime.go` + `pkg/docker/client.go` — added
+  `ApplyNetworkBlockAll(containerIP)` to the `Runtime` interface and the Docker client.
+- `internal/service/service.go` — `StartSandbox` reapplies the rule after a Stop+Start
+  cycle (the stop event clears it). Fail-closed on reapply error.
+- `internal/service/service.go` — `Reconcile` running-sandbox branch reapplies the rule on
+  every pass (idempotent at the netrules layer); heals after host iptables flush, daemon
+  restart, or a missed install. Best-effort with a warn log; the next pass retries.
+- `cmd/toolboxd/main.go` — `os.Unsetenv("SB_TOOLBOX_TOKEN")` immediately after the token is
+  read, so user commands and `/exec`/streaming-exec children no longer inherit the token
+  via `os.Environ()`.


### PR DESCRIPTION
This pull request introduces significant improvements to the network isolation features for sandboxes, specifically addressing the reliability and enforcement of per-IP egress DROP rules when `NetworkBlockAll` is enabled. The changes ensure that network isolation is consistently applied during sandbox lifecycle events (creation, start, and reconciliation), and that failures to apply these rules are handled securely ("fail closed"). Additionally, a new open security issue is documented, detailing a race condition where outbound traffic may escape before the DROP rule is enforced.

**Network isolation hardening:**

* Added a new `ApplyNetworkBlockAll(containerIP string) error` method to the `Runtime` interface and implemented it in the Docker client (`pkg/docker/client.go`). This method is idempotent and ensures the egress DROP rule is (re)applied as needed. [[1]](diffhunk://#diff-dfb217f99ae89452063f7bc651da92476ba387fc6de37495c98096ad67f5ba10R72-R78) [[2]](diffhunk://#diff-8bf93ad63bae86468a921c6200ea881313726b38dda047b8188330d1379aa161R108-R119)
* Modified sandbox lifecycle in `internal/service/service.go`:
  - On sandbox start, `ApplyNetworkBlockAll` is called if `NetworkBlockAll` is set; if it fails, the sandbox is stopped and marked as errored ("fail closed").
  - During reconciliation, the DROP rule is reapplied for running sandboxes with `NetworkBlockAll`, healing after host-side state loss (e.g., iptables flush, daemon restart). Errors are logged as warnings and retried on the next pass.
* Updated the Docker client `Create` method to fail closed if applying the network block fails, ensuring no sandbox is left running without the intended isolation.
* Extended the test runtime in `internal/service/reconcile_destroy_test.go` to implement the new method, maintaining test coverage.

**Documentation and open issues:**

* Added `plans/issues.md` to document an open security race condition: there is a small window after container start but before the DROP rule is installed where outbound traffic may escape. The document describes the issue, affected code, proposed fixes, and test plans for future work.<!--
GitHub auto-fills new PR descriptions with this template. Fill in EVERY
section below. "N/A — <one-line reason>" is a valid answer; an empty answer
is not. See pr-review.md at the repo root for what each section is asking.
-->
