### PR TITLE
fix: correct import paths for sidebar configuration and navigation types

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -12,9 +12,13 @@ export default defineConfig({
     starlight({
       title: 'AerolVM',
       favicon: '/favicon.svg',
-      social: {
-        github: 'https://github.com/aerol-ai/microvm',
-      },
+      social: [
+        {
+          icon: 'github',
+          label: 'GitHub',
+          href: 'https://github.com/aerol-ai/microvm',
+        },
+      ],
       editLink: {
         baseUrl:
           'https://github.com/aerol-ai/microvm/blob/main/docs/src/content/docs/',

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2230,6 +2230,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2316,6 +2317,7 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-6.3.1.tgz",
       "integrity": "sha512-atz6dmkE3Gu24bDgb7g2RE/BYnKqPYIHd6hTUM1UXvu/i7qNZOKLAqEHvgYpv9PQVcgWsXpk4/OOXZ0E/FzvSQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",
         "@astrojs/internal-helpers": "0.9.0",
@@ -5278,6 +5280,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5770,6 +5773,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
       "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -5827,6 +5831,7 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
       "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.1.5",
@@ -6153,6 +6158,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6528,6 +6534,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
       "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/docs/src/components/ContentPanel.astro
+++ b/docs/src/components/ContentPanel.astro
@@ -7,6 +7,10 @@
     padding: 1.5rem var(--sl-content-pad-x);
   }
 
+  .content-panel:has(.page-title) {
+    padding-bottom: 0.875rem;
+  }
+
   .content-panel + .content-panel {
     border-top: 1px solid var(--sl-color-hairline);
   }

--- a/docs/src/components/ExploreMore.astro
+++ b/docs/src/components/ExploreMore.astro
@@ -1,5 +1,5 @@
 ---
-import { getSidebarConfig } from '../content/config'
+import { getSidebarConfig } from '../content.config'
 import { getExploreMoreData } from '../utils/navigation'
 
 const exploreMoreData = getExploreMoreData(getSidebarConfig(Astro.url.pathname), Astro.url.pathname)

--- a/docs/src/components/Hero.astro
+++ b/docs/src/components/Hero.astro
@@ -1,25 +1,30 @@
 ---
 import { PAGE_TITLE_ID } from './TableOfContent/constants'
 
-const { data } = Astro.props.entry
-const { title = data.title, tagline, actions = [] } = data.hero || {}
+const entry = Astro.locals.starlightRoute?.entry
+const data = entry?.data
+const { title = data?.title, tagline, actions = [] } = data?.hero || {}
 ---
 
-<div class="hero">
-  <h1 id={PAGE_TITLE_ID} data-page-title>{title}</h1>
-  {tagline && <div class="tagline" set:html={tagline} />}
-  {
-    actions.length > 0 && (
-      <div class="hero-actions">
-        {actions.map(action => (
-          <a href={action.link} class:list={['hero-action', action.variant || 'secondary']}>
-            {action.text}
-          </a>
-        ))}
-      </div>
-    )
-  }
-</div>
+{
+  data && (
+    <div class="hero">
+      <h1 id={PAGE_TITLE_ID} data-page-title>{title}</h1>
+      {tagline && <div class="tagline" set:html={tagline} />}
+      {
+        actions.length > 0 && (
+          <div class="hero-actions">
+            {actions.map(action => (
+              <a href={action.link} class:list={['hero-action', action.variant || 'secondary']}>
+                {action.text}
+              </a>
+            ))}
+          </div>
+        )
+      }
+    </div>
+  )
+}
 
 <style>
   .hero {

--- a/docs/src/components/MarkdownContent.astro
+++ b/docs/src/components/MarkdownContent.astro
@@ -1,8 +1,8 @@
-<div class="markdown-content"><slot /></div>
+<div class="sl-markdown-content markdown-content"><slot /></div>
 
 <script>
   const onReady = () => {
-    document.querySelectorAll('table').forEach(table => {
+    document.querySelectorAll('.markdown-content table').forEach(table => {
       if (table.parentElement?.classList.contains('table-wrapper')) {
         return
       }
@@ -12,21 +12,6 @@
       table.parentNode?.insertBefore(wrapper, table)
       wrapper.appendChild(table)
     })
-
-    document
-      .querySelectorAll('.markdown-content h2[id], .markdown-content h3[id], .markdown-content h4[id], .markdown-content h5[id]')
-      .forEach(heading => {
-        if (heading.querySelector('.heading-anchor')) {
-          return
-        }
-
-        const anchor = document.createElement('a')
-        anchor.href = `#${heading.id}`
-        anchor.className = 'heading-anchor'
-        anchor.setAttribute('aria-hidden', 'true')
-        anchor.textContent = '#'
-        heading.prepend(anchor)
-      })
   }
 
   document.addEventListener('DOMContentLoaded', onReady)

--- a/docs/src/components/PageTitle.astro
+++ b/docs/src/components/PageTitle.astro
@@ -1,11 +1,12 @@
 ---
 import { PAGE_TITLE_ID } from './TableOfContent/constants'
 
-const { entry } = Astro.props
+const entry = Astro.locals.starlightRoute?.entry
+const data = entry?.data
 ---
 
 {
-  !entry.data.hideTitleOnPage && <h1 id={PAGE_TITLE_ID} class="page-title">{entry.data.title}</h1>
+  data && !data.hideTitleOnPage && <h1 id={PAGE_TITLE_ID} class="page-title">{data.title}</h1>
 }
 
 <style>

--- a/docs/src/components/Pagination.astro
+++ b/docs/src/components/Pagination.astro
@@ -1,5 +1,5 @@
 ---
-import { getSidebarConfig } from '../content/config'
+import { getSidebarConfig } from '../content.config'
 import { getPagination } from '../utils/navigation'
 
 const { prev, next } = getPagination(getSidebarConfig(Astro.url.pathname), Astro.url.pathname)

--- a/docs/src/components/Sidebar.astro
+++ b/docs/src/components/Sidebar.astro
@@ -1,5 +1,5 @@
 ---
-import { getSidebarConfig } from '../content/config'
+import { getSidebarConfig } from '../content.config'
 import { getSidebar } from '../utils/navigation'
 import SidebarSublist from './SidebarSublist.astro'
 

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,10 +1,13 @@
+import { docsLoader } from '@astrojs/starlight/loaders'
 import { docsSchema } from '@astrojs/starlight/schema'
-import { defineCollection, z } from 'astro:content'
+import { defineCollection } from 'astro:content'
+import { z } from 'astro/zod'
 
-import type { NavigationGroup } from '../utils/navigation'
+import type { NavigationGroup } from './utils/navigation'
 
 export const collections = {
   docs: defineCollection({
+    loader: docsLoader(),
     schema: docsSchema({
       extend: z.object({
         hideTitleOnPage: z.boolean().optional(),

--- a/docs/src/styles/components/markdown.scss
+++ b/docs/src/styles/components/markdown.scss
@@ -3,6 +3,10 @@
     margin-top: 0;
   }
 
+  > .sl-heading-wrapper:first-child {
+    margin-top: 0;
+  }
+
   > h2[id]:first-child,
   > h3[id]:first-child,
   > h4[id]:first-child,
@@ -10,8 +14,17 @@
     margin-top: 0;
   }
 
-  > :not(h1, h2, h3, h4, h5, h6, p, aside) {
+  > :not(h1, h2, h3, h4, h5, h6, p, aside, .sl-heading-wrapper) {
     margin-bottom: 48px;
+  }
+
+  > .sl-heading-wrapper.level-h2,
+  > .sl-heading-wrapper.level-h3,
+  > .sl-heading-wrapper.level-h4,
+  > .sl-heading-wrapper.level-h5 {
+    margin-top: 48px;
+    margin-bottom: 16px;
+    position: relative;
   }
 
   > h2[id],
@@ -21,29 +34,6 @@
     margin-top: 48px;
     margin-bottom: 16px;
     position: relative;
-  }
-
-  > h2[id] .heading-anchor,
-  > h3[id] .heading-anchor,
-  > h4[id] .heading-anchor,
-  > h5[id] .heading-anchor {
-    opacity: 0;
-    position: absolute;
-    right: 100%;
-    top: 50%;
-    transform: translateY(-50%);
-    padding-right: 0.25em;
-    font-size: 0.875em;
-    color: var(--secondary-text-color);
-    text-decoration: none;
-    transition: opacity 150ms ease, color 150ms ease;
-  }
-
-  > h2[id]:hover .heading-anchor,
-  > h3[id]:hover .heading-anchor,
-  > h4[id]:hover .heading-anchor,
-  > h5[id]:hover .heading-anchor {
-    opacity: 1;
   }
 
   > p {

--- a/docs/src/utils/navigation.ts
+++ b/docs/src/utils/navigation.ts
@@ -1,4 +1,4 @@
-import type { NavigationCategory } from '../content/config'
+import type { NavigationCategory } from '../content.config'
 
 export interface NavigationItem {
   type: 'link' | 'group'


### PR DESCRIPTION
This pull request primarily refactors the documentation site's configuration by renaming and updating the import paths for the main content config file, and makes several dependency metadata adjustments in `package-lock.json`. The changes improve code organization and ensure compatibility with tooling and dependencies.

Key changes include:

**Configuration Refactor:**

* Renamed `docs/src/content/config.ts` to `docs/src/content.config.ts` and updated all relevant imports across components (`ExploreMore.astro`, `Pagination.astro`, `Sidebar.astro`, and `navigation.ts`) to use the new path. This centralizes and clarifies the location of the content configuration. [[1]](diffhunk://#diff-2bb832707e6fc60cea2e4eb55ca55838934f36d18e1708b45a8a8a37d2a13f0dL2-R2) [[2]](diffhunk://#diff-e236612867eabe570a60472e68093674f2b7aa5b5ace7548277042faa0e1712dL2-R2) [[3]](diffhunk://#diff-ab0bb6f8c2fcfa5b01aab9b04bf3f82b1256648f18c12fe3154b8ae45bde50c4L2-R2) [[4]](diffhunk://#diff-3c77bd19d81880d0f5739e83a4ae589c80940aedc6e4208018361c53ae761d56R1-R10) [[5]](diffhunk://#diff-dd27ca7c3355f6083da02060af3a3c22fba3e50e5a83c5fa4feb67e300fd3aeaL1-R1)
* Updated the content config file to use `docsLoader` from `@astrojs/starlight/loaders`, changed how `z` is imported (now from `astro/zod`), and fixed the import path for `NavigationGroup`.

**Dependency Metadata Updates:**

* Added `"peer": true` to several dependencies in `docs/package-lock.json` (`acorn`, `astro`, `rollup`, `sass`, `typescript`, `vite`, and others), which clarifies their peer dependency status and may help with dependency resolution in complex setups. [[1]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0R2233) [[2]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0R2320) [[3]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0R5283) [[4]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0R5776) [[5]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0R5834) [[6]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0R6161) [[7]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0R6537)<!--
GitHub auto-fills new PR descriptions with this template. Fill in EVERY
section below. "N/A — <one-line reason>" is a valid answer; an empty answer
is not. See pr-review.md at the repo root for what each section is asking.
-->

