### PR TITLE
chore: harden database file and directory permissions to owner-only

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -23,8 +23,18 @@ type Store struct {
 const sqliteBusyTimeoutMS = 5000
 
 func Open(path string) (*Store, error) {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	// The DB stores secrets (env_json, toolbox_token, sealed mount blobs).
+	// Lock the directory and file to owner-only so a custom DBPath, a dev
+	// run on a shared host, or any setup that doesn't go through the
+	// installer can't leak them via the default 0o755 / umask-derived modes.
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("create db directory: %w", err)
+	}
+	// MkdirAll leaves a pre-existing directory's mode untouched, so chmod
+	// explicitly to tighten dirs created by older builds at 0o755.
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("chmod db directory: %w", err)
 	}
 
 	db, err := sql.Open("sqlite3", sqliteDSN(path))
@@ -136,6 +146,19 @@ func Open(path string) (*Store, error) {
 	if _, err := db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_exposed_ports_host_port ON exposed_ports(host_port) WHERE host_port > 0;`); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("create exposed_ports host_port index: %w", err)
+	}
+
+	// SQLite materialized the DB file (and the WAL/SHM sidecars on the
+	// first write) using the process umask — typically 0o644, leaving
+	// env_json and toolbox_token world-readable. Tighten to owner-only.
+	// Sidecars may not exist on a fresh DB if no transaction has run yet;
+	// ignore not-found and let the next writer create them with the now
+	// owner-only directory mode protecting them in transit.
+	for _, p := range []string{path, path + "-wal", path + "-shm"} {
+		if err := os.Chmod(p, 0o600); err != nil && !errors.Is(err, os.ErrNotExist) {
+			db.Close()
+			return nil, fmt.Errorf("chmod db file %s: %w", p, err)
+		}
 	}
 
 	return &Store{db: db}, nil

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -3,8 +3,10 @@ package store
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 
@@ -30,6 +32,62 @@ func TestStoreCases(t *testing.T) {
 				defer st.Close()
 				if err := st.Close(); err != nil {
 					t.Fatalf("Close() error = %v", err)
+				}
+			},
+		},
+		{
+			// Regression: env_json and toolbox_token are secrets. The DB
+			// directory and file must end up owner-only so a custom DBPath
+			// or a dev run on a shared host can't leak them via umask
+			// defaults. Re-chmod also has to tighten a directory the
+			// caller created at 0o755 before opening.
+			name: "open_locks_db_dir_and_file_to_owner_only",
+			run: func(t *testing.T) {
+				if runtime.GOOS == "windows" {
+					t.Skip("POSIX permission bits not meaningful on Windows")
+				}
+				dir := t.TempDir()
+				// Pre-create the dir at the old, lax mode so we exercise
+				// the chmod-on-existing path, not just MkdirAll.
+				if err := os.Chmod(dir, 0o755); err != nil {
+					t.Fatalf("seed dir mode: %v", err)
+				}
+				path := filepath.Join(dir, "state.db")
+				st, err := Open(path)
+				if err != nil {
+					t.Fatalf("Open() error = %v", err)
+				}
+				defer st.Close()
+
+				dirInfo, err := os.Stat(dir)
+				if err != nil {
+					t.Fatalf("stat dir: %v", err)
+				}
+				if mode := dirInfo.Mode().Perm(); mode != 0o700 {
+					t.Fatalf("dir mode = %o, want 0700", mode)
+				}
+
+				fileInfo, err := os.Stat(path)
+				if err != nil {
+					t.Fatalf("stat db file: %v", err)
+				}
+				if mode := fileInfo.Mode().Perm(); mode != 0o600 {
+					t.Fatalf("db file mode = %o, want 0600", mode)
+				}
+
+				// WAL/SHM sidecars carry the same data — if they exist
+				// after schema setup, they must be owner-only too.
+				for _, sidecar := range []string{path + "-wal", path + "-shm"} {
+					info, err := os.Stat(sidecar)
+					if errors.Is(err, os.ErrNotExist) {
+						continue
+					}
+					if err != nil {
+						t.Fatalf("stat %s: %v", sidecar, err)
+					}
+					if mode := info.Mode().Perm(); mode != 0o600 {
+						t.Fatalf("%s mode = %o, want 0600", sidecar, mode)
+					}
 				}
 			},
 		},


### PR DESCRIPTION
This pull request enhances the security of the SQLite database used by the application by ensuring that both the database directory and files are restricted to owner-only access. It also adds comprehensive regression tests to verify these permissions. The changes are grouped below:

**Security improvements to database storage:**

* The `Open` function in `store.go` now creates the database directory with `0o700` permissions (owner-only) instead of `0o755`, and explicitly applies `chmod` to existing directories to ensure old directories are also secured.
* After opening the database, the code now sets the database file and its WAL/SHM sidecars (if present) to `0o600` (owner-only), preventing world-readable secrets due to default umask settings.

**Testing and validation:**

* A new regression test, `open_locks_db_dir_and_file_to_owner_only`, is added to `store_test.go` to verify that both the database directory and files (including WAL/SHM sidecars) are properly restricted to owner-only permissions, catching regressions and ensuring sensitive data is not exposed.
* Test imports updated to include `os` and `runtime` for permission and platform checks.<!--
GitHub auto-fills new PR descriptions with this template. Fill in EVERY
section below. "N/A — <one-line reason>" is a valid answer; an empty answer
is not. See pr-review.md at the repo root for what each section is asking.
-->