### PR TITLE
Fix TCP host name issue

### DIFF
--- a/docs/src/content/docs/use-cases/customer-facing-product-experiences/spawn-postgres.mdx
+++ b/docs/src/content/docs/use-cases/customer-facing-product-experiences/spawn-postgres.mdx
@@ -100,7 +100,7 @@ def query_database() -> bytes:
 class Handler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:
         if self.path == "/healthz":
-            body = b"ok\n"
+            body = b"ok\\n"
             self.send_response(200)
             self.send_header("Content-Type", "text/plain; charset=utf-8")
             self.send_header("Content-Length", str(len(body)))

--- a/pkg/caddy/client.go
+++ b/pkg/caddy/client.go
@@ -61,10 +61,15 @@ func (c *Client) Enabled() bool {
 	return c.enabled
 }
 
-// PublicHost is the parent host's reachable address (IP or DNS) used as the
-// dial target for raw-TCP exposures. Surfaced so the service layer can return
-// it as a structured field on the expose response without re-parsing the URL.
-func (c *Client) PublicHost() string { return c.publicHost }
+// PublicHost returns the dial target for raw-TCP exposures. In domain mode the
+// base domain is returned so TCP URLs are consistent with HTTP sandbox URLs;
+// otherwise falls back to the configured publicHost IP.
+func (c *Client) PublicHost() string {
+	if c.domain != "" {
+		return c.domain
+	}
+	return c.publicHost
+}
 
 func (c *Client) Ping(ctx context.Context) error {
 	if !c.enabled {
@@ -100,12 +105,15 @@ func (c *Client) PortPublicURL(id string, port int) string {
 }
 
 // TCPPublicEndpoint returns the URL clients dial for a raw TCP exposure
-// allocated at hostPort. Always uses the publicHost as the dial target — TCP
-// has no DNS-shaped wildcard equivalent, so even in domain mode the parent
-// host's address is the right value here. Operators that want a friendly DNS
-// name should add their own A record pointing at PublicHost.
+// allocated at hostPort. In domain mode the base domain is used as the dial
+// target (e.g. tcp://sandbox.aerol.cloud:22534); otherwise falls back to
+// publicHost.
 func (c *Client) TCPPublicEndpoint(hostPort int) string {
-	return fmt.Sprintf("tcp://%s:%d", c.publicHost, hostPort)
+	host := c.publicHost
+	if c.domain != "" {
+		host = c.domain
+	}
+	return fmt.Sprintf("tcp://%s:%d", host, hostPort)
 }
 
 // TLSPublicEndpoint returns the dial target for a TLS-SNI multiplexed

--- a/pkg/caddy/client_test.go
+++ b/pkg/caddy/client_test.go
@@ -501,9 +501,22 @@ func TestL4Cases(t *testing.T) {
 }
 
 func TestPublicEndpointHelpers(t *testing.T) {
-	t.Run("tcp_endpoint_uses_public_host", func(t *testing.T) {
+	t.Run("tcp_endpoint_uses_127_in_local_mode", func(t *testing.T) {
+		// --local writes SB_PUBLIC_HOST=127.0.0.1 and no SB_DOMAIN.
+		client := &Client{publicHost: "127.0.0.1"}
+		if got := client.TCPPublicEndpoint(37412); got != "tcp://127.0.0.1:37412" {
+			t.Fatalf("TCPPublicEndpoint() = %q", got)
+		}
+	})
+	t.Run("tcp_endpoint_uses_public_host_in_ip_mode", func(t *testing.T) {
 		client := &Client{publicHost: "203.0.113.10"}
 		if got := client.TCPPublicEndpoint(37412); got != "tcp://203.0.113.10:37412" {
+			t.Fatalf("TCPPublicEndpoint() = %q", got)
+		}
+	})
+	t.Run("tcp_endpoint_uses_domain_in_domain_mode", func(t *testing.T) {
+		client := &Client{domain: "sandbox.example.com", publicHost: "203.0.113.10"}
+		if got := client.TCPPublicEndpoint(37412); got != "tcp://sandbox.example.com:37412" {
 			t.Fatalf("TCPPublicEndpoint() = %q", got)
 		}
 	})

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -278,7 +278,7 @@ if [[ -z "$PAT_TOKEN" ]]; then
 	fi
 fi
 
-if [[ -z "$DOMAIN" && -z "$PUBLIC_HOST" ]]; then
+if [[ -z "$PUBLIC_HOST" ]]; then
 	PUBLIC_HOST="$(hostname -I 2>/dev/null | awk '{print $1}')"
 	PUBLIC_HOST="${PUBLIC_HOST:-127.0.0.1}"
 fi


### PR DESCRIPTION
This pull request updates how TCP public endpoints are determined and exposed in both the application logic and supporting scripts, focusing on improving consistency between domain and IP-based modes. It also expands test coverage to ensure the new behavior is correct. Additionally, there's a minor fix in a documentation code sample.

**TCP Endpoint Exposure Logic Updates:**

* The `PublicHost` and `TCPPublicEndpoint` methods in `pkg/caddy/client.go` now prefer the `domain` field (if set) as the dial target for raw TCP exposures, falling back to `publicHost` otherwise. This ensures that in domain mode, TCP URLs are consistent with HTTP sandbox URLs. [[1]](diffhunk://#diff-e2697ade00da575e2af1db8770f761aa5427954becb14f61944ca31a3b032595L64-R72) [[2]](diffhunk://#diff-e2697ade00da575e2af1db8770f761aa5427954becb14f61944ca31a3b032595L103-R116)

**Test Coverage Improvements:**

* The `TestPublicEndpointHelpers` test in `pkg/caddy/client_test.go` now includes cases for local, IP, and domain modes to verify that `TCPPublicEndpoint` returns the correct dial target in each scenario.

**Script and Documentation Fixes:**

* The install script (`scripts/install.sh`) now only sets `PUBLIC_HOST` if it is not already set, regardless of the value of `DOMAIN`, ensuring correct environment variable initialization.
* Minor fix in a documentation code sample to use a literal newline character in the health check response.