### PR TITLE
feat(docs): add SKILLS.md for comprehensive changes

### DIFF
--- a/.claude/skills/add-daytona-route/SKILL.md
+++ b/.claude/skills/add-daytona-route/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: add-daytona-route
+description: Add a Daytona-SDK-compatible route under /daytona/... by translating Daytona's wire shape to internal/service calls. Keeps version branching out of internal/. Use when the user asks to "support this in the Daytona facade", "add a /daytona route", "make Daytona SDK work with X", or wants to extend Daytona compatibility coverage. Proactively suggest when adding a feature that has a corresponding Daytona SDK call.
+---
+
+# Add a Daytona compatibility route
+
+The Daytona facade lives at `pkg/api/daytona/` and translates Daytona's wire shape to `pkg/models` + `service.Service` calls.
+
+**No version-specific branching in `internal/`.** If you find yourself wanting `if facade == "daytona"` inside `internal/service`, stop — that translation belongs in the facade.
+
+## File layout
+
+```
+pkg/api/daytona/
+  routes.go             Route table.
+  handlers.go           Wire decode → service call → wire encode.
+  dto.go                Daytona-shaped request/response types.
+  meta.go               Daytona-specific metadata helpers.
+  toolbox.go            Toolbox-proxy paths (/daytona/toolbox/{id}/...).
+  contract_test.go      Wire-level contract tests.
+  contract_harness_test.go
+  routes_test.go
+  handlers_test.go
+  toolbox_test.go
+```
+
+## Steps
+
+1. **Route.** Add to `pkg/api/daytona/routes.go`. Follow the existing pattern:
+   ```go
+   mux.Handle("POST "+PathPrefix+"/sandbox/{idOrName}/myop", d.Auth(http.HandlerFunc(h.myOp)))
+   ```
+   The `PathPrefix` constant is `/daytona`. Use `{idOrName}` (not `{id}`) where Daytona's API accepts either form — the existing handlers resolve names via `Store.ResolveDaytonaSandboxID`.
+2. **Handler.** Add to `pkg/api/daytona/handlers.go`. Translate the Daytona DTO into a `pkg/models.*` shape, then call `service.*`.
+3. **DTO.** If the Daytona wire shape differs from `pkg/models`, add a translation type in `pkg/api/daytona/dto.go`. Don't pollute `pkg/models` with Daytona-shaped fields.
+4. **Daytona-specific metadata** (labels, name aliases, autostop/autodelete intervals) goes through `Service.UpsertDaytonaMetadata` / `Store.UpsertDaytonaMetadata`. Business logic lives in `internal/service/daytona.go`.
+5. **Update the support table** in `plans/sdk-compatibility/daytona/control-plane-matrix.md` or `toolbox-matrix.md`. Move rows from "Unsupported" to "Supported" / "Partial".
+6. **Contract test.** Add to `pkg/api/daytona/contract_test.go` — these check the wire shape matches what the Daytona SDK expects.
+
+## Hard rules (same as `/v1`)
+
+- **Idempotency** is required (`pr-review.md` §1). Retries must be safe under the Daytona SDK's retry policy too — Daytona clients can be more aggressive than native ones.
+- **Sandbox-boot impact** must be called out in the PR if the new route triggers a create path.
+- **Failure-path consistency** must be documented for any route that writes to both caddy and the store.
+
+## Where Daytona behaves differently from `/v1`
+
+- Identifiers can be sandbox ID *or* user-supplied name → use `{idOrName}` and resolve via the store helper.
+- Labels and metadata are first-class on Daytona but live in a separate metadata table on the AerolVM side.
+- `/daytona/toolbox/{id}/...` is a thin proxy to the in-sandbox toolbox; see `toolbox.go`.

--- a/.claude/skills/add-docs-page/SKILL.md
+++ b/.claude/skills/add-docs-page/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: add-docs-page
+description: Add a new AerolVM docs page (.mdx) with synced five-language tabs and register it in the Starlight sidebar. Enforces the repo's hard rules — no raw curl, all five SDK languages, syncKey="lang" on every tab block. Use when the user asks to "add a docs page", "document this feature", "write the docs for X", or after shipping a user-facing capability that isn't documented yet. Proactively suggest after a new SDK method or top-level feature lands.
+---
+
+# Add a docs page
+
+## Hard rules (from CLAUDE.md)
+
+- **No raw curl / HTTP examples.** Only the install one-liner in `getting-started.md` may use curl. Every other code example uses one of the five SDK languages.
+- **New top-level feature → new `.mdx` file**, not a subsection on an existing page.
+- **Every code example covers all five SDK languages** in `<Tabs syncKey="lang">` blocks. Order: TypeScript, Python, Go, Rust, Java.
+
+## Steps
+
+1. **Create the file.** `docs/src/content/docs/<slug>.mdx`. Use `.mdx` (not `.md`) — feature pages need MDX for `<Tabs>`.
+2. **Frontmatter:**
+   ```yaml
+   ---
+   title: Human-Readable Title
+   description: One-line summary used in metadata + sidebar.
+   ---
+   ```
+3. **Tabbed examples:**
+   ```mdx
+   import { Tabs, TabItem } from '@astrojs/starlight/components'
+
+   <Tabs syncKey="lang">
+     <TabItem label="TypeScript">…</TabItem>
+     <TabItem label="Python">…</TabItem>
+     <TabItem label="Go">…</TabItem>
+     <TabItem label="Rust">…</TabItem>
+     <TabItem label="Java">…</TabItem>
+   </Tabs>
+   ```
+   Same `syncKey="lang"` across every Tabs block on the page (and the site) so picking a language sticks.
+4. **Register in the sidebar.** Edit `docs/src/content.config.ts` (note: file is `content.config.ts`, not `content/config.ts`):
+   - Pick a `NavigationCategory` (`OVERVIEW`, `SANDBOX`, `TOOLBOX`, `ACCESS`, `SDKS`, `FEATURES`, `USE_CASES`).
+   - Add an entry to the right group in `getDocsSidebarConfig()` (or `getUseCasesSidebarConfig()` for use-cases):
+     ```ts
+     { type: 'link', href: '/<slug>', label: 'Label', description: 'Sidebar hover text.' }
+     ```
+5. **Local preview:** `make docs-dev` → http://localhost:4321.
+6. **Build smoke-test:** `make docs-build` before committing.
+
+## Style
+
+- Open with a one-paragraph description of *what the feature is and why a user wants it*, not implementation detail.
+- Lead with the simplest working code example, then expand.
+- Keep tab content roughly the same length per language — large length skew suggests an inconsistent example.

--- a/.claude/skills/add-e2b-route/SKILL.md
+++ b/.claude/skills/add-e2b-route/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: add-e2b-route
+description: Add an E2B-SDK-compatible route under /e2b/... by mirroring the Daytona facade pattern. The /e2b package does not exist yet — copy pkg/api/daytona/ as the template. Forces the open create-idempotency design question to be answered before coding. Use when the user asks to "build the e2b facade", "add an /e2b route", "make E2B Python SDK work with X", or work on plans/sdk-compatibility/e2b/. Proactively suggest when an E2B SDK call needs server-side support.
+---
+
+# Add an E2B compatibility route
+
+E2B compatibility is **planned, not yet built**. The canonical design is in [`plans/sdk-compatibility/e2b/facade-plan.md`](../../plans/sdk-compatibility/e2b/facade-plan.md). Read it before coding — the open design questions there are not optional polish, they're blockers.
+
+## Status
+
+- `pkg/api/e2b/` does **not exist yet**. The first PR that adds an `/e2b` route creates it.
+- `internal/service/e2b.go` exists and currently holds metadata-storage helpers (Upsert/Get/List/Delete for sandbox metadata and snapshots).
+- `pkg/models/e2b.go` exists with `E2BSandboxMetadata` and `E2BSnapshotMetadata`.
+- Store helpers exist on `*Store`: `UpsertE2BSandboxMetadata`, `GetE2BSandboxMetadata`, `ListE2BSandboxMetadata`, `UpsertE2BSnapshot`, `GetE2BSnapshot`, `ListE2BSnapshots`, `DeleteE2BSnapshot`.
+
+## Steps
+
+1. **Create the package.** Copy the file shape of `pkg/api/daytona/`:
+   ```
+   pkg/api/e2b/
+     routes.go        const PathPrefix = "/e2b"; RegisterRoutes(mux, Deps)
+     handlers.go      newHandlers(Deps); thin wire ↔ service translation
+     dto.go           E2B-shaped DTOs
+     contract_test.go E2B SDK wire-shape contracts
+     handlers_test.go
+   ```
+2. **Wire into the server.** In `pkg/api/server.go` `routes()`, add `e2b.RegisterRoutes(s.mux, e2b.Deps{...})` next to the existing `daytona.RegisterRoutes` and `apiv1.RegisterRoutes` calls. The Deps shape is the same (`Service`, `Logger`, `Auth`).
+3. **Service-layer helpers** go in `internal/service/e2b.go`. Keep `internal/service` version-agnostic — no `if facade == "e2b"`.
+4. **Store helpers** go in `internal/store/store.go`. Mirror the existing `Daytona*` and `E2B*` shapes. Use additive schema only.
+5. **Update** `plans/sdk-compatibility/e2b/facade-plan.md` support tables when you mark a route done.
+
+## Blocker: create-path idempotency
+
+`POST /e2b/sandboxes` is the open design question.
+
+The upstream E2B create body has `templateID`, timeout/lifecycle inputs, metadata, env vars, network options, secure mode, and volume mounts — but **no caller-supplied sandbox name, alias, or request ID**. There is no natural stable key for retry deduplication.
+
+You must pick a deterministic retry story before coding the create handler. Options (in order of preference):
+
+1. **Persisted request fingerprint.** Hash the canonical form of the create body, persist `(fingerprint, sandbox_id)` in a new table, and dedupe within a TTL window. Survives daemon restarts. Required schema change in `internal/store/store.go`.
+2. **Explicit `Idempotency-Key` header.** E2B SDK doesn't send one today, but the facade can accept one and propagate it. Sandbox under the assumption that clients without the header get a documented "may double-create on retry" warning.
+3. **Best-effort dedupe in memory.** Simplest; loses guarantees across daemon restarts. Not acceptable for production per `pr-review.md` §1 — listed only to be argued against.
+
+Whichever you pick, write it down in the facade-plan.md and the PR description.
+
+## Idempotency for other E2B routes
+
+Each of these needs an explicit retry story (`pr-review.md` §1):
+
+- `POST /e2b/sandboxes/{id}/connect`
+- `POST /e2b/sandboxes/{id}/pause`
+- `POST /e2b/sandboxes/{id}/timeout`
+- `POST /e2b/sandboxes/{id}/snapshots`
+- `DELETE /e2b/templates/{id}`
+
+Pattern from the existing facades: lookups return the existing resource on retry; state transitions are no-ops if already in the target state.

--- a/.claude/skills/add-mount-adapter/SKILL.md
+++ b/.claude/skills/add-mount-adapter/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: add-mount-adapter
+description: Add an external-storage mount adapter (S3, NFS, SSHFS, rclone, etc.) under pkg/mounts/adapters/. Enforces the host-side input threat model and the per-sandbox cleanup contract. Use when the user asks to "add a mount type", "support mounting X", "add a storage adapter", or wants AerolVM sandboxes to consume a new backing storage. Proactively suggest when a feature request implies a new mount backend.
+---
+
+# Add an external-storage mount adapter
+
+## Threat-model warning (read first)
+
+Mount inputs run on the host, **outside** the microVM isolation boundary, as the daemon user:
+
+- `source` is passed to mount-tool commands
+- `options.opts` (NFS) is passed verbatim
+- `options.extra_args` (S3) is passed verbatim
+- mount-tool flags generally
+
+**The current assumption is "PAT holder == host operator".** PAT holders are trusted as if they had shell on the host. Their mount input is already-trusted by the threat model.
+
+**If this PR widens what a PAT holder can pass into a host-side mount command, you must explicitly re-justify safety under that assumption** in the PR template's mount section. If anyone is considering moving to multi-tenant PATs (sub-accounts, hosted offering, external CI) — these fields become a host attack surface and must be allowlisted / isolated. See `pr-review.md` §5.
+
+## File layout
+
+```
+pkg/mounts/
+  manager.go            Top-level Manager + adapter dispatch.
+  types.go              Mount type interface; Mount, MountSpec, etc.
+  sweep.go              Background unmount sweep for orphaned sandboxes.
+  adapters/             ← new adapter goes here
+    <yourthing>.go
+  manager_test.go
+  recovery_test.go
+```
+
+## Steps
+
+1. **New adapter file** under `pkg/mounts/adapters/`. Implement the adapter interface (look at the existing adapters for the exact shape — it's small and stable). The adapter must support:
+   - `Mount(ctx, sandboxID, spec)` — installs the mount, returns the host path for the docker bind.
+   - `Unmount(sandboxID)` — must be idempotent; called from `mounts.UnmountAll` on cleanup *and* by the sweep.
+   - Validation hooks for the adapter-specific options.
+2. **Register** in the manager's adapter table in `pkg/mounts/manager.go`. Look for the existing dispatch — add a case for your mount kind.
+3. **Validate inputs at the adapter boundary.** Schemes, control characters in `source`, and any flags you copy through. Even though the threat model trusts PATs today, garbage-in errors should be 4xx-shaped at the API, not opaque mount-tool stderr.
+4. **Credentials.** If your adapter needs secrets, seal them via `pkg/secrets.Cipher` so they're encrypted at rest in the DB. The `MountsCredentialsRuntimeDir` is wiped + recreated on daemon start.
+5. **Idempotency.** Re-mounting the same `(sandboxID, mountPath)` must be a no-op, not a "already mounted" error.
+6. **Tests.** Add to `pkg/mounts/manager_test.go` (happy path + validation) and `recovery_test.go` (sweep / orphan cleanup).
+7. **Docs.** Add to `docs/src/content/docs/external-storage.mdx` with all five SDK languages and `syncKey="lang"`. No curl.
+
+## Limits
+
+`models.MaxMountsPerSandbox` caps per-sandbox mount count. Don't bypass it for your adapter.
+
+## What you must call out in the PR
+
+- Anything you add to the `CreateSandbox` boot path via `mounts.MountAll` (most adapters fire here on every sandbox create). State the per-mount latency expectation.
+- Any new field on `models.Mount` (ripples to facades + SDK Go transport).
+- Any new place that runs a host command — re-check the threat-model paragraph above.

--- a/.claude/skills/add-sdk-method/SKILL.md
+++ b/.claude/skills/add-sdk-method/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: add-sdk-method
+description: Add a method across all five AerolVM SDKs (TypeScript, Python, Go, Rust, Java) in lockstep, plus the synced docs example. Use when the user asks to "expose this in the SDK", "add an SDK method", "wire this up in the clients", or whenever a new /v1 endpoint needs SDK coverage. Proactively suggest after a new /v1 endpoint lands to keep SDK parity.
+---
+
+# Add a method to all five SDKs
+
+The SDKs are kept lockstep so the docs' five-tab examples stay accurate.
+Touching one SDK without the others should be rare and explained in the PR.
+
+## Per-SDK file map
+
+| SDK | Public surface | Transport (versioned) | Tests |
+|---|---|---|---|
+| TypeScript | `sdk/typescript/src/Sandbox.ts`, `MicroVM.ts`, `types.ts` | `sdk/typescript/src/internal/api/v1/` | `sdk/typescript/src/*.test.ts` |
+| Python | `sdk/python/microvm/client.py`, `types.py` | `sdk/python/microvm/_internal/api/v1/` | `sdk/python/tests/` |
+| Go | `sdk/go/pkg/microvm/`, `sdk/go/pkg/types/` | `sdk/go/internal/apiclient/v1/` | `*_test.go` next to source |
+| Rust | `sdk/rust/src/lib.rs`, `types.rs` | `sdk/rust/src/` | inline `#[cfg(test)]` |
+| Java | `sdk/java/src/main/java/...` | same tree | `sdk/java/src/test/java/...` |
+
+## Per-SDK steps (repeat 5×)
+
+1. Add request/response types in that SDK's `types.*`.
+2. Add the transport call in the `v1/` (or equivalent) versioned module.
+   **Use the SDK's existing `versioned()` helper / `apiVersion` option — do not
+   hand-build `/v1/...` URLs at the call site.** This is what lets `apiVersion`
+   pin work without rewriting every method.
+3. Surface the new method on the public client (`Sandbox` or `MicroVM`).
+4. Add a test.
+5. If this SDK is the canonical example for any docs page, update the example.
+
+## Verify locally
+
+```
+(cd sdk/typescript && npm ci && npm run build && npm test)
+(cd sdk/python && python -m unittest discover -s tests -v)
+(cd sdk/go && go test ./...)
+(cd sdk/rust && cargo test)
+(cd sdk/java && mvn -B -ntp test)
+```
+
+CI is path-filtered (`.github/workflows/test.yml`) — only the SDKs whose folders changed will run on PR, so local verification of unchanged SDKs is the only way to catch parity drift before merge.
+
+## Style
+
+- **One PR per method, all 5 SDKs.** Splitting drift across PRs has burned us — keep parity atomic.
+- **No version-leakage into the public surface.** Callers pick `apiVersion`; method signatures don't include `v1`.
+- **Match the existing argument style of nearby methods** in each SDK. Don't impose Go-isms on Python, etc.

--- a/.claude/skills/add-store-column/SKILL.md
+++ b/.claude/skills/add-store-column/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: add-store-column
+description: Add a column or table to the SQLite store at internal/store/store.go. Covers idempotent CREATE/ALTER, scanner updates, Create/Upsert wiring, and the mandatory regression test for host-port pool changes. Use when the user asks to "add a column to the store", "persist X for sandboxes", "store this in the database", or any schema change. Proactively suggest when a feature needs durable per-sandbox state.
+---
+
+# Add a column / table to the store
+
+## Architecture constraints
+
+- **SQLite, single-writer in-process.** `Open()` sets `MaxOpenConns=1` so API handlers, the event monitor, and background sweeps queue through `database/sql` instead of racing separate SQLite connections into "database is locked". Don't add a second `*sql.DB`.
+- **No migrations framework.** The schema is additive + idempotent on startup: `CREATE TABLE IF NOT EXISTS` and additive `ALTER TABLE` only. Renames and drops are not supported.
+- **Secrets on disk.** `env_json`, `toolbox_token`, and sealed mount blobs live in this DB. `Open()` chmods the directory and file to 0700. Don't loosen those modes.
+
+## Steps
+
+1. **Edit `internal/store/store.go`:**
+   - **New table:** add a `CREATE TABLE IF NOT EXISTS …` statement to the `stmts` slice in `Open()`.
+   - **New column on existing table:** add an `ALTER TABLE … ADD COLUMN … DEFAULT …` after the `CREATE TABLE IF NOT EXISTS` for that table. Adding a column with a `DEFAULT` is safe on existing rows.
+   - **Foreign keys:** keep `PRAGMA foreign_keys = ON;` (already set).
+
+2. **Read path:** update the matching `scan*` function (`scanSandbox`, `scanDaytonaMetadata`, `scanE2BSandboxMetadata`, `scanE2BSnapshotMetadata`, `scanSnapshot`, …) so the new column is loaded into the model.
+
+3. **Write path:** update `Create` and/or `Upsert` so the new column is inserted/updated. For sandboxes that's `Store.Create` and `Store.Upsert`.
+
+4. **Models:** if the column belongs on a wire DTO, mirror it on `pkg/models/*.go`. Be aware that `pkg/models` is shared between the server, the facades, and the SDKs' internal Go transport — a field added there ripples widely. Keep DTOs lean.
+
+5. **Tests:** add a regression test in `internal/store/store_test.go`.
+
+## Mandatory regression tests
+
+A regression test in `internal/store/store_test.go` is **required** (not optional) if your change touches any of:
+
+- `Store.TryReserveHostPort` semantics
+- The partial unique index on `exposed_ports.host_port`
+- `Service.allocateHostPort` allocator loop
+
+Filling in the PR template's "L4 / host-port-pool changes" section linking the test is also required. See `pr-review.md` §7.
+
+## Common scanner functions (current)
+
+`store.go` has scanners around line 1115+: `scanSandbox`, `scanDaytonaMetadata`, `scanE2BSandboxMetadata`, `scanE2BSnapshotMetadata`, `scanSnapshot`. If you add a new table, add a `scan<NewType>` next to the others.

--- a/.claude/skills/add-v1-endpoint/SKILL.md
+++ b/.claude/skills/add-v1-endpoint/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: add-v1-endpoint
+description: Add a new route under /v1/... to the AerolVM HTTP server. Walks through DTOs, handler, route registration, service-layer call, tests, and the idempotency check. Use when the user asks to "add a v1 endpoint", "add an API route", "add a new HTTP handler", or describes a new sandbox/admin operation that needs to be exposed over /v1. Proactively suggest when the user proposes a server feature without saying which version it belongs in — and remind them v1 is soft-frozen.
+---
+
+# Add a `/v1` endpoint
+
+**Hard constraint:** `/v1` is **soft-frozen** (see `pr-review.md` §6).
+
+- Adding a brand-new route → fine.
+- Changing an existing v1 response body, status code, header, or path → **not fine**. Put it in `pkg/api/v2/` instead.
+- No `if version == "v1"` branching in `internal/`. The service layer is version-agnostic.
+
+## Steps
+
+1. **DTOs.** Add request + response types to `pkg/api/v1/dto.go` if they're version-shaped. If they match `pkg/models/*`, reuse those directly — don't duplicate.
+2. **Handler.** Add a method on `*handlers` in `pkg/api/v1/handlers.go`. Keep it thin:
+   ```go
+   func (h *handlers) myThing(w http.ResponseWriter, r *http.Request) {
+       var req models.MyRequest
+       if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+           apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
+           return
+       }
+       resp, err := h.deps.Service.MyThing(r.Context(), req)
+       if err != nil {
+           apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+           return
+       }
+       apihttp.WriteJSON(w, http.StatusOK, resp)
+   }
+   ```
+   - Use `apihttp.WriteStoreAwareError` so `models.ErrNotFound` / capacity errors map to the right status.
+3. **Route.** Register in `pkg/api/v1/routes.go` with the method baked into the pattern and `d.Auth(...)`:
+   ```go
+   mux.Handle("POST "+PathPrefix+"/my/route", d.Auth(http.HandlerFunc(h.myThing)))
+   ```
+4. **Service method.** Add the business logic on `*service.Service` (in `internal/service/`, topical file).
+5. **Tests.** Add a handler-level test in `pkg/api/v1/routes_test.go` AND a service test in `internal/service/*_test.go`.
+
+## Before opening the PR
+
+Answer these in your head (and fill in the PR template):
+
+- **Idempotency** (`pr-review.md` §1): what happens if this exact request is retried 5× concurrently with the same inputs? Retrying must not leak resources or return "already exists".
+- **Sandbox boot impact** (`pr-review.md` §2): does this add ANY work to `CreateSandbox` or anything it transitively calls? If yes, call it out explicitly — even "only on the first call" counts.
+- **Failure-path consistency** (`pr-review.md` §4): if the handler writes to both caddy and the store, what cleans up on partial failure?

--- a/.claude/skills/touch-create-sandbox/SKILL.md
+++ b/.claude/skills/touch-create-sandbox/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: touch-create-sandbox
+description: Safely modify Service.CreateSandbox or anything it transitively calls. Walks the boot path step-by-step, enforces the failure-cleanup rules, and reminds you to document boot-latency impact in the PR. Use when the user asks to "change sandbox creation", "add this to sandbox boot", "modify CreateSandbox", or any change that lands inside internal/service/service.go near the create path. Proactively suggest as soon as a change is proposed that adds DB queries, HTTP calls, file I/O, or lock acquisitions to sandbox boot.
+---
+
+# Touch `CreateSandbox` / the sandbox boot path
+
+`Service.CreateSandbox` (`internal/service/service.go:80`) latency is a load-bearing UX metric. Treat the boot path as protected.
+
+## The boot path, in order
+
+1. `normalizeCreateRequest(req)` + image / runtime / mount / lifecycle / GPU validation
+2. `s.sealMounts(req.Mounts)` (AEAD via `pkg/secrets`)
+3. Generate `toolboxToken`, sandbox SSH keypair, sandbox ID
+4. `s.admitter.Admit(...)` — capacity reservation
+5. `s.mounts.MountAll(...)` — external storage mount
+6. `s.docker.Create(...)` — container creation
+7. Store row insert (`Store.Create`) + caddy route install
+
+## Failure-cleanup rules
+
+Every failure path **below** admission must call `releaseAdmission()`. Every failure path **below** `mounts.MountAll` must call `cleanupMounts()`. These are local closures in `CreateSandbox` — use them, don't reinvent.
+
+If you add a new step between two existing steps, ALSO add a defer/cleanup for it and call out the rollback rule in the PR description's "Failure-path consistency" section.
+
+## What you must document in the PR
+
+Fill in **"Sandbox boot impact"** in the PR template. Don't leave it blank.
+
+Answer:
+- What was added (DB query, HTTP round-trip, file I/O, lock acquisition)?
+- Expected added latency in the success case
+- When it fires (every create? first create? on a flag? on a feature gate?)
+- Whether it's bounded
+
+> "It's only on the first call" is **still impact** and must be called out.
+
+If the added work is best-effort and could fail on a cold start, use the lazy-bootstrap pattern instead of putting it inline. See `Service.EnsureLayer4Ready` in `internal/service/service.go` as the canonical shape.
+
+## The lazy-bootstrap pattern (when "first-call only" is justified)
+
+```go
+type Service struct {
+    xMu    sync.Mutex     // serializes the slow path
+    xReady atomic.Bool    // lock-free fast-path latch
+}
+
+func (s *Service) EnsureXReady(ctx context.Context) error {
+    if s.xReady.Load() { return nil }        // fast path: single atomic load
+    s.xMu.Lock()
+    defer s.xMu.Unlock()
+    if s.xReady.Load() { return nil }        // double-check after lock
+    if err := s.bootstrapX(ctx); err != nil {
+        return err                           // leave latch false, next caller retries
+    }
+    s.xReady.Store(true)                     // latch forever
+    return nil
+}
+```
+
+Mirror `EnsureLayer4Ready` — don't reinvent. **Anti-patterns:** retrying bootstrap on every request; failing the daemon outright on a transient bootstrap error; logging-and-forgetting so the first user request gets a confusing "X not found".
+
+## Idempotency
+
+Whatever you add must be safe under retry + concurrent duplicate creates. See `pr-review.md` §1.

--- a/.claude/skills/touch-tcp-pool/SKILL.md
+++ b/.claude/skills/touch-tcp-pool/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: touch-tcp-pool
+description: Make changes to the TCP host-port pool or L4 bootstrap safely. Highest-risk area in the repo — PR #16 was a live incident here. Mandates a regression test in store_test.go or layer4_bootstrap_test.go and the matching PR call-out. Use when the user asks to "change the port allocator", "fix TCP routing", "touch host_port", "change EnsureLayer4", or any code path involving TryReserveHostPort / allocateHostPort / l4Ready. Proactively block-suggest before any patch that touches these symbols.
+---
+
+# Change the TCP host-port pool or L4 bootstrap
+
+**Highest-risk area in the repo. Read `pr-review.md` §7 in full before editing.**
+
+## What counts as "touching" this area
+
+Any change to:
+
+- `Store.TryReserveHostPort` semantics (`internal/store/store.go`)
+- The partial unique index on `exposed_ports.host_port`
+- `Service.allocateHostPort` allocator loop (`internal/service/`)
+- `Service.EnsureLayer4` / `Service.EnsureLayer4Ready` (`internal/service/service.go`)
+- The `l4Ready` `atomic.Bool` latch or the `l4Mu` mutex
+- `allocatorRandomAttempts` constant (`internal/service/service.go:37`)
+- `pkg/caddy/client.go` L4 route installation
+
+## What you MUST do
+
+1. **Regression test, required, not optional:**
+   - Pool / allocator / `TryReserveHostPort` changes → `internal/store/store_test.go`.
+   - `EnsureLayer4` / `EnsureLayer4Ready` / latch changes → `internal/service/layer4_bootstrap_test.go`.
+   - The existing tests give you the shape — copy and adapt.
+2. **PR call-out:** fill in the **"L4 / host-port-pool changes"** section of the PR template with a link to the regression test.
+3. **Never collapse `ReserveHostPortResult` back into a `bool`.** The three states (`Reserved` / `Existing` / neither) are what prevents pool walks on PK collisions. Look up the type before editing — the middle state matters.
+
+## Why this area is fragile
+
+- The allocator is randomized-first (`allocatorRandomAttempts = 16` random tries) then falls back to a linear scan. Removing the random phase makes p95 spike under load; removing the fallback fails near pool exhaustion.
+- The partial unique index lets multiple sandboxes "use" port 0 (sentinel) while still uniquing real allocations. Don't replace it with a non-partial unique constraint.
+- L4 bootstrap is **best-effort at daemon start**. Caddy may not be reachable on a cold restart, so the expose path retries under `l4Mu` when the latch is still false. Failure must leave the latch unset so the next caller retries. Success latches forever.
+
+## Worked anti-patterns
+
+- Walking the host-port pool on a primary-key conflict during re-expose → caused the live incident in PR #16.
+- Retrying L4 bootstrap on every request instead of behind the latch → thundering herd on the caddy admin API.
+- Failing the daemon outright on a transient bootstrap error → makes the daemon un-restartable after a caddy hiccup.
+- Logging-and-forgetting an L4 bootstrap error → the user's first TCP expose gets a confusing "layer4 server not found" from caddy.
+
+## Reference reading
+
+- `pr-review.md` §3 (lazy-bootstrap pattern) — canonical shape mirrored from `EnsureLayer4Ready`.
+- `pr-review.md` §7 (this area specifically) — the rules above are summarized from here.
+- `internal/service/layer4_bootstrap_test.go` — read the existing test names; they describe the invariants you must preserve.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,18 +1,177 @@
 # AerolVM — Claude Code Instructions
 
-## Documentation rules
+Self-hosted Docker-backed sandbox platform. Go daemon + 5 SDKs + Astro docs site.
+For non-trivial changes, invoke the matching project skill before coding (they live in
+[`.claude/skills/`](./.claude/skills/) — see the "Project skills" table below).
+Read [`pr-review.md`](./pr-review.md) before opening any PR that touches the server.
 
-- **Never use raw HTTP / curl examples in docs or in any md file.** All code examples must use one of the five SDK languages (TypeScript, Python, Go, Rust, Java) shown in `<Tabs syncKey="lang">` blocks. curl is only acceptable in `getting-started.md` for the initial server-install one-liners, not for sandbox API calls.
-- When adding a new top-level feature to the docs (GPU sandboxes, a new runtime, a new resource type, etc.), create a **new `.mdx` file** rather than appending a subsection to an existing page. Register the new page in the sidebar config at `docs/src/content/config.ts`.
-- Every new docs page must cover all five SDK languages with synced tab keys (`syncKey="lang"`).
+## Hard rules
 
-## API design & PR review
+### Documentation
 
-Before opening or reviewing any PR that touches `internal/service`, `internal/store`, `pkg/caddy`, `pkg/api`, or the SDKs, read [`pr-review.md`](./pr-review.md). It is the canonical source for:
+- **No raw HTTP / `curl` examples in any `.md` / `.mdx` file.** Code examples must
+  use one of the five SDK languages (TypeScript, Python, Go, Rust, Java) inside
+  `<Tabs syncKey="lang">` blocks. The only allowed curl is the install one-liner
+  in `getting-started.md`.
+- **New top-level feature → new `.mdx` file**, not a subsection on an existing
+  page. Register it in the sidebar at `docs/src/content.config.ts` (note: file
+  is `content.config.ts`, not `content/config.ts`).
+- Every new docs page must cover all five SDK languages with matching
+  `syncKey="lang"` tab order.
 
-- the idempotency requirement on all sandbox APIs,
-- the rule that any work added to `CreateSandbox` / sandbox boot must be explicitly called out,
-- the lazy-bootstrap pattern (atomic latch + single-flight mutex) for best-effort daemon-start work,
-- failure-path state-consistency rules for caddy + store writes,
-- the regression-test requirement on changes to the TCP host-port pool or the L4 bootstrap,
-- the PR description template that must be filled in for every PR (silence is not acceptable on these axes).
+### API & server changes
+
+Before touching `internal/service`, `internal/store`, `pkg/caddy`, `pkg/api`, or
+the SDKs, read [`pr-review.md`](./pr-review.md). Non-negotiables (silence in the
+PR description is **not** acceptable on these axes):
+
+1. **Idempotency.** Every sandbox API must be safe under retry + concurrent
+   duplicate calls. `expose_port` returns the existing URL; never walks the
+   TCP host-port pool on PK conflict.
+2. **Boot-path latency.** Any new work on `CreateSandbox` / its callees must be
+   explicitly called out in the PR description, including the first-call case.
+3. **Lazy bootstrap pattern.** Best-effort daemon-start work uses the
+   `atomic.Bool` latch + `sync.Mutex` single-flight pattern. Canonical example:
+   `Service.EnsureLayer4Ready` (`internal/service/service.go` →
+   `layer4_bootstrap_test.go`).
+4. **Failure-path consistency.** Multi-step writes touching both caddy and the
+   store must have a documented rollback rule. Don't lean on reconcile as
+   routine cleanup.
+5. **`/v1` is soft-frozen.** No behavioral changes to v1 wire bodies, status
+   codes, or paths. New capabilities go in `pkg/api/v2`. No
+   `if version == "v1"` in `internal/`.
+6. **TCP host-port pool & L4 bootstrap are fragile.** Any change to
+   `TryReserveHostPort`, the `host_port` partial unique index, `allocateHostPort`,
+   `EnsureLayer4`, `EnsureLayer4Ready`, or the `l4Ready` latch needs a
+   regression test (see `store_test.go` / `layer4_bootstrap_test.go`) AND a PR
+   call-out.
+
+## Repository map
+
+```
+cmd/
+  sandboxd/      Daemon entrypoint (main.go wires config → store → docker →
+                 caddy → service → api server).
+  toolboxd/      In-container agent (file/exec/sessions proxy target).
+internal/
+  config/        Env-driven config loader.
+  runtime/       Runtime.Runtime interface (Docker today, gVisor/Kata later).
+  service/       Business logic. Version-agnostic. Owns Service struct,
+                 CreateSandbox path, lifecycle, snapshots, l4 latch, mounts.
+                 Daytona/E2B helpers live here as named files (daytona.go,
+                 e2b.go), NOT version-aware branching.
+  store/         SQLite store. Single-writer (MaxOpenConns=1, WAL).
+                 store.go has all schema + CRUD; store_test.go is the
+                 regression-test target for host-port pool changes.
+  version/       Build version string.
+pkg/
+  api/           HTTP server entrypoint (server.go) + middleware + auth.
+    apihttp/     Shared helpers (WriteJSON, WriteError, WriteStoreAwareError).
+    v1/          Soft-frozen v1 routes. routes.go is the single grep target
+                 for "what does v1 expose?". handlers.go is thin: decode →
+                 service call → encode.
+    v2/          Empty — where future breaking changes land.
+    daytona/     Daytona-SDK compatibility facade (/daytona/...).
+  caddy/         Caddy admin API client (L7 routes + L4 routes for TCP).
+  capacity/      Host capacity detection + admission control (Admitter).
+  docker/        Docker client, /events stream, image GC, netrules (egress fw).
+  models/        Wire types + validation (CreateSandboxRequest, Sandbox,
+                 ExposedPort, Lifecycle, Mount, Runtime constants, E2B/Daytona
+                 metadata DTOs). Lives outside internal/ because SDKs and
+                 facades depend on it.
+  mounts/        External-storage mount manager (S3, NFS, SSHFS, rclone).
+                 Mount inputs run on the host — see pr-review.md §5.
+  secrets/       Credential AEAD cipher (env_json + sealed mount blobs).
+  sshgateway/    SSH gateway for per-sandbox Ed25519 keys.
+sdk/
+  typescript/    @aerol-ai/aerolvm-sdk. src/MicroVM.ts + Sandbox.ts; transport
+                 in src/internal/api/v1/.
+  python/        microvm package. client.py + types.py; transport in
+                 microvm/_internal/api/v1/.
+  go/            pkg/microvm + pkg/types; transport in internal/apiclient/v1/.
+  rust/          src/lib.rs + types.rs.
+  java/          Maven; src/main/java/...
+docs/
+  src/content/docs/   Astro/Starlight .md / .mdx pages.
+  src/content.config.ts   Sidebar nav config (register new pages here).
+plans/
+  sdk-compatibility/  Daytona + E2B compat planning & support matrices.
+  *.md                Active design docs.
+.github/
+  pull_request_template.md   Auto-fills PR descriptions; sections are required.
+  workflows/                 test.yml (path-filtered), release.yml, publish-sdks.yml.
+pr-review.md     The canonical PR review rules. Read before reviewing.
+.claude/skills/  Project-local Claude Code skills — invocable via /<name>.
+                 See "Project skills" below.
+Makefile         fmt, test, build, build-sandboxd, build-toolboxd, docs-*.
+```
+
+## Build, test, format
+
+```
+make fmt                          # go fmt ./...
+make test                         # go test ./...   (server + SDK Go)
+go test ./internal/service/...    # narrow run
+go test -run TestEnsureLayer4 ./internal/service/...
+make build                        # sandboxd + toolboxd into bin/
+make docs-dev                     # local Astro dev server
+make docs-build                   # static docs build
+```
+
+Per-SDK tests:
+
+```
+(cd sdk/typescript && npm ci && npm run build && npm test)
+(cd sdk/python && python -m unittest discover -s tests -v)
+(cd sdk/go && go test ./...)
+(cd sdk/java && mvn -B -ntp test)
+(cd sdk/rust && cargo test)
+```
+
+CI is path-filtered (`.github/workflows/test.yml`): touching `docs/**`
+short-circuits the Go and SDK jobs, and each SDK only runs when its own folder
+changes.
+
+## Project skills
+
+These live in `.claude/skills/<name>/SKILL.md` and are invocable as `/<name>`.
+Each one enforces the rules above for one common change shape and lists the
+exact files to touch. Prefer invoking the skill over working from memory.
+
+| Skill | Use when |
+|---|---|
+| `/add-v1-endpoint` | Adding a new route under `/v1/...` |
+| `/add-sdk-method` | Adding a method across all 5 SDKs in lockstep |
+| `/add-docs-page` | Adding a new `.mdx` page with five-tab examples |
+| `/add-store-column` | Adding a column or table to `internal/store/store.go` |
+| `/touch-create-sandbox` | Changing `CreateSandbox` or any boot-path callee |
+| `/touch-tcp-pool` | Touching the TCP host-port pool or L4 bootstrap |
+| `/add-daytona-route` | Adding to the Daytona compatibility facade |
+| `/add-e2b-route` | Adding to the (planned) E2B compatibility facade |
+| `/add-mount-adapter` | Adding an external-storage mount adapter |
+
+For changes that don't match a skill, the file-level "where to look" map is:
+
+| Task | Start here |
+|---|---|
+| Add server business logic | `internal/service/service.go` (or new file in same package) |
+| Caddy route / TLS / L4 wiring | `pkg/caddy/client.go` |
+| Capacity / admission rules | `pkg/capacity/` |
+| Docker events / image GC | `pkg/docker/events.go`, `pkg/docker/image_gc_test.go` |
+| SSH gateway behavior | `pkg/sshgateway/gateway.go` |
+| In-sandbox toolbox agent | `cmd/toolboxd/` |
+
+## Conventions
+
+- **Comments explain WHY, not WHAT.** This codebase has dense rationale comments
+  on non-obvious decisions (latches, allocator caps, partial unique indexes,
+  schema reasoning). Match that style. Don't narrate trivia.
+- **Service layer is version-agnostic.** v1/v2/daytona/e2b handlers translate
+  wire DTOs ↔ `pkg/models` and call `service.*`. No version checks in
+  `internal/`.
+- **Errors that the API surfaces use `apihttp.WriteStoreAwareError`** so
+  `models.ErrNotFound`, capacity errors, etc. get the right HTTP status.
+- **SQLite is single-writer in this process** (`MaxOpenConns=1`). Don't add a
+  second `*sql.DB` — queue through the existing one.
+- **`pkg/models` is shared between server, facades, and SDK-internal Go
+  transport.** Adding a field there ripples; keep DTOs lean and stable.


### PR DESCRIPTION
This pull request adds a set of new "skills" documentation files to the `.claude/skills/` directory. Each file provides detailed, step-by-step guides and hard rules for common, high-impact engineering tasks in the AerolVM codebase, such as adding API routes, SDK methods, storage adapters, and database schema changes. These documents are intended to standardize contributions, enforce architectural constraints, and proactively surface design and security considerations for contributors.

The most important changes are:

**API Route and Facade Additions**
* Added a guide for implementing Daytona SDK-compatible routes under `/daytona`, including file layout, translation responsibilities, and contract testing requirements.
* Added a guide for building E2B SDK-compatible routes under `/e2b`, covering facade creation, idempotency design blockers, and integration points.
* Added a guide for adding new `/v1` HTTP endpoints, outlining DTO, handler, route, service, and test requirements, with emphasis on versioning constraints and idempotency.

**SDK and Documentation Parity**
* Added a guide for implementing new methods across all five SDKs (TypeScript, Python, Go, Rust, Java) in lockstep, including file mappings, test requirements, and style rules to prevent parity drift.
* Added a guide for creating new documentation pages with synchronized five-language tab blocks and sidebar registration, enforcing consistent example coverage and style.

**Storage, Mounts, and Database Schema**
* Added a guide for implementing new external-storage mount adapters, with threat model warnings, file structure, validation, and cleanup requirements.
* Added a guide for making additive changes to the SQLite store schema, including scanner updates, write path wiring, and mandatory regression tests for host-port pool changes.