### PR TITLE
fix: update component props to use Astro.locals for routing

### DIFF
--- a/docs/src/components/EditLink.astro
+++ b/docs/src/components/EditLink.astro
@@ -1,5 +1,5 @@
 ---
-const { editUrl } = Astro.props
+const editUrl = Astro.locals.starlightRoute?.editUrl
 ---
 
 {

--- a/docs/src/components/PageSidebar.astro
+++ b/docs/src/components/PageSidebar.astro
@@ -2,4 +2,4 @@
 import TableOfContents from 'virtual:starlight/components/TableOfContents'
 ---
 
-<TableOfContents {...Astro.props} />
+<TableOfContents />

--- a/docs/src/components/TableOfContents.astro
+++ b/docs/src/components/TableOfContents.astro
@@ -1,7 +1,7 @@
 ---
 import TableOfContentsList from './TableOfContentsList.astro'
 
-const { toc } = Astro.props
+const { toc } = Astro.locals.starlightRoute
 ---
 
 {

--- a/docs/src/components/TableOfContentsList.astro
+++ b/docs/src/components/TableOfContentsList.astro
@@ -59,7 +59,8 @@ const { toc = [], depth = 0, isMobile = false } = Astro.props
 
   ul.nested > li > a {
     font-size: 0.78125rem;
-    color: var(--accent-text-color);
+    color: var(--secondary-text-color);
+    opacity: 0.75;
   }
 
   a:hover {

--- a/docs/src/components/TwoColumnContent.astro
+++ b/docs/src/components/TwoColumnContent.astro
@@ -1,5 +1,5 @@
 ---
-const hasToc = Astro.props.toc
+const hasToc = Astro.locals.starlightRoute?.toc
 ---
 
 <div class={`main-pane-wrapper ${hasToc ? '' : 'no-toc'}`}>


### PR DESCRIPTION
<!--
GitHub auto-fills new PR descriptions with this template. Fill in EVERY
section below. "N/A — <one-line reason>" is a valid answer; an empty answer
is not. See pr-review.md at the repo root for what each section is asking.
-->

## Summary
This pull request updates how data is accessed and passed between components in the documentation site, moving from using `Astro.props` to using `Astro.locals.starlightRoute`. It also makes a minor style adjustment to the table of contents links.

**Refactoring to use `Astro.locals.starlightRoute`:**

* Updated `EditLink.astro`, `TwoColumnContent.astro`, and `TableOfContents.astro` to access data (such as `editUrl` and `toc`) from `Astro.locals.starlightRoute` instead of `Astro.props` for more consistent and reliable data flow. [[1]](diffhunk://#diff-adecd910647e5b553e229eff11bff012be1c2ddb1cd94e5e9adeab042bbbad9eL2-R2) [[2]](diffhunk://#diff-53d3c3186a00956d9adc9a648836db559308cff40f0403a71a171b42f232804aL2-R2) [[3]](diffhunk://#diff-96cc3091c6a514f2dba71629dd1bce52464f660e11ffb71c13a25bf18de798b5L4-R4)
* Changed `PageSidebar.astro` to render `TableOfContents` without passing props, aligning with the new data access pattern.

**Style update:**

* Adjusted the color and opacity of nested table of contents links in `TableOfContentsList.astro` for improved visual hierarchy and readability.
