### PR TITLE
Update API paths and improve toolbox path handling in Daytona

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,26 +33,26 @@ type Config struct {
 	// Runtime is the host default container runtime for new sandboxes.
 	// Per-sandbox CreateSandboxRequest.Runtime overrides it. Allowed values
 	// are "docker" (default), "gvisor", or "kata"; validation lives in Load().
-	Runtime string
-	AutoReconcile       bool
-	EnableCaddy         bool
-	EnableNetworkRules  bool
-	EnableEventMonitor  bool
-	EnableSSHGateway    bool
-	SSHListenAddr       string
-	SSHHostKeyPath      string
+	Runtime                     string
+	AutoReconcile               bool
+	EnableCaddy                 bool
+	EnableNetworkRules          bool
+	EnableEventMonitor          bool
+	EnableSSHGateway            bool
+	SSHListenAddr               string
+	SSHHostKeyPath              string
 	CredentialEncryptionKey     string
 	CredentialEncryptionKeyPath string
 	MountsRootPath              string
 	MountsCredentialsRuntimeDir string
 	MountWaitTimeout            time.Duration
-	LogLevel                 string
-	ShutdownTimeout          time.Duration
-	HTTPClientTimeout        time.Duration
-	DockerRuntimeWaitTimeout time.Duration
-	ToolboxWaitTimeout       time.Duration
-	ReconcileInterval        time.Duration
-	UploadMaxBytes           int64
+	LogLevel                    string
+	ShutdownTimeout             time.Duration
+	HTTPClientTimeout           time.Duration
+	DockerRuntimeWaitTimeout    time.Duration
+	ToolboxWaitTimeout          time.Duration
+	ReconcileInterval           time.Duration
+	UploadMaxBytes              int64
 
 	// Admission control. Admission is purely resource-math: CPU/memory
 	// reservation ratios plus a live memory floor. There is no fixed sandbox
@@ -113,41 +113,41 @@ func Load() (Config, error) {
 	defaultToolboxPath := filepath.Join(filepath.Dir(exe), "toolboxd")
 
 	cfg := Config{
-		PATToken:            strings.TrimSpace(os.Getenv("SB_PAT_TOKEN")),
-		APIHost:             getEnv("SB_API_HOST", "0.0.0.0"),
-		APIPort:             getEnvInt("SB_API_PORT", 21212),
-		Domain:              normalizeHost(os.Getenv("SB_DOMAIN")),
-		PublicHost:          normalizeHost(getEnv("SB_PUBLIC_HOST", "127.0.0.1")),
-		CaddyAdminURL:       getEnv("SB_CADDY_ADMIN_URL", "http://127.0.0.1:2019"),
-		CaddyServerID:       getEnv("SB_CADDY_SERVER_ID", "srv0"),
-		DBPath:              getEnv("SB_DB_PATH", "/var/lib/sandboxd/state.db"),
-		DockerNetwork:       getEnv("SB_DOCKER_NETWORK", "bridge"),
-		ToolboxBinaryPath:   getEnv("SB_TOOLBOX_BINARY_PATH", defaultToolboxPath),
-		ToolboxMountPath:    getEnv("SB_TOOLBOX_MOUNT_PATH", "/usr/local/bin/toolboxd"),
-		ToolboxPort:         getEnvInt("SB_TOOLBOX_PORT", defaultToolboxPort),
-		IdleTimeoutMinutes:  getEnvInt("SB_IDLE_TIMEOUT_MIN", 0),
-		ContainerPrivileged: getEnvBool("SB_CONTAINER_PRIVILEGED", false),
-		ResourceLimitsOff:   getEnvBool("SB_RESOURCE_LIMITS_DISABLED", false),
-		Runtime:             getEnv("SB_CONTAINER_RUNTIME", models.RuntimeDocker),
-		AutoReconcile:       getEnvBool("SB_AUTO_RECONCILE", true),
-		EnableCaddy:         getEnvBool("SB_ENABLE_CADDY", true),
-		EnableNetworkRules:  getEnvBool("SB_ENABLE_NETWORK_RULES", true),
-		EnableEventMonitor:  getEnvBool("SB_ENABLE_EVENT_MONITOR", true),
-		EnableSSHGateway:    getEnvBool("SB_ENABLE_SSH_GATEWAY", true),
-		SSHListenAddr:       getEnv("SB_SSH_LISTEN_ADDR", "0.0.0.0:2220"),
-		SSHHostKeyPath:      getEnv("SB_SSH_HOST_KEY_PATH", "/var/lib/sandboxd/ssh_host_ed25519_key"),
+		PATToken:                    strings.TrimSpace(os.Getenv("SB_PAT_TOKEN")),
+		APIHost:                     getEnv("SB_API_HOST", "0.0.0.0"),
+		APIPort:                     getEnvInt("SB_API_PORT", 21212),
+		Domain:                      normalizeHost(os.Getenv("SB_DOMAIN")),
+		PublicHost:                  normalizeHost(getEnv("SB_PUBLIC_HOST", "127.0.0.1")),
+		CaddyAdminURL:               getEnv("SB_CADDY_ADMIN_URL", "http://127.0.0.1:2019"),
+		CaddyServerID:               getEnv("SB_CADDY_SERVER_ID", "srv0"),
+		DBPath:                      getEnv("SB_DB_PATH", "/var/lib/sandboxd/state.db"),
+		DockerNetwork:               getEnv("SB_DOCKER_NETWORK", "bridge"),
+		ToolboxBinaryPath:           getEnv("SB_TOOLBOX_BINARY_PATH", defaultToolboxPath),
+		ToolboxMountPath:            getEnv("SB_TOOLBOX_MOUNT_PATH", "/usr/local/bin/toolboxd"),
+		ToolboxPort:                 getEnvInt("SB_TOOLBOX_PORT", defaultToolboxPort),
+		IdleTimeoutMinutes:          getEnvInt("SB_IDLE_TIMEOUT_MIN", 0),
+		ContainerPrivileged:         getEnvBool("SB_CONTAINER_PRIVILEGED", false),
+		ResourceLimitsOff:           getEnvBool("SB_RESOURCE_LIMITS_DISABLED", false),
+		Runtime:                     getEnv("SB_CONTAINER_RUNTIME", models.RuntimeDocker),
+		AutoReconcile:               getEnvBool("SB_AUTO_RECONCILE", true),
+		EnableCaddy:                 getEnvBool("SB_ENABLE_CADDY", true),
+		EnableNetworkRules:          getEnvBool("SB_ENABLE_NETWORK_RULES", true),
+		EnableEventMonitor:          getEnvBool("SB_ENABLE_EVENT_MONITOR", true),
+		EnableSSHGateway:            getEnvBool("SB_ENABLE_SSH_GATEWAY", true),
+		SSHListenAddr:               getEnv("SB_SSH_LISTEN_ADDR", "0.0.0.0:2220"),
+		SSHHostKeyPath:              getEnv("SB_SSH_HOST_KEY_PATH", "/var/lib/sandboxd/ssh_host_ed25519_key"),
 		CredentialEncryptionKey:     strings.TrimSpace(os.Getenv("SB_CREDENTIAL_ENCRYPTION_KEY")),
 		CredentialEncryptionKeyPath: getEnv("SB_CREDENTIAL_ENCRYPTION_KEY_PATH", "/var/lib/sandboxd/credential_encryption.key"),
 		MountsRootPath:              getEnv("SB_MOUNTS_ROOT", "/var/lib/sandboxd/mounts"),
 		MountsCredentialsRuntimeDir: getEnv("SB_MOUNTS_CRED_DIR", "/run/sandboxd"),
 		MountWaitTimeout:            getEnvDuration("SB_MOUNT_WAIT_TIMEOUT", 30*time.Second),
-		LogLevel:            strings.ToLower(getEnv("SB_LOG_LEVEL", "info")),
-		ShutdownTimeout:          getEnvDuration("SB_SHUTDOWN_TIMEOUT", 10*time.Second),
-		HTTPClientTimeout:        getEnvDuration("SB_HTTP_CLIENT_TIMEOUT", 60*time.Second),
-		DockerRuntimeWaitTimeout: getEnvDuration("SB_DOCKER_WAIT_TIMEOUT", 30*time.Second),
-		ToolboxWaitTimeout:       getEnvDuration("SB_TOOLBOX_WAIT_TIMEOUT", 30*time.Second),
-		ReconcileInterval:        getEnvDuration("SB_RECONCILE_INTERVAL", 5*time.Minute),
-		UploadMaxBytes:           int64(getEnvInt("SB_UPLOAD_MAX_BYTES", 256*1024*1024)),
+		LogLevel:                    strings.ToLower(getEnv("SB_LOG_LEVEL", "info")),
+		ShutdownTimeout:             getEnvDuration("SB_SHUTDOWN_TIMEOUT", 10*time.Second),
+		HTTPClientTimeout:           getEnvDuration("SB_HTTP_CLIENT_TIMEOUT", 180*time.Second),
+		DockerRuntimeWaitTimeout:    getEnvDuration("SB_DOCKER_WAIT_TIMEOUT", 30*time.Second),
+		ToolboxWaitTimeout:          getEnvDuration("SB_TOOLBOX_WAIT_TIMEOUT", 30*time.Second),
+		ReconcileInterval:           getEnvDuration("SB_RECONCILE_INTERVAL", 5*time.Minute),
+		UploadMaxBytes:              int64(getEnvInt("SB_UPLOAD_MAX_BYTES", 256*1024*1024)),
 
 		CPUReservationRatio:       getEnvFloat("SB_CPU_RESERVATION_RATIO", 0.9),
 		MemoryReservationRatio:    getEnvFloat("SB_MEMORY_RESERVATION_RATIO", 0.85),

--- a/packaging/Caddyfile.template
+++ b/packaging/Caddyfile.template
@@ -19,7 +19,7 @@ https://{{ROOT_SITE_ADDRESS}} {
     tls {
         dns {{DNS_PROVIDER}} {env.SB_DNS_API_TOKEN}
     }
-    @api path /health /v1 /v1/*
+    @api path /health /v1 /v1/* /daytona /daytona/*
     handle @api {
         reverse_proxy 127.0.0.1:21212
     }

--- a/pkg/api/daytona/toolbox.go
+++ b/pkg/api/daytona/toolbox.go
@@ -42,7 +42,7 @@ func (h *handlers) toolbox(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	path := strings.TrimPrefix(r.PathValue("path"), "/")
+	path := normalizeToolboxPath(r.PathValue("path"))
 	switch {
 	case r.Method == http.MethodGet && path == "":
 		h.forwardToolbox(w, r, sandboxID, "/")
@@ -81,6 +81,17 @@ func (h *handlers) toolbox(w http.ResponseWriter, r *http.Request) {
 	default:
 		apihttp.WriteError(w, http.StatusNotImplemented, "daytona toolbox route not implemented")
 	}
+}
+
+func normalizeToolboxPath(path string) string {
+	trimmed := strings.Trim(strings.TrimSpace(path), "/")
+	if trimmed == "toolbox" {
+		return ""
+	}
+	if strings.HasPrefix(trimmed, "toolbox/") {
+		return strings.TrimPrefix(trimmed, "toolbox/")
+	}
+	return trimmed
 }
 
 func (h *handlers) executeCommand(w http.ResponseWriter, r *http.Request, sandboxID string) {

--- a/pkg/api/daytona/toolbox_test.go
+++ b/pkg/api/daytona/toolbox_test.go
@@ -1,0 +1,26 @@
+package daytona
+
+import "testing"
+
+func TestNormalizeToolboxPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "empty path stays empty", path: "", want: ""},
+		{name: "leading slash trimmed", path: "/process/execute", want: "process/execute"},
+		{name: "generated toolbox prefix stripped", path: "toolbox/process/execute", want: "process/execute"},
+		{name: "generated toolbox prefix stripped with slashes", path: "/toolbox/files/info/", want: "files/info"},
+		{name: "bare toolbox maps to root", path: "toolbox", want: ""},
+		{name: "plain path preserved", path: "git/status", want: "git/status"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeToolboxPath(tc.path); got != tc.want {
+				t.Fatalf("normalizeToolboxPath(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+		})
+	}
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -588,7 +588,7 @@ https://$DOMAIN:8443 {
 	tls {
 		dns $DNS_PROVIDER {env.SB_DNS_API_TOKEN}
 	}
-	@api path /health /v1 /v1/*
+	@api path /health /v1 /v1/* /daytona /daytona/*
 	handle @api {
 		reverse_proxy 127.0.0.1:21212
 	}


### PR DESCRIPTION
This pull request introduces improvements to the handling of toolbox API paths, expands API routing in Caddy configuration files, and adjusts a configuration timeout. The most significant changes are grouped below.

### Toolbox API Path Handling

* Introduced a new function `normalizeToolboxPath` in `pkg/api/daytona/toolbox.go` to standardize and clean up incoming toolbox API paths, ensuring consistent routing logic. [[1]](diffhunk://#diff-641b8c2afffb3e55cb2017e7d4462f4fe4a0911160ebe7f8751e6ed3a8656d57L45-R45) [[2]](diffhunk://#diff-641b8c2afffb3e55cb2017e7d4462f4fe4a0911160ebe7f8751e6ed3a8656d57R86-R96)
* Added a unit test `TestNormalizeToolboxPath` in `pkg/api/daytona/toolbox_test.go` to verify correct path normalization for various input cases.

### API Routing Updates

* Updated the API route matcher in `packaging/Caddyfile.template` and `scripts/install.sh` to include `/daytona` and `/daytona/*` paths, ensuring requests to these endpoints are properly proxied. [[1]](diffhunk://#diff-cbf76e4c5183605606ac16a3ae0a1e219cf4991ccc9fc1afa0cd5fa24beb4177L22-R22) [[2]](diffhunk://#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09ccL591-R591)

### Configuration Adjustment

* Increased the default `HTTPClientTimeout` in `internal/config/config.go` from 60 seconds to 180 seconds, allowing longer-running HTTP operations before timing out.