### PR TITLE
feat: Implement Daytona compatibility facade and metadata management

### DIFF
--- a/cmd/toolboxd/daytona_files_git.go
+++ b/cmd/toolboxd/daytona_files_git.go
@@ -1,0 +1,752 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+type daytonaFileInfoResponse struct {
+	Group       string `json:"group"`
+	IsDir       bool   `json:"isDir"`
+	ModTime     string `json:"modTime"`
+	Mode        string `json:"mode"`
+	Name        string `json:"name"`
+	Owner       string `json:"owner"`
+	Permissions string `json:"permissions"`
+	Size        int32  `json:"size"`
+}
+
+type daytonaMatchResponse struct {
+	Content string `json:"content"`
+	File    string `json:"file"`
+	Line    int32  `json:"line"`
+}
+
+type daytonaSearchFilesResponse struct {
+	Files []string `json:"files"`
+}
+
+type daytonaGitStatusResponse struct {
+	Ahead           *int32                 `json:"ahead,omitempty"`
+	Behind          *int32                 `json:"behind,omitempty"`
+	BranchPublished *bool                  `json:"branchPublished,omitempty"`
+	CurrentBranch   string                 `json:"currentBranch"`
+	FileStatus      []daytonaGitFileStatus `json:"fileStatus"`
+}
+
+type daytonaGitFileStatus struct {
+	Extra    string `json:"extra"`
+	Name     string `json:"name"`
+	Staging  string `json:"staging"`
+	Worktree string `json:"worktree"`
+}
+
+type daytonaGitCommitInfo struct {
+	Author    string `json:"author"`
+	Email     string `json:"email"`
+	Hash      string `json:"hash"`
+	Message   string `json:"message"`
+	Timestamp string `json:"timestamp"`
+}
+
+type daytonaListBranchesResponse struct {
+	Branches []string `json:"branches"`
+}
+
+type daytonaGitCommitResponse struct {
+	Hash string `json:"hash"`
+}
+
+type daytonaGitAddRequest struct {
+	Files []string `json:"files"`
+	Path  string   `json:"path"`
+}
+
+type daytonaGitCheckoutRequest struct {
+	Branch string `json:"branch"`
+	Path   string `json:"path"`
+}
+
+type daytonaGitBranchRequest struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
+type daytonaGitDeleteBranchRequest struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
+type daytonaGitCloneRequest struct {
+	Branch   *string `json:"branch,omitempty"`
+	CommitID *string `json:"commit_id,omitempty"`
+	Password *string `json:"password,omitempty"`
+	Path     string  `json:"path"`
+	URL      string  `json:"url"`
+	Username *string `json:"username,omitempty"`
+}
+
+type daytonaGitCommitRequest struct {
+	AllowEmpty *bool  `json:"allow_empty,omitempty"`
+	Author     string `json:"author"`
+	Email      string `json:"email"`
+	Message    string `json:"message"`
+	Path       string `json:"path"`
+}
+
+type gitCommandError struct {
+	message string
+}
+
+func (e *gitCommandError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.message
+}
+
+func (s *server) handleDaytonaFileInfo(w http.ResponseWriter, r *http.Request) {
+	targetPath, err := resolveDaytonaPath(r.URL.Query().Get("path"), false)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	info, err := os.Stat(targetPath)
+	if err != nil {
+		writeFilesystemError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, buildDaytonaFileInfo(targetPath, info))
+}
+
+func (s *server) handleDaytonaListFiles(w http.ResponseWriter, r *http.Request) {
+	targetPath, err := resolveDaytonaPath(r.URL.Query().Get("path"), true)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	entries, err := os.ReadDir(targetPath)
+	if err != nil {
+		writeFilesystemError(w, err)
+		return
+	}
+	items := make([]daytonaFileInfoResponse, 0, len(entries))
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			writeFilesystemError(w, err)
+			return
+		}
+		items = append(items, buildDaytonaFileInfo(filepath.Join(targetPath, entry.Name()), info))
+	}
+	writeJSON(w, http.StatusOK, items)
+}
+
+func (s *server) handleDaytonaMoveFile(w http.ResponseWriter, r *http.Request) {
+	source, err := resolveDaytonaPath(r.URL.Query().Get("source"), false)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	destination, err := resolveDaytonaPath(r.URL.Query().Get("destination"), false)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := os.Rename(source, destination); err != nil {
+		writeFilesystemError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *server) handleDaytonaSearchFiles(w http.ResponseWriter, r *http.Request) {
+	root, err := resolveDaytonaPath(r.URL.Query().Get("path"), false)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	pattern := strings.TrimSpace(r.URL.Query().Get("pattern"))
+	if pattern == "" {
+		writeError(w, http.StatusBadRequest, "pattern is required")
+		return
+	}
+	if _, err := filepath.Match(pattern, ""); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid pattern")
+		return
+	}
+	matches := []string{}
+	err = filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if matchesPattern(root, path, entry.Name(), pattern) {
+			matches = append(matches, path)
+		}
+		return nil
+	})
+	if err != nil {
+		writeFilesystemError(w, err)
+		return
+	}
+	sort.Strings(matches)
+	writeJSON(w, http.StatusOK, daytonaSearchFilesResponse{Files: matches})
+}
+
+func (s *server) handleDaytonaFindInFiles(w http.ResponseWriter, r *http.Request) {
+	root, err := resolveDaytonaPath(r.URL.Query().Get("path"), false)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	pattern := r.URL.Query().Get("pattern")
+	if pattern == "" {
+		writeError(w, http.StatusBadRequest, "pattern is required")
+		return
+	}
+	matches := []daytonaMatchResponse{}
+	err = filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		scanner := bufio.NewScanner(file)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		lineNumber := 0
+		for scanner.Scan() {
+			lineNumber++
+			line := scanner.Text()
+			if strings.Contains(line, pattern) {
+				matches = append(matches, daytonaMatchResponse{Content: line, File: path, Line: int32(lineNumber)})
+			}
+		}
+		return scanner.Err()
+	})
+	if err != nil {
+		writeFilesystemError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, matches)
+}
+
+func (s *server) handleDaytonaGitRoute(w http.ResponseWriter, r *http.Request) bool {
+	switch {
+	case r.Method == http.MethodPost && r.URL.Path == "/git/add":
+		s.handleDaytonaGitAdd(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == "/git/checkout":
+		s.handleDaytonaGitCheckout(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == "/git/clone":
+		s.handleDaytonaGitClone(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == "/git/commit":
+		s.handleDaytonaGitCommit(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == "/git/branches":
+		s.handleDaytonaGitCreateBranch(w, r)
+	case r.Method == http.MethodDelete && r.URL.Path == "/git/branches":
+		s.handleDaytonaGitDeleteBranch(w, r)
+	case r.Method == http.MethodGet && r.URL.Path == "/git/branches":
+		s.handleDaytonaGitListBranches(w, r)
+	case r.Method == http.MethodGet && r.URL.Path == "/git/history":
+		s.handleDaytonaGitHistory(w, r)
+	case r.Method == http.MethodGet && r.URL.Path == "/git/status":
+		s.handleDaytonaGitStatus(w, r)
+	case r.Method == http.MethodPost && (r.URL.Path == "/git/pull" || r.URL.Path == "/git/push"):
+		writeError(w, http.StatusNotImplemented, "git remote sync is not implemented")
+	default:
+		return false
+	}
+	return true
+}
+
+func (s *server) handleDaytonaGitAdd(w http.ResponseWriter, r *http.Request) {
+	var req daytonaGitAddRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	repoPath, err := resolveGitPath(req.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if len(req.Files) == 0 {
+		writeError(w, http.StatusBadRequest, "files is required")
+		return
+	}
+	args := append([]string{"add", "--"}, req.Files...)
+	if _, err := runGit(repoPath, args...); err != nil {
+		writeGitError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *server) handleDaytonaGitCheckout(w http.ResponseWriter, r *http.Request) {
+	var req daytonaGitCheckoutRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	repoPath, err := resolveGitPath(req.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if strings.TrimSpace(req.Branch) == "" {
+		writeError(w, http.StatusBadRequest, "branch is required")
+		return
+	}
+	if _, err := runGit(repoPath, "checkout", req.Branch); err != nil {
+		writeGitError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *server) handleDaytonaGitClone(w http.ResponseWriter, r *http.Request) {
+	var req daytonaGitCloneRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	clonePath, err := resolveDaytonaPath(req.Path, false)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if strings.TrimSpace(req.URL) == "" {
+		writeError(w, http.StatusBadRequest, "url is required")
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(clonePath), 0o755); err != nil {
+		writeFilesystemError(w, err)
+		return
+	}
+	cloneURL := gitURLWithCredentials(req.URL, valueOrEmptyString(req.Username), valueOrEmptyString(req.Password))
+	args := []string{"clone"}
+	if branch := strings.TrimSpace(valueOrEmptyString(req.Branch)); branch != "" {
+		args = append(args, "--branch", branch)
+	}
+	args = append(args, cloneURL, clonePath)
+	if _, err := runGitNoRepo(args...); err != nil {
+		writeGitError(w, err)
+		return
+	}
+	if commitID := strings.TrimSpace(valueOrEmptyString(req.CommitID)); commitID != "" {
+		if _, err := runGit(clonePath, "checkout", commitID); err != nil {
+			writeGitError(w, err)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *server) handleDaytonaGitCommit(w http.ResponseWriter, r *http.Request) {
+	var req daytonaGitCommitRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	repoPath, err := resolveGitPath(req.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if strings.TrimSpace(req.Author) == "" || strings.TrimSpace(req.Email) == "" || strings.TrimSpace(req.Message) == "" {
+		writeError(w, http.StatusBadRequest, "author, email, and message are required")
+		return
+	}
+	args := []string{"-C", repoPath, "-c", "user.name=" + req.Author, "-c", "user.email=" + req.Email, "commit", "-m", req.Message}
+	if req.AllowEmpty != nil && *req.AllowEmpty {
+		args = append(args, "--allow-empty")
+	}
+	if _, err := runGitNoRepo(args...); err != nil {
+		writeGitError(w, err)
+		return
+	}
+	hash, err := runGit(repoPath, "rev-parse", "HEAD")
+	if err != nil {
+		writeGitError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, daytonaGitCommitResponse{Hash: strings.TrimSpace(hash)})
+}
+
+func (s *server) handleDaytonaGitCreateBranch(w http.ResponseWriter, r *http.Request) {
+	var req daytonaGitBranchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	repoPath, err := resolveGitPath(req.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if _, err := runGit(repoPath, "branch", req.Name); err != nil {
+		writeGitError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *server) handleDaytonaGitDeleteBranch(w http.ResponseWriter, r *http.Request) {
+	var req daytonaGitDeleteBranchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	repoPath, err := resolveGitPath(req.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if _, err := runGit(repoPath, "branch", "-D", req.Name); err != nil {
+		writeGitError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *server) handleDaytonaGitListBranches(w http.ResponseWriter, r *http.Request) {
+	repoPath, err := resolveGitPath(r.URL.Query().Get("path"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	output, err := runGit(repoPath, "branch", "--format=%(refname:short)")
+	if err != nil {
+		writeGitError(w, err)
+		return
+	}
+	branches := []string{}
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			branches = append(branches, trimmed)
+		}
+	}
+	writeJSON(w, http.StatusOK, daytonaListBranchesResponse{Branches: branches})
+}
+
+func (s *server) handleDaytonaGitHistory(w http.ResponseWriter, r *http.Request) {
+	repoPath, err := resolveGitPath(r.URL.Query().Get("path"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	output, err := runGit(repoPath, "log", "--date=iso-strict", "--pretty=format:%H%x00%an%x00%ae%x00%cI%x00%s")
+	if err != nil {
+		writeGitError(w, err)
+		return
+	}
+	commits := []daytonaGitCommitInfo{}
+	for _, line := range strings.Split(output, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\x00", 5)
+		if len(parts) != 5 {
+			continue
+		}
+		commits = append(commits, daytonaGitCommitInfo{Hash: parts[0], Author: parts[1], Email: parts[2], Timestamp: parts[3], Message: parts[4]})
+	}
+	writeJSON(w, http.StatusOK, commits)
+}
+
+func (s *server) handleDaytonaGitStatus(w http.ResponseWriter, r *http.Request) {
+	repoPath, err := resolveGitPath(r.URL.Query().Get("path"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	output, err := runGit(repoPath, "status", "--porcelain=v1", "-b")
+	if err != nil {
+		writeGitError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, parseGitStatus(output))
+}
+
+func buildDaytonaFileInfo(path string, info os.FileInfo) daytonaFileInfoResponse {
+	owner, group := fileOwnerGroup(info)
+	return daytonaFileInfoResponse{
+		Group:       group,
+		IsDir:       info.IsDir(),
+		ModTime:     info.ModTime().UTC().Format(time.RFC3339),
+		Mode:        info.Mode().String(),
+		Name:        filepath.Base(path),
+		Owner:       owner,
+		Permissions: fmt.Sprintf("%04o", info.Mode().Perm()),
+		Size:        clampInt32(info.Size()),
+	}
+}
+
+func resolveDaytonaPath(raw string, defaultToWorkDir bool) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		if !defaultToWorkDir {
+			return "", errors.New("path is required")
+		}
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		return cwd, nil
+	}
+	if filepath.IsAbs(trimmed) {
+		return filepath.Clean(trimmed), nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(filepath.Join(cwd, trimmed)), nil
+}
+
+func resolveGitPath(raw string) (string, error) {
+	path, err := resolveDaytonaPath(raw, false)
+	if err != nil {
+		return "", err
+	}
+	if _, err := os.Stat(path); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func matchesPattern(root, fullPath, name, pattern string) bool {
+	if ok, _ := filepath.Match(pattern, name); ok {
+		return true
+	}
+	rel, err := filepath.Rel(root, fullPath)
+	if err == nil {
+		if ok, _ := filepath.Match(pattern, rel); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func fileOwnerGroup(info os.FileInfo) (string, string) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return "", ""
+	}
+	uid := strconv.FormatUint(uint64(stat.Uid), 10)
+	gid := strconv.FormatUint(uint64(stat.Gid), 10)
+	owner := uid
+	group := gid
+	if found, err := user.LookupId(uid); err == nil && strings.TrimSpace(found.Username) != "" {
+		owner = found.Username
+	}
+	if found, err := user.LookupGroupId(gid); err == nil && strings.TrimSpace(found.Name) != "" {
+		group = found.Name
+	}
+	return owner, group
+}
+
+func clampInt32(value int64) int32 {
+	if value > int64(^uint32(0)>>1) {
+		return int32(^uint32(0) >> 1)
+	}
+	if value < 0 {
+		return 0
+	}
+	return int32(value)
+}
+
+func writeFilesystemError(w http.ResponseWriter, err error) {
+	status := http.StatusInternalServerError
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		status = http.StatusNotFound
+	case errors.Is(err, os.ErrPermission):
+		status = http.StatusForbidden
+	}
+	writeError(w, status, err.Error())
+}
+
+func writeGitError(w http.ResponseWriter, err error) {
+	status := http.StatusInternalServerError
+	var gitErr *gitCommandError
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		status = http.StatusNotFound
+	case errors.Is(err, os.ErrPermission):
+		status = http.StatusForbidden
+	case errors.As(err, &gitErr):
+		status = http.StatusBadRequest
+	}
+	writeError(w, status, err.Error())
+}
+
+func runGit(repoPath string, args ...string) (string, error) {
+	return runGitNoRepo(append([]string{"-C", repoPath}, args...)...)
+}
+
+func runGitNoRepo(args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			message = err.Error()
+		}
+		return "", &gitCommandError{message: message}
+	}
+	return string(output), nil
+}
+
+func gitURLWithCredentials(rawURL, username, password string) string {
+	username = strings.TrimSpace(username)
+	password = strings.TrimSpace(password)
+	if username == "" && password == "" {
+		return rawURL
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return rawURL
+	}
+	if password != "" {
+		parsed.User = url.UserPassword(username, password)
+	} else {
+		parsed.User = url.User(username)
+	}
+	return parsed.String()
+}
+
+func valueOrEmptyString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func parseGitStatus(output string) daytonaGitStatusResponse {
+	response := daytonaGitStatusResponse{CurrentBranch: "HEAD", FileStatus: []daytonaGitFileStatus{}}
+	for _, line := range strings.Split(strings.ReplaceAll(output, "\r\n", "\n"), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "## ") {
+			parseGitBranchHeader(strings.TrimPrefix(line, "## "), &response)
+			continue
+		}
+		if len(line) < 3 {
+			continue
+		}
+		statusCode := line[:2]
+		name := strings.TrimSpace(line[3:])
+		extra := ""
+		if strings.Contains(name, " -> ") {
+			parts := strings.SplitN(name, " -> ", 2)
+			extra = parts[0]
+			name = parts[1]
+		}
+		response.FileStatus = append(response.FileStatus, daytonaGitFileStatus{
+			Extra:    extra,
+			Name:     name,
+			Staging:  mapGitStatus(statusCode[0], statusCode),
+			Worktree: mapGitStatus(statusCode[1], statusCode),
+		})
+	}
+	return response
+}
+
+func parseGitBranchHeader(header string, response *daytonaGitStatusResponse) {
+	branchPart := header
+	if split := strings.SplitN(header, "...", 2); len(split) == 2 {
+		branchPart = split[0]
+		published := true
+		if strings.Contains(split[1], "[gone]") {
+			published = false
+		}
+		response.BranchPublished = boolPtr(published)
+		if index := strings.Index(split[1], "["); index >= 0 {
+			parseAheadBehind(strings.Trim(split[1][index:], "[]"), response)
+		}
+	} else {
+		response.BranchPublished = boolPtr(false)
+	}
+	branchPart = strings.TrimSpace(strings.SplitN(branchPart, " ", 2)[0])
+	if branchPart != "" {
+		response.CurrentBranch = branchPart
+	}
+}
+
+func parseAheadBehind(raw string, response *daytonaGitStatusResponse) {
+	for _, item := range strings.Split(raw, ",") {
+		trimmed := strings.TrimSpace(item)
+		switch {
+		case strings.HasPrefix(trimmed, "ahead "):
+			if value, err := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(trimmed, "ahead "))); err == nil {
+				response.Ahead = int32Ptr(int32(value))
+			}
+		case strings.HasPrefix(trimmed, "behind "):
+			if value, err := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(trimmed, "behind "))); err == nil {
+				response.Behind = int32Ptr(int32(value))
+			}
+		}
+	}
+}
+
+func mapGitStatus(value byte, code string) string {
+	if strings.Contains(code, "U") || code == "AA" || code == "DD" {
+		return "Updated but unmerged"
+	}
+	switch value {
+	case ' ':
+		return "Unmodified"
+	case '?':
+		return "Untracked"
+	case 'M', 'T':
+		return "Modified"
+	case 'A':
+		return "Added"
+	case 'D':
+		return "Deleted"
+	case 'R':
+		return "Renamed"
+	case 'C':
+		return "Copied"
+	default:
+		return "Modified"
+	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}

--- a/cmd/toolboxd/daytona_files_git.go
+++ b/cmd/toolboxd/daytona_files_git.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -343,13 +344,13 @@ func (s *server) handleDaytonaGitClone(w http.ResponseWriter, r *http.Request) {
 		writeFilesystemError(w, err)
 		return
 	}
-	cloneURL := gitURLWithCredentials(req.URL, valueOrEmptyString(req.Username), valueOrEmptyString(req.Password))
+	cloneURL, gitEnv := gitCloneURLAndAuthEnv(req.URL, valueOrEmptyString(req.Username), valueOrEmptyString(req.Password))
 	args := []string{"clone"}
 	if branch := strings.TrimSpace(valueOrEmptyString(req.Branch)); branch != "" {
 		args = append(args, "--branch", branch)
 	}
 	args = append(args, cloneURL, clonePath)
-	if _, err := runGitNoRepo(args...); err != nil {
+	if _, err := runGitNoRepoWithEnv(gitEnv, args...); err != nil {
 		writeGitError(w, err)
 		return
 	}
@@ -615,7 +616,14 @@ func runGit(repoPath string, args ...string) (string, error) {
 }
 
 func runGitNoRepo(args ...string) (string, error) {
+	return runGitNoRepoWithEnv(nil, args...)
+}
+
+func runGitNoRepoWithEnv(extraEnv []string, args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
+	if len(extraEnv) > 0 {
+		cmd.Env = append(os.Environ(), extraEnv...)
+	}
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		message := strings.TrimSpace(string(output))
@@ -627,25 +635,31 @@ func runGitNoRepo(args ...string) (string, error) {
 	return string(output), nil
 }
 
-func gitURLWithCredentials(rawURL, username, password string) string {
+func gitCloneURLAndAuthEnv(rawURL, username, password string) (string, []string) {
 	username = strings.TrimSpace(username)
 	password = strings.TrimSpace(password)
-	if username == "" && password == "" {
-		return rawURL
-	}
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
-		return rawURL
+		return rawURL, nil
 	}
 	if parsed.Scheme != "http" && parsed.Scheme != "https" {
-		return rawURL
+		return rawURL, nil
 	}
-	if password != "" {
-		parsed.User = url.UserPassword(username, password)
-	} else {
-		parsed.User = url.User(username)
+	if parsed.User != nil && username == "" && password == "" {
+		username = parsed.User.Username()
+		password, _ = parsed.User.Password()
 	}
-	return parsed.String()
+	parsed.User = nil
+	if username == "" && password == "" {
+		return parsed.String(), nil
+	}
+	header := "Authorization: Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
+	env := []string{
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=http.extraHeader",
+		"GIT_CONFIG_VALUE_0=" + header,
+	}
+	return parsed.String(), env
 }
 
 func valueOrEmptyString(value *string) string {

--- a/cmd/toolboxd/daytona_files_git_test.go
+++ b/cmd/toolboxd/daytona_files_git_test.go
@@ -1,0 +1,40 @@
+package main
+
+import "testing"
+
+func TestGitCloneURLAndAuthEnvUsesSanitizedURL(t *testing.T) {
+	cloneURL, env := gitCloneURLAndAuthEnv("https://example.com/org/repo.git", "user", "pass")
+	if cloneURL != "https://example.com/org/repo.git" {
+		t.Fatalf("cloneURL = %q", cloneURL)
+	}
+	if len(env) != 3 {
+		t.Fatalf("env length = %d, want 3", len(env))
+	}
+	if env[0] != "GIT_CONFIG_COUNT=1" || env[1] != "GIT_CONFIG_KEY_0=http.extraHeader" {
+		t.Fatalf("unexpected git config env: %+v", env)
+	}
+	if env[2] != "GIT_CONFIG_VALUE_0=Authorization: Basic dXNlcjpwYXNz" {
+		t.Fatalf("unexpected auth header env: %q", env[2])
+	}
+}
+
+func TestGitCloneURLAndAuthEnvExtractsEmbeddedCredentials(t *testing.T) {
+	cloneURL, env := gitCloneURLAndAuthEnv("https://user:pass@example.com/org/repo.git", "", "")
+	if cloneURL != "https://example.com/org/repo.git" {
+		t.Fatalf("cloneURL = %q", cloneURL)
+	}
+	if len(env) != 3 || env[2] != "GIT_CONFIG_VALUE_0=Authorization: Basic dXNlcjpwYXNz" {
+		t.Fatalf("unexpected env: %+v", env)
+	}
+}
+
+func TestGitCloneURLAndAuthEnvLeavesSSHURLAlone(t *testing.T) {
+	rawURL := "git@github.com:aerol-ai/microvm.git"
+	cloneURL, env := gitCloneURLAndAuthEnv(rawURL, "user", "pass")
+	if cloneURL != rawURL {
+		t.Fatalf("cloneURL = %q, want %q", cloneURL, rawURL)
+	}
+	if len(env) != 0 {
+		t.Fatalf("env = %+v, want empty", env)
+	}
+}

--- a/cmd/toolboxd/daytona_process.go
+++ b/cmd/toolboxd/daytona_process.go
@@ -160,8 +160,6 @@ func (s *daytonaSessionState) command(commandID string) (*daytonaCommandState, b
 		return nil, false
 	}
 	copy := *command
-	theActiveID := s.activeCommandID
-	_ = theActiveID
 	s.mu.RUnlock()
 	return &copy, true
 }

--- a/cmd/toolboxd/daytona_process.go
+++ b/cmd/toolboxd/daytona_process.go
@@ -1,0 +1,550 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aerol-ai/microvm/cmd/toolboxd/sessions"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+type daytonaCompat struct {
+	mu       sync.Mutex
+	sessions map[string]*daytonaSessionState
+}
+
+type daytonaSessionState struct {
+	execMu sync.Mutex
+	mu     sync.RWMutex
+
+	commands        map[string]*daytonaCommandState
+	activeCommandID string
+}
+
+type daytonaCommandState struct {
+	id        string
+	command   string
+	stdout    string
+	stderr    string
+	output    string
+	exitCode  *int32
+	running   bool
+	createdAt time.Time
+}
+
+type daytonaCreateSessionRequest struct {
+	SessionID string `json:"sessionId"`
+}
+
+type daytonaSessionResponse struct {
+	Commands  []daytonaCommandResponse `json:"commands"`
+	SessionID string                   `json:"sessionId"`
+}
+
+type daytonaCommandResponse struct {
+	Command  string `json:"command"`
+	ExitCode *int32 `json:"exitCode,omitempty"`
+	ID       string `json:"id"`
+}
+
+type daytonaSessionExecuteRequest struct {
+	Async             *bool  `json:"async,omitempty"`
+	Command           string `json:"command"`
+	RunAsync          *bool  `json:"runAsync,omitempty"`
+	SuppressInputEcho *bool  `json:"suppressInputEcho,omitempty"`
+}
+
+type daytonaSessionExecuteResponse struct {
+	CmdID    string  `json:"cmdId"`
+	ExitCode *int32  `json:"exitCode,omitempty"`
+	Output   *string `json:"output,omitempty"`
+	Stderr   *string `json:"stderr,omitempty"`
+	Stdout   *string `json:"stdout,omitempty"`
+}
+
+type daytonaSessionLogsResponse struct {
+	Output string `json:"output"`
+	Stderr string `json:"stderr"`
+	Stdout string `json:"stdout"`
+}
+
+func newDaytonaCompat() *daytonaCompat {
+	return &daytonaCompat{sessions: map[string]*daytonaSessionState{}}
+}
+
+func (c *daytonaCompat) ensureSession(sessionID string) *daytonaSessionState {
+	trimmed := strings.TrimSpace(sessionID)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	state := c.sessions[trimmed]
+	if state == nil {
+		state = &daytonaSessionState{commands: map[string]*daytonaCommandState{}}
+		c.sessions[trimmed] = state
+	}
+	return state
+}
+
+func (c *daytonaCompat) session(sessionID string) (*daytonaSessionState, bool) {
+	trimmed := strings.TrimSpace(sessionID)
+	c.mu.Lock()
+	state, ok := c.sessions[trimmed]
+	c.mu.Unlock()
+	return state, ok
+}
+
+func (c *daytonaCompat) deleteSession(sessionID string) {
+	c.mu.Lock()
+	delete(c.sessions, strings.TrimSpace(sessionID))
+	c.mu.Unlock()
+}
+
+func (c *daytonaCompat) listSessionIDs() []string {
+	c.mu.Lock()
+	ids := make([]string, 0, len(c.sessions))
+	for sessionID := range c.sessions {
+		ids = append(ids, sessionID)
+	}
+	c.mu.Unlock()
+	sort.Strings(ids)
+	return ids
+}
+
+func (s *daytonaSessionState) addCommand(command *daytonaCommandState) {
+	s.mu.Lock()
+	if s.commands == nil {
+		s.commands = map[string]*daytonaCommandState{}
+	}
+	s.commands[command.id] = command
+	s.mu.Unlock()
+}
+
+func (s *daytonaSessionState) setActive(commandID string) {
+	s.mu.Lock()
+	if command, ok := s.commands[commandID]; ok {
+		command.running = true
+	}
+	s.activeCommandID = commandID
+	s.mu.Unlock()
+}
+
+func (s *daytonaSessionState) finishCommand(commandID, stdout, stderr string, exitCode int32) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	command, ok := s.commands[commandID]
+	if !ok {
+		return
+	}
+	command.stdout = stdout
+	command.stderr = stderr
+	command.output = stdout + stderr
+	command.exitCode = int32Ptr(exitCode)
+	command.running = false
+	if s.activeCommandID == commandID {
+		s.activeCommandID = ""
+	}
+}
+
+func (s *daytonaSessionState) command(commandID string) (*daytonaCommandState, bool) {
+	s.mu.RLock()
+	command, ok := s.commands[commandID]
+	if !ok {
+		s.mu.RUnlock()
+		return nil, false
+	}
+	copy := *command
+	theActiveID := s.activeCommandID
+	_ = theActiveID
+	s.mu.RUnlock()
+	return &copy, true
+}
+
+func (s *daytonaSessionState) commandsSnapshot() []daytonaCommandState {
+	s.mu.RLock()
+	items := make([]daytonaCommandState, 0, len(s.commands))
+	for _, command := range s.commands {
+		items = append(items, *command)
+	}
+	s.mu.RUnlock()
+	sort.Slice(items, func(i, j int) bool { return items[i].createdAt.Before(items[j].createdAt) })
+	return items
+}
+
+func (s *daytonaSessionState) acceptsInput(commandID string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	command, ok := s.commands[commandID]
+	if !ok {
+		return false
+	}
+	return command.running && s.activeCommandID == commandID
+}
+
+func (s *server) handleDaytonaProcessRoute(w http.ResponseWriter, r *http.Request) bool {
+	if s.sessions == nil {
+		writeError(w, http.StatusNotImplemented, "sessions are disabled")
+		return true
+	}
+	if r.URL.Path == "/process/session" {
+		switch r.Method {
+		case http.MethodPost:
+			s.handleDaytonaSessionCreate(w, r)
+		case http.MethodGet:
+			s.handleDaytonaSessionList(w, r)
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
+		return true
+	}
+	const prefix = "/process/session/"
+	if !strings.HasPrefix(r.URL.Path, prefix) {
+		return false
+	}
+	rest := strings.TrimPrefix(r.URL.Path, prefix)
+	if rest == "entrypoint" || rest == "entrypoint/logs" {
+		writeError(w, http.StatusNotImplemented, "entrypoint session compatibility is not implemented")
+		return true
+	}
+	sessionID, action, _ := strings.Cut(rest, "/")
+	if strings.TrimSpace(sessionID) == "" {
+		writeError(w, http.StatusBadRequest, "session id is required")
+		return true
+	}
+	switch {
+	case action == "":
+		switch r.Method {
+		case http.MethodGet:
+			s.handleDaytonaSessionGet(w, r, sessionID)
+		case http.MethodDelete:
+			s.handleDaytonaSessionDelete(w, r, sessionID)
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
+	case action == "exec":
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return true
+		}
+		s.handleDaytonaSessionExec(w, r, sessionID)
+	case strings.HasPrefix(action, "command/"):
+		s.handleDaytonaSessionCommandRoute(w, r, sessionID, strings.TrimPrefix(action, "command/"))
+	default:
+		writeError(w, http.StatusNotFound, "not found")
+	}
+	return true
+}
+
+func (s *server) handleDaytonaSessionCommandRoute(w http.ResponseWriter, r *http.Request, sessionID, rest string) {
+	commandID, action, _ := strings.Cut(rest, "/")
+	if strings.TrimSpace(commandID) == "" {
+		writeError(w, http.StatusBadRequest, "command id is required")
+		return
+	}
+	switch action {
+	case "":
+		if r.Method != http.MethodGet {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		s.handleDaytonaSessionCommandGet(w, r, sessionID, commandID)
+	case "logs":
+		if r.Method != http.MethodGet {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		s.handleDaytonaSessionCommandLogs(w, r, sessionID, commandID)
+	case "input":
+		writeError(w, http.StatusNotImplemented, "interactive command input is not implemented")
+	default:
+		writeError(w, http.StatusNotFound, "not found")
+	}
+}
+
+func (s *server) handleDaytonaSessionCreate(w http.ResponseWriter, r *http.Request) {
+	var req daytonaCreateSessionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	sessionID := strings.TrimSpace(req.SessionID)
+	if sessionID == "" {
+		writeError(w, http.StatusBadRequest, "sessionId is required")
+		return
+	}
+	_, created, err := s.sessions.GetOrCreate(r.Context(), models.CreateSessionRequest{Name: sessionID, PTY: false})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	s.daytona.ensureSession(sessionID)
+	status := http.StatusOK
+	if created {
+		status = http.StatusCreated
+	}
+	w.WriteHeader(status)
+}
+
+func (s *server) handleDaytonaSessionList(w http.ResponseWriter, r *http.Request) {
+	items := make([]daytonaSessionResponse, 0)
+	for _, sessionID := range s.daytona.listSessionIDs() {
+		sess, state, ok := s.lookupDaytonaSession(sessionID)
+		if !ok {
+			continue
+		}
+		items = append(items, buildDaytonaSessionResponse(sess.Name(), state))
+	}
+	writeJSON(w, http.StatusOK, items)
+}
+
+func (s *server) handleDaytonaSessionGet(w http.ResponseWriter, r *http.Request, sessionID string) {
+	sess, state, ok := s.lookupDaytonaSession(sessionID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, buildDaytonaSessionResponse(sess.Name(), state))
+}
+
+func (s *server) handleDaytonaSessionDelete(w http.ResponseWriter, r *http.Request, sessionID string) {
+	sess, _, ok := s.lookupDaytonaSession(sessionID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	if err := s.sessions.Delete(sess.ID()); err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, sessions.ErrNotFound) {
+			status = http.StatusNotFound
+		}
+		writeError(w, status, err.Error())
+		return
+	}
+	s.daytona.deleteSession(sessionID)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *server) handleDaytonaSessionExec(w http.ResponseWriter, r *http.Request, sessionID string) {
+	sess, state, ok := s.lookupDaytonaSession(sessionID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	var req daytonaSessionExecuteRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	commandText := strings.TrimSpace(req.Command)
+	if commandText == "" {
+		writeError(w, http.StatusBadRequest, "command is required")
+		return
+	}
+	commandID, err := newDaytonaCommandID()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	command := &daytonaCommandState{
+		id:        commandID,
+		command:   commandText,
+		createdAt: time.Now().UTC(),
+		running:   true,
+	}
+	state.addCommand(command)
+	async := (req.RunAsync != nil && *req.RunAsync) || (req.Async != nil && *req.Async)
+	if async {
+		go s.runDaytonaSessionCommand(sess, state, command)
+		writeJSON(w, http.StatusOK, daytonaSessionExecuteResponse{CmdID: commandID})
+		return
+	}
+	response, err := s.runDaytonaSessionCommand(sess, state, command)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (s *server) handleDaytonaSessionCommandGet(w http.ResponseWriter, r *http.Request, sessionID, commandID string) {
+	_, state, ok := s.lookupDaytonaSession(sessionID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	command, ok := state.command(commandID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "command not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, daytonaCommandResponse{Command: command.command, ExitCode: cloneInt32Ptr(command.exitCode), ID: command.id})
+}
+
+func (s *server) handleDaytonaSessionCommandLogs(w http.ResponseWriter, r *http.Request, sessionID, commandID string) {
+	_, state, ok := s.lookupDaytonaSession(sessionID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	command, ok := state.command(commandID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "command not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, daytonaSessionLogsResponse{Output: command.output, Stderr: command.stderr, Stdout: command.stdout})
+}
+
+func (s *server) lookupDaytonaSession(sessionID string) (*sessions.Session, *daytonaSessionState, bool) {
+	state, ok := s.daytona.session(sessionID)
+	if !ok {
+		return nil, nil, false
+	}
+	sess, err := s.sessions.GetByName(sessionID)
+	if err != nil {
+		if errors.Is(err, sessions.ErrNotFound) {
+			s.daytona.deleteSession(sessionID)
+			return nil, nil, false
+		}
+		return nil, nil, false
+	}
+	return sess, state, true
+}
+
+func buildDaytonaSessionResponse(sessionID string, state *daytonaSessionState) daytonaSessionResponse {
+	commands := state.commandsSnapshot()
+	response := make([]daytonaCommandResponse, 0, len(commands))
+	for _, command := range commands {
+		response = append(response, daytonaCommandResponse{Command: command.command, ExitCode: cloneInt32Ptr(command.exitCode), ID: command.id})
+	}
+	return daytonaSessionResponse{Commands: response, SessionID: sessionID}
+}
+
+func (s *server) runDaytonaSessionCommand(sess *sessions.Session, state *daytonaSessionState, command *daytonaCommandState) (*daytonaSessionExecuteResponse, error) {
+	state.execMu.Lock()
+	defer state.execMu.Unlock()
+
+	startMarker := "__SB_DAYTONA_START_" + command.id + "__"
+	endMarker := "__SB_DAYTONA_END_" + command.id + "__"
+	frames, cancel := sess.Subscribe()
+	defer cancel()
+	state.setActive(command.id)
+
+	payload := "printf '%s\\n' " + shellSingleQuote(startMarker) + "\n" + command.command + "\n__sb_daytona_status=$?\nprintf '%s:%s\\n' " + shellSingleQuote(endMarker) + " \"$__sb_daytona_status\"\n"
+	if _, err := sess.Write([]byte(payload)); err != nil {
+		state.finishCommand(command.id, "", err.Error(), 1)
+		return nil, err
+	}
+
+	var stdout strings.Builder
+	var stderr strings.Builder
+	started := false
+	for frame := range frames {
+		chunk := string(frame.Data)
+		if frame.Stream == sessions.StreamStderr {
+			if started {
+				stderr.WriteString(chunk)
+			}
+			continue
+		}
+
+		stdout.WriteString(chunk)
+		captured := stdout.String()
+		if !started {
+			index := strings.Index(captured, startMarker)
+			if index < 0 {
+				if stdout.Len() > len(startMarker)*2 {
+					tail := captured[len(captured)-len(startMarker):]
+					stdout.Reset()
+					stdout.WriteString(tail)
+				}
+				continue
+			}
+			started = true
+			captured = captured[index+len(startMarker):]
+			captured = strings.TrimPrefix(captured, "\n")
+			stdout.Reset()
+			stdout.WriteString(captured)
+		}
+
+		captured = stdout.String()
+		pattern := endMarker + ":"
+		index := strings.Index(captured, pattern)
+		if index < 0 {
+			continue
+		}
+		rest := captured[index+len(pattern):]
+		lineEnd := strings.IndexByte(rest, '\n')
+		if lineEnd < 0 {
+			continue
+		}
+		exitCode, err := strconv.Atoi(strings.TrimSpace(rest[:lineEnd]))
+		if err != nil {
+			exitCode = 1
+		}
+		stdoutText := captured[:index]
+		stderrText := stderr.String()
+		state.finishCommand(command.id, stdoutText, stderrText, int32(exitCode))
+		output := stdoutText + stderrText
+		return &daytonaSessionExecuteResponse{
+			CmdID:    command.id,
+			ExitCode: int32Ptr(int32(exitCode)),
+			Output:   stringOrNil(output),
+			Stderr:   stringOrNil(stderrText),
+			Stdout:   stringOrNil(stdoutText),
+		}, nil
+	}
+
+	stdoutText := stdout.String()
+	stderrText := stderr.String()
+	exitCode, _ := sess.ExitInfo()
+	if exitCode < 0 {
+		exitCode = 1
+	}
+	state.finishCommand(command.id, stdoutText, stderrText, int32(exitCode))
+	output := stdoutText + stderrText
+	return &daytonaSessionExecuteResponse{
+		CmdID:    command.id,
+		ExitCode: int32Ptr(int32(exitCode)),
+		Output:   stringOrNil(output),
+		Stderr:   stringOrNil(stderrText),
+		Stdout:   stringOrNil(stdoutText),
+	}, nil
+}
+
+func newDaytonaCommandID() (string, error) {
+	buf := make([]byte, 8)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+func shellSingleQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}
+
+func int32Ptr(value int32) *int32 {
+	return &value
+}
+
+func cloneInt32Ptr(value *int32) *int32 {
+	if value == nil {
+		return nil
+	}
+	v := *value
+	return &v
+}
+
+func stringOrNil(value string) *string {
+	if value == "" {
+		return nil
+	}
+	v := value
+	return &v
+}

--- a/cmd/toolboxd/daytona_process_test.go
+++ b/cmd/toolboxd/daytona_process_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/aerol-ai/microvm/cmd/toolboxd/sessions"
+)
+
+func newDaytonaTestServer(t *testing.T) *server {
+	t.Helper()
+	mgr, err := sessions.New(slog.New(slog.NewTextHandler(io.Discard, nil)), sessions.Config{
+		SandboxID:    "sb-test",
+		RecordingDir: filepath.Join(t.TempDir(), "recordings"),
+		BufferBytes:  1 << 14,
+	})
+	if err != nil {
+		t.Fatalf("sessions.New: %v", err)
+	}
+	t.Cleanup(mgr.Close)
+	return &server{sessions: mgr, daytona: newDaytonaCompat()}
+}
+
+func TestHandleDaytonaProcessRouteSessionLifecycle(t *testing.T) {
+	srv := newDaytonaTestServer(t)
+
+	createBody := bytes.NewBufferString(`{"sessionId":"sdk-session"}`)
+	createReq := httptest.NewRequest(http.MethodPost, "/process/session", createBody)
+	createRec := httptest.NewRecorder()
+	if !srv.handleDaytonaProcessRoute(createRec, createReq) {
+		t.Fatal("expected create route to be handled")
+	}
+	if createRec.Code != http.StatusCreated && createRec.Code != http.StatusOK {
+		t.Fatalf("create status = %d", createRec.Code)
+	}
+
+	execBody := bytes.NewBufferString(`{"command":"printf hello-daytona"}`)
+	execReq := httptest.NewRequest(http.MethodPost, "/process/session/sdk-session/exec", execBody)
+	execRec := httptest.NewRecorder()
+	if !srv.handleDaytonaProcessRoute(execRec, execReq) {
+		t.Fatal("expected exec route to be handled")
+	}
+	if execRec.Code != http.StatusOK {
+		t.Fatalf("exec status = %d body=%s", execRec.Code, execRec.Body.String())
+	}
+
+	var execResp daytonaSessionExecuteResponse
+	if err := json.Unmarshal(execRec.Body.Bytes(), &execResp); err != nil {
+		t.Fatalf("decode exec response: %v", err)
+	}
+	if execResp.CmdID == "" {
+		t.Fatal("expected cmdId in exec response")
+	}
+	if execResp.ExitCode == nil || *execResp.ExitCode != 0 {
+		t.Fatalf("exitCode = %+v, want 0", execResp.ExitCode)
+	}
+	if execResp.Stdout == nil || *execResp.Stdout != "hello-daytona" {
+		t.Fatalf("stdout = %+v, want hello-daytona", execResp.Stdout)
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/process/session/sdk-session", nil)
+	getRec := httptest.NewRecorder()
+	if !srv.handleDaytonaProcessRoute(getRec, getReq) {
+		t.Fatal("expected get route to be handled")
+	}
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("get status = %d", getRec.Code)
+	}
+	var sessionResp daytonaSessionResponse
+	if err := json.Unmarshal(getRec.Body.Bytes(), &sessionResp); err != nil {
+		t.Fatalf("decode session response: %v", err)
+	}
+	if sessionResp.SessionID != "sdk-session" {
+		t.Fatalf("sessionId = %q, want sdk-session", sessionResp.SessionID)
+	}
+	if len(sessionResp.Commands) != 1 || sessionResp.Commands[0].ID != execResp.CmdID {
+		t.Fatalf("unexpected commands: %+v", sessionResp.Commands)
+	}
+
+	logsReq := httptest.NewRequest(http.MethodGet, "/process/session/sdk-session/command/"+execResp.CmdID+"/logs", nil)
+	logsRec := httptest.NewRecorder()
+	if !srv.handleDaytonaProcessRoute(logsRec, logsReq) {
+		t.Fatal("expected logs route to be handled")
+	}
+	if logsRec.Code != http.StatusOK {
+		t.Fatalf("logs status = %d", logsRec.Code)
+	}
+	var logsResp daytonaSessionLogsResponse
+	if err := json.Unmarshal(logsRec.Body.Bytes(), &logsResp); err != nil {
+		t.Fatalf("decode logs response: %v", err)
+	}
+	if logsResp.Stdout != "hello-daytona" {
+		t.Fatalf("stdout logs = %q, want hello-daytona", logsResp.Stdout)
+	}
+
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/process/session/sdk-session", nil)
+	deleteRec := httptest.NewRecorder()
+	if !srv.handleDaytonaProcessRoute(deleteRec, deleteReq) {
+		t.Fatal("expected delete route to be handled")
+	}
+	if deleteRec.Code != http.StatusNoContent {
+		t.Fatalf("delete status = %d", deleteRec.Code)
+	}
+}

--- a/cmd/toolboxd/main.go
+++ b/cmd/toolboxd/main.go
@@ -38,6 +38,7 @@ type server struct {
 	allowedPorts map[int]struct{}
 
 	sessions *sessions.Manager
+	daytona  *daytonaCompat
 }
 
 func (s *server) setAllowedPorts(ports []int) {
@@ -68,6 +69,7 @@ func main() {
 		authToken:    strings.TrimSpace(os.Getenv("SB_TOOLBOX_TOKEN")),
 		port:         envInt("SB_TOOLBOX_PORT", 2280),
 		allowedPorts: map[int]struct{}{},
+		daytona:      newDaytonaCompat(),
 	}
 	// Evict the token from the process env table so child processes spawned
 	// for the user command and /exec endpoints don't inherit it via os.Environ().
@@ -195,6 +197,13 @@ func (s *server) routes() http.Handler {
 				return
 			}
 			s.handleExec(w, r)
+		case strings.HasPrefix(r.URL.Path, "/process/session"):
+			if !s.requireAuth(w, r) {
+				return
+			}
+			if !s.handleDaytonaProcessRoute(w, r) {
+				writeError(w, http.StatusNotFound, "not found")
+			}
 		case r.Method == http.MethodPost && r.URL.Path == "/files/upload":
 			if !s.requireAuth(w, r) {
 				return
@@ -205,6 +214,38 @@ func (s *server) routes() http.Handler {
 				return
 			}
 			s.handleDownload(w, r)
+		case r.Method == http.MethodGet && r.URL.Path == "/files":
+			if !s.requireAuth(w, r) {
+				return
+			}
+			s.handleDaytonaListFiles(w, r)
+		case r.Method == http.MethodGet && r.URL.Path == "/files/info":
+			if !s.requireAuth(w, r) {
+				return
+			}
+			s.handleDaytonaFileInfo(w, r)
+		case r.Method == http.MethodPost && r.URL.Path == "/files/move":
+			if !s.requireAuth(w, r) {
+				return
+			}
+			s.handleDaytonaMoveFile(w, r)
+		case r.Method == http.MethodGet && r.URL.Path == "/files/search":
+			if !s.requireAuth(w, r) {
+				return
+			}
+			s.handleDaytonaSearchFiles(w, r)
+		case r.Method == http.MethodGet && r.URL.Path == "/files/find":
+			if !s.requireAuth(w, r) {
+				return
+			}
+			s.handleDaytonaFindInFiles(w, r)
+		case strings.HasPrefix(r.URL.Path, "/git/"):
+			if !s.requireAuth(w, r) {
+				return
+			}
+			if !s.handleDaytonaGitRoute(w, r) {
+				writeError(w, http.StatusNotFound, "not found")
+			}
 		case r.Method == http.MethodPost && r.URL.Path == "/admin/allowed-ports":
 			if !s.requireAuth(w, r) {
 				return
@@ -299,7 +340,11 @@ func isKnownToolboxPath(path string) bool {
 		return true
 	case strings.HasPrefix(path, "/process/"):
 		return true
+	case path == "/files":
+		return true
 	case strings.HasPrefix(path, "/files/"):
+		return true
+	case strings.HasPrefix(path, "/git/"):
 		return true
 	case strings.HasPrefix(path, "/proxy/"):
 		return true

--- a/cmd/toolboxd/main_test.go
+++ b/cmd/toolboxd/main_test.go
@@ -32,6 +32,8 @@ func TestNormalizeSandboxPathCases(t *testing.T) {
 		{name: "exact_prefix_subpath", path: "/7f3c2a1b9d4e/process/execute", sandboxID: "7f3c2a1b9d4e", want: "/process/execute"},
 		{name: "heuristic_root_strip", path: "/7f3c2a1b9d4e/", sandboxID: "", want: "/"},
 		{name: "heuristic_proxy_strip", path: "/7f3c2a1b9d4e/proxy/3000", sandboxID: "", want: "/proxy/3000"},
+		{name: "heuristic_files_strip", path: "/7f3c2a1b9d4e/files", sandboxID: "", want: "/files"},
+		{name: "heuristic_git_strip", path: "/7f3c2a1b9d4e/git/status", sandboxID: "", want: "/git/status"},
 		{name: "direct_toolbox_path_kept", path: "/process/execute", sandboxID: "", want: "/process/execute"},
 		{name: "direct_proxy_path_kept", path: "/proxy/3000", sandboxID: "", want: "/proxy/3000"},
 	}

--- a/cmd/toolboxd/sessions/manager.go
+++ b/cmd/toolboxd/sessions/manager.go
@@ -121,6 +121,19 @@ func (m *Manager) Get(id string) (*Session, error) {
 	return s, nil
 }
 
+// GetByName fetches a running session by its stable name. Exited sessions are
+// not returned because the byName map is cleared when a session finishes.
+func (m *Manager) GetByName(name string) (*Session, error) {
+	trimmed := strings.TrimSpace(name)
+	m.mu.Lock()
+	s := m.byName[trimmed]
+	m.mu.Unlock()
+	if s == nil {
+		return nil, ErrNotFound
+	}
+	return s, nil
+}
+
 // GetOrCreate returns the running session with the given Name (creating it
 // from req if absent). Used by SSH attach so `ssh sandbox+default@host`
 // idempotently lands on a single shared shell.

--- a/cmd/toolboxd/sessions/manager_test.go
+++ b/cmd/toolboxd/sessions/manager_test.go
@@ -92,6 +92,14 @@ func TestManagerGetOrCreateIsIdempotent(t *testing.T) {
 	if first.ID() != second.ID() {
 		t.Fatalf("expected same id; got %q vs %q", first.ID(), second.ID())
 	}
+
+	byName, err := mgr.GetByName("shared")
+	if err != nil {
+		t.Fatalf("GetByName: %v", err)
+	}
+	if byName.ID() != first.ID() {
+		t.Fatalf("GetByName() returned %q, want %q", byName.ID(), first.ID())
+	}
 }
 
 func TestManagerListSortedByCreatedAt(t *testing.T) {

--- a/internal/service/daytona.go
+++ b/internal/service/daytona.go
@@ -1,0 +1,23 @@
+package service
+
+import (
+	"context"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func (s *Service) UpsertDaytonaMetadata(ctx context.Context, meta models.DaytonaSandboxMetadata) error {
+	return s.store.UpsertDaytonaMetadata(ctx, meta)
+}
+
+func (s *Service) GetDaytonaMetadata(ctx context.Context, sandboxID string) (*models.DaytonaSandboxMetadata, error) {
+	return s.store.GetDaytonaMetadata(ctx, sandboxID)
+}
+
+func (s *Service) ListDaytonaMetadata(ctx context.Context) (map[string]models.DaytonaSandboxMetadata, error) {
+	return s.store.ListDaytonaMetadata(ctx)
+}
+
+func (s *Service) ResolveDaytonaSandboxID(ctx context.Context, name string) (string, error) {
+	return s.store.ResolveDaytonaSandboxID(ctx, name)
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/aerol-ai/microvm/pkg/models"
-	_ "github.com/mattn/go-sqlite3"
+	sqlite3 "github.com/mattn/go-sqlite3"
 )
 
 type Store struct {
@@ -84,6 +84,21 @@ func Open(path string) (*Store, error) {
 			sandbox_id TEXT PRIMARY KEY,
 			sealed_blob BLOB NOT NULL,
 			created_at DATETIME NOT NULL,
+			FOREIGN KEY (sandbox_id) REFERENCES sandboxes(id) ON DELETE CASCADE
+		);`,
+		`CREATE TABLE IF NOT EXISTS daytona_sandboxes (
+			sandbox_id TEXT PRIMARY KEY,
+			name TEXT NOT NULL UNIQUE,
+			snapshot TEXT NOT NULL DEFAULT '',
+			user_name TEXT NOT NULL DEFAULT '',
+			labels_json TEXT NOT NULL DEFAULT '{}',
+			target TEXT NOT NULL DEFAULT '',
+			network_allow_list TEXT NOT NULL DEFAULT '',
+			auto_stop_interval_minutes REAL,
+			auto_archive_interval_minutes REAL,
+			auto_delete_interval_minutes REAL,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
 			FOREIGN KEY (sandbox_id) REFERENCES sandboxes(id) ON DELETE CASCADE
 		);`,
 		`CREATE INDEX IF NOT EXISTS idx_sandboxes_status ON sandboxes(status);`,
@@ -496,6 +511,111 @@ func (s *Store) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
+func (s *Store) UpsertDaytonaMetadata(ctx context.Context, meta models.DaytonaSandboxMetadata) error {
+	labelsJSON, err := marshalJSON(meta.Labels, "{}")
+	if err != nil {
+		return fmt.Errorf("marshal daytona labels: %w", err)
+	}
+	name := strings.TrimSpace(meta.Name)
+	if name == "" {
+		name = strings.TrimSpace(meta.SandboxID)
+	}
+	now := time.Now().UTC()
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO daytona_sandboxes (
+			sandbox_id, name, snapshot, user_name, labels_json, target, network_allow_list,
+			auto_stop_interval_minutes, auto_archive_interval_minutes, auto_delete_interval_minutes,
+			created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(sandbox_id) DO UPDATE SET
+			name = excluded.name,
+			snapshot = excluded.snapshot,
+			user_name = excluded.user_name,
+			labels_json = excluded.labels_json,
+			target = excluded.target,
+			network_allow_list = excluded.network_allow_list,
+			auto_stop_interval_minutes = excluded.auto_stop_interval_minutes,
+			auto_archive_interval_minutes = excluded.auto_archive_interval_minutes,
+			auto_delete_interval_minutes = excluded.auto_delete_interval_minutes,
+			updated_at = excluded.updated_at
+	`,
+		strings.TrimSpace(meta.SandboxID),
+		name,
+		strings.TrimSpace(meta.Snapshot),
+		strings.TrimSpace(meta.User),
+		labelsJSON,
+		strings.TrimSpace(meta.Target),
+		strings.TrimSpace(meta.NetworkAllowList),
+		nullableFloat32(meta.AutoStopIntervalMinutes),
+		nullableFloat32(meta.AutoArchiveIntervalMinutes),
+		nullableFloat32(meta.AutoDeleteIntervalMinutes),
+		now,
+		now,
+	)
+	if err != nil {
+		if isSQLiteUniqueConstraint(err) {
+			return ErrDaytonaNameConflict
+		}
+		return fmt.Errorf("upsert daytona metadata: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) GetDaytonaMetadata(ctx context.Context, sandboxID string) (*models.DaytonaSandboxMetadata, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT sandbox_id, name, snapshot, user_name, labels_json, target, network_allow_list,
+			auto_stop_interval_minutes, auto_archive_interval_minutes, auto_delete_interval_minutes
+		FROM daytona_sandboxes
+		WHERE sandbox_id = ?
+	`, sandboxID)
+	meta, err := scanDaytonaMetadata(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get daytona metadata: %w", err)
+	}
+	return meta, nil
+}
+
+func (s *Store) ListDaytonaMetadata(ctx context.Context) (map[string]models.DaytonaSandboxMetadata, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT sandbox_id, name, snapshot, user_name, labels_json, target, network_allow_list,
+			auto_stop_interval_minutes, auto_archive_interval_minutes, auto_delete_interval_minutes
+		FROM daytona_sandboxes
+		ORDER BY sandbox_id ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list daytona metadata: %w", err)
+	}
+	defer rows.Close()
+
+	items := map[string]models.DaytonaSandboxMetadata{}
+	for rows.Next() {
+		meta, err := scanDaytonaMetadata(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan daytona metadata: %w", err)
+		}
+		items[meta.SandboxID] = *meta
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate daytona metadata: %w", err)
+	}
+	return items, nil
+}
+
+func (s *Store) ResolveDaytonaSandboxID(ctx context.Context, name string) (string, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT sandbox_id FROM daytona_sandboxes WHERE name = ?`, strings.TrimSpace(name))
+	var sandboxID string
+	if err := row.Scan(&sandboxID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", ErrNotFound
+		}
+		return "", fmt.Errorf("resolve daytona sandbox id: %w", err)
+	}
+	return sandboxID, nil
+}
+
 func (s *Store) UpdateStatus(ctx context.Context, id string, status models.SandboxStatus, lastError string) error {
 	result, err := s.db.ExecContext(ctx, `
 		UPDATE sandboxes
@@ -762,6 +882,43 @@ func scanSandbox(scanner interface {
 	return &sandbox, nil
 }
 
+func scanDaytonaMetadata(scanner interface {
+	Scan(dest ...any) error
+}) (*models.DaytonaSandboxMetadata, error) {
+	var meta models.DaytonaSandboxMetadata
+	var labelsJSON string
+	var autoStop sql.NullFloat64
+	var autoArchive sql.NullFloat64
+	var autoDelete sql.NullFloat64
+	err := scanner.Scan(
+		&meta.SandboxID,
+		&meta.Name,
+		&meta.Snapshot,
+		&meta.User,
+		&labelsJSON,
+		&meta.Target,
+		&meta.NetworkAllowList,
+		&autoStop,
+		&autoArchive,
+		&autoDelete,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if labelsJSON != "" {
+		if err := json.Unmarshal([]byte(labelsJSON), &meta.Labels); err != nil {
+			return nil, fmt.Errorf("decode daytona labels: %w", err)
+		}
+	}
+	if meta.Labels == nil {
+		meta.Labels = map[string]string{}
+	}
+	meta.AutoStopIntervalMinutes = nullableFloat32Ptr(autoStop)
+	meta.AutoArchiveIntervalMinutes = nullableFloat32Ptr(autoArchive)
+	meta.AutoDeleteIntervalMinutes = nullableFloat32Ptr(autoDelete)
+	return &meta, nil
+}
+
 func marshalJSON(value any, fallback string) (string, error) {
 	if value == nil {
 		return fallback, nil
@@ -793,7 +950,32 @@ func boolToInt(value bool) int {
 	return 0
 }
 
+func nullableFloat32(value *float32) any {
+	if value == nil {
+		return nil
+	}
+	return float64(*value)
+}
+
+func nullableFloat32Ptr(value sql.NullFloat64) *float32 {
+	if !value.Valid {
+		return nil
+	}
+	v := float32(value.Float64)
+	return &v
+}
+
+func isSQLiteUniqueConstraint(err error) bool {
+	var sqliteErr sqlite3.Error
+	if !errors.As(err, &sqliteErr) {
+		return false
+	}
+	return sqliteErr.Code == sqlite3.ErrConstraint && (sqliteErr.ExtendedCode == sqlite3.ErrConstraintUnique || sqliteErr.ExtendedCode == sqlite3.ErrConstraintPrimaryKey)
+}
+
 var ErrNotFound = errors.New("sandbox not found")
+
+var ErrDaytonaNameConflict = errors.New("daytona sandbox name already in use")
 
 // PutMounts stores an encrypted mount blob for a sandbox. The blob is opaque
 // to the store layer; encryption / decryption happens in the service layer.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -372,6 +372,106 @@ func TestStoreCases(t *testing.T) {
 			},
 		},
 		{
+			name: "daytona_metadata_roundtrip_and_resolve_by_name",
+			run: func(t *testing.T) {
+				st := newTestStore(t)
+				sandbox := sampleSandbox("sb-daytona")
+				if err := st.Create(ctx, sandbox); err != nil {
+					t.Fatalf("Create() error = %v", err)
+				}
+				autoStop := float32(15)
+				autoArchive := float32(60)
+				meta := models.DaytonaSandboxMetadata{
+					SandboxID:                  sandbox.ID,
+					Name:                       "workspace-alpha",
+					Snapshot:                   "snapshot-123",
+					User:                       "ubuntu",
+					Labels:                     map[string]string{"team": "sdk"},
+					Target:                     "default",
+					NetworkAllowList:           "10.0.0.0/24",
+					AutoStopIntervalMinutes:    &autoStop,
+					AutoArchiveIntervalMinutes: &autoArchive,
+				}
+				if err := st.UpsertDaytonaMetadata(ctx, meta); err != nil {
+					t.Fatalf("UpsertDaytonaMetadata() error = %v", err)
+				}
+
+				got, err := st.GetDaytonaMetadata(ctx, sandbox.ID)
+				if err != nil {
+					t.Fatalf("GetDaytonaMetadata() error = %v", err)
+				}
+				if got.Name != meta.Name || got.Snapshot != meta.Snapshot || got.User != meta.User || got.Target != meta.Target || got.NetworkAllowList != meta.NetworkAllowList {
+					t.Fatalf("unexpected metadata: %+v", got)
+				}
+				if !reflect.DeepEqual(got.Labels, meta.Labels) {
+					t.Fatalf("labels = %+v, want %+v", got.Labels, meta.Labels)
+				}
+				if got.AutoStopIntervalMinutes == nil || *got.AutoStopIntervalMinutes != autoStop {
+					t.Fatalf("AutoStopIntervalMinutes = %+v, want %v", got.AutoStopIntervalMinutes, autoStop)
+				}
+				if got.AutoArchiveIntervalMinutes == nil || *got.AutoArchiveIntervalMinutes != autoArchive {
+					t.Fatalf("AutoArchiveIntervalMinutes = %+v, want %v", got.AutoArchiveIntervalMinutes, autoArchive)
+				}
+
+				resolved, err := st.ResolveDaytonaSandboxID(ctx, meta.Name)
+				if err != nil {
+					t.Fatalf("ResolveDaytonaSandboxID() error = %v", err)
+				}
+				if resolved != sandbox.ID {
+					t.Fatalf("resolved sandbox id = %q, want %q", resolved, sandbox.ID)
+				}
+
+				items, err := st.ListDaytonaMetadata(ctx)
+				if err != nil {
+					t.Fatalf("ListDaytonaMetadata() error = %v", err)
+				}
+				if listed, ok := items[sandbox.ID]; !ok || listed.Name != meta.Name {
+					t.Fatalf("expected listed metadata for %q, got %+v", sandbox.ID, items)
+				}
+			},
+		},
+		{
+			name: "daytona_metadata_name_conflict_returns_error",
+			run: func(t *testing.T) {
+				st := newTestStore(t)
+				first := sampleSandbox("sb-daytona-first")
+				second := sampleSandbox("sb-daytona-second")
+				for _, sandbox := range []*models.Sandbox{first, second} {
+					if err := st.Create(ctx, sandbox); err != nil {
+						t.Fatalf("Create(%s) error = %v", sandbox.ID, err)
+					}
+				}
+				if err := st.UpsertDaytonaMetadata(ctx, models.DaytonaSandboxMetadata{SandboxID: first.ID, Name: "shared-name"}); err != nil {
+					t.Fatalf("first UpsertDaytonaMetadata() error = %v", err)
+				}
+				if err := st.UpsertDaytonaMetadata(ctx, models.DaytonaSandboxMetadata{SandboxID: second.ID, Name: "shared-name"}); !errors.Is(err, ErrDaytonaNameConflict) {
+					t.Fatalf("expected ErrDaytonaNameConflict, got %v", err)
+				}
+			},
+		},
+		{
+			name: "delete_sandbox_cascades_daytona_metadata",
+			run: func(t *testing.T) {
+				st := newTestStore(t)
+				sandbox := sampleSandbox("sb-daytona-cascade")
+				if err := st.Create(ctx, sandbox); err != nil {
+					t.Fatalf("Create() error = %v", err)
+				}
+				if err := st.UpsertDaytonaMetadata(ctx, models.DaytonaSandboxMetadata{SandboxID: sandbox.ID, Name: "cascade-name"}); err != nil {
+					t.Fatalf("UpsertDaytonaMetadata() error = %v", err)
+				}
+				if err := st.Delete(ctx, sandbox.ID); err != nil {
+					t.Fatalf("Delete() error = %v", err)
+				}
+				if _, err := st.GetDaytonaMetadata(ctx, sandbox.ID); !errors.Is(err, ErrNotFound) {
+					t.Fatalf("expected ErrNotFound after delete, got %v", err)
+				}
+				if _, err := st.ResolveDaytonaSandboxID(ctx, "cascade-name"); !errors.Is(err, ErrNotFound) {
+					t.Fatalf("expected ErrNotFound from ResolveDaytonaSandboxID(), got %v", err)
+				}
+			},
+		},
+		{
 			name: "try_reserve_host_port_distinguishes_pk_collision_from_host_port_collision",
 			run: func(t *testing.T) {
 				st := newTestStore(t)

--- a/pkg/api/daytona/dto.go
+++ b/pkg/api/daytona/dto.go
@@ -1,5 +1,9 @@
 package daytona
 
+type buildInfoRequest struct {
+	DockerfileContent *string `json:"dockerfileContent,omitempty"`
+}
+
 type createSandboxRequest struct {
 	Name                *string            `json:"name,omitempty"`
 	Snapshot            *string            `json:"snapshot,omitempty"`
@@ -19,7 +23,7 @@ type createSandboxRequest struct {
 	AutoArchiveInterval *int32             `json:"autoArchiveInterval,omitempty"`
 	AutoDeleteInterval  *int32             `json:"autoDeleteInterval,omitempty"`
 	Volumes             []map[string]any   `json:"volumes,omitempty"`
-	BuildInfo           map[string]any     `json:"buildInfo,omitempty"`
+	BuildInfo           *buildInfoRequest  `json:"buildInfo,omitempty"`
 }
 
 type resizeSandboxRequest struct {

--- a/pkg/api/daytona/dto.go
+++ b/pkg/api/daytona/dto.go
@@ -1,0 +1,104 @@
+package daytona
+
+type createSandboxRequest struct {
+	Name                *string            `json:"name,omitempty"`
+	Snapshot            *string            `json:"snapshot,omitempty"`
+	User                *string            `json:"user,omitempty"`
+	Env                 *map[string]string `json:"env,omitempty"`
+	Labels              *map[string]string `json:"labels,omitempty"`
+	Public              *bool              `json:"public,omitempty"`
+	NetworkBlockAll     *bool              `json:"networkBlockAll,omitempty"`
+	NetworkAllowList    *string            `json:"networkAllowList,omitempty"`
+	Class               *string            `json:"class,omitempty"`
+	Target              *string            `json:"target,omitempty"`
+	Cpu                 *int32             `json:"cpu,omitempty"`
+	Gpu                 *int32             `json:"gpu,omitempty"`
+	Memory              *int32             `json:"memory,omitempty"`
+	Disk                *int32             `json:"disk,omitempty"`
+	AutoStopInterval    *int32             `json:"autoStopInterval,omitempty"`
+	AutoArchiveInterval *int32             `json:"autoArchiveInterval,omitempty"`
+	AutoDeleteInterval  *int32             `json:"autoDeleteInterval,omitempty"`
+	Volumes             []map[string]any   `json:"volumes,omitempty"`
+	BuildInfo           map[string]any     `json:"buildInfo,omitempty"`
+}
+
+type resizeSandboxRequest struct {
+	Cpu    *int32 `json:"cpu,omitempty"`
+	Memory *int32 `json:"memory,omitempty"`
+	Disk   *int32 `json:"disk,omitempty"`
+}
+
+type sandboxResponse struct {
+	ID                  string            `json:"id"`
+	OrganizationID      string            `json:"organizationId"`
+	Name                string            `json:"name"`
+	Snapshot            *string           `json:"snapshot,omitempty"`
+	User                string            `json:"user"`
+	Env                 map[string]string `json:"env"`
+	Labels              map[string]string `json:"labels"`
+	Public              bool              `json:"public"`
+	NetworkBlockAll     bool              `json:"networkBlockAll"`
+	NetworkAllowList    *string           `json:"networkAllowList,omitempty"`
+	Target              string            `json:"target"`
+	CPU                 float32           `json:"cpu"`
+	GPU                 float32           `json:"gpu"`
+	Memory              float32           `json:"memory"`
+	Disk                float32           `json:"disk"`
+	State               *string           `json:"state,omitempty"`
+	ErrorReason         *string           `json:"errorReason,omitempty"`
+	AutoStopInterval    *float32          `json:"autoStopInterval,omitempty"`
+	AutoArchiveInterval *float32          `json:"autoArchiveInterval,omitempty"`
+	AutoDeleteInterval  *float32          `json:"autoDeleteInterval,omitempty"`
+	CreatedAt           *string           `json:"createdAt,omitempty"`
+	UpdatedAt           *string           `json:"updatedAt,omitempty"`
+	LastActivityAt      *string           `json:"lastActivityAt,omitempty"`
+	ToolboxProxyURL     string            `json:"toolboxProxyUrl"`
+}
+
+type paginatedSandboxesResponse struct {
+	Items      []sandboxResponse `json:"items"`
+	Total      float32           `json:"total"`
+	Page       float32           `json:"page"`
+	TotalPages float32           `json:"totalPages"`
+}
+
+type toolboxProxyURLResponse struct {
+	URL string `json:"url"`
+}
+
+type portPreviewURLResponse struct {
+	SandboxID string `json:"sandboxId"`
+	URL       string `json:"url"`
+	Token     string `json:"token"`
+}
+
+type sandboxLabelsResponse struct {
+	Labels map[string]string `json:"labels"`
+}
+
+type executeRequest struct {
+	Command string             `json:"command"`
+	Cwd     *string            `json:"cwd,omitempty"`
+	Envs    *map[string]string `json:"envs,omitempty"`
+	Timeout *int32             `json:"timeout,omitempty"`
+}
+
+type executeResponse struct {
+	ExitCode *int32 `json:"exitCode,omitempty"`
+	Result   string `json:"result"`
+}
+
+type filesDownloadRequest struct {
+	Paths []string `json:"paths"`
+}
+
+type dirResponse struct {
+	Dir string `json:"dir"`
+}
+
+type listFilters struct {
+	ID     string
+	Name   string
+	Labels map[string]string
+	States map[string]struct{}
+}

--- a/pkg/api/daytona/handlers.go
+++ b/pkg/api/daytona/handlers.go
@@ -1,0 +1,695 @@
+package daytona
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/api/apihttp"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+type handlers struct {
+	deps       Deps
+	meta       *metadataStore
+	httpClient *http.Client
+}
+
+func newHandlers(d Deps) *handlers {
+	return &handlers{
+		deps:       d,
+		meta:       newMetadataStore(),
+		httpClient: &http.Client{},
+	}
+}
+
+func (h *handlers) createSandbox(w http.ResponseWriter, r *http.Request) {
+	var req createSandboxRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	if req.Public != nil && !*req.Public {
+		apihttp.WriteError(w, http.StatusBadRequest, "public=false is not supported by the Daytona facade")
+		return
+	}
+	if req.NetworkAllowList != nil && strings.TrimSpace(*req.NetworkAllowList) != "" {
+		apihttp.WriteError(w, http.StatusBadRequest, "networkAllowList is not supported by the Daytona facade")
+		return
+	}
+	if req.Gpu != nil && *req.Gpu > 0 {
+		apihttp.WriteError(w, http.StatusBadRequest, "gpu allocation is not supported by the Daytona facade")
+		return
+	}
+	if len(req.Volumes) > 0 {
+		apihttp.WriteError(w, http.StatusBadRequest, "volumes are not supported by the Daytona facade")
+		return
+	}
+	if req.BuildInfo != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, "buildInfo is not supported by the Daytona facade")
+		return
+	}
+
+	requestedName := trimmedString(req.Name)
+	if requestedName != "" {
+		if h.meta.nameInUse(requestedName) {
+			apihttp.WriteError(w, http.StatusConflict, errNameConflict.Error())
+			return
+		}
+		if _, err := h.deps.Service.GetSandbox(r.Context(), requestedName); err == nil {
+			apihttp.WriteError(w, http.StatusConflict, errNameConflict.Error())
+			return
+		} else if err != nil && !errors.Is(err, store.ErrNotFound) {
+			apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+			return
+		}
+	}
+
+	lifecycle := models.Lifecycle{}
+	if req.AutoStopInterval != nil && *req.AutoStopInterval > 0 {
+		lifecycle.StopIfIdleFor = durationFromMinutes(float32(*req.AutoStopInterval))
+	}
+	if req.AutoDeleteInterval != nil && *req.AutoDeleteInterval > 0 {
+		lifecycle.DestroyIfIdleFor = durationFromMinutes(float32(*req.AutoDeleteInterval))
+	}
+
+	serviceReq := models.CreateSandboxRequest{
+		Image:           h.createImage(req),
+		CPU:             float64(int32Value(req.Cpu, 0)),
+		MemoryMB:        int(int32Value(req.Memory, 0)) * 1024,
+		DiskGB:          int(int32Value(req.Disk, 0)),
+		Env:             cloneStringMap(mapValue(req.Env)),
+		OSUser:          trimmedString(req.User),
+		NetworkBlockAll: boolValue(req.NetworkBlockAll),
+	}
+	if !lifecycle.IsZero() {
+		serviceReq.Lifecycle = &lifecycle
+	}
+
+	response, err := h.deps.Service.CreateSandbox(r.Context(), serviceReq)
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+
+	meta := sandboxMeta{
+		Name:                requestedName,
+		Snapshot:            nonEmptyStringPtr(req.Snapshot),
+		User:                firstNonEmpty(trimmedString(req.User), response.OSUser),
+		Labels:              cloneStringMap(mapValue(req.Labels)),
+		Target:              trimmedString(req.Target),
+		AutoStopInterval:    int32MinutesPtr(req.AutoStopInterval),
+		AutoArchiveInterval: int32MinutesPtr(req.AutoArchiveInterval),
+		AutoDeleteInterval:  int32MinutesPtr(req.AutoDeleteInterval),
+	}
+	if err := h.meta.upsert(response.ID, meta); err != nil {
+		if destroyErr := h.deps.Service.DestroySandbox(r.Context(), response.ID); destroyErr != nil && h.deps.Logger != nil {
+			h.deps.Logger.Warn("daytona metadata conflict cleanup failed", "sandbox_id", response.ID, "error", destroyErr)
+		}
+		apihttp.WriteError(w, http.StatusConflict, err.Error())
+		return
+	}
+
+	apihttp.WriteJSON(w, http.StatusCreated, h.toSandboxResponse(r, &response.Sandbox))
+}
+
+func (h *handlers) listSandboxes(w http.ResponseWriter, r *http.Request) {
+	sandboxes, err := h.deps.Service.ListSandboxes(r.Context())
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+
+	filters, err := parseListFilters(r)
+	if err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	items := h.filteredSandboxes(r, sandboxes, filters)
+	apihttp.WriteJSON(w, http.StatusOK, items)
+}
+
+func (h *handlers) listSandboxesPaginated(w http.ResponseWriter, r *http.Request) {
+	sandboxes, err := h.deps.Service.ListSandboxes(r.Context())
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+
+	filters, err := parseListFilters(r)
+	if err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	page, err := parsePositiveFloatQuery(r, "page", 1)
+	if err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	limit, err := parsePositiveFloatQuery(r, "limit", 100)
+	if err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	items := h.filteredSandboxes(r, sandboxes, filters)
+	total := len(items)
+	start := int((page - 1) * limit)
+	if start > total {
+		start = total
+	}
+	end := start + int(limit)
+	if end > total {
+		end = total
+	}
+	totalPages := float32(0)
+	if total > 0 {
+		totalPages = float32((total + int(limit) - 1) / int(limit))
+	}
+
+	apihttp.WriteJSON(w, http.StatusOK, paginatedSandboxesResponse{
+		Items:      items[start:end],
+		Total:      float32(total),
+		Page:       page,
+		TotalPages: totalPages,
+	})
+}
+
+func (h *handlers) getSandbox(w http.ResponseWriter, r *http.Request) {
+	sandbox, _, err := h.resolveSandbox(r.Context(), r.PathValue("idOrName"))
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	apihttp.WriteJSON(w, http.StatusOK, h.toSandboxResponse(r, sandbox))
+}
+
+func (h *handlers) destroySandbox(w http.ResponseWriter, r *http.Request) {
+	sandbox, sandboxID, err := h.resolveSandbox(r.Context(), r.PathValue("idOrName"))
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	if err := h.deps.Service.DestroySandbox(r.Context(), sandboxID); err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	h.meta.delete(sandboxID)
+	snapshot := *sandbox
+	snapshot.Status = models.SandboxStatusDestroyed
+	now := time.Now().UTC()
+	snapshot.UpdatedAt = now
+	apihttp.WriteJSON(w, http.StatusOK, h.toSandboxResponse(r, &snapshot))
+}
+
+func (h *handlers) startSandbox(w http.ResponseWriter, r *http.Request) {
+	_, sandboxID, err := h.resolveSandbox(r.Context(), r.PathValue("idOrName"))
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	sandbox, err := h.deps.Service.StartSandbox(r.Context(), sandboxID)
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	apihttp.WriteJSON(w, http.StatusOK, h.toSandboxResponse(r, sandbox))
+}
+
+func (h *handlers) stopSandbox(w http.ResponseWriter, r *http.Request) {
+	_, sandboxID, err := h.resolveSandbox(r.Context(), r.PathValue("idOrName"))
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	sandbox, err := h.deps.Service.StopSandbox(r.Context(), sandboxID)
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	apihttp.WriteJSON(w, http.StatusOK, h.toSandboxResponse(r, sandbox))
+}
+
+func (h *handlers) resizeSandbox(w http.ResponseWriter, r *http.Request) {
+	_, sandboxID, err := h.resolveSandbox(r.Context(), r.PathValue("idOrName"))
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+
+	var req resizeSandboxRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	sandbox, err := h.deps.Service.ResizeSandbox(r.Context(), sandboxID, models.ResizeSandboxRequest{
+		CPU:      float64(int32Value(req.Cpu, 0)),
+		MemoryMB: int(int32Value(req.Memory, 0)) * 1024,
+		DiskGB:   int(int32Value(req.Disk, 0)),
+	})
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	apihttp.WriteJSON(w, http.StatusOK, h.toSandboxResponse(r, sandbox))
+}
+
+func (h *handlers) toolboxProxyURL(w http.ResponseWriter, r *http.Request) {
+	_, _, err := h.resolveSandbox(r.Context(), r.PathValue("id"))
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	apihttp.WriteJSON(w, http.StatusOK, toolboxProxyURLResponse{URL: h.toolboxProxyBaseURL(r)})
+}
+
+func (h *handlers) previewURL(w http.ResponseWriter, r *http.Request) {
+	_, sandboxID, err := h.resolveSandbox(r.Context(), r.PathValue("idOrName"))
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	port, err := strconv.Atoi(r.PathValue("port"))
+	if err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, "invalid port")
+		return
+	}
+	preview, err := h.deps.Service.ExposePort(r.Context(), sandboxID, port, models.ExposedPortProtocolHTTP)
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	apihttp.WriteJSON(w, http.StatusOK, portPreviewURLResponse{
+		SandboxID: sandboxID,
+		URL:       preview.PublicURL,
+		Token:     "",
+	})
+}
+
+func (h *handlers) replaceLabels(w http.ResponseWriter, r *http.Request) {
+	sandbox, sandboxID, err := h.resolveSandbox(r.Context(), r.PathValue("idOrName"))
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	var req sandboxLabelsResponse
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	meta, ok := h.meta.get(sandboxID)
+	if !ok {
+		meta = sandboxMeta{Name: sandbox.ID, User: sandbox.OSUser}
+	}
+	meta.Labels = cloneStringMap(req.Labels)
+	if err := h.meta.upsert(sandboxID, meta); err != nil {
+		apihttp.WriteError(w, http.StatusConflict, err.Error())
+		return
+	}
+	apihttp.WriteJSON(w, http.StatusOK, sandboxLabelsResponse{Labels: cloneStringMap(req.Labels)})
+}
+
+func (h *handlers) setAutoStopInterval(w http.ResponseWriter, r *http.Request) {
+	h.updateIdleLifecycle(w, r, true)
+}
+
+func (h *handlers) setAutoDeleteInterval(w http.ResponseWriter, r *http.Request) {
+	h.updateIdleLifecycle(w, r, false)
+}
+
+func (h *handlers) setAutoArchiveInterval(w http.ResponseWriter, r *http.Request) {
+	sandbox, sandboxID, err := h.resolveSandbox(r.Context(), r.PathValue("idOrName"))
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	interval, err := parseFloat32Path(r, "interval")
+	if err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, "invalid interval")
+		return
+	}
+	meta, ok := h.meta.get(sandboxID)
+	if !ok {
+		meta = sandboxMeta{Name: sandbox.ID, User: sandbox.OSUser}
+	}
+	meta.AutoArchiveInterval = float32Ptr(interval)
+	if err := h.meta.upsert(sandboxID, meta); err != nil {
+		apihttp.WriteError(w, http.StatusConflict, err.Error())
+		return
+	}
+	apihttp.WriteJSON(w, http.StatusOK, h.toSandboxResponse(r, sandbox))
+}
+
+func (h *handlers) updateIdleLifecycle(w http.ResponseWriter, r *http.Request, stop bool) {
+	sandbox, sandboxID, err := h.resolveSandbox(r.Context(), r.PathValue("idOrName"))
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	interval, err := parseFloat32Path(r, "interval")
+	if err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, "invalid interval")
+		return
+	}
+	lifecycle := sandbox.Lifecycle
+	if stop {
+		if interval <= 0 {
+			lifecycle.StopIfIdleFor = 0
+		} else {
+			lifecycle.StopIfIdleFor = durationFromMinutes(interval)
+		}
+	} else {
+		if interval <= 0 {
+			lifecycle.DestroyIfIdleFor = 0
+		} else {
+			lifecycle.DestroyIfIdleFor = durationFromMinutes(interval)
+		}
+	}
+	updated, err := h.deps.Service.UpdateLifecycle(r.Context(), sandboxID, lifecycle)
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	meta, ok := h.meta.get(sandboxID)
+	if !ok {
+		meta = sandboxMeta{Name: sandbox.ID, User: sandbox.OSUser}
+	}
+	if stop {
+		meta.AutoStopInterval = float32Ptr(interval)
+	} else {
+		meta.AutoDeleteInterval = float32Ptr(interval)
+	}
+	if err := h.meta.upsert(sandboxID, meta); err != nil {
+		apihttp.WriteError(w, http.StatusConflict, err.Error())
+		return
+	}
+	apihttp.WriteJSON(w, http.StatusOK, h.toSandboxResponse(r, updated))
+}
+
+func (h *handlers) resolveSandbox(ctx context.Context, idOrName string) (*models.Sandbox, string, error) {
+	trimmed := strings.TrimSpace(idOrName)
+	sandbox, err := h.deps.Service.GetSandbox(ctx, trimmed)
+	if err == nil {
+		return sandbox, sandbox.ID, nil
+	}
+	if !errors.Is(err, store.ErrNotFound) {
+		return nil, "", err
+	}
+	resolved := h.meta.resolve(trimmed)
+	if resolved == trimmed {
+		return nil, "", err
+	}
+	sandbox, err = h.deps.Service.GetSandbox(ctx, resolved)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			h.meta.delete(resolved)
+		}
+		return nil, "", err
+	}
+	return sandbox, sandbox.ID, nil
+}
+
+func (h *handlers) filteredSandboxes(r *http.Request, sandboxes []*models.Sandbox, filters listFilters) []sandboxResponse {
+	items := make([]sandboxResponse, 0, len(sandboxes))
+	for _, sandbox := range sandboxes {
+		if sandbox == nil {
+			continue
+		}
+		item := h.toSandboxResponse(r, sandbox)
+		if filters.ID != "" && !strings.Contains(item.ID, filters.ID) {
+			continue
+		}
+		if filters.Name != "" && !strings.Contains(strings.ToLower(item.Name), strings.ToLower(filters.Name)) {
+			continue
+		}
+		if len(filters.Labels) > 0 && !labelsMatch(item.Labels, filters.Labels) {
+			continue
+		}
+		if len(filters.States) > 0 {
+			state := ""
+			if item.State != nil {
+				state = *item.State
+			}
+			if _, ok := filters.States[state]; !ok {
+				continue
+			}
+		}
+		items = append(items, item)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		left := ""
+		right := ""
+		if items[i].CreatedAt != nil {
+			left = *items[i].CreatedAt
+		}
+		if items[j].CreatedAt != nil {
+			right = *items[j].CreatedAt
+		}
+		return left > right
+	})
+	return items
+}
+
+func labelsMatch(labels map[string]string, wanted map[string]string) bool {
+	for key, value := range wanted {
+		if labels[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func parseListFilters(r *http.Request) (listFilters, error) {
+	filters := listFilters{
+		ID:   strings.TrimSpace(r.URL.Query().Get("id")),
+		Name: strings.TrimSpace(r.URL.Query().Get("name")),
+	}
+	if raw := strings.TrimSpace(r.URL.Query().Get("labels")); raw != "" {
+		if err := json.Unmarshal([]byte(raw), &filters.Labels); err != nil {
+			return listFilters{}, errors.New("labels must be a JSON object")
+		}
+	}
+	if states := r.URL.Query()["states"]; len(states) > 0 {
+		filters.States = make(map[string]struct{}, len(states))
+		for _, state := range states {
+			trimmed := strings.TrimSpace(state)
+			if trimmed != "" {
+				filters.States[trimmed] = struct{}{}
+			}
+		}
+	}
+	return filters, nil
+}
+
+func (h *handlers) toSandboxResponse(r *http.Request, sandbox *models.Sandbox) sandboxResponse {
+	meta, _ := h.meta.get(sandbox.ID)
+	name := firstNonEmpty(meta.Name, sandbox.ID)
+	user := firstNonEmpty(meta.User, sandbox.OSUser)
+	labels := cloneStringMap(meta.Labels)
+	state := stringPtr(mapSandboxState(sandbox.Status))
+	var errorReason *string
+	if strings.TrimSpace(sandbox.LastError) != "" {
+		errorReason = stringPtr(strings.TrimSpace(sandbox.LastError))
+	}
+	gpu := float32(0)
+	if sandbox.GPUs != nil && sandbox.GPUs.Count != 0 {
+		gpu = float32(sandbox.GPUs.Count)
+	}
+	return sandboxResponse{
+		ID:                  sandbox.ID,
+		OrganizationID:      strings.TrimSpace(r.Header.Get("X-Daytona-Organization-ID")),
+		Name:                name,
+		Snapshot:            cloneStringPtr(meta.Snapshot),
+		User:                user,
+		Env:                 cloneStringMap(sandbox.Env),
+		Labels:              labels,
+		Public:              true,
+		NetworkBlockAll:     sandbox.NetworkBlockAll,
+		NetworkAllowList:    cloneStringPtr(meta.NetworkAllowList),
+		Target:              meta.Target,
+		CPU:                 float32(sandbox.CPU),
+		GPU:                 gpu,
+		Memory:              float32(sandbox.MemoryMB) / 1024,
+		Disk:                float32(sandbox.DiskGB),
+		State:               state,
+		ErrorReason:         errorReason,
+		AutoStopInterval:    firstFloat32Ptr(meta.AutoStopInterval, durationMinutesPtr(sandbox.Lifecycle.StopIfIdleFor)),
+		AutoArchiveInterval: cloneFloat32Ptr(meta.AutoArchiveInterval),
+		AutoDeleteInterval:  firstFloat32Ptr(meta.AutoDeleteInterval, durationMinutesPtr(sandbox.Lifecycle.DestroyIfIdleFor)),
+		CreatedAt:           timePtr(sandbox.CreatedAt),
+		UpdatedAt:           timePtr(sandbox.UpdatedAt),
+		LastActivityAt:      timePtr(sandbox.LastActiveAt),
+		ToolboxProxyURL:     h.toolboxProxyBaseURL(r),
+	}
+}
+
+func (h *handlers) toolboxProxyBaseURL(r *http.Request) string {
+	return requestBaseURL(r) + ToolboxPrefix
+}
+
+func (h *handlers) createImage(req createSandboxRequest) string {
+	if snapshot := strings.TrimSpace(valueOrEmpty(req.Snapshot)); snapshot != "" {
+		return snapshot
+	}
+	if configured := strings.TrimSpace(os.Getenv("SB_DAYTONA_DEFAULT_IMAGE")); configured != "" {
+		return configured
+	}
+	return "ubuntu:22.04"
+}
+
+func parsePositiveFloatQuery(r *http.Request, key string, fallback float32) (float32, error) {
+	raw := strings.TrimSpace(r.URL.Query().Get(key))
+	if raw == "" {
+		return fallback, nil
+	}
+	value, err := strconv.ParseFloat(raw, 32)
+	if err != nil || value <= 0 {
+		return 0, errors.New(key + " must be a positive number")
+	}
+	return float32(value), nil
+}
+
+func parseFloat32Path(r *http.Request, name string) (float32, error) {
+	value, err := strconv.ParseFloat(strings.TrimSpace(r.PathValue(name)), 32)
+	if err != nil {
+		return 0, err
+	}
+	return float32(value), nil
+}
+
+func mapSandboxState(status models.SandboxStatus) string {
+	switch status {
+	case models.SandboxStatusCreating:
+		return "creating"
+	case models.SandboxStatusStarted:
+		return "started"
+	case models.SandboxStatusStopped:
+		return "stopped"
+	case models.SandboxStatusDestroyed:
+		return "destroyed"
+	case models.SandboxStatusError:
+		return "error"
+	default:
+		return "unknown"
+	}
+}
+
+func requestBaseURL(r *http.Request) string {
+	scheme := "http"
+	if forwarded := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")); forwarded != "" {
+		scheme = strings.Split(forwarded, ",")[0]
+	} else if r.TLS != nil {
+		scheme = "https"
+	}
+	host := strings.TrimSpace(r.Header.Get("X-Forwarded-Host"))
+	if host == "" {
+		host = r.Host
+	}
+	return scheme + "://" + host
+}
+
+func durationFromMinutes(value float32) time.Duration {
+	if value <= 0 {
+		return 0
+	}
+	return time.Duration(float64(value) * float64(time.Minute))
+}
+
+func durationMinutesPtr(value time.Duration) *float32 {
+	if value <= 0 {
+		return nil
+	}
+	v := float32(float64(value) / float64(time.Minute))
+	return &v
+}
+
+func timePtr(value time.Time) *string {
+	if value.IsZero() {
+		return nil
+	}
+	v := value.UTC().Format(time.RFC3339)
+	return &v
+}
+
+func int32MinutesPtr(value *int32) *float32 {
+	if value == nil {
+		return nil
+	}
+	v := float32(*value)
+	return &v
+}
+
+func int32Value(value *int32, fallback int32) int32 {
+	if value == nil {
+		return fallback
+	}
+	return *value
+}
+
+func boolValue(value *bool) bool {
+	return value != nil && *value
+}
+
+func mapValue(value *map[string]string) map[string]string {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+func trimmedString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(*value)
+}
+
+func nonEmptyStringPtr(value *string) *string {
+	trimmed := trimmedString(value)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
+}
+
+func valueOrEmpty(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func stringPtr(value string) *string {
+	return &value
+}
+
+func float32Ptr(value float32) *float32 {
+	return &value
+}
+
+func firstFloat32Ptr(primary *float32, fallback *float32) *float32 {
+	if primary != nil {
+		return cloneFloat32Ptr(primary)
+	}
+	return cloneFloat32Ptr(fallback)
+}

--- a/pkg/api/daytona/handlers.go
+++ b/pkg/api/daytona/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"sort"
@@ -35,27 +36,6 @@ func (h *handlers) createSandbox(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Public != nil && !*req.Public {
-		apihttp.WriteError(w, http.StatusBadRequest, "public=false is not supported by the Daytona facade")
-		return
-	}
-	if req.NetworkAllowList != nil && strings.TrimSpace(*req.NetworkAllowList) != "" {
-		apihttp.WriteError(w, http.StatusBadRequest, "networkAllowList is not supported by the Daytona facade")
-		return
-	}
-	if req.Gpu != nil && *req.Gpu > 0 {
-		apihttp.WriteError(w, http.StatusBadRequest, "gpu allocation is not supported by the Daytona facade")
-		return
-	}
-	if len(req.Volumes) > 0 {
-		apihttp.WriteError(w, http.StatusBadRequest, "volumes are not supported by the Daytona facade")
-		return
-	}
-	if req.BuildInfo != nil {
-		apihttp.WriteError(w, http.StatusBadRequest, "buildInfo is not supported by the Daytona facade")
-		return
-	}
-
 	requestedName := trimmedString(req.Name)
 	if requestedName != "" {
 		if _, err := h.deps.Service.GetSandbox(r.Context(), requestedName); err == nil {
@@ -74,25 +54,10 @@ func (h *handlers) createSandbox(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	lifecycle := models.Lifecycle{}
-	if req.AutoStopInterval != nil && *req.AutoStopInterval > 0 {
-		lifecycle.StopIfIdleFor = durationFromMinutes(float32(*req.AutoStopInterval))
-	}
-	if req.AutoDeleteInterval != nil && *req.AutoDeleteInterval > 0 {
-		lifecycle.DestroyIfIdleFor = durationFromMinutes(float32(*req.AutoDeleteInterval))
-	}
-
-	serviceReq := models.CreateSandboxRequest{
-		Image:           h.createImage(req),
-		CPU:             float64(int32Value(req.Cpu, 0)),
-		MemoryMB:        int(int32Value(req.Memory, 0)) * 1024,
-		DiskGB:          int(int32Value(req.Disk, 0)),
-		Env:             cloneStringMap(mapValue(req.Env)),
-		OSUser:          trimmedString(req.User),
-		NetworkBlockAll: boolValue(req.NetworkBlockAll),
-	}
-	if !lifecycle.IsZero() {
-		serviceReq.Lifecycle = &lifecycle
+	serviceReq, err := h.translateCreateSandboxRequest(req)
+	if err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, err.Error())
+		return
 	}
 
 	response, err := h.deps.Service.CreateSandbox(r.Context(), serviceReq)
@@ -623,14 +588,87 @@ func (h *handlers) toolboxProxyBaseURL(r *http.Request) string {
 	return requestBaseURL(r) + ToolboxPrefix
 }
 
-func (h *handlers) createImage(req createSandboxRequest) string {
+func (h *handlers) translateCreateSandboxRequest(req createSandboxRequest) (models.CreateSandboxRequest, error) {
+	if req.NetworkAllowList != nil && strings.TrimSpace(*req.NetworkAllowList) != "" {
+		return models.CreateSandboxRequest{}, errors.New("networkAllowList is not supported by the Daytona facade")
+	}
+	if req.Gpu != nil && *req.Gpu > 0 {
+		return models.CreateSandboxRequest{}, errors.New("gpu allocation is not supported by the Daytona facade")
+	}
+	if len(req.Volumes) > 0 {
+		return models.CreateSandboxRequest{}, errors.New("volumes are not supported by the Daytona facade")
+	}
+
+	lifecycle := models.Lifecycle{}
+	if req.AutoStopInterval != nil && *req.AutoStopInterval > 0 {
+		lifecycle.StopIfIdleFor = durationFromMinutes(float32(*req.AutoStopInterval))
+	}
+	if req.AutoDeleteInterval != nil && *req.AutoDeleteInterval > 0 {
+		lifecycle.DestroyIfIdleFor = durationFromMinutes(float32(*req.AutoDeleteInterval))
+	}
+
+	image, err := h.createImage(req)
+	if err != nil {
+		return models.CreateSandboxRequest{}, err
+	}
+
+	serviceReq := models.CreateSandboxRequest{
+		Image:           image,
+		CPU:             float64(int32Value(req.Cpu, 0)),
+		MemoryMB:        int(int32Value(req.Memory, 0)) * 1024,
+		DiskGB:          int(int32Value(req.Disk, 0)),
+		Env:             cloneStringMap(mapValue(req.Env)),
+		OSUser:          trimmedString(req.User),
+		NetworkBlockAll: boolValue(req.NetworkBlockAll),
+	}
+	if !lifecycle.IsZero() {
+		serviceReq.Lifecycle = &lifecycle
+	}
+	return serviceReq, nil
+}
+
+func (h *handlers) createImage(req createSandboxRequest) (string, error) {
 	if snapshot := strings.TrimSpace(valueOrEmpty(req.Snapshot)); snapshot != "" {
-		return snapshot
+		return snapshot, nil
+	}
+	if buildImage, err := buildInfoBaseImage(req.BuildInfo); err != nil {
+		return "", err
+	} else if buildImage != "" {
+		return buildImage, nil
 	}
 	if configured := strings.TrimSpace(os.Getenv("SB_DAYTONA_DEFAULT_IMAGE")); configured != "" {
-		return configured
+		return configured, nil
 	}
-	return "ubuntu:22.04"
+	return "ubuntu:22.04", nil
+}
+
+func buildInfoBaseImage(info *buildInfoRequest) (string, error) {
+	if info == nil {
+		return "", nil
+	}
+	dockerfile := strings.TrimSpace(valueOrEmpty(info.DockerfileContent))
+	if dockerfile == "" {
+		return "", errors.New("buildInfo is only supported when dockerfileContent is present")
+	}
+	lines := make([]string, 0, 4)
+	for _, line := range strings.Split(dockerfile, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		lines = append(lines, trimmed)
+	}
+	if len(lines) != 1 {
+		return "", errors.New("buildInfo is only supported for simple single-line Dockerfiles of the form `FROM <image>`")
+	}
+	parts := strings.Fields(lines[0])
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "FROM") {
+		return "", fmt.Errorf("buildInfo dockerfileContent %q is unsupported; expected `FROM <image>`", lines[0])
+	}
+	if strings.TrimSpace(parts[1]) == "" {
+		return "", errors.New("buildInfo dockerfileContent must include a base image")
+	}
+	return parts[1], nil
 }
 
 func parsePositiveFloatQuery(r *http.Request, key string, fallback float32) (float32, error) {

--- a/pkg/api/daytona/handlers.go
+++ b/pkg/api/daytona/handlers.go
@@ -18,14 +18,12 @@ import (
 
 type handlers struct {
 	deps       Deps
-	meta       *metadataStore
 	httpClient *http.Client
 }
 
 func newHandlers(d Deps) *handlers {
 	return &handlers{
 		deps:       d,
-		meta:       newMetadataStore(),
 		httpClient: &http.Client{},
 	}
 }
@@ -60,11 +58,14 @@ func (h *handlers) createSandbox(w http.ResponseWriter, r *http.Request) {
 
 	requestedName := trimmedString(req.Name)
 	if requestedName != "" {
-		if h.meta.nameInUse(requestedName) {
+		if _, err := h.deps.Service.GetSandbox(r.Context(), requestedName); err == nil {
 			apihttp.WriteError(w, http.StatusConflict, errNameConflict.Error())
 			return
+		} else if err != nil && !errors.Is(err, store.ErrNotFound) {
+			apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+			return
 		}
-		if _, err := h.deps.Service.GetSandbox(r.Context(), requestedName); err == nil {
+		if _, err := h.deps.Service.ResolveDaytonaSandboxID(r.Context(), requestedName); err == nil {
 			apihttp.WriteError(w, http.StatusConflict, errNameConflict.Error())
 			return
 		} else if err != nil && !errors.Is(err, store.ErrNotFound) {
@@ -110,15 +111,19 @@ func (h *handlers) createSandbox(w http.ResponseWriter, r *http.Request) {
 		AutoArchiveInterval: int32MinutesPtr(req.AutoArchiveInterval),
 		AutoDeleteInterval:  int32MinutesPtr(req.AutoDeleteInterval),
 	}
-	if err := h.meta.upsert(response.ID, meta); err != nil {
+	if err := h.persistSandboxMeta(r.Context(), response.ID, meta); err != nil {
 		if destroyErr := h.deps.Service.DestroySandbox(r.Context(), response.ID); destroyErr != nil && h.deps.Logger != nil {
 			h.deps.Logger.Warn("daytona metadata conflict cleanup failed", "sandbox_id", response.ID, "error", destroyErr)
 		}
-		apihttp.WriteError(w, http.StatusConflict, err.Error())
+		if errors.Is(err, store.ErrDaytonaNameConflict) {
+			apihttp.WriteError(w, http.StatusConflict, errNameConflict.Error())
+			return
+		}
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
 		return
 	}
 
-	apihttp.WriteJSON(w, http.StatusCreated, h.toSandboxResponse(r, &response.Sandbox))
+	apihttp.WriteJSON(w, http.StatusCreated, h.toSandboxResponse(r, &response.Sandbox, meta))
 }
 
 func (h *handlers) listSandboxes(w http.ResponseWriter, r *http.Request) {
@@ -134,7 +139,13 @@ func (h *handlers) listSandboxes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	items := h.filteredSandboxes(r, sandboxes, filters)
+	metadata, err := h.listSandboxMeta(r.Context())
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+
+	items := h.filteredSandboxes(r, sandboxes, metadata, filters)
 	apihttp.WriteJSON(w, http.StatusOK, items)
 }
 
@@ -150,6 +161,11 @@ func (h *handlers) listSandboxesPaginated(w http.ResponseWriter, r *http.Request
 		apihttp.WriteError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	metadata, err := h.listSandboxMeta(r.Context())
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
 
 	page, err := parsePositiveFloatQuery(r, "page", 1)
 	if err != nil {
@@ -162,7 +178,7 @@ func (h *handlers) listSandboxesPaginated(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	items := h.filteredSandboxes(r, sandboxes, filters)
+	items := h.filteredSandboxes(r, sandboxes, metadata, filters)
 	total := len(items)
 	start := int((page - 1) * limit)
 	if start > total {
@@ -191,7 +207,12 @@ func (h *handlers) getSandbox(w http.ResponseWriter, r *http.Request) {
 		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
 		return
 	}
-	apihttp.WriteJSON(w, http.StatusOK, h.toSandboxResponse(r, sandbox))
+	meta, err := h.loadSandboxMeta(r.Context(), sandbox)
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	apihttp.WriteJSON(w, http.StatusOK, h.toSandboxResponse(r, sandbox, meta))
 }
 
 func (h *handlers) destroySandbox(w http.ResponseWriter, r *http.Request) {
@@ -200,16 +221,20 @@ func (h *handlers) destroySandbox(w http.ResponseWriter, r *http.Request) {
 		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
 		return
 	}
+	meta, err := h.loadSandboxMeta(r.Context(), sandbox)
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
 	if err := h.deps.Service.DestroySandbox(r.Context(), sandboxID); err != nil {
 		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
 		return
 	}
-	h.meta.delete(sandboxID)
 	snapshot := *sandbox
 	snapshot.Status = models.SandboxStatusDestroyed
 	now := time.Now().UTC()
 	snapshot.UpdatedAt = now
-	apihttp.WriteJSON(w, http.StatusOK, h.toSandboxResponse(r, &snapshot))
+	apihttp.WriteJSON(w, http.StatusOK, h.toSandboxResponse(r, &snapshot, meta))
 }
 
 func (h *handlers) startSandbox(w http.ResponseWriter, r *http.Request) {
@@ -223,7 +248,12 @@ func (h *handlers) startSandbox(w http.ResponseWriter, r *http.Request) {
 		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
 		return
 	}
-	apihttp.WriteJSON(w, http.StatusOK, h.toSandboxResponse(r, sandbox))
+	meta, err := h.loadSandboxMeta(r.Context(), sandbox)
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	apihttp.WriteJSON(w, http.StatusOK, h.toSandboxResponse(r, sandbox, meta))
 }
 
 func (h *handlers) stopSandbox(w http.ResponseWriter, r *http.Request) {
@@ -237,7 +267,12 @@ func (h *handlers) stopSandbox(w http.ResponseWriter, r *http.Request) {
 		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
 		return
 	}
-	apihttp.WriteJSON(w, http.StatusOK, h.toSandboxResponse(r, sandbox))
+	meta, err := h.loadSandboxMeta(r.Context(), sandbox)
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	apihttp.WriteJSON(w, http.StatusOK, h.toSandboxResponse(r, sandbox, meta))
 }
 
 func (h *handlers) resizeSandbox(w http.ResponseWriter, r *http.Request) {
@@ -262,7 +297,12 @@ func (h *handlers) resizeSandbox(w http.ResponseWriter, r *http.Request) {
 		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
 		return
 	}
-	apihttp.WriteJSON(w, http.StatusOK, h.toSandboxResponse(r, sandbox))
+	meta, err := h.loadSandboxMeta(r.Context(), sandbox)
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	apihttp.WriteJSON(w, http.StatusOK, h.toSandboxResponse(r, sandbox, meta))
 }
 
 func (h *handlers) toolboxProxyURL(w http.ResponseWriter, r *http.Request) {
@@ -308,13 +348,18 @@ func (h *handlers) replaceLabels(w http.ResponseWriter, r *http.Request) {
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-	meta, ok := h.meta.get(sandboxID)
-	if !ok {
-		meta = sandboxMeta{Name: sandbox.ID, User: sandbox.OSUser}
+	meta, err := h.loadSandboxMeta(r.Context(), sandbox)
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
 	}
 	meta.Labels = cloneStringMap(req.Labels)
-	if err := h.meta.upsert(sandboxID, meta); err != nil {
-		apihttp.WriteError(w, http.StatusConflict, err.Error())
+	if err := h.persistSandboxMeta(r.Context(), sandboxID, meta); err != nil {
+		if errors.Is(err, store.ErrDaytonaNameConflict) {
+			apihttp.WriteError(w, http.StatusConflict, errNameConflict.Error())
+			return
+		}
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
 		return
 	}
 	apihttp.WriteJSON(w, http.StatusOK, sandboxLabelsResponse{Labels: cloneStringMap(req.Labels)})
@@ -339,16 +384,21 @@ func (h *handlers) setAutoArchiveInterval(w http.ResponseWriter, r *http.Request
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid interval")
 		return
 	}
-	meta, ok := h.meta.get(sandboxID)
-	if !ok {
-		meta = sandboxMeta{Name: sandbox.ID, User: sandbox.OSUser}
-	}
-	meta.AutoArchiveInterval = float32Ptr(interval)
-	if err := h.meta.upsert(sandboxID, meta); err != nil {
-		apihttp.WriteError(w, http.StatusConflict, err.Error())
+	meta, err := h.loadSandboxMeta(r.Context(), sandbox)
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
 		return
 	}
-	apihttp.WriteJSON(w, http.StatusOK, h.toSandboxResponse(r, sandbox))
+	meta.AutoArchiveInterval = float32Ptr(interval)
+	if err := h.persistSandboxMeta(r.Context(), sandboxID, meta); err != nil {
+		if errors.Is(err, store.ErrDaytonaNameConflict) {
+			apihttp.WriteError(w, http.StatusConflict, errNameConflict.Error())
+			return
+		}
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	apihttp.WriteJSON(w, http.StatusOK, h.toSandboxResponse(r, sandbox, meta))
 }
 
 func (h *handlers) updateIdleLifecycle(w http.ResponseWriter, r *http.Request, stop bool) {
@@ -381,20 +431,25 @@ func (h *handlers) updateIdleLifecycle(w http.ResponseWriter, r *http.Request, s
 		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
 		return
 	}
-	meta, ok := h.meta.get(sandboxID)
-	if !ok {
-		meta = sandboxMeta{Name: sandbox.ID, User: sandbox.OSUser}
+	meta, err := h.loadSandboxMeta(r.Context(), sandbox)
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
 	}
 	if stop {
 		meta.AutoStopInterval = float32Ptr(interval)
 	} else {
 		meta.AutoDeleteInterval = float32Ptr(interval)
 	}
-	if err := h.meta.upsert(sandboxID, meta); err != nil {
-		apihttp.WriteError(w, http.StatusConflict, err.Error())
+	if err := h.persistSandboxMeta(r.Context(), sandboxID, meta); err != nil {
+		if errors.Is(err, store.ErrDaytonaNameConflict) {
+			apihttp.WriteError(w, http.StatusConflict, errNameConflict.Error())
+			return
+		}
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
 		return
 	}
-	apihttp.WriteJSON(w, http.StatusOK, h.toSandboxResponse(r, updated))
+	apihttp.WriteJSON(w, http.StatusOK, h.toSandboxResponse(r, updated, meta))
 }
 
 func (h *handlers) resolveSandbox(ctx context.Context, idOrName string) (*models.Sandbox, string, error) {
@@ -406,27 +461,27 @@ func (h *handlers) resolveSandbox(ctx context.Context, idOrName string) (*models
 	if !errors.Is(err, store.ErrNotFound) {
 		return nil, "", err
 	}
-	resolved := h.meta.resolve(trimmed)
-	if resolved == trimmed {
+	resolved, err := h.deps.Service.ResolveDaytonaSandboxID(ctx, trimmed)
+	if errors.Is(err, store.ErrNotFound) {
+		return nil, "", err
+	}
+	if err != nil {
 		return nil, "", err
 	}
 	sandbox, err = h.deps.Service.GetSandbox(ctx, resolved)
 	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
-			h.meta.delete(resolved)
-		}
 		return nil, "", err
 	}
 	return sandbox, sandbox.ID, nil
 }
 
-func (h *handlers) filteredSandboxes(r *http.Request, sandboxes []*models.Sandbox, filters listFilters) []sandboxResponse {
+func (h *handlers) filteredSandboxes(r *http.Request, sandboxes []*models.Sandbox, metadata map[string]sandboxMeta, filters listFilters) []sandboxResponse {
 	items := make([]sandboxResponse, 0, len(sandboxes))
 	for _, sandbox := range sandboxes {
 		if sandbox == nil {
 			continue
 		}
-		item := h.toSandboxResponse(r, sandbox)
+		item := h.toSandboxResponse(r, sandbox, metadata[sandbox.ID])
 		if filters.ID != "" && !strings.Contains(item.ID, filters.ID) {
 			continue
 		}
@@ -461,6 +516,37 @@ func (h *handlers) filteredSandboxes(r *http.Request, sandboxes []*models.Sandbo
 	return items
 }
 
+func (h *handlers) persistSandboxMeta(ctx context.Context, sandboxID string, meta sandboxMeta) error {
+	return h.deps.Service.UpsertDaytonaMetadata(ctx, sandboxMetaToStored(sandboxID, meta))
+}
+
+func (h *handlers) loadSandboxMeta(ctx context.Context, sandbox *models.Sandbox) (sandboxMeta, error) {
+	if sandbox == nil {
+		return sandboxMeta{Labels: map[string]string{}}, nil
+	}
+	stored, err := h.deps.Service.GetDaytonaMetadata(ctx, sandbox.ID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return defaultSandboxMeta(sandbox), nil
+		}
+		return sandboxMeta{}, err
+	}
+	return sandboxMetaFromStored(stored, sandbox), nil
+}
+
+func (h *handlers) listSandboxMeta(ctx context.Context) (map[string]sandboxMeta, error) {
+	stored, err := h.deps.Service.ListDaytonaMetadata(ctx)
+	if err != nil {
+		return nil, err
+	}
+	items := make(map[string]sandboxMeta, len(stored))
+	for sandboxID, meta := range stored {
+		copied := meta
+		items[sandboxID] = sandboxMetaFromStored(&copied, nil)
+	}
+	return items, nil
+}
+
 func labelsMatch(labels map[string]string, wanted map[string]string) bool {
 	for key, value := range wanted {
 		if labels[key] != value {
@@ -492,8 +578,7 @@ func parseListFilters(r *http.Request) (listFilters, error) {
 	return filters, nil
 }
 
-func (h *handlers) toSandboxResponse(r *http.Request, sandbox *models.Sandbox) sandboxResponse {
-	meta, _ := h.meta.get(sandbox.ID)
+func (h *handlers) toSandboxResponse(r *http.Request, sandbox *models.Sandbox, meta sandboxMeta) sandboxResponse {
 	name := firstNonEmpty(meta.Name, sandbox.ID)
 	user := firstNonEmpty(meta.User, sandbox.OSUser)
 	labels := cloneStringMap(meta.Labels)

--- a/pkg/api/daytona/handlers.go
+++ b/pkg/api/daytona/handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"os"
 	"sort"
@@ -349,12 +350,17 @@ func (h *handlers) setAutoArchiveInterval(w http.ResponseWriter, r *http.Request
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid interval")
 		return
 	}
+	intervalPtr, err := intervalMetadataPtr(interval)
+	if err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	meta, err := h.loadSandboxMeta(r.Context(), sandbox)
 	if err != nil {
 		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
 		return
 	}
-	meta.AutoArchiveInterval = float32Ptr(interval)
+	meta.AutoArchiveInterval = intervalPtr
 	if err := h.persistSandboxMeta(r.Context(), sandboxID, meta); err != nil {
 		if errors.Is(err, store.ErrDaytonaNameConflict) {
 			apihttp.WriteError(w, http.StatusConflict, errNameConflict.Error())
@@ -377,15 +383,20 @@ func (h *handlers) updateIdleLifecycle(w http.ResponseWriter, r *http.Request, s
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid interval")
 		return
 	}
+	intervalPtr, err := intervalMetadataPtr(interval)
+	if err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	lifecycle := sandbox.Lifecycle
 	if stop {
-		if interval <= 0 {
+		if intervalPtr == nil {
 			lifecycle.StopIfIdleFor = 0
 		} else {
 			lifecycle.StopIfIdleFor = durationFromMinutes(interval)
 		}
 	} else {
-		if interval <= 0 {
+		if intervalPtr == nil {
 			lifecycle.DestroyIfIdleFor = 0
 		} else {
 			lifecycle.DestroyIfIdleFor = durationFromMinutes(interval)
@@ -402,9 +413,9 @@ func (h *handlers) updateIdleLifecycle(w http.ResponseWriter, r *http.Request, s
 		return
 	}
 	if stop {
-		meta.AutoStopInterval = float32Ptr(interval)
+		meta.AutoStopInterval = intervalPtr
 	} else {
-		meta.AutoDeleteInterval = float32Ptr(interval)
+		meta.AutoDeleteInterval = intervalPtr
 	}
 	if err := h.persistSandboxMeta(r.Context(), sandboxID, meta); err != nil {
 		if errors.Is(err, store.ErrDaytonaNameConflict) {
@@ -688,6 +699,9 @@ func parseFloat32Path(r *http.Request, name string) (float32, error) {
 	if err != nil {
 		return 0, err
 	}
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, errors.New(name + " must be finite")
+	}
 	return float32(value), nil
 }
 
@@ -749,6 +763,9 @@ func int32MinutesPtr(value *int32) *float32 {
 	if value == nil {
 		return nil
 	}
+	if *value <= 0 {
+		return nil
+	}
 	v := float32(*value)
 	return &v
 }
@@ -808,6 +825,16 @@ func stringPtr(value string) *string {
 
 func float32Ptr(value float32) *float32 {
 	return &value
+}
+
+func intervalMetadataPtr(value float32) (*float32, error) {
+	if value < 0 {
+		return nil, errors.New("interval must be non-negative")
+	}
+	if value == 0 {
+		return nil, nil
+	}
+	return float32Ptr(value), nil
 }
 
 func firstFloat32Ptr(primary *float32, fallback *float32) *float32 {

--- a/pkg/api/daytona/handlers_test.go
+++ b/pkg/api/daytona/handlers_test.go
@@ -96,6 +96,41 @@ func TestTranslateCreateSandboxRequestPreservesIdleLifecycleFields(t *testing.T)
 	}
 }
 
+func TestIntervalMetadataPtrRejectsNegativeAndClearsZero(t *testing.T) {
+	if _, err := intervalMetadataPtr(-1); err == nil {
+		t.Fatal("expected negative interval error")
+	}
+	if got, err := intervalMetadataPtr(0); err != nil || got != nil {
+		t.Fatalf("intervalMetadataPtr(0) = (%+v, %v), want nil, nil", got, err)
+	}
+	got, err := intervalMetadataPtr(2.5)
+	if err != nil {
+		t.Fatalf("intervalMetadataPtr(2.5) error = %v", err)
+	}
+	if got == nil || *got != 2.5 {
+		t.Fatalf("intervalMetadataPtr(2.5) = %+v, want 2.5", got)
+	}
+}
+
+func TestInt32MinutesPtrOmitsDisabledIntervals(t *testing.T) {
+	zero := int32(0)
+	negative := int32(-1)
+	positive := int32(7)
+	if got := int32MinutesPtr(nil); got != nil {
+		t.Fatalf("int32MinutesPtr(nil) = %+v, want nil", got)
+	}
+	if got := int32MinutesPtr(&zero); got != nil {
+		t.Fatalf("int32MinutesPtr(0) = %+v, want nil", got)
+	}
+	if got := int32MinutesPtr(&negative); got != nil {
+		t.Fatalf("int32MinutesPtr(-1) = %+v, want nil", got)
+	}
+	got := int32MinutesPtr(&positive)
+	if got == nil || *got != 7 {
+		t.Fatalf("int32MinutesPtr(7) = %+v, want 7", got)
+	}
+}
+
 func boolPtr(value bool) *bool {
 	return &value
 }

--- a/pkg/api/daytona/handlers_test.go
+++ b/pkg/api/daytona/handlers_test.go
@@ -1,0 +1,101 @@
+package daytona
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestTranslateCreateSandboxRequestAcceptsDaytonaGoImageFixture(t *testing.T) {
+	fixture := []byte(`{
+		"public": false,
+		"buildInfo": {
+			"dockerfileContent": "FROM alpine"
+		}
+	}`)
+
+	var req createSandboxRequest
+	if err := json.Unmarshal(fixture, &req); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	h := newHandlers(Deps{})
+	translated, err := h.translateCreateSandboxRequest(req)
+	if err != nil {
+		t.Fatalf("translateCreateSandboxRequest() error = %v", err)
+	}
+	if translated.Image != "alpine" {
+		t.Fatalf("translated.Image = %q, want %q", translated.Image, "alpine")
+	}
+	if translated.NetworkBlockAll {
+		t.Fatal("translated.NetworkBlockAll unexpectedly true")
+	}
+	if translated.Lifecycle != nil {
+		t.Fatalf("translated.Lifecycle = %+v, want nil", translated.Lifecycle)
+	}
+	if translated.CPU != 0 || translated.MemoryMB != 0 || translated.DiskGB != 0 {
+		t.Fatalf("unexpected translated resource values: %+v", translated)
+	}
+	if len(translated.Env) != 0 {
+		t.Fatalf("translated.Env = %+v, want empty", translated.Env)
+	}
+}
+
+func TestTranslateCreateSandboxRequestRejectsComplexBuildInfo(t *testing.T) {
+	fixture := []byte(`{
+		"buildInfo": {
+			"dockerfileContent": "FROM alpine\nRUN echo hello"
+		}
+	}`)
+
+	var req createSandboxRequest
+	if err := json.Unmarshal(fixture, &req); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	h := newHandlers(Deps{})
+	_, err := h.translateCreateSandboxRequest(req)
+	if err == nil {
+		t.Fatal("expected translateCreateSandboxRequest() error for complex buildInfo")
+	}
+	if got := err.Error(); got != "buildInfo is only supported for simple single-line Dockerfiles of the form `FROM <image>`" {
+		t.Fatalf("error = %q", got)
+	}
+}
+
+func TestTranslateCreateSandboxRequestPreservesIdleLifecycleFields(t *testing.T) {
+	autoStop := int32(5)
+	autoDelete := int32(15)
+	req := createSandboxRequest{
+		Public:             boolPtr(false),
+		BuildInfo:          &buildInfoRequest{DockerfileContent: stringPtr("FROM alpine")},
+		AutoStopInterval:   &autoStop,
+		AutoDeleteInterval: &autoDelete,
+		NetworkBlockAll:    boolPtr(true),
+	}
+
+	h := newHandlers(Deps{})
+	translated, err := h.translateCreateSandboxRequest(req)
+	if err != nil {
+		t.Fatalf("translateCreateSandboxRequest() error = %v", err)
+	}
+	if translated.Image != "alpine" {
+		t.Fatalf("translated.Image = %q, want alpine", translated.Image)
+	}
+	if !translated.NetworkBlockAll {
+		t.Fatal("translated.NetworkBlockAll = false, want true")
+	}
+	if translated.Lifecycle == nil {
+		t.Fatal("translated.Lifecycle = nil, want non-nil")
+	}
+	if translated.Lifecycle.StopIfIdleFor != 5*time.Minute {
+		t.Fatalf("StopIfIdleFor = %v, want 5m", translated.Lifecycle.StopIfIdleFor)
+	}
+	if translated.Lifecycle.DestroyIfIdleFor != 15*time.Minute {
+		t.Fatalf("DestroyIfIdleFor = %v, want 15m", translated.Lifecycle.DestroyIfIdleFor)
+	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}

--- a/pkg/api/daytona/meta.go
+++ b/pkg/api/daytona/meta.go
@@ -1,0 +1,139 @@
+package daytona
+
+import (
+	"errors"
+	"strings"
+	"sync"
+)
+
+var errNameConflict = errors.New("daytona sandbox name already in use")
+
+type sandboxMeta struct {
+	Name                string
+	Snapshot            *string
+	User                string
+	Labels              map[string]string
+	Target              string
+	NetworkAllowList    *string
+	AutoStopInterval    *float32
+	AutoArchiveInterval *float32
+	AutoDeleteInterval  *float32
+}
+
+type metadataStore struct {
+	mu     sync.RWMutex
+	byID   map[string]sandboxMeta
+	byName map[string]string
+}
+
+func newMetadataStore() *metadataStore {
+	return &metadataStore{
+		byID:   map[string]sandboxMeta{},
+		byName: map[string]string{},
+	}
+}
+
+func (m *metadataStore) nameInUse(name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false
+	}
+	m.mu.RLock()
+	_, ok := m.byName[name]
+	m.mu.RUnlock()
+	return ok
+}
+
+func (m *metadataStore) resolve(idOrName string) string {
+	trimmed := strings.TrimSpace(idOrName)
+	m.mu.RLock()
+	resolved, ok := m.byName[trimmed]
+	m.mu.RUnlock()
+	if ok {
+		return resolved
+	}
+	return trimmed
+}
+
+func (m *metadataStore) get(id string) (sandboxMeta, bool) {
+	m.mu.RLock()
+	meta, ok := m.byID[id]
+	m.mu.RUnlock()
+	if !ok {
+		return sandboxMeta{}, false
+	}
+	return cloneMeta(meta), true
+}
+
+func (m *metadataStore) upsert(id string, meta sandboxMeta) error {
+	meta = cloneMeta(meta)
+	meta.Name = strings.TrimSpace(meta.Name)
+	if meta.Name == "" {
+		meta.Name = id
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if existingID, ok := m.byName[meta.Name]; ok && existingID != id {
+		return errNameConflict
+	}
+
+	if existing, ok := m.byID[id]; ok && existing.Name != "" && existing.Name != meta.Name {
+		delete(m.byName, existing.Name)
+	}
+
+	m.byID[id] = cloneMeta(meta)
+	m.byName[meta.Name] = id
+	return nil
+}
+
+func (m *metadataStore) delete(id string) {
+	m.mu.Lock()
+	if existing, ok := m.byID[id]; ok && existing.Name != "" {
+		delete(m.byName, existing.Name)
+	}
+	delete(m.byID, id)
+	m.mu.Unlock()
+}
+
+func cloneMeta(meta sandboxMeta) sandboxMeta {
+	return sandboxMeta{
+		Name:                meta.Name,
+		Snapshot:            cloneStringPtr(meta.Snapshot),
+		User:                meta.User,
+		Labels:              cloneStringMap(meta.Labels),
+		Target:              meta.Target,
+		NetworkAllowList:    cloneStringPtr(meta.NetworkAllowList),
+		AutoStopInterval:    cloneFloat32Ptr(meta.AutoStopInterval),
+		AutoArchiveInterval: cloneFloat32Ptr(meta.AutoArchiveInterval),
+		AutoDeleteInterval:  cloneFloat32Ptr(meta.AutoDeleteInterval),
+	}
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return map[string]string{}
+	}
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func cloneStringPtr(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	v := *value
+	return &v
+}
+
+func cloneFloat32Ptr(value *float32) *float32 {
+	if value == nil {
+		return nil
+	}
+	v := *value
+	return &v
+}

--- a/pkg/api/daytona/meta.go
+++ b/pkg/api/daytona/meta.go
@@ -3,7 +3,8 @@ package daytona
 import (
 	"errors"
 	"strings"
-	"sync"
+
+	"github.com/aerol-ai/microvm/pkg/models"
 )
 
 var errNameConflict = errors.New("daytona sandbox name already in use")
@@ -20,81 +21,52 @@ type sandboxMeta struct {
 	AutoDeleteInterval  *float32
 }
 
-type metadataStore struct {
-	mu     sync.RWMutex
-	byID   map[string]sandboxMeta
-	byName map[string]string
-}
-
-func newMetadataStore() *metadataStore {
-	return &metadataStore{
-		byID:   map[string]sandboxMeta{},
-		byName: map[string]string{},
+func defaultSandboxMeta(sandbox *models.Sandbox) sandboxMeta {
+	if sandbox == nil {
+		return sandboxMeta{Labels: map[string]string{}}
+	}
+	return sandboxMeta{
+		Name:   sandbox.ID,
+		User:   sandbox.OSUser,
+		Labels: map[string]string{},
 	}
 }
 
-func (m *metadataStore) nameInUse(name string) bool {
-	name = strings.TrimSpace(name)
+func sandboxMetaFromStored(meta *models.DaytonaSandboxMetadata, sandbox *models.Sandbox) sandboxMeta {
+	if meta == nil {
+		return defaultSandboxMeta(sandbox)
+	}
+	fallback := defaultSandboxMeta(sandbox)
+	return sandboxMeta{
+		Name:                firstNonEmpty(strings.TrimSpace(meta.Name), fallback.Name),
+		Snapshot:            emptyStringToPtr(meta.Snapshot),
+		User:                firstNonEmpty(strings.TrimSpace(meta.User), fallback.User),
+		Labels:              cloneStringMap(meta.Labels),
+		Target:              strings.TrimSpace(meta.Target),
+		NetworkAllowList:    emptyStringToPtr(meta.NetworkAllowList),
+		AutoStopInterval:    cloneFloat32Ptr(meta.AutoStopIntervalMinutes),
+		AutoArchiveInterval: cloneFloat32Ptr(meta.AutoArchiveIntervalMinutes),
+		AutoDeleteInterval:  cloneFloat32Ptr(meta.AutoDeleteIntervalMinutes),
+	}
+}
+
+func sandboxMetaToStored(sandboxID string, meta sandboxMeta) models.DaytonaSandboxMetadata {
+	name := strings.TrimSpace(meta.Name)
 	if name == "" {
-		return false
+		name = strings.TrimSpace(sandboxID)
 	}
-	m.mu.RLock()
-	_, ok := m.byName[name]
-	m.mu.RUnlock()
-	return ok
-}
-
-func (m *metadataStore) resolve(idOrName string) string {
-	trimmed := strings.TrimSpace(idOrName)
-	m.mu.RLock()
-	resolved, ok := m.byName[trimmed]
-	m.mu.RUnlock()
-	if ok {
-		return resolved
+	return models.DaytonaSandboxMetadata{
+		SandboxID:                  strings.TrimSpace(sandboxID),
+		Name:                       name,
+		Snapshot:                   strings.TrimSpace(valueOrEmpty(meta.Snapshot)),
+		User:                       strings.TrimSpace(meta.User),
+		Labels:                     cloneStringMap(meta.Labels),
+		Target:                     strings.TrimSpace(meta.Target),
+		NetworkAllowList:           strings.TrimSpace(valueOrEmpty(meta.NetworkAllowList)),
+		AutoStopIntervalMinutes:    cloneFloat32Ptr(meta.AutoStopInterval),
+		AutoArchiveIntervalMinutes: cloneFloat32Ptr(meta.AutoArchiveInterval),
+		AutoDeleteIntervalMinutes:  cloneFloat32Ptr(meta.AutoDeleteInterval),
 	}
-	return trimmed
-}
-
-func (m *metadataStore) get(id string) (sandboxMeta, bool) {
-	m.mu.RLock()
-	meta, ok := m.byID[id]
-	m.mu.RUnlock()
-	if !ok {
-		return sandboxMeta{}, false
-	}
-	return cloneMeta(meta), true
-}
-
-func (m *metadataStore) upsert(id string, meta sandboxMeta) error {
-	meta = cloneMeta(meta)
-	meta.Name = strings.TrimSpace(meta.Name)
-	if meta.Name == "" {
-		meta.Name = id
-	}
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	if existingID, ok := m.byName[meta.Name]; ok && existingID != id {
-		return errNameConflict
-	}
-
-	if existing, ok := m.byID[id]; ok && existing.Name != "" && existing.Name != meta.Name {
-		delete(m.byName, existing.Name)
-	}
-
-	m.byID[id] = cloneMeta(meta)
-	m.byName[meta.Name] = id
-	return nil
-}
-
-func (m *metadataStore) delete(id string) {
-	m.mu.Lock()
-	if existing, ok := m.byID[id]; ok && existing.Name != "" {
-		delete(m.byName, existing.Name)
-	}
-	delete(m.byID, id)
-	m.mu.Unlock()
 }
 
 func cloneMeta(meta sandboxMeta) sandboxMeta {
@@ -109,6 +81,14 @@ func cloneMeta(meta sandboxMeta) sandboxMeta {
 		AutoArchiveInterval: cloneFloat32Ptr(meta.AutoArchiveInterval),
 		AutoDeleteInterval:  cloneFloat32Ptr(meta.AutoDeleteInterval),
 	}
+}
+
+func emptyStringToPtr(value string) *string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
 }
 
 func cloneStringMap(values map[string]string) map[string]string {

--- a/pkg/api/daytona/routes.go
+++ b/pkg/api/daytona/routes.go
@@ -1,0 +1,44 @@
+package daytona
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/aerol-ai/microvm/internal/service"
+)
+
+const (
+	PathPrefix    = "/daytona"
+	ToolboxPrefix = PathPrefix + "/toolbox"
+)
+
+// Deps are the shared dependencies the Daytona facade needs from the
+// top-level API package.
+type Deps struct {
+	Service *service.Service
+	Logger  *slog.Logger
+	Auth    func(http.Handler) http.Handler
+}
+
+// RegisterRoutes mounts the supported Daytona compatibility surface.
+func RegisterRoutes(mux *http.ServeMux, d Deps) {
+	h := newHandlers(d)
+
+	mux.Handle("POST "+PathPrefix+"/sandbox", d.Auth(http.HandlerFunc(h.createSandbox)))
+	mux.Handle("GET "+PathPrefix+"/sandbox", d.Auth(http.HandlerFunc(h.listSandboxes)))
+	mux.Handle("GET "+PathPrefix+"/sandbox/paginated", d.Auth(http.HandlerFunc(h.listSandboxesPaginated)))
+	mux.Handle("GET "+PathPrefix+"/sandbox/{idOrName}", d.Auth(http.HandlerFunc(h.getSandbox)))
+	mux.Handle("DELETE "+PathPrefix+"/sandbox/{idOrName}", d.Auth(http.HandlerFunc(h.destroySandbox)))
+	mux.Handle("POST "+PathPrefix+"/sandbox/{idOrName}/start", d.Auth(http.HandlerFunc(h.startSandbox)))
+	mux.Handle("POST "+PathPrefix+"/sandbox/{idOrName}/stop", d.Auth(http.HandlerFunc(h.stopSandbox)))
+	mux.Handle("POST "+PathPrefix+"/sandbox/{idOrName}/resize", d.Auth(http.HandlerFunc(h.resizeSandbox)))
+	mux.Handle("GET "+PathPrefix+"/sandbox/{id}/toolbox-proxy-url", d.Auth(http.HandlerFunc(h.toolboxProxyURL)))
+	mux.Handle("GET "+PathPrefix+"/sandbox/{idOrName}/ports/{port}/preview-url", d.Auth(http.HandlerFunc(h.previewURL)))
+	mux.Handle("PUT "+PathPrefix+"/sandbox/{idOrName}/labels", d.Auth(http.HandlerFunc(h.replaceLabels)))
+	mux.Handle("POST "+PathPrefix+"/sandbox/{idOrName}/autostop/{interval}", d.Auth(http.HandlerFunc(h.setAutoStopInterval)))
+	mux.Handle("POST "+PathPrefix+"/sandbox/{idOrName}/autodelete/{interval}", d.Auth(http.HandlerFunc(h.setAutoDeleteInterval)))
+	mux.Handle("POST "+PathPrefix+"/sandbox/{idOrName}/autoarchive/{interval}", d.Auth(http.HandlerFunc(h.setAutoArchiveInterval)))
+
+	mux.Handle(ToolboxPrefix+"/{id}", d.Auth(http.HandlerFunc(h.toolbox)))
+	mux.Handle(ToolboxPrefix+"/{id}/{path...}", d.Auth(http.HandlerFunc(h.toolbox)))
+}

--- a/pkg/api/daytona/routes_test.go
+++ b/pkg/api/daytona/routes_test.go
@@ -1,0 +1,31 @@
+package daytona_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aerol-ai/microvm/pkg/api/daytona"
+)
+
+func TestRegisterRoutesAllUseDaytonaPrefix(t *testing.T) {
+	mux := http.NewServeMux()
+	daytona.RegisterRoutes(mux, daytona.Deps{
+		Auth: func(h http.Handler) http.Handler { return h },
+	})
+
+	probes := []string{
+		"/daytona/sandbox",
+		"/daytona/sandbox/paginated",
+		"/daytona/sandbox/abc",
+		"/daytona/sandbox/abc/toolbox-proxy-url",
+		"/daytona/toolbox/abc/version",
+	}
+	for _, probe := range probes {
+		req, _ := http.NewRequest(http.MethodGet, probe, nil)
+		_, pattern := mux.Handler(req)
+		if pattern == "" || !strings.Contains(pattern, daytona.PathPrefix+"/") {
+			t.Errorf("path %q resolved to pattern %q, expected one containing %q", probe, pattern, daytona.PathPrefix)
+		}
+	}
+}

--- a/pkg/api/daytona/toolbox.go
+++ b/pkg/api/daytona/toolbox.go
@@ -1,0 +1,426 @@
+package daytona
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"net/url"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/aerol-ai/microvm/pkg/api/apihttp"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+var bulkUploadField = regexp.MustCompile(`^files\[(\d+)\]\.(path|file)$`)
+
+type toolboxHTTPError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *toolboxHTTPError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Message != "" {
+		return e.Message
+	}
+	return http.StatusText(e.StatusCode)
+}
+
+func (h *handlers) toolbox(w http.ResponseWriter, r *http.Request) {
+	_, sandboxID, err := h.resolveSandbox(r.Context(), r.PathValue("id"))
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+
+	path := strings.TrimPrefix(r.PathValue("path"), "/")
+	switch {
+	case r.Method == http.MethodGet && path == "":
+		h.forwardToolbox(w, r, sandboxID, "/")
+	case r.Method == http.MethodGet && path == "health":
+		h.forwardToolbox(w, r, sandboxID, "/health")
+	case r.Method == http.MethodGet && path == "version":
+		h.forwardToolbox(w, r, sandboxID, "/version")
+	case r.Method == http.MethodGet && path == "user-home-dir":
+		h.userHomeDir(w, r, sandboxID)
+	case r.Method == http.MethodGet && path == "workdir":
+		h.workDir(w, r, sandboxID)
+	case r.Method == http.MethodPost && path == "process/execute":
+		h.executeCommand(w, r, sandboxID)
+	case r.Method == http.MethodPost && path == "files/upload":
+		h.forwardToolbox(w, r, sandboxID, "/files/upload")
+	case r.Method == http.MethodGet && path == "files/download":
+		h.forwardToolbox(w, r, sandboxID, "/files/download")
+	case r.Method == http.MethodPost && path == "files/bulk-upload":
+		h.bulkUpload(w, r, sandboxID)
+	case r.Method == http.MethodPost && path == "files/bulk-download":
+		h.bulkDownload(w, r, sandboxID)
+	default:
+		apihttp.WriteError(w, http.StatusNotImplemented, "daytona toolbox route not implemented")
+	}
+}
+
+func (h *handlers) executeCommand(w http.ResponseWriter, r *http.Request, sandboxID string) {
+	var req executeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	result, err := h.runToolboxCommand(r.Context(), sandboxID, models.ExecRequest{
+		Command:        req.Command,
+		WorkDir:        strings.TrimSpace(valueOrEmpty(req.Cwd)),
+		Env:            cloneStringMap(mapValue(req.Envs)),
+		TimeoutSeconds: int(int32Value(req.Timeout, 0)),
+	})
+	if err != nil {
+		h.writeToolboxError(w, err)
+		return
+	}
+	value := result.Stdout
+	if value == "" {
+		value = result.Stderr
+	}
+	exitCode := int32(result.ExitCode)
+	apihttp.WriteJSON(w, http.StatusOK, executeResponse{ExitCode: &exitCode, Result: value})
+}
+
+func (h *handlers) userHomeDir(w http.ResponseWriter, r *http.Request, sandboxID string) {
+	dir, err := h.runToolboxString(r.Context(), sandboxID, `printf %s "$HOME"`)
+	if err != nil {
+		h.writeToolboxError(w, err)
+		return
+	}
+	apihttp.WriteJSON(w, http.StatusOK, dirResponse{Dir: dir})
+}
+
+func (h *handlers) workDir(w http.ResponseWriter, r *http.Request, sandboxID string) {
+	dir, err := h.runToolboxString(r.Context(), sandboxID, "pwd")
+	if err != nil {
+		h.writeToolboxError(w, err)
+		return
+	}
+	apihttp.WriteJSON(w, http.StatusOK, dirResponse{Dir: dir})
+}
+
+func (h *handlers) bulkUpload(w http.ResponseWriter, r *http.Request, sandboxID string) {
+	if err := r.ParseMultipartForm(64 << 20); err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, "invalid multipart form")
+		return
+	}
+
+	type uploadFile struct {
+		path string
+		file *multipart.FileHeader
+	}
+	files := map[string]*uploadFile{}
+	for key, values := range r.MultipartForm.Value {
+		match := bulkUploadField.FindStringSubmatch(key)
+		if len(match) != 3 || match[2] != "path" || len(values) == 0 {
+			continue
+		}
+		entry := files[match[1]]
+		if entry == nil {
+			entry = &uploadFile{}
+			files[match[1]] = entry
+		}
+		entry.path = strings.TrimSpace(values[0])
+	}
+	for key, values := range r.MultipartForm.File {
+		match := bulkUploadField.FindStringSubmatch(key)
+		if len(match) != 3 || match[2] != "file" || len(values) == 0 {
+			continue
+		}
+		entry := files[match[1]]
+		if entry == nil {
+			entry = &uploadFile{}
+			files[match[1]] = entry
+		}
+		entry.file = values[0]
+	}
+
+	if len(files) == 0 {
+		apihttp.WriteError(w, http.StatusBadRequest, "no files provided")
+		return
+	}
+
+	for _, entry := range files {
+		if entry == nil || entry.path == "" || entry.file == nil {
+			apihttp.WriteError(w, http.StatusBadRequest, "each uploaded file must include files[n].path and files[n].file")
+			return
+		}
+		if err := h.uploadSingleFile(r.Context(), sandboxID, entry.path, entry.file); err != nil {
+			h.writeToolboxError(w, err)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *handlers) bulkDownload(w http.ResponseWriter, r *http.Request, sandboxID string) {
+	var req filesDownloadRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if len(req.Paths) == 0 {
+		apihttp.WriteError(w, http.StatusBadRequest, "paths is required")
+		return
+	}
+
+	writer := multipart.NewWriter(w)
+	w.Header().Set("Content-Type", writer.FormDataContentType())
+	w.WriteHeader(http.StatusOK)
+
+	for _, targetPath := range req.Paths {
+		resp, err := h.sendToolboxRequest(r.Context(), sandboxID, http.MethodGet, "/files/download", url.Values{"path": []string{targetPath}}, nil, nil)
+		if err != nil {
+			h.writeMultipartErrorPart(writer, errorPayload(err))
+			continue
+		}
+
+		if resp.StatusCode >= http.StatusMultipleChoices {
+			body, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			h.writeMultipartErrorPart(writer, responseErrorPayload(resp.StatusCode, body))
+			continue
+		}
+
+		headers := textproto.MIMEHeader{
+			"Content-Disposition": []string{fmt.Sprintf(`form-data; name="file"; filename=%q`, filepath.Base(targetPath))},
+			"Content-Type":        []string{"application/octet-stream"},
+		}
+		if resp.ContentLength >= 0 {
+			headers.Set("Content-Length", fmt.Sprintf("%d", resp.ContentLength))
+		}
+		part, err := writer.CreatePart(headers)
+		if err == nil {
+			_, _ = io.Copy(part, resp.Body)
+		}
+		_ = resp.Body.Close()
+	}
+	_ = writer.Close()
+}
+
+func (h *handlers) writeMultipartErrorPart(writer *multipart.Writer, body []byte) {
+	if len(body) == 0 {
+		body = responseErrorPayload(http.StatusBadGateway, nil)
+	}
+	part, err := writer.CreatePart(textproto.MIMEHeader{
+		"Content-Disposition": []string{`form-data; name="error"`},
+		"Content-Type":        []string{"application/json"},
+	})
+	if err == nil {
+		_, _ = part.Write(body)
+	}
+}
+
+func (h *handlers) uploadSingleFile(ctx context.Context, sandboxID, targetPath string, fileHeader *multipart.FileHeader) error {
+	file, err := fileHeader.Open()
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	reader, writer := io.Pipe()
+	multipartWriter := multipart.NewWriter(writer)
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(errCh)
+		part, err := multipartWriter.CreateFormFile("file", fileHeader.Filename)
+		if err == nil {
+			_, err = io.Copy(part, file)
+		}
+		closeErr := multipartWriter.Close()
+		if err == nil {
+			err = closeErr
+		}
+		_ = writer.CloseWithError(err)
+		errCh <- err
+	}()
+
+	headers := http.Header{}
+	headers.Set("Content-Type", multipartWriter.FormDataContentType())
+	resp, err := h.sendToolboxRequest(ctx, sandboxID, http.MethodPost, "/files/upload", url.Values{"path": []string{targetPath}}, reader, headers)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if writeErr := <-errCh; writeErr != nil {
+		return writeErr
+	}
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		return readToolboxHTTPError(resp)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return nil
+}
+
+func (h *handlers) runToolboxString(ctx context.Context, sandboxID, command string) (string, error) {
+	result, err := h.runToolboxCommand(ctx, sandboxID, models.ExecRequest{Command: command, TimeoutSeconds: 10})
+	if err != nil {
+		return "", err
+	}
+	value := strings.TrimSpace(result.Stdout)
+	if value == "" {
+		value = strings.TrimSpace(result.Stderr)
+	}
+	return value, nil
+}
+
+func (h *handlers) runToolboxCommand(ctx context.Context, sandboxID string, req models.ExecRequest) (*models.ExecResult, error) {
+	var result models.ExecResult
+	statusCode, err := h.sendToolboxJSON(ctx, sandboxID, http.MethodPost, "/process/execute", nil, req, &result)
+	if err != nil {
+		return nil, err
+	}
+	if statusCode >= http.StatusMultipleChoices {
+		return nil, &toolboxHTTPError{StatusCode: statusCode, Message: http.StatusText(statusCode)}
+	}
+	return &result, nil
+}
+
+func (h *handlers) forwardToolbox(w http.ResponseWriter, r *http.Request, sandboxID, path string) {
+	resp, err := h.sendToolboxRequest(r.Context(), sandboxID, r.Method, path, r.URL.Query(), r.Body, r.Header.Clone())
+	if err != nil {
+		h.writeToolboxError(w, err)
+		return
+	}
+	defer resp.Body.Close()
+	copyResponseHeaders(w.Header(), resp.Header)
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}
+
+func (h *handlers) sendToolboxJSON(ctx context.Context, sandboxID, method, path string, query url.Values, requestBody any, responseBody any) (int, error) {
+	var body io.Reader
+	headers := http.Header{}
+	headers.Set("Accept", "application/json")
+	if requestBody != nil {
+		payload, err := json.Marshal(requestBody)
+		if err != nil {
+			return 0, err
+		}
+		body = strings.NewReader(string(payload))
+		headers.Set("Content-Type", "application/json")
+	}
+	resp, err := h.sendToolboxRequest(ctx, sandboxID, method, path, query, body, headers)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		return resp.StatusCode, readToolboxHTTPError(resp)
+	}
+	if responseBody != nil {
+		if err := json.NewDecoder(resp.Body).Decode(responseBody); err != nil {
+			return resp.StatusCode, err
+		}
+	}
+	return resp.StatusCode, nil
+}
+
+func (h *handlers) sendToolboxRequest(ctx context.Context, sandboxID, method, path string, query url.Values, body io.Reader, headers http.Header) (*http.Response, error) {
+	endpoint, err := h.deps.Service.ToolboxTarget(ctx, sandboxID)
+	if err != nil {
+		return nil, err
+	}
+	target, err := url.Parse(endpoint.URL)
+	if err != nil {
+		return nil, err
+	}
+	resolved := target.ResolveReference(&url.URL{Path: path, RawQuery: query.Encode()})
+	req, err := http.NewRequestWithContext(ctx, method, resolved.String(), body)
+	if err != nil {
+		return nil, err
+	}
+	for key, values := range headers {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+	if endpoint.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+endpoint.Token)
+	}
+	return h.httpClient.Do(req)
+}
+
+func (h *handlers) writeToolboxError(w http.ResponseWriter, err error) {
+	var httpErr *toolboxHTTPError
+	if errors.As(err, &httpErr) {
+		apihttp.WriteError(w, httpErr.StatusCode, httpErr.Error())
+		return
+	}
+	if h.deps.Logger != nil {
+		h.deps.Logger.Warn("daytona toolbox request failed", "error", err)
+	}
+	apihttp.WriteError(w, http.StatusBadGateway, "toolbox unavailable")
+}
+
+func readToolboxHTTPError(resp *http.Response) error {
+	if resp == nil {
+		return &toolboxHTTPError{StatusCode: http.StatusBadGateway, Message: "toolbox unavailable"}
+	}
+	body, _ := io.ReadAll(resp.Body)
+	message := strings.TrimSpace(string(body))
+	if len(body) > 0 {
+		var payload struct {
+			Error string `json:"error"`
+		}
+		if err := json.Unmarshal(body, &payload); err == nil && strings.TrimSpace(payload.Error) != "" {
+			message = strings.TrimSpace(payload.Error)
+		}
+	}
+	if message == "" {
+		message = http.StatusText(resp.StatusCode)
+	}
+	return &toolboxHTTPError{StatusCode: resp.StatusCode, Message: message}
+}
+
+func errorPayload(err error) []byte {
+	message := "toolbox unavailable"
+	var httpErr *toolboxHTTPError
+	if errors.As(err, &httpErr) {
+		message = httpErr.Error()
+	} else if err != nil && strings.TrimSpace(err.Error()) != "" {
+		message = strings.TrimSpace(err.Error())
+	}
+	return []byte(fmt.Sprintf(`{"error":%q}`, message))
+}
+
+func responseErrorPayload(statusCode int, body []byte) []byte {
+	message := strings.TrimSpace(string(body))
+	if len(body) > 0 {
+		var payload struct {
+			Error string `json:"error"`
+		}
+		if err := json.Unmarshal(body, &payload); err == nil && strings.TrimSpace(payload.Error) != "" {
+			message = strings.TrimSpace(payload.Error)
+		}
+	}
+	if message == "" {
+		message = http.StatusText(statusCode)
+	}
+	return []byte(fmt.Sprintf(`{"error":%q}`, message))
+}
+
+func copyResponseHeaders(dst, src http.Header) {
+	for key, values := range src {
+		switch http.CanonicalHeaderKey(key) {
+		case "Connection", "Keep-Alive", "Proxy-Authenticate", "Proxy-Authorization", "Te", "Trailer", "Transfer-Encoding", "Upgrade":
+			continue
+		}
+		for _, value := range values {
+			dst.Add(key, value)
+		}
+	}
+}

--- a/pkg/api/daytona/toolbox.go
+++ b/pkg/api/daytona/toolbox.go
@@ -246,10 +246,17 @@ func (h *handlers) uploadSingleFile(ctx context.Context, sandboxID, targetPath s
 
 	reader, writer := io.Pipe()
 	multipartWriter := multipart.NewWriter(writer)
-	errCh := make(chan error, 1)
+	headers := http.Header{}
+	headers.Set("Content-Type", multipartWriter.FormDataContentType())
 
+	req, err := h.newToolboxRequest(ctx, sandboxID, http.MethodPost, "/files/upload", url.Values{"path": []string{targetPath}}, reader, headers)
+	if err != nil {
+		_ = reader.CloseWithError(err)
+		return err
+	}
+
+	errCh := make(chan error, 1)
 	go func() {
-		defer close(errCh)
 		part, err := multipartWriter.CreateFormFile("file", fileHeader.Filename)
 		if err == nil {
 			_, err = io.Copy(part, file)
@@ -262,10 +269,10 @@ func (h *handlers) uploadSingleFile(ctx context.Context, sandboxID, targetPath s
 		errCh <- err
 	}()
 
-	headers := http.Header{}
-	headers.Set("Content-Type", multipartWriter.FormDataContentType())
-	resp, err := h.sendToolboxRequest(ctx, sandboxID, http.MethodPost, "/files/upload", url.Values{"path": []string{targetPath}}, reader, headers)
+	resp, err := h.httpClient.Do(req)
 	if err != nil {
+		_ = reader.CloseWithError(err)
+		<-errCh
 		return err
 	}
 	defer resp.Body.Close()
@@ -344,6 +351,14 @@ func (h *handlers) sendToolboxJSON(ctx context.Context, sandboxID, method, path 
 }
 
 func (h *handlers) sendToolboxRequest(ctx context.Context, sandboxID, method, path string, query url.Values, body io.Reader, headers http.Header) (*http.Response, error) {
+	req, err := h.newToolboxRequest(ctx, sandboxID, method, path, query, body, headers)
+	if err != nil {
+		return nil, err
+	}
+	return h.httpClient.Do(req)
+}
+
+func (h *handlers) newToolboxRequest(ctx context.Context, sandboxID, method, path string, query url.Values, body io.Reader, headers http.Header) (*http.Request, error) {
 	endpoint, err := h.deps.Service.ToolboxTarget(ctx, sandboxID)
 	if err != nil {
 		return nil, err
@@ -365,7 +380,7 @@ func (h *handlers) sendToolboxRequest(ctx context.Context, sandboxID, method, pa
 	if endpoint.Token != "" {
 		req.Header.Set("Authorization", "Bearer "+endpoint.Token)
 	}
-	return h.httpClient.Do(req)
+	return req, nil
 }
 
 func (h *handlers) writeToolboxError(w http.ResponseWriter, err error) {

--- a/pkg/api/daytona/toolbox.go
+++ b/pkg/api/daytona/toolbox.go
@@ -56,14 +56,28 @@ func (h *handlers) toolbox(w http.ResponseWriter, r *http.Request) {
 		h.workDir(w, r, sandboxID)
 	case r.Method == http.MethodPost && path == "process/execute":
 		h.executeCommand(w, r, sandboxID)
+	case path == "process/session" || strings.HasPrefix(path, "process/session/"):
+		h.forwardToolbox(w, r, sandboxID, "/"+path)
+	case r.Method == http.MethodGet && path == "files":
+		h.forwardToolbox(w, r, sandboxID, "/files")
+	case r.Method == http.MethodGet && path == "files/info":
+		h.forwardToolbox(w, r, sandboxID, "/files/info")
 	case r.Method == http.MethodPost && path == "files/upload":
 		h.forwardToolbox(w, r, sandboxID, "/files/upload")
 	case r.Method == http.MethodGet && path == "files/download":
 		h.forwardToolbox(w, r, sandboxID, "/files/download")
+	case r.Method == http.MethodPost && path == "files/move":
+		h.forwardToolbox(w, r, sandboxID, "/files/move")
+	case r.Method == http.MethodGet && path == "files/search":
+		h.forwardToolbox(w, r, sandboxID, "/files/search")
+	case r.Method == http.MethodGet && path == "files/find":
+		h.forwardToolbox(w, r, sandboxID, "/files/find")
 	case r.Method == http.MethodPost && path == "files/bulk-upload":
 		h.bulkUpload(w, r, sandboxID)
 	case r.Method == http.MethodPost && path == "files/bulk-download":
 		h.bulkDownload(w, r, sandboxID)
+	case strings.HasPrefix(path, "git/"):
+		h.forwardToolbox(w, r, sandboxID, "/"+path)
 	default:
 		apihttp.WriteError(w, http.StatusNotImplemented, "daytona toolbox route not implemented")
 	}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -16,8 +16,9 @@ import (
 	"log/slog"
 	"net/http"
 
-	apiv1 "github.com/aerol-ai/microvm/pkg/api/v1"
 	"github.com/aerol-ai/microvm/internal/service"
+	"github.com/aerol-ai/microvm/pkg/api/daytona"
+	apiv1 "github.com/aerol-ai/microvm/pkg/api/v1"
 )
 
 type Server struct {
@@ -49,6 +50,12 @@ func (s *Server) routes() {
 
 	// Each registered version owns its own URL prefix and is responsible for
 	// every route under it. Auth is shared across versions via Deps.Auth.
+	daytona.RegisterRoutes(s.mux, daytona.Deps{
+		Service: s.service,
+		Logger:  s.logger,
+		Auth:    s.requireAuth,
+	})
+
 	apiv1.RegisterRoutes(s.mux, apiv1.Deps{
 		Service: s.service,
 		Logger:  s.logger,

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -12,21 +12,32 @@ import (
 func TestRequireAuthCases(t *testing.T) {
 	tests := []struct {
 		name          string
+		path          string
 		authorization string
 		body          string
 		wantStatus    int
 	}{
 		{
 			name:       "missing_authorization_is_rejected",
+			path:       "/v1/sandboxes",
 			wantStatus: http.StatusUnauthorized,
 		},
 		{
 			name:          "wrong_pat_token_is_rejected",
+			path:          "/v1/sandboxes",
 			authorization: "Bearer wrong-token",
 			wantStatus:    http.StatusUnauthorized,
 		},
 		{
 			name:          "valid_pat_token_reaches_handler",
+			path:          "/v1/sandboxes",
+			authorization: "Bearer pat-token",
+			body:          "not-json",
+			wantStatus:    http.StatusBadRequest,
+		},
+		{
+			name:          "daytona_routes_share_auth_contract",
+			path:          "/daytona/sandbox",
 			authorization: "Bearer pat-token",
 			body:          "not-json",
 			wantStatus:    http.StatusBadRequest,
@@ -36,7 +47,7 @@ func TestRequireAuthCases(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			server := NewServer(slog.New(slog.NewTextHandler(io.Discard, nil)), nil, "pat-token")
-			request := httptest.NewRequest(http.MethodPost, "/v1/sandboxes", strings.NewReader(tc.body))
+			request := httptest.NewRequest(http.MethodPost, tc.path, strings.NewReader(tc.body))
 			if tc.authorization != "" {
 				request.Header.Set("Authorization", tc.authorization)
 			}

--- a/pkg/models/daytona.go
+++ b/pkg/models/daytona.go
@@ -1,0 +1,16 @@
+package models
+
+// DaytonaSandboxMetadata stores compatibility-only fields for the /daytona
+// facade without changing the native sandbox contract.
+type DaytonaSandboxMetadata struct {
+	SandboxID                  string
+	Name                       string
+	Snapshot                   string
+	User                       string
+	Labels                     map[string]string
+	Target                     string
+	NetworkAllowList           string
+	AutoStopIntervalMinutes    *float32
+	AutoArchiveIntervalMinutes *float32
+	AutoDeleteIntervalMinutes  *float32
+}

--- a/plans/daytona-e2b-compatibility-facades.md
+++ b/plans/daytona-e2b-compatibility-facades.md
@@ -1,0 +1,453 @@
+# Daytona and E2B Compatibility Facade Plan
+
+## Objective
+
+Make AerolVM consumable by external sandbox SDKs without changing AerolVM's own SDKs, starting with Daytona and then E2B.
+
+The concrete target is:
+
+1. Expose a `/daytona` endpoint surface that accepts Daytona-style requests and maps them onto AerolVM's existing control-plane and toolbox capabilities.
+2. Expose a parallel `/e2b` compatibility surface using the same facade architecture.
+3. Keep AerolVM's native API and SDKs unchanged. In particular, do not modify `sdk/go` to look like Daytona.
+4. Document the setup from the server side, primarily in `docs/src/content/docs/getting-started.md` and `docs/src/content/docs/sdk-setup.md`.
+
+## Non-goals
+
+- Do not change `/v1` behavior to impersonate Daytona or E2B.
+- Do not rename AerolVM models to external product terminology internally.
+- Do not promise full Daytona or E2B parity on day one when the underlying capability does not exist.
+- Do not add server-side behavior only to satisfy an external SDK unless the behavior is also a sensible AerolVM primitive.
+
+## Current Code Structure
+
+These are the key code paths the compatibility work should build on.
+
+### Top-level HTTP router
+
+- `pkg/api/server.go` is the only place that wires top-level route families.
+- Today it mounts `/health` and `/v1/...`.
+- This is the correct insertion point for new top-level facades such as `/daytona/...` and `/e2b/...`.
+
+### Versioned AerolVM API
+
+- `pkg/api/v1/routes.go` and `pkg/api/v1/handlers.go` are intentionally thin.
+- They decode AerolVM wire DTOs, call `internal/service`, and encode responses.
+- `pkg/api/v1/proxy.go` already contains the reverse-proxy pattern for per-sandbox toolbox routing.
+
+### Core server capabilities already present
+
+`internal/service/service.go` already gives us a strong substrate for a compatibility layer:
+
+- sandbox create, get, list, start, stop, destroy, resize
+- lifecycle timers
+- encrypted mount persistence
+- toolbox target discovery per sandbox
+- HTTP/TCP/TLS port exposure
+- idempotent port exposure behavior already called out in `pr-review.md`
+
+This is important because it means the compatibility work should mostly be translation and selective augmentation, not a second orchestration stack.
+
+### Current toolbox surface
+
+`cmd/toolboxd/main.go` currently exposes a narrower toolbox API than Daytona expects. AerolVM toolbox support today includes:
+
+- `POST /process/execute`
+- `GET /process/exec/stream`
+- `POST /files/upload`
+- `GET /files/download`
+- `/sessions/...`
+
+This is a major planning constraint. Daytona's sandbox object is not just a control-plane client; it also constructs a Daytona toolbox client and expects a richer file/process surface.
+
+### Docs entry points requested by the user
+
+- `docs/src/content/docs/getting-started.md`
+- `docs/src/content/docs/sdk-setup.md`
+
+Those are the right places for setup guidance, but if compatibility mode grows beyond a short setup section we should consider a dedicated docs page later to stay aligned with the repo's docs conventions.
+
+## Daytona SDK Contract: What It Actually Needs
+
+The local Daytona Go SDK at `/Users/sumansaurabh/Documents/startup-3/opensource-repos/daytona/libs/sdk-go` is configurable via `DAYTONA_API_URL` or `DaytonaConfig.APIUrl`, so AerolVM can be targeted without changing Daytona's SDK.
+
+From the code reviewed, the Daytona SDK expects two separate surfaces:
+
+1. A Daytona-shaped control plane under the configured base URL.
+2. A Daytona-shaped toolbox base URL returned in sandbox responses, which the SDK then uses for process, file system, PTY, git, code interpreter, and related sandbox operations.
+
+### Strong overlap with AerolVM today
+
+These Daytona concepts map well to existing AerolVM primitives:
+
+- create sandbox from an image string
+- get sandbox
+- list sandboxes
+- start sandbox
+- stop sandbox
+- delete sandbox
+- resize sandbox
+- execute a command in the sandbox
+- upload and download files
+- session-style process continuity
+- per-port public URL exposure
+- network block-all and allowlist at create time
+
+### Partial overlap that needs translation logic
+
+These can likely be supported, but only with explicit mapping rules:
+
+- Daytona `AutoStopInterval` -> AerolVM lifecycle idle-stop
+- Daytona `AutoDeleteInterval` -> AerolVM lifecycle idle-destroy
+- Daytona preview link -> AerolVM `ExposePort(..., "http")` with an adapter-shaped response
+- Daytona toolbox URL -> AerolVM proxy URL that points at a Daytona-specific toolbox facade
+
+### Capability gaps that are not solved by a path rewrite
+
+These are real gaps and should be called out up front:
+
+- sandbox names are not first-class in AerolVM's current public model
+- sandbox labels are not a first-class persisted API concept
+- Daytona target/region does not exist in AerolVM
+- Daytona snapshot APIs do not exist in AerolVM
+- Daytona image-build and build-log flows do not exist in AerolVM's current create path
+- Daytona volume lifecycle APIs do not exist; AerolVM has external mounts instead
+- Daytona archive APIs do not exist in AerolVM
+- Daytona dynamic network-update APIs do not exist as a public AerolVM surface today
+- Daytona toolbox filesystem APIs are much richer than AerolVM's current upload/download-only toolbox implementation
+- Daytona toolbox services like Git, LSP, computer-use, and code interpreter are not current AerolVM toolbox features
+
+## Key Architectural Conclusion
+
+`/daytona` cannot be implemented as a naive reverse proxy to `/v1`.
+
+The control-plane shapes differ, and the Daytona SDK also expects a Daytona toolbox API. The correct design is a facade layer with explicit request/response translation and selective proxying.
+
+The same logic applies to `/e2b`.
+
+## Proposed Package Layout
+
+Add two new top-level API packages and one shared compatibility helper area.
+
+```text
+pkg/api/
+  daytona/
+    routes.go
+    handlers.go
+    dto.go
+    toolbox_proxy.go
+    translate.go
+  e2b/
+    routes.go
+    handlers.go
+    dto.go
+    toolbox_proxy.go
+    translate.go
+internal/compat/
+  lifecycle.go
+  errors.go
+  urls.go
+```
+
+### Design rules
+
+- `pkg/api/daytona` owns Daytona wire contracts.
+- `pkg/api/e2b` owns E2B wire contracts.
+- `internal/service` stays external-product agnostic.
+- Shared translation helpers must stay generic. If a helper starts embedding Daytona-only or E2B-only semantics, keep it inside that facade package instead.
+
+## Router Plan
+
+Update `pkg/api/server.go` to register:
+
+- `/daytona/...`
+- `/e2b/...`
+
+This mirrors the existing route-family pattern used for `/v1` and keeps the compatibility surfaces isolated from AerolVM's native API.
+
+## Daytona Facade Plan
+
+### Phase 0: Pin the supported Daytona contract
+
+Before implementing handlers, capture the exact HTTP contract we want to support from the current Daytona SDK version.
+
+Scope this to the subset that provides real value immediately:
+
+- image-based sandbox lifecycle
+- resize
+- command execution
+- file upload/download
+- sessions or PTY continuity where feasible
+- preview links
+
+Anything outside that subset should be intentionally marked unsupported instead of being silently approximated.
+
+### Phase 1: Control-plane facade
+
+Implement Daytona control-plane endpoints under `/daytona` that translate into AerolVM service calls.
+
+Initial support target:
+
+- create sandbox from image string
+- get sandbox
+- list sandboxes
+- start sandbox
+- stop sandbox
+- delete sandbox
+- resize sandbox
+
+Translation rules:
+
+- image string -> `models.CreateSandboxRequest.Image`
+- env vars -> `Env`
+- user -> map to `OSUser` when valid, otherwise reject explicitly
+- resource CPU/memory/disk -> AerolVM resource fields
+- network block-all / allowlist -> existing AerolVM create fields
+- auto-stop interval -> lifecycle stop-if-idle
+- auto-delete interval -> lifecycle destroy-if-idle
+
+Unsupported create inputs should fail clearly, for example:
+
+- snapshot-based create
+- custom build info / Dockerfile build
+- target region
+- public/private semantics if Daytona requires behavior AerolVM does not have
+- labels if we do not introduce them as a true AerolVM capability
+- Daytona volumes during initial rollout
+
+### Phase 2: Daytona response shaping
+
+Every Daytona sandbox response needs to look like a Daytona sandbox, not an AerolVM sandbox.
+
+That means synthesizing or mapping fields such as:
+
+- `id`
+- `name`
+- `state`
+- `target`
+- `autoArchiveInterval`
+- `autoDeleteInterval`
+- `networkBlockAll`
+- `networkAllowList`
+- `toolboxProxyUrl`
+
+Important choices:
+
+- If AerolVM does not truly support a field, prefer an empty or omitted value plus explicit documentation over a misleading fake value.
+- `toolboxProxyUrl` should point at a Daytona facade path, not directly at `/v1/sandboxes/{id}/toolbox`.
+
+Recommended shape:
+
+- return `toolboxProxyUrl` as something like `/daytona/toolbox`
+- let the Daytona SDK append `/{sandboxId}` exactly as it already does
+
+### Phase 3: Daytona toolbox facade
+
+This is the critical piece that makes the Daytona SDK actually usable after sandbox creation.
+
+Implement `/daytona/toolbox/{sandboxId}/...` as a compatibility facade that does one of three things per endpoint:
+
+1. direct proxy to an existing AerolVM toolbox endpoint
+2. path and body translation around an existing AerolVM toolbox endpoint
+3. explicit `501 Not Implemented` when AerolVM has no equivalent capability
+
+Initial Daytona toolbox support target:
+
+- process execution
+- streaming process output if the Daytona SDK path can be mapped cleanly
+- single-file upload
+- single-file download
+- session-style process continuity where semantics match closely enough
+
+Expected follow-up work on `toolboxd` for better Daytona compatibility:
+
+- folder creation
+- file listing and metadata
+- file delete and move
+- bulk upload/download aliases
+- any PTY-specific endpoints the Daytona SDK actually exercises
+
+This work should be treated as AerolVM toolbox expansion, not as Daytona-only hacks, when the feature is generally useful.
+
+### Phase 4: Preview and port compatibility
+
+Map Daytona preview-style access onto AerolVM port exposure.
+
+Recommended initial behavior:
+
+- Daytona preview URL request -> call AerolVM `ExposePort(..., "http")`
+- return the public URL
+- return an empty token if AerolVM keeps the route public
+
+Do not implement signed preview semantics unless we add a real signed-preview concept server-side.
+
+### Phase 5: Explicitly unsupported Daytona features
+
+Return clear unsupported responses for the first iteration of:
+
+- snapshots
+- build logs
+- archive
+- volumes API
+- labels replacement
+- dynamic network-update APIs
+- Git service
+- LSP service
+- computer-use service
+- code interpreter service
+
+The goal is a dependable subset, not a broad but misleading surface.
+
+## E2B Facade Plan
+
+There is no local E2B SDK or repo checked out alongside Daytona in `opensource-repos`, so `/e2b` should be planned as a second facade on the same architecture, but with an explicit discovery step first.
+
+### Phase 0: Contract discovery
+
+Before implementing `/e2b`, pin:
+
+- which E2B SDK version we are targeting
+- which language SDKs matter first
+- which exact control-plane and runtime APIs must work
+
+Do not start coding `/e2b` from memory.
+
+### Phase 1: Reuse the same facade pattern
+
+After contract discovery:
+
+- add `pkg/api/e2b`
+- register it from `pkg/api/server.go`
+- reuse the same generic helper patterns used by `/daytona`
+- add an E2B-specific toolbox/runtime facade only where the wire contract differs
+
+### Expected likely overlap
+
+Based on AerolVM's current capabilities, E2B compatibility is most likely feasible first around:
+
+- sandbox lifecycle
+- command execution
+- file upload/download
+- port exposure and browser previews
+- network restriction
+
+### Expected likely gaps
+
+These should be assumed unknown until we inspect the actual E2B SDK we intend to support:
+
+- template semantics
+- env initialization behavior
+- filesystem APIs beyond upload/download
+- browser or desktop-specific APIs
+- code interpreter semantics
+
+## Why the Daytona and E2B work should share one architecture
+
+Both integrations are adapter problems around the same AerolVM substrate.
+
+Shared concerns:
+
+- auth translation
+- error translation
+- lifecycle interval conversion
+- URL shaping for control-plane and toolbox paths
+- unsupported-feature handling
+- contract-test scaffolding
+
+If we do `/daytona` first in a way that hardcodes one-off assumptions into `internal/service`, `/e2b` will be slower and messier. If we build proper facades now, `/e2b` becomes an incremental adapter rather than a second rewrite.
+
+## Testing Plan
+
+### Control-plane adapter tests
+
+Add focused tests for each facade package that verify:
+
+- request translation into `internal/service`
+- response shaping back into Daytona/E2B wire formats
+- unsupported fields fail clearly
+- auth behavior is consistent with the external SDK's expectations
+
+### Toolbox facade tests
+
+Add tests that prove the adapter routes either:
+
+- proxy correctly to existing toolbox endpoints, or
+- translate correctly, or
+- return `501` with a stable error body
+
+### End-to-end compatibility tests
+
+For Daytona first:
+
+- point a real or fixture-based Daytona client at AerolVM `/daytona`
+- create sandbox from image string
+- execute a command
+- upload and download a file
+- stop and delete the sandbox
+
+This should be the acceptance gate for the first implementation.
+
+### Guardrails from `pr-review.md`
+
+The compatibility work touches `pkg/api`, and likely `internal/service` and `cmd/toolboxd`, so explicitly preserve:
+
+- idempotency on repeated requests
+- no accidental added work in the AerolVM create hot path unless called out
+- no `/v1` wire behavior drift
+- clean failure-path rollback rules when facades create side effects such as exposing ports
+
+## Documentation Plan
+
+The user specifically wants docs updates centered on:
+
+- `docs/src/content/docs/getting-started.md`
+- `docs/src/content/docs/sdk-setup.md`
+
+Recommended changes after implementation:
+
+### `getting-started.md`
+
+Add a short compatibility section that explains:
+
+- AerolVM can expose Daytona- and E2B-compatible facades
+- the Daytona base URL should point at `/daytona`
+- the E2B base URL should point at `/e2b`
+- compatibility mode is server-side and does not require AerolVM SDK changes
+
+### `sdk-setup.md`
+
+Add a compatibility section that explains:
+
+- native AerolVM SDKs remain the primary API
+- Daytona and E2B SDKs can target AerolVM through compatibility endpoints
+- which features are supported in the current compatibility subset
+- which features remain unsupported
+
+Important docs note:
+
+- if the compatibility setup grows beyond a short section, promote it to a dedicated docs page instead of bloating setup pages.
+
+## Recommended Implementation Order
+
+1. Freeze the Daytona support subset and exact route inventory.
+2. Scaffold `pkg/api/daytona` and register `/daytona` in `pkg/api/server.go`.
+3. Implement Daytona control-plane lifecycle subset.
+4. Implement Daytona toolbox facade for process plus basic file transfer.
+5. Add contract-style end-to-end tests using the Daytona SDK.
+6. Document Daytona setup in the requested docs files.
+7. Inspect the target E2B SDK and freeze its support subset.
+8. Scaffold `pkg/api/e2b` and implement the same pattern.
+
+## Open Questions To Resolve Before Coding
+
+1. Which Daytona SDK version do we want to pin as the compatibility target?
+2. Do we want to support only API-key auth initially and explicitly reject Daytona JWT org flows?
+3. Should sandbox `name` be introduced as a first-class AerolVM field, or omitted from the compatibility subset initially?
+4. Should preview URLs in compatibility mode always be public, or do we want to add a true signed-preview feature first?
+5. For E2B, which SDK and language should define the first supported contract?
+6. Do we want the first delivery to be a narrow but working Daytona subset, or do we want to delay until richer filesystem coverage is added to `toolboxd`?
+
+## Recommendation
+
+Implement Daytona first, but only as a well-defined subset with a real toolbox facade. Do not start with E2B in parallel until the shared facade scaffolding exists and the E2B target SDK is pinned.
+
+That sequence gives us the fastest path to a credible compatibility story while keeping AerolVM's native API clean.

--- a/plans/sdk-compatibility/README.md
+++ b/plans/sdk-compatibility/README.md
@@ -1,0 +1,31 @@
+# SDK Compatibility Matrix
+
+This folder tracks the current AerolVM versus Daytona SDK compatibility state.
+
+It is intentionally split into folders so the language-level view and the endpoint-level view stay separate:
+
+| Folder | Purpose |
+|---|---|
+| `aerolvm/` | Native AerolVM SDK inventory and support status. |
+| `daytona/` | Daytona SDK language inventory plus detailed `/daytona` facade support tables. |
+| `comparison/` | High-level side-by-side summary of native AerolVM SDKs versus Daytona compatibility. |
+
+## Status Legend
+
+| Status | Meaning |
+|---|---|
+| Supported | Implemented and intended for normal use. |
+| Partial | Implemented only for a subset of the external contract or with reduced semantics. |
+| Unsupported | Not implemented in the current AerolVM facade. |
+
+## Files
+
+| File | Description |
+|---|---|
+| `aerolvm/native-sdk-matrix.md` | First-party AerolVM SDKs and their support level. |
+| `daytona/sdk-language-matrix.md` | Official Daytona SDK families and how they map onto the AerolVM `/daytona` facade. |
+| `daytona/control-plane-matrix.md` | Daytona control-plane routes and feature fields supported by AerolVM. |
+| `daytona/toolbox-matrix.md` | Daytona toolbox routes and feature families supported by AerolVM. |
+| `comparison/daytona-vs-aerolvm.md` | Short side-by-side view of native AerolVM SDKs versus Daytona compatibility mode. |
+
+All tables reflect the current implementation in the repository as of 2026-05-13.

--- a/plans/sdk-compatibility/aerolvm/native-sdk-matrix.md
+++ b/plans/sdk-compatibility/aerolvm/native-sdk-matrix.md
@@ -1,0 +1,19 @@
+# AerolVM Native SDK Matrix
+
+These are the first-party AerolVM SDKs that are shipped directly from this repository.
+
+| AerolVM SDK | Repository path | Status | Notes |
+|---|---|---|---|
+| Go | `sdk/go` | Supported | First-party native SDK for the AerolVM `/v1` API. |
+| Java | `sdk/java` | Supported | First-party native SDK for the AerolVM `/v1` API. |
+| Python | `sdk/python` | Supported | First-party native SDK for the AerolVM `/v1` API. |
+| Rust | `sdk/rust` | Supported | First-party native SDK for the AerolVM `/v1` API. |
+| TypeScript | `sdk/typescript` | Supported | First-party native SDK for the AerolVM `/v1` API. |
+
+## Notes
+
+| Topic | Current state |
+|---|---|
+| Native API target | AerolVM SDKs target the native `/v1` API, not the `/daytona` compatibility facade. |
+| Language parity | The repo ships five first-party AerolVM SDK languages today: Go, Java, Python, Rust, and TypeScript. |
+| Compatibility mode | Daytona compatibility is additive and does not replace or modify the native AerolVM SDKs. |

--- a/plans/sdk-compatibility/comparison/daytona-vs-aerolvm.md
+++ b/plans/sdk-compatibility/comparison/daytona-vs-aerolvm.md
@@ -1,0 +1,29 @@
+# Daytona vs AerolVM SDK Summary
+
+This is the short side-by-side view. The detailed route tables live under `../daytona/`, and the native AerolVM SDK inventory lives under `../aerolvm/`.
+
+| Category | AerolVM native SDKs | Daytona SDKs against AerolVM | Notes |
+|---|---|---|---|
+| Primary API target | Supported | Partial | AerolVM SDKs target `/v1`. Daytona SDKs target the `/daytona` facade, which is only a subset. |
+| First-party language SDKs | Supported | N/A | AerolVM ships Go, Java, Python, Rust, and TypeScript SDKs from this repo. |
+| Official Daytona high-level SDKs | N/A | Partial | Go, Java, Python, Ruby, and TypeScript can only use the implemented `/daytona` subset. |
+| Sandbox lifecycle | Supported | Supported | Create, list, get, start, stop, destroy, resize all exist in the current facade. |
+| Persistent Daytona names and labels | N/A | Supported | Stored as compatibility metadata so lookup survives restarts. |
+| Daytona auto-stop and auto-delete | N/A | Supported | Mapped to native AerolVM lifecycle timers. |
+| Daytona auto-archive | N/A | Partial | Metadata is stored, but there is no real archive behavior. |
+| Toolbox exec | Supported | Supported | One-shot command execution works on both sides. |
+| Toolbox persistent sessions | Supported | Partial | Native toolbox sessions exist; Daytona-compatible session semantics are implemented only partially. |
+| Toolbox file upload and download | Supported | Supported | Single-file plus bulk compatibility helpers exist. |
+| Toolbox file listing, info, move, search, find | Partial native surface | Supported in Daytona facade | Added in toolboxd for Daytona compatibility. |
+| Toolbox Git | Limited native surface | Supported subset | Add, checkout, clone, commit, branches, history, and status exist. Pull and push do not. |
+| Toolbox LSP | Unsupported | Unsupported | No LSP backend exists in AerolVM toolboxd yet. |
+| Toolbox computer-use | Unsupported | Unsupported | No desktop/browser automation compatibility layer exists. |
+| Toolbox interpreter or code-run | Unsupported | Unsupported | No Daytona interpreter facade exists. |
+
+## Bottom line
+
+| Question | Answer |
+|---|---|
+| If you want full AerolVM support today, what should you use? | The native AerolVM SDKs in `sdk/`. |
+| If you want to reuse an existing Daytona integration, what should you expect? | Partial compatibility only. Use only the supported `/daytona` routes listed in the detailed matrices. |
+| Is the current Daytona status a language problem or an endpoint problem? | An endpoint problem. The same subset applies across Daytona SDK languages. |

--- a/plans/sdk-compatibility/daytona/control-plane-matrix.md
+++ b/plans/sdk-compatibility/daytona/control-plane-matrix.md
@@ -38,12 +38,12 @@ These tables describe the current `/daytona` control-plane compatibility surface
 | `snapshot` | Partial | Accepted only as an image fallback/input alias, not as a true Daytona snapshot lifecycle. |
 | `target` | Partial | Stored as metadata only. No AerolVM scheduling or region semantics exist. |
 | `public=true` or omitted | Supported | Facade assumes public sandbox routing. |
-| `public=false` | Unsupported | Explicitly rejected by the facade. |
+| `public=false` | Partial | Accepted for compatibility, but AerolVM still treats the sandbox as public in the current Daytona facade. |
 | `networkBlockAll` | Supported | Mapped onto native egress-block setting. |
 | `networkAllowList` | Unsupported | Non-empty values are explicitly rejected on create. |
 | `gpu` | Unsupported | Positive GPU requests are explicitly rejected in the Daytona facade. |
 | `volumes` | Unsupported | Daytona volume lifecycle is not mapped. |
-| `buildInfo` | Unsupported | Native AerolVM sandbox create does not implement Daytona image-build semantics. |
+| `buildInfo` | Partial | The facade accepts the simple Daytona Go SDK shape `dockerfileContent: "FROM <image>"` and translates it to a native AerolVM image. Richer Dockerfile build semantics remain unsupported. |
 
 ## Known control-plane gaps
 

--- a/plans/sdk-compatibility/daytona/control-plane-matrix.md
+++ b/plans/sdk-compatibility/daytona/control-plane-matrix.md
@@ -1,0 +1,57 @@
+# Daytona Control-plane Matrix
+
+These tables describe the current `/daytona` control-plane compatibility surface implemented by AerolVM.
+
+## Route-level support
+
+| Daytona route or capability | Status | AerolVM mapping | Notes |
+|---|---|---|---|
+| `POST /daytona/sandbox` | Partial | Maps onto native sandbox create | Image-based create is supported. Some Daytona create fields are unsupported or metadata-only. |
+| `GET /daytona/sandbox` | Supported | Maps onto native sandbox list | Includes Daytona-shaped response translation. |
+| `GET /daytona/sandbox/paginated` | Supported | Maps onto native sandbox list with facade pagination | Pagination is handled in the facade layer. |
+| `GET /daytona/sandbox/{idOrName}` | Supported | Maps onto native sandbox get plus stored Daytona name resolution | Name lookup survives restarts via persistent store metadata. |
+| `DELETE /daytona/sandbox/{idOrName}` | Supported | Maps onto native sandbox destroy | Supports lookup by Daytona name or AerolVM sandbox ID. |
+| `POST /daytona/sandbox/{idOrName}/start` | Supported | Maps onto native sandbox start | Native lifecycle operation. |
+| `POST /daytona/sandbox/{idOrName}/stop` | Supported | Maps onto native sandbox stop | Native lifecycle operation. |
+| `POST /daytona/sandbox/{idOrName}/resize` | Supported | Maps onto native sandbox resize | Native resource resize operation. |
+| `GET /daytona/sandbox/{id}/toolbox-proxy-url` | Supported | Returns AerolVM Daytona toolbox facade base | Used by Daytona SDKs to reach toolbox routes. |
+| `GET /daytona/sandbox/{idOrName}/ports/{port}/preview-url` | Supported | Calls native port exposure | Returns Daytona-shaped preview URL response. |
+| `PUT /daytona/sandbox/{idOrName}/labels` | Supported | Stored in persistent Daytona metadata | Labels are compatibility metadata, not a native AerolVM first-class resource. |
+| `POST /daytona/sandbox/{idOrName}/autostop/{interval}` | Supported | Maps onto native idle-stop lifecycle | Operationally enforced by AerolVM lifecycle logic. |
+| `POST /daytona/sandbox/{idOrName}/autodelete/{interval}` | Supported | Maps onto native idle-destroy lifecycle | Operationally enforced by AerolVM lifecycle logic. |
+| `POST /daytona/sandbox/{idOrName}/autoarchive/{interval}` | Partial | Stored in persistent Daytona metadata only | AerolVM does not implement real archive behavior today. |
+
+## Create-field support
+
+| Daytona create field | Status | Current behavior |
+|---|---|---|
+| `name` | Supported | Persisted in store-backed Daytona metadata and resolved after restart. |
+| `env` | Supported | Mapped onto native sandbox environment variables. |
+| `labels` | Supported | Persisted in store-backed Daytona metadata. |
+| `cpu` | Supported | Mapped onto native sandbox CPU request. |
+| `memory` | Supported | Mapped onto native sandbox memory request. |
+| `disk` | Supported | Mapped onto native sandbox disk request. |
+| `user` | Partial | Mapped to native `OSUser` when provided. |
+| `autoStopInterval` | Supported | Mapped to AerolVM idle-stop lifecycle. |
+| `autoDeleteInterval` | Supported | Mapped to AerolVM idle-destroy lifecycle. |
+| `autoArchiveInterval` | Partial | Stored as metadata only. No archive runtime behavior exists. |
+| `snapshot` | Partial | Accepted only as an image fallback/input alias, not as a true Daytona snapshot lifecycle. |
+| `target` | Partial | Stored as metadata only. No AerolVM scheduling or region semantics exist. |
+| `public=true` or omitted | Supported | Facade assumes public sandbox routing. |
+| `public=false` | Unsupported | Explicitly rejected by the facade. |
+| `networkBlockAll` | Supported | Mapped onto native egress-block setting. |
+| `networkAllowList` | Unsupported | Non-empty values are explicitly rejected on create. |
+| `gpu` | Unsupported | Positive GPU requests are explicitly rejected in the Daytona facade. |
+| `volumes` | Unsupported | Daytona volume lifecycle is not mapped. |
+| `buildInfo` | Unsupported | Native AerolVM sandbox create does not implement Daytona image-build semantics. |
+
+## Known control-plane gaps
+
+| Daytona area | Status | Gap |
+|---|---|---|
+| Snapshot lifecycle APIs | Unsupported | No Daytona snapshot create/list/restore management surface exists in AerolVM. |
+| Build/image pipeline APIs | Unsupported | AerolVM create is image-based; no Daytona-style build flow is exposed. |
+| Archive lifecycle | Unsupported beyond metadata | `autoarchive` is stored, but real archive behavior is not implemented. |
+| Dynamic network allowlist management | Unsupported | No separate Daytona-shaped update API is exposed. |
+| Target or region scheduling | Unsupported beyond metadata | `target` is stored only for compatibility display. |
+| Daytona volume lifecycle | Unsupported | AerolVM has external mounts, but not Daytona volume APIs. |

--- a/plans/sdk-compatibility/daytona/sdk-language-matrix.md
+++ b/plans/sdk-compatibility/daytona/sdk-language-matrix.md
@@ -1,0 +1,28 @@
+# Daytona SDK Language Matrix
+
+Daytona compatibility in AerolVM is HTTP-surface based. That means support is primarily determined by which Daytona routes are implemented under `/daytona`, not by a language-specific adapter.
+
+## High-level Daytona SDKs
+
+| Daytona SDK | Upstream path | Status against AerolVM | Notes |
+|---|---|---|---|
+| Go | `libs/sdk-go` | Partial | Best current reference contract for the AerolVM `/daytona` facade. Works only for implemented control-plane and toolbox routes. |
+| Java | `libs/sdk-java` | Partial | Same HTTP compatibility surface as Go. Not separately validated language-by-language. |
+| Python | `libs/sdk-python` | Partial | Same HTTP compatibility surface as Go. Not separately validated language-by-language. |
+| Ruby | `libs/sdk-ruby` | Partial | Same HTTP compatibility surface as Go. Not separately validated language-by-language. |
+| TypeScript | `libs/sdk-typescript` | Partial | Same HTTP compatibility surface as Go. Not separately validated language-by-language. |
+
+## Generated Daytona Client Families
+
+| Daytona client family | Upstream paths | Status against AerolVM | Notes |
+|---|---|---|---|
+| Control-plane API clients | `libs/api-client-go`, `libs/api-client-java`, `libs/api-client-python`, `libs/api-client-python-async`, `libs/api-client-ruby` | Partial | Works only for the subset of control-plane endpoints and fields implemented under `/daytona`. |
+| Toolbox API clients | `libs/toolbox-api-client-go`, `libs/toolbox-api-client-java`, `libs/toolbox-api-client-python`, `libs/toolbox-api-client-python-async`, `libs/toolbox-api-client-ruby` | Partial | Works only for the subset of toolbox routes implemented behind `/daytona/toolbox/{sandboxId}`. |
+
+## Important Interpretation
+
+| Question | Answer |
+|---|---|
+| Are any Daytona SDK languages fully supported end-to-end? | No. The current status is partial across the board because the AerolVM facade implements only part of the Daytona contract. |
+| Are any Daytona SDK languages uniquely unsupported? | No language is singled out. The limitation is the shared HTTP compatibility surface, not the client language. |
+| What determines success with a Daytona SDK today? | Whether the code path uses only the supported `/daytona` control-plane and toolbox routes listed in the detailed matrices. |

--- a/plans/sdk-compatibility/daytona/toolbox-matrix.md
+++ b/plans/sdk-compatibility/daytona/toolbox-matrix.md
@@ -1,0 +1,69 @@
+# Daytona Toolbox Matrix
+
+These tables describe the current toolbox compatibility surface exposed through `/daytona/toolbox/{sandboxId}`.
+
+## General and process routes
+
+| Daytona toolbox route or capability | Status | AerolVM mapping | Notes |
+|---|---|---|---|
+| `GET /daytona/toolbox/{id}` | Supported | Proxies toolbox root | Basic toolbox identity/version entry point. |
+| `GET /daytona/toolbox/{id}/health` | Supported | Proxies toolbox health | Native toolbox health check. |
+| `GET /daytona/toolbox/{id}/version` | Supported | Proxies toolbox version | Native toolbox version response. |
+| `GET /daytona/toolbox/{id}/user-home-dir` | Supported | Implemented via shell lookup | Compatibility helper on top of toolbox exec. |
+| `GET /daytona/toolbox/{id}/workdir` | Supported | Implemented via shell lookup | Compatibility helper on top of toolbox exec. |
+| `POST /daytona/toolbox/{id}/process/execute` | Supported | Maps onto native toolbox exec | One-shot command execution. |
+| `POST /daytona/toolbox/{id}/process/session` | Supported | Maps onto native toolbox session manager | Creates or reuses a named non-PTY session. |
+| `GET /daytona/toolbox/{id}/process/session` | Supported | Facade over native toolbox session manager | Lists tracked Daytona-compatible sessions. |
+| `GET /daytona/toolbox/{id}/process/session/{sessionId}` | Supported | Facade over native toolbox session manager | Returns Daytona-shaped session view. |
+| `DELETE /daytona/toolbox/{id}/process/session/{sessionId}` | Supported | Maps onto native toolbox session delete | Deletes the backing session and Daytona compatibility state. |
+| `POST /daytona/toolbox/{id}/process/session/{sessionId}/exec` | Partial | Runs commands inside a persistent shell session | Commands are serialized per session and do not fully reproduce Daytona's richer command lifecycle. |
+| `GET /daytona/toolbox/{id}/process/session/{sessionId}/command/{commandId}` | Partial | Reads facade-maintained command state | Works only for commands executed through the compatibility layer. |
+| `GET /daytona/toolbox/{id}/process/session/{sessionId}/command/{commandId}/logs` | Partial | Reads facade-maintained command logs | Works only for commands executed through the compatibility layer. |
+| `POST /daytona/toolbox/{id}/process/session/{sessionId}/command/{commandId}/input` | Unsupported | No mapping | Interactive command input is not implemented. |
+| `GET /daytona/toolbox/{id}/process/session/entrypoint` | Unsupported | No mapping | Entry-point session compatibility is not implemented. |
+| `GET /daytona/toolbox/{id}/process/session/entrypoint/logs` | Unsupported | No mapping | Entry-point session log compatibility is not implemented. |
+| PTY session routes | Unsupported | No Daytona PTY facade yet | Native toolbox has sessions, but Daytona PTY endpoints are not mapped. |
+| Code-run or interpreter routes | Unsupported | No mapping | No Daytona code interpreter facade exists. |
+
+## File-system routes
+
+| Daytona toolbox route or capability | Status | AerolVM mapping | Notes |
+|---|---|---|---|
+| `GET /daytona/toolbox/{id}/files` | Supported | Native toolbox file listing | Lists directory contents. |
+| `GET /daytona/toolbox/{id}/files/info` | Supported | Native toolbox file stat helper | Returns file metadata in Daytona shape. |
+| `POST /daytona/toolbox/{id}/files/upload` | Supported | Native toolbox upload | Single-file upload. |
+| `GET /daytona/toolbox/{id}/files/download` | Supported | Native toolbox download | Single-file download. |
+| `POST /daytona/toolbox/{id}/files/move` | Supported | Native toolbox move helper | Move or rename using query parameters. |
+| `GET /daytona/toolbox/{id}/files/search` | Supported | Native toolbox filename search helper | Pattern-based recursive filename search. |
+| `GET /daytona/toolbox/{id}/files/find` | Supported | Native toolbox text search helper | Recursive text search across files. |
+| `POST /daytona/toolbox/{id}/files/bulk-upload` | Supported | Facade helper over native single-file upload | Multipart compatibility helper. |
+| `POST /daytona/toolbox/{id}/files/bulk-download` | Supported | Facade helper over native single-file download | Multipart compatibility helper. |
+| `POST /daytona/toolbox/{id}/files/replace` | Unsupported | No mapping | No Daytona replace-in-files facade exists. |
+| `POST /daytona/toolbox/{id}/files/folder` | Unsupported | No mapping | Folder-create alias is not implemented. |
+| `DELETE /daytona/toolbox/{id}/files` | Unsupported | No mapping | Daytona delete-file route is not implemented. |
+| `POST /daytona/toolbox/{id}/files/permissions` | Unsupported | No mapping | Permission and ownership updates are not implemented. |
+
+## Git routes
+
+| Daytona toolbox route or capability | Status | AerolVM mapping | Notes |
+|---|---|---|---|
+| `POST /daytona/toolbox/{id}/git/add` | Supported | Native toolbox git CLI wrapper | Stages specific files. |
+| `POST /daytona/toolbox/{id}/git/checkout` | Supported | Native toolbox git CLI wrapper | Branch or commit checkout. |
+| `POST /daytona/toolbox/{id}/git/clone` | Supported | Native toolbox git CLI wrapper | Clone plus optional branch and commit checkout. |
+| `POST /daytona/toolbox/{id}/git/commit` | Supported | Native toolbox git CLI wrapper | Commit with supplied author, email, and message. |
+| `GET /daytona/toolbox/{id}/git/branches` | Supported | Native toolbox git CLI wrapper | Lists branches. |
+| `POST /daytona/toolbox/{id}/git/branches` | Supported | Native toolbox git CLI wrapper | Creates a branch. |
+| `DELETE /daytona/toolbox/{id}/git/branches` | Supported | Native toolbox git CLI wrapper | Deletes a branch. |
+| `GET /daytona/toolbox/{id}/git/history` | Supported | Native toolbox git CLI wrapper | Returns commit history in Daytona-shaped JSON. |
+| `GET /daytona/toolbox/{id}/git/status` | Supported | Native toolbox git CLI wrapper | Returns Daytona-shaped git status. |
+| `POST /daytona/toolbox/{id}/git/pull` | Unsupported | No mapping | Remote sync is not implemented. |
+| `POST /daytona/toolbox/{id}/git/push` | Unsupported | No mapping | Remote sync is not implemented. |
+
+## Larger toolbox gaps
+
+| Daytona area | Status | Gap |
+|---|---|---|
+| LSP routes | Unsupported | No language-server backend exists in toolboxd for Daytona LSP APIs. |
+| Computer-use routes | Unsupported | No browser or desktop automation compatibility layer exists. |
+| Interpreter routes | Unsupported | No Daytona interpreter/code-run compatibility layer exists. |
+| Full command interactivity | Partial | Persistent sessions exist, but command input and the richer Daytona command model are not fully implemented. |


### PR DESCRIPTION
This pull request introduces significant enhancements to Daytona compatibility and metadata management in the codebase. The main changes include adding a new persistent metadata layer for Daytona sandboxes, new helper methods for session and metadata lookup, expanded HTTP routing for Daytona endpoints, and comprehensive tests for both the new and existing functionality.

**Daytona Metadata Management and Persistence:**

* Added a new `daytona_sandboxes` table to the database schema to persist Daytona-specific metadata, along with helper methods in the store to upsert, fetch, list, and resolve sandboxes by name. This includes handling for unique name constraints and cascading deletes. (`internal/store/store.go`, `internal/service/daytona.go`, `internal/store/store_test.go`) [[1]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daR89-R103) [[2]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daR514-R618) [[3]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daR885-R921) [[4]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daR953-R979) [[5]](diffhunk://#diff-564e6c00501fbf00b26bac9300922d217f7a64831d7261c6484e78dbb22ea603R1-R23)
* Implemented a new service layer in `internal/service/daytona.go` exposing methods for Daytona metadata operations, delegating to the store.

**Session and API Routing Enhancements:**

* Added a `GetByName` method to the `sessions.Manager` for fetching sessions by stable name, with corresponding tests. (`cmd/toolboxd/sessions/manager.go`, `cmd/toolboxd/sessions/manager_test.go`) [[1]](diffhunk://#diff-8cb5438c5e448181b2936110c5a429f30d635514d362ac7b8692338a386bbb9eR124-R136) [[2]](diffhunk://#diff-8b1c953fa80a7814c3fcc87a8da3d89ec723c5cc627b23f26483206b259cecefR95-R102)
* Expanded the HTTP routing in `cmd/toolboxd/main.go` to support new Daytona-compatible process, file, and git endpoints, and updated the known path logic to recognize these routes. [[1]](diffhunk://#diff-e91f7073ddf9918c24938a18fa5277d310676570cb3e30ec5b26cd08f4866db2R200-R206) [[2]](diffhunk://#diff-e91f7073ddf9918c24938a18fa5277d310676570cb3e30ec5b26cd08f4866db2R217-R248) [[3]](diffhunk://#diff-e91f7073ddf9918c24938a18fa5277d310676570cb3e30ec5b26cd08f4866db2R343-R348) [[4]](diffhunk://#diff-e91f7073ddf9918c24938a18fa5277d310676570cb3e30ec5b26cd08f4866db2R41) [[5]](diffhunk://#diff-e91f7073ddf9918c24938a18fa5277d310676570cb3e30ec5b26cd08f4866db2R72)

**Testing Improvements:**

* Added comprehensive integration tests for the Daytona process session lifecycle, including session creation, command execution, logs retrieval, and deletion. (`cmd/toolboxd/daytona_process_test.go`)
* Extended existing path normalization and store tests to cover new Daytona and file/git routes and the new metadata layer. (`cmd/toolboxd/main_test.go`, `internal/store/store_test.go`) [[1]](diffhunk://#diff-9a10594732b519d5cf53af04ed8d1e18ace982b00effc542fce27b8d298d87c5R35-R36) [[2]](diffhunk://#diff-564e6c00501fbf00b26bac9300922d217f7a64831d7261c6484e78dbb22ea603R1-R23)

These changes lay the groundwork for robust Daytona compatibility, enabling persistent workspace metadata, stable session and sandbox naming, and full API support for Daytona clients.