### PR TITLE
docs: Enhance documentation and workflows for data processing and ML

### DIFF
--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -196,13 +196,6 @@ const getUseCasesSidebarConfig = (): NavigationGroup[] => [
     category: NavigationCategory.USE_CASES,
     entries: [
       {
-        type: 'link',
-        href: '/use-cases',
-        label: 'Overview',
-        description: 'Top-priority AerolVM use cases selected from the planning matrix.',
-        exact: true,
-      },
-      {
         type: 'group',
         label: 'Coding Agents & Harness Engineering',
         entries: [
@@ -278,6 +271,36 @@ const getUseCasesSidebarConfig = (): NavigationGroup[] => [
             href: '/use-cases/customer-facing-product-experiences/one-click-user-sandbox',
             label: 'One-click user sandbox per workspace',
             description: 'Provision an isolated sandbox as part of each product workspace.',
+          },
+        ],
+      },
+      {
+        type: 'group',
+        label: 'Data Processing & ML',
+        entries: [
+          {
+            type: 'link',
+            href: '/use-cases/data-processing-ml/kaggle-to-parquet',
+            label: 'Kaggle Dataset to Parquet',
+            description: 'Download a large dataset from Kaggle, process it using Polars inside an AerolVM sandbox, and export the optimized Parquet file.',
+          },
+          {
+            type: 'link',
+            href: '/use-cases/data-processing-ml/duckdb-dataset-explorer',
+            label: 'SQL on Kaggle with DuckDB',
+            description: 'Launch a DuckDB instance inside a sandbox to run SQL queries directly on Kaggle datasets without a traditional database setup.',
+          },
+          {
+            type: 'link',
+            href: '/use-cases/data-processing-ml/hyperparameter-tuning-farm',
+            label: 'Hyperparameter Tuning Farm',
+            description: 'Spin up multiple concurrent sandboxes to test different model configurations in parallel.',
+          },
+          {
+            type: 'link',
+            href: '/use-cases/data-processing-ml/headless-jupyter-notebook',
+            label: 'Headless Jupyter Notebook',
+            description: 'Spin up a full JupyterLab environment in a sandbox and access it via a public URL.',
           },
         ],
       },

--- a/docs/src/content/docs/use-cases/data-processing-ml/duckdb-dataset-explorer.mdx
+++ b/docs/src/content/docs/use-cases/data-processing-ml/duckdb-dataset-explorer.mdx
@@ -1,0 +1,101 @@
+---
+title: SQL on Kaggle with DuckDB
+description: Launch a DuckDB instance inside a sandbox to run SQL queries directly on Kaggle datasets without a traditional database setup.
+---
+
+This use case shows how to use **DuckDB** inside an AerolVM sandbox to perform high-performance SQL analytics on Kaggle datasets. DuckDB is an in-process SQL OLAP database management system that is perfect for analyzing large CSV or Parquet files.
+
+## The DuckDB Advantage
+
+- **No Installation:** Run complex SQL queries without setting up a full database server.
+- **Direct CSV/Parquet Querying:** DuckDB can query files directly from disk (or even HTTP) with high efficiency.
+- **Sandboxed Analytics:** Each analyst or project gets their own isolated compute environment.
+
+## Copy-paste TypeScript script
+
+Code URL: [https://github.com/aerol-ai/aerolvm-examples/tree/main/ml-data-engineering/duckdb-dataset-explorer](https://github.com/aerol-ai/aerolvm-examples/tree/main/ml-data-engineering/duckdb-dataset-explorer)
+
+This script downloads a dataset and starts a simple HTTP proxy that allows you to send SQL queries to the sandbox.
+
+```ts
+import { MicroVM } from "@aerol-ai/aerolvm-sdk";
+
+const apiUrl = process.env.SB_API_URL ?? "http://127.0.0.1:21212";
+const patToken = process.env.SB_PAT_TOKEN;
+const kaggleUsername = process.env.KAGGLE_USERNAME;
+const kaggleKey = process.env.KAGGLE_KEY;
+const kaggleDataset = process.env.KAGGLE_DATASET ?? "dgomonov/new-york-city-airbnb-open-data";
+
+if (!patToken || !kaggleUsername || !kaggleKey) {
+  throw new Error("Set SB_PAT_TOKEN, KAGGLE_USERNAME, and KAGGLE_KEY.");
+}
+
+const sqlProxyScript = `
+import os
+import json
+import duckdb
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+# 1. Download Dataset
+api = KaggleApi()
+api.authenticate()
+api.dataset_download_files(os.environ.get('KAGGLE_DATASET'), path='./data', unzip=True)
+
+# 2. Init DuckDB
+db = duckdb.connect(':memory:')
+csv_file = [f for f in os.listdir('./data') if f.endswith('.csv')][0]
+db.execute(f"CREATE VIEW data AS SELECT * FROM read_csv_auto('./data/{csv_file}')")
+
+# 3. Simple SQL HTTP Proxy
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        content_length = int(self.headers['Content-Length'])
+        query = self.rfile.read(content_length).decode('utf-8')
+        try:
+            result = db.execute(query).df().to_json(orient='records')
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(result.encode())
+        except Exception as e:
+            self.send_response(500)
+            self.end_headers()
+            self.wfile.write(str(e).encode())
+
+print("DuckDB Proxy listening on port 8080...")
+ThreadingHTTPServer(('0.0.0.0', 8080), Handler).serve_forever()
+`;
+
+async function main() {
+  const client = new MicroVM({ apiUrl, patToken });
+  const sandbox = await client.create({
+    image: "python:3.11-bookworm",
+    cpu: 2,
+    memoryMB: 4096,
+    env: { KAGGLE_USERNAME: kaggleUsername, KAGGLE_KEY: kaggleKey, KAGGLE_DATASET: kaggleDataset }
+  });
+
+  console.log("Installing DuckDB and Kaggle...");
+  await sandbox.exec("pip install duckdb kaggle pandas");
+
+  console.log("Starting DuckDB SQL Proxy...");
+  await sandbox.uploadFile("/workspace/proxy.py", sqlProxyScript);
+  const session = await sandbox.createSession({
+    name: "duckdb-proxy",
+    command: "python3 /workspace/proxy.py",
+  });
+
+  const exposure = await sandbox.exposePort(8080);
+  console.log(\`DuckDB SQL Proxy ready at: \${exposure.url}\`);
+  console.log(\`Try running: curl -X POST -d "SELECT * FROM data LIMIT 5" \${exposure.url}\`);
+}
+
+main().catch(console.error);
+```
+
+## Related docs
+- [Exposing Ports](/tcp-ports/)
+- [Sessions](/sessions/)
+- [Environment Variables](/environment/)
+---

--- a/docs/src/content/docs/use-cases/data-processing-ml/duckdb-dataset-explorer.mdx
+++ b/docs/src/content/docs/use-cases/data-processing-ml/duckdb-dataset-explorer.mdx
@@ -23,12 +23,10 @@ import { MicroVM } from "@aerol-ai/aerolvm-sdk";
 const apiUrl = process.env.SB_API_URL ?? "http://127.0.0.1:21212";
 const patToken = process.env.SB_PAT_TOKEN;
 const kaggleUsername = process.env.KAGGLE_USERNAME;
-const kaggleKey = process.env.KAGGLE_KEY;
+const kaggleKey = process.env.KAGGLE_KEY || process.env.KAGGLE_API_TOKEN;
 const kaggleDataset = process.env.KAGGLE_DATASET ?? "dgomonov/new-york-city-airbnb-open-data";
 
-if (!patToken || !kaggleUsername || !kaggleKey) {
-  throw new Error("Set SB_PAT_TOKEN, KAGGLE_USERNAME, and KAGGLE_KEY.");
-}
+
 
 const sqlProxyScript = `
 import os
@@ -68,27 +66,41 @@ ThreadingHTTPServer(('0.0.0.0', 8080), Handler).serve_forever()
 `;
 
 async function main() {
+  if (!patToken || !kaggleUsername || !kaggleKey) {
+    throw new Error("Set SB_PAT_TOKEN, KAGGLE_USERNAME, and KAGGLE_KEY (or KAGGLE_API_TOKEN).");
+  }
+  console.log("Initializing AerolVM client...");
   const client = new MicroVM({ apiUrl, patToken });
+  console.log("Creating DuckDB sandbox (0.5 CPU, 2GB RAM)...");
   const sandbox = await client.create({
     image: "python:3.11-bookworm",
-    cpu: 2,
-    memoryMB: 4096,
+    cpu: 0.5,
+    memoryMB: 2048,
     env: { KAGGLE_USERNAME: kaggleUsername, KAGGLE_KEY: kaggleKey, KAGGLE_DATASET: kaggleDataset }
   });
+  console.log(`Sandbox created successfully! ID: ${sandbox.id}`);
 
-  console.log("Installing DuckDB and Kaggle...");
-  await sandbox.exec("pip install duckdb kaggle pandas");
+  console.log("Installing DuckDB and Kaggle dependencies...");
+  const installRes = await sandbox.exec("pip install duckdb kaggle pandas");
+  console.log(`Dependencies installed (exit code: ${installRes.exitCode}, duration: ${installRes.durationMS}ms)`);
 
-  console.log("Starting DuckDB SQL Proxy...");
+  console.log("Uploading DuckDB SQL Proxy script...");
   await sandbox.uploadFile("/workspace/proxy.py", sqlProxyScript);
+  console.log("Script uploaded to /workspace/proxy.py");
+
+  console.log("Starting DuckDB SQL Proxy session...");
   const session = await sandbox.createSession({
     name: "duckdb-proxy",
     command: "python3 /workspace/proxy.py",
   });
+  console.log(`Session started! ID: ${session.id}`);
 
+  console.log("Exposing port 8080...");
   const exposure = await sandbox.exposePort(8080);
-  console.log(\`DuckDB SQL Proxy ready at: \${exposure.url}\`);
-  console.log(\`Try running: curl -X POST -d "SELECT * FROM data LIMIT 5" \${exposure.url}\`);
+  console.log(`Port exposed!`);
+  
+  console.log(`\n✅ DuckDB SQL Proxy ready at: ${exposure.url}`);
+  console.log(`Try running: curl -X POST -d "SELECT * FROM data LIMIT 5" ${exposure.url}`);
 }
 
 main().catch(console.error);

--- a/docs/src/content/docs/use-cases/data-processing-ml/headless-jupyter-notebook.mdx
+++ b/docs/src/content/docs/use-cases/data-processing-ml/headless-jupyter-notebook.mdx
@@ -22,39 +22,45 @@ const apiUrl = process.env.SB_API_URL ?? "http://127.0.0.1:21212";
 const patToken = process.env.SB_PAT_TOKEN;
 const jupyterToken = "aerolvm-secret-token"; // Choose a secure token
 
-if (!patToken) throw new Error("Set SB_PAT_TOKEN.");
+
 
 async function main() {
+  if (!patToken) throw new Error("Set SB_PAT_TOKEN.");
+  console.log("Initializing AerolVM client...");
   const client = new MicroVM({ apiUrl, patToken });
 
-  console.log("Creating Jupyter sandbox (2 CPU, 4GB RAM)...");
+  console.log("Creating Jupyter sandbox (1 CPU, 2GB RAM)...");
   const sandbox = await client.create({
     image: "python:3.11-bookworm",
-    cpu: 2,
-    memoryMB: 4096,
+    cpu: 1,
+    memoryMB: 2048,
   });
+  console.log(`Sandbox created successfully! ID: ${sandbox.id}`);
 
-  console.log("Installing JupyterLab and Data Science stack...");
-  // This may take a minute or two
-  await sandbox.exec("pip install jupyterlab pandas matplotlib polars");
+  console.log("Installing JupyterLab and Data Science stack (this may take a minute)...");
+  const installRes = await sandbox.exec("pip install jupyterlab pandas matplotlib polars");
+  console.log(`Packages installed (exit code: ${installRes.exitCode}, duration: ${installRes.durationMS}ms)`);
 
-  console.log("Starting JupyterLab...");
+  console.log("Starting JupyterLab server session...");
   const session = await sandbox.createSession({
     name: "jupyter-server",
-    command: \`jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --NotebookApp.token='\${jupyterToken}' --allow-root\`,
+    command: `jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --NotebookApp.token='${jupyterToken}' --allow-root`,
   });
+  console.log(`JupyterLab session started! ID: ${session.id}`);
 
   console.log("Exposing Jupyter port 8888...");
   const exposure = await sandbox.exposePort(8888);
+  console.log(`Port exposed successfully!`);
 
-  console.log("\\n--- JupyterLab Ready ---");
-  console.log(\`URL: \${exposure.url}?token=\${jupyterToken}\`);
-  console.log("-------------------------\\n");
+  console.log("\n--- JupyterLab Ready ---");
+  console.log(`URL: ${exposure.url}?token=${jupyterToken}`);
+  console.log("-------------------------\n");
   
   console.log("The sandbox will stay alive as long as you use the notebook.");
 }
 
 main().catch(console.error);
+
 ```
 
 ## Related docs

--- a/docs/src/content/docs/use-cases/data-processing-ml/headless-jupyter-notebook.mdx
+++ b/docs/src/content/docs/use-cases/data-processing-ml/headless-jupyter-notebook.mdx
@@ -1,0 +1,64 @@
+---
+title: Headless Jupyter Notebook
+description: Spin up a full JupyterLab environment in a sandbox and access it via a public URL.
+---
+
+Sometimes you need a clean, interactive environment to explore a new dataset or library. This use case shows how to boot a sandbox, install a data science stack, and start a **JupyterLab** server that you can access from your browser.
+
+## Interactive Sandboxes
+
+- **Disposable Labs:** Spin up a new lab for every experiment.
+- **Pre-configured Stacks:** Launch a notebook with specific versions of PyTorch, TensorFlow, or JAX already installed.
+- **Secure Access:** Only the bearer of the token (and the public URL) can access the environment.
+
+## Copy-paste TypeScript script
+
+Code URL: [https://github.com/aerol-ai/aerolvm-examples/tree/main/ml-data-engineering/headless-jupyter-notebook](https://github.com/aerol-ai/aerolvm-examples/tree/main/ml-data-engineering/headless-jupyter-notebook)
+
+```ts
+import { MicroVM } from "@aerol-ai/aerolvm-sdk";
+
+const apiUrl = process.env.SB_API_URL ?? "http://127.0.0.1:21212";
+const patToken = process.env.SB_PAT_TOKEN;
+const jupyterToken = "aerolvm-secret-token"; // Choose a secure token
+
+if (!patToken) throw new Error("Set SB_PAT_TOKEN.");
+
+async function main() {
+  const client = new MicroVM({ apiUrl, patToken });
+
+  console.log("Creating Jupyter sandbox (2 CPU, 4GB RAM)...");
+  const sandbox = await client.create({
+    image: "python:3.11-bookworm",
+    cpu: 2,
+    memoryMB: 4096,
+  });
+
+  console.log("Installing JupyterLab and Data Science stack...");
+  // This may take a minute or two
+  await sandbox.exec("pip install jupyterlab pandas matplotlib polars");
+
+  console.log("Starting JupyterLab...");
+  const session = await sandbox.createSession({
+    name: "jupyter-server",
+    command: \`jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --NotebookApp.token='\${jupyterToken}' --allow-root\`,
+  });
+
+  console.log("Exposing Jupyter port 8888...");
+  const exposure = await sandbox.exposePort(8888);
+
+  console.log("\\n--- JupyterLab Ready ---");
+  console.log(\`URL: \${exposure.url}?token=\${jupyterToken}\`);
+  console.log("-------------------------\\n");
+  
+  console.log("The sandbox will stay alive as long as you use the notebook.");
+}
+
+main().catch(console.error);
+```
+
+## Related docs
+- [Exposing Ports](/tcp-ports/)
+- [Sessions](/sessions/)
+- [Preview URLs](/preview/)
+---

--- a/docs/src/content/docs/use-cases/data-processing-ml/hyperparameter-tuning-farm.mdx
+++ b/docs/src/content/docs/use-cases/data-processing-ml/hyperparameter-tuning-farm.mdx
@@ -1,0 +1,82 @@
+---
+title: Hyperparameter Tuning Farm
+description: Spin up multiple concurrent sandboxes to test different model configurations in parallel.
+---
+
+This pattern demonstrates the true power of AerolVM: horizontal scaling. By spinning up multiple sandboxes, you can benchmark different hyperparameters (like learning rates or model architectures) across a fleet of isolated workers simultaneously.
+
+## Parallel Tuning Benefits
+
+- **Speed:** Reduce total tuning time from hours to minutes by running jobs in parallel.
+- **Isolation:** A crash in one training job doesn't affect the others.
+- **Resource Management:** Each sandbox gets its own dedicated CPU and RAM, preventing resource contention.
+
+## Copy-paste TypeScript script
+
+Code URL: [https://github.com/aerol-ai/aerolvm-examples/tree/main/ml-data-engineering/hyperparameter-tuning-farm](https://github.com/aerol-ai/aerolvm-examples/tree/main/ml-data-engineering/hyperparameter-tuning-farm)
+
+This script creates 3 concurrent sandboxes, each training a Scikit-Learn model with a different `n_estimators` value.
+
+```ts
+import { MicroVM } from "@aerol-ai/aerolvm-sdk";
+
+const apiUrl = process.env.SB_API_URL ?? "http://127.0.0.1:21212";
+const patToken = process.env.SB_PAT_TOKEN;
+
+if (!patToken) throw new Error("Set SB_PAT_TOKEN.");
+
+const trainingScript = `
+import os
+import time
+from sklearn.datasets import make_classification
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import cross_val_score
+
+n_estimators = int(os.environ.get("N_ESTIMATORS", 10))
+print(f"Training RandomForest with n_estimators={n_estimators}...")
+
+X, y = make_classification(n_samples=1000, n_features=20)
+clf = RandomForestClassifier(n_estimators=n_estimators)
+scores = cross_val_score(clf, X, y, cv=5)
+
+print(f"RESULT: accuracy={scores.mean():.4f}")
+`;
+
+async function trainModel(client: MicroVM, nEstimators: number) {
+  const sandbox = await client.create({
+    image: "python:3.11-bookworm",
+    cpu: 1,
+    memoryMB: 1024,
+    env: { N_ESTIMATORS: String(nEstimators) }
+  });
+
+  await sandbox.exec("pip install scikit-learn");
+  await sandbox.uploadFile("/train.py", trainingScript);
+  
+  const result = await sandbox.exec("python3 /train.py");
+  const output = result.stdout.split("RESULT: ")[1]?.trim();
+  
+  await sandbox.destroy();
+  return { nEstimators, output };
+}
+
+async function main() {
+  const client = new MicroVM({ apiUrl, patToken });
+  const hyperparams = [10, 50, 100];
+
+  console.log(\`Spinning up \${hyperparams.length} parallel training jobs...\`);
+  
+  const jobs = hyperparams.map(val => trainModel(client, val));
+  const results = await Promise.all(jobs);
+
+  console.table(results);
+}
+
+main().catch(console.error);
+```
+
+## Related docs
+- [Creating Sandboxes](/environment/)
+- [Executions](/executions/)
+- [Lifecycle](/lifecycle/)
+---

--- a/docs/src/content/docs/use-cases/data-processing-ml/hyperparameter-tuning-farm.mdx
+++ b/docs/src/content/docs/use-cases/data-processing-ml/hyperparameter-tuning-farm.mdx
@@ -23,7 +23,7 @@ import { MicroVM } from "@aerol-ai/aerolvm-sdk";
 const apiUrl = process.env.SB_API_URL ?? "http://127.0.0.1:21212";
 const patToken = process.env.SB_PAT_TOKEN;
 
-if (!patToken) throw new Error("Set SB_PAT_TOKEN.");
+
 
 const trainingScript = `
 import os
@@ -43,32 +43,45 @@ print(f"RESULT: accuracy={scores.mean():.4f}")
 `;
 
 async function trainModel(client: MicroVM, nEstimators: number) {
+  console.log(`[Job n_estimators=${nEstimators}] Creating sandbox...`);
   const sandbox = await client.create({
     image: "python:3.11-bookworm",
     cpu: 1,
     memoryMB: 1024,
     env: { N_ESTIMATORS: String(nEstimators) }
   });
+  console.log(`[Job n_estimators=${nEstimators}] Sandbox created: ${sandbox.id}`);
 
+  console.log(`[Job n_estimators=${nEstimators}] Installing scikit-learn...`);
   await sandbox.exec("pip install scikit-learn");
+
+  console.log(`[Job n_estimators=${nEstimators}] Uploading training script...`);
   await sandbox.uploadFile("/train.py", trainingScript);
   
+  console.log(`[Job n_estimators=${nEstimators}] Running training script...`);
   const result = await sandbox.exec("python3 /train.py");
+  console.log(`[Job n_estimators=${nEstimators}] Script finished (exit code: ${result.exitCode})`);
+  
   const output = result.stdout.split("RESULT: ")[1]?.trim();
   
+  console.log(`[Job n_estimators=${nEstimators}] Destroying sandbox...`);
   await sandbox.destroy();
+  console.log(`[Job n_estimators=${nEstimators}] Sandbox destroyed.`);
   return { nEstimators, output };
 }
 
 async function main() {
+  if (!patToken) throw new Error("Set SB_PAT_TOKEN.");
+  console.log("Initializing AerolVM client...");
   const client = new MicroVM({ apiUrl, patToken });
   const hyperparams = [10, 50, 100];
 
-  console.log(\`Spinning up \${hyperparams.length} parallel training jobs...\`);
+  console.log(`Spinning up ${hyperparams.length} parallel training jobs...`);
   
   const jobs = hyperparams.map(val => trainModel(client, val));
   const results = await Promise.all(jobs);
 
+  console.log("\nAll training jobs completed successfully! Results:");
   console.table(results);
 }
 

--- a/docs/src/content/docs/use-cases/data-processing-ml/kaggle-to-parquet.mdx
+++ b/docs/src/content/docs/use-cases/data-processing-ml/kaggle-to-parquet.mdx
@@ -28,12 +28,10 @@ import { MicroVM } from "@aerol-ai/aerolvm-sdk";
 const apiUrl = process.env.SB_API_URL ?? "http://127.0.0.1:21212";
 const patToken = process.env.SB_PAT_TOKEN;
 const kaggleUsername = process.env.KAGGLE_USERNAME;
-const kaggleKey = process.env.KAGGLE_KEY;
+const kaggleKey = process.env.KAGGLE_API_TOKEN ;
 const kaggleDataset = process.env.KAGGLE_DATASET ?? "mlg-ulb/creditcardfraud";
 
-if (!patToken || !kaggleUsername || !kaggleKey) {
-  throw new Error("Set SB_PAT_TOKEN, KAGGLE_USERNAME, and KAGGLE_KEY before running.");
-}
+
 
 const processingScript = `
 import os
@@ -56,7 +54,7 @@ input_file = os.path.join('./data', csv_files[0])
 output_file = "processed_data.parquet"
 
 print(f"Processing {input_file} with Polars...")
-df = pl.read_csv(input_file)
+df = pl.read_csv(input_file, infer_schema_length=1000000)
 
 # Perform some basic cleaning/optimization
 df = df.drop_nulls()
@@ -67,43 +65,59 @@ print("Done!")
 `;
 
 async function main() {
+  if (!patToken || !kaggleUsername || !kaggleKey) {
+    throw new Error("Set SB_PAT_TOKEN, KAGGLE_USERNAME, and KAGGLE_KEY before running.");
+  }
+  console.log("Initializing AerolVM client...");
   const client = new MicroVM({ apiUrl, patToken });
 
-  console.log("Creating ETL sandbox (4 CPU, 8GB RAM)...");
+  console.log("Creating ETL sandbox (1 CPU, 2GB RAM)...");
   const sandbox = await client.create({
     image: "python:3.11-bookworm",
-    cpu: 4,
-    memoryMB: 8192,
+    cpu: 1,
+    memoryMB: 2048,
     env: {
       KAGGLE_USERNAME: kaggleUsername,
       KAGGLE_KEY: kaggleKey,
       KAGGLE_DATASET: kaggleDataset,
     }
   });
+  console.log(`Sandbox created successfully! ID: ${sandbox.id}`);
 
   console.log("Installing dependencies (polars, kaggle)...");
-  await sandbox.exec("pip install polars kaggle");
+  const installRes = await sandbox.exec("pip install polars kaggle");
+  console.log(`Dependencies installed (exit code: ${installRes.exitCode}, duration: ${installRes.durationMS}ms)`);
+
+  console.log("Preparing ETL directory...");
+  await sandbox.exec("mkdir -p /etl");
 
   console.log("Uploading processing script...");
-  await sandbox.exec("mkdir -p /etl");
   await sandbox.uploadFile("/etl/process.py", processingScript);
+  console.log("Script uploaded to /etl/process.py");
 
-  console.log("Running ETL pipeline...");
-  const result = await sandbox.exec("python3 /etl/process.py", { workDir: "/etl" });
+  console.log("Running ETL pipeline (this downloads and processes data)...");
+  const result = await sandbox.exec({ command: "python3 /etl/process.py", workDir: "/etl" });
+  console.log(`ETL Pipeline finished! (exit code: ${result.exitCode}, duration: ${result.durationMS}ms)`);
   
   if (result.exitCode !== 0) {
-    console.error("ETL Failed:", result.stderr);
+    console.error("ETL Failed.");
+    console.error("--- STDOUT ---");
+    console.error(result.stdout);
+    console.error("--- STDERR ---");
+    console.error(result.stderr);
     process.exit(1)
   }
 
-  console.log("ETL Complete. Downloading optimized Parquet file...");
+  console.log("ETL Complete. Downloading optimized Parquet file to local machine...");
   const parquetData = await sandbox.downloadFile("/etl/processed_data.parquet");
-  await writeFile("processed_data.parquet", Buffer.from(parquetData));
-
-  console.log("Success! File saved as processed_data.parquet");
+  console.log(`Downloaded ${parquetData.byteLength} bytes.`);
   
-  // Cleanup
+  await writeFile("processed_data.parquet", Buffer.from(parquetData));
+  console.log("Success! File saved to disk as processed_data.parquet");
+  
+  console.log("Cleaning up: Destroying sandbox...");
   await sandbox.destroy();
+  console.log("Sandbox destroyed.");
 }
 
 main().catch(console.error);

--- a/docs/src/content/docs/use-cases/data-processing-ml/kaggle-to-parquet.mdx
+++ b/docs/src/content/docs/use-cases/data-processing-ml/kaggle-to-parquet.mdx
@@ -1,0 +1,116 @@
+---
+title: Kaggle Dataset to Parquet
+description: Download a large dataset from Kaggle, process it using Polars inside an AerolVM sandbox, and export the optimized Parquet file.
+---
+
+This workflow demonstrates how to use a high-memory AerolVM sandbox as an ephemeral ETL (Extract, Transform, Load) worker. We download a dataset from Kaggle, use **Polars** for lightning-fast data manipulation, and save the result as an optimized Parquet file.
+
+## Why use a sandbox for ETL?
+
+- **Isolation:** Don't clutter your local machine with multi-gigabyte CSVs.
+- **Resource Scaling:** Spin up a sandbox with 16GB or 32GB of RAM for heavy processing, then destroy it when done.
+- **Reproducibility:** The environment (Python version, libraries) is locked and consistent every time.
+
+## Copy-paste TypeScript script
+
+Code URL: [https://github.com/aerol-ai/aerolvm-examples/tree/main/ml-data-engineering/kaggle-to-parquet](https://github.com/aerol-ai/aerolvm-examples/tree/main/ml-data-engineering/kaggle-to-parquet)
+
+Set these environment variables before running:
+- `SB_PAT_TOKEN`
+- `KAGGLE_USERNAME`
+- `KAGGLE_KEY`
+- `KAGGLE_DATASET` (e.g., `mlg-ulb/creditcardfraud`)
+
+```ts
+import { writeFile } from "node:fs/promises";
+import { MicroVM } from "@aerol-ai/aerolvm-sdk";
+
+const apiUrl = process.env.SB_API_URL ?? "http://127.0.0.1:21212";
+const patToken = process.env.SB_PAT_TOKEN;
+const kaggleUsername = process.env.KAGGLE_USERNAME;
+const kaggleKey = process.env.KAGGLE_KEY;
+const kaggleDataset = process.env.KAGGLE_DATASET ?? "mlg-ulb/creditcardfraud";
+
+if (!patToken || !kaggleUsername || !kaggleKey) {
+  throw new Error("Set SB_PAT_TOKEN, KAGGLE_USERNAME, and KAGGLE_KEY before running.");
+}
+
+const processingScript = `
+import os
+import polars as pl
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+api = KaggleApi()
+api.authenticate()
+
+dataset = os.environ.get('KAGGLE_DATASET')
+print(f"Downloading {dataset}...")
+api.dataset_download_files(dataset, path='./data', unzip=True)
+
+# Find the CSV file
+csv_files = [f for f in os.listdir('./data') if f.endswith('.csv')]
+if not csv_files:
+    raise Exception("No CSV file found in dataset")
+
+input_file = os.path.join('./data', csv_files[0])
+output_file = "processed_data.parquet"
+
+print(f"Processing {input_file} with Polars...")
+df = pl.read_csv(input_file)
+
+# Perform some basic cleaning/optimization
+df = df.drop_nulls()
+
+print(f"Saving to {output_file}...")
+df.write_parquet(output_file)
+print("Done!")
+`;
+
+async function main() {
+  const client = new MicroVM({ apiUrl, patToken });
+
+  console.log("Creating ETL sandbox (4 CPU, 8GB RAM)...");
+  const sandbox = await client.create({
+    image: "python:3.11-bookworm",
+    cpu: 4,
+    memoryMB: 8192,
+    env: {
+      KAGGLE_USERNAME: kaggleUsername,
+      KAGGLE_KEY: kaggleKey,
+      KAGGLE_DATASET: kaggleDataset,
+    }
+  });
+
+  console.log("Installing dependencies (polars, kaggle)...");
+  await sandbox.exec("pip install polars kaggle");
+
+  console.log("Uploading processing script...");
+  await sandbox.exec("mkdir -p /etl");
+  await sandbox.uploadFile("/etl/process.py", processingScript);
+
+  console.log("Running ETL pipeline...");
+  const result = await sandbox.exec("python3 /etl/process.py", { workDir: "/etl" });
+  
+  if (result.exitCode !== 0) {
+    console.error("ETL Failed:", result.stderr);
+    process.exit(1)
+  }
+
+  console.log("ETL Complete. Downloading optimized Parquet file...");
+  const parquetData = await sandbox.downloadFile("/etl/processed_data.parquet");
+  await writeFile("processed_data.parquet", Buffer.from(parquetData));
+
+  console.log("Success! File saved as processed_data.parquet");
+  
+  // Cleanup
+  await sandbox.destroy();
+}
+
+main().catch(console.error);
+```
+
+## Related docs
+- [Creating Sandboxes](/environment/)
+- [File Transfers](/files/)
+- [Compute Resources](/compute/)
+---


### PR DESCRIPTION
This pull request expands the documentation for AerolVM by adding a new "Data Processing & ML" section to the Use Cases sidebar, along with four detailed example guides for common machine learning and data engineering workflows. It also removes the previous generic use case overview link to streamline navigation.

**Documentation structure improvements:**

* Added a new "Data Processing & ML" group to the use cases sidebar, featuring four focused entries: Kaggle Dataset to Parquet, SQL on Kaggle with DuckDB, Hyperparameter Tuning Farm, and Headless Jupyter Notebook. This organizes ML/data workflows separately for easier discovery and navigation. [[1]](diffhunk://#diff-3c77bd19d81880d0f5739e83a4ae589c80940aedc6e4208018361c53ae761d56L198-L204) [[2]](diffhunk://#diff-3c77bd19d81880d0f5739e83a4ae589c80940aedc6e4208018361c53ae761d56R277-R306)

**New example guides for ML/data workflows:**

* Added `kaggle-to-parquet.mdx`: Demonstrates using a high-memory AerolVM sandbox to download a Kaggle dataset, process it with Polars, and export an optimized Parquet file. Includes a ready-to-use TypeScript script and step-by-step instructions.
* Added `duckdb-dataset-explorer.mdx`: Shows how to launch DuckDB in a sandbox to run SQL queries directly on Kaggle datasets, with an HTTP proxy for remote querying. Includes a complete example script.
* Added `hyperparameter-tuning-farm.mdx`: Provides a scalable pattern for parallel hyperparameter tuning by spinning up multiple sandboxes, each training a model with different parameters.
* Added `headless-jupyter-notebook.mdx`: Guides users through launching a JupyterLab server in a sandbox, installing a data science stack, and exposing it securely via a public URL.