### PR TITLE
feat: Implement E2B compatibility facade and enhance API functionality

### DIFF
--- a/agentic_docs/README.md
+++ b/agentic_docs/README.md
@@ -1,0 +1,17 @@
+# E2B Compatibility Notes
+
+This folder captures the implementation details behind the E2B compatibility work added in this session.
+
+Files in this pack:
+
+- `e2b-request-flow.md`: exact request flow from `Sandbox.create()` through `sandbox.commands.run()`.
+- `e2b-idempotency-timeline.md`: why create idempotency was required and how the persisted retry window works.
+- `e2b-sdk-method-map.md`: which E2B SDK methods map to which AerolVM handler or toolboxd runtime path.
+
+These notes are focused on the current path-based compatibility shape:
+
+- control plane under `/e2b`
+- runtime gateway under `/e2b/runtime`
+- toolboxd compatibility surface under `/envd`
+
+They are intended as implementation notes, not end-user product docs.

--- a/agentic_docs/e2b-idempotency-timeline.md
+++ b/agentic_docs/e2b-idempotency-timeline.md
@@ -1,0 +1,151 @@
+# Create Idempotency Timeline
+
+The hardest compatibility problem on the control plane was `POST /e2b/sandboxes`.
+
+## Why it mattered
+
+Create is not like list or get.
+
+If a caller retries the same create request because of a timeout, proxy retry, client reconnect, or race, a naive implementation can launch two live sandboxes for what the caller believes was one request.
+
+That is especially dangerous for an SDK facade because the upstream SDK does not provide a caller-supplied idempotency key or request ID that AerolVM can reuse directly.
+
+So the facade had to design its own safe replay behavior.
+
+## Implemented design
+
+The implemented strategy is:
+
+1. Build a canonical fingerprint from the effective create semantics.
+2. Persist that fingerprint in SQLite.
+3. Treat the first matching request as the owner of a short-lived pending lock.
+4. Let concurrent matching requests wait for that owner to finish.
+5. Replay the same sandbox only inside a short replay window.
+6. Allow the same request to create a fresh sandbox again once that replay window expires.
+
+This is backed by the `e2b_create_requests` table.
+
+## What goes into the fingerprint
+
+The fingerprint is not based on raw JSON bytes.
+
+It is built from the normalized semantics of the create request, including:
+
+- template ID
+- metadata
+- env vars
+- timeout seconds
+- timeout behavior such as pause or kill
+- secure mode
+- supported network fields
+- public-traffic and host-masking intent when present
+
+That means semantically identical requests still match even if the JSON field order differs.
+
+## The concrete timing rules
+
+The current values are:
+
+- pending lock TTL: 2 minutes
+- wait timeout for other callers: 30 seconds
+- replay window after success: 10 seconds
+
+## Retry timeline example
+
+Assume two identical `Sandbox.create(...)` calls happen close together.
+
+### T0: first request arrives
+
+- Request A hits `POST /e2b/sandboxes`.
+- AerolVM computes fingerprint `F`.
+- No row exists for `F`, so AerolVM inserts a `pending` record.
+- The row gets `locked_until = T0 + 2m`.
+- Request A is now the owner of the create attempt.
+
+### T0 + 100 ms: duplicate retry arrives
+
+- Request B hits `POST /e2b/sandboxes` with the same effective payload.
+- AerolVM computes the same fingerprint `F`.
+- It sees a `pending` row whose lock is still valid.
+- Request B does not create a second sandbox.
+- Instead, it waits up to 30 seconds for the original create to finish.
+
+### T0 + 1.2 s: native create succeeds
+
+- Request A finishes native `CreateSandbox(...)`.
+- E2B metadata is persisted.
+- The create record moves from `pending` to `ready`.
+- The row is updated with:
+  - `sandbox_id = sb_123`
+  - `replay_until = T0 + 11.2s`
+
+### T0 + 1.3 s: waiting retry wakes up
+
+- Request B re-checks the record.
+- It sees `ready` and a valid replay window.
+- It returns the same sandbox `sb_123` instead of creating a duplicate.
+
+### T0 + 5 s: another identical retry arrives
+
+- Request C arrives with the same payload.
+- The row is still `ready` and still inside the replay window.
+- Request C also gets `sb_123`.
+
+### T0 + 12 s: legitimate identical launch later
+
+- Request D arrives with the same payload.
+- The replay window has expired.
+- AerolVM treats this as a new legitimate create.
+- It refreshes the record back to `pending` and allows a fresh sandbox launch.
+
+This is the key balance:
+
+- accidental retries replay briefly
+- real later launches are still allowed
+
+## Failure handling
+
+The failure behavior matters as much as the success behavior.
+
+### If native create fails
+
+- the pending reservation is deleted
+- the next retry is free to try again cleanly
+
+### If native create succeeds but E2B metadata persistence fails
+
+- AerolVM destroys the newly created sandbox
+- the pending reservation is deleted
+- the client gets an error instead of a half-created compatibility record
+
+### If the owner dies or stalls
+
+- the pending lock has a TTL
+- once it expires, the next matching request can reclaim the fingerprint and try again
+
+## Why this was better than simpler alternatives
+
+### Better than no dedupe
+
+Without it, a client-side retry can create multiple real sandboxes.
+
+### Better than permanent dedupe
+
+Permanent dedupe would make two legitimate identical launches impossible.
+
+### Better than in-memory locking only
+
+In-memory locking disappears on process restart and does not survive concurrent request paths safely.
+
+Persisting the state in SQLite makes the behavior durable and restart-safe.
+
+## Relationship to other lifecycle endpoints
+
+Create needed the special persisted replay design because it allocates a brand-new sandbox.
+
+The other control-plane operations are simpler:
+
+- `connect` is safe because it only starts or extends the sandbox when needed
+- `pause` is safe because pausing an already paused sandbox is a no-op success
+- `timeout` is safe because it updates lifecycle state in place
+- snapshot creation uses stable external snapshot IDs so later delete calls resolve deterministically

--- a/agentic_docs/e2b-request-flow.md
+++ b/agentic_docs/e2b-request-flow.md
@@ -1,0 +1,149 @@
+# Request Flow: `Sandbox.create()` to `sandbox.commands.run()`
+
+This walkthrough describes the concrete path the real E2B Python SDK now takes through AerolVM.
+
+## 1. SDK bootstrap
+
+The Python SDK is configured with:
+
+- `E2B_API_URL=https://.../e2b`
+- `E2B_SANDBOX_URL=https://.../e2b/runtime`
+- `E2B_API_KEY=<pat>`
+
+That split is important.
+
+- `/e2b` is the control plane.
+- `/e2b/runtime` is the runtime gateway.
+
+## 2. `Sandbox.create(...)`
+
+When the SDK calls `Sandbox.create(...)`, it sends a control-plane request to:
+
+- `POST /e2b/sandboxes`
+
+with:
+
+- `X-API-KEY: <pat>`
+- the E2B create JSON body containing fields such as `templateID`, `timeout`, `metadata`, `envs`, and `secure`
+
+Inside AerolVM, the request enters `pkg/api/e2b/handlers.go:createSandbox`.
+
+That handler does five important things before returning:
+
+1. Translates the E2B body into native `models.CreateSandboxRequest` plus E2B-only metadata.
+2. Computes a canonical request fingerprint for safe retry handling.
+3. Claims a persisted create reservation so concurrent retries do not launch duplicate sandboxes.
+4. Calls native `Service.CreateSandbox(...)`.
+5. Persists E2B metadata and completes the create reservation.
+
+The response is then shaped like E2B, including:
+
+- `sandboxID`
+- `envdAccessToken`
+- `envdVersion`
+- the template and lifecycle fields the SDK expects
+
+## 3. Why the create response matters
+
+The SDK does not stop at create.
+
+It immediately uses the returned sandbox identity and runtime token to talk to the sandbox runtime. That is why returning `envdAccessToken` and a stable `sandboxID` was required for real compatibility.
+
+## 4. Runtime calls switch to `/e2b/runtime`
+
+When the SDK later performs runtime work such as file I/O, command execution, or health checks, it targets:
+
+- `GET /e2b/runtime/health`
+- `GET /e2b/runtime/files`
+- `POST /e2b/runtime/files`
+- `POST /e2b/runtime/process.Process/Start`
+- `POST /e2b/runtime/filesystem.Filesystem/ListDir`
+
+Those requests carry runtime-scoped headers such as:
+
+- `E2b-Sandbox-Id`
+- `X-Access-Token`
+- optional `Authorization: Basic ...` when the SDK wants user impersonation semantics
+
+## 5. Runtime gateway behavior
+
+Every runtime request first enters `pkg/api/e2b/runtime_proxy.go:runtimeProxy`.
+
+That proxy is responsible for the compatibility bridge between the public E2B-shaped surface and the native toolboxd surface.
+
+It does the following:
+
+1. Reads `E2b-Sandbox-Id`.
+2. Loads the sandbox and its stored E2B metadata.
+3. Validates `X-Access-Token` against the sandbox's stored toolbox token when the sandbox is secure.
+4. Resolves the sandbox's toolbox endpoint with `Service.ToolboxTarget(...)`.
+5. Rewrites `/e2b/runtime/...` to `/envd/...`.
+6. Preserves inbound Basic auth as `X-E2B-User-Authorization`.
+7. Injects native `Authorization: Bearer <toolbox token>` when forwarding to toolboxd.
+
+That translation is the reason the public E2B runtime API can stay E2B-shaped while toolboxd remains protected by its existing bearer-token model.
+
+## 6. Why `/envd` exists inside toolboxd
+
+The E2B SDK expects envd-style runtime endpoints.
+
+Toolboxd already had Daytona-oriented `/files` and `/process` behavior, so adding a separate internal namespace avoided collisions and made the compatibility layer explicit.
+
+Inside toolboxd, `cmd/toolboxd/main.go:normalizeSandboxPath` preserves `/envd/...` instead of collapsing it into older route families.
+
+Then `cmd/toolboxd/envd.go:handleEnvdRoute` dispatches the request to the matching envd-compatible handler.
+
+## 7. `sandbox.commands.run(...)`
+
+When the SDK runs a command, it eventually reaches:
+
+- `POST /e2b/runtime/process.Process/Start`
+
+The public runtime proxy rewrites that to:
+
+- `POST /envd/process.Process/Start`
+
+Toolboxd handles that in `cmd/toolboxd/envd.go:handleEnvdProcessStart`.
+
+That handler:
+
+1. Decodes the Connect JSON request body.
+2. Translates the E2B process config into a native toolboxd session request.
+3. Creates a process session through the existing `sessions.Manager`.
+4. Registers the session in the envd compatibility index by PID or tag.
+5. Streams process events back as Connect JSON envelopes.
+
+The stream includes:
+
+- a start event with the PID
+- stdout or stderr data events
+- a final end event with exit information
+
+The SDK reads that event stream and turns it into the command result object returned by `sandbox.commands.run()`.
+
+## 8. Example end-to-end trace
+
+For the smoke harness path:
+
+1. `Sandbox.create(template="base", timeout=120, metadata=..., envs=..., secure=True)`
+2. `POST /e2b/sandboxes`
+3. `createSandbox` translates, dedupes, creates, persists metadata, returns `sandboxID` and `envdAccessToken`
+4. `sandbox.commands.run("printf $E2B_SMOKE", envs={...})`
+5. `POST /e2b/runtime/process.Process/Start`
+6. `runtimeProxy` validates headers and rewrites to `/envd/process.Process/Start`
+7. toolboxd `handleEnvdProcessStart` creates a session and streams output
+8. SDK reads the stream and returns `stdout == "smoke"`
+
+## 9. Why this split was necessary
+
+Without the control plane, the SDK could not create, reconnect, pause, snapshot, or delete sandboxes.
+
+Without the runtime gateway and `/envd` compatibility surface, the SDK could create a sandbox but would immediately fail on:
+
+- `sandbox.files.read(...)`
+- `sandbox.files.write(...)`
+- `sandbox.files.list(...)`
+- `sandbox.commands.run(...)`
+- PTY and reconnect flows
+
+Real E2B compatibility required both planes.

--- a/agentic_docs/e2b-sdk-method-map.md
+++ b/agentic_docs/e2b-sdk-method-map.md
@@ -1,0 +1,76 @@
+# E2B SDK Method Map
+
+This file maps the supported E2B SDK methods to the AerolVM handler or toolboxd path they now hit.
+
+## Control-plane methods
+
+| E2B SDK method | External path | AerolVM entry point | Notes |
+|---|---|---|---|
+| `Sandbox.create(...)` | `POST /e2b/sandboxes` | `pkg/api/e2b/handlers.go:createSandbox` | Creates a sandbox, persists E2B metadata, and returns runtime token info. |
+| `Sandbox.list(...)` | `GET /e2b/sandboxes` or `GET /e2b/v2/sandboxes` | `pkg/api/e2b/handlers.go:listSandboxes` | Supports state and metadata filtering on the shaped E2B response. |
+| `Sandbox.connect(...)` | `POST /e2b/sandboxes/{id}/connect` | `pkg/api/e2b/handlers.go:connectSandbox` | Starts a stopped sandbox if needed and only extends timeouts forward. |
+| `sandbox.pause()` | `POST /e2b/sandboxes/{id}/pause` | `pkg/api/e2b/handlers.go:pauseSandbox` | No-op success if the sandbox is already paused. |
+| `sandbox.kill()` | `DELETE /e2b/sandboxes/{id}` | `pkg/api/e2b/handlers.go:deleteSandbox` | Destroys the sandbox. |
+| timeout update methods | `POST /e2b/sandboxes/{id}/timeout` | `pkg/api/e2b/handlers.go:updateTimeout` | Updates lifecycle timeout semantics. |
+| `sandbox.create_snapshot(...)` | `POST /e2b/sandboxes/{id}/snapshots` | `pkg/api/e2b/handlers.go:createSnapshot` | Persists a stable E2B-facing snapshot ID. |
+| `sandbox.list_snapshots(...)` | `GET /e2b/snapshots` | `pkg/api/e2b/handlers.go:listSnapshots` | Lists snapshot metadata in the E2B response shape. |
+| `Sandbox.delete_snapshot(snapshot_id)` | `DELETE /e2b/templates/{id}` | `pkg/api/e2b/handlers.go:deleteSnapshot` | Deletes by the same stable external snapshot ID returned at create time. |
+
+## Runtime file methods
+
+All runtime methods first pass through the public runtime gateway:
+
+- `pkg/api/e2b/runtime_proxy.go:runtimeProxy`
+
+That proxy rewrites `/e2b/runtime/...` to `/envd/...` inside toolboxd.
+
+| E2B SDK method | Public runtime path | Toolboxd path after rewrite | Toolboxd handler |
+|---|---|---|---|
+| `sandbox.files.read(path)` | `GET /e2b/runtime/files?path=...` | `GET /envd/files?path=...` | `cmd/toolboxd/envd.go:handleEnvdFileRead` |
+| `sandbox.files.write(path, content)` | `POST /e2b/runtime/files?path=...` | `POST /envd/files?path=...` | `cmd/toolboxd/envd.go:handleEnvdFileWrite` |
+| `sandbox.files.list(path, depth=...)` | `POST /e2b/runtime/filesystem.Filesystem/ListDir` | `POST /envd/filesystem.Filesystem/ListDir` | `cmd/toolboxd/envd.go:handleEnvdFilesystemListDir` |
+| directory stat calls | `POST /e2b/runtime/filesystem.Filesystem/Stat` | `POST /envd/filesystem.Filesystem/Stat` | `cmd/toolboxd/envd.go:handleEnvdFilesystemStat` |
+| directory creation calls | `POST /e2b/runtime/filesystem.Filesystem/MakeDir` | `POST /envd/filesystem.Filesystem/MakeDir` | `cmd/toolboxd/envd.go:handleEnvdFilesystemMakeDir` |
+| move or rename calls | `POST /e2b/runtime/filesystem.Filesystem/Move` | `POST /envd/filesystem.Filesystem/Move` | `cmd/toolboxd/envd.go:handleEnvdFilesystemMove` |
+| remove calls | `POST /e2b/runtime/filesystem.Filesystem/Remove` | `POST /envd/filesystem.Filesystem/Remove` | `cmd/toolboxd/envd.go:handleEnvdFilesystemRemove` |
+
+## Runtime process methods
+
+| E2B SDK method | Public runtime path | Toolboxd path after rewrite | Toolboxd handler |
+|---|---|---|---|
+| `sandbox.commands.run(...)` | `POST /e2b/runtime/process.Process/Start` | `POST /envd/process.Process/Start` | `cmd/toolboxd/envd.go:handleEnvdProcessStart` |
+| process reconnect flows | `POST /e2b/runtime/process.Process/Connect` | `POST /envd/process.Process/Connect` | `cmd/toolboxd/envd.go:handleEnvdProcessConnect` |
+| process listing | `POST /e2b/runtime/process.Process/List` | `POST /envd/process.Process/List` | `cmd/toolboxd/envd.go:handleEnvdProcessList` |
+| PTY resize | `POST /e2b/runtime/process.Process/Update` | `POST /envd/process.Process/Update` | `cmd/toolboxd/envd.go:handleEnvdProcessUpdate` |
+| stdin or PTY input | `POST /e2b/runtime/process.Process/SendInput` | `POST /envd/process.Process/SendInput` | `cmd/toolboxd/envd.go:handleEnvdProcessSendInput` |
+| signal delivery | `POST /e2b/runtime/process.Process/SendSignal` | `POST /envd/process.Process/SendSignal` | `cmd/toolboxd/envd.go:handleEnvdProcessSendSignal` |
+| stdin close without killing process | `POST /e2b/runtime/process.Process/CloseStdin` | `POST /envd/process.Process/CloseStdin` | `cmd/toolboxd/envd.go:handleEnvdProcessCloseStdin` |
+
+## Runtime health
+
+| E2B operation | Public runtime path | Toolboxd path after rewrite | Toolboxd handler |
+|---|---|---|---|
+| runtime health check | `GET /e2b/runtime/health` | `GET /envd/health` | `cmd/toolboxd/envd.go:handleEnvdHealth` |
+
+## Unsupported runtime watcher APIs
+
+These paths currently exist only to return explicit `501 Not Implemented` responses:
+
+- `POST /e2b/runtime/filesystem.Filesystem/WatchDir`
+- `POST /e2b/runtime/filesystem.Filesystem/CreateWatcher`
+- `POST /e2b/runtime/filesystem.Filesystem/GetWatcherEvents`
+- `POST /e2b/runtime/filesystem.Filesystem/RemoveWatcher`
+
+After rewrite, toolboxd handles those under `/envd/...` and returns a clear not-implemented error instead of silently pretending support.
+
+## One important nuance: `sandbox.is_running()`
+
+`sandbox.is_running()` is usually a client-side convenience check against the current sandbox object's state, not a dedicated AerolVM endpoint of its own.
+
+In practice, the state it inspects comes from prior control-plane responses such as:
+
+- `Sandbox.create(...)`
+- `Sandbox.connect(...)`
+- sandbox fetch or list operations
+
+So it is useful to think of it as reading the latest known E2B-shaped sandbox state rather than issuing its own runtime call.

--- a/cmd/toolboxd/envd.go
+++ b/cmd/toolboxd/envd.go
@@ -1,0 +1,1148 @@
+package main
+
+import (
+	"compress/gzip"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	iofs "io/fs"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aerol-ai/microvm/cmd/toolboxd/sessions"
+	"github.com/aerol-ai/microvm/internal/version"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+const (
+	envdPrefix               = "/envd"
+	connectEnvelopeHeaderLen = 5
+	connectFlagEndStream     = 0x02
+	connectFlagCompressed    = 0x01
+	envdFileTypeFile         = "FILE_TYPE_FILE"
+	envdFileTypeDirectory    = "FILE_TYPE_DIRECTORY"
+)
+
+var errEnvdProcessTagConflict = errors.New("process tag already in use")
+
+type envdCompat struct {
+	mu    sync.RWMutex
+	byPID map[int]*envdProcessState
+	byTag map[string]int
+}
+
+type envdProcessState struct {
+	PID       int
+	SessionID string
+	Tag       string
+	Config    envdProcessConfig
+	PTY       bool
+	Stdin     bool
+}
+
+type envdProcessConfig struct {
+	Cmd  string            `json:"cmd,omitempty"`
+	Args []string          `json:"args,omitempty"`
+	Envs map[string]string `json:"envs,omitempty"`
+	Cwd  string            `json:"cwd,omitempty"`
+}
+
+type envdPTY struct {
+	Size *envdPTYSize `json:"size,omitempty"`
+}
+
+type envdPTYSize struct {
+	Cols uint32 `json:"cols,omitempty"`
+	Rows uint32 `json:"rows,omitempty"`
+}
+
+type envdProcessSelector struct {
+	PID *int   `json:"pid,omitempty"`
+	Tag string `json:"tag,omitempty"`
+}
+
+type envdStartRequest struct {
+	Process envdProcessConfig `json:"process"`
+	PTY     *envdPTY          `json:"pty,omitempty"`
+	Tag     string            `json:"tag,omitempty"`
+	Stdin   *bool             `json:"stdin,omitempty"`
+}
+
+type envdConnectRequest struct {
+	Process envdProcessSelector `json:"process"`
+}
+
+type envdUpdateRequest struct {
+	Process envdProcessSelector `json:"process"`
+	PTY     *envdPTY            `json:"pty,omitempty"`
+}
+
+type envdSendInputRequest struct {
+	Process envdProcessSelector `json:"process"`
+	Input   envdProcessInput    `json:"input"`
+}
+
+type envdProcessInput struct {
+	Stdin string `json:"stdin,omitempty"`
+	PTY   string `json:"pty,omitempty"`
+}
+
+type envdSendSignalRequest struct {
+	Process envdProcessSelector `json:"process"`
+	Signal  string              `json:"signal"`
+}
+
+type envdCloseStdinRequest struct {
+	Process envdProcessSelector `json:"process"`
+}
+
+type envdListResponse struct {
+	Processes []envdProcessInfo `json:"processes"`
+}
+
+type envdProcessInfo struct {
+	Config envdProcessConfig `json:"config"`
+	PID    int               `json:"pid"`
+	Tag    string            `json:"tag,omitempty"`
+}
+
+type envdProcessEvent struct {
+	Start     *envdProcessStartEvent `json:"start,omitempty"`
+	Data      *envdProcessDataEvent  `json:"data,omitempty"`
+	End       *envdProcessEndEvent   `json:"end,omitempty"`
+	Keepalive *struct{}              `json:"keepalive,omitempty"`
+}
+
+type envdProcessStartEvent struct {
+	PID int `json:"pid"`
+}
+
+type envdProcessDataEvent struct {
+	Stdout string `json:"stdout,omitempty"`
+	Stderr string `json:"stderr,omitempty"`
+	PTY    string `json:"pty,omitempty"`
+}
+
+type envdProcessEndEvent struct {
+	ExitCode int    `json:"exitCode"`
+	Exited   bool   `json:"exited"`
+	Status   string `json:"status,omitempty"`
+	Error    string `json:"error,omitempty"`
+}
+
+type envdProcessStreamResponse struct {
+	Event envdProcessEvent `json:"event"`
+}
+
+type envdEmptyResponse struct{}
+
+type envdStatRequest struct {
+	Path string `json:"path"`
+}
+
+type envdStatResponse struct {
+	Entry envdEntryInfo `json:"entry"`
+}
+
+type envdMakeDirRequest struct {
+	Path string `json:"path"`
+}
+
+type envdMakeDirResponse struct {
+	Entry envdEntryInfo `json:"entry"`
+}
+
+type envdMoveRequest struct {
+	Source      string `json:"source"`
+	Destination string `json:"destination"`
+}
+
+type envdMoveResponse struct {
+	Entry envdEntryInfo `json:"entry"`
+}
+
+type envdListDirRequest struct {
+	Path  string `json:"path"`
+	Depth uint32 `json:"depth,omitempty"`
+}
+
+type envdListDirResponse struct {
+	Entries []envdEntryInfo `json:"entries"`
+}
+
+type envdRemoveRequest struct {
+	Path string `json:"path"`
+}
+
+type envdEntryInfo struct {
+	Name          string  `json:"name"`
+	Type          string  `json:"type"`
+	Path          string  `json:"path"`
+	Size          int64   `json:"size"`
+	Mode          uint32  `json:"mode"`
+	Permissions   string  `json:"permissions"`
+	Owner         string  `json:"owner"`
+	Group         string  `json:"group"`
+	ModifiedTime  string  `json:"modifiedTime"`
+	SymlinkTarget *string `json:"symlinkTarget,omitempty"`
+}
+
+type envdWriteInfo struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+	Path string `json:"path"`
+}
+
+type envdErrorResponse struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type connectJSONStream struct {
+	w http.ResponseWriter
+}
+
+func newEnvdCompat() *envdCompat {
+	return &envdCompat{
+		byPID: map[int]*envdProcessState{},
+		byTag: map[string]int{},
+	}
+}
+
+func (c *envdCompat) registerSession(sess *sessions.Session, tag string, cfg envdProcessConfig, pty, stdin bool) (*envdProcessState, error) {
+	if c == nil {
+		return nil, errors.New("envd state is not available")
+	}
+	if sess == nil {
+		return nil, errors.New("session is required")
+	}
+	pid := sess.PID()
+	if pid <= 0 {
+		return nil, errors.New("session pid is not available")
+	}
+	tag = strings.TrimSpace(tag)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if tag != "" {
+		if existingPID, ok := c.byTag[tag]; ok {
+			if _, ok := c.byPID[existingPID]; ok {
+				return nil, errEnvdProcessTagConflict
+			}
+		}
+	}
+	state := &envdProcessState{
+		PID:       pid,
+		SessionID: sess.ID(),
+		Tag:       tag,
+		Config: envdProcessConfig{
+			Cmd:  strings.TrimSpace(cfg.Cmd),
+			Args: append([]string{}, cfg.Args...),
+			Envs: cloneEnvdStringMap(cfg.Envs),
+			Cwd:  strings.TrimSpace(cfg.Cwd),
+		},
+		PTY:   pty,
+		Stdin: stdin,
+	}
+	c.byPID[pid] = state
+	if tag != "" {
+		c.byTag[tag] = pid
+	}
+	return cloneEnvdProcessState(state), nil
+}
+
+func (c *envdCompat) removeSession(pid int, sessionID string) {
+	if c == nil || pid <= 0 {
+		return
+	}
+	c.mu.Lock()
+	state, ok := c.byPID[pid]
+	if ok && state.SessionID == sessionID {
+		delete(c.byPID, pid)
+		if state.Tag != "" && c.byTag[state.Tag] == pid {
+			delete(c.byTag, state.Tag)
+		}
+	}
+	c.mu.Unlock()
+}
+
+func (c *envdCompat) lookup(selector envdProcessSelector) (*envdProcessState, bool) {
+	if c == nil {
+		return nil, false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if selector.PID != nil {
+		state, ok := c.byPID[*selector.PID]
+		if !ok {
+			return nil, false
+		}
+		return cloneEnvdProcessState(state), true
+	}
+	tag := strings.TrimSpace(selector.Tag)
+	if tag == "" {
+		return nil, false
+	}
+	pid, ok := c.byTag[tag]
+	if !ok {
+		return nil, false
+	}
+	state, ok := c.byPID[pid]
+	if !ok {
+		return nil, false
+	}
+	return cloneEnvdProcessState(state), true
+}
+
+func (c *envdCompat) list() []*envdProcessState {
+	if c == nil {
+		return nil
+	}
+	c.mu.RLock()
+	items := make([]*envdProcessState, 0, len(c.byPID))
+	for _, state := range c.byPID {
+		items = append(items, cloneEnvdProcessState(state))
+	}
+	c.mu.RUnlock()
+	sort.Slice(items, func(i, j int) bool { return items[i].PID < items[j].PID })
+	return items
+}
+
+func cloneEnvdProcessState(state *envdProcessState) *envdProcessState {
+	if state == nil {
+		return nil
+	}
+	cloned := *state
+	cloned.Config = envdProcessConfig{
+		Cmd:  state.Config.Cmd,
+		Args: append([]string{}, state.Config.Args...),
+		Envs: cloneEnvdStringMap(state.Config.Envs),
+		Cwd:  state.Config.Cwd,
+	}
+	return &cloned
+}
+
+func cloneEnvdStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return map[string]string{}
+	}
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func (s *server) handleEnvdRoute(w http.ResponseWriter, r *http.Request) bool {
+	switch {
+	case r.Method == http.MethodGet && r.URL.Path == envdPrefix+"/health":
+		s.handleEnvdHealth(w, r)
+	case r.Method == http.MethodGet && r.URL.Path == envdPrefix+"/files":
+		s.handleEnvdFileRead(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == envdPrefix+"/files":
+		s.handleEnvdFileWrite(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == envdPrefix+"/process.Process/List":
+		s.handleEnvdProcessList(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == envdPrefix+"/process.Process/Start":
+		s.handleEnvdProcessStart(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == envdPrefix+"/process.Process/Connect":
+		s.handleEnvdProcessConnect(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == envdPrefix+"/process.Process/Update":
+		s.handleEnvdProcessUpdate(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == envdPrefix+"/process.Process/SendInput":
+		s.handleEnvdProcessSendInput(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == envdPrefix+"/process.Process/SendSignal":
+		s.handleEnvdProcessSendSignal(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == envdPrefix+"/process.Process/CloseStdin":
+		s.handleEnvdProcessCloseStdin(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == envdPrefix+"/process.Process/StreamInput":
+		writeEnvdError(w, http.StatusNotImplemented, "process stream input is not implemented")
+	case r.Method == http.MethodPost && r.URL.Path == envdPrefix+"/filesystem.Filesystem/Stat":
+		s.handleEnvdFilesystemStat(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == envdPrefix+"/filesystem.Filesystem/MakeDir":
+		s.handleEnvdFilesystemMakeDir(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == envdPrefix+"/filesystem.Filesystem/Move":
+		s.handleEnvdFilesystemMove(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == envdPrefix+"/filesystem.Filesystem/ListDir":
+		s.handleEnvdFilesystemListDir(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == envdPrefix+"/filesystem.Filesystem/Remove":
+		s.handleEnvdFilesystemRemove(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == envdPrefix+"/filesystem.Filesystem/WatchDir":
+		writeEnvdError(w, http.StatusNotImplemented, "filesystem watchers are not implemented")
+	case r.Method == http.MethodPost && r.URL.Path == envdPrefix+"/filesystem.Filesystem/CreateWatcher":
+		writeEnvdError(w, http.StatusNotImplemented, "filesystem watchers are not implemented")
+	case r.Method == http.MethodPost && r.URL.Path == envdPrefix+"/filesystem.Filesystem/GetWatcherEvents":
+		writeEnvdError(w, http.StatusNotImplemented, "filesystem watchers are not implemented")
+	case r.Method == http.MethodPost && r.URL.Path == envdPrefix+"/filesystem.Filesystem/RemoveWatcher":
+		writeEnvdError(w, http.StatusNotImplemented, "filesystem watchers are not implemented")
+	default:
+		return false
+	}
+	return true
+}
+
+func (s *server) handleEnvdHealth(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{"status": "ok", "version": version.Version})
+}
+
+func (s *server) handleEnvdFileRead(w http.ResponseWriter, r *http.Request) {
+	targetPath, err := resolveDaytonaPath(r.URL.Query().Get("path"), false)
+	if err != nil {
+		writeEnvdError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		writeEnvdFilesystemError(w, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
+func (s *server) handleEnvdFileWrite(w http.ResponseWriter, r *http.Request) {
+	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(r.Header.Get("Content-Type"))), "application/octet-stream") {
+		s.handleEnvdOctetStreamWrite(w, r)
+		return
+	}
+	s.handleEnvdMultipartWrite(w, r)
+}
+
+func (s *server) handleEnvdOctetStreamWrite(w http.ResponseWriter, r *http.Request) {
+	targetPath, err := resolveDaytonaPath(r.URL.Query().Get("path"), false)
+	if err != nil {
+		writeEnvdError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	var reader io.Reader = r.Body
+	if strings.EqualFold(strings.TrimSpace(r.Header.Get("Content-Encoding")), "gzip") {
+		gz, err := gzip.NewReader(r.Body)
+		if err != nil {
+			writeEnvdError(w, http.StatusBadRequest, "invalid gzip body")
+			return
+		}
+		defer gz.Close()
+		reader = gz
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		writeEnvdFilesystemError(w, err)
+		return
+	}
+	file, err := os.Create(targetPath)
+	if err != nil {
+		writeEnvdFilesystemError(w, err)
+		return
+	}
+	defer file.Close()
+	if _, err := io.Copy(file, reader); err != nil {
+		writeEnvdFilesystemError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, []envdWriteInfo{buildEnvdWriteInfo(targetPath)})
+}
+
+func (s *server) handleEnvdMultipartWrite(w http.ResponseWriter, r *http.Request) {
+	maxBytes := envInt64("SB_UPLOAD_MAX_BYTES", 256*1024*1024)
+	r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+	if err := r.ParseMultipartForm(64 << 20); err != nil {
+		writeEnvdError(w, http.StatusBadRequest, "invalid multipart form")
+		return
+	}
+	files := r.MultipartForm.File["file"]
+	if len(files) == 0 {
+		writeEnvdError(w, http.StatusBadRequest, "file is required")
+		return
+	}
+	targetOverride := strings.TrimSpace(r.URL.Query().Get("path"))
+	results := make([]envdWriteInfo, 0, len(files))
+	for index, header := range files {
+		targetPath := header.Filename
+		if index == 0 && targetOverride != "" {
+			targetPath = targetOverride
+		}
+		resolvedPath, err := resolveDaytonaPath(targetPath, false)
+		if err != nil {
+			writeEnvdError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		file, err := header.Open()
+		if err != nil {
+			writeEnvdFilesystemError(w, err)
+			return
+		}
+		if err := os.MkdirAll(filepath.Dir(resolvedPath), 0o755); err != nil {
+			file.Close()
+			writeEnvdFilesystemError(w, err)
+			return
+		}
+		output, err := os.Create(resolvedPath)
+		if err != nil {
+			file.Close()
+			writeEnvdFilesystemError(w, err)
+			return
+		}
+		_, copyErr := io.Copy(output, file)
+		closeErr := output.Close()
+		file.Close()
+		if copyErr != nil {
+			writeEnvdFilesystemError(w, copyErr)
+			return
+		}
+		if closeErr != nil {
+			writeEnvdFilesystemError(w, closeErr)
+			return
+		}
+		results = append(results, buildEnvdWriteInfo(resolvedPath))
+	}
+	writeJSON(w, http.StatusOK, results)
+}
+
+func (s *server) handleEnvdProcessList(w http.ResponseWriter, r *http.Request) {
+	if s.sessions == nil {
+		writeEnvdError(w, http.StatusServiceUnavailable, "sessions are disabled")
+		return
+	}
+	states := s.envd.list()
+	processes := make([]envdProcessInfo, 0, len(states))
+	for _, state := range states {
+		sess, err := s.sessions.Get(state.SessionID)
+		if err != nil {
+			s.envd.removeSession(state.PID, state.SessionID)
+			continue
+		}
+		if code, signal := sess.ExitInfo(); code >= 0 || signal != "" {
+			s.envd.removeSession(state.PID, state.SessionID)
+			continue
+		}
+		processes = append(processes, envdProcessInfo{Config: state.Config, PID: state.PID, Tag: state.Tag})
+	}
+	writeJSON(w, http.StatusOK, envdListResponse{Processes: processes})
+}
+
+func (s *server) handleEnvdProcessStart(w http.ResponseWriter, r *http.Request) {
+	if s.sessions == nil {
+		writeEnvdError(w, http.StatusServiceUnavailable, "sessions are disabled")
+		return
+	}
+	var req envdStartRequest
+	if err := readConnectJSONRequest(r, &req); err != nil {
+		writeEnvdError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if strings.TrimSpace(req.Process.Cmd) == "" {
+		writeEnvdError(w, http.StatusBadRequest, "process.cmd is required")
+		return
+	}
+	argv := append([]string{req.Process.Cmd}, req.Process.Args...)
+	createReq := models.CreateSessionRequest{
+		Name:    uniqueEnvdSessionName(req.Tag),
+		Argv:    argv,
+		WorkDir: strings.TrimSpace(req.Process.Cwd),
+		Env:     cloneEnvdStringMap(req.Process.Envs),
+		PTY:     req.PTY != nil,
+	}
+	if req.PTY != nil && req.PTY.Size != nil {
+		createReq.Cols = int(req.PTY.Size.Cols)
+		createReq.Rows = int(req.PTY.Size.Rows)
+	}
+	sess, err := s.sessions.Create(r.Context(), createReq)
+	if err != nil {
+		writeEnvdError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	stdinEnabled := req.Stdin != nil && *req.Stdin
+	state, err := s.envd.registerSession(sess, req.Tag, req.Process, req.PTY != nil, stdinEnabled)
+	if err != nil {
+		_ = s.sessions.Delete(sess.ID())
+		status := http.StatusInternalServerError
+		if errors.Is(err, errEnvdProcessTagConflict) {
+			status = http.StatusConflict
+		}
+		writeEnvdError(w, status, err.Error())
+		return
+	}
+	go func(pid int, sessionID string, done <-chan struct{}) {
+		<-done
+		s.envd.removeSession(pid, sessionID)
+	}(state.PID, state.SessionID, sess.Done())
+	if err := s.streamEnvdProcessSession(w, r, sess, state); err != nil {
+		s.logger.Debug("envd process start stream ended", "pid", state.PID, "error", err)
+	}
+}
+
+func (s *server) handleEnvdProcessConnect(w http.ResponseWriter, r *http.Request) {
+	state, sess, ok := s.lookupEnvdProcessSession(w, r)
+	if !ok {
+		return
+	}
+	if err := s.streamEnvdProcessSession(w, r, sess, state); err != nil {
+		s.logger.Debug("envd process connect stream ended", "pid", state.PID, "error", err)
+	}
+}
+
+func (s *server) handleEnvdProcessUpdate(w http.ResponseWriter, r *http.Request) {
+	var req envdUpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeEnvdError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	_, sess, ok := s.lookupEnvdProcessSessionFromSelector(w, req.Process)
+	if !ok {
+		return
+	}
+	if req.PTY == nil || req.PTY.Size == nil {
+		writeJSON(w, http.StatusOK, envdEmptyResponse{})
+		return
+	}
+	if err := sess.Resize(int(req.PTY.Size.Cols), int(req.PTY.Size.Rows)); err != nil {
+		writeEnvdError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, envdEmptyResponse{})
+}
+
+func (s *server) handleEnvdProcessSendInput(w http.ResponseWriter, r *http.Request) {
+	var req envdSendInputRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeEnvdError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	state, sess, ok := s.lookupEnvdProcessSessionFromSelector(w, req.Process)
+	if !ok {
+		return
+	}
+	payload, isPTY, err := req.Input.decode()
+	if err != nil {
+		writeEnvdError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if !state.PTY && isPTY {
+		writeEnvdError(w, http.StatusBadRequest, "pty input is not valid for a pipe process")
+		return
+	}
+	if state.PTY && !isPTY {
+		writeEnvdError(w, http.StatusBadRequest, "stdin input is not valid for a PTY process")
+		return
+	}
+	if !state.PTY && !state.Stdin {
+		writeEnvdError(w, http.StatusFailedDependency, "stdin is not enabled for this process")
+		return
+	}
+	if _, err := sess.Write(payload); err != nil {
+		writeEnvdError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, envdEmptyResponse{})
+}
+
+func (s *server) handleEnvdProcessSendSignal(w http.ResponseWriter, r *http.Request) {
+	var req envdSendSignalRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeEnvdError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	_, sess, ok := s.lookupEnvdProcessSessionFromSelector(w, req.Process)
+	if !ok {
+		return
+	}
+	signalName, err := mapEnvdSignal(req.Signal)
+	if err != nil {
+		writeEnvdError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := sess.Signal(signalName); err != nil {
+		writeEnvdError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, envdEmptyResponse{})
+}
+
+func (s *server) handleEnvdProcessCloseStdin(w http.ResponseWriter, r *http.Request) {
+	var req envdCloseStdinRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeEnvdError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	state, sess, ok := s.lookupEnvdProcessSessionFromSelector(w, req.Process)
+	if !ok {
+		return
+	}
+	if !state.PTY && !state.Stdin {
+		writeJSON(w, http.StatusOK, envdEmptyResponse{})
+		return
+	}
+	if err := sess.CloseStdin(); err != nil {
+		writeEnvdError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, envdEmptyResponse{})
+}
+
+func (s *server) streamEnvdProcessSession(w http.ResponseWriter, r *http.Request, sess *sessions.Session, state *envdProcessState) error {
+	stream := startConnectJSONStream(w)
+	if err := stream.Send(envdProcessStreamResponse{Event: envdProcessEvent{Start: &envdProcessStartEvent{PID: state.PID}}}); err != nil {
+		return err
+	}
+	frames, cancel := sess.Subscribe()
+	defer cancel()
+	keepaliveTicker := newKeepaliveTicker(r)
+	if keepaliveTicker != nil {
+		defer keepaliveTicker.Stop()
+	}
+	for {
+		select {
+		case <-r.Context().Done():
+			return r.Context().Err()
+		case <-sess.Done():
+			s.drainEnvdProcessFrames(stream, frames, state.PTY)
+			code, signal := sess.ExitInfo()
+			end := envdProcessEndEvent{ExitCode: code, Exited: true, Status: signal}
+			if code != 0 {
+				if signal != "" {
+					end.Error = signal
+				} else {
+					end.Error = fmt.Sprintf("process exited with code %d", code)
+				}
+			}
+			if err := stream.Send(envdProcessStreamResponse{Event: envdProcessEvent{End: &end}}); err != nil {
+				return err
+			}
+			return stream.End()
+		case frame, ok := <-frames:
+			if !ok {
+				continue
+			}
+			if err := stream.Send(envdProcessStreamResponse{Event: envdProcessEvent{Data: buildEnvdProcessDataEvent(frame, state.PTY)}}); err != nil {
+				return err
+			}
+		case <-keepaliveChan(keepaliveTicker):
+			if err := stream.Send(envdProcessStreamResponse{Event: envdProcessEvent{Keepalive: &struct{}{}}}); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (s *server) drainEnvdProcessFrames(stream *connectJSONStream, frames <-chan sessions.Frame, isPTY bool) {
+	for {
+		select {
+		case frame, ok := <-frames:
+			if !ok {
+				return
+			}
+			if err := stream.Send(envdProcessStreamResponse{Event: envdProcessEvent{Data: buildEnvdProcessDataEvent(frame, isPTY)}}); err != nil {
+				return
+			}
+		default:
+			return
+		}
+	}
+}
+
+func buildEnvdProcessDataEvent(frame sessions.Frame, isPTY bool) *envdProcessDataEvent {
+	encoded := base64.StdEncoding.EncodeToString(frame.Data)
+	data := &envdProcessDataEvent{}
+	if isPTY {
+		data.PTY = encoded
+		return data
+	}
+	if frame.Stream == sessions.StreamStderr {
+		data.Stderr = encoded
+	} else {
+		data.Stdout = encoded
+	}
+	return data
+}
+
+func (s *server) lookupEnvdProcessSession(w http.ResponseWriter, r *http.Request) (*envdProcessState, *sessions.Session, bool) {
+	var req envdConnectRequest
+	if err := readConnectJSONRequest(r, &req); err != nil {
+		writeEnvdError(w, http.StatusBadRequest, err.Error())
+		return nil, nil, false
+	}
+	return s.lookupEnvdProcessSessionFromSelector(w, req.Process)
+}
+
+func (s *server) lookupEnvdProcessSessionFromSelector(w http.ResponseWriter, selector envdProcessSelector) (*envdProcessState, *sessions.Session, bool) {
+	if s.sessions == nil {
+		writeEnvdError(w, http.StatusServiceUnavailable, "sessions are disabled")
+		return nil, nil, false
+	}
+	state, ok := s.envd.lookup(selector)
+	if !ok {
+		writeEnvdError(w, http.StatusNotFound, "process not found")
+		return nil, nil, false
+	}
+	sess, err := s.sessions.Get(state.SessionID)
+	if err != nil {
+		s.envd.removeSession(state.PID, state.SessionID)
+		writeEnvdError(w, http.StatusNotFound, "process not found")
+		return nil, nil, false
+	}
+	if code, signal := sess.ExitInfo(); code >= 0 || signal != "" {
+		s.envd.removeSession(state.PID, state.SessionID)
+		writeEnvdError(w, http.StatusNotFound, "process not found")
+		return nil, nil, false
+	}
+	return state, sess, true
+}
+
+func (s *server) handleEnvdFilesystemStat(w http.ResponseWriter, r *http.Request) {
+	var req envdStatRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeEnvdError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	targetPath, err := resolveDaytonaPath(req.Path, false)
+	if err != nil {
+		writeEnvdError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	entry, err := buildEnvdEntryInfo(targetPath)
+	if err != nil {
+		writeEnvdFilesystemError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, envdStatResponse{Entry: entry})
+}
+
+func (s *server) handleEnvdFilesystemMakeDir(w http.ResponseWriter, r *http.Request) {
+	var req envdMakeDirRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeEnvdError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	targetPath, err := resolveDaytonaPath(req.Path, false)
+	if err != nil {
+		writeEnvdError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if info, err := os.Stat(targetPath); err == nil {
+		if info.IsDir() {
+			writeEnvdError(w, http.StatusConflict, "directory already exists")
+			return
+		}
+		writeEnvdError(w, http.StatusConflict, "path already exists")
+		return
+	} else if !errors.Is(err, os.ErrNotExist) {
+		writeEnvdFilesystemError(w, err)
+		return
+	}
+	if err := os.MkdirAll(targetPath, 0o755); err != nil {
+		writeEnvdFilesystemError(w, err)
+		return
+	}
+	entry, err := buildEnvdEntryInfo(targetPath)
+	if err != nil {
+		writeEnvdFilesystemError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, envdMakeDirResponse{Entry: entry})
+}
+
+func (s *server) handleEnvdFilesystemMove(w http.ResponseWriter, r *http.Request) {
+	var req envdMoveRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeEnvdError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	source, err := resolveDaytonaPath(req.Source, false)
+	if err != nil {
+		writeEnvdError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	destination, err := resolveDaytonaPath(req.Destination, false)
+	if err != nil {
+		writeEnvdError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+		writeEnvdFilesystemError(w, err)
+		return
+	}
+	if err := os.Rename(source, destination); err != nil {
+		writeEnvdFilesystemError(w, err)
+		return
+	}
+	entry, err := buildEnvdEntryInfo(destination)
+	if err != nil {
+		writeEnvdFilesystemError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, envdMoveResponse{Entry: entry})
+}
+
+func (s *server) handleEnvdFilesystemListDir(w http.ResponseWriter, r *http.Request) {
+	var req envdListDirRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeEnvdError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if req.Depth == 0 {
+		req.Depth = 1
+	}
+	targetPath, err := resolveDaytonaPath(req.Path, false)
+	if err != nil {
+		writeEnvdError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	entries, err := listEnvdEntries(targetPath, int(req.Depth))
+	if err != nil {
+		writeEnvdFilesystemError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, envdListDirResponse{Entries: entries})
+}
+
+func (s *server) handleEnvdFilesystemRemove(w http.ResponseWriter, r *http.Request) {
+	var req envdRemoveRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeEnvdError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	targetPath, err := resolveDaytonaPath(req.Path, false)
+	if err != nil {
+		writeEnvdError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if _, err := os.Lstat(targetPath); err != nil {
+		writeEnvdFilesystemError(w, err)
+		return
+	}
+	if err := os.RemoveAll(targetPath); err != nil {
+		writeEnvdFilesystemError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, envdEmptyResponse{})
+}
+
+func buildEnvdWriteInfo(path string) envdWriteInfo {
+	return envdWriteInfo{Name: filepath.Base(path), Type: "file", Path: path}
+}
+
+func buildEnvdEntryInfo(path string) (envdEntryInfo, error) {
+	return buildEnvdEntryInfoAt(path, path)
+}
+
+func buildEnvdEntryInfoAt(path, displayPath string) (envdEntryInfo, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return envdEntryInfo{}, err
+	}
+	owner, group := fileOwnerGroup(info)
+	entry := envdEntryInfo{
+		Name:         filepath.Base(displayPath),
+		Type:         envdFileTypeFile,
+		Path:         displayPath,
+		Size:         info.Size(),
+		Mode:         uint32(info.Mode()),
+		Permissions:  envdPermissionString(info.Mode()),
+		Owner:        owner,
+		Group:        group,
+		ModifiedTime: info.ModTime().UTC().Format(time.RFC3339Nano),
+	}
+	if info.IsDir() {
+		entry.Type = envdFileTypeDirectory
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		if target, err := os.Readlink(path); err == nil {
+			entry.SymlinkTarget = &target
+		}
+	}
+	return entry, nil
+}
+
+func envdPermissionString(mode os.FileMode) string {
+	text := mode.String()
+	if len(text) == 0 {
+		return ""
+	}
+	return text[1:]
+}
+
+func listEnvdEntries(root string, depth int) ([]envdEntryInfo, error) {
+	walkRoot := root
+	if resolvedRoot, err := filepath.EvalSymlinks(root); err == nil {
+		if info, statErr := os.Stat(resolvedRoot); statErr == nil && info.IsDir() {
+			walkRoot = resolvedRoot
+		}
+	}
+	entries := []envdEntryInfo{}
+	err := filepath.WalkDir(walkRoot, func(path string, entry iofs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == walkRoot {
+			return nil
+		}
+		rel, err := filepath.Rel(walkRoot, path)
+		if err != nil {
+			return err
+		}
+		level := strings.Count(rel, string(os.PathSeparator)) + 1
+		if level > depth {
+			if entry.IsDir() {
+				return iofs.SkipDir
+			}
+			return nil
+		}
+		displayPath := filepath.Join(root, rel)
+		info, err := buildEnvdEntryInfoAt(path, displayPath)
+		if err != nil {
+			return err
+		}
+		entries = append(entries, info)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Path < entries[j].Path })
+	return entries, nil
+}
+
+func (in envdProcessInput) decode() ([]byte, bool, error) {
+	if in.PTY != "" {
+		payload, err := base64.StdEncoding.DecodeString(in.PTY)
+		if err != nil {
+			return nil, false, errors.New("invalid pty input encoding")
+		}
+		return payload, true, nil
+	}
+	if in.Stdin == "" {
+		return nil, false, errors.New("input is required")
+	}
+	payload, err := base64.StdEncoding.DecodeString(in.Stdin)
+	if err != nil {
+		return nil, false, errors.New("invalid stdin input encoding")
+	}
+	return payload, false, nil
+}
+
+func mapEnvdSignal(raw string) (string, error) {
+	switch strings.TrimSpace(raw) {
+	case "SIGNAL_SIGTERM", "15", "SIGTERM", "TERM":
+		return "TERM", nil
+	case "SIGNAL_SIGKILL", "9", "SIGKILL", "KILL":
+		return "KILL", nil
+	case "SIGNAL_UNSPECIFIED", "", "0":
+		return "TERM", nil
+	default:
+		return "", fmt.Errorf("unsupported signal %q", raw)
+	}
+}
+
+func uniqueEnvdSessionName(tag string) string {
+	tag = strings.TrimSpace(tag)
+	if tag == "" {
+		return fmt.Sprintf("envd-%d", time.Now().UTC().UnixNano())
+	}
+	return fmt.Sprintf("envd-%s-%d", tag, time.Now().UTC().UnixNano())
+}
+
+func readConnectJSONRequest(r *http.Request, dst any) error {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	if len(body) < connectEnvelopeHeaderLen {
+		return errors.New("invalid connect request envelope")
+	}
+	flags := body[0]
+	if flags&connectFlagCompressed != 0 {
+		return errors.New("compressed connect requests are not supported")
+	}
+	size := binary.BigEndian.Uint32(body[1:connectEnvelopeHeaderLen])
+	end := connectEnvelopeHeaderLen + int(size)
+	if end > len(body) {
+		return errors.New("truncated connect request envelope")
+	}
+	if err := json.Unmarshal(body[connectEnvelopeHeaderLen:end], dst); err != nil {
+		return err
+	}
+	return nil
+}
+
+func startConnectJSONStream(w http.ResponseWriter) *connectJSONStream {
+	w.Header().Set("Content-Type", "application/connect+json")
+	w.WriteHeader(http.StatusOK)
+	flushResponse(w)
+	return &connectJSONStream{w: w}
+}
+
+func (s *connectJSONStream) Send(value any) error {
+	return writeConnectEnvelope(s.w, 0, value)
+}
+
+func (s *connectJSONStream) End() error {
+	return writeConnectEnvelope(s.w, connectFlagEndStream, map[string]any{})
+}
+
+func writeConnectEnvelope(w http.ResponseWriter, flags byte, value any) error {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	header := make([]byte, connectEnvelopeHeaderLen)
+	header[0] = flags
+	binary.BigEndian.PutUint32(header[1:], uint32(len(payload)))
+	if _, err := w.Write(header); err != nil {
+		return err
+	}
+	if _, err := w.Write(payload); err != nil {
+		return err
+	}
+	flushResponse(w)
+	return nil
+}
+
+func newKeepaliveTicker(r *http.Request) *time.Ticker {
+	raw := strings.TrimSpace(r.Header.Get("Keepalive-Ping-Interval"))
+	if raw == "" {
+		return nil
+	}
+	seconds, err := time.ParseDuration(raw + "s")
+	if err != nil || seconds <= 0 {
+		return nil
+	}
+	return time.NewTicker(seconds)
+}
+
+func keepaliveChan(ticker *time.Ticker) <-chan time.Time {
+	if ticker == nil {
+		return nil
+	}
+	return ticker.C
+}
+
+func flushResponse(w http.ResponseWriter) {
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func writeEnvdError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, envdErrorResponse{Code: status, Message: message})
+}
+
+func writeEnvdFilesystemError(w http.ResponseWriter, err error) {
+	status := http.StatusInternalServerError
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		status = http.StatusNotFound
+	case errors.Is(err, os.ErrPermission):
+		status = http.StatusForbidden
+	case errors.Is(err, os.ErrExist):
+		status = http.StatusConflict
+	}
+	writeEnvdError(w, status, err.Error())
+}

--- a/cmd/toolboxd/envd.go
+++ b/cmd/toolboxd/envd.go
@@ -25,6 +25,7 @@ import (
 const (
 	envdPrefix               = "/envd"
 	connectEnvelopeHeaderLen = 5
+	connectJSONMaxPayloadLen = 4 * 1024 * 1024
 	connectFlagEndStream     = 0x02
 	connectFlagCompressed    = 0x01
 	envdFileTypeFile         = "FILE_TYPE_FILE"
@@ -1119,23 +1120,29 @@ func uniqueEnvdSessionName(tag string) string {
 }
 
 func readConnectJSONRequest(r *http.Request, dst any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
+	header := make([]byte, connectEnvelopeHeaderLen)
+	if _, err := io.ReadFull(r.Body, header); err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			return errors.New("invalid connect request envelope")
+		}
 		return err
 	}
-	if len(body) < connectEnvelopeHeaderLen {
-		return errors.New("invalid connect request envelope")
-	}
-	flags := body[0]
+	flags := header[0]
 	if flags&connectFlagCompressed != 0 {
 		return errors.New("compressed connect requests are not supported")
 	}
-	size := binary.BigEndian.Uint32(body[1:connectEnvelopeHeaderLen])
-	end := connectEnvelopeHeaderLen + int(size)
-	if end > len(body) {
-		return errors.New("truncated connect request envelope")
+	size := binary.BigEndian.Uint32(header[1:connectEnvelopeHeaderLen])
+	if size > connectJSONMaxPayloadLen {
+		return fmt.Errorf("connect request envelope exceeds %d bytes", connectJSONMaxPayloadLen)
 	}
-	if err := json.Unmarshal(body[connectEnvelopeHeaderLen:end], dst); err != nil {
+	payload := make([]byte, int(size))
+	if _, err := io.ReadFull(r.Body, payload); err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			return errors.New("truncated connect request envelope")
+		}
+		return err
+	}
+	if err := json.Unmarshal(payload, dst); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/toolboxd/envd.go
+++ b/cmd/toolboxd/envd.go
@@ -342,6 +342,10 @@ func cloneEnvdStringMap(values map[string]string) map[string]string {
 }
 
 func (s *server) handleEnvdRoute(w http.ResponseWriter, r *http.Request) bool {
+	if !validateEnvdRequestedUser(w, r) {
+		return true
+	}
+
 	switch {
 	case r.Method == http.MethodGet && r.URL.Path == envdPrefix+"/health":
 		s.handleEnvdHealth(w, r)
@@ -387,6 +391,71 @@ func (s *server) handleEnvdRoute(w http.ResponseWriter, r *http.Request) bool {
 		return false
 	}
 	return true
+}
+
+func validateEnvdRequestedUser(w http.ResponseWriter, r *http.Request) bool {
+	username, err := requestedEnvdUsername(r)
+	if err != nil {
+		writeEnvdError(w, http.StatusBadRequest, err.Error())
+		return false
+	}
+	if username == "" || isSupportedEnvdUser(username) {
+		return true
+	}
+	writeEnvdError(w, http.StatusNotImplemented, fmt.Sprintf("envd user %q is not supported", username))
+	return false
+}
+
+func requestedEnvdUsername(r *http.Request) (string, error) {
+	if r == nil {
+		return "", nil
+	}
+	username := strings.TrimSpace(r.URL.Query().Get("username"))
+	if basic := strings.TrimSpace(r.Header.Get("X-E2B-User-Authorization")); basic != "" {
+		basicUsername, err := parseEnvdBasicUsername(basic)
+		if err != nil {
+			return "", err
+		}
+		if username != "" && basicUsername != "" && username != basicUsername {
+			return "", errors.New("conflicting envd users")
+		}
+		if username == "" {
+			username = basicUsername
+		}
+	}
+	return username, nil
+}
+
+func parseEnvdBasicUsername(header string) (string, error) {
+	const prefix = "Basic "
+	if !strings.HasPrefix(header, prefix) {
+		return "", errors.New("invalid envd user authorization")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(strings.TrimPrefix(header, prefix)))
+	if err != nil {
+		return "", errors.New("invalid envd user authorization")
+	}
+	username, _, ok := strings.Cut(string(decoded), ":")
+	if !ok {
+		return "", errors.New("invalid envd user authorization")
+	}
+	return strings.TrimSpace(username), nil
+}
+
+func isSupportedEnvdUser(username string) bool {
+	username = strings.TrimSpace(username)
+	if username == "" {
+		return true
+	}
+	if username == "root" {
+		return os.Geteuid() == 0
+	}
+	for _, current := range []string{os.Getenv("USER"), os.Getenv("LOGNAME")} {
+		if current != "" && username == current {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *server) handleEnvdHealth(w http.ResponseWriter, r *http.Request) {

--- a/cmd/toolboxd/envd_test.go
+++ b/cmd/toolboxd/envd_test.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aerol-ai/microvm/cmd/toolboxd/sessions"
+)
+
+func TestEnvdFilesystemRoundTrip(t *testing.T) {
+	srv := newEnvdTestServer(t)
+	handler := srv.routes()
+	root := t.TempDir()
+	targetPath := filepath.Join(root, "notes.txt")
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	fileWriter, err := writer.CreateFormFile("file", targetPath)
+	if err != nil {
+		t.Fatalf("CreateFormFile() error = %v", err)
+	}
+	if _, err := io.WriteString(fileWriter, "hello envd"); err != nil {
+		t.Fatalf("WriteString() error = %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("multipart close error = %v", err)
+	}
+
+	writeReq := httptest.NewRequest(http.MethodPost, envdPrefix+"/files?path="+targetPath, &body)
+	writeReq.Header.Set("Authorization", "Bearer toolbox-token")
+	writeReq.Header.Set("Content-Type", writer.FormDataContentType())
+	writeResp := httptest.NewRecorder()
+	handler.ServeHTTP(writeResp, writeReq)
+	if writeResp.Code != http.StatusOK {
+		t.Fatalf("write status = %d, want %d; body=%s", writeResp.Code, http.StatusOK, writeResp.Body.String())
+	}
+	var writes []envdWriteInfo
+	if err := json.NewDecoder(writeResp.Body).Decode(&writes); err != nil {
+		t.Fatalf("decode write response error = %v", err)
+	}
+	if len(writes) != 1 || writes[0].Path != targetPath {
+		t.Fatalf("unexpected write response: %+v", writes)
+	}
+
+	readReq := httptest.NewRequest(http.MethodGet, envdPrefix+"/files?path="+targetPath, nil)
+	readReq.Header.Set("Authorization", "Bearer toolbox-token")
+	readResp := httptest.NewRecorder()
+	handler.ServeHTTP(readResp, readReq)
+	if readResp.Code != http.StatusOK {
+		t.Fatalf("read status = %d, want %d; body=%s", readResp.Code, http.StatusOK, readResp.Body.String())
+	}
+	if got := readResp.Body.String(); got != "hello envd" {
+		t.Fatalf("read body = %q, want %q", got, "hello envd")
+	}
+
+	listBody, err := json.Marshal(envdListDirRequest{Path: root, Depth: 1})
+	if err != nil {
+		t.Fatalf("marshal list request error = %v", err)
+	}
+	listReq := httptest.NewRequest(http.MethodPost, envdPrefix+"/filesystem.Filesystem/ListDir", bytes.NewReader(listBody))
+	listReq.Header.Set("Authorization", "Bearer toolbox-token")
+	listResp := httptest.NewRecorder()
+	handler.ServeHTTP(listResp, listReq)
+	if listResp.Code != http.StatusOK {
+		t.Fatalf("list status = %d, want %d; body=%s", listResp.Code, http.StatusOK, listResp.Body.String())
+	}
+	var listed envdListDirResponse
+	if err := json.NewDecoder(listResp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode list response error = %v", err)
+	}
+	if len(listed.Entries) != 1 || listed.Entries[0].Path != targetPath {
+		t.Fatalf("unexpected listed entries: %+v", listed.Entries)
+	}
+}
+
+func TestListEnvdEntriesFollowsSymlinkRoot(t *testing.T) {
+	realRoot := t.TempDir()
+	linkRoot := filepath.Join(t.TempDir(), "tmp-link")
+	if err := os.Symlink(realRoot, linkRoot); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(realRoot, "hello.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write file error = %v", err)
+	}
+
+	entries, err := listEnvdEntries(linkRoot, 1)
+	if err != nil {
+		t.Fatalf("listEnvdEntries error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("entry count = %d, want 1", len(entries))
+	}
+	if entries[0].Path != filepath.Join(linkRoot, "hello.txt") {
+		t.Fatalf("entry path = %q, want %q", entries[0].Path, filepath.Join(linkRoot, "hello.txt"))
+	}
+}
+
+func TestEnvdProcessStartStreamsConnectJSON(t *testing.T) {
+	srv := newEnvdTestServer(t)
+	handler := srv.routes()
+
+	payload, err := json.Marshal(envdStartRequest{
+		Process: envdProcessConfig{
+			Cmd:  "/bin/sh",
+			Args: []string{"-c", "printf hello"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal start request error = %v", err)
+	}
+	startReq := httptest.NewRequest(http.MethodPost, envdPrefix+"/process.Process/Start", bytes.NewReader(encodeConnectEnvelopeForTest(payload)))
+	startReq.Header.Set("Authorization", "Bearer toolbox-token")
+	startReq.Header.Set("Content-Type", "application/connect+json")
+	startResp := httptest.NewRecorder()
+	handler.ServeHTTP(startResp, startReq)
+	if startResp.Code != http.StatusOK {
+		t.Fatalf("start status = %d, want %d; body=%s", startResp.Code, http.StatusOK, startResp.Body.String())
+	}
+
+	envelopes := decodeConnectEnvelopesForTest(t, startResp.Body.Bytes())
+	if len(envelopes) < 4 {
+		t.Fatalf("envelope count = %d, want at least 4", len(envelopes))
+	}
+	var start envdProcessStreamResponse
+	if err := json.Unmarshal(envelopes[0].Payload, &start); err != nil {
+		t.Fatalf("decode start envelope error = %v", err)
+	}
+	if start.Event.Start == nil || start.Event.Start.PID <= 0 {
+		t.Fatalf("unexpected start event: %+v", start)
+	}
+
+	stdout := ""
+	ended := false
+	for _, envelope := range envelopes[1:] {
+		if envelope.Flags&connectFlagEndStream != 0 {
+			continue
+		}
+		var event envdProcessStreamResponse
+		if err := json.Unmarshal(envelope.Payload, &event); err != nil {
+			t.Fatalf("decode event envelope error = %v", err)
+		}
+		if event.Event.Data != nil && event.Event.Data.Stdout != "" {
+			decoded, err := base64.StdEncoding.DecodeString(event.Event.Data.Stdout)
+			if err != nil {
+				t.Fatalf("decode stdout error = %v", err)
+			}
+			stdout += string(decoded)
+		}
+		if event.Event.End != nil {
+			ended = true
+			if event.Event.End.ExitCode != 0 {
+				t.Fatalf("end exit code = %d, want 0", event.Event.End.ExitCode)
+			}
+		}
+	}
+	if !strings.Contains(stdout, "hello") {
+		t.Fatalf("stdout = %q, want to contain %q", stdout, "hello")
+	}
+	if !ended {
+		t.Fatal("expected end event in process stream")
+	}
+	last := envelopes[len(envelopes)-1]
+	if last.Flags&connectFlagEndStream == 0 {
+		t.Fatalf("last envelope flags = %d, want end stream flag", last.Flags)
+	}
+}
+
+type decodedConnectEnvelope struct {
+	Flags   byte
+	Payload []byte
+}
+
+func newEnvdTestServer(t *testing.T) *server {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	sessionsMgr, err := sessions.New(logger, sessions.Config{
+		SandboxID:    "sb-test",
+		RecordingDir: filepath.Join(t.TempDir(), "recordings"),
+		BufferBytes:  1 << 20,
+	})
+	if err != nil {
+		t.Fatalf("sessions.New() error = %v", err)
+	}
+	t.Cleanup(sessionsMgr.Close)
+	return &server{
+		logger:       logger,
+		sandboxID:    "sb-test",
+		authToken:    "toolbox-token",
+		allowedPorts: map[int]struct{}{},
+		sessions:     sessionsMgr,
+		daytona:      newDaytonaCompat(),
+		envd:         newEnvdCompat(),
+	}
+}
+
+func encodeConnectEnvelopeForTest(payload []byte) []byte {
+	header := make([]byte, connectEnvelopeHeaderLen)
+	binary.BigEndian.PutUint32(header[1:], uint32(len(payload)))
+	return append(header, payload...)
+}
+
+func decodeConnectEnvelopesForTest(t *testing.T, body []byte) []decodedConnectEnvelope {
+	t.Helper()
+	items := []decodedConnectEnvelope{}
+	for len(body) > 0 {
+		if len(body) < connectEnvelopeHeaderLen {
+			t.Fatalf("short connect envelope header: %d bytes", len(body))
+		}
+		flags := body[0]
+		size := binary.BigEndian.Uint32(body[1:connectEnvelopeHeaderLen])
+		body = body[connectEnvelopeHeaderLen:]
+		if int(size) > len(body) {
+			t.Fatalf("truncated connect envelope payload: size=%d remaining=%d", size, len(body))
+		}
+		payload := append([]byte(nil), body[:size]...)
+		body = body[size:]
+		items = append(items, decodedConnectEnvelope{Flags: flags, Payload: payload})
+	}
+	return items
+}

--- a/cmd/toolboxd/envd_test.go
+++ b/cmd/toolboxd/envd_test.go
@@ -227,6 +227,18 @@ func encodeConnectEnvelopeForTest(payload []byte) []byte {
 	return append(header, payload...)
 }
 
+func TestReadConnectJSONRequestRejectsOversizedEnvelope(t *testing.T) {
+	header := make([]byte, connectEnvelopeHeaderLen)
+	binary.BigEndian.PutUint32(header[1:], uint32(connectJSONMaxPayloadLen+1))
+	req := httptest.NewRequest(http.MethodPost, envdPrefix+"/processes/start", bytes.NewReader(header))
+
+	var dst envdStartRequest
+	err := readConnectJSONRequest(req, &dst)
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("readConnectJSONRequest() error = %v, want oversized envelope error", err)
+	}
+}
+
 func basicUserHeaderForTest(username string) string {
 	return "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"))
 }

--- a/cmd/toolboxd/envd_test.go
+++ b/cmd/toolboxd/envd_test.go
@@ -176,6 +176,23 @@ func TestEnvdProcessStartStreamsConnectJSON(t *testing.T) {
 	}
 }
 
+func TestEnvdRejectsUnsupportedRequestedUser(t *testing.T) {
+	srv := newEnvdTestServer(t)
+	handler := srv.routes()
+
+	req := httptest.NewRequest(http.MethodGet, envdPrefix+"/files?path=/tmp/missing", nil)
+	req.Header.Set("Authorization", "Bearer toolbox-token")
+	req.Header.Set("X-E2B-User-Authorization", basicUserHeaderForTest("aerolvm-unsupported-user"))
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want %d; body=%s", resp.Code, http.StatusNotImplemented, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "aerolvm-unsupported-user") {
+		t.Fatalf("body = %q, want unsupported user message", resp.Body.String())
+	}
+}
+
 type decodedConnectEnvelope struct {
 	Flags   byte
 	Payload []byte
@@ -208,6 +225,10 @@ func encodeConnectEnvelopeForTest(payload []byte) []byte {
 	header := make([]byte, connectEnvelopeHeaderLen)
 	binary.BigEndian.PutUint32(header[1:], uint32(len(payload)))
 	return append(header, payload...)
+}
+
+func basicUserHeaderForTest(username string) string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"))
 }
 
 func decodeConnectEnvelopesForTest(t *testing.T, body []byte) []decodedConnectEnvelope {

--- a/cmd/toolboxd/main.go
+++ b/cmd/toolboxd/main.go
@@ -39,6 +39,7 @@ type server struct {
 
 	sessions *sessions.Manager
 	daytona  *daytonaCompat
+	envd     *envdCompat
 }
 
 func (s *server) setAllowedPorts(ports []int) {
@@ -70,6 +71,7 @@ func main() {
 		port:         envInt("SB_TOOLBOX_PORT", 2280),
 		allowedPorts: map[int]struct{}{},
 		daytona:      newDaytonaCompat(),
+		envd:         newEnvdCompat(),
 	}
 	// Evict the token from the process env table so child processes spawned
 	// for the user command and /exec endpoints don't inherit it via os.Environ().
@@ -192,6 +194,13 @@ func (s *server) routes() http.Handler {
 			writeJSON(w, http.StatusOK, map[string]any{"version": version.Version})
 		case strings.HasPrefix(r.URL.Path, "/proxy/"):
 			s.handleProxy(w, r)
+		case strings.HasPrefix(r.URL.Path, "/envd/"):
+			if !s.requireAuth(w, r) {
+				return
+			}
+			if !s.handleEnvdRoute(w, r) {
+				writeEnvdError(w, http.StatusNotFound, "not found")
+			}
 		case r.Method == http.MethodPost && r.URL.Path == "/process/execute":
 			if !s.requireAuth(w, r) {
 				return
@@ -290,6 +299,9 @@ func normalizeSandboxPath(path, sandboxID string) string {
 	if path == "" {
 		return "/"
 	}
+	if path == envdPrefix || strings.HasPrefix(path, envdPrefix+"/") {
+		return path
+	}
 
 	if sandboxID != "" {
 		prefix := "/" + sandboxID
@@ -347,6 +359,8 @@ func isKnownToolboxPath(path string) bool {
 	case strings.HasPrefix(path, "/git/"):
 		return true
 	case strings.HasPrefix(path, "/proxy/"):
+		return true
+	case strings.HasPrefix(path, "/envd/"):
 		return true
 	case path == "/sessions" || strings.HasPrefix(path, "/sessions/"):
 		return true

--- a/cmd/toolboxd/sessions/session.go
+++ b/cmd/toolboxd/sessions/session.go
@@ -108,6 +108,15 @@ func (s *Session) ID() string { return s.id }
 // Name returns the human-friendly session name.
 func (s *Session) Name() string { return s.name }
 
+// PID returns the OS process identifier for the session, or 0 when the
+// session has not started successfully.
+func (s *Session) PID() int {
+	if s == nil || s.cmd == nil || s.cmd.Process == nil {
+		return 0
+	}
+	return s.cmd.Process.Pid
+}
+
 // IsPTY reports whether the session was started in PTY mode.
 func (s *Session) IsPTY() bool { return s.pty }
 

--- a/docs/src/content/docs/sdk-setup.md
+++ b/docs/src/content/docs/sdk-setup.md
@@ -49,6 +49,31 @@ print(sandbox['public_url'])
 sandbox.destroy()
 ```
 
+## E2B Python SDK Compatibility
+
+AerolVM also exposes a compatibility facade for the unmodified E2B Python SDK. Point both the E2B control plane and runtime plane at the AerolVM `/e2b` routes:
+
+```bash
+pip install e2b
+
+export E2B_API_URL=https://sandbox.example.com/e2b
+export E2B_SANDBOX_URL=https://sandbox.example.com/e2b/runtime
+export E2B_API_KEY="$SB_PAT_TOKEN"
+```
+
+```py
+from e2b import Sandbox
+
+sandbox = Sandbox.create(template="base")
+result = sandbox.commands.run("python --version")
+print(result.stdout)
+sandbox.kill()
+```
+
+`E2B_SANDBOX_URL` is required for this compatibility mode. Without it, the E2B SDK builds runtime URLs like `https://49983-<sandbox>.<domain>`, which are not the path-based AerolVM runtime gateway.
+
+This facade supports the core create, list, connect, pause, kill, file, command, and snapshot flows. E2B template builds, volumes, traffic access tokens, metrics, logs, and E2B-style public host routing are not part of this first compatibility surface.
+
 ## Go
 
 ```bash

--- a/internal/service/e2b.go
+++ b/internal/service/e2b.go
@@ -1,0 +1,35 @@
+package service
+
+import (
+	"context"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func (s *Service) UpsertE2BSandboxMetadata(ctx context.Context, meta models.E2BSandboxMetadata) error {
+	return s.store.UpsertE2BSandboxMetadata(ctx, meta)
+}
+
+func (s *Service) GetE2BSandboxMetadata(ctx context.Context, sandboxID string) (*models.E2BSandboxMetadata, error) {
+	return s.store.GetE2BSandboxMetadata(ctx, sandboxID)
+}
+
+func (s *Service) ListE2BSandboxMetadata(ctx context.Context) (map[string]models.E2BSandboxMetadata, error) {
+	return s.store.ListE2BSandboxMetadata(ctx)
+}
+
+func (s *Service) UpsertE2BSnapshot(ctx context.Context, meta models.E2BSnapshotMetadata) error {
+	return s.store.UpsertE2BSnapshot(ctx, meta)
+}
+
+func (s *Service) GetE2BSnapshot(ctx context.Context, snapshotID string) (*models.E2BSnapshotMetadata, error) {
+	return s.store.GetE2BSnapshot(ctx, snapshotID)
+}
+
+func (s *Service) ListE2BSnapshots(ctx context.Context) (map[string]models.E2BSnapshotMetadata, error) {
+	return s.store.ListE2BSnapshots(ctx)
+}
+
+func (s *Service) DeleteE2BSnapshot(ctx context.Context, snapshotID string) error {
+	return s.store.DeleteE2BSnapshot(ctx, snapshotID)
+}

--- a/internal/service/e2b.go
+++ b/internal/service/e2b.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"time"
 
 	"github.com/aerol-ai/microvm/pkg/models"
 )
@@ -32,4 +33,20 @@ func (s *Service) ListE2BSnapshots(ctx context.Context) (map[string]models.E2BSn
 
 func (s *Service) DeleteE2BSnapshot(ctx context.Context, snapshotID string) error {
 	return s.store.DeleteE2BSnapshot(ctx, snapshotID)
+}
+
+func (s *Service) ClaimE2BCreateRequest(ctx context.Context, fingerprint string, now time.Time, pendingTTL time.Duration) (*models.E2BCreateRequestRecord, bool, error) {
+	return s.store.ClaimE2BCreateRequest(ctx, fingerprint, now, pendingTTL)
+}
+
+func (s *Service) GetE2BCreateRequest(ctx context.Context, fingerprint string) (*models.E2BCreateRequestRecord, error) {
+	return s.store.GetE2BCreateRequest(ctx, fingerprint)
+}
+
+func (s *Service) CompleteE2BCreateRequest(ctx context.Context, fingerprint, sandboxID string, now time.Time, replayTTL time.Duration) error {
+	return s.store.CompleteE2BCreateRequest(ctx, fingerprint, sandboxID, now, replayTTL)
+}
+
+func (s *Service) DeleteE2BCreateRequest(ctx context.Context, fingerprint string) error {
+	return s.store.DeleteE2BCreateRequest(ctx, fingerprint)
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -492,9 +492,17 @@ func (s *Service) DestroySandbox(ctx context.Context, id string) error {
 // name return the stored snapshot metadata, while a different sandbox trying
 // to claim the same name is rejected with a conflict.
 func (s *Service) CreateSnapshot(ctx context.Context, sandboxID string, req models.CreateSandboxSnapshotRequest) (*models.SandboxSnapshot, error) {
+	snapshot, _, err := s.CreateSnapshotWithOwnership(ctx, sandboxID, req)
+	return snapshot, err
+}
+
+// CreateSnapshotWithOwnership commits a sandbox image and reports whether this
+// call created the native snapshot row. Callers that add companion metadata can
+// use the flag to avoid rolling back a snapshot that already existed.
+func (s *Service) CreateSnapshotWithOwnership(ctx context.Context, sandboxID string, req models.CreateSandboxSnapshotRequest) (*models.SandboxSnapshot, bool, error) {
 	name := strings.TrimSpace(req.Name)
 	if name == "" {
-		return nil, errors.New("snapshot name is required")
+		return nil, false, errors.New("snapshot name is required")
 	}
 
 	s.snapshotMu.Lock()
@@ -502,21 +510,21 @@ func (s *Service) CreateSnapshot(ctx context.Context, sandboxID string, req mode
 
 	if existing, err := s.store.GetSnapshot(ctx, name); err == nil {
 		if existing.SourceSandboxID == sandboxID {
-			return existing, nil
+			return existing, false, nil
 		}
-		return nil, store.ErrSnapshotNameConflict
+		return nil, false, store.ErrSnapshotNameConflict
 	} else if !errors.Is(err, store.ErrNotFound) {
-		return nil, err
+		return nil, false, err
 	}
 
 	sandbox, err := s.store.Get(ctx, sandboxID)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	imageID, err := s.docker.CreateSnapshot(ctx, sandboxContainerRef(sandbox), name)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	snapshot := &models.SandboxSnapshot{
@@ -530,12 +538,12 @@ func (s *Service) CreateSnapshot(ctx context.Context, sandboxID string, req mode
 		if errors.Is(err, store.ErrSnapshotNameConflict) {
 			existing, getErr := s.store.GetSnapshot(ctx, name)
 			if getErr == nil && existing.SourceSandboxID == sandboxID {
-				return existing, nil
+				return existing, false, nil
 			}
 		}
-		return nil, err
+		return nil, false, err
 	}
-	return snapshot, nil
+	return snapshot, true, nil
 }
 
 func (s *Service) GetSnapshot(ctx context.Context, idOrName string) (*models.SandboxSnapshot, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -121,11 +121,12 @@ func Open(path string) (*Store, error) {
 		);`,
 		`CREATE TABLE IF NOT EXISTS e2b_snapshots (
 			snapshot_id TEXT PRIMARY KEY,
-			snapshot_name TEXT NOT NULL,
+			snapshot_name TEXT NOT NULL UNIQUE,
 			names_json TEXT NOT NULL DEFAULT '[]',
 			source_sandbox_id TEXT NOT NULL DEFAULT '',
 			created_at DATETIME NOT NULL,
-			updated_at DATETIME NOT NULL
+			updated_at DATETIME NOT NULL,
+			FOREIGN KEY (snapshot_name) REFERENCES sandbox_snapshots(name) ON DELETE CASCADE
 		);`,
 		`CREATE TABLE IF NOT EXISTS e2b_create_requests (
 			fingerprint TEXT PRIMARY KEY,
@@ -152,6 +153,7 @@ func Open(path string) (*Store, error) {
 		// status values is small enough that a composite buys nothing.
 		`CREATE INDEX IF NOT EXISTS idx_sandboxes_image ON sandboxes(image);`,
 		`CREATE INDEX IF NOT EXISTS idx_e2b_create_requests_replay_until ON e2b_create_requests(replay_until);`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_e2b_snapshots_snapshot_name ON e2b_snapshots(snapshot_name);`,
 		`CREATE INDEX IF NOT EXISTS idx_e2b_snapshots_source_sandbox_id ON e2b_snapshots(source_sandbox_id);`,
 		`CREATE INDEX IF NOT EXISTS idx_sandbox_snapshots_source_sandbox_id ON sandbox_snapshots(source_sandbox_id);`,
 	}
@@ -830,32 +832,42 @@ func (s *Store) ClaimE2BCreateRequest(ctx context.Context, fingerprint string, n
 	}
 	defer tx.Rollback()
 
-	record, err := scanE2BCreateRequestRecord(tx.QueryRowContext(ctx, `
+	record := &models.E2BCreateRequestRecord{
+		Fingerprint: trimmed,
+		State:       models.E2BCreateRequestStatePending,
+		LockedUntil: now.Add(pendingTTL),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	result, err := tx.ExecContext(ctx, `
+		INSERT INTO e2b_create_requests (fingerprint, sandbox_id, state, locked_until, replay_until, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(fingerprint) DO NOTHING
+	`, record.Fingerprint, "", record.State, record.LockedUntil, nil, record.CreatedAt, record.UpdatedAt)
+	if err != nil {
+		return nil, false, fmt.Errorf("claim e2b create request: insert: %w", err)
+	}
+	inserted, err := result.RowsAffected()
+	if err != nil {
+		return nil, false, fmt.Errorf("claim e2b create request: inspect insert: %w", err)
+	}
+	if inserted > 0 {
+		if err := tx.Commit(); err != nil {
+			return nil, false, fmt.Errorf("claim e2b create request: commit insert: %w", err)
+		}
+		return record, true, nil
+	}
+
+	record, err = scanE2BCreateRequestRecord(tx.QueryRowContext(ctx, `
 		SELECT fingerprint, sandbox_id, state, locked_until, replay_until, created_at, updated_at
 		FROM e2b_create_requests
 		WHERE fingerprint = ?
 	`, trimmed))
 	if err != nil {
-		if !errors.Is(err, sql.ErrNoRows) {
-			return nil, false, fmt.Errorf("claim e2b create request: query: %w", err)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, false, fmt.Errorf("claim e2b create request: missing row after insert conflict")
 		}
-		record = &models.E2BCreateRequestRecord{
-			Fingerprint: trimmed,
-			State:       models.E2BCreateRequestStatePending,
-			LockedUntil: now.Add(pendingTTL),
-			CreatedAt:   now,
-			UpdatedAt:   now,
-		}
-		if _, err := tx.ExecContext(ctx, `
-			INSERT INTO e2b_create_requests (fingerprint, sandbox_id, state, locked_until, replay_until, created_at, updated_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?)
-		`, record.Fingerprint, "", record.State, record.LockedUntil, nil, record.CreatedAt, record.UpdatedAt); err != nil {
-			return nil, false, fmt.Errorf("claim e2b create request: insert: %w", err)
-		}
-		if err := tx.Commit(); err != nil {
-			return nil, false, fmt.Errorf("claim e2b create request: commit insert: %w", err)
-		}
-		return record, true, nil
+		return nil, false, fmt.Errorf("claim e2b create request: query: %w", err)
 	}
 
 	if record.State == models.E2BCreateRequestStateReady && !record.ReplayUntil.IsZero() && record.ReplayUntil.After(now) && strings.TrimSpace(record.SandboxID) != "" {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -101,6 +101,32 @@ func Open(path string) (*Store, error) {
 			updated_at DATETIME NOT NULL,
 			FOREIGN KEY (sandbox_id) REFERENCES sandboxes(id) ON DELETE CASCADE
 		);`,
+		`CREATE TABLE IF NOT EXISTS e2b_sandboxes (
+			sandbox_id TEXT PRIMARY KEY,
+			template_id TEXT NOT NULL DEFAULT '',
+			template_alias TEXT NOT NULL DEFAULT '',
+			metadata_json TEXT NOT NULL DEFAULT '{}',
+			timeout_seconds INTEGER NOT NULL DEFAULT 0,
+			on_timeout TEXT NOT NULL DEFAULT 'kill',
+			auto_resume INTEGER NOT NULL DEFAULT 0,
+			secure INTEGER NOT NULL DEFAULT 1,
+			allow_internet_access INTEGER,
+			network_allow_out_json TEXT NOT NULL DEFAULT '[]',
+			network_deny_out_json TEXT NOT NULL DEFAULT '[]',
+			allow_public_traffic INTEGER,
+			mask_request_host TEXT NOT NULL DEFAULT '',
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			FOREIGN KEY (sandbox_id) REFERENCES sandboxes(id) ON DELETE CASCADE
+		);`,
+		`CREATE TABLE IF NOT EXISTS e2b_snapshots (
+			snapshot_id TEXT PRIMARY KEY,
+			snapshot_name TEXT NOT NULL,
+			names_json TEXT NOT NULL DEFAULT '[]',
+			source_sandbox_id TEXT NOT NULL DEFAULT '',
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL
+		);`,
 		`CREATE TABLE IF NOT EXISTS sandbox_snapshots (
 			name TEXT PRIMARY KEY,
 			image TEXT NOT NULL,
@@ -116,6 +142,7 @@ func Open(path string) (*Store, error) {
 		// status using the index's row pointers, and the cardinality of
 		// status values is small enough that a composite buys nothing.
 		`CREATE INDEX IF NOT EXISTS idx_sandboxes_image ON sandboxes(image);`,
+		`CREATE INDEX IF NOT EXISTS idx_e2b_snapshots_source_sandbox_id ON e2b_snapshots(source_sandbox_id);`,
 		`CREATE INDEX IF NOT EXISTS idx_sandbox_snapshots_source_sandbox_id ON sandbox_snapshots(source_sandbox_id);`,
 	}
 
@@ -586,6 +613,201 @@ func (s *Store) GetDaytonaMetadata(ctx context.Context, sandboxID string) (*mode
 	return meta, nil
 }
 
+func (s *Store) UpsertE2BSandboxMetadata(ctx context.Context, meta models.E2BSandboxMetadata) error {
+	metadataJSON, err := marshalJSON(meta.Metadata, "{}")
+	if err != nil {
+		return fmt.Errorf("marshal e2b metadata: %w", err)
+	}
+	allowOutJSON, err := marshalJSON(meta.NetworkAllowOut, "[]")
+	if err != nil {
+		return fmt.Errorf("marshal e2b allowOut: %w", err)
+	}
+	denyOutJSON, err := marshalJSON(meta.NetworkDenyOut, "[]")
+	if err != nil {
+		return fmt.Errorf("marshal e2b denyOut: %w", err)
+	}
+	now := time.Now().UTC()
+	createdAt := meta.CreatedAt.UTC()
+	if meta.CreatedAt.IsZero() {
+		createdAt = now
+	}
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO e2b_sandboxes (
+			sandbox_id, template_id, template_alias, metadata_json, timeout_seconds,
+			on_timeout, auto_resume, secure, allow_internet_access,
+			network_allow_out_json, network_deny_out_json, allow_public_traffic,
+			mask_request_host, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(sandbox_id) DO UPDATE SET
+			template_id = excluded.template_id,
+			template_alias = excluded.template_alias,
+			metadata_json = excluded.metadata_json,
+			timeout_seconds = excluded.timeout_seconds,
+			on_timeout = excluded.on_timeout,
+			auto_resume = excluded.auto_resume,
+			secure = excluded.secure,
+			allow_internet_access = excluded.allow_internet_access,
+			network_allow_out_json = excluded.network_allow_out_json,
+			network_deny_out_json = excluded.network_deny_out_json,
+			allow_public_traffic = excluded.allow_public_traffic,
+			mask_request_host = excluded.mask_request_host,
+			updated_at = excluded.updated_at
+	`,
+		strings.TrimSpace(meta.SandboxID),
+		strings.TrimSpace(meta.TemplateID),
+		strings.TrimSpace(meta.TemplateAlias),
+		metadataJSON,
+		meta.TimeoutSeconds,
+		firstNonEmptyString(strings.TrimSpace(meta.OnTimeout), "kill"),
+		boolToInt(meta.AutoResume),
+		boolToInt(meta.Secure),
+		nullableBool(meta.AllowInternetAccess),
+		allowOutJSON,
+		denyOutJSON,
+		nullableBool(meta.AllowPublicTraffic),
+		strings.TrimSpace(meta.MaskRequestHost),
+		createdAt,
+		now,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert e2b sandbox metadata: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) GetE2BSandboxMetadata(ctx context.Context, sandboxID string) (*models.E2BSandboxMetadata, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT sandbox_id, template_id, template_alias, metadata_json, timeout_seconds,
+			on_timeout, auto_resume, secure, allow_internet_access,
+			network_allow_out_json, network_deny_out_json, allow_public_traffic,
+			mask_request_host, created_at, updated_at
+		FROM e2b_sandboxes
+		WHERE sandbox_id = ?
+	`, sandboxID)
+	meta, err := scanE2BSandboxMetadata(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get e2b sandbox metadata: %w", err)
+	}
+	return meta, nil
+}
+
+func (s *Store) ListE2BSandboxMetadata(ctx context.Context) (map[string]models.E2BSandboxMetadata, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT sandbox_id, template_id, template_alias, metadata_json, timeout_seconds,
+			on_timeout, auto_resume, secure, allow_internet_access,
+			network_allow_out_json, network_deny_out_json, allow_public_traffic,
+			mask_request_host, created_at, updated_at
+		FROM e2b_sandboxes
+		ORDER BY sandbox_id ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list e2b sandbox metadata: %w", err)
+	}
+	defer rows.Close()
+
+	items := map[string]models.E2BSandboxMetadata{}
+	for rows.Next() {
+		meta, err := scanE2BSandboxMetadata(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan e2b sandbox metadata: %w", err)
+		}
+		items[meta.SandboxID] = *meta
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate e2b sandbox metadata: %w", err)
+	}
+	return items, nil
+}
+
+func (s *Store) UpsertE2BSnapshot(ctx context.Context, meta models.E2BSnapshotMetadata) error {
+	namesJSON, err := marshalJSON(meta.Names, "[]")
+	if err != nil {
+		return fmt.Errorf("marshal e2b snapshot names: %w", err)
+	}
+	now := time.Now().UTC()
+	createdAt := meta.CreatedAt.UTC()
+	if meta.CreatedAt.IsZero() {
+		createdAt = now
+	}
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO e2b_snapshots (
+			snapshot_id, snapshot_name, names_json, source_sandbox_id, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(snapshot_id) DO UPDATE SET
+			snapshot_name = excluded.snapshot_name,
+			names_json = excluded.names_json,
+			source_sandbox_id = excluded.source_sandbox_id,
+			updated_at = excluded.updated_at
+	`,
+		strings.TrimSpace(meta.SnapshotID),
+		strings.TrimSpace(meta.SnapshotName),
+		namesJSON,
+		strings.TrimSpace(meta.SourceSandboxID),
+		createdAt,
+		now,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert e2b snapshot metadata: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) GetE2BSnapshot(ctx context.Context, snapshotID string) (*models.E2BSnapshotMetadata, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT snapshot_id, snapshot_name, names_json, source_sandbox_id, created_at, updated_at
+		FROM e2b_snapshots
+		WHERE snapshot_id = ?
+	`, strings.TrimSpace(snapshotID))
+	meta, err := scanE2BSnapshotMetadata(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get e2b snapshot metadata: %w", err)
+	}
+	return meta, nil
+}
+
+func (s *Store) ListE2BSnapshots(ctx context.Context) (map[string]models.E2BSnapshotMetadata, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT snapshot_id, snapshot_name, names_json, source_sandbox_id, created_at, updated_at
+		FROM e2b_snapshots
+		ORDER BY created_at DESC, snapshot_id ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list e2b snapshot metadata: %w", err)
+	}
+	defer rows.Close()
+
+	items := map[string]models.E2BSnapshotMetadata{}
+	for rows.Next() {
+		meta, err := scanE2BSnapshotMetadata(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan e2b snapshot metadata: %w", err)
+		}
+		items[meta.SnapshotID] = *meta
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate e2b snapshot metadata: %w", err)
+	}
+	return items, nil
+}
+
+func (s *Store) DeleteE2BSnapshot(ctx context.Context, snapshotID string) error {
+	result, err := s.db.ExecContext(ctx, `DELETE FROM e2b_snapshots WHERE snapshot_id = ?`, strings.TrimSpace(snapshotID))
+	if err != nil {
+		return fmt.Errorf("delete e2b snapshot metadata: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err == nil && affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 func (s *Store) CreateSnapshot(ctx context.Context, snapshot *models.SandboxSnapshot) error {
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO sandbox_snapshots (name, image, image_id, source_sandbox_id, created_at)
@@ -1000,6 +1222,95 @@ func scanDaytonaMetadata(scanner interface {
 	return &meta, nil
 }
 
+func scanE2BSandboxMetadata(scanner interface {
+	Scan(dest ...any) error
+}) (*models.E2BSandboxMetadata, error) {
+	var meta models.E2BSandboxMetadata
+	var metadataJSON string
+	var allowOutJSON string
+	var denyOutJSON string
+	var autoResume int
+	var secure int
+	var allowInternetAccess sql.NullInt64
+	var allowPublicTraffic sql.NullInt64
+	err := scanner.Scan(
+		&meta.SandboxID,
+		&meta.TemplateID,
+		&meta.TemplateAlias,
+		&metadataJSON,
+		&meta.TimeoutSeconds,
+		&meta.OnTimeout,
+		&autoResume,
+		&secure,
+		&allowInternetAccess,
+		&allowOutJSON,
+		&denyOutJSON,
+		&allowPublicTraffic,
+		&meta.MaskRequestHost,
+		&meta.CreatedAt,
+		&meta.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if metadataJSON != "" {
+		if err := json.Unmarshal([]byte(metadataJSON), &meta.Metadata); err != nil {
+			return nil, fmt.Errorf("decode e2b metadata: %w", err)
+		}
+	}
+	if meta.Metadata == nil {
+		meta.Metadata = map[string]string{}
+	}
+	if allowOutJSON != "" {
+		if err := json.Unmarshal([]byte(allowOutJSON), &meta.NetworkAllowOut); err != nil {
+			return nil, fmt.Errorf("decode e2b allowOut: %w", err)
+		}
+	}
+	if meta.NetworkAllowOut == nil {
+		meta.NetworkAllowOut = []string{}
+	}
+	if denyOutJSON != "" {
+		if err := json.Unmarshal([]byte(denyOutJSON), &meta.NetworkDenyOut); err != nil {
+			return nil, fmt.Errorf("decode e2b denyOut: %w", err)
+		}
+	}
+	if meta.NetworkDenyOut == nil {
+		meta.NetworkDenyOut = []string{}
+	}
+	meta.AutoResume = autoResume != 0
+	meta.Secure = secure != 0
+	meta.AllowInternetAccess = nullableBoolPtr(allowInternetAccess)
+	meta.AllowPublicTraffic = nullableBoolPtr(allowPublicTraffic)
+	return &meta, nil
+}
+
+func scanE2BSnapshotMetadata(scanner interface {
+	Scan(dest ...any) error
+}) (*models.E2BSnapshotMetadata, error) {
+	var meta models.E2BSnapshotMetadata
+	var namesJSON string
+	err := scanner.Scan(
+		&meta.SnapshotID,
+		&meta.SnapshotName,
+		&namesJSON,
+		&meta.SourceSandboxID,
+		&meta.CreatedAt,
+		&meta.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if namesJSON != "" {
+		if err := json.Unmarshal([]byte(namesJSON), &meta.Names); err != nil {
+			return nil, fmt.Errorf("decode e2b snapshot names: %w", err)
+		}
+	}
+	if meta.Names == nil {
+		meta.Names = []string{}
+	}
+	return &meta, nil
+}
+
 func scanSnapshot(scanner interface {
 	Scan(dest ...any) error
 }) (*models.SandboxSnapshot, error) {
@@ -1061,6 +1372,34 @@ func nullableFloat32Ptr(value sql.NullFloat64) *float32 {
 	}
 	v := float32(value.Float64)
 	return &v
+}
+
+func nullableBool(value *bool) any {
+	if value == nil {
+		return nil
+	}
+	if *value {
+		return 1
+	}
+	return 0
+}
+
+func nullableBoolPtr(value sql.NullInt64) *bool {
+	if !value.Valid {
+		return nil
+	}
+	v := value.Int64 != 0
+	return &v
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }
 
 func isSQLiteUniqueConstraint(err error) bool {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -127,6 +127,15 @@ func Open(path string) (*Store, error) {
 			created_at DATETIME NOT NULL,
 			updated_at DATETIME NOT NULL
 		);`,
+		`CREATE TABLE IF NOT EXISTS e2b_create_requests (
+			fingerprint TEXT PRIMARY KEY,
+			sandbox_id TEXT NOT NULL DEFAULT '',
+			state TEXT NOT NULL DEFAULT 'pending',
+			locked_until DATETIME NOT NULL,
+			replay_until DATETIME,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL
+		);`,
 		`CREATE TABLE IF NOT EXISTS sandbox_snapshots (
 			name TEXT PRIMARY KEY,
 			image TEXT NOT NULL,
@@ -142,6 +151,7 @@ func Open(path string) (*Store, error) {
 		// status using the index's row pointers, and the cardinality of
 		// status values is small enough that a composite buys nothing.
 		`CREATE INDEX IF NOT EXISTS idx_sandboxes_image ON sandboxes(image);`,
+		`CREATE INDEX IF NOT EXISTS idx_e2b_create_requests_replay_until ON e2b_create_requests(replay_until);`,
 		`CREATE INDEX IF NOT EXISTS idx_e2b_snapshots_source_sandbox_id ON e2b_snapshots(source_sandbox_id);`,
 		`CREATE INDEX IF NOT EXISTS idx_sandbox_snapshots_source_sandbox_id ON sandbox_snapshots(source_sandbox_id);`,
 	}
@@ -808,6 +818,122 @@ func (s *Store) DeleteE2BSnapshot(ctx context.Context, snapshotID string) error 
 	return nil
 }
 
+func (s *Store) ClaimE2BCreateRequest(ctx context.Context, fingerprint string, now time.Time, pendingTTL time.Duration) (*models.E2BCreateRequestRecord, bool, error) {
+	trimmed := strings.TrimSpace(fingerprint)
+	if trimmed == "" {
+		return nil, false, fmt.Errorf("claim e2b create request: fingerprint is required")
+	}
+	now = now.UTC()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("claim e2b create request: begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	record, err := scanE2BCreateRequestRecord(tx.QueryRowContext(ctx, `
+		SELECT fingerprint, sandbox_id, state, locked_until, replay_until, created_at, updated_at
+		FROM e2b_create_requests
+		WHERE fingerprint = ?
+	`, trimmed))
+	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			return nil, false, fmt.Errorf("claim e2b create request: query: %w", err)
+		}
+		record = &models.E2BCreateRequestRecord{
+			Fingerprint: trimmed,
+			State:       models.E2BCreateRequestStatePending,
+			LockedUntil: now.Add(pendingTTL),
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO e2b_create_requests (fingerprint, sandbox_id, state, locked_until, replay_until, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?)
+		`, record.Fingerprint, "", record.State, record.LockedUntil, nil, record.CreatedAt, record.UpdatedAt); err != nil {
+			return nil, false, fmt.Errorf("claim e2b create request: insert: %w", err)
+		}
+		if err := tx.Commit(); err != nil {
+			return nil, false, fmt.Errorf("claim e2b create request: commit insert: %w", err)
+		}
+		return record, true, nil
+	}
+
+	if record.State == models.E2BCreateRequestStateReady && !record.ReplayUntil.IsZero() && record.ReplayUntil.After(now) && strings.TrimSpace(record.SandboxID) != "" {
+		if err := tx.Commit(); err != nil {
+			return nil, false, fmt.Errorf("claim e2b create request: commit ready: %w", err)
+		}
+		return record, false, nil
+	}
+	if record.State == models.E2BCreateRequestStatePending && record.LockedUntil.After(now) {
+		if err := tx.Commit(); err != nil {
+			return nil, false, fmt.Errorf("claim e2b create request: commit pending: %w", err)
+		}
+		return record, false, nil
+	}
+
+	record.SandboxID = ""
+	record.State = models.E2BCreateRequestStatePending
+	record.LockedUntil = now.Add(pendingTTL)
+	record.ReplayUntil = time.Time{}
+	record.UpdatedAt = now
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE e2b_create_requests
+		SET sandbox_id = '', state = ?, locked_until = ?, replay_until = NULL, updated_at = ?
+		WHERE fingerprint = ?
+	`, record.State, record.LockedUntil, record.UpdatedAt, record.Fingerprint); err != nil {
+		return nil, false, fmt.Errorf("claim e2b create request: refresh: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, false, fmt.Errorf("claim e2b create request: commit refresh: %w", err)
+	}
+	return record, true, nil
+}
+
+func (s *Store) GetE2BCreateRequest(ctx context.Context, fingerprint string) (*models.E2BCreateRequestRecord, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT fingerprint, sandbox_id, state, locked_until, replay_until, created_at, updated_at
+		FROM e2b_create_requests
+		WHERE fingerprint = ?
+	`, strings.TrimSpace(fingerprint))
+	record, err := scanE2BCreateRequestRecord(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get e2b create request: %w", err)
+	}
+	return record, nil
+}
+
+func (s *Store) CompleteE2BCreateRequest(ctx context.Context, fingerprint, sandboxID string, now time.Time, replayTTL time.Duration) error {
+	now = now.UTC()
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE e2b_create_requests
+		SET sandbox_id = ?, state = ?, locked_until = ?, replay_until = ?, updated_at = ?
+		WHERE fingerprint = ?
+	`, strings.TrimSpace(sandboxID), models.E2BCreateRequestStateReady, now, now.Add(replayTTL), now, strings.TrimSpace(fingerprint))
+	if err != nil {
+		return fmt.Errorf("complete e2b create request: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err == nil && affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *Store) DeleteE2BCreateRequest(ctx context.Context, fingerprint string) error {
+	result, err := s.db.ExecContext(ctx, `DELETE FROM e2b_create_requests WHERE fingerprint = ?`, strings.TrimSpace(fingerprint))
+	if err != nil {
+		return fmt.Errorf("delete e2b create request: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err == nil && affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 func (s *Store) CreateSnapshot(ctx context.Context, snapshot *models.SandboxSnapshot) error {
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO sandbox_snapshots (name, image, image_id, source_sandbox_id, created_at)
@@ -1309,6 +1435,32 @@ func scanE2BSnapshotMetadata(scanner interface {
 		meta.Names = []string{}
 	}
 	return &meta, nil
+}
+
+func scanE2BCreateRequestRecord(scanner interface {
+	Scan(dest ...any) error
+}) (*models.E2BCreateRequestRecord, error) {
+	var record models.E2BCreateRequestRecord
+	var replayUntil sql.NullTime
+	err := scanner.Scan(
+		&record.Fingerprint,
+		&record.SandboxID,
+		&record.State,
+		&record.LockedUntil,
+		&replayUntil,
+		&record.CreatedAt,
+		&record.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if replayUntil.Valid {
+		record.ReplayUntil = replayUntil.Time.UTC()
+	}
+	record.LockedUntil = record.LockedUntil.UTC()
+	record.CreatedAt = record.CreatedAt.UTC()
+	record.UpdatedAt = record.UpdatedAt.UTC()
+	return &record, nil
 }
 
 func scanSnapshot(scanner interface {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -574,6 +574,69 @@ func TestStoreCases(t *testing.T) {
 			},
 		},
 		{
+			name: "e2b_create_request_claim_complete_and_reclaim",
+			run: func(t *testing.T) {
+				st := newTestStore(t)
+				now := time.Now().UTC().Round(0)
+				fingerprint := "fp:test"
+
+				record, acquired, err := st.ClaimE2BCreateRequest(ctx, fingerprint, now, 30*time.Second)
+				if err != nil {
+					t.Fatalf("first ClaimE2BCreateRequest() error = %v", err)
+				}
+				if !acquired {
+					t.Fatal("expected first claim to acquire reservation")
+				}
+				if record.State != models.E2BCreateRequestStatePending {
+					t.Fatalf("record.State = %q, want %q", record.State, models.E2BCreateRequestStatePending)
+				}
+
+				record, acquired, err = st.ClaimE2BCreateRequest(ctx, fingerprint, now.Add(5*time.Second), 30*time.Second)
+				if err != nil {
+					t.Fatalf("second ClaimE2BCreateRequest() error = %v", err)
+				}
+				if acquired {
+					t.Fatal("expected second claim to observe pending reservation")
+				}
+				if record.State != models.E2BCreateRequestStatePending {
+					t.Fatalf("pending record.State = %q, want %q", record.State, models.E2BCreateRequestStatePending)
+				}
+
+				if err := st.CompleteE2BCreateRequest(ctx, fingerprint, "sb-e2b-claim", now.Add(8*time.Second), 15*time.Second); err != nil {
+					t.Fatalf("CompleteE2BCreateRequest() error = %v", err)
+				}
+
+				record, acquired, err = st.ClaimE2BCreateRequest(ctx, fingerprint, now.Add(10*time.Second), 30*time.Second)
+				if err != nil {
+					t.Fatalf("ready ClaimE2BCreateRequest() error = %v", err)
+				}
+				if acquired {
+					t.Fatal("expected ready claim to replay existing sandbox")
+				}
+				if record.State != models.E2BCreateRequestStateReady || record.SandboxID != "sb-e2b-claim" {
+					t.Fatalf("unexpected ready record: %+v", record)
+				}
+
+				record, acquired, err = st.ClaimE2BCreateRequest(ctx, fingerprint, now.Add(40*time.Second), 30*time.Second)
+				if err != nil {
+					t.Fatalf("stale ready ClaimE2BCreateRequest() error = %v", err)
+				}
+				if !acquired {
+					t.Fatal("expected stale ready record to be reclaimed")
+				}
+				if record.State != models.E2BCreateRequestStatePending || record.SandboxID != "" {
+					t.Fatalf("unexpected reclaimed record: %+v", record)
+				}
+
+				if err := st.DeleteE2BCreateRequest(ctx, fingerprint); err != nil {
+					t.Fatalf("DeleteE2BCreateRequest() error = %v", err)
+				}
+				if _, err := st.GetE2BCreateRequest(ctx, fingerprint); !errors.Is(err, ErrNotFound) {
+					t.Fatalf("expected ErrNotFound after delete, got %v", err)
+				}
+			},
+		},
+		{
 			name: "snapshot_roundtrip_by_name",
 			run: func(t *testing.T) {
 				st := newTestStore(t)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -472,6 +472,108 @@ func TestStoreCases(t *testing.T) {
 			},
 		},
 		{
+			name: "e2b_sandbox_metadata_roundtrip",
+			run: func(t *testing.T) {
+				st := newTestStore(t)
+				sandbox := sampleSandbox("sb-e2b")
+				if err := st.Create(ctx, sandbox); err != nil {
+					t.Fatalf("Create() error = %v", err)
+				}
+				allowInternet := false
+				allowPublic := true
+				createdAt := time.Now().UTC().Add(-time.Minute)
+				meta := models.E2BSandboxMetadata{
+					SandboxID:           sandbox.ID,
+					TemplateID:          "base",
+					TemplateAlias:       "base",
+					Metadata:            map[string]string{"team": "sdk"},
+					TimeoutSeconds:      45,
+					OnTimeout:           "pause",
+					AutoResume:          true,
+					Secure:              true,
+					AllowInternetAccess: &allowInternet,
+					NetworkAllowOut:     []string{"10.0.0.0/24"},
+					NetworkDenyOut:      []string{"0.0.0.0/0"},
+					AllowPublicTraffic:  &allowPublic,
+					MaskRequestHost:     "sandbox.example.com",
+					CreatedAt:           createdAt,
+				}
+				if err := st.UpsertE2BSandboxMetadata(ctx, meta); err != nil {
+					t.Fatalf("UpsertE2BSandboxMetadata() error = %v", err)
+				}
+
+				got, err := st.GetE2BSandboxMetadata(ctx, sandbox.ID)
+				if err != nil {
+					t.Fatalf("GetE2BSandboxMetadata() error = %v", err)
+				}
+				if got.TemplateID != meta.TemplateID || got.TemplateAlias != meta.TemplateAlias || got.TimeoutSeconds != meta.TimeoutSeconds || got.OnTimeout != meta.OnTimeout || got.MaskRequestHost != meta.MaskRequestHost {
+					t.Fatalf("unexpected e2b metadata: %+v", got)
+				}
+				if !reflect.DeepEqual(got.Metadata, meta.Metadata) {
+					t.Fatalf("Metadata = %+v, want %+v", got.Metadata, meta.Metadata)
+				}
+				if !reflect.DeepEqual(got.NetworkAllowOut, meta.NetworkAllowOut) {
+					t.Fatalf("NetworkAllowOut = %+v, want %+v", got.NetworkAllowOut, meta.NetworkAllowOut)
+				}
+				if !reflect.DeepEqual(got.NetworkDenyOut, meta.NetworkDenyOut) {
+					t.Fatalf("NetworkDenyOut = %+v, want %+v", got.NetworkDenyOut, meta.NetworkDenyOut)
+				}
+				if got.AllowInternetAccess == nil || *got.AllowInternetAccess != allowInternet {
+					t.Fatalf("AllowInternetAccess = %+v, want %v", got.AllowInternetAccess, allowInternet)
+				}
+				if got.AllowPublicTraffic == nil || *got.AllowPublicTraffic != allowPublic {
+					t.Fatalf("AllowPublicTraffic = %+v, want %v", got.AllowPublicTraffic, allowPublic)
+				}
+				items, err := st.ListE2BSandboxMetadata(ctx)
+				if err != nil {
+					t.Fatalf("ListE2BSandboxMetadata() error = %v", err)
+				}
+				if listed, ok := items[sandbox.ID]; !ok || listed.TemplateID != meta.TemplateID {
+					t.Fatalf("expected listed e2b metadata for %q, got %+v", sandbox.ID, items)
+				}
+			},
+		},
+		{
+			name: "e2b_snapshot_metadata_roundtrip_and_delete",
+			run: func(t *testing.T) {
+				st := newTestStore(t)
+				meta := models.E2BSnapshotMetadata{
+					SnapshotID:      "snapshot-name:default",
+					SnapshotName:    "snapshot-name",
+					Names:           []string{"snapshot-name:default"},
+					SourceSandboxID: "sb-1",
+					CreatedAt:       time.Now().UTC(),
+				}
+				if err := st.UpsertE2BSnapshot(ctx, meta); err != nil {
+					t.Fatalf("UpsertE2BSnapshot() error = %v", err)
+				}
+
+				got, err := st.GetE2BSnapshot(ctx, meta.SnapshotID)
+				if err != nil {
+					t.Fatalf("GetE2BSnapshot() error = %v", err)
+				}
+				if got.SnapshotName != meta.SnapshotName || got.SourceSandboxID != meta.SourceSandboxID {
+					t.Fatalf("unexpected e2b snapshot metadata: %+v", got)
+				}
+				if !reflect.DeepEqual(got.Names, meta.Names) {
+					t.Fatalf("Names = %+v, want %+v", got.Names, meta.Names)
+				}
+				items, err := st.ListE2BSnapshots(ctx)
+				if err != nil {
+					t.Fatalf("ListE2BSnapshots() error = %v", err)
+				}
+				if listed, ok := items[meta.SnapshotID]; !ok || listed.SnapshotName != meta.SnapshotName {
+					t.Fatalf("expected listed snapshot metadata for %q, got %+v", meta.SnapshotID, items)
+				}
+				if err := st.DeleteE2BSnapshot(ctx, meta.SnapshotID); err != nil {
+					t.Fatalf("DeleteE2BSnapshot() error = %v", err)
+				}
+				if _, err := st.GetE2BSnapshot(ctx, meta.SnapshotID); !errors.Is(err, ErrNotFound) {
+					t.Fatalf("expected ErrNotFound after delete, got %v", err)
+				}
+			},
+		},
+		{
 			name: "snapshot_roundtrip_by_name",
 			run: func(t *testing.T) {
 				st := newTestStore(t)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -3,10 +3,12 @@ package store
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,7 +18,6 @@ import (
 func TestStoreCases(t *testing.T) {
 	ctx := context.Background()
 
-	// 25 cases
 	tests := []struct {
 		name string
 		run  func(t *testing.T)
@@ -544,6 +545,15 @@ func TestStoreCases(t *testing.T) {
 					SourceSandboxID: "sb-1",
 					CreatedAt:       time.Now().UTC(),
 				}
+				if err := st.CreateSnapshot(ctx, &models.SandboxSnapshot{
+					Name:            meta.SnapshotName,
+					Image:           meta.SnapshotName,
+					ImageID:         "sha256:e2b-snapshot",
+					SourceSandboxID: meta.SourceSandboxID,
+					CreatedAt:       meta.CreatedAt,
+				}); err != nil {
+					t.Fatalf("CreateSnapshot() error = %v", err)
+				}
 				if err := st.UpsertE2BSnapshot(ctx, meta); err != nil {
 					t.Fatalf("UpsertE2BSnapshot() error = %v", err)
 				}
@@ -570,6 +580,37 @@ func TestStoreCases(t *testing.T) {
 				}
 				if _, err := st.GetE2BSnapshot(ctx, meta.SnapshotID); !errors.Is(err, ErrNotFound) {
 					t.Fatalf("expected ErrNotFound after delete, got %v", err)
+				}
+			},
+		},
+		{
+			name: "e2b_snapshot_metadata_cascades_with_native_snapshot_delete",
+			run: func(t *testing.T) {
+				st := newTestStore(t)
+				meta := models.E2BSnapshotMetadata{
+					SnapshotID:      "snapshot-cascade:default",
+					SnapshotName:    "snapshot-cascade",
+					Names:           []string{"snapshot-cascade:default"},
+					SourceSandboxID: "sb-cascade",
+					CreatedAt:       time.Now().UTC(),
+				}
+				if err := st.CreateSnapshot(ctx, &models.SandboxSnapshot{
+					Name:            meta.SnapshotName,
+					Image:           meta.SnapshotName,
+					ImageID:         "sha256:e2b-cascade",
+					SourceSandboxID: meta.SourceSandboxID,
+					CreatedAt:       meta.CreatedAt,
+				}); err != nil {
+					t.Fatalf("CreateSnapshot() error = %v", err)
+				}
+				if err := st.UpsertE2BSnapshot(ctx, meta); err != nil {
+					t.Fatalf("UpsertE2BSnapshot() error = %v", err)
+				}
+				if err := st.DeleteSnapshot(ctx, meta.SnapshotName); err != nil {
+					t.Fatalf("DeleteSnapshot() error = %v", err)
+				}
+				if _, err := st.GetE2BSnapshot(ctx, meta.SnapshotID); !errors.Is(err, ErrNotFound) {
+					t.Fatalf("expected E2B snapshot metadata cascade delete, got %v", err)
 				}
 			},
 		},
@@ -633,6 +674,57 @@ func TestStoreCases(t *testing.T) {
 				}
 				if _, err := st.GetE2BCreateRequest(ctx, fingerprint); !errors.Is(err, ErrNotFound) {
 					t.Fatalf("expected ErrNotFound after delete, got %v", err)
+				}
+			},
+		},
+		{
+			name: "e2b_create_request_concurrent_claims_share_pending_record",
+			run: func(t *testing.T) {
+				path := filepath.Join(t.TempDir(), "state.db")
+				const contenders = 6
+				stores := make([]*Store, 0, contenders)
+				for i := 0; i < contenders; i++ {
+					st, err := Open(path)
+					if err != nil {
+						t.Fatalf("Open(%d) error = %v", i, err)
+					}
+					defer st.Close()
+					stores = append(stores, st)
+				}
+
+				start := make(chan struct{})
+				var wg sync.WaitGroup
+				var mu sync.Mutex
+				var errs []error
+				acquiredCount := 0
+				for _, st := range stores {
+					wg.Add(1)
+					go func(st *Store) {
+						defer wg.Done()
+						<-start
+						record, acquired, err := st.ClaimE2BCreateRequest(ctx, "fp:concurrent", time.Now().UTC(), time.Minute)
+						mu.Lock()
+						defer mu.Unlock()
+						if err != nil {
+							errs = append(errs, err)
+							return
+						}
+						if record.State != models.E2BCreateRequestStatePending {
+							errs = append(errs, fmt.Errorf("record.State = %q, want %q", record.State, models.E2BCreateRequestStatePending))
+							return
+						}
+						if acquired {
+							acquiredCount++
+						}
+					}(st)
+				}
+				close(start)
+				wg.Wait()
+				if len(errs) > 0 {
+					t.Fatalf("concurrent ClaimE2BCreateRequest() errors = %v", errs)
+				}
+				if acquiredCount != 1 {
+					t.Fatalf("acquired claims = %d, want 1", acquiredCount)
 				}
 			},
 		},

--- a/packaging/Caddyfile.template
+++ b/packaging/Caddyfile.template
@@ -19,7 +19,7 @@ https://{{ROOT_SITE_ADDRESS}} {
     tls {
         dns {{DNS_PROVIDER}} {env.SB_DNS_API_TOKEN}
     }
-    @api path /health /v1 /v1/* /daytona /daytona/*
+    @api path /health /v1 /v1/* /daytona /daytona/* /e2b /e2b/*
     handle @api {
         reverse_proxy 127.0.0.1:21212
     }

--- a/pkg/api/e2b/contract_test.go
+++ b/pkg/api/e2b/contract_test.go
@@ -1,0 +1,157 @@
+package e2b
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/config"
+)
+
+func TestE2BPythonSDKSmoke(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping python smoke test in short mode")
+	}
+	if strings.TrimSpace(os.Getenv("SB_E2B_PYTHON_SMOKE")) != "1" {
+		t.Skip("set SB_E2B_PYTHON_SMOKE=1 to run the real Python SDK smoke test")
+	}
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 not available")
+	}
+	sdkPath := strings.TrimSpace(os.Getenv("SB_E2B_PYTHON_SDK_PATH"))
+	sdkSpec := strings.TrimSpace(os.Getenv("SB_E2B_PYTHON_SDK_SPEC"))
+	if sdkPath == "" && sdkSpec == "" {
+		sdkSpec = "e2b==2.21.0"
+	}
+
+	venvDir := filepath.Join(t.TempDir(), "venv")
+	venvPython := filepath.Join(venvDir, "bin", "python")
+	venvPip := filepath.Join(venvDir, "bin", "pip")
+	venvCmd := exec.Command(python, "-m", "venv", venvDir)
+	if output, err := venvCmd.CombinedOutput(); err != nil {
+		t.Fatalf("create python venv error = %v\n%s", err, output)
+	}
+	installTarget := sdkSpec
+	if sdkPath != "" {
+		installTarget = sdkPath
+	}
+	installCmd := exec.Command(venvPip, "install", installTarget)
+	if output, err := installCmd.CombinedOutput(); err != nil {
+		t.Fatalf("install python sdk error = %v\n%s", err, output)
+	}
+
+	repoRoot := repoRootFromCaller(t)
+	toolboxPort := freeTCPPort(t)
+	toolboxBin := filepath.Join(t.TempDir(), "toolboxd")
+	buildCmd := exec.Command("go", "build", "-o", toolboxBin, "./cmd/toolboxd")
+	buildCmd.Dir = repoRoot
+	if output, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("build toolboxd error = %v\n%s", err, output)
+	}
+
+	toolboxCtx, toolboxCancel := context.WithCancel(context.Background())
+	defer toolboxCancel()
+	toolboxCmd := exec.CommandContext(toolboxCtx, toolboxBin)
+	toolboxCmd.Env = append(os.Environ(),
+		fmt.Sprintf("SB_TOOLBOX_PORT=%d", toolboxPort),
+		"SB_RECORDING_DIR="+filepath.Join(t.TempDir(), "recordings"),
+	)
+	toolboxCmd.Stdout = io.Discard
+	toolboxCmd.Stderr = io.Discard
+	if err := toolboxCmd.Start(); err != nil {
+		t.Fatalf("start toolboxd error = %v", err)
+	}
+	t.Cleanup(func() {
+		toolboxCancel()
+		_ = toolboxCmd.Wait()
+	})
+	waitForHTTP(t, fmt.Sprintf("http://127.0.0.1:%d/health", toolboxPort), 5*time.Second)
+
+	fakeRuntime := newFakeE2BRuntime()
+	fakeRuntime.containerIP = "127.0.0.1"
+	svc, _, _ := newE2BHandlerTestEnvWithRuntime(t, fakeRuntime, config.Config{PublicHost: "sandbox.test", EnableCaddy: false, ToolboxPort: toolboxPort})
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, Deps{
+		Service: svc,
+		Logger:  logger,
+		Auth: func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.TrimSpace(r.Header.Get("X-API-KEY")) != "test-pat" {
+					WriteError(w, http.StatusUnauthorized, "Unauthorized")
+					return
+				}
+				next.ServeHTTP(w, r)
+			})
+		},
+	})
+	apiServer := httptest.NewServer(mux)
+	defer apiServer.Close()
+
+	scriptPath := filepath.Join(repoRoot, "scripts", "e2b_sdk_smoke.py")
+	smokeCtx, smokeCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer smokeCancel()
+	smokeCmd := exec.CommandContext(smokeCtx, venvPython, scriptPath)
+	smokeEnv := append(os.Environ(),
+		"E2B_API_URL="+apiServer.URL+PathPrefix,
+		"E2B_SANDBOX_URL="+apiServer.URL+PathPrefix+"/runtime",
+		"E2B_API_KEY=test-pat",
+	)
+	smokeCmd.Env = smokeEnv
+	output, err := smokeCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("python smoke harness failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "E2B SDK smoke passed") {
+		t.Fatalf("unexpected python smoke output: %s", output)
+	}
+}
+
+func repoRootFromCaller(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller() failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
+}
+
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen on ephemeral port error = %v", err)
+	}
+	defer listener.Close()
+	return listener.Addr().(*net.TCPAddr).Port
+}
+
+func waitForHTTP(t *testing.T, endpoint string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", endpoint)
+		}
+		resp, err := http.Get(endpoint)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode < 500 {
+				return
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/pkg/api/e2b/contract_test.go
+++ b/pkg/api/e2b/contract_test.go
@@ -142,10 +142,16 @@ func waitForHTTP(t *testing.T, endpoint string, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for {
-		if time.Now().After(deadline) {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
 			t.Fatalf("timed out waiting for %s", endpoint)
 		}
-		resp, err := http.Get(endpoint)
+		attemptTimeout := 2 * time.Second
+		if remaining < attemptTimeout {
+			attemptTimeout = remaining
+		}
+		client := http.Client{Timeout: attemptTimeout}
+		resp, err := client.Get(endpoint)
 		if err == nil {
 			resp.Body.Close()
 			if resp.StatusCode < 500 {

--- a/pkg/api/e2b/dto.go
+++ b/pkg/api/e2b/dto.go
@@ -1,0 +1,113 @@
+package e2b
+
+type createSandboxRequest struct {
+	TemplateID          string                     `json:"templateID"`
+	AllowInternetAccess *bool                      `json:"allow_internet_access,omitempty"`
+	AutoPause           *bool                      `json:"autoPause,omitempty"`
+	AutoResume          *sandboxAutoResumeRequest  `json:"autoResume,omitempty"`
+	EnvVars             map[string]any             `json:"envVars,omitempty"`
+	MCP                 any                        `json:"mcp,omitempty"`
+	Metadata            map[string]any             `json:"metadata,omitempty"`
+	Network             *sandboxNetworkRequest     `json:"network,omitempty"`
+	Secure              *bool                      `json:"secure,omitempty"`
+	Timeout             *int                       `json:"timeout,omitempty"`
+	VolumeMounts        []sandboxVolumeMountCreate `json:"volumeMounts,omitempty"`
+}
+
+type sandboxAutoResumeRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
+type sandboxNetworkRequest struct {
+	AllowOut           []string `json:"allowOut,omitempty"`
+	AllowPublicTraffic *bool    `json:"allowPublicTraffic,omitempty"`
+	DenyOut            []string `json:"denyOut,omitempty"`
+	MaskRequestHost    string   `json:"maskRequestHost,omitempty"`
+}
+
+type sandboxVolumeMountCreate struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
+type connectSandboxRequest struct {
+	Timeout int `json:"timeout"`
+}
+
+type timeoutRequest struct {
+	Timeout int `json:"timeout"`
+}
+
+type createSnapshotRequest struct {
+	Name string `json:"name,omitempty"`
+}
+
+type sandboxResponse struct {
+	ClientID           string  `json:"clientID"`
+	EnvdVersion        string  `json:"envdVersion"`
+	SandboxID          string  `json:"sandboxID"`
+	TemplateID         string  `json:"templateID"`
+	Alias              string  `json:"alias,omitempty"`
+	Domain             *string `json:"domain,omitempty"`
+	EnvdAccessToken    string  `json:"envdAccessToken,omitempty"`
+	TrafficAccessToken *string `json:"trafficAccessToken,omitempty"`
+}
+
+type listedSandboxResponse struct {
+	ClientID     string                      `json:"clientID"`
+	CPUCount     int                         `json:"cpuCount"`
+	DiskSizeMB   int                         `json:"diskSizeMB"`
+	EndAt        string                      `json:"endAt"`
+	EnvdVersion  string                      `json:"envdVersion"`
+	MemoryMB     int                         `json:"memoryMB"`
+	SandboxID    string                      `json:"sandboxID"`
+	StartedAt    string                      `json:"startedAt"`
+	State        string                      `json:"state"`
+	TemplateID   string                      `json:"templateID"`
+	Alias        string                      `json:"alias,omitempty"`
+	Metadata     map[string]string           `json:"metadata,omitempty"`
+	VolumeMounts []sandboxVolumeMountPayload `json:"volumeMounts,omitempty"`
+}
+
+type sandboxDetailResponse struct {
+	ClientID            string                      `json:"clientID"`
+	CPUCount            int                         `json:"cpuCount"`
+	DiskSizeMB          int                         `json:"diskSizeMB"`
+	EndAt               string                      `json:"endAt"`
+	EnvdVersion         string                      `json:"envdVersion"`
+	MemoryMB            int                         `json:"memoryMB"`
+	SandboxID           string                      `json:"sandboxID"`
+	StartedAt           string                      `json:"startedAt"`
+	State               string                      `json:"state"`
+	TemplateID          string                      `json:"templateID"`
+	Alias               string                      `json:"alias,omitempty"`
+	AllowInternetAccess *bool                       `json:"allowInternetAccess,omitempty"`
+	Domain              *string                     `json:"domain,omitempty"`
+	EnvdAccessToken     string                      `json:"envdAccessToken,omitempty"`
+	Lifecycle           *sandboxLifecyclePayload    `json:"lifecycle,omitempty"`
+	Metadata            map[string]string           `json:"metadata,omitempty"`
+	Network             *sandboxNetworkPayload      `json:"network,omitempty"`
+	VolumeMounts        []sandboxVolumeMountPayload `json:"volumeMounts,omitempty"`
+}
+
+type sandboxLifecyclePayload struct {
+	AutoResume bool   `json:"autoResume"`
+	OnTimeout  string `json:"onTimeout"`
+}
+
+type sandboxNetworkPayload struct {
+	AllowOut           []string `json:"allowOut,omitempty"`
+	AllowPublicTraffic *bool    `json:"allowPublicTraffic,omitempty"`
+	DenyOut            []string `json:"denyOut,omitempty"`
+	MaskRequestHost    string   `json:"maskRequestHost,omitempty"`
+}
+
+type sandboxVolumeMountPayload struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
+type snapshotInfoResponse struct {
+	Names      []string `json:"names"`
+	SnapshotID string   `json:"snapshotID"`
+}

--- a/pkg/api/e2b/errors.go
+++ b/pkg/api/e2b/errors.go
@@ -1,0 +1,85 @@
+package e2b
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/capacity"
+)
+
+type errorResponse struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type requestError struct {
+	status  int
+	message string
+}
+
+func (e requestError) Error() string { return e.message }
+
+func badRequest(message string) error {
+	return requestError{status: http.StatusBadRequest, message: message}
+}
+
+func conflict(message string) error {
+	return requestError{status: http.StatusConflict, message: message}
+}
+
+func notImplemented(message string) error {
+	return requestError{status: http.StatusNotImplemented, message: message}
+}
+
+// WriteError writes the E2B error envelope shape expected by the SDK.
+func WriteError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(errorResponse{Code: status, Message: message})
+}
+
+func writeKnownError(w http.ResponseWriter, err error) bool {
+	var reqErr requestError
+	if errors.As(err, &reqErr) {
+		WriteError(w, reqErr.status, reqErr.message)
+		return true
+	}
+	return false
+}
+
+func writeStoreAwareError(logger *slog.Logger, w http.ResponseWriter, err error) {
+	if writeKnownError(w, err) {
+		return
+	}
+	if errors.Is(err, store.ErrNotFound) {
+		WriteError(w, http.StatusNotFound, "Not found")
+		return
+	}
+	if errors.Is(err, store.ErrSnapshotNameConflict) {
+		WriteError(w, http.StatusConflict, "Snapshot name already in use")
+		return
+	}
+	if errors.Is(err, capacity.ErrCapacityExceeded) {
+		if logger != nil {
+			logger.Info("capacity rejected", "error", err)
+		}
+		w.Header().Set("Retry-After", "30")
+		message := err.Error()
+		if len(message) > 200 {
+			message = message[:200]
+		}
+		WriteError(w, http.StatusServiceUnavailable, message)
+		return
+	}
+	if logger != nil {
+		logger.Warn("e2b request failed", "error", err)
+	}
+	message := err.Error()
+	if len(message) > 200 {
+		message = message[:200]
+	}
+	WriteError(w, http.StatusBadRequest, message)
+}

--- a/pkg/api/e2b/errors.go
+++ b/pkg/api/e2b/errors.go
@@ -30,6 +30,10 @@ func conflict(message string) error {
 	return requestError{status: http.StatusConflict, message: message}
 }
 
+func serviceUnavailable(message string) error {
+	return requestError{status: http.StatusServiceUnavailable, message: message}
+}
+
 func notImplemented(message string) error {
 	return requestError{status: http.StatusNotImplemented, message: message}
 }

--- a/pkg/api/e2b/handlers.go
+++ b/pkg/api/e2b/handlers.go
@@ -362,12 +362,7 @@ func (h *handlers) createSnapshot(w http.ResponseWriter, r *http.Request) {
 	h.snapshotMu.Lock()
 	defer h.snapshotMu.Unlock()
 
-	existedBefore, err := h.snapshotExistsForSandbox(r.Context(), snapshotName, sandbox.ID)
-	if err != nil {
-		writeStoreAwareError(h.deps.Logger, w, err)
-		return
-	}
-	snapshot, err := h.deps.Service.CreateSnapshot(r.Context(), sandbox.ID, models.CreateSandboxSnapshotRequest{Name: snapshotName})
+	snapshot, createdSnapshot, err := h.deps.Service.CreateSnapshotWithOwnership(r.Context(), sandbox.ID, models.CreateSandboxSnapshotRequest{Name: snapshotName})
 	if err != nil {
 		if errors.Is(err, store.ErrSnapshotNameConflict) {
 			WriteError(w, http.StatusConflict, "Snapshot name already in use")
@@ -387,7 +382,7 @@ func (h *handlers) createSnapshot(w http.ResponseWriter, r *http.Request) {
 		Names:           resp.Names,
 		SourceSandboxID: sandbox.ID,
 	}); err != nil {
-		if !existedBefore {
+		if createdSnapshot {
 			if deleteErr := h.deps.Service.DeleteSnapshot(r.Context(), snapshot.Name); deleteErr != nil && h.deps.Logger != nil {
 				h.deps.Logger.Warn("e2b snapshot metadata rollback failed", "snapshot_name", snapshot.Name, "error", deleteErr)
 			}
@@ -703,6 +698,12 @@ func (h *handlers) waitForCreateReplay(ctx context.Context, fingerprint string) 
 		}
 
 		if record.State == models.E2BCreateRequestStateReady {
+			if record.ReplayUntil.IsZero() || !record.ReplayUntil.After(now) {
+				if err := h.deps.Service.DeleteE2BCreateRequest(ctx, fingerprint); err != nil && !errors.Is(err, store.ErrNotFound) {
+					return nil, sandboxMeta{}, false, err
+				}
+				return nil, sandboxMeta{}, false, nil
+			}
 			return h.loadReplayableCreateResult(ctx, record)
 		}
 		if record.State != models.E2BCreateRequestStatePending || !record.LockedUntil.After(now) {
@@ -724,17 +725,6 @@ func (h *handlers) waitForCreateReplay(ctx context.Context, fingerprint string) 
 		case <-timer.C:
 		}
 	}
-}
-
-func (h *handlers) snapshotExistsForSandbox(ctx context.Context, snapshotName, sandboxID string) (bool, error) {
-	snapshot, err := h.deps.Service.GetSnapshot(ctx, snapshotName)
-	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
-			return false, nil
-		}
-		return false, err
-	}
-	return snapshot.SourceSandboxID == sandboxID, nil
 }
 
 func (h *handlers) resolveSnapshotDeleteTarget(ctx context.Context, snapshotID string) (string, string, error) {

--- a/pkg/api/e2b/handlers.go
+++ b/pkg/api/e2b/handlers.go
@@ -1,0 +1,977 @@
+package e2b
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+type handlers struct {
+	deps           Deps
+	templateMap    map[string]string
+	clientID       string
+	defaultDomain  *string
+	defaultEnvdVer string
+}
+
+func newHandlers(d Deps) *handlers {
+	return &handlers{
+		deps:           d,
+		templateMap:    loadTemplateMap(d.Logger),
+		clientID:       loadClientID(),
+		defaultEnvdVer: defaultEnvdVersion,
+	}
+}
+
+func (h *handlers) createSandbox(w http.ResponseWriter, r *http.Request) {
+	var req createSandboxRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		WriteError(w, http.StatusBadRequest, "Invalid JSON body")
+		return
+	}
+
+	serviceReq, meta, err := h.translateCreateSandboxRequest(r.Context(), req)
+	if err != nil {
+		if !writeKnownError(w, err) {
+			writeStoreAwareError(h.deps.Logger, w, err)
+		}
+		return
+	}
+
+	response, err := h.deps.Service.CreateSandbox(r.Context(), serviceReq)
+	if err != nil {
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+
+	if err := h.persistSandboxMeta(r.Context(), response.ID, meta); err != nil {
+		if destroyErr := h.deps.Service.DestroySandbox(r.Context(), response.ID); destroyErr != nil && h.deps.Logger != nil {
+			h.deps.Logger.Warn("e2b metadata rollback failed", "sandbox_id", response.ID, "error", destroyErr)
+		}
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+
+	storedMeta, err := h.loadSandboxMeta(r.Context(), &response.Sandbox)
+	if err != nil {
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, h.toSandboxResponse(r, &response.Sandbox, storedMeta))
+}
+
+func (h *handlers) listSandboxes(w http.ResponseWriter, r *http.Request) {
+	sandboxes, err := h.deps.Service.ListSandboxes(r.Context())
+	if err != nil {
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+
+	limit, offset, err := parsePagination(r, 100)
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	metadataFilter, err := parseMetadataFilter(r.URL.Query().Get("metadata"))
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	stateFilter, err := parseStateFilter(r.URL.Query().Get("state"))
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	stored, err := h.deps.Service.ListE2BSandboxMetadata(r.Context())
+	if err != nil {
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+
+	items := make([]listedSandboxResponse, 0, len(sandboxes))
+	for _, sandbox := range sandboxes {
+		if sandbox == nil {
+			continue
+		}
+		meta := sandboxMetaFromStored(storedSandboxMeta(stored, sandbox.ID), sandbox)
+		state := mapSandboxState(sandbox.Status)
+		if len(stateFilter) > 0 {
+			if _, ok := stateFilter[state]; !ok {
+				continue
+			}
+		}
+		if len(metadataFilter) > 0 && !metadataContains(meta.Metadata, metadataFilter) {
+			continue
+		}
+		items = append(items, h.toListedSandboxResponse(sandbox, meta))
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].StartedAt == items[j].StartedAt {
+			return items[i].SandboxID < items[j].SandboxID
+		}
+		return items[i].StartedAt > items[j].StartedAt
+	})
+
+	page, nextToken := paginateListedSandboxes(items, offset, limit)
+	if nextToken != "" {
+		w.Header().Set("x-next-token", nextToken)
+	}
+	writeJSON(w, http.StatusOK, page)
+}
+
+func (h *handlers) getSandbox(w http.ResponseWriter, r *http.Request) {
+	sandbox, err := h.deps.Service.GetSandbox(r.Context(), r.PathValue("id"))
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, "Sandbox not found")
+			return
+		}
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	meta, err := h.loadSandboxMeta(r.Context(), sandbox)
+	if err != nil {
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, h.toSandboxDetailResponse(r, sandbox, meta))
+}
+
+func (h *handlers) deleteSandbox(w http.ResponseWriter, r *http.Request) {
+	if err := h.deps.Service.DestroySandbox(r.Context(), r.PathValue("id")); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, "Sandbox not found")
+			return
+		}
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *handlers) connectSandbox(w http.ResponseWriter, r *http.Request) {
+	var req connectSandboxRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		WriteError(w, http.StatusBadRequest, "Invalid JSON body")
+		return
+	}
+	if req.Timeout <= 0 {
+		WriteError(w, http.StatusBadRequest, "timeout must be greater than zero")
+		return
+	}
+
+	sandbox, err := h.deps.Service.GetSandbox(r.Context(), r.PathValue("id"))
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, "Sandbox not found")
+			return
+		}
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	meta, err := h.loadSandboxMeta(r.Context(), sandbox)
+	if err != nil {
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+
+	if sandbox.Status == models.SandboxStatusStopped {
+		sandbox, err = h.deps.Service.StartSandbox(r.Context(), sandbox.ID)
+		if err != nil {
+			writeStoreAwareError(h.deps.Logger, w, err)
+			return
+		}
+	} else if sandbox.Status != models.SandboxStatusStarted {
+		WriteError(w, http.StatusConflict, "Sandbox is not available for connect")
+		return
+	}
+
+	currentDeadline, hasDeadline := timeoutDeadline(sandbox, meta)
+	desiredLifecycle := lifecycleForTimeout(sandbox, meta.OnTimeout, req.Timeout)
+	desiredDeadline, _ := timeoutDeadline(&models.Sandbox{CreatedAt: sandbox.CreatedAt, Lifecycle: desiredLifecycle}, meta)
+	if !hasDeadline || desiredDeadline.After(currentDeadline) {
+		sandbox, err = h.deps.Service.UpdateLifecycle(r.Context(), sandbox.ID, desiredLifecycle)
+		if err != nil {
+			writeStoreAwareError(h.deps.Logger, w, err)
+			return
+		}
+		meta.TimeoutSeconds = req.Timeout
+		if err := h.persistSandboxMeta(r.Context(), sandbox.ID, meta); err != nil {
+			writeStoreAwareError(h.deps.Logger, w, err)
+			return
+		}
+	}
+
+	writeJSON(w, http.StatusOK, h.toSandboxResponse(r, sandbox, meta))
+}
+
+func (h *handlers) pauseSandbox(w http.ResponseWriter, r *http.Request) {
+	sandbox, err := h.deps.Service.GetSandbox(r.Context(), r.PathValue("id"))
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, "Sandbox not found")
+			return
+		}
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	if sandbox.Status == models.SandboxStatusStopped {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if sandbox.Status != models.SandboxStatusStarted {
+		WriteError(w, http.StatusConflict, "Sandbox is not running")
+		return
+	}
+	if _, err := h.deps.Service.StopSandbox(r.Context(), sandbox.ID); err != nil {
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *handlers) updateTimeout(w http.ResponseWriter, r *http.Request) {
+	var req timeoutRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		WriteError(w, http.StatusBadRequest, "Invalid JSON body")
+		return
+	}
+	if req.Timeout <= 0 {
+		WriteError(w, http.StatusBadRequest, "timeout must be greater than zero")
+		return
+	}
+
+	sandbox, err := h.deps.Service.GetSandbox(r.Context(), r.PathValue("id"))
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, "Sandbox not found")
+			return
+		}
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	meta, err := h.loadSandboxMeta(r.Context(), sandbox)
+	if err != nil {
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+
+	lifecycle := lifecycleForTimeout(sandbox, meta.OnTimeout, req.Timeout)
+	if _, err := h.deps.Service.UpdateLifecycle(r.Context(), sandbox.ID, lifecycle); err != nil {
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	meta.TimeoutSeconds = req.Timeout
+	if err := h.persistSandboxMeta(r.Context(), sandbox.ID, meta); err != nil {
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *handlers) createSnapshot(w http.ResponseWriter, r *http.Request) {
+	var req createSnapshotRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		WriteError(w, http.StatusBadRequest, "Invalid JSON body")
+		return
+	}
+	sandbox, err := h.deps.Service.GetSandbox(r.Context(), r.PathValue("id"))
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, "Sandbox not found")
+			return
+		}
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+
+	snapshotName := canonicalSnapshotName(req.Name)
+	if snapshotName == "" {
+		snapshotName = canonicalSnapshotName(fmt.Sprintf("%s-%d", sandbox.ID, time.Now().UTC().UnixNano()))
+	}
+	snapshot, err := h.deps.Service.CreateSnapshot(r.Context(), sandbox.ID, models.CreateSandboxSnapshotRequest{Name: snapshotName})
+	if err != nil {
+		if errors.Is(err, store.ErrSnapshotNameConflict) {
+			WriteError(w, http.StatusConflict, "Snapshot name already in use")
+			return
+		}
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+
+	resp := snapshotInfoResponse{
+		SnapshotID: snapshotIDFromName(snapshot.Name),
+		Names:      []string{canonicalSnapshotName(snapshot.Name)},
+	}
+	if err := h.deps.Service.UpsertE2BSnapshot(r.Context(), models.E2BSnapshotMetadata{
+		SnapshotID:      resp.SnapshotID,
+		SnapshotName:    snapshot.Name,
+		Names:           resp.Names,
+		SourceSandboxID: sandbox.ID,
+	}); err != nil {
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, resp)
+}
+
+func (h *handlers) listSnapshots(w http.ResponseWriter, r *http.Request) {
+	limit, offset, err := parsePagination(r, 100)
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	sandboxFilter := strings.TrimSpace(r.URL.Query().Get("sandboxID"))
+
+	snapshots, err := h.deps.Service.ListSnapshots(r.Context())
+	if err != nil {
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	stored, err := h.deps.Service.ListE2BSnapshots(r.Context())
+	if err != nil {
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+
+	type snapshotRow struct {
+		response  snapshotInfoResponse
+		createdAt time.Time
+	}
+	rows := make([]snapshotRow, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		if snapshot == nil {
+			continue
+		}
+		meta, ok := stored[snapshotIDFromName(snapshot.Name)]
+		if sandboxFilter != "" {
+			sourceSandboxID := snapshot.SourceSandboxID
+			if ok && strings.TrimSpace(meta.SourceSandboxID) != "" {
+				sourceSandboxID = strings.TrimSpace(meta.SourceSandboxID)
+			}
+			if sourceSandboxID != sandboxFilter {
+				continue
+			}
+		}
+		response := snapshotInfoResponse{
+			SnapshotID: snapshotIDFromName(snapshot.Name),
+			Names:      []string{canonicalSnapshotName(snapshot.Name)},
+		}
+		createdAt := snapshot.CreatedAt
+		if ok {
+			if strings.TrimSpace(meta.SnapshotID) != "" {
+				response.SnapshotID = strings.TrimSpace(meta.SnapshotID)
+			}
+			if len(meta.Names) > 0 {
+				response.Names = cloneStringSlice(meta.Names)
+			}
+			if !meta.CreatedAt.IsZero() {
+				createdAt = meta.CreatedAt
+			}
+		}
+		rows = append(rows, snapshotRow{response: response, createdAt: createdAt})
+	}
+
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].createdAt.Equal(rows[j].createdAt) {
+			return rows[i].response.SnapshotID < rows[j].response.SnapshotID
+		}
+		return rows[i].createdAt.After(rows[j].createdAt)
+	})
+
+	items := make([]snapshotInfoResponse, len(rows))
+	for i, row := range rows {
+		items[i] = row.response
+	}
+	page, nextToken := paginateSnapshots(items, offset, limit)
+	if nextToken != "" {
+		w.Header().Set("x-next-token", nextToken)
+	}
+	writeJSON(w, http.StatusOK, page)
+}
+
+func (h *handlers) deleteSnapshot(w http.ResponseWriter, r *http.Request) {
+	snapshotID := strings.TrimSpace(r.PathValue("id"))
+	if snapshotID == "" {
+		WriteError(w, http.StatusNotFound, "Snapshot not found")
+		return
+	}
+
+	targetName, storedID, err := h.resolveSnapshotDeleteTarget(r.Context(), snapshotID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, "Snapshot not found")
+			return
+		}
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	if err := h.deps.Service.DeleteSnapshot(r.Context(), targetName); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, "Snapshot not found")
+			return
+		}
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	if storedID != "" {
+		if err := h.deps.Service.DeleteE2BSnapshot(r.Context(), storedID); err != nil && !errors.Is(err, store.ErrNotFound) {
+			writeStoreAwareError(h.deps.Logger, w, err)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *handlers) translateCreateSandboxRequest(ctx context.Context, req createSandboxRequest) (models.CreateSandboxRequest, sandboxMeta, error) {
+	templateID := strings.TrimSpace(req.TemplateID)
+	if templateID == "" {
+		return models.CreateSandboxRequest{}, sandboxMeta{}, badRequest("templateID is required")
+	}
+	if req.MCP != nil {
+		return models.CreateSandboxRequest{}, sandboxMeta{}, notImplemented("MCP template startup is not implemented yet")
+	}
+	if len(req.VolumeMounts) > 0 {
+		return models.CreateSandboxRequest{}, sandboxMeta{}, notImplemented("E2B volume mounts are not implemented yet")
+	}
+
+	metadata, err := stringMap(req.Metadata, "metadata")
+	if err != nil {
+		return models.CreateSandboxRequest{}, sandboxMeta{}, err
+	}
+	envVars, err := stringMap(req.EnvVars, "envVars")
+	if err != nil {
+		return models.CreateSandboxRequest{}, sandboxMeta{}, err
+	}
+
+	networkAllowOut := []string{}
+	networkDenyOut := []string{}
+	allowPublicTraffic := (*bool)(nil)
+	maskRequestHost := ""
+	if req.Network != nil {
+		networkAllowOut = cloneStringSlice(req.Network.AllowOut)
+		networkDenyOut = cloneStringSlice(req.Network.DenyOut)
+		allowPublicTraffic = cloneBoolPtr(req.Network.AllowPublicTraffic)
+		maskRequestHost = strings.TrimSpace(req.Network.MaskRequestHost)
+	}
+	if len(networkAllowOut) > 0 {
+		return models.CreateSandboxRequest{}, sandboxMeta{}, notImplemented("network.allowOut is not implemented yet")
+	}
+	if len(networkDenyOut) > 0 && !(len(networkDenyOut) == 1 && networkDenyOut[0] == "0.0.0.0/0") {
+		return models.CreateSandboxRequest{}, sandboxMeta{}, notImplemented("network.denyOut is only supported for blocking all outbound traffic")
+	}
+	if allowPublicTraffic != nil && !*allowPublicTraffic {
+		return models.CreateSandboxRequest{}, sandboxMeta{}, notImplemented("network.allowPublicTraffic=false is not implemented yet")
+	}
+	if maskRequestHost != "" {
+		return models.CreateSandboxRequest{}, sandboxMeta{}, notImplemented("network.maskRequestHost is not implemented yet")
+	}
+
+	secure := true
+	if req.Secure != nil {
+		secure = *req.Secure
+	}
+	allowInternetAccess := cloneBoolPtr(req.AllowInternetAccess)
+	networkBlockAll := false
+	if allowInternetAccess != nil && !*allowInternetAccess {
+		networkBlockAll = true
+	}
+	if len(networkDenyOut) == 1 && networkDenyOut[0] == "0.0.0.0/0" {
+		networkBlockAll = true
+		if allowInternetAccess == nil {
+			value := false
+			allowInternetAccess = &value
+		}
+	}
+
+	timeoutSeconds := defaultSandboxTimeout
+	if req.Timeout != nil {
+		timeoutSeconds = *req.Timeout
+	}
+	if timeoutSeconds <= 0 {
+		return models.CreateSandboxRequest{}, sandboxMeta{}, badRequest("timeout must be greater than zero")
+	}
+
+	autoPause := req.AutoPause != nil && *req.AutoPause
+	autoResume := req.AutoResume != nil && req.AutoResume.Enabled
+	onTimeout := "kill"
+	if autoPause || autoResume {
+		onTimeout = "pause"
+	}
+
+	resolvedImage, templateAlias, err := h.resolveTemplate(ctx, templateID)
+	if err != nil {
+		return models.CreateSandboxRequest{}, sandboxMeta{}, err
+	}
+
+	serviceReq := models.CreateSandboxRequest{
+		Image:           resolvedImage,
+		Env:             envVars,
+		NetworkBlockAll: networkBlockAll,
+		Lifecycle:       lifecyclePtr(timeoutSeconds, onTimeout),
+	}
+	meta := sandboxMeta{
+		TemplateID:          templateID,
+		TemplateAlias:       templateAlias,
+		Metadata:            metadata,
+		TimeoutSeconds:      timeoutSeconds,
+		OnTimeout:           onTimeout,
+		AutoResume:          autoResume,
+		Secure:              secure,
+		AllowInternetAccess: allowInternetAccess,
+		NetworkAllowOut:     networkAllowOut,
+		NetworkDenyOut:      networkDenyOut,
+		AllowPublicTraffic:  allowPublicTraffic,
+		MaskRequestHost:     maskRequestHost,
+	}
+	return serviceReq, meta, nil
+}
+
+func (h *handlers) resolveTemplate(ctx context.Context, templateID string) (string, string, error) {
+	if snapshotMeta, err := h.deps.Service.GetE2BSnapshot(ctx, templateID); err == nil {
+		return strings.TrimSpace(snapshotMeta.SnapshotName), "", nil
+	} else if !errors.Is(err, store.ErrNotFound) {
+		return "", "", err
+	}
+	if decoded, ok := snapshotNameFromID(templateID); ok {
+		if snapshot, err := h.deps.Service.GetSnapshot(ctx, decoded); err == nil {
+			return snapshot.Name, "", nil
+		} else if !errors.Is(err, store.ErrNotFound) {
+			return "", "", err
+		}
+	}
+	if snapshot, err := h.deps.Service.GetSnapshot(ctx, templateID); err == nil {
+		return snapshot.Name, "", nil
+	} else if !errors.Is(err, store.ErrNotFound) {
+		return "", "", err
+	}
+	if canonical := canonicalSnapshotName(templateID); canonical != templateID {
+		if snapshot, err := h.deps.Service.GetSnapshot(ctx, canonical); err == nil {
+			return snapshot.Name, "", nil
+		} else if !errors.Is(err, store.ErrNotFound) {
+			return "", "", err
+		}
+	}
+	if image, ok := h.templateMap[templateID]; ok {
+		return image, "", nil
+	}
+	return "", "", badRequest(fmt.Sprintf("unsupported templateID %q", templateID))
+}
+
+func (h *handlers) loadSandboxMeta(ctx context.Context, sandbox *models.Sandbox) (sandboxMeta, error) {
+	if sandbox == nil {
+		return defaultSandboxMeta(nil), nil
+	}
+	stored, err := h.deps.Service.GetE2BSandboxMetadata(ctx, sandbox.ID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return defaultSandboxMeta(sandbox), nil
+		}
+		return sandboxMeta{}, err
+	}
+	return sandboxMetaFromStored(stored, sandbox), nil
+}
+
+func (h *handlers) persistSandboxMeta(ctx context.Context, sandboxID string, meta sandboxMeta) error {
+	if h.deps.Service == nil {
+		return nil
+	}
+	return h.deps.Service.UpsertE2BSandboxMetadata(ctx, sandboxMetaToStored(sandboxID, meta))
+}
+
+func (h *handlers) resolveSnapshotDeleteTarget(ctx context.Context, snapshotID string) (string, string, error) {
+	if stored, err := h.deps.Service.GetE2BSnapshot(ctx, snapshotID); err == nil {
+		return strings.TrimSpace(stored.SnapshotName), strings.TrimSpace(stored.SnapshotID), nil
+	} else if !errors.Is(err, store.ErrNotFound) {
+		return "", "", err
+	}
+	if decoded, ok := snapshotNameFromID(snapshotID); ok {
+		return decoded, snapshotID, nil
+	}
+	if snapshot, err := h.deps.Service.GetSnapshot(ctx, snapshotID); err == nil {
+		return snapshot.Name, snapshotIDFromName(snapshot.Name), nil
+	} else if !errors.Is(err, store.ErrNotFound) {
+		return "", "", err
+	}
+	if canonical := canonicalSnapshotName(snapshotID); canonical != snapshotID {
+		if snapshot, err := h.deps.Service.GetSnapshot(ctx, canonical); err == nil {
+			return snapshot.Name, snapshotIDFromName(snapshot.Name), nil
+		} else if !errors.Is(err, store.ErrNotFound) {
+			return "", "", err
+		}
+	}
+	return "", "", store.ErrNotFound
+}
+
+func (h *handlers) toSandboxResponse(r *http.Request, sandbox *models.Sandbox, meta sandboxMeta) sandboxResponse {
+	return sandboxResponse{
+		ClientID:        h.clientID,
+		EnvdVersion:     h.defaultEnvdVer,
+		SandboxID:       sandbox.ID,
+		TemplateID:      firstNonEmpty(meta.TemplateID, sandbox.Image),
+		Alias:           meta.TemplateAlias,
+		Domain:          requestDomain(r),
+		EnvdAccessToken: envdAccessToken(sandbox, meta),
+	}
+}
+
+func (h *handlers) toListedSandboxResponse(sandbox *models.Sandbox, meta sandboxMeta) listedSandboxResponse {
+	endAt := timeoutEndAt(sandbox, meta)
+	return listedSandboxResponse{
+		ClientID:     h.clientID,
+		CPUCount:     sandboxCPUCount(sandbox),
+		DiskSizeMB:   sandbox.DiskGB * 1024,
+		EndAt:        endAt.Format(time.RFC3339Nano),
+		EnvdVersion:  h.defaultEnvdVer,
+		MemoryMB:     sandbox.MemoryMB,
+		SandboxID:    sandbox.ID,
+		StartedAt:    startedAt(sandbox).Format(time.RFC3339Nano),
+		State:        mapSandboxState(sandbox.Status),
+		TemplateID:   firstNonEmpty(meta.TemplateID, sandbox.Image),
+		Alias:        meta.TemplateAlias,
+		Metadata:     cloneStringMap(meta.Metadata),
+		VolumeMounts: []sandboxVolumeMountPayload{},
+	}
+}
+
+func (h *handlers) toSandboxDetailResponse(r *http.Request, sandbox *models.Sandbox, meta sandboxMeta) sandboxDetailResponse {
+	endAt := timeoutEndAt(sandbox, meta)
+	return sandboxDetailResponse{
+		ClientID:            h.clientID,
+		CPUCount:            sandboxCPUCount(sandbox),
+		DiskSizeMB:          sandbox.DiskGB * 1024,
+		EndAt:               endAt.Format(time.RFC3339Nano),
+		EnvdVersion:         h.defaultEnvdVer,
+		MemoryMB:            sandbox.MemoryMB,
+		SandboxID:           sandbox.ID,
+		StartedAt:           startedAt(sandbox).Format(time.RFC3339Nano),
+		State:               mapSandboxState(sandbox.Status),
+		TemplateID:          firstNonEmpty(meta.TemplateID, sandbox.Image),
+		Alias:               meta.TemplateAlias,
+		AllowInternetAccess: cloneBoolPtr(meta.AllowInternetAccess),
+		Domain:              requestDomain(r),
+		EnvdAccessToken:     envdAccessToken(sandbox, meta),
+		Lifecycle:           lifecyclePayload(meta),
+		Metadata:            cloneStringMap(meta.Metadata),
+		Network:             networkPayload(meta),
+		VolumeMounts:        []sandboxVolumeMountPayload{},
+	}
+}
+
+func lifecyclePayload(meta sandboxMeta) *sandboxLifecyclePayload {
+	if strings.TrimSpace(meta.OnTimeout) == "" {
+		return nil
+	}
+	return &sandboxLifecyclePayload{AutoResume: meta.AutoResume, OnTimeout: meta.OnTimeout}
+}
+
+func networkPayload(meta sandboxMeta) *sandboxNetworkPayload {
+	if len(meta.NetworkAllowOut) == 0 && len(meta.NetworkDenyOut) == 0 && meta.AllowPublicTraffic == nil && strings.TrimSpace(meta.MaskRequestHost) == "" {
+		return nil
+	}
+	return &sandboxNetworkPayload{
+		AllowOut:           cloneStringSlice(meta.NetworkAllowOut),
+		AllowPublicTraffic: cloneBoolPtr(meta.AllowPublicTraffic),
+		DenyOut:            cloneStringSlice(meta.NetworkDenyOut),
+		MaskRequestHost:    strings.TrimSpace(meta.MaskRequestHost),
+	}
+}
+
+func lifecyclePtr(timeoutSeconds int, onTimeout string) *models.Lifecycle {
+	lifecycle := models.Lifecycle{}
+	duration := time.Duration(timeoutSeconds) * time.Second
+	if strings.EqualFold(onTimeout, "pause") {
+		lifecycle.StopAtAge = duration
+	} else {
+		lifecycle.DestroyAtAge = duration
+	}
+	return &lifecycle
+}
+
+func lifecycleForTimeout(sandbox *models.Sandbox, onTimeout string, timeoutSeconds int) models.Lifecycle {
+	base := models.Lifecycle{}
+	if sandbox != nil {
+		base = sandbox.Lifecycle
+	}
+	base.StopAtAge = 0
+	base.DestroyAtAge = 0
+	duration := time.Duration(timeoutSeconds) * time.Second
+	if sandbox != nil && !sandbox.CreatedAt.IsZero() {
+		elapsed := time.Since(sandbox.CreatedAt)
+		if elapsed > 0 {
+			duration += elapsed
+		}
+	}
+	if strings.EqualFold(onTimeout, "pause") {
+		base.StopAtAge = duration
+	} else {
+		base.DestroyAtAge = duration
+	}
+	return base
+}
+
+func timeoutDeadline(sandbox *models.Sandbox, meta sandboxMeta) (time.Time, bool) {
+	if sandbox == nil || sandbox.CreatedAt.IsZero() {
+		return time.Time{}, false
+	}
+	switch strings.ToLower(strings.TrimSpace(meta.OnTimeout)) {
+	case "pause":
+		if sandbox.Lifecycle.StopAtAge > 0 {
+			return sandbox.CreatedAt.Add(sandbox.Lifecycle.StopAtAge), true
+		}
+	case "kill":
+		if sandbox.Lifecycle.DestroyAtAge > 0 {
+			return sandbox.CreatedAt.Add(sandbox.Lifecycle.DestroyAtAge), true
+		}
+	}
+	if sandbox.Lifecycle.DestroyAtAge > 0 {
+		return sandbox.CreatedAt.Add(sandbox.Lifecycle.DestroyAtAge), true
+	}
+	if sandbox.Lifecycle.StopAtAge > 0 {
+		return sandbox.CreatedAt.Add(sandbox.Lifecycle.StopAtAge), true
+	}
+	return time.Time{}, false
+}
+
+func timeoutEndAt(sandbox *models.Sandbox, meta sandboxMeta) time.Time {
+	if deadline, ok := timeoutDeadline(sandbox, meta); ok {
+		return deadline
+	}
+	if sandbox != nil && meta.TimeoutSeconds > 0 {
+		return sandbox.CreatedAt.Add(time.Duration(meta.TimeoutSeconds) * time.Second)
+	}
+	if sandbox != nil && !sandbox.CreatedAt.IsZero() {
+		return sandbox.CreatedAt
+	}
+	return time.Now().UTC()
+}
+
+func envdAccessToken(sandbox *models.Sandbox, meta sandboxMeta) string {
+	if sandbox == nil || !meta.Secure {
+		return ""
+	}
+	return sandbox.ToolboxToken
+}
+
+func sandboxCPUCount(sandbox *models.Sandbox) int {
+	if sandbox == nil || sandbox.CPU <= 0 {
+		return 1
+	}
+	return int(math.Ceil(sandbox.CPU))
+}
+
+func startedAt(sandbox *models.Sandbox) time.Time {
+	if sandbox == nil || sandbox.CreatedAt.IsZero() {
+		return time.Now().UTC()
+	}
+	return sandbox.CreatedAt
+}
+
+func mapSandboxState(status models.SandboxStatus) string {
+	if status == models.SandboxStatusStarted {
+		return "running"
+	}
+	return "paused"
+}
+
+func metadataContains(values map[string]string, filter map[string]string) bool {
+	for key, value := range filter {
+		if values[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func parseMetadataFilter(raw string) (map[string]string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	parsed, err := url.ParseQuery(raw)
+	if err != nil {
+		return nil, badRequest("invalid metadata filter")
+	}
+	result := make(map[string]string, len(parsed))
+	for key, values := range parsed {
+		if len(values) == 0 {
+			result[key] = ""
+			continue
+		}
+		result[key] = values[len(values)-1]
+	}
+	return result, nil
+}
+
+func parseStateFilter(raw string) (map[string]struct{}, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	result := map[string]struct{}{}
+	for _, part := range strings.Split(raw, ",") {
+		state := strings.ToLower(strings.TrimSpace(part))
+		switch state {
+		case "running", "paused":
+			result[state] = struct{}{}
+		default:
+			return nil, badRequest(fmt.Sprintf("invalid state %q", part))
+		}
+	}
+	return result, nil
+}
+
+func parsePagination(r *http.Request, defaultLimit int) (int, int, error) {
+	limit := defaultLimit
+	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed <= 0 {
+			return 0, 0, badRequest("invalid limit")
+		}
+		limit = parsed
+	}
+	offset := 0
+	if raw := strings.TrimSpace(r.URL.Query().Get("nextToken")); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 0 {
+			return 0, 0, badRequest("invalid nextToken")
+		}
+		offset = parsed
+	}
+	return limit, offset, nil
+}
+
+func paginateListedSandboxes(items []listedSandboxResponse, offset, limit int) ([]listedSandboxResponse, string) {
+	if offset > len(items) {
+		offset = len(items)
+	}
+	end := offset + limit
+	if end > len(items) {
+		end = len(items)
+	}
+	page := items[offset:end]
+	if end < len(items) {
+		return page, strconv.Itoa(end)
+	}
+	return page, ""
+}
+
+func paginateSnapshots(items []snapshotInfoResponse, offset, limit int) ([]snapshotInfoResponse, string) {
+	if offset > len(items) {
+		offset = len(items)
+	}
+	end := offset + limit
+	if end > len(items) {
+		end = len(items)
+	}
+	page := items[offset:end]
+	if end < len(items) {
+		return page, strconv.Itoa(end)
+	}
+	return page, ""
+}
+
+func stringMap(input map[string]any, field string) (map[string]string, error) {
+	if len(input) == 0 {
+		return map[string]string{}, nil
+	}
+	result := make(map[string]string, len(input))
+	for key, value := range input {
+		stringValue, ok := value.(string)
+		if !ok {
+			return nil, badRequest(fmt.Sprintf("%s values must be strings", field))
+		}
+		result[key] = stringValue
+	}
+	return result, nil
+}
+
+func loadTemplateMap(logger *slog.Logger) map[string]string {
+	aliases := map[string]string{"base": "ubuntu:22.04"}
+	raw := strings.TrimSpace(os.Getenv("SB_E2B_TEMPLATE_MAP_JSON"))
+	if raw == "" {
+		return aliases
+	}
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		if logger != nil {
+			logger.Warn("invalid SB_E2B_TEMPLATE_MAP_JSON, using defaults", "error", err)
+		}
+		return aliases
+	}
+	for key, value := range parsed {
+		trimmedKey := strings.TrimSpace(key)
+		trimmedValue := strings.TrimSpace(value)
+		if trimmedKey != "" && trimmedValue != "" {
+			aliases[trimmedKey] = trimmedValue
+		}
+	}
+	if _, ok := aliases["base"]; !ok {
+		aliases["base"] = "ubuntu:22.04"
+	}
+	return aliases
+}
+
+func loadClientID() string {
+	clientID := strings.TrimSpace(os.Getenv("SB_E2B_CLIENT_ID"))
+	if clientID == "" {
+		return defaultClientID
+	}
+	return clientID
+}
+
+func requestDomain(r *http.Request) *string {
+	if r == nil {
+		return nil
+	}
+	host := strings.TrimSpace(r.Host)
+	if host == "" {
+		return nil
+	}
+	if parsedHost, _, err := net.SplitHostPort(host); err == nil {
+		host = parsedHost
+	}
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return nil
+	}
+	return &host
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func storedSandboxMeta(items map[string]models.E2BSandboxMetadata, sandboxID string) *models.E2BSandboxMetadata {
+	meta, ok := items[sandboxID]
+	if !ok {
+		return nil
+	}
+	copy := meta
+	return &copy
+}

--- a/pkg/api/e2b/handlers.go
+++ b/pkg/api/e2b/handlers.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aerol-ai/microvm/internal/store"
@@ -26,6 +27,7 @@ type handlers struct {
 	clientID       string
 	defaultDomain  *string
 	defaultEnvdVer string
+	snapshotMu     sync.Mutex
 }
 
 func newHandlers(d Deps) *handlers {
@@ -354,7 +356,16 @@ func (h *handlers) createSnapshot(w http.ResponseWriter, r *http.Request) {
 
 	snapshotName := canonicalSnapshotName(req.Name)
 	if snapshotName == "" {
-		snapshotName = canonicalSnapshotName(fmt.Sprintf("%s-%d", sandbox.ID, time.Now().UTC().UnixNano()))
+		snapshotName = defaultSnapshotName(sandbox.ID)
+	}
+
+	h.snapshotMu.Lock()
+	defer h.snapshotMu.Unlock()
+
+	existedBefore, err := h.snapshotExistsForSandbox(r.Context(), snapshotName, sandbox.ID)
+	if err != nil {
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
 	}
 	snapshot, err := h.deps.Service.CreateSnapshot(r.Context(), sandbox.ID, models.CreateSandboxSnapshotRequest{Name: snapshotName})
 	if err != nil {
@@ -376,6 +387,11 @@ func (h *handlers) createSnapshot(w http.ResponseWriter, r *http.Request) {
 		Names:           resp.Names,
 		SourceSandboxID: sandbox.ID,
 	}); err != nil {
+		if !existedBefore {
+			if deleteErr := h.deps.Service.DeleteSnapshot(r.Context(), snapshot.Name); deleteErr != nil && h.deps.Logger != nil {
+				h.deps.Logger.Warn("e2b snapshot metadata rollback failed", "snapshot_name", snapshot.Name, "error", deleteErr)
+			}
+		}
 		writeStoreAwareError(h.deps.Logger, w, err)
 		return
 	}
@@ -708,6 +724,17 @@ func (h *handlers) waitForCreateReplay(ctx context.Context, fingerprint string) 
 		case <-timer.C:
 		}
 	}
+}
+
+func (h *handlers) snapshotExistsForSandbox(ctx context.Context, snapshotName, sandboxID string) (bool, error) {
+	snapshot, err := h.deps.Service.GetSnapshot(ctx, snapshotName)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	return snapshot.SourceSandboxID == sandboxID, nil
 }
 
 func (h *handlers) resolveSnapshotDeleteTarget(ctx context.Context, snapshotID string) (string, string, error) {

--- a/pkg/api/e2b/handlers.go
+++ b/pkg/api/e2b/handlers.go
@@ -51,9 +51,56 @@ func (h *handlers) createSandbox(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	fingerprint, err := createRequestFingerprint(req.TemplateID, serviceReq, meta)
+	if err != nil {
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	cleanupReservation := func() {
+		if err := h.deps.Service.DeleteE2BCreateRequest(r.Context(), fingerprint); err != nil && !errors.Is(err, store.ErrNotFound) && h.deps.Logger != nil {
+			h.deps.Logger.Warn("e2b create reservation cleanup failed", "fingerprint", fingerprint, "error", err)
+		}
+	}
+
+	for {
+		record, acquired, err := h.deps.Service.ClaimE2BCreateRequest(r.Context(), fingerprint, time.Now().UTC(), e2bCreatePendingTTL)
+		if err != nil {
+			writeStoreAwareError(h.deps.Logger, w, err)
+			return
+		}
+		if acquired {
+			break
+		}
+
+		if record.State == models.E2BCreateRequestStateReady {
+			sandbox, storedMeta, replayed, err := h.loadReplayableCreateResult(r.Context(), record)
+			if err != nil {
+				writeStoreAwareError(h.deps.Logger, w, err)
+				return
+			}
+			if replayed {
+				writeJSON(w, http.StatusCreated, h.toSandboxResponse(r, sandbox, storedMeta))
+				return
+			}
+			continue
+		}
+
+		sandbox, storedMeta, replayed, err := h.waitForCreateReplay(r.Context(), fingerprint)
+		if err != nil {
+			if !writeKnownError(w, err) {
+				writeStoreAwareError(h.deps.Logger, w, err)
+			}
+			return
+		}
+		if replayed {
+			writeJSON(w, http.StatusCreated, h.toSandboxResponse(r, sandbox, storedMeta))
+			return
+		}
+	}
 
 	response, err := h.deps.Service.CreateSandbox(r.Context(), serviceReq)
 	if err != nil {
+		cleanupReservation()
 		writeStoreAwareError(h.deps.Logger, w, err)
 		return
 	}
@@ -62,16 +109,20 @@ func (h *handlers) createSandbox(w http.ResponseWriter, r *http.Request) {
 		if destroyErr := h.deps.Service.DestroySandbox(r.Context(), response.ID); destroyErr != nil && h.deps.Logger != nil {
 			h.deps.Logger.Warn("e2b metadata rollback failed", "sandbox_id", response.ID, "error", destroyErr)
 		}
+		cleanupReservation()
 		writeStoreAwareError(h.deps.Logger, w, err)
 		return
 	}
 
-	storedMeta, err := h.loadSandboxMeta(r.Context(), &response.Sandbox)
-	if err != nil {
+	if err := h.deps.Service.CompleteE2BCreateRequest(r.Context(), fingerprint, response.ID, time.Now().UTC(), e2bCreateReplayWindow); err != nil {
+		if destroyErr := h.deps.Service.DestroySandbox(r.Context(), response.ID); destroyErr != nil && h.deps.Logger != nil {
+			h.deps.Logger.Warn("e2b create idempotency rollback failed", "sandbox_id", response.ID, "error", destroyErr)
+		}
+		cleanupReservation()
 		writeStoreAwareError(h.deps.Logger, w, err)
 		return
 	}
-	writeJSON(w, http.StatusCreated, h.toSandboxResponse(r, &response.Sandbox, storedMeta))
+	writeJSON(w, http.StatusCreated, h.toSandboxResponse(r, &response.Sandbox, meta))
 }
 
 func (h *handlers) listSandboxes(w http.ResponseWriter, r *http.Request) {
@@ -593,6 +644,70 @@ func (h *handlers) persistSandboxMeta(ctx context.Context, sandboxID string, met
 		return nil
 	}
 	return h.deps.Service.UpsertE2BSandboxMetadata(ctx, sandboxMetaToStored(sandboxID, meta))
+}
+
+func (h *handlers) loadReplayableCreateResult(ctx context.Context, record *models.E2BCreateRequestRecord) (*models.Sandbox, sandboxMeta, bool, error) {
+	if record == nil || strings.TrimSpace(record.SandboxID) == "" {
+		return nil, sandboxMeta{}, false, nil
+	}
+	sandbox, err := h.deps.Service.GetSandbox(ctx, record.SandboxID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			if deleteErr := h.deps.Service.DeleteE2BCreateRequest(ctx, record.Fingerprint); deleteErr != nil && !errors.Is(deleteErr, store.ErrNotFound) {
+				return nil, sandboxMeta{}, false, deleteErr
+			}
+			return nil, sandboxMeta{}, false, nil
+		}
+		return nil, sandboxMeta{}, false, err
+	}
+	meta, err := h.loadSandboxMeta(ctx, sandbox)
+	if err != nil {
+		return nil, sandboxMeta{}, false, err
+	}
+	return sandbox, meta, true, nil
+}
+
+func (h *handlers) waitForCreateReplay(ctx context.Context, fingerprint string) (*models.Sandbox, sandboxMeta, bool, error) {
+	deadline := time.Now().UTC().Add(e2bCreateWaitTimeout)
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, sandboxMeta{}, false, err
+		}
+		now := time.Now().UTC()
+		if !now.Before(deadline) {
+			return nil, sandboxMeta{}, false, serviceUnavailable("An identical sandbox create is already in progress; retry shortly.")
+		}
+
+		record, err := h.deps.Service.GetE2BCreateRequest(ctx, fingerprint)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				return nil, sandboxMeta{}, false, nil
+			}
+			return nil, sandboxMeta{}, false, err
+		}
+
+		if record.State == models.E2BCreateRequestStateReady {
+			return h.loadReplayableCreateResult(ctx, record)
+		}
+		if record.State != models.E2BCreateRequestStatePending || !record.LockedUntil.After(now) {
+			return nil, sandboxMeta{}, false, nil
+		}
+
+		waitFor := e2bCreatePollInterval
+		if remaining := time.Until(deadline); remaining > 0 && remaining < waitFor {
+			waitFor = remaining
+		}
+		if remaining := time.Until(record.LockedUntil); remaining > 0 && remaining < waitFor {
+			waitFor = remaining
+		}
+		timer := time.NewTimer(waitFor)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, sandboxMeta{}, false, ctx.Err()
+		case <-timer.C:
+		}
+	}
 }
 
 func (h *handlers) resolveSnapshotDeleteTarget(ctx context.Context, snapshotID string) (string, string, error) {

--- a/pkg/api/e2b/handlers_test.go
+++ b/pkg/api/e2b/handlers_test.go
@@ -7,9 +7,12 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	neturl "net/url"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -202,12 +205,116 @@ func TestCreateSandboxRejectsUnsupportedNetworkAllowOut(t *testing.T) {
 	}
 }
 
+func TestCreateSandboxIdempotentReplay(t *testing.T) {
+	runtime := newFakeE2BRuntime()
+	_, _, handler := newE2BHandlerTestEnvWithRuntime(t, runtime, config.Config{PublicHost: "sandbox.test", EnableCaddy: false, ToolboxPort: 2280})
+
+	body := `{"templateID":"base","metadata":{"team":"sdk"},"timeout":120}`
+	firstReq := httptest.NewRequest(http.MethodPost, "/e2b/sandboxes", strings.NewReader(body))
+	firstResp := httptest.NewRecorder()
+	handler.ServeHTTP(firstResp, firstReq)
+	if firstResp.Code != http.StatusCreated {
+		t.Fatalf("first create status = %d, want %d; body=%s", firstResp.Code, http.StatusCreated, firstResp.Body.String())
+	}
+	var first sandboxResponse
+	if err := json.NewDecoder(firstResp.Body).Decode(&first); err != nil {
+		t.Fatalf("decode first create response error = %v", err)
+	}
+
+	secondReq := httptest.NewRequest(http.MethodPost, "/e2b/sandboxes", strings.NewReader(body))
+	secondResp := httptest.NewRecorder()
+	handler.ServeHTTP(secondResp, secondReq)
+	if secondResp.Code != http.StatusCreated {
+		t.Fatalf("second create status = %d, want %d; body=%s", secondResp.Code, http.StatusCreated, secondResp.Body.String())
+	}
+	var second sandboxResponse
+	if err := json.NewDecoder(secondResp.Body).Decode(&second); err != nil {
+		t.Fatalf("decode second create response error = %v", err)
+	}
+	if second.SandboxID != first.SandboxID {
+		t.Fatalf("second SandboxID = %q, want %q", second.SandboxID, first.SandboxID)
+	}
+	runtime.mu.Lock()
+	createHits := runtime.createHits
+	runtime.mu.Unlock()
+	if createHits != 1 {
+		t.Fatalf("runtime create hits = %d, want 1", createHits)
+	}
+}
+
+func TestRuntimeProxyRewritesToEnvdToolboxSurface(t *testing.T) {
+	toolboxRequests := make(chan *http.Request, 1)
+	toolboxServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		toolboxRequests <- r.Clone(r.Context())
+		writeJSON(w, http.StatusOK, map[string]any{"status": "ok"})
+	}))
+	defer toolboxServer.Close()
+
+	parsedURL, err := neturl.Parse(toolboxServer.URL)
+	if err != nil {
+		t.Fatalf("parse toolbox url error = %v", err)
+	}
+	host, portText, err := net.SplitHostPort(parsedURL.Host)
+	if err != nil {
+		t.Fatalf("split toolbox host error = %v", err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatalf("parse toolbox port error = %v", err)
+	}
+
+	runtime := newFakeE2BRuntime()
+	runtime.containerIP = host
+	_, _, handler := newE2BHandlerTestEnvWithRuntime(t, runtime, config.Config{PublicHost: "sandbox.test", EnableCaddy: false, ToolboxPort: port})
+
+	createReq := httptest.NewRequest(http.MethodPost, "/e2b/sandboxes", strings.NewReader(`{"templateID":"base","secure":true}`))
+	createResp := httptest.NewRecorder()
+	handler.ServeHTTP(createResp, createReq)
+	if createResp.Code != http.StatusCreated {
+		t.Fatalf("create status = %d, want %d; body=%s", createResp.Code, http.StatusCreated, createResp.Body.String())
+	}
+	var created sandboxResponse
+	if err := json.NewDecoder(createResp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response error = %v", err)
+	}
+
+	runtimeReq := httptest.NewRequest(http.MethodGet, "/e2b/runtime/health", nil)
+	runtimeReq.Header.Set("E2b-Sandbox-Id", created.SandboxID)
+	runtimeReq.Header.Set("X-Access-Token", created.EnvdAccessToken)
+	runtimeReq.Header.Set("Authorization", "Basic dXNlcjo=")
+	runtimeResp := httptest.NewRecorder()
+	handler.ServeHTTP(runtimeResp, runtimeReq)
+	if runtimeResp.Code != http.StatusOK {
+		t.Fatalf("runtime status = %d, want %d; body=%s", runtimeResp.Code, http.StatusOK, runtimeResp.Body.String())
+	}
+
+	select {
+	case forwarded := <-toolboxRequests:
+		if forwarded.URL.Path != "/envd/health" {
+			t.Fatalf("forwarded path = %q, want %q", forwarded.URL.Path, "/envd/health")
+		}
+		if forwarded.Header.Get("Authorization") == "" || !strings.HasPrefix(forwarded.Header.Get("Authorization"), "Bearer ") {
+			t.Fatalf("forwarded Authorization = %q, want Bearer token", forwarded.Header.Get("Authorization"))
+		}
+		if forwarded.Header.Get("X-E2B-User-Authorization") != "Basic dXNlcjo=" {
+			t.Fatalf("forwarded X-E2B-User-Authorization = %q", forwarded.Header.Get("X-E2B-User-Authorization"))
+		}
+		if forwarded.Header.Get("X-E2B-Sandbox-Id") != created.SandboxID {
+			t.Fatalf("forwarded X-E2B-Sandbox-Id = %q, want %q", forwarded.Header.Get("X-E2B-Sandbox-Id"), created.SandboxID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected toolbox request to be forwarded")
+	}
+}
+
 type fakeE2BRuntime struct {
 	mu            sync.Mutex
 	states        map[string]*models.SandboxRuntimeState
 	removedImages []string
 	imageSeq      int
 	ipSeq         int
+	createHits    int
+	containerIP   string
 }
 
 func newFakeE2BRuntime() *fakeE2BRuntime {
@@ -221,10 +328,15 @@ func (f *fakeE2BRuntime) Create(_ context.Context, _ models.CreateSandboxRequest
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.ipSeq++
+	f.createHits++
+	containerIP := f.containerIP
+	if containerIP == "" {
+		containerIP = fmt.Sprintf("10.42.0.%d", f.ipSeq)
+	}
 	state := &models.SandboxRuntimeState{
 		SandboxID:   sandboxID,
 		ContainerID: "ctr-" + sandboxID,
-		ContainerIP: fmt.Sprintf("10.42.0.%d", f.ipSeq),
+		ContainerIP: containerIP,
 		Status:      models.SandboxStatusStarted,
 	}
 	f.states[sandboxID] = cloneRuntimeState(state)
@@ -334,6 +446,10 @@ func sanitizeSnapshotID(value string) string {
 }
 
 func newE2BHandlerTestEnv(t *testing.T) (*service.Service, *store.Store, http.Handler) {
+	return newE2BHandlerTestEnvWithRuntime(t, newFakeE2BRuntime(), config.Config{PublicHost: "sandbox.test", EnableCaddy: false, ToolboxPort: 2280})
+}
+
+func newE2BHandlerTestEnvWithRuntime(t *testing.T, runtime *fakeE2BRuntime, cfg config.Config) (*service.Service, *store.Store, http.Handler) {
 	t.Helper()
 	t.Setenv("SB_E2B_TEMPLATE_MAP_JSON", `{"base":"ubuntu:22.04"}`)
 
@@ -360,8 +476,6 @@ func newE2BHandlerTestEnv(t *testing.T) (*service.Service, *store.Store, http.Ha
 		t.Fatalf("secrets.NewCipher() error = %v", err)
 	}
 
-	runtime := newFakeE2BRuntime()
-	cfg := config.Config{PublicHost: "sandbox.test", EnableCaddy: false, ToolboxPort: 2280}
 	svc := service.New(cfg, logger, st, runtime, nil, caddy.New(cfg), cipher, mountManager, nil)
 	mux := http.NewServeMux()
 	RegisterRoutes(mux, Deps{

--- a/pkg/api/e2b/handlers_test.go
+++ b/pkg/api/e2b/handlers_test.go
@@ -242,6 +242,57 @@ func TestCreateSandboxIdempotentReplay(t *testing.T) {
 	}
 }
 
+func TestCreateSnapshotWithoutNameIsIdempotent(t *testing.T) {
+	runtime := newFakeE2BRuntime()
+	_, _, handler := newE2BHandlerTestEnvWithRuntime(t, runtime, config.Config{PublicHost: "sandbox.test", EnableCaddy: false, ToolboxPort: 2280})
+
+	createReq := httptest.NewRequest(http.MethodPost, "/e2b/sandboxes", strings.NewReader(`{"templateID":"base"}`))
+	createResp := httptest.NewRecorder()
+	handler.ServeHTTP(createResp, createReq)
+	if createResp.Code != http.StatusCreated {
+		t.Fatalf("create status = %d, want %d; body=%s", createResp.Code, http.StatusCreated, createResp.Body.String())
+	}
+	var created sandboxResponse
+	if err := json.NewDecoder(createResp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response error = %v", err)
+	}
+
+	firstReq := httptest.NewRequest(http.MethodPost, "/e2b/sandboxes/"+created.SandboxID+"/snapshots", strings.NewReader(`{}`))
+	firstResp := httptest.NewRecorder()
+	handler.ServeHTTP(firstResp, firstReq)
+	if firstResp.Code != http.StatusCreated {
+		t.Fatalf("first snapshot status = %d, want %d; body=%s", firstResp.Code, http.StatusCreated, firstResp.Body.String())
+	}
+	var first snapshotInfoResponse
+	if err := json.NewDecoder(firstResp.Body).Decode(&first); err != nil {
+		t.Fatalf("decode first snapshot response error = %v", err)
+	}
+
+	secondReq := httptest.NewRequest(http.MethodPost, "/e2b/sandboxes/"+created.SandboxID+"/snapshots", strings.NewReader(`{}`))
+	secondResp := httptest.NewRecorder()
+	handler.ServeHTTP(secondResp, secondReq)
+	if secondResp.Code != http.StatusCreated {
+		t.Fatalf("second snapshot status = %d, want %d; body=%s", secondResp.Code, http.StatusCreated, secondResp.Body.String())
+	}
+	var second snapshotInfoResponse
+	if err := json.NewDecoder(secondResp.Body).Decode(&second); err != nil {
+		t.Fatalf("decode second snapshot response error = %v", err)
+	}
+	if second.SnapshotID != first.SnapshotID {
+		t.Fatalf("second SnapshotID = %q, want %q", second.SnapshotID, first.SnapshotID)
+	}
+	if len(second.Names) != 1 || second.Names[0] != defaultSnapshotName(created.SandboxID) {
+		t.Fatalf("second.Names = %+v, want [%q]", second.Names, defaultSnapshotName(created.SandboxID))
+	}
+
+	runtime.mu.Lock()
+	imageSeq := runtime.imageSeq
+	runtime.mu.Unlock()
+	if imageSeq != 1 {
+		t.Fatalf("runtime snapshot creates = %d, want 1", imageSeq)
+	}
+}
+
 func TestRuntimeProxyRewritesToEnvdToolboxSurface(t *testing.T) {
 	toolboxRequests := make(chan *http.Request, 1)
 	toolboxServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/api/e2b/handlers_test.go
+++ b/pkg/api/e2b/handlers_test.go
@@ -1,0 +1,375 @@
+package e2b
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/internal/service"
+	"github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/caddy"
+	"github.com/aerol-ai/microvm/pkg/models"
+	"github.com/aerol-ai/microvm/pkg/mounts"
+	"github.com/aerol-ai/microvm/pkg/secrets"
+)
+
+func TestE2BSandboxFlow(t *testing.T) {
+	ctx := context.Background()
+	_, st, handler := newE2BHandlerTestEnv(t)
+
+	createBody := `{"templateID":"base","metadata":{"team":"sdk"},"timeout":120,"autoPause":true,"autoResume":{"enabled":true},"secure":true,"allow_internet_access":false}`
+	createReq := httptest.NewRequest(http.MethodPost, "/e2b/sandboxes", strings.NewReader(createBody))
+	createResp := httptest.NewRecorder()
+	handler.ServeHTTP(createResp, createReq)
+	if createResp.Code != http.StatusCreated {
+		t.Fatalf("create status = %d, want %d; body=%s", createResp.Code, http.StatusCreated, createResp.Body.String())
+	}
+
+	var created sandboxResponse
+	if err := json.NewDecoder(createResp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response error = %v", err)
+	}
+	if created.SandboxID == "" {
+		t.Fatal("create response missing sandboxID")
+	}
+	if created.TemplateID != "base" {
+		t.Fatalf("TemplateID = %q, want %q", created.TemplateID, "base")
+	}
+	if created.EnvdVersion != defaultEnvdVersion {
+		t.Fatalf("EnvdVersion = %q, want %q", created.EnvdVersion, defaultEnvdVersion)
+	}
+	if created.EnvdAccessToken == "" {
+		t.Fatal("create response missing envdAccessToken for secure sandbox")
+	}
+
+	storedMeta, err := st.GetE2BSandboxMetadata(ctx, created.SandboxID)
+	if err != nil {
+		t.Fatalf("GetE2BSandboxMetadata() error = %v", err)
+	}
+	if storedMeta.OnTimeout != "pause" || !storedMeta.AutoResume {
+		t.Fatalf("unexpected stored lifecycle metadata: %+v", storedMeta)
+	}
+	if storedMeta.AllowInternetAccess == nil || *storedMeta.AllowInternetAccess {
+		t.Fatalf("AllowInternetAccess = %+v, want false", storedMeta.AllowInternetAccess)
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/e2b/sandboxes/"+created.SandboxID, nil)
+	getResp := httptest.NewRecorder()
+	handler.ServeHTTP(getResp, getReq)
+	if getResp.Code != http.StatusOK {
+		t.Fatalf("get status = %d, want %d; body=%s", getResp.Code, http.StatusOK, getResp.Body.String())
+	}
+	var detail sandboxDetailResponse
+	if err := json.NewDecoder(getResp.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode get response error = %v", err)
+	}
+	if detail.State != "running" {
+		t.Fatalf("detail.State = %q, want %q", detail.State, "running")
+	}
+	if detail.Lifecycle == nil || detail.Lifecycle.OnTimeout != "pause" || !detail.Lifecycle.AutoResume {
+		t.Fatalf("unexpected lifecycle payload: %+v", detail.Lifecycle)
+	}
+	if detail.AllowInternetAccess == nil || *detail.AllowInternetAccess {
+		t.Fatalf("detail.AllowInternetAccess = %+v, want false", detail.AllowInternetAccess)
+	}
+	if detail.Metadata["team"] != "sdk" {
+		t.Fatalf("detail.Metadata = %+v, want team=sdk", detail.Metadata)
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/e2b/v2/sandboxes?metadata=team%3Dsdk&state=running", nil)
+	listResp := httptest.NewRecorder()
+	handler.ServeHTTP(listResp, listReq)
+	if listResp.Code != http.StatusOK {
+		t.Fatalf("list status = %d, want %d; body=%s", listResp.Code, http.StatusOK, listResp.Body.String())
+	}
+	var listed []listedSandboxResponse
+	if err := json.NewDecoder(listResp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode list response error = %v", err)
+	}
+	if len(listed) != 1 || listed[0].SandboxID != created.SandboxID {
+		t.Fatalf("unexpected sandbox list: %+v", listed)
+	}
+
+	pauseReq := httptest.NewRequest(http.MethodPost, "/e2b/sandboxes/"+created.SandboxID+"/pause", nil)
+	pauseResp := httptest.NewRecorder()
+	handler.ServeHTTP(pauseResp, pauseReq)
+	if pauseResp.Code != http.StatusNoContent {
+		t.Fatalf("pause status = %d, want %d; body=%s", pauseResp.Code, http.StatusNoContent, pauseResp.Body.String())
+	}
+
+	connectReq := httptest.NewRequest(http.MethodPost, "/e2b/sandboxes/"+created.SandboxID+"/connect", strings.NewReader(`{"timeout":90}`))
+	connectResp := httptest.NewRecorder()
+	handler.ServeHTTP(connectResp, connectReq)
+	if connectResp.Code != http.StatusOK {
+		t.Fatalf("connect status = %d, want %d; body=%s", connectResp.Code, http.StatusOK, connectResp.Body.String())
+	}
+
+	getAfterConnectReq := httptest.NewRequest(http.MethodGet, "/e2b/sandboxes/"+created.SandboxID, nil)
+	getAfterConnectResp := httptest.NewRecorder()
+	handler.ServeHTTP(getAfterConnectResp, getAfterConnectReq)
+	if getAfterConnectResp.Code != http.StatusOK {
+		t.Fatalf("get-after-connect status = %d, want %d; body=%s", getAfterConnectResp.Code, http.StatusOK, getAfterConnectResp.Body.String())
+	}
+	var detailAfterConnect sandboxDetailResponse
+	if err := json.NewDecoder(getAfterConnectResp.Body).Decode(&detailAfterConnect); err != nil {
+		t.Fatalf("decode get-after-connect response error = %v", err)
+	}
+	if detailAfterConnect.State != "running" {
+		t.Fatalf("detailAfterConnect.State = %q, want %q", detailAfterConnect.State, "running")
+	}
+
+	timeoutReq := httptest.NewRequest(http.MethodPost, "/e2b/sandboxes/"+created.SandboxID+"/timeout", strings.NewReader(`{"timeout":30}`))
+	timeoutResp := httptest.NewRecorder()
+	handler.ServeHTTP(timeoutResp, timeoutReq)
+	if timeoutResp.Code != http.StatusNoContent {
+		t.Fatalf("timeout status = %d, want %d; body=%s", timeoutResp.Code, http.StatusNoContent, timeoutResp.Body.String())
+	}
+	storedMeta, err = st.GetE2BSandboxMetadata(ctx, created.SandboxID)
+	if err != nil {
+		t.Fatalf("GetE2BSandboxMetadata() after timeout error = %v", err)
+	}
+	if storedMeta.TimeoutSeconds != 30 {
+		t.Fatalf("storedMeta.TimeoutSeconds = %d, want %d", storedMeta.TimeoutSeconds, 30)
+	}
+
+	snapshotReq := httptest.NewRequest(http.MethodPost, "/e2b/sandboxes/"+created.SandboxID+"/snapshots", strings.NewReader(`{"name":"team/demo"}`))
+	snapshotResp := httptest.NewRecorder()
+	handler.ServeHTTP(snapshotResp, snapshotReq)
+	if snapshotResp.Code != http.StatusCreated {
+		t.Fatalf("snapshot status = %d, want %d; body=%s", snapshotResp.Code, http.StatusCreated, snapshotResp.Body.String())
+	}
+	var snapshot snapshotInfoResponse
+	if err := json.NewDecoder(snapshotResp.Body).Decode(&snapshot); err != nil {
+		t.Fatalf("decode snapshot response error = %v", err)
+	}
+	if strings.Contains(snapshot.SnapshotID, "/") {
+		t.Fatalf("SnapshotID = %q, want path-safe identifier", snapshot.SnapshotID)
+	}
+	if len(snapshot.Names) != 1 || snapshot.Names[0] != "team/demo:default" {
+		t.Fatalf("snapshot.Names = %+v, want [team/demo:default]", snapshot.Names)
+	}
+
+	listSnapshotsReq := httptest.NewRequest(http.MethodGet, "/e2b/snapshots?sandboxID="+created.SandboxID, nil)
+	listSnapshotsResp := httptest.NewRecorder()
+	handler.ServeHTTP(listSnapshotsResp, listSnapshotsReq)
+	if listSnapshotsResp.Code != http.StatusOK {
+		t.Fatalf("list snapshots status = %d, want %d; body=%s", listSnapshotsResp.Code, http.StatusOK, listSnapshotsResp.Body.String())
+	}
+	var snapshots []snapshotInfoResponse
+	if err := json.NewDecoder(listSnapshotsResp.Body).Decode(&snapshots); err != nil {
+		t.Fatalf("decode snapshot list error = %v", err)
+	}
+	if len(snapshots) != 1 || snapshots[0].SnapshotID != snapshot.SnapshotID {
+		t.Fatalf("unexpected snapshots list: %+v", snapshots)
+	}
+
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/e2b/templates/"+snapshot.SnapshotID, nil)
+	deleteResp := httptest.NewRecorder()
+	handler.ServeHTTP(deleteResp, deleteReq)
+	if deleteResp.Code != http.StatusNoContent {
+		t.Fatalf("delete snapshot status = %d, want %d; body=%s", deleteResp.Code, http.StatusNoContent, deleteResp.Body.String())
+	}
+	if _, err := st.GetE2BSnapshot(ctx, snapshot.SnapshotID); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("expected E2B snapshot metadata to be deleted, got %v", err)
+	}
+}
+
+func TestCreateSandboxRejectsUnsupportedNetworkAllowOut(t *testing.T) {
+	_, _, handler := newE2BHandlerTestEnv(t)
+	req := httptest.NewRequest(http.MethodPost, "/e2b/sandboxes", strings.NewReader(`{"templateID":"base","network":{"allowOut":["1.1.1.1"]}}`))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusNotImplemented, rr.Body.String())
+	}
+	var resp errorResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error response error = %v", err)
+	}
+	if resp.Code != http.StatusNotImplemented {
+		t.Fatalf("resp.Code = %d, want %d", resp.Code, http.StatusNotImplemented)
+	}
+}
+
+type fakeE2BRuntime struct {
+	mu            sync.Mutex
+	states        map[string]*models.SandboxRuntimeState
+	removedImages []string
+	imageSeq      int
+	ipSeq         int
+}
+
+func newFakeE2BRuntime() *fakeE2BRuntime {
+	return &fakeE2BRuntime{
+		states: make(map[string]*models.SandboxRuntimeState),
+		ipSeq:  20,
+	}
+}
+
+func (f *fakeE2BRuntime) Create(_ context.Context, _ models.CreateSandboxRequest, sandboxID, _ string, _ []mounts.ContainerBind) (*models.SandboxRuntimeState, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ipSeq++
+	state := &models.SandboxRuntimeState{
+		SandboxID:   sandboxID,
+		ContainerID: "ctr-" + sandboxID,
+		ContainerIP: fmt.Sprintf("10.42.0.%d", f.ipSeq),
+		Status:      models.SandboxStatusStarted,
+	}
+	f.states[sandboxID] = cloneRuntimeState(state)
+	return cloneRuntimeState(state), nil
+}
+
+func (f *fakeE2BRuntime) Start(_ context.Context, containerRef string) (*models.SandboxRuntimeState, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	state, ok := f.lookup(containerRef)
+	if !ok {
+		return nil, fmt.Errorf("sandbox %q not found", containerRef)
+	}
+	state.Status = models.SandboxStatusStarted
+	return cloneRuntimeState(state), nil
+}
+
+func (f *fakeE2BRuntime) Stop(_ context.Context, containerRef string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	state, ok := f.lookup(containerRef)
+	if !ok {
+		return fmt.Errorf("sandbox %q not found", containerRef)
+	}
+	state.Status = models.SandboxStatusStopped
+	return nil
+}
+
+func (f *fakeE2BRuntime) Destroy(_ context.Context, sandbox *models.Sandbox) error {
+	if sandbox == nil {
+		return nil
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.states, sandbox.ID)
+	return nil
+}
+
+func (f *fakeE2BRuntime) CreateSnapshot(_ context.Context, _ string, imageRef string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.imageSeq++
+	return fmt.Sprintf("sha256:%s-%03d", sanitizeSnapshotID(imageRef), f.imageSeq), nil
+}
+
+func (f *fakeE2BRuntime) Resize(context.Context, string, models.ResizeSandboxRequest) error {
+	return nil
+}
+
+func (f *fakeE2BRuntime) Inspect(_ context.Context, containerRef string) (*models.SandboxRuntimeState, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	state, ok := f.lookup(containerRef)
+	if !ok {
+		return nil, fmt.Errorf("sandbox %q not found", containerRef)
+	}
+	return cloneRuntimeState(state), nil
+}
+
+func (f *fakeE2BRuntime) ListManaged(context.Context) (map[string]*models.SandboxRuntimeState, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	items := make(map[string]*models.SandboxRuntimeState, len(f.states))
+	for sandboxID, state := range f.states {
+		items[sandboxID] = cloneRuntimeState(state)
+	}
+	return items, nil
+}
+
+func (f *fakeE2BRuntime) Ping(context.Context) error { return nil }
+
+func (f *fakeE2BRuntime) RemoveImage(_ context.Context, imageRef string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.removedImages = append(f.removedImages, imageRef)
+	return nil
+}
+
+func (f *fakeE2BRuntime) PushAllowedPorts(context.Context, string, string, []int) error { return nil }
+func (f *fakeE2BRuntime) ClearNetworkRules(string) error                                { return nil }
+func (f *fakeE2BRuntime) ApplyNetworkBlockAll(string) error                             { return nil }
+
+func (f *fakeE2BRuntime) lookup(containerRef string) (*models.SandboxRuntimeState, bool) {
+	if state, ok := f.states[containerRef]; ok {
+		return state, true
+	}
+	for _, state := range f.states {
+		if state.ContainerID == containerRef {
+			return state, true
+		}
+	}
+	return nil, false
+}
+
+func cloneRuntimeState(state *models.SandboxRuntimeState) *models.SandboxRuntimeState {
+	if state == nil {
+		return nil
+	}
+	cloned := *state
+	return &cloned
+}
+
+func sanitizeSnapshotID(value string) string {
+	value = strings.ReplaceAll(value, "/", "-")
+	value = strings.ReplaceAll(value, ":", "-")
+	return value
+}
+
+func newE2BHandlerTestEnv(t *testing.T) (*service.Service, *store.Store, http.Handler) {
+	t.Helper()
+	t.Setenv("SB_E2B_TEMPLATE_MAP_JSON", `{"base":"ubuntu:22.04"}`)
+
+	dir := t.TempDir()
+	st, err := store.Open(filepath.Join(dir, "state.db"))
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	mountManager, err := mounts.New(logger, mounts.Config{
+		RootDir:     filepath.Join(dir, "mounts"),
+		CredDir:     filepath.Join(dir, "creds"),
+		WaitTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("mounts.New() error = %v", err)
+	}
+	t.Cleanup(mountManager.Close)
+
+	cipher, err := secrets.NewCipher("", filepath.Join(dir, "cipher.key"))
+	if err != nil {
+		t.Fatalf("secrets.NewCipher() error = %v", err)
+	}
+
+	runtime := newFakeE2BRuntime()
+	cfg := config.Config{PublicHost: "sandbox.test", EnableCaddy: false, ToolboxPort: 2280}
+	svc := service.New(cfg, logger, st, runtime, nil, caddy.New(cfg), cipher, mountManager, nil)
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, Deps{
+		Service: svc,
+		Logger:  logger,
+		Auth: func(next http.Handler) http.Handler {
+			return next
+		},
+	})
+	return svc, st, mux
+}

--- a/pkg/api/e2b/handlers_test.go
+++ b/pkg/api/e2b/handlers_test.go
@@ -242,6 +242,55 @@ func TestCreateSandboxIdempotentReplay(t *testing.T) {
 	}
 }
 
+func TestWaitForCreateReplayIgnoresExpiredReadyRecord(t *testing.T) {
+	ctx := context.Background()
+	svc, st, _ := newE2BHandlerTestEnv(t)
+	now := time.Now().UTC().Add(-time.Minute).Round(0)
+	fingerprint := "fp:expired-ready"
+	sandbox := &models.Sandbox{
+		ID:               "sb-expired-ready",
+		Image:            "ubuntu:22.04",
+		Status:           models.SandboxStatusStarted,
+		PublicURL:        "https://sb-expired-ready.example.com",
+		ContainerID:      "container-sb-expired-ready",
+		ContainerIP:      "10.0.0.10",
+		CPU:              2,
+		MemoryMB:         2048,
+		DiskGB:           20,
+		OSUser:           "root",
+		Env:              map[string]string{},
+		ToolboxEnabled:   true,
+		ContainerCommand: []string{"bash"},
+		CreatedAt:        now,
+		UpdatedAt:        now,
+		LastActiveAt:     now,
+		Runtime:          models.RuntimeGvisor,
+	}
+	if err := st.Create(ctx, sandbox); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if _, acquired, err := st.ClaimE2BCreateRequest(ctx, fingerprint, now, time.Second); err != nil {
+		t.Fatalf("ClaimE2BCreateRequest() error = %v", err)
+	} else if !acquired {
+		t.Fatal("expected initial create request claim to acquire")
+	}
+	if err := st.CompleteE2BCreateRequest(ctx, fingerprint, sandbox.ID, now, time.Second); err != nil {
+		t.Fatalf("CompleteE2BCreateRequest() error = %v", err)
+	}
+
+	h := newHandlers(Deps{Service: svc, Logger: slog.New(slog.NewTextHandler(io.Discard, nil))})
+	_, _, replayed, err := h.waitForCreateReplay(ctx, fingerprint)
+	if err != nil {
+		t.Fatalf("waitForCreateReplay() error = %v", err)
+	}
+	if replayed {
+		t.Fatal("expected expired ready record not to replay")
+	}
+	if _, err := st.GetE2BCreateRequest(ctx, fingerprint); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("expected expired ready record to be cleared, got %v", err)
+	}
+}
+
 func TestCreateSnapshotWithoutNameIsIdempotent(t *testing.T) {
 	runtime := newFakeE2BRuntime()
 	_, _, handler := newE2BHandlerTestEnvWithRuntime(t, runtime, config.Config{PublicHost: "sandbox.test", EnableCaddy: false, ToolboxPort: 2280})

--- a/pkg/api/e2b/meta.go
+++ b/pkg/api/e2b/meta.go
@@ -1,0 +1,188 @@
+package e2b
+
+import (
+	"encoding/base64"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+const (
+	defaultClientID       = "aerolvm"
+	defaultEnvdVersion    = "0.1.0"
+	defaultSandboxTimeout = 300
+	snapshotIDPrefix      = "snapshot_"
+)
+
+type sandboxMeta struct {
+	TemplateID          string
+	TemplateAlias       string
+	Metadata            map[string]string
+	TimeoutSeconds      int
+	OnTimeout           string
+	AutoResume          bool
+	Secure              bool
+	AllowInternetAccess *bool
+	NetworkAllowOut     []string
+	NetworkDenyOut      []string
+	AllowPublicTraffic  *bool
+	MaskRequestHost     string
+}
+
+func defaultSandboxMeta(sandbox *models.Sandbox) sandboxMeta {
+	meta := sandboxMeta{
+		Metadata:        map[string]string{},
+		OnTimeout:       "kill",
+		Secure:          true,
+		NetworkAllowOut: []string{},
+		NetworkDenyOut:  []string{},
+	}
+	if sandbox == nil {
+		return meta
+	}
+	meta.TemplateID = strings.TrimSpace(sandbox.Image)
+	if sandbox.NetworkBlockAll {
+		allowInternet := false
+		meta.AllowInternetAccess = &allowInternet
+	}
+	if timeoutSeconds, onTimeout := deriveTimeoutConfig(sandbox); timeoutSeconds > 0 {
+		meta.TimeoutSeconds = timeoutSeconds
+		meta.OnTimeout = onTimeout
+	}
+	return meta
+}
+
+func sandboxMetaFromStored(stored *models.E2BSandboxMetadata, sandbox *models.Sandbox) sandboxMeta {
+	meta := defaultSandboxMeta(sandbox)
+	if stored == nil {
+		return meta
+	}
+	if trimmed := strings.TrimSpace(stored.TemplateID); trimmed != "" {
+		meta.TemplateID = trimmed
+	}
+	meta.TemplateAlias = strings.TrimSpace(stored.TemplateAlias)
+	meta.Metadata = cloneStringMap(stored.Metadata)
+	if stored.TimeoutSeconds > 0 {
+		meta.TimeoutSeconds = stored.TimeoutSeconds
+	}
+	if trimmed := strings.TrimSpace(stored.OnTimeout); trimmed != "" {
+		meta.OnTimeout = trimmed
+	}
+	meta.AutoResume = stored.AutoResume
+	meta.Secure = stored.Secure
+	meta.AllowInternetAccess = cloneBoolPtr(stored.AllowInternetAccess)
+	meta.NetworkAllowOut = cloneStringSlice(stored.NetworkAllowOut)
+	meta.NetworkDenyOut = cloneStringSlice(stored.NetworkDenyOut)
+	meta.AllowPublicTraffic = cloneBoolPtr(stored.AllowPublicTraffic)
+	meta.MaskRequestHost = strings.TrimSpace(stored.MaskRequestHost)
+	return meta
+}
+
+func sandboxMetaToStored(sandboxID string, meta sandboxMeta) models.E2BSandboxMetadata {
+	return models.E2BSandboxMetadata{
+		SandboxID:           strings.TrimSpace(sandboxID),
+		TemplateID:          strings.TrimSpace(meta.TemplateID),
+		TemplateAlias:       strings.TrimSpace(meta.TemplateAlias),
+		Metadata:            cloneStringMap(meta.Metadata),
+		TimeoutSeconds:      meta.TimeoutSeconds,
+		OnTimeout:           strings.TrimSpace(meta.OnTimeout),
+		AutoResume:          meta.AutoResume,
+		Secure:              meta.Secure,
+		AllowInternetAccess: cloneBoolPtr(meta.AllowInternetAccess),
+		NetworkAllowOut:     cloneStringSlice(meta.NetworkAllowOut),
+		NetworkDenyOut:      cloneStringSlice(meta.NetworkDenyOut),
+		AllowPublicTraffic:  cloneBoolPtr(meta.AllowPublicTraffic),
+		MaskRequestHost:     strings.TrimSpace(meta.MaskRequestHost),
+	}
+}
+
+func deriveTimeoutConfig(sandbox *models.Sandbox) (int, string) {
+	if sandbox == nil {
+		return 0, "kill"
+	}
+	if sandbox.Lifecycle.StopAtAge > 0 {
+		remaining := int(math.Ceil(time.Until(sandbox.CreatedAt.Add(sandbox.Lifecycle.StopAtAge)).Seconds()))
+		if remaining < 0 {
+			remaining = 0
+		}
+		return remaining, "pause"
+	}
+	if sandbox.Lifecycle.DestroyAtAge > 0 {
+		remaining := int(math.Ceil(time.Until(sandbox.CreatedAt.Add(sandbox.Lifecycle.DestroyAtAge)).Seconds()))
+		if remaining < 0 {
+			remaining = 0
+		}
+		return remaining, "kill"
+	}
+	return 0, "kill"
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return map[string]string{}
+	}
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func cloneStringSlice(values []string) []string {
+	if len(values) == 0 {
+		return []string{}
+	}
+	cloned := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			cloned = append(cloned, trimmed)
+		}
+	}
+	return cloned
+}
+
+func cloneBoolPtr(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	v := *value
+	return &v
+}
+
+func canonicalSnapshotName(name string) string {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return ""
+	}
+	if strings.LastIndex(trimmed, ":") > strings.LastIndex(trimmed, "/") {
+		return trimmed
+	}
+	return trimmed + ":default"
+}
+
+func snapshotIDFromName(name string) string {
+	canonical := canonicalSnapshotName(name)
+	if canonical == "" {
+		return ""
+	}
+	return snapshotIDPrefix + base64.RawURLEncoding.EncodeToString([]byte(canonical))
+}
+
+func snapshotNameFromID(snapshotID string) (string, bool) {
+	if !strings.HasPrefix(snapshotID, snapshotIDPrefix) {
+		return "", false
+	}
+	raw := strings.TrimPrefix(snapshotID, snapshotIDPrefix)
+	decoded, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return "", false
+	}
+	name := strings.TrimSpace(string(decoded))
+	if name == "" {
+		return "", false
+	}
+	return name, true
+}

--- a/pkg/api/e2b/meta.go
+++ b/pkg/api/e2b/meta.go
@@ -1,8 +1,12 @@
 package e2b
 
 import (
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
 	"math"
+	"sort"
 	"strings"
 	"time"
 
@@ -14,6 +18,10 @@ const (
 	defaultEnvdVersion    = "0.1.0"
 	defaultSandboxTimeout = 300
 	snapshotIDPrefix      = "snapshot_"
+	e2bCreatePendingTTL   = 2 * time.Minute
+	e2bCreateWaitTimeout  = 30 * time.Second
+	e2bCreateReplayWindow = 10 * time.Second
+	e2bCreatePollInterval = 250 * time.Millisecond
 )
 
 type sandboxMeta struct {
@@ -185,4 +193,50 @@ func snapshotNameFromID(snapshotID string) (string, bool) {
 		return "", false
 	}
 	return name, true
+}
+
+type createFingerprintPayload struct {
+	TemplateID          string            `json:"templateID"`
+	Metadata            map[string]string `json:"metadata,omitempty"`
+	EnvVars             map[string]string `json:"envVars,omitempty"`
+	TimeoutSeconds      int               `json:"timeoutSeconds"`
+	OnTimeout           string            `json:"onTimeout"`
+	AutoResume          bool              `json:"autoResume"`
+	Secure              bool              `json:"secure"`
+	AllowInternetAccess bool              `json:"allowInternetAccess"`
+	NetworkBlockAll     bool              `json:"networkBlockAll"`
+	NetworkAllowOut     []string          `json:"networkAllowOut,omitempty"`
+	NetworkDenyOut      []string          `json:"networkDenyOut,omitempty"`
+	AllowPublicTraffic  bool              `json:"allowPublicTraffic"`
+	MaskRequestHost     string            `json:"maskRequestHost,omitempty"`
+}
+
+func createRequestFingerprint(templateID string, serviceReq models.CreateSandboxRequest, meta sandboxMeta) (string, error) {
+	payload := createFingerprintPayload{
+		TemplateID:          strings.TrimSpace(templateID),
+		Metadata:            cloneStringMap(meta.Metadata),
+		EnvVars:             cloneStringMap(serviceReq.Env),
+		TimeoutSeconds:      meta.TimeoutSeconds,
+		OnTimeout:           strings.TrimSpace(meta.OnTimeout),
+		AutoResume:          meta.AutoResume,
+		Secure:              meta.Secure,
+		AllowInternetAccess: !serviceReq.NetworkBlockAll,
+		NetworkBlockAll:     serviceReq.NetworkBlockAll,
+		NetworkAllowOut:     sortedStringSlice(meta.NetworkAllowOut),
+		NetworkDenyOut:      sortedStringSlice(meta.NetworkDenyOut),
+		AllowPublicTraffic:  meta.AllowPublicTraffic == nil || *meta.AllowPublicTraffic,
+		MaskRequestHost:     strings.TrimSpace(meta.MaskRequestHost),
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(encoded)
+	return "fingerprint:" + hex.EncodeToString(sum[:]), nil
+}
+
+func sortedStringSlice(values []string) []string {
+	cloned := cloneStringSlice(values)
+	sort.Strings(cloned)
+	return cloned
 }

--- a/pkg/api/e2b/meta.go
+++ b/pkg/api/e2b/meta.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	defaultClientID       = "aerolvm"
-	defaultEnvdVersion    = "0.1.0"
+	defaultEnvdVersion    = "0.4.0"
 	defaultSandboxTimeout = 300
 	snapshotIDPrefix      = "snapshot_"
 	e2bCreatePendingTTL   = 2 * time.Minute
@@ -169,6 +169,10 @@ func canonicalSnapshotName(name string) string {
 		return trimmed
 	}
 	return trimmed + ":default"
+}
+
+func defaultSnapshotName(sandboxID string) string {
+	return canonicalSnapshotName("e2b/" + strings.TrimSpace(sandboxID))
 }
 
 func snapshotIDFromName(name string) string {

--- a/pkg/api/e2b/routes.go
+++ b/pkg/api/e2b/routes.go
@@ -1,0 +1,35 @@
+package e2b
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/aerol-ai/microvm/internal/service"
+)
+
+const PathPrefix = "/e2b"
+
+// Deps are the shared dependencies the E2B facade needs from the top-level
+// API package.
+type Deps struct {
+	Service *service.Service
+	Logger  *slog.Logger
+	Auth    func(http.Handler) http.Handler
+}
+
+// RegisterRoutes mounts the supported E2B control-plane compatibility surface.
+func RegisterRoutes(mux *http.ServeMux, d Deps) {
+	h := newHandlers(d)
+
+	mux.Handle("POST "+PathPrefix+"/sandboxes", d.Auth(http.HandlerFunc(h.createSandbox)))
+	mux.Handle("GET "+PathPrefix+"/sandboxes", d.Auth(http.HandlerFunc(h.listSandboxes)))
+	mux.Handle("GET "+PathPrefix+"/v2/sandboxes", d.Auth(http.HandlerFunc(h.listSandboxes)))
+	mux.Handle("GET "+PathPrefix+"/sandboxes/{id}", d.Auth(http.HandlerFunc(h.getSandbox)))
+	mux.Handle("DELETE "+PathPrefix+"/sandboxes/{id}", d.Auth(http.HandlerFunc(h.deleteSandbox)))
+	mux.Handle("POST "+PathPrefix+"/sandboxes/{id}/connect", d.Auth(http.HandlerFunc(h.connectSandbox)))
+	mux.Handle("POST "+PathPrefix+"/sandboxes/{id}/pause", d.Auth(http.HandlerFunc(h.pauseSandbox)))
+	mux.Handle("POST "+PathPrefix+"/sandboxes/{id}/timeout", d.Auth(http.HandlerFunc(h.updateTimeout)))
+	mux.Handle("POST "+PathPrefix+"/sandboxes/{id}/snapshots", d.Auth(http.HandlerFunc(h.createSnapshot)))
+	mux.Handle("GET "+PathPrefix+"/snapshots", d.Auth(http.HandlerFunc(h.listSnapshots)))
+	mux.Handle("DELETE "+PathPrefix+"/templates/{id}", d.Auth(http.HandlerFunc(h.deleteSnapshot)))
+}

--- a/pkg/api/e2b/routes.go
+++ b/pkg/api/e2b/routes.go
@@ -32,4 +32,6 @@ func RegisterRoutes(mux *http.ServeMux, d Deps) {
 	mux.Handle("POST "+PathPrefix+"/sandboxes/{id}/snapshots", d.Auth(http.HandlerFunc(h.createSnapshot)))
 	mux.Handle("GET "+PathPrefix+"/snapshots", d.Auth(http.HandlerFunc(h.listSnapshots)))
 	mux.Handle("DELETE "+PathPrefix+"/templates/{id}", d.Auth(http.HandlerFunc(h.deleteSnapshot)))
+	mux.Handle(PathPrefix+"/runtime", http.HandlerFunc(h.runtimeProxy))
+	mux.Handle(PathPrefix+"/runtime/", http.HandlerFunc(h.runtimeProxy))
 }

--- a/pkg/api/e2b/runtime_proxy.go
+++ b/pkg/api/e2b/runtime_proxy.go
@@ -1,0 +1,88 @@
+package e2b
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"github.com/aerol-ai/microvm/internal/store"
+)
+
+const runtimeProxyPrefix = PathPrefix + "/runtime"
+
+func (h *handlers) runtimeProxy(w http.ResponseWriter, r *http.Request) {
+	sandboxID := strings.TrimSpace(r.Header.Get("E2b-Sandbox-Id"))
+	if sandboxID == "" {
+		WriteError(w, http.StatusBadRequest, "Missing E2b-Sandbox-Id header")
+		return
+	}
+
+	sandbox, err := h.deps.Service.GetSandbox(r.Context(), sandboxID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, "Sandbox not found")
+			return
+		}
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	meta, err := h.loadSandboxMeta(r.Context(), sandbox)
+	if err != nil {
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	if meta.Secure {
+		accessToken := strings.TrimSpace(r.Header.Get("X-Access-Token"))
+		if accessToken == "" || accessToken != sandbox.ToolboxToken {
+			WriteError(w, http.StatusUnauthorized, "Unauthorized")
+			return
+		}
+	}
+
+	endpoint, err := h.deps.Service.ToolboxTarget(r.Context(), sandboxID)
+	if err != nil {
+		writeStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	target, err := url.Parse(endpoint.URL)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, "Invalid toolbox target")
+		return
+	}
+
+	publicPath := strings.TrimPrefix(r.URL.Path, runtimeProxyPrefix)
+	if publicPath == "" {
+		publicPath = "/"
+	}
+	if !strings.HasPrefix(publicPath, "/") {
+		publicPath = "/" + publicPath
+	}
+	toolboxPath := "/envd" + publicPath
+
+	userAuthorization := strings.TrimSpace(r.Header.Get("Authorization"))
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	originalDirector := proxy.Director
+	toolboxToken := endpoint.Token
+	proxy.Director = func(req *http.Request) {
+		originalDirector(req)
+		req.URL.Path = toolboxPath
+		req.Host = target.Host
+		req.Header.Set("X-E2B-Sandbox-Id", sandboxID)
+		if strings.HasPrefix(userAuthorization, "Basic ") {
+			req.Header.Set("X-E2B-User-Authorization", userAuthorization)
+		} else {
+			req.Header.Del("X-E2B-User-Authorization")
+		}
+		if toolboxToken != "" {
+			req.Header.Set("Authorization", "Bearer "+toolboxToken)
+		} else {
+			req.Header.Del("Authorization")
+		}
+	}
+	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+		WriteError(w, http.StatusBadGateway, "Sandbox runtime unavailable")
+	}
+	proxy.ServeHTTP(w, r)
+}

--- a/pkg/api/middleware.go
+++ b/pkg/api/middleware.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/aerol-ai/microvm/pkg/api/apihttp"
+	apie2b "github.com/aerol-ai/microvm/pkg/api/e2b"
 )
 
 // extractBearerToken returns the caller's bearer token from either:
@@ -46,6 +47,17 @@ func (s *Server) requireAuth(next http.Handler) http.Handler {
 			return
 		}
 		apihttp.WriteError(w, http.StatusUnauthorized, "unauthorized")
+	})
+}
+
+func (s *Server) requireE2BAuth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiKey := strings.TrimSpace(r.Header.Get("X-API-KEY"))
+		if apiKey == s.patToken || extractBearerToken(r) == s.patToken {
+			next.ServeHTTP(w, r)
+			return
+		}
+		apie2b.WriteError(w, http.StatusUnauthorized, "Unauthorized, please check your credentials.")
 	})
 }
 

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/aerol-ai/microvm/internal/service"
 	"github.com/aerol-ai/microvm/pkg/api/daytona"
+	"github.com/aerol-ai/microvm/pkg/api/e2b"
 	apiv1 "github.com/aerol-ai/microvm/pkg/api/v1"
 )
 
@@ -54,6 +55,12 @@ func (s *Server) routes() {
 		Service: s.service,
 		Logger:  s.logger,
 		Auth:    s.requireAuth,
+	})
+
+	e2b.RegisterRoutes(s.mux, e2b.Deps{
+		Service: s.service,
+		Logger:  s.logger,
+		Auth:    s.requireE2BAuth,
 	})
 
 	apiv1.RegisterRoutes(s.mux, apiv1.Deps{

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -14,6 +14,7 @@ func TestRequireAuthCases(t *testing.T) {
 		name          string
 		path          string
 		authorization string
+		apiKey        string
 		body          string
 		wantStatus    int
 	}{
@@ -56,6 +57,31 @@ func TestRequireAuthCases(t *testing.T) {
 			body:          "not-json",
 			wantStatus:    http.StatusBadRequest,
 		},
+		{
+			name:       "e2b_missing_api_key_is_rejected",
+			path:       "/e2b/sandboxes",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "e2b_wrong_api_key_is_rejected",
+			path:       "/e2b/sandboxes",
+			apiKey:     "wrong-token",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "e2b_routes_accept_x_api_key",
+			path:       "/e2b/sandboxes",
+			apiKey:     "pat-token",
+			body:       "not-json",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:          "e2b_routes_also_accept_bearer_pat",
+			path:          "/e2b/sandboxes",
+			authorization: "Bearer pat-token",
+			body:          "not-json",
+			wantStatus:    http.StatusBadRequest,
+		},
 	}
 
 	for _, tc := range tests {
@@ -64,6 +90,9 @@ func TestRequireAuthCases(t *testing.T) {
 			request := httptest.NewRequest(http.MethodPost, tc.path, strings.NewReader(tc.body))
 			if tc.authorization != "" {
 				request.Header.Set("Authorization", tc.authorization)
+			}
+			if tc.apiKey != "" {
+				request.Header.Set("X-API-KEY", tc.apiKey)
 			}
 			response := httptest.NewRecorder()
 

--- a/pkg/models/e2b.go
+++ b/pkg/models/e2b.go
@@ -32,3 +32,21 @@ type E2BSnapshotMetadata struct {
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
 }
+
+const (
+	E2BCreateRequestStatePending = "pending"
+	E2BCreateRequestStateReady   = "ready"
+)
+
+// E2BCreateRequestRecord tracks create-path idempotency for the /e2b facade.
+// Fingerprint keys are short-lived for body-hash-based dedupe and may be
+// longer-lived when an explicit Idempotency-Key is supplied.
+type E2BCreateRequestRecord struct {
+	Fingerprint string
+	SandboxID   string
+	State       string
+	LockedUntil time.Time
+	ReplayUntil time.Time
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}

--- a/pkg/models/e2b.go
+++ b/pkg/models/e2b.go
@@ -1,0 +1,34 @@
+package models
+
+import "time"
+
+// E2BSandboxMetadata stores compatibility-only fields for the /e2b facade
+// without changing the native sandbox contract.
+type E2BSandboxMetadata struct {
+	SandboxID           string
+	TemplateID          string
+	TemplateAlias       string
+	Metadata            map[string]string
+	TimeoutSeconds      int
+	OnTimeout           string
+	AutoResume          bool
+	Secure              bool
+	AllowInternetAccess *bool
+	NetworkAllowOut     []string
+	NetworkDenyOut      []string
+	AllowPublicTraffic  *bool
+	MaskRequestHost     string
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+}
+
+// E2BSnapshotMetadata stores the E2B-facing snapshot identifier for a native
+// snapshot so create/list/delete flows can round-trip through /e2b.
+type E2BSnapshotMetadata struct {
+	SnapshotID      string
+	SnapshotName    string
+	Names           []string
+	SourceSandboxID string
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}

--- a/plans/daytona-e2b-compatibility-facades.md
+++ b/plans/daytona-e2b-compatibility-facades.md
@@ -1,5 +1,7 @@
 # Daytona and E2B Compatibility Facade Plan
 
+Note: the E2B portion of this document is now historical context. The active E2B implementation plan lives in `plans/sdk-compatibility/e2b/facade-plan.md`.
+
 ## Objective
 
 Make AerolVM consumable by external sandbox SDKs without changing AerolVM's own SDKs, starting with Daytona and then E2B.

--- a/plans/facade-tables-consolidation.md
+++ b/plans/facade-tables-consolidation.md
@@ -2,15 +2,30 @@
 
 ## Context
 
-`internal/store/store.go` today creates three tables that exist purely to back
-the compatibility facades:
+`internal/store/store.go` today creates **four** tables that exist purely to
+back the compatibility facades:
 
 - `daytona_sandboxes` — extra fields for `/daytona/...` responses
 - `e2b_sandboxes` — extra fields for `/e2b/...` responses
 - `e2b_snapshots` — E2B-shaped snapshot ID / alias on top of native snapshots
+- `e2b_create_requests` — request-fingerprint idempotency state for the
+  `POST /e2b/sandboxes` create path (added after the first revision of this
+  plan)
 
-There are no other facade-specific tables (the native tables are `sandboxes`,
-`exposed_ports`, `sandbox_mounts`, `sandbox_snapshots`).
+The native tables are `sandboxes`, `exposed_ports`, `sandbox_mounts`, and
+`sandbox_snapshots`. No other facade-specific tables exist.
+
+The first three tables are per-sandbox metadata (one row per sandbox). The
+fourth is structurally different: it's a request-level state machine
+(`pending` → `ready`, with `locked_until` / `replay_until` TTLs) keyed on
+a SHA-256 fingerprint of the canonicalised create request. Same architectural
+smell — facade-named schema — but a different fix.
+
+Worth calling out alongside the data-model work: the recent `/e2b/runtime`
+gateway in `pkg/api/e2b/runtime_proxy.go` and the toolboxd `/envd` namespace
+in `cmd/toolboxd/envd.go` are *exactly* the pattern this plan endorses —
+pure translation layers with no new schema. The data-model work below is
+what's left to bring into the same shape.
 
 This document answers three things the user asked:
 
@@ -32,7 +47,8 @@ writers. Cross-API behavior today:
 |---|---|---|
 | `/v1/sandboxes/...` | yes | never |
 | `/daytona/...` | yes | `daytona_sandboxes` |
-| `/e2b/...` | yes | `e2b_sandboxes`, `e2b_snapshots` |
+| `/e2b/...` | yes | `e2b_sandboxes`, `e2b_snapshots`, `e2b_create_requests` |
+| `/e2b/runtime/...` | yes (to resolve `E2b-Sandbox-Id`) | none — proxies through to toolboxd `/envd` |
 
 Consequences worth flagging:
 
@@ -109,9 +125,36 @@ proposed disposition.
 | `source_sandbox_id` | Already on `sandbox_snapshots` | `[drop]` |
 | `created_at` / `updated_at` | Already on `sandbox_snapshots` | `[drop]` |
 
+### `e2b_create_requests`
+
+This one is not per-sandbox metadata — it's a per-request idempotency state
+machine. Fingerprint is the canonical SHA-256 hash of the normalized create
+inputs (`pkg/api/e2b/meta.go`'s `createRequestFingerprint`). The facade
+claims a row, runs `CreateSandbox`, then moves the row from `pending` to
+`ready` with a 10-second replay window.
+
+| Column | What it stores | Verdict |
+|---|---|---|
+| `fingerprint` | Canonical hash of normalized create body | `[generic idempotency table]` — keying primitive |
+| `sandbox_id` | The sandbox eventually produced (empty while pending) | `[generic idempotency table]` |
+| `state` | `pending` or `ready` | `[generic idempotency table]` |
+| `locked_until` | TTL preventing duplicate creates while one is in flight | `[generic idempotency table]` |
+| `replay_until` | TTL during which retries get the same response | `[generic idempotency table]` |
+| `created_at` / `updated_at` | Row timestamps | `[keep]` — non-redundant here |
+
+Verdict: this is a **generic request-idempotency primitive** that we should
+not bake into an E2B-named table. The same shape will be useful for
+`/daytona/sandboxes` if Daytona retries become a problem, and arguably for
+`/v1/sandboxes` too — the native API has zero create-side dedupe today.
+
+Importantly, the design itself is right (state machine, replay window,
+fingerprint-based key). Only the naming and table location are facade-shaped.
+The handler logic in `pkg/api/e2b/handlers.go` does not need to change in
+spirit, only in what table it talks to.
+
 ## Summary of the verdict
 
-Across the three tables, the columns reduce to four real categories:
+Across the four tables, the columns reduce to five real categories:
 
 1. **Truly duplicated native state.** Lifecycle intervals, OS user, internet
    access, snapshot-via-image. These should be derived from `sandboxes`
@@ -136,6 +179,11 @@ Across the three tables, the columns reduce to four real categories:
 4. **Alias / alternate-ID mappings.** `e2b_snapshots` is mostly this.
    Daytona currently has no snapshot aliases but is likely to need
    something similar.
+
+5. **Request-idempotency state.** `e2b_create_requests` is this whole
+   category by itself. Not metadata, not sandbox-scoped — it's transient
+   state about an in-flight request and its replay window. Belongs in a
+   facade-agnostic idempotency table that any route family can use.
 
 ## Recommended target shape
 
@@ -201,7 +249,44 @@ Result:
 - The store stays facade-agnostic; the schema name `sandbox_compat_state`
   describes a category, not a vendor.
 
-### 4. Collapse `e2b_snapshots` into a generic alias table
+### 4. Replace `e2b_create_requests` with a generic request-idempotency table
+
+The fingerprint-based dedupe is well-designed and worth keeping. Just give
+it a facade-agnostic home:
+
+```sql
+CREATE TABLE request_idempotency (
+    fingerprint TEXT NOT NULL,
+    scope TEXT NOT NULL,                 -- 'e2b.create' | 'daytona.create' | ...
+    target_id TEXT NOT NULL DEFAULT '',  -- sandbox id, snapshot id, etc.
+    state TEXT NOT NULL DEFAULT 'pending',
+    locked_until DATETIME NOT NULL,
+    replay_until DATETIME,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    PRIMARY KEY (scope, fingerprint)
+);
+CREATE INDEX idx_request_idempotency_replay_until
+    ON request_idempotency(replay_until);
+```
+
+Notes:
+
+- The composite primary key `(scope, fingerprint)` means E2B and Daytona
+  fingerprints don't share a namespace, so we don't have to worry about
+  cross-facade collisions even though both use SHA-256.
+- `target_id` is intentionally generic — it's currently always a sandbox
+  ID, but the same machinery works for snapshot create idempotency later
+  without schema churn.
+- Store helpers stay the same shape (`ClaimRequest`, `CompleteRequest`,
+  `GetRequest`, `DeleteRequest`) and just take an extra `scope` argument.
+  The E2B handler passes `"e2b.create"`.
+- Eventually `/v1/sandboxes` POST could opt in to the same primitive
+  behind an `Idempotency-Key` header. That work is out of scope here, but
+  the table shape is designed so we don't have to migrate again to enable
+  it.
+
+### 5. Collapse `e2b_snapshots` into a generic alias table
 
 Replace with:
 
@@ -222,7 +307,7 @@ Adding the missing FK to `sandbox_snapshots` also fixes the orphan-row
 bug where `/v1/snapshots/{name}` delete leaves an `e2b_snapshots` row
 behind.
 
-### 5. Derive everything else on read
+### 6. Derive everything else on read
 
 Eliminate the duplicated columns. The facade response layer recomputes
 them from `sandboxes`:
@@ -259,9 +344,14 @@ snapshot_aliases(                        -- NEW (replaces e2b_snapshots)
     alias, snapshot_name, facade,
     extra_names_json, created_at, updated_at
 )
+request_idempotency(                     -- NEW (replaces e2b_create_requests)
+    scope, fingerprint, target_id, state,
+    locked_until, replay_until,
+    created_at, updated_at
+)
 ```
 
-Six tables, none of them named after a third-party product.
+Seven tables, none named after a third-party product.
 
 ## Migration plan
 
@@ -274,13 +364,16 @@ destructive in a follow-up.
 1. `ALTER TABLE sandboxes ADD COLUMN name TEXT NOT NULL DEFAULT '';`
 2. `CREATE UNIQUE INDEX idx_sandboxes_name ON sandboxes(name) WHERE name <> '';`
 3. `ALTER TABLE sandboxes ADD COLUMN tags_json TEXT NOT NULL DEFAULT '{}';`
-4. Create `sandbox_compat_state` and `snapshot_aliases`.
+4. Create `sandbox_compat_state`, `snapshot_aliases`, and
+   `request_idempotency`.
 5. Backfill from existing tables (one-shot at startup, idempotent):
    - `sandboxes.name` ← `daytona_sandboxes.name`
    - `sandboxes.tags_json` ← `daytona_sandboxes.labels_json` (and merge
      with `e2b_sandboxes.metadata_json` for sandboxes that have both)
    - `sandbox_compat_state` rows derived from leftover Daytona/E2B columns
    - `snapshot_aliases` rows from `e2b_snapshots`
+   - `request_idempotency` rows from `e2b_create_requests` with
+     `scope = 'e2b.create'`
 6. Switch reads in `pkg/api/daytona` and `pkg/api/e2b` to the new
    tables. Writes go to both old and new until Phase B.
 7. Keep `/v1` unchanged. Internally everyone reads from `sandboxes` +
@@ -288,14 +381,21 @@ destructive in a follow-up.
 
 ### Phase B — destructive (next release)
 
-1. Stop writing to `daytona_sandboxes`, `e2b_sandboxes`, `e2b_snapshots`.
+1. Stop writing to `daytona_sandboxes`, `e2b_sandboxes`, `e2b_snapshots`,
+   `e2b_create_requests`.
 2. `DROP TABLE daytona_sandboxes;`
 3. `DROP TABLE e2b_sandboxes;`
 4. `DROP TABLE e2b_snapshots;`
-5. Delete the old store helpers (`UpsertDaytonaMetadata`,
-   `GetDaytonaMetadata`, …, `DeleteE2BSnapshot`).
-6. Rename `ResolveDaytonaSandboxID` → `ResolveSandboxIDByName` (now in
+5. `DROP TABLE e2b_create_requests;`
+6. Delete the old store helpers (`UpsertDaytonaMetadata`,
+   `GetDaytonaMetadata`, …, `DeleteE2BSnapshot`,
+   `ClaimE2BCreateRequest`, `CompleteE2BCreateRequest`,
+   `GetE2BCreateRequest`, `DeleteE2BCreateRequest`).
+7. Rename `ResolveDaytonaSandboxID` → `ResolveSandboxIDByName` (now in
    the native service surface, not a Daytona-named helper).
+8. Rename the idempotency service methods to drop the `E2B` prefix
+   (`ClaimRequest`, `CompleteRequest`, `GetRequest`, `DeleteRequest`)
+   and take a `scope` argument.
 
 Splitting it in two releases keeps the dev DB safe across a downgrade and
 lets us run tests against the new path while the old path is still
@@ -304,21 +404,46 @@ authoritative.
 ## Files that change
 
 - `internal/store/store.go` — schema, helpers, scanners, the `Resolve*`
-  function rename.
-- `internal/store/store_test.go` — new tests for `name` uniqueness and
-  the generic `sandbox_compat_state` upsert path.
+  function rename, generic `request_idempotency` helpers.
+- `internal/store/store_test.go` — new tests for `name` uniqueness, the
+  generic `sandbox_compat_state` upsert path, and the
+  `request_idempotency` claim/complete/reclaim cycle (port the existing
+  `e2b_create_request_claim_complete_and_reclaim` test to the generic
+  scope keying).
 - `internal/service/daytona.go` — collapse to wrappers around
   `sandbox_compat_state`.
-- `internal/service/e2b.go` — same.
+- `internal/service/e2b.go` — same, plus rename
+  `Claim/Complete/Get/DeleteE2BCreateRequest` to scope-aware generic
+  methods.
 - `pkg/models/daytona.go`, `pkg/models/e2b.go` — keep the structs for
   facade-internal use, but they no longer have a 1:1 column mapping;
   the facade serializes them into `state_json`.
+- `pkg/models/e2b.go` — `E2BCreateRequestRecord` becomes a generic
+  `IdempotentRequestRecord` (or stays E2B-named but is just an alias
+  over the generic record; either is fine).
 - `pkg/models/types.go` — add `Name` and `Tags` to `Sandbox` and
   `CreateSandboxRequest`. SDKs follow when ready.
 - `pkg/api/daytona/handlers.go`, `pkg/api/e2b/handlers.go` — read derived
   fields from `sandbox` first, fall back to facade state for opaque
   wire-only bits. Most of this logic already exists as the
   "metadata-not-found fallback" branches.
+- `pkg/api/e2b/meta.go` — `createRequestFingerprint` stays put; the
+  handler passes its output to the generic idempotency primitive with
+  `scope = "e2b.create"`.
+
+## What's already in the right shape
+
+These pieces of the recent E2B work do not need to change:
+
+- `pkg/api/e2b/runtime_proxy.go` — pure HTTP gateway, no schema.
+- `cmd/toolboxd/envd.go` — Connect-RPC translation layer in toolboxd;
+  no native model assumptions leak in.
+- `pkg/api/e2b/meta.go` `createRequestFingerprint` — canonicalisation is
+  facade-specific *by design* (E2B's create body shape) and that's fine.
+  Only the table it writes to is wrong.
+- The handler's `pending`/`ready`/replay state machine in
+  `pkg/api/e2b/handlers.go` `createSandbox` — semantics are right;
+  only the underlying store call changes.
 
 ## Open questions before coding
 
@@ -342,8 +467,12 @@ authoritative.
 - Eliminates the orphan-row bug for `e2b_snapshots` by adding the
   missing FK to `sandbox_snapshots`.
 - Removes the "Daytona-named, but actually generic" capabilities (name
-  lookup, labels) from a facade silo and gives them to the whole API
-  surface.
+  lookup, labels, create idempotency) from a facade silo and gives them
+  to the whole API surface.
+- Specifically for idempotency: the create-dedupe machinery that landed
+  for E2B is the right design to eventually offer on `/v1` as well. A
+  generic table makes that a 2-line handler change later instead of
+  another schema migration.
 - Adding a third facade later (Modal, Replit, anything) becomes a wire
   translation patch, not a schema change — which is the whole point of
   the user's framing: **AerolVM is the product; the facades are

--- a/plans/facade-tables-consolidation.md
+++ b/plans/facade-tables-consolidation.md
@@ -1,0 +1,361 @@
+# Consolidating the Daytona and E2B Facade Tables
+
+## Context
+
+`internal/store/store.go` today creates three tables that exist purely to back
+the compatibility facades:
+
+- `daytona_sandboxes` — extra fields for `/daytona/...` responses
+- `e2b_sandboxes` — extra fields for `/e2b/...` responses
+- `e2b_snapshots` — E2B-shaped snapshot ID / alias on top of native snapshots
+
+There are no other facade-specific tables (the native tables are `sandboxes`,
+`exposed_ports`, `sandbox_mounts`, `sandbox_snapshots`).
+
+This document answers three things the user asked:
+
+1. Are these tables compatible with the rest of the API surface?
+2. Why were they introduced (what is each column actually doing)?
+3. Can they be merged, and what would that take?
+
+The user's stated direction is that **AerolVM owns the data model**, and the
+Daytona / E2B endpoints are translation facades, not parallel products. The
+recommendation below is consistent with that direction.
+
+## Are these tables compatible with other APIs?
+
+Yes — but only in the weak sense that they do not break anything. The native
+`/v1` API does not read or write any of them; the facades are the only
+writers. Cross-API behavior today:
+
+| Path | Reads native `sandboxes` | Reads facade tables |
+|---|---|---|
+| `/v1/sandboxes/...` | yes | never |
+| `/daytona/...` | yes | `daytona_sandboxes` |
+| `/e2b/...` | yes | `e2b_sandboxes`, `e2b_snapshots` |
+
+Consequences worth flagging:
+
+- A sandbox created via `/v1` is visible in `/daytona/sandboxes` and
+  `/e2b/sandboxes` list responses with **default** facade metadata
+  (empty name, empty labels, empty template alias). That is a quietly
+  surprising user-facing behavior — a Daytona client sees E2B sandboxes
+  with `name == id`, and an E2B client sees `/v1` sandboxes with the raw
+  AerolVM image as the `templateID`.
+- `FOREIGN KEY (sandbox_id) REFERENCES sandboxes(id) ON DELETE CASCADE`
+  is set on both `daytona_sandboxes` and `e2b_sandboxes`, so destroying
+  a sandbox through any API surface cleans both metadata rows. Good.
+- `e2b_snapshots` does **not** have a foreign key back to
+  `sandbox_snapshots(name)`. Deleting via `/v1/snapshots/{name}` would
+  orphan an `e2b_snapshots` row. The facade compensates by calling
+  `DeleteE2BSnapshot` in the same handler, but a `/v1` delete bypasses
+  that path. This is a latent inconsistency, not a hot bug.
+- `daytona_sandboxes.name` has a `UNIQUE` constraint and is consulted by
+  `ResolveDaytonaSandboxID`. This effectively gives sandboxes a
+  **Daytona-only** name namespace that `/v1` callers cannot see or
+  collide with — also surprising, since names feel global.
+
+Net: nothing is broken, but the tables encode a worldview where "Daytona
+sandboxes" and "E2B sandboxes" are first-class species. That is exactly the
+worldview the user rejected.
+
+## Why each column exists (column-by-column verdict)
+
+The columns fall into three categories. The label in `[brackets]` is the
+proposed disposition.
+
+### `daytona_sandboxes`
+
+| Column | What it stores | Verdict |
+|---|---|---|
+| `sandbox_id` | FK to `sandboxes.id` | `[join key — needed only if a table survives]` |
+| `name` | User-supplied Daytona sandbox name | `[promote to native]` — name lookup is a generic capability, not a Daytona quirk |
+| `snapshot` | The Daytona `Snapshot` field, remembered verbatim | `[drop, derive]` — the resolved image is already in `sandboxes.image`; if we need the original wire-level snapshot ref, it belongs in a generic metadata bag, not a column |
+| `user_name` | The `User` field from the request | `[drop, derive]` — `sandboxes.os_user` already stores this |
+| `labels_json` | Free-form key/value labels | `[promote to native]` — labels are a feature every API will eventually want |
+| `target` | Daytona region/target string | `[drop or generic bag]` — AerolVM is single-host, this is pure echo-back; remember only if a Daytona client expects round-tripping |
+| `network_allow_list` | Daytona-shaped allowlist (single string) | `[drop or generic bag]` — AerolVM's real network policy is `network_block_all`; this column is just echo-back |
+| `auto_stop_interval_minutes` | Daytona's wire-format interval | `[drop, derive]` — `sandboxes.stop_if_idle_for_ns` already stores this; convert on read |
+| `auto_archive_interval_minutes` | Daytona's archive interval | `[drop or generic bag]` — AerolVM has no archive concept; this is echo-back |
+| `auto_delete_interval_minutes` | Daytona's destroy interval | `[drop, derive]` — `sandboxes.destroy_if_idle_for_ns` already stores this |
+| `created_at` / `updated_at` | Row timestamps | `[drop]` — redundant with `sandboxes` |
+
+### `e2b_sandboxes`
+
+| Column | What it stores | Verdict |
+|---|---|---|
+| `sandbox_id` | FK to `sandboxes.id` | `[join key]` |
+| `template_id` | The E2B template token the client sent | `[generic bag]` — opaque wire string, no native equivalent |
+| `template_alias` | Friendly alias resolved from template map | `[generic bag]` — same |
+| `metadata_json` | Free-form key/value metadata | `[promote to native]` — same shape as Daytona labels; one table can serve both |
+| `timeout_seconds` | E2B-shaped timeout | `[drop, derive]` — `sandboxes.stop_at_age_ns` / `destroy_at_age_ns` already encode this |
+| `on_timeout` | `"kill"` vs `"pause"` semantics | `[generic bag]` — controls which lifecycle axis the facade writes; not a native concept but needed to round-trip |
+| `auto_resume` | E2B auto-resume flag | `[generic bag]` — pure wire echo |
+| `secure` | E2B `secure` flag | `[generic bag]` — pure wire echo |
+| `allow_internet_access` | E2B internet flag (nullable) | `[drop, derive]` — inverse of `sandboxes.network_block_all`; reconstruct on read |
+| `network_allow_out_json` | E2B allow-out CIDR list | `[generic bag]` — AerolVM has no per-sandbox allow-out today |
+| `network_deny_out_json` | E2B deny-out CIDR list | `[drop, derive]` — collapses to `network_block_all` per existing handler logic |
+| `allow_public_traffic` | E2B public flag | `[generic bag]` |
+| `mask_request_host` | E2B host masking | `[generic bag]` |
+| `created_at` / `updated_at` | Row timestamps | `[drop]` |
+
+### `e2b_snapshots`
+
+| Column | What it stores | Verdict |
+|---|---|---|
+| `snapshot_id` | E2B-shaped opaque ID (base64-ish) | `[generic alias table]` — a snapshot can have alternate IDs in any facade |
+| `snapshot_name` | Native `sandbox_snapshots.name` it aliases | `[join key into native]` |
+| `names_json` | Extra Daytona/E2B-visible names | `[generic alias table]` |
+| `source_sandbox_id` | Already on `sandbox_snapshots` | `[drop]` |
+| `created_at` / `updated_at` | Already on `sandbox_snapshots` | `[drop]` |
+
+## Summary of the verdict
+
+Across the three tables, the columns reduce to four real categories:
+
+1. **Truly duplicated native state.** Lifecycle intervals, OS user, internet
+   access, snapshot-via-image. These should be derived from `sandboxes`
+   on read. Storing them twice is the bug — they can drift on partial
+   failures (the handler updates `Lifecycle` and then the metadata row;
+   a crash between the two leaves them inconsistent).
+
+2. **Genuinely useful generic capabilities AerolVM should own natively.**
+   - `name` (with uniqueness) — `daytona_sandboxes.name`
+   - tag/label map — `daytona_sandboxes.labels_json` and
+     `e2b_sandboxes.metadata_json` are the same shape
+
+3. **Opaque wire-only state that has no native meaning.**
+   - Daytona: `target`, `network_allow_list`, `auto_archive_interval_minutes`,
+     `snapshot` echo.
+   - E2B: `template_id`, `template_alias`, `on_timeout`, `auto_resume`,
+     `secure`, `allow_public_traffic`, `mask_request_host`,
+     `network_allow_out`.
+   - These exist only so a client that wrote `X` reads `X` back. They are
+     facade-private state.
+
+4. **Alias / alternate-ID mappings.** `e2b_snapshots` is mostly this.
+   Daytona currently has no snapshot aliases but is likely to need
+   something similar.
+
+## Recommended target shape
+
+Goal: zero facade-named tables. AerolVM owns the data model; each facade
+keeps only an opaque "remember-what-the-client-said" bag for round-tripping.
+
+### 1. Promote `name` to a native first-class field
+
+Add `name TEXT NOT NULL DEFAULT '' UNIQUE COLLATE NOCASE` (or with a partial
+unique index on `name <> ''` to keep older rows valid) to `sandboxes`.
+
+- Native API can ignore it for now; SDKs can opt in later.
+- `ResolveDaytonaSandboxID` becomes `ResolveSandboxIDByName` in `service`.
+- Daytona creates pass `req.Name` straight to `models.CreateSandboxRequest`.
+
+This is the only change that touches `pkg/models/types.go` and the SDK
+transport. Worth doing because Daytona+E2B both lean on name-like lookup
+anyway, and the user has stated this should not be Daytona-specific.
+
+### 2. Promote labels/metadata to one native table
+
+Replace `daytona_sandboxes.labels_json` and `e2b_sandboxes.metadata_json`
+with one of:
+
+a. `sandboxes.tags_json TEXT NOT NULL DEFAULT '{}'` — simplest, mirrors
+   how `env_json`/`gpus_json` already live as JSON columns.
+b. `sandbox_tags(sandbox_id, key, value)` — better for filtering at scale,
+   but list filtering today is in-memory anyway.
+
+Recommendation: **(a)**. AerolVM list endpoints already iterate in memory;
+the JSON column is consistent with the existing pattern and is the
+smallest change. Filtering on labels in `/daytona/sandboxes?labels=...`
+keeps working unchanged.
+
+### 3. Collapse remaining wire-only state into one generic table
+
+Add a single facade-agnostic table:
+
+```sql
+CREATE TABLE sandbox_compat_state (
+    sandbox_id TEXT NOT NULL,
+    facade TEXT NOT NULL,                -- 'daytona' | 'e2b'
+    state_json TEXT NOT NULL DEFAULT '{}',
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    PRIMARY KEY (sandbox_id, facade),
+    FOREIGN KEY (sandbox_id) REFERENCES sandboxes(id) ON DELETE CASCADE
+);
+```
+
+The `state_json` blob is opaque to the store layer. Each facade defines
+its own JSON shape — Daytona stores `{target, snapshot_ref,
+network_allow_list, auto_archive_interval_minutes}`, E2B stores
+`{template_id, template_alias, on_timeout, auto_resume, secure,
+allow_public_traffic, mask_request_host, network_allow_out}`.
+
+Result:
+
+- `daytona_sandboxes` → gone.
+- `e2b_sandboxes` → gone.
+- Adding a third facade later (e.g. Modal, Replit) needs zero schema
+  changes.
+- The store stays facade-agnostic; the schema name `sandbox_compat_state`
+  describes a category, not a vendor.
+
+### 4. Collapse `e2b_snapshots` into a generic alias table
+
+Replace with:
+
+```sql
+CREATE TABLE snapshot_aliases (
+    alias TEXT PRIMARY KEY,
+    snapshot_name TEXT NOT NULL,         -- FK to sandbox_snapshots.name
+    facade TEXT NOT NULL,                -- 'e2b' (others later)
+    extra_names_json TEXT NOT NULL DEFAULT '[]',
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    FOREIGN KEY (snapshot_name) REFERENCES sandbox_snapshots(name) ON DELETE CASCADE
+);
+CREATE INDEX idx_snapshot_aliases_snapshot_name ON snapshot_aliases(snapshot_name);
+```
+
+Adding the missing FK to `sandbox_snapshots` also fixes the orphan-row
+bug where `/v1/snapshots/{name}` delete leaves an `e2b_snapshots` row
+behind.
+
+### 5. Derive everything else on read
+
+Eliminate the duplicated columns. The facade response layer recomputes
+them from `sandboxes`:
+
+- Daytona `autoStopInterval` ← `Lifecycle.StopIfIdleFor / time.Minute`
+- Daytona `autoDeleteInterval` ← `Lifecycle.DestroyIfIdleFor / time.Minute`
+- Daytona `user` ← `sandboxes.os_user`
+- E2B `timeoutSeconds` ← `Lifecycle.StopAtAge` or `Lifecycle.DestroyAtAge`
+  (whichever is non-zero, choose by `state.on_timeout`)
+- E2B `allowInternetAccess` ← `!sandboxes.network_block_all`
+
+This is exactly what the handlers already do as a fallback when the
+metadata row is missing (`durationMinutesPtr(sandbox.Lifecycle.StopIfIdleFor)`,
+etc.) — the consolidation just makes that the **only** path.
+
+## End-state schema
+
+After the consolidation:
+
+```text
+sandboxes(
+    ...existing columns...,
+    name TEXT UNIQUE,                    -- NEW (native)
+    tags_json TEXT DEFAULT '{}'          -- NEW (native, generic)
+)
+exposed_ports(...)                       -- unchanged
+sandbox_mounts(...)                      -- unchanged
+sandbox_snapshots(...)                   -- unchanged
+sandbox_compat_state(                    -- NEW (one row per (sandbox,facade))
+    sandbox_id, facade, state_json,
+    created_at, updated_at
+)
+snapshot_aliases(                        -- NEW (replaces e2b_snapshots)
+    alias, snapshot_name, facade,
+    extra_names_json, created_at, updated_at
+)
+```
+
+Six tables, none of them named after a third-party product.
+
+## Migration plan
+
+The data lives in the dev DB only; AerolVM is self-hosted, so we control
+the upgrade. Migrations should be idempotent and additive in one release,
+destructive in a follow-up.
+
+### Phase A — additive (one release)
+
+1. `ALTER TABLE sandboxes ADD COLUMN name TEXT NOT NULL DEFAULT '';`
+2. `CREATE UNIQUE INDEX idx_sandboxes_name ON sandboxes(name) WHERE name <> '';`
+3. `ALTER TABLE sandboxes ADD COLUMN tags_json TEXT NOT NULL DEFAULT '{}';`
+4. Create `sandbox_compat_state` and `snapshot_aliases`.
+5. Backfill from existing tables (one-shot at startup, idempotent):
+   - `sandboxes.name` ← `daytona_sandboxes.name`
+   - `sandboxes.tags_json` ← `daytona_sandboxes.labels_json` (and merge
+     with `e2b_sandboxes.metadata_json` for sandboxes that have both)
+   - `sandbox_compat_state` rows derived from leftover Daytona/E2B columns
+   - `snapshot_aliases` rows from `e2b_snapshots`
+6. Switch reads in `pkg/api/daytona` and `pkg/api/e2b` to the new
+   tables. Writes go to both old and new until Phase B.
+7. Keep `/v1` unchanged. Internally everyone reads from `sandboxes` +
+   the new generic tables.
+
+### Phase B — destructive (next release)
+
+1. Stop writing to `daytona_sandboxes`, `e2b_sandboxes`, `e2b_snapshots`.
+2. `DROP TABLE daytona_sandboxes;`
+3. `DROP TABLE e2b_sandboxes;`
+4. `DROP TABLE e2b_snapshots;`
+5. Delete the old store helpers (`UpsertDaytonaMetadata`,
+   `GetDaytonaMetadata`, …, `DeleteE2BSnapshot`).
+6. Rename `ResolveDaytonaSandboxID` → `ResolveSandboxIDByName` (now in
+   the native service surface, not a Daytona-named helper).
+
+Splitting it in two releases keeps the dev DB safe across a downgrade and
+lets us run tests against the new path while the old path is still
+authoritative.
+
+## Files that change
+
+- `internal/store/store.go` — schema, helpers, scanners, the `Resolve*`
+  function rename.
+- `internal/store/store_test.go` — new tests for `name` uniqueness and
+  the generic `sandbox_compat_state` upsert path.
+- `internal/service/daytona.go` — collapse to wrappers around
+  `sandbox_compat_state`.
+- `internal/service/e2b.go` — same.
+- `pkg/models/daytona.go`, `pkg/models/e2b.go` — keep the structs for
+  facade-internal use, but they no longer have a 1:1 column mapping;
+  the facade serializes them into `state_json`.
+- `pkg/models/types.go` — add `Name` and `Tags` to `Sandbox` and
+  `CreateSandboxRequest`. SDKs follow when ready.
+- `pkg/api/daytona/handlers.go`, `pkg/api/e2b/handlers.go` — read derived
+  fields from `sandbox` first, fall back to facade state for opaque
+  wire-only bits. Most of this logic already exists as the
+  "metadata-not-found fallback" branches.
+
+## Open questions before coding
+
+1. Do we want `name` exposed in `/v1` now, or only stored and reserved
+   for SDK plumbing later? Recommendation: store it now, expose in `/v1`
+   when SDKs catch up. The schema change is the irreversible part.
+2. Do we want `tags`/`labels` exposed in `/v1` now? Same answer.
+3. For `e2b_snapshots`, the current schema lets one native snapshot have
+   one E2B ID. Do we ever expect to expose the same snapshot under
+   multiple facades simultaneously? If yes, `snapshot_aliases` keyed on
+   `alias` is correct. If no, a per-snapshot JSON column would suffice
+   and is even simpler.
+4. Are we willing to do the two-phase migration, or do we want to drop
+   the old tables in the same release? Self-hosted means we can usually
+   afford the one-shot — but two phases makes test/rollback trivial.
+
+## Why this is a real cleanup, not just churn
+
+- Eliminates the drift class: `Lifecycle` and `auto_*_interval_minutes`
+  can no longer disagree because only `Lifecycle` exists.
+- Eliminates the orphan-row bug for `e2b_snapshots` by adding the
+  missing FK to `sandbox_snapshots`.
+- Removes the "Daytona-named, but actually generic" capabilities (name
+  lookup, labels) from a facade silo and gives them to the whole API
+  surface.
+- Adding a third facade later (Modal, Replit, anything) becomes a wire
+  translation patch, not a schema change — which is the whole point of
+  the user's framing: **AerolVM is the product; the facades are
+  translation**.
+
+## Out of scope
+
+- SDK changes. The native SDKs can pick up `name` and `tags` whenever
+  they want; nothing in this plan forces them to.
+- Network policy. The fact that AerolVM's per-sandbox allow-out / deny-out
+  is weaker than E2B's wire contract is a separate question — for now,
+  the facade just remembers what the client sent in the generic state
+  bag and refuses requests AerolVM cannot honor.
+- Snapshot lifecycle reform. `sandbox_snapshots` itself is fine; we only
+  touch `e2b_snapshots`.

--- a/plans/sdk-compatibility/README.md
+++ b/plans/sdk-compatibility/README.md
@@ -1,6 +1,6 @@
 # SDK Compatibility Matrix
 
-This folder tracks the current AerolVM versus Daytona SDK compatibility state.
+This folder tracks the current AerolVM versus external SDK compatibility state.
 
 It is intentionally split into folders so the language-level view and the endpoint-level view stay separate:
 
@@ -8,6 +8,7 @@ It is intentionally split into folders so the language-level view and the endpoi
 |---|---|
 | `aerolvm/` | Native AerolVM SDK inventory and support status. |
 | `daytona/` | Daytona SDK language inventory plus detailed `/daytona` facade support tables. |
+| `e2b/` | E2B compatibility planning and, later, support tables for the `/e2b` facade. |
 | `comparison/` | High-level side-by-side summary of native AerolVM SDKs versus Daytona compatibility. |
 
 ## Status Legend
@@ -26,6 +27,7 @@ It is intentionally split into folders so the language-level view and the endpoi
 | `daytona/sdk-language-matrix.md` | Official Daytona SDK families and how they map onto the AerolVM `/daytona` facade. |
 | `daytona/control-plane-matrix.md` | Daytona control-plane routes and feature fields supported by AerolVM. |
 | `daytona/toolbox-matrix.md` | Daytona toolbox routes and feature families supported by AerolVM. |
+| `e2b/facade-plan.md` | Concrete plan for exposing the E2B Python SDK contract through a new `/e2b` compatibility facade. |
 | `comparison/daytona-vs-aerolvm.md` | Short side-by-side view of native AerolVM SDKs versus Daytona compatibility mode. |
 
-All tables reflect the current implementation in the repository as of 2026-05-13.
+All tables reflect the current implementation in the repository as of 2026-05-14.

--- a/plans/sdk-compatibility/e2b/facade-plan.md
+++ b/plans/sdk-compatibility/e2b/facade-plan.md
@@ -1,0 +1,590 @@
+# E2B Python SDK Compatibility Plan
+
+## Objective
+
+Make AerolVM consumable by the unmodified E2B Python SDK without changing AerolVM's native SDKs or `/v1` API.
+
+This plan replaces the earlier placeholder E2B discovery section in `plans/daytona-e2b-compatibility-facades.md` with a concrete target based on the local E2B SDK checkout.
+
+## Constraints
+
+- Do not modify `sdk/python` in this repository.
+- Do not change `/v1` request or response behavior.
+- Keep compatibility logic in facade packages and toolbox compatibility handlers, not in `internal/service` business logic.
+- Document setup later in:
+  - `docs/src/content/docs/sdk-setup.md`
+  - `docs/src/content/docs/getting-started.md`
+
+## Implementation Guardrails
+
+These are not optional polish items. They are design constraints from the repo's API review rules and need to be satisfied by the implementation plan from the first patch onward.
+
+### Idempotency is a hard requirement
+
+All `/e2b` sandbox APIs must be safe under retries and concurrent duplicate calls.
+
+That means the implementation must define explicit retry behavior for:
+
+- `POST /e2b/sandboxes`
+- `POST /e2b/sandboxes/{id}/connect`
+- `POST /e2b/sandboxes/{id}/pause`
+- `POST /e2b/sandboxes/{id}/timeout`
+- `POST /e2b/sandboxes/{id}/snapshots`
+- `DELETE /e2b/templates/{id}`
+
+The main unresolved design point is create idempotency. Before coding starts, the facade needs a deterministic retry story for `POST /e2b/sandboxes`. If the upstream request shape does not include a natural stable key, the facade will need a persisted request fingerprint or another explicit compatibility key instead of best-effort duplicate creation.
+
+The upstream create body makes this stricter than it first appears: it has `templateID`, timeout and lifecycle inputs, metadata, env vars, network options, secure mode, and volume mounts, but it does not carry a caller-supplied sandbox name, alias, or request ID that can be reused as an obvious idempotency key.
+
+Minimum expected behavior:
+
+- repeated `connect` must not double-start a sandbox or shorten a longer timeout already in force
+- repeated `pause` against an already-paused sandbox should be a success no-op
+- repeated snapshot create for the same effective snapshot identity should return the existing snapshot or fail with a clear conflict, never create ambiguous duplicates
+
+### Protect the create path
+
+Sandbox creation latency is a protected path in this repo.
+
+Phase-one `/e2b/sandboxes` work is allowed to add:
+
+- one bounded template-alias lookup
+- one bounded metadata read or write sequence
+- normal native `CreateSandbox` work already performed by AerolVM
+
+Phase one should not add:
+
+- external catalog lookups
+- wildcard-host bootstrap
+- Caddy bootstrap
+- runtime proxy warm-up
+- any best-effort daemon recovery loop on the create request path
+
+If any future E2B feature needs best-effort daemon-start bootstrap, mirror the `EnsureLayer4Ready` shape from `internal/service`: atomic fast-path latch plus single-flight mutex, with retries only on the first API path that actually needs the feature.
+
+### Define rollback ownership on partial failure
+
+The plan needs explicit cleanup rules anywhere the facade touches both native resources and compatibility metadata.
+
+Required rules:
+
+- if native sandbox creation succeeds and the `e2b_sandboxes` metadata write fails, destroy the newly created sandbox before returning an error so retries do not leak live sandboxes
+- if native snapshot creation succeeds and the facade fails while recording E2B-facing metadata, pick and document one behavior before implementation: either roll back the native snapshot immediately or preserve it and make the next identical request reuse it deterministically
+- when later ingress work touches both Caddy and persisted state, use explicit "did I create this?" ownership tracking; do not rely on reconcile as the primary cleanup path
+
+### Deployment touch points are part of the plan
+
+Adding `/e2b` is not only a Go router change.
+
+When the facade lands, update both API allowlists:
+
+- `packaging/Caddyfile.template`
+- `scripts/install.sh`
+
+Both need `/e2b` and `/e2b/*`, the same way `/daytona` was wired.
+
+## Inputs Reviewed
+
+### Upstream SDK target
+
+- Local SDK path: `/Users/sumansaurabh/Documents/startup-3/opensource-repos/E2B/packages/python-sdk`
+- Package: `e2b`
+- Version: `2.21.0`
+- Primary initial contract: sync Python SDK
+- Secondary validation target: async Python SDK, because it uses the same wire contract
+
+### AerolVM implementation areas reviewed
+
+- `pkg/api/server.go`
+- `pkg/api/daytona/*`
+- `internal/service/service.go`
+- `internal/store/store.go`
+- `cmd/toolboxd/*`
+- `pkg/models/*`
+- `docs/src/content/docs/sdk-setup.md`
+- `docs/src/content/docs/getting-started.md`
+
+## Confirmed E2B Contract
+
+### Control-plane API
+
+The Python SDK uses an HTTP control plane rooted at `ConnectionConfig.api_url`.
+
+Important route families exercised by the SDK:
+
+| Route family | Purpose | Current importance |
+|---|---|---|
+| `POST /sandboxes` | create sandbox from `templateID` | Required for MVP |
+| `GET /sandboxes` | list sandboxes | Required for MVP |
+| `GET /sandboxes/{id}` | get sandbox info | Required for MVP |
+| `DELETE /sandboxes/{id}` | kill sandbox | Required for MVP |
+| `POST /sandboxes/{id}/connect` | reconnect and optionally extend timeout | Required for MVP |
+| `POST /sandboxes/{id}/pause` | pause sandbox | Required for MVP |
+| `POST /sandboxes/{id}/timeout` | update timeout | Required for MVP |
+| `POST /sandboxes/{id}/snapshots` | create snapshot | Required for MVP |
+| `GET /snapshots` | list snapshots | Required for MVP |
+| `DELETE /templates/{id}` | delete snapshot by template id | Required for MVP because `delete_snapshot()` uses this path |
+| `GET /sandboxes/{id}/metrics` | sandbox metrics | Later |
+| `GET /sandboxes/{id}/logs`, `GET /v2/sandboxes/{id}/logs` | sandbox logs | Later |
+| `/templates`, `/v2/templates`, `/v3/templates`, `/tags`, `/volumes` | template, build, tag, and volume APIs | Explicitly out of MVP |
+
+### Sandbox runtime API
+
+The SDK does not stop at the control plane. After create or connect it talks to a sandbox-side API using:
+
+- HTTP endpoints such as `GET /files`, `POST /files`, `GET /health`
+- Connect-RPC style endpoints such as:
+  - `/process.Process/List`
+  - `/process.Process/Connect`
+  - `/process.Process/Start`
+  - `/process.Process/Update`
+  - `/process.Process/SendInput`
+  - `/process.Process/SendSignal`
+  - `/process.Process/CloseStdin`
+  - `/filesystem.Filesystem/Stat`
+  - `/filesystem.Filesystem/MakeDir`
+  - `/filesystem.Filesystem/Move`
+  - `/filesystem.Filesystem/ListDir`
+  - `/filesystem.Filesystem/Remove`
+  - watcher routes under `/filesystem.Filesystem/...`
+
+This means `/e2b` cannot be a control-plane-only adapter. It also needs a runtime facade that makes toolboxd look enough like E2B envd.
+
+### Auth and per-sandbox headers
+
+The SDK uses different auth shapes on the two planes:
+
+| Surface | Upstream auth shape | Notes for AerolVM |
+|---|---|---|
+| Control plane | `X-API-KEY: <token>` | Reuse AerolVM PAT token, but accept the E2B header name on `/e2b` routes. |
+| Sandbox runtime | `X-Access-Token`, `E2b-Sandbox-Id`, `E2b-Sandbox-Port` | Emitted by the SDK after `create()` and `connect()`. The facade must accept these and route to the right toolbox target. Phase-one recommendation: surface AerolVM's existing per-sandbox toolbox token as `envdAccessToken`, validate `X-Access-Token` against it at `/e2b/runtime`, then forward the native bearer token to toolboxd. |
+| User impersonation on envd calls | `Authorization: Basic <base64(user:)>` | Used for file and process operations with an explicit user. |
+| Public traffic gating | `e2b-traffic-access-token` | Needed later for `allow_public_traffic=false`. AerolVM does not have this today. |
+
+### Runtime token mapping
+
+The current AerolVM runtime path already stores a per-sandbox toolbox token and injects it when proxying to toolboxd. The E2B facade should reuse that instead of introducing a second runtime secret store.
+
+Recommended phase-one mapping:
+
+- on create and connect responses, emit the sandbox's toolbox token as E2B `envdAccessToken` when the facade is operating in secure runtime mode
+- on `GET /e2b/sandboxes` and `GET /e2b/sandboxes/{id}`, shape the same token into the E2B response fields where the SDK expects it
+- at `/e2b/runtime`, compare incoming `X-Access-Token` with the sandbox's stored toolbox token
+- when proxying to toolboxd, continue forwarding `Authorization: Bearer <toolbox token>` exactly as the native toolbox proxy already does
+
+This keeps the runtime credential story aligned with the existing daemon and avoids adding extra secret persistence for phase one.
+
+### Base URL and path-prefix viability
+
+The generated E2B client issues absolute-looking request paths such as `/sandboxes`, but the current `httpx` behavior still resolves them correctly against a base URL with a path segment.
+
+That means this works as an initial setup target:
+
+```text
+E2B_API_URL=https://sandbox.example.com/e2b
+```
+
+and requests resolve under:
+
+```text
+/e2b/sandboxes
+```
+
+So the user's requested `/e2b` path family is viable.
+
+## Key AerolVM Findings
+
+### Good overlap already exists
+
+The current AerolVM server already gives the facade most of the core substrate it needs:
+
+- create, get, list, start, stop, destroy sandboxes
+- per-sandbox lifecycle timers
+- native sandbox snapshots
+- toolbox target resolution
+- public HTTP port exposure
+- persistent store-backed compatibility metadata pattern via `/daytona`
+
+### The runtime split is the main architectural constraint
+
+`cmd/toolboxd` already supports command execution, sessions, upload, download, and Daytona-oriented file and git helpers, but it does not currently expose the E2B envd contract.
+
+That means the E2B work needs:
+
+1. top-level control-plane handlers in `pkg/api/e2b`
+2. runtime-side compatibility handlers in `cmd/toolboxd`
+3. a routing layer that proxies E2B runtime requests to the correct sandbox toolbox endpoint
+
+### Some E2B features are true gaps today
+
+The current repo does not have first-class support for:
+
+- traffic access tokens for public ingress
+- `mask_request_host` host rewrite semantics
+- automatic resume on inbound public traffic when `auto_resume=true`
+- per-destination network allow and deny lists
+- E2B template catalog, template builds, tags, or volumes
+- sandbox metrics and logs in E2B's shapes
+
+Those must be phased explicitly instead of being approximated silently.
+
+## Recommended Architecture
+
+### Route ownership
+
+Add a new facade package and register it from `pkg/api/server.go`:
+
+```text
+pkg/api/
+  e2b/
+    routes.go
+    handlers.go
+    dto.go
+    translate.go
+    runtime_proxy.go
+```
+
+The route family should be rooted at `/e2b`.
+
+### Runtime gateway for phase one
+
+Do not make initial compatibility depend on wildcard hostnames.
+
+Instead, support a fixed runtime gateway under the same facade family, for example:
+
+```text
+/e2b/runtime
+/e2b/runtime/{path...}
+```
+
+The setup then becomes:
+
+```text
+E2B_API_URL=https://sandbox.example.com/e2b
+E2B_SANDBOX_URL=https://sandbox.example.com/e2b/runtime
+E2B_API_KEY=<same PAT token>
+```
+
+This is the cleanest way to satisfy the user's request for a path-based `/e2b` endpoint while avoiding immediate wildcard host-routing work.
+
+The runtime proxy should:
+
+- read `E2b-Sandbox-Id`
+- resolve the sandbox's toolbox target through `Service.ToolboxTarget(...)`
+- forward the request path and body to toolboxd
+- preserve E2B runtime headers that toolboxd needs, especially `X-Access-Token`, `E2b-Sandbox-Id`, `E2b-Sandbox-Port`, and `Authorization`
+
+### Metadata storage
+
+Follow the Daytona pattern instead of stuffing compatibility-only fields into the native sandbox model.
+
+Add a new metadata model and store table, for example:
+
+```text
+pkg/models/e2b.go
+internal/store: e2b_sandboxes table + helpers
+```
+
+Persist fields that AerolVM either does not model natively or models differently, including:
+
+- requested `template_id`
+- resolved template alias returned to the SDK, when one exists
+- metadata map
+- lifecycle mode: `on_timeout` and `auto_resume`
+- requested timeout seconds
+- secure mode
+- allow-public-traffic intent
+- requested network allow and deny lists
+- requested host mask
+- any E2B-facing alias values needed for stable response shaping
+
+### Keep `internal/service` product-agnostic
+
+The service layer should continue dealing in AerolVM primitives only:
+
+- create sandbox
+- start or stop sandbox
+- update lifecycle
+- create or remove snapshot
+- expose port
+- resolve toolbox target
+
+All E2B naming, status, auth, timeout, and template semantics should stay in the facade layer or toolbox compatibility layer.
+
+## Translation Rules
+
+### State mapping
+
+Map native AerolVM state to E2B state like this:
+
+| AerolVM | E2B |
+|---|---|
+| `started` | `running` |
+| `stopped` | `paused` |
+
+Destroyed sandboxes should remain 404 on read and `False` on `delete_snapshot()`-style boolean methods where the SDK expects that behavior.
+
+### Timeout and pause semantics
+
+E2B timeout is not AerolVM's native wire shape, but it maps cleanly onto lifecycle timers.
+
+Recommended translation:
+
+- `lifecycle.on_timeout = "kill"` -> native `DestroyAtAge = timeout`
+- `lifecycle.on_timeout = "pause"` -> native `StopAtAge = timeout`
+- `POST /e2b/sandboxes/{id}/timeout` updates the same lifecycle field according to stored E2B timeout mode
+- `POST /e2b/sandboxes/{id}/connect` must only extend the deadline when the new timeout is longer than the existing one, matching the upstream SDK contract
+
+### Template resolution
+
+E2B creates sandboxes from `templateID`, not from an image name.
+
+We need an explicit resolver instead of guessing:
+
+1. If `templateID` matches a native AerolVM snapshot created through the E2B facade, create from that snapshot image.
+2. Otherwise resolve the template through a facade-owned alias map.
+3. If no mapping exists, return a clear 4xx error.
+
+The minimum viable mapping should include `base`, because `Sandbox.create()` defaults to it in the Python SDK.
+
+Recommended config shape:
+
+```text
+SB_E2B_TEMPLATE_MAP_JSON={"base":"ubuntu:22.04"}
+```
+
+That keeps template aliasing explicit and out of native AerolVM APIs.
+
+The control-plane response shaping also needs to preserve E2B's template-facing fields accurately:
+
+- `templateID` should reflect the E2B-facing template identifier the caller used or the facade resolved
+- optional `alias` in list and get responses is template alias information, not a sandbox-specific name
+- metadata must round-trip through create, list, and get because the SDK supports metadata filters on list calls
+
+### Snapshot identifier mapping
+
+E2B uses the returned `snapshot_id` string as the stable external identifier for both recreate and delete flows.
+
+That means the facade should treat the E2B snapshot identifier as first-class metadata, not as an incidental formatting detail.
+
+Recommended rule:
+
+- persist the exact E2B-facing `snapshot_id` string for each snapshot created through the facade
+- when the caller supplied a snapshot name, preserve an E2B-style named identifier such as `namespace/name:tag`
+- when the caller did not supply a name, persist a generated fallback identifier that is still stable for later `DELETE /e2b/templates/{id}` resolution
+- resolve deletes by E2B `snapshot_id` first, with native snapshot-name lookup only as an internal fallback
+
+This matches the upstream SDK, where `delete_snapshot()` deletes by the same template-style identifier previously returned from `create_snapshot()`.
+
+### Public host and ingress note
+
+The SDK's `get_host(port)` builds `port-sandboxid.domain`, while AerolVM's current public port URLs are documented as `sandboxid-port.domain`.
+
+For phase one, avoid depending on this by requiring `E2B_SANDBOX_URL=/e2b/runtime` for SDK runtime operations.
+
+Full `get_host()` compatibility should be a later phase that adds E2B-specific host generation and Caddy routing.
+
+## Phased Delivery
+
+### Phase 1: Control-plane MVP
+
+Implement these under `/e2b`:
+
+| Route | Status | Mapping |
+|---|---|---|
+| `POST /e2b/sandboxes` | MVP | create sandbox via template resolver + metadata persistence |
+| `GET /e2b/sandboxes` | MVP | native list + E2B response shaping + metadata filter support |
+| `GET /e2b/sandboxes/{id}` | MVP | native get + E2B response shaping |
+| `DELETE /e2b/sandboxes/{id}` | MVP | native destroy |
+| `POST /e2b/sandboxes/{id}/connect` | MVP | native start or no-op + timeout extension |
+| `POST /e2b/sandboxes/{id}/pause` | MVP | native stop |
+| `POST /e2b/sandboxes/{id}/timeout` | MVP | lifecycle update |
+| `POST /e2b/sandboxes/{id}/snapshots` | MVP | native snapshot create |
+| `GET /e2b/snapshots` | MVP | native snapshot list, with optional facade filter shaping |
+| `DELETE /e2b/templates/{id}` | MVP | native snapshot delete by id or mapped name |
+
+The goal of phase one is to make create, connect, pause, timeout, kill, and snapshot workflows usable from the Python SDK.
+
+### Phase 2: Runtime MVP via `/e2b/runtime`
+
+Add E2B envd compatibility to toolboxd and proxy it through the top-level API.
+
+Recommended runtime scope:
+
+| Capability | Status | Notes |
+|---|---|---|
+| `GET /health` | MVP | simple sandbox liveness |
+| `GET /files`, `POST /files` | MVP | read and write file contents |
+| `filesystem.Stat` | MVP | map to file info helper |
+| `filesystem.MakeDir` | MVP | add directory creation |
+| `filesystem.Move` | MVP | reuse move helper |
+| `filesystem.ListDir` | MVP | list entries with mode, owner, size, timestamps |
+| `filesystem.Remove` | MVP | add remove helper |
+| `process.List` | MVP | list running process handles |
+| `process.Start` | MVP | run command or PTY |
+| `process.Connect` | MVP | reconnect to running process |
+| `process.Update` | MVP | PTY resize |
+| `process.SendInput` | MVP | stdin and PTY input |
+| `process.SendSignal` | MVP | signal process |
+| `process.CloseStdin` | MVP | EOF stdin without killing process |
+
+Implementation note:
+
+- Using `connectrpc.com/connect` for the runtime handlers is the most direct fit to the upstream Python client.
+- The current repo does not expose Connect RPC today, so this will be a new dependency and handler family.
+- Under the hood, process operations should reuse or extend the existing session machinery instead of inventing a third process model.
+
+### Phase 3: Ingress compatibility
+
+These features matter for E2B host URLs and browser-facing flows, but they should not block the first SDK-compatible control-plane and runtime pass:
+
+- `allow_public_traffic=false` and `e2b-traffic-access-token`
+- `mask_request_host`
+- automatic resume on inbound HTTP traffic when `auto_resume=true`
+- `sandbox.get_host(port)` and `sandbox_domain` behavior that matches E2B's `port-sandboxid.domain` scheme
+
+This phase likely touches:
+
+- Caddy route generation
+- public URL builders
+- maybe installation templates and allowlists, the same way Daytona path exposure needed explicit Caddy updates
+
+### Regression gates for later phases
+
+If E2B ingress compatibility ends up changing any of the fragile networking paths already called out in `pr-review.md`, the implementation must add the same regression coverage required elsewhere in the repo.
+
+Specifically:
+
+- any change to host-port allocation semantics requires store regression coverage in `internal/store/store_test.go`
+- any change to L4 bootstrap or readiness latching requires regression coverage in `internal/service/layer4_bootstrap_test.go`
+- any PR that adds work to native sandbox boot through the E2B facade must explicitly call out the latency impact in the PR description
+
+### Phase 4: Explicitly unsupported or later-surface APIs
+
+Return clear 501 or 4xx responses for these until we choose to build them:
+
+- `GET /sandboxes/{id}/metrics`
+- `GET /sandboxes/{id}/logs`
+- `GET /v2/sandboxes/{id}/logs`
+- template catalog and template build APIs
+- tag APIs
+- volume APIs
+- per-destination `allow_out` and `deny_out` semantics
+- filesystem watchers
+
+Do not fake these as successful with incomplete semantics.
+
+## Open Design Questions
+
+These should be resolved before implementation starts, or answered in the first implementation PR description.
+
+1. What is the exact idempotency key for `POST /e2b/sandboxes` when the same request is retried concurrently?
+2. Should secure=false omit `envdAccessToken` entirely from create, connect, get, and list responses, or should the facade always return the toolbox-backed token for simplicity?
+3. For named snapshots, do we preserve the user-supplied snapshot name directly as the native snapshot name, or store a separate facade alias while keeping native snapshot names collision-free?
+4. Should phase-one runtime MVP stop at process and filesystem primitives, with all watcher APIs returning explicit 501, or is there a narrower subset the user already knows they need?
+
+## Testing Plan
+
+### Go facade tests
+
+Add `pkg/api/e2b` handler tests for:
+
+- auth translation from `X-API-KEY`
+- create and connect translation
+- timeout extension rules
+- state mapping `started <-> running`, `stopped <-> paused`
+- snapshot creation and delete mapping
+- metadata persistence and restart-safe reads
+
+Use the same style as the Daytona harness:
+
+- real service
+- temp SQLite store
+- real mounts manager
+- no external Caddy admin dependency
+
+### Toolbox compatibility tests
+
+Add `cmd/toolboxd` tests for:
+
+- `/files` read and write behavior with E2B headers
+- filesystem RPC handlers
+- process RPC handlers for command mode and PTY mode
+- `close stdin` versus process termination
+- resize and reconnect behavior
+
+### Python contract harness
+
+Add a focused smoke harness that runs against the real upstream Python SDK `e2b==2.21.0`.
+
+Do not try to run the entire upstream test suite first. Start with a pinned subset that matches our delivery phases:
+
+#### Phase 1 subset
+
+- create
+- connect
+- pause
+- kill
+- timeout
+- snapshot create, list, delete, recreate from snapshot
+
+#### Phase 2 subset
+
+- commands run, connect, stdin, kill
+- files read, write, list, mkdir, move, remove
+- PTY create, connect, resize, input
+
+#### Phase 3 subset
+
+- host access
+- allow public traffic token behavior
+- host masking
+- auto-resume on public request
+
+## Docs Plan
+
+After implementation, update the requested docs pages as follows.
+
+### `docs/src/content/docs/sdk-setup.md`
+
+Add an E2B compatibility section that shows:
+
+```bash
+export E2B_API_URL=https://sandbox.example.com/e2b
+export E2B_SANDBOX_URL=https://sandbox.example.com/e2b/runtime
+export E2B_API_KEY=<your-pat-token>
+```
+
+and make clear that this is a compatibility facade, not the native AerolVM Python SDK.
+
+### `docs/src/content/docs/getting-started.md`
+
+Add a short server-side compatibility note covering:
+
+- `/e2b` control-plane availability
+- PAT token reuse as `E2B_API_KEY`
+- the need for `E2B_SANDBOX_URL` in the first rollout
+- domain-mode host compatibility as a later enhancement if we add full E2B public host semantics
+
+If the docs section grows beyond a short setup note, split it into a dedicated page later.
+
+## Recommended Implementation Order
+
+1. Scaffold `pkg/api/e2b` and register `/e2b` from `pkg/api/server.go`.
+2. Add E2B metadata model and store helpers.
+3. Implement the control-plane MVP routes and snapshot delete alias.
+4. Add `E2B_API_URL=/e2b` response shaping and timeout translation tests.
+5. Add `/e2b/runtime` proxy routing through `Service.ToolboxTarget(...)`.
+6. Implement toolboxd E2B file and process compatibility handlers.
+7. Run a pinned Python smoke harness for create, connect, commands, files, PTY, and snapshots.
+8. Decide whether to tackle ingress compatibility next or hold it for a second pass.
+9. Update `sdk-setup.md` and `getting-started.md` after the first working path is stable.
+
+## Recommendation
+
+Build `/e2b` in two deliberate layers:
+
+1. a control-plane facade plus fixed runtime gateway under `/e2b`
+2. full public-host and traffic-token compatibility only after the SDK's core command, file, PTY, and snapshot flows work
+
+That approach satisfies the user's requested path-based setup, avoids premature wildcard-host routing work, and reuses the proven Daytona facade architecture without forcing E2B terminology into the native AerolVM API.

--- a/plans/sdk-compatibility/e2b/facade-plan.md
+++ b/plans/sdk-compatibility/e2b/facade-plan.md
@@ -6,6 +6,13 @@ Make AerolVM consumable by the unmodified E2B Python SDK without changing AerolV
 
 This plan replaces the earlier placeholder E2B discovery section in `plans/daytona-e2b-compatibility-facades.md` with a concrete target based on the local E2B SDK checkout.
 
+## Current Status
+
+- Control-plane MVP under `/e2b` is implemented.
+- Runtime MVP under `/e2b/runtime` is implemented and proxies into toolboxd's internal `/envd` compatibility surface.
+- Create idempotency is implemented with a persisted request-fingerprint table and bounded replay window.
+- A real Python smoke harness against `e2b==2.21.0` is implemented and passes against the local SDK checkout.
+
 ## Constraints
 
 - Do not modify `sdk/python` in this repository.
@@ -32,9 +39,17 @@ That means the implementation must define explicit retry behavior for:
 - `POST /e2b/sandboxes/{id}/snapshots`
 - `DELETE /e2b/templates/{id}`
 
-The main unresolved design point is create idempotency. Before coding starts, the facade needs a deterministic retry story for `POST /e2b/sandboxes`. If the upstream request shape does not include a natural stable key, the facade will need a persisted request fingerprint or another explicit compatibility key instead of best-effort duplicate creation.
+The implemented create strategy uses a canonical request fingerprint persisted in `e2b_create_requests`.
 
-The upstream create body makes this stricter than it first appears: it has `templateID`, timeout and lifecycle inputs, metadata, env vars, network options, secure mode, and volume mounts, but it does not carry a caller-supplied sandbox name, alias, or request ID that can be reused as an obvious idempotency key.
+The fingerprint is built from the normalized create semantics, not the raw JSON body text. It covers the effective template ID, timeout and lifecycle settings, metadata, env vars, secure mode, and supported network fields. This keeps semantically identical retries stable even when JSON field order differs.
+
+The replay behavior is intentionally bounded so legitimate duplicate launches are still allowed:
+
+- first identical request claims the fingerprint and writes a pending row with a 2 minute lock TTL
+- concurrent identical requests wait up to 30 seconds for that pending create to finish instead of launching a duplicate sandbox
+- once the create succeeds, the row moves to `ready` and replays the same sandbox for a 10 second replay window
+- after the replay window expires, the same request is allowed to create a new sandbox again
+- if native sandbox creation or metadata persistence fails, the reservation is deleted and any newly created sandbox is rolled back
 
 Minimum expected behavior:
 
@@ -274,6 +289,14 @@ The runtime proxy should:
 - forward the request path and body to toolboxd
 - preserve E2B runtime headers that toolboxd needs, especially `X-Access-Token`, `E2b-Sandbox-Id`, `E2b-Sandbox-Port`, and `Authorization`
 
+The implemented gateway rewrites `/e2b/runtime/...` into toolboxd's internal `/envd/...` namespace. This keeps the E2B envd contract separate from Daytona's existing `/files` and `/process` semantics.
+
+The implemented header flow is:
+
+- validate `X-Access-Token` against the sandbox's stored toolbox token when the sandbox is secure
+- preserve inbound `Authorization: Basic ...` as `X-E2B-User-Authorization` for toolbox-side user impersonation compatibility
+- inject `Authorization: Bearer <toolbox token>` on the hop from the public gateway to toolboxd
+
 ### Metadata storage
 
 Follow the Daytona pattern instead of stuffing compatibility-only fields into the native sandbox model.
@@ -392,16 +415,16 @@ Implement these under `/e2b`:
 
 | Route | Status | Mapping |
 |---|---|---|
-| `POST /e2b/sandboxes` | MVP | create sandbox via template resolver + metadata persistence |
-| `GET /e2b/sandboxes` | MVP | native list + E2B response shaping + metadata filter support |
-| `GET /e2b/sandboxes/{id}` | MVP | native get + E2B response shaping |
-| `DELETE /e2b/sandboxes/{id}` | MVP | native destroy |
-| `POST /e2b/sandboxes/{id}/connect` | MVP | native start or no-op + timeout extension |
-| `POST /e2b/sandboxes/{id}/pause` | MVP | native stop |
-| `POST /e2b/sandboxes/{id}/timeout` | MVP | lifecycle update |
-| `POST /e2b/sandboxes/{id}/snapshots` | MVP | native snapshot create |
-| `GET /e2b/snapshots` | MVP | native snapshot list, with optional facade filter shaping |
-| `DELETE /e2b/templates/{id}` | MVP | native snapshot delete by id or mapped name |
+| `POST /e2b/sandboxes` | Implemented | create sandbox via template resolver + metadata persistence + persisted idempotent replay |
+| `GET /e2b/sandboxes` | Implemented | native list + E2B response shaping + metadata filter support |
+| `GET /e2b/sandboxes/{id}` | Implemented | native get + E2B response shaping |
+| `DELETE /e2b/sandboxes/{id}` | Implemented | native destroy |
+| `POST /e2b/sandboxes/{id}/connect` | Implemented | native start or no-op + timeout extension |
+| `POST /e2b/sandboxes/{id}/pause` | Implemented | native stop |
+| `POST /e2b/sandboxes/{id}/timeout` | Implemented | lifecycle update |
+| `POST /e2b/sandboxes/{id}/snapshots` | Implemented | native snapshot create |
+| `GET /e2b/snapshots` | Implemented | native snapshot list, with optional facade filter shaping |
+| `DELETE /e2b/templates/{id}` | Implemented | native snapshot delete by id or mapped name |
 
 The goal of phase one is to make create, connect, pause, timeout, kill, and snapshot workflows usable from the Python SDK.
 
@@ -413,26 +436,27 @@ Recommended runtime scope:
 
 | Capability | Status | Notes |
 |---|---|---|
-| `GET /health` | MVP | simple sandbox liveness |
-| `GET /files`, `POST /files` | MVP | read and write file contents |
-| `filesystem.Stat` | MVP | map to file info helper |
-| `filesystem.MakeDir` | MVP | add directory creation |
-| `filesystem.Move` | MVP | reuse move helper |
-| `filesystem.ListDir` | MVP | list entries with mode, owner, size, timestamps |
-| `filesystem.Remove` | MVP | add remove helper |
-| `process.List` | MVP | list running process handles |
-| `process.Start` | MVP | run command or PTY |
-| `process.Connect` | MVP | reconnect to running process |
-| `process.Update` | MVP | PTY resize |
-| `process.SendInput` | MVP | stdin and PTY input |
-| `process.SendSignal` | MVP | signal process |
-| `process.CloseStdin` | MVP | EOF stdin without killing process |
+| `GET /health` | Implemented | simple sandbox liveness |
+| `GET /files`, `POST /files` | Implemented | read and write file contents |
+| `filesystem.Stat` | Implemented | map to file info helper |
+| `filesystem.MakeDir` | Implemented | add directory creation |
+| `filesystem.Move` | Implemented | reuse move helper |
+| `filesystem.ListDir` | Implemented | list entries with mode, owner, size, timestamps |
+| `filesystem.Remove` | Implemented | add remove helper |
+| `process.List` | Implemented | list running process handles |
+| `process.Start` | Implemented | run command or PTY |
+| `process.Connect` | Implemented | reconnect to running process |
+| `process.Update` | Implemented | PTY resize |
+| `process.SendInput` | Implemented | stdin and PTY input |
+| `process.SendSignal` | Implemented | signal process |
+| `process.CloseStdin` | Implemented | EOF stdin without killing process |
 
 Implementation note:
 
-- Using `connectrpc.com/connect` for the runtime handlers is the most direct fit to the upstream Python client.
-- The current repo does not expose Connect RPC today, so this will be a new dependency and handler family.
-- Under the hood, process operations should reuse or extend the existing session machinery instead of inventing a third process model.
+- The implemented runtime surface uses manual Connect JSON encoding and decoding instead of adding a new Connect dependency.
+- The internal toolbox namespace is `/envd`, not `/files` or `/process`, to avoid collisions with Daytona compatibility routes.
+- Under the hood, process operations reuse the existing session machinery instead of inventing a third process model.
+- Watcher APIs remain explicit 501 responses in this phase.
 
 ### Phase 3: Ingress compatibility
 
@@ -478,10 +502,8 @@ Do not fake these as successful with incomplete semantics.
 
 These should be resolved before implementation starts, or answered in the first implementation PR description.
 
-1. What is the exact idempotency key for `POST /e2b/sandboxes` when the same request is retried concurrently?
-2. Should secure=false omit `envdAccessToken` entirely from create, connect, get, and list responses, or should the facade always return the toolbox-backed token for simplicity?
-3. For named snapshots, do we preserve the user-supplied snapshot name directly as the native snapshot name, or store a separate facade alias while keeping native snapshot names collision-free?
-4. Should phase-one runtime MVP stop at process and filesystem primitives, with all watcher APIs returning explicit 501, or is there a narrower subset the user already knows they need?
+1. For named snapshots, do we preserve the user-supplied snapshot name directly as the native snapshot name, or store a separate facade alias while keeping native snapshot names collision-free?
+2. When phase-three ingress work starts, do we want to preserve `secure=false` as a fully tokenless runtime mode, or should later browser-facing flows still issue a traffic-scoped token for consistency?
 
 ## Testing Plan
 
@@ -516,6 +538,12 @@ Add `cmd/toolboxd` tests for:
 ### Python contract harness
 
 Add a focused smoke harness that runs against the real upstream Python SDK `e2b==2.21.0`.
+
+Implemented harness shape:
+
+- `scripts/e2b_sdk_smoke.py` exercises create, runtime health, file read and write, file list, commands, pause, reconnect, snapshot create, snapshot list, snapshot delete, and sandbox delete
+- `pkg/api/e2b/contract_test.go` builds a temporary `toolboxd`, starts an in-process `/e2b` API server, creates a temporary Python virtualenv, installs either `SB_E2B_PYTHON_SDK_PATH` or `SB_E2B_PYTHON_SDK_SPEC` into it, and runs the smoke script
+- the smoke test is opt-in via `SB_E2B_PYTHON_SMOKE=1` so normal `go test ./...` stays fast and hermetic
 
 Do not try to run the entire upstream test suite first. Start with a pinned subset that matches our delivery phases:
 

--- a/scripts/e2b_sdk_smoke.py
+++ b/scripts/e2b_sdk_smoke.py
@@ -1,0 +1,75 @@
+import os
+import sys
+
+from e2b import Sandbox
+
+
+def require_env(name: str) -> str:
+    value = os.getenv(name, "").strip()
+    if not value:
+        raise RuntimeError(f"missing required environment variable: {name}")
+    return value
+
+
+def main() -> int:
+    require_env("E2B_API_URL")
+    require_env("E2B_SANDBOX_URL")
+    require_env("E2B_API_KEY")
+
+    sandbox = None
+    snapshot = None
+    try:
+        sandbox = Sandbox.create(
+            template="base",
+            timeout=120,
+            metadata={"suite": "smoke"},
+            envs={"E2B_SMOKE": "smoke"},
+            secure=True,
+        )
+        assert sandbox.sandbox_id, "sandbox_id was empty"
+        assert sandbox.is_running(), "sandbox should report running"
+
+        sandbox.files.write("/tmp/e2b-smoke.txt", "hello from sdk")
+        content = sandbox.files.read("/tmp/e2b-smoke.txt")
+        assert content == "hello from sdk", content
+
+        entries = sandbox.files.list("/tmp", depth=1)
+        assert any(entry.path == "/tmp/e2b-smoke.txt" for entry in entries), entries
+
+        result = sandbox.commands.run("printf $E2B_SMOKE", envs={"E2B_SMOKE": "smoke"})
+        assert result.stdout == "smoke", result.stdout
+
+        listed = Sandbox.list(limit=20).next_items()
+        assert any(item.sandbox_id == sandbox.sandbox_id for item in listed), listed
+
+        snapshot = sandbox.create_snapshot()
+        assert snapshot.snapshot_id, "snapshot_id was empty"
+
+        snapshots = sandbox.list_snapshots(limit=20).next_items()
+        assert any(item.snapshot_id == snapshot.snapshot_id for item in snapshots), snapshots
+
+        sandbox.pause()
+        sandbox = sandbox.connect(timeout=180)
+        assert sandbox.is_running(), "sandbox should resume after connect"
+
+        print("E2B SDK smoke passed")
+        return 0
+    finally:
+        if snapshot is not None:
+            try:
+                Sandbox.delete_snapshot(snapshot.snapshot_id)
+            except Exception:
+                pass
+        if sandbox is not None:
+            try:
+                sandbox.kill()
+            except Exception:
+                pass
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except AssertionError as exc:
+        print(f"assertion failed: {exc}", file=sys.stderr)
+        raise

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -588,7 +588,7 @@ https://$DOMAIN:8443 {
 	tls {
 		dns $DNS_PROVIDER {env.SB_DNS_API_TOKEN}
 	}
-	@api path /health /v1 /v1/* /daytona /daytona/*
+	@api path /health /v1 /v1/* /daytona /daytona/* /e2b /e2b/*
 	handle @api {
 		reverse_proxy 127.0.0.1:21212
 	}


### PR DESCRIPTION
This pull request adds comprehensive documentation and initial test coverage for the new E2B compatibility layer, and updates the toolboxd server to support a dedicated envd compatibility surface. The most important changes are grouped below.

**Documentation for E2B Compatibility:**

* Added `agentic_docs/README.md` to introduce the purpose and structure of the E2B compatibility implementation notes, clarifying the separation between control plane, runtime gateway, and toolboxd compatibility surface.
* Added `agentic_docs/e2b-request-flow.md` to provide a detailed, step-by-step walkthrough of how the E2B Python SDK interacts with AerolVM, including request/response flows and the rationale behind the compatibility split.
* Added `agentic_docs/e2b-idempotency-timeline.md` explaining the design and implementation of idempotency for sandbox creation, including fingerprinting, replay window, and failure handling.
* Added `agentic_docs/e2b-sdk-method-map.md` mapping E2B SDK methods to AerolVM and toolboxd handler paths, covering both control-plane and runtime methods, and noting unsupported APIs.

**Code and Test Coverage for Envd Compatibility:**

* Added a new test file `cmd/toolboxd/envd_test.go` with round-trip tests for the envd file and process APIs, including multipart upload, symlink handling, and Connect JSON streaming, ensuring the envd compatibility layer works as expected.
* Updated the toolboxd server struct and initialization in `cmd/toolboxd/main.go` to include an `envd` field and instantiate it, enabling the new compatibility surface. [[1]](diffhunk://#diff-e91f7073ddf9918c24938a18fa5277d310676570cb3e30ec5b26cd08f4866db2R42) [[2]](diffhunk://#diff-e91f7073ddf9918c24938a18fa5277d310676570cb3e30ec5b26cd08f4866db2R74)