### PR TITLE
feat: per-sandbox network usage tracking and quota enforcement

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+
+[requires]
+python_version = "3.14"

--- a/cmd/sandboxd/main.go
+++ b/cmd/sandboxd/main.go
@@ -119,6 +119,12 @@ func main() {
 	if err := svc.EnsureLayer4Ready(ctx); err != nil {
 		logger.Warn("failed to ensure caddy layer4 app at startup; will retry on first L4 exposure", "error", err)
 	}
+	// Bootstrap the netstats poller at boot so the first /network/usage call
+	// doesn't pay for it. Best-effort by design — failure here just means
+	// counters stay at zero until the next attempt at lazy bootstrap.
+	if err := svc.EnsureNetstatsReady(ctx); err != nil {
+		logger.Warn("failed to start netstats poller at startup", "error", err)
+	}
 	svc.ReplayReservations(ctx)
 
 	if cfg.AutoReconcile {

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -187,6 +187,12 @@ const getDocsSidebarConfig = (): NavigationGroup[] => [
       },
       {
         type: 'link',
+        href: '/network-usage',
+        label: 'Network Usage & Quotas',
+        description: 'Per-sandbox ingress / egress byte counters with optional caps that drop traffic when exceeded.',
+      },
+      {
+        type: 'link',
         href: '/port-allowlist',
         label: 'Port Allowlist',
         description: 'Require explicit exposure before public traffic reaches a sandbox port.',

--- a/docs/src/content/docs/network-usage.mdx
+++ b/docs/src/content/docs/network-usage.mdx
@@ -122,7 +122,7 @@ The response shape:
 | `bytes_in_limit` / `bytes_out_limit` | Active cap. `0` means unlimited. |
 | `quota_exceeded` | `true` if either direction has hit its cap. The drop rule is installed while this is true. |
 | `quota_exceeded_at` | RFC 3339 timestamp of when the quota was first hit. Cleared when the cap is raised. |
-| `last_sampled_at` | RFC 3339 timestamp of the last counter sample. |
+| `last_sampled_at` | RFC 3339 timestamp of the last counter sample. **Absent until the netstats poller has produced at least one sample** — typically up to one poll interval after a sandbox starts. |
 
 ## Raise or lift the limits at runtime
 

--- a/docs/src/content/docs/network-usage.mdx
+++ b/docs/src/content/docs/network-usage.mdx
@@ -1,0 +1,199 @@
+---
+title: Network Usage
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+Every sandbox has a per-direction byte counter and an optional cap. You can set the cap at create time, read live counters, and raise or lift the cap while the sandbox is running. When a cap is hit, the platform installs an iptables drop on the sandbox's container IP — the container keeps running, but its network goes dark until the cap is raised.
+
+This is the model AerolVM uses for billing-style network quotas and for shutting down a sandbox that has started behaving badly without killing it outright.
+
+## How it works
+
+- Counters are sampled from `/proc/<pid>/net/dev` at a fixed interval and persisted to the sandbox row. They are cumulative across container restarts.
+- `bytes_in` is ingress (rx, traffic delivered to the container). `bytes_out` is egress (tx, traffic sent from the container).
+- A cap of `0` means unlimited. This is the default and matches the historical behaviour.
+- When `bytes_in >= bytes_in_limit` (and the limit is non-zero), the platform installs an ingress drop. The same applies to egress. `quota_exceeded` flips to `true` and `quota_exceeded_at` is set.
+- Raising the cap above current usage clears the drop on the next reconcile pass, or immediately when you call `setNetworkLimits` with a higher limit.
+
+## Create a sandbox with limits
+
+Caps are optional fields on the create request. Either or both can be set; omit a field (or pass `0`) to leave it unlimited.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    const sandbox = await client.create({
+      image: 'ubuntu:22.04',
+      networkBytesInLimit:  1 * 1024 * 1024 * 1024, // 1 GiB ingress
+      networkBytesOutLimit: 5 * 1024 * 1024 * 1024, // 5 GiB egress
+    })
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    sandbox = client.create({
+        'image': 'ubuntu:22.04',
+        'networkBytesInLimit':  1 * 1024 * 1024 * 1024,
+        'networkBytesOutLimit': 5 * 1024 * 1024 * 1024,
+    })
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    sandbox, err := client.Create(ctx, sdktypes.CreateSandboxOptions{
+        Image:                "ubuntu:22.04",
+        NetworkBytesInLimit:  1 << 30,
+        NetworkBytesOutLimit: 5 << 30,
+    })
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let sandbox = client.create(CreateOptions {
+        image: "ubuntu:22.04".to_string(),
+        network_bytes_in_limit:  Some(1 << 30),
+        network_bytes_out_limit: Some(5 << 30),
+        ..Default::default()
+    })?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    import ai.aerol.microvm.model.CreateOptions;
+
+    Sandbox sandbox = client.create(
+        new CreateOptions()
+            .setImage("ubuntu:22.04")
+            .setNetworkBytesInLimit(1L << 30)
+            .setNetworkBytesOutLimit(5L << 30)
+    );
+    ```
+  </TabItem>
+</Tabs>
+
+## Read current usage
+
+`getNetworkUsage` returns the latest cumulative counters, the active caps, and whether the quota has been exceeded.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    const usage = await sandbox.getNetworkUsage()
+    console.log(usage.bytesIn, usage.bytesOut, usage.quotaExceeded)
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    usage = sandbox.get_network_usage()
+    print(usage['bytesIn'], usage['bytesOut'], usage['quotaExceeded'])
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    usage, err := sandbox.GetNetworkUsage(ctx)
+    if err != nil {
+        return err
+    }
+    fmt.Println(usage.BytesIn, usage.BytesOut, usage.QuotaExceeded)
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let usage = sandbox.get_network_usage()?;
+    println!("{} {} {}", usage.bytes_in, usage.bytes_out, usage.quota_exceeded);
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    import ai.aerol.microvm.model.NetworkUsage;
+
+    NetworkUsage usage = sandbox.getNetworkUsage();
+    System.out.println(usage.bytesIn + " " + usage.bytesOut + " " + usage.quotaExceeded);
+    ```
+  </TabItem>
+</Tabs>
+
+The response shape:
+
+| Field | Meaning |
+|---|---|
+| `bytes_in` / `bytes_out` | Cumulative ingress / egress in bytes since the sandbox was created. |
+| `bytes_in_limit` / `bytes_out_limit` | Active cap. `0` means unlimited. |
+| `quota_exceeded` | `true` if either direction has hit its cap. The drop rule is installed while this is true. |
+| `quota_exceeded_at` | RFC 3339 timestamp of when the quota was first hit. Cleared when the cap is raised. |
+| `last_sampled_at` | RFC 3339 timestamp of the last counter sample. |
+
+## Raise or lift the limits at runtime
+
+`setNetworkLimits` is a PATCH — only the fields you set are changed. Pass `0` to lift a cap (back to unlimited), or a higher number to raise it. Omit a field to leave it alone.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    // Raise the egress cap to 20 GiB; leave ingress alone.
+    const usage = await sandbox.setNetworkLimits({
+      networkBytesOutLimit: 20 * 1024 * 1024 * 1024,
+    })
+
+    // Lift the ingress cap entirely (0 = unlimited).
+    await sandbox.setNetworkLimits({ networkBytesInLimit: 0 })
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    usage = sandbox.set_network_limits({
+        'networkBytesOutLimit': 20 * 1024 * 1024 * 1024,
+    })
+
+    sandbox.set_network_limits({'networkBytesInLimit': 0})
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    out := int64(20) << 30
+    usage, err := sandbox.SetNetworkLimits(ctx, sdktypes.SetNetworkLimitsOptions{
+        NetworkBytesOutLimit: &out,
+    })
+    if err != nil {
+        return err
+    }
+
+    zero := int64(0)
+    if _, err := sandbox.SetNetworkLimits(ctx, sdktypes.SetNetworkLimitsOptions{
+        NetworkBytesInLimit: &zero,
+    }); err != nil {
+        return err
+    }
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let usage = sandbox.set_network_limits(SetNetworkLimitsOptions {
+        network_bytes_out_limit: Some(20 << 30),
+        ..Default::default()
+    })?;
+
+    sandbox.set_network_limits(SetNetworkLimitsOptions {
+        network_bytes_in_limit: Some(0),
+        ..Default::default()
+    })?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    import ai.aerol.microvm.model.NetworkUsage;
+    import ai.aerol.microvm.model.SetNetworkLimitsOptions;
+
+    NetworkUsage usage = sandbox.setNetworkLimits(
+        new SetNetworkLimitsOptions().setNetworkBytesOutLimit(20L << 30)
+    );
+
+    sandbox.setNetworkLimits(
+        new SetNetworkLimitsOptions().setNetworkBytesInLimit(0L)
+    );
+    ```
+  </TabItem>
+</Tabs>
+
+When the new cap is above current usage, the per-IP drop is removed immediately and traffic flows again. When the new cap is still below usage, the drop stays in place until usage falls back under the limit (which only happens when you raise it further or destroy the sandbox).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	DockerRuntimeWaitTimeout    time.Duration
 	ToolboxWaitTimeout          time.Duration
 	ReconcileInterval           time.Duration
+	NetstatsPollInterval        time.Duration
 	UploadMaxBytes              int64
 
 	// Admission control. Admission is purely resource-math: CPU/memory
@@ -147,6 +148,7 @@ func Load() (Config, error) {
 		DockerRuntimeWaitTimeout:    getEnvDuration("SB_DOCKER_WAIT_TIMEOUT", 30*time.Second),
 		ToolboxWaitTimeout:          getEnvDuration("SB_TOOLBOX_WAIT_TIMEOUT", 30*time.Second),
 		ReconcileInterval:           getEnvDuration("SB_RECONCILE_INTERVAL", 5*time.Minute),
+		NetstatsPollInterval:        getEnvDuration("SB_NETSTATS_POLL_INTERVAL", 10*time.Second),
 		UploadMaxBytes:              int64(getEnvInt("SB_UPLOAD_MAX_BYTES", 256*1024*1024)),
 
 		CPUReservationRatio:       getEnvFloat("SB_CPU_RESERVATION_RATIO", 0.9),

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -80,4 +80,23 @@ type Runtime interface {
 	// cycles (which clear it on the stop event) and after host-side state
 	// loss (iptables flush, daemon restart that rebuilds chains).
 	ApplyNetworkBlockAll(containerIP string) error
+
+	// ApplyNetworkBlockIngress installs the per-IP ingress DROP rule. Used
+	// by the network-quota enforcer when net_bytes_in_limit is crossed.
+	// Idempotent at the netrules layer. Distinct from the egress block so
+	// quota enforcement composes with NetworkBlockAll independently on each
+	// direction.
+	ApplyNetworkBlockIngress(containerIP string) error
+
+	// ClearNetworkBlockIngress removes the per-IP ingress DROP rule. The
+	// caller is responsible for not racing this against quota state — the
+	// service layer only clears when limits are raised above current usage.
+	ClearNetworkBlockIngress(containerIP string) error
+
+	// ClearNetworkBlockEgress removes the per-IP egress DROP rule. Symmetric
+	// to ApplyNetworkBlockAll for callers that need to walk back a quota-
+	// driven block without also undoing NetworkBlockAll. Today the underlying
+	// rule is shared, so the service must consult NetworkBlockAll before
+	// invoking this on a quota-clear path.
+	ClearNetworkBlockEgress(containerIP string) error
 }

--- a/internal/service/capacity_lifecycle_test.go
+++ b/internal/service/capacity_lifecycle_test.go
@@ -63,8 +63,11 @@ func (f *fakeCapacityRuntime) RemoveImage(context.Context, string) error { retur
 func (f *fakeCapacityRuntime) PushAllowedPorts(context.Context, string, string, []int) error {
 	return nil
 }
-func (f *fakeCapacityRuntime) ClearNetworkRules(string) error    { return nil }
-func (f *fakeCapacityRuntime) ApplyNetworkBlockAll(string) error { return nil }
+func (f *fakeCapacityRuntime) ClearNetworkRules(string) error        { return nil }
+func (f *fakeCapacityRuntime) ApplyNetworkBlockAll(string) error     { return nil }
+func (f *fakeCapacityRuntime) ApplyNetworkBlockIngress(string) error { return nil }
+func (f *fakeCapacityRuntime) ClearNetworkBlockIngress(string) error { return nil }
+func (f *fakeCapacityRuntime) ClearNetworkBlockEgress(string) error  { return nil }
 
 func newCapacityHarness(t *testing.T, managed, inspect map[string]*models.SandboxRuntimeState) (*Service, *capacity.Admitter, *store.Store) {
 	t.Helper()

--- a/internal/service/gc_zombie_test.go
+++ b/internal/service/gc_zombie_test.go
@@ -148,15 +148,15 @@ func TestGCZombieCaddyEntries(t *testing.T) {
 	fake.l4TLSRouteIDs["sandbox-abc-port-6379-tls"] = struct{}{}
 
 	// Zombies that must be deleted.
-	fake.httpRouteIDs["sandbox-ded"] = struct{}{}                       // destroyed sandbox
-	fake.httpRouteIDs["sandbox-ghost-port-8080"] = struct{}{}           // sandbox row no longer in DB
-	fake.l4TCPServerIDs["tcp-port-39999"] = struct{}{}                  // host port reservation lost
-	fake.l4TLSRouteIDs["sandbox-ded-port-6379-tls"] = struct{}{}        // destroyed sandbox's TLS route
-	fake.l4TLSRouteIDs["sandbox-ghost-port-1234-tls"] = struct{}{}      // unrelated TLS route
+	fake.httpRouteIDs["sandbox-ded"] = struct{}{}                  // destroyed sandbox
+	fake.httpRouteIDs["sandbox-ghost-port-8080"] = struct{}{}      // sandbox row no longer in DB
+	fake.l4TCPServerIDs["tcp-port-39999"] = struct{}{}             // host port reservation lost
+	fake.l4TLSRouteIDs["sandbox-ded-port-6379-tls"] = struct{}{}   // destroyed sandbox's TLS route
+	fake.l4TLSRouteIDs["sandbox-ghost-port-1234-tls"] = struct{}{} // unrelated TLS route
 
 	// Non-matching prefixes — must not be touched.
-	fake.httpRouteIDs["unrelated-route"] = struct{}{}                   // no "sandbox-" prefix
-	fake.l4TCPServerIDs["operator-managed-server"] = struct{}{}         // no "tcp-port-" prefix
+	fake.httpRouteIDs["unrelated-route"] = struct{}{}           // no "sandbox-" prefix
+	fake.l4TCPServerIDs["operator-managed-server"] = struct{}{} // no "tcp-port-" prefix
 
 	server := httptest.NewServer(fake.handler(t))
 	t.Cleanup(server.Close)

--- a/internal/service/netstats.go
+++ b/internal/service/netstats.go
@@ -1,0 +1,227 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/docker/netstats"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// EnsureNetstatsReady boots the per-sandbox network byte-counter poller
+// under a single-flight latch. Same lazy-bootstrap shape as
+// EnsureLayer4Ready: caller pays the bootstrap cost only once across the
+// daemon's lifetime, and the poller goroutine survives until ctx — typically
+// the daemon's signal context — is cancelled.
+//
+// Failure here is non-fatal: callers log and continue. Without the poller,
+// network counters stay at zero and quotas never trigger; both Create and
+// reads of /network/usage still work.
+func (s *Service) EnsureNetstatsReady(ctx context.Context) error {
+	if s.netstatsReady.Load() {
+		return nil
+	}
+	s.netstatsMu.Lock()
+	defer s.netstatsMu.Unlock()
+	if s.netstatsReady.Load() {
+		return nil
+	}
+	if s.cfg.NetstatsPollInterval <= 0 {
+		return errors.New("netstats poll interval must be > 0")
+	}
+	if s.events == nil {
+		return errors.New("netstats requires the docker events client for PID lookup")
+	}
+
+	poller := netstats.NewPoller(
+		s.logger,
+		netstats.NewReader(),
+		s.events,
+		netstatsServiceLister{svc: s},
+		netstatsServiceSink{svc: s},
+		s.cfg.NetstatsPollInterval,
+	)
+	if err := poller.Start(ctx); err != nil {
+		return fmt.Errorf("start netstats poller: %w", err)
+	}
+	s.netstatsPoller = poller
+	s.netstatsReady.Store(true)
+	return nil
+}
+
+// GetNetworkUsage returns the current cumulative byte counters and
+// configured limits for a sandbox. Callers handle ErrNotFound translation.
+func (s *Service) GetNetworkUsage(ctx context.Context, id string) (*models.NetworkUsage, error) {
+	sandbox, err := s.store.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	usage := &models.NetworkUsage{
+		SandboxID:       sandbox.ID,
+		BytesIn:         sandbox.NetworkBytesIn,
+		BytesOut:        sandbox.NetworkBytesOut,
+		BytesInLimit:    sandbox.NetworkBytesInLimit,
+		BytesOutLimit:   sandbox.NetworkBytesOutLimit,
+		QuotaExceeded:   sandbox.NetworkQuotaExceeded,
+		QuotaExceededAt: sandbox.NetworkQuotaExceededAt,
+	}
+	if last := s.netstatsLastTick.Load(); last > 0 {
+		usage.LastSampledAt = time.Unix(0, last).UTC()
+	}
+	return usage, nil
+}
+
+// SetNetworkLimits writes new caps (0 = unlimited) and re-evaluates the
+// quota state. If the new limit moves the sandbox back under-quota, the
+// matching ingress/egress block is cleared. If it leaves the sandbox over,
+// the matching block is (re-)applied.
+//
+// Egress clears are conditional: NetworkBlockAll uses the same DOCKER-USER
+// row as the quota egress block, so we must not lift it here when the
+// operator's blanket egress block is still on. See pkg/docker/netrules
+// commentary on the shared rule.
+func (s *Service) SetNetworkLimits(ctx context.Context, id string, bytesInLimit, bytesOutLimit int64) (*models.NetworkUsage, error) {
+	if bytesInLimit < 0 || bytesOutLimit < 0 {
+		return nil, errors.New("network byte limits must be >= 0")
+	}
+	if err := s.store.SetNetworkLimits(ctx, id, bytesInLimit, bytesOutLimit); err != nil {
+		return nil, err
+	}
+	sandbox, err := s.store.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	overIn := bytesInLimit > 0 && sandbox.NetworkBytesIn >= bytesInLimit
+	overOut := bytesOutLimit > 0 && sandbox.NetworkBytesOut >= bytesOutLimit
+	s.applyNetworkQuotaState(ctx, sandbox, overIn, overOut)
+
+	return s.GetNetworkUsage(ctx, id)
+}
+
+// applyNetworkQuotaState reconciles iptables and the quota flag with the
+// observed (over-in, over-out) state for a single sandbox. Idempotent on
+// both sides — called from the poller sink, the SetNetworkLimits path, and
+// the reconcile re-heal path.
+func (s *Service) applyNetworkQuotaState(ctx context.Context, sandbox *models.Sandbox, overIn, overOut bool) {
+	if sandbox == nil || sandbox.ContainerIP == "" {
+		return
+	}
+
+	// Egress: only clear when NetworkBlockAll is also off. NetworkBlockAll
+	// owns the same DOCKER-USER row, so ApplyNetworkBlockAll is the right
+	// shared installer for the quota path too.
+	if overOut {
+		if err := s.docker.ApplyNetworkBlockAll(sandbox.ContainerIP); err != nil {
+			s.logger.Warn("apply quota egress block failed",
+				"sandbox_id", sandbox.ID, "ip", sandbox.ContainerIP, "error", err)
+		}
+	} else if !sandbox.NetworkBlockAll {
+		if err := s.docker.ClearNetworkBlockEgress(sandbox.ContainerIP); err != nil {
+			s.logger.Warn("clear quota egress block failed",
+				"sandbox_id", sandbox.ID, "ip", sandbox.ContainerIP, "error", err)
+		}
+	}
+
+	if overIn {
+		if err := s.docker.ApplyNetworkBlockIngress(sandbox.ContainerIP); err != nil {
+			s.logger.Warn("apply quota ingress block failed",
+				"sandbox_id", sandbox.ID, "ip", sandbox.ContainerIP, "error", err)
+		}
+	} else {
+		if err := s.docker.ClearNetworkBlockIngress(sandbox.ContainerIP); err != nil {
+			s.logger.Warn("clear quota ingress block failed",
+				"sandbox_id", sandbox.ID, "ip", sandbox.ContainerIP, "error", err)
+		}
+	}
+
+	if overIn || overOut {
+		if err := s.store.MarkNetworkQuotaExceeded(ctx, sandbox.ID, time.Now().UTC()); err != nil && !errors.Is(err, store.ErrNotFound) {
+			s.logger.Warn("mark network quota exceeded failed",
+				"sandbox_id", sandbox.ID, "error", err)
+		}
+	} else if sandbox.NetworkQuotaExceeded {
+		if err := s.store.ClearNetworkQuotaExceeded(ctx, sandbox.ID); err != nil && !errors.Is(err, store.ErrNotFound) {
+			s.logger.Warn("clear network quota exceeded failed",
+				"sandbox_id", sandbox.ID, "error", err)
+		}
+	}
+}
+
+// netstatsServiceLister adapts Service to the netstats.SandboxLister
+// interface. Defined as a wrapper struct so Service itself doesn't grow a
+// public NetstatsTargets method that would be confusing on the API surface.
+type netstatsServiceLister struct{ svc *Service }
+
+func (l netstatsServiceLister) NetstatsTargets(ctx context.Context) []netstats.Target {
+	sandboxes, err := l.svc.store.List(ctx)
+	if err != nil {
+		l.svc.logger.Warn("netstats: list sandboxes failed", "error", err)
+		return nil
+	}
+	out := make([]netstats.Target, 0, len(sandboxes))
+	for _, sb := range sandboxes {
+		if sb == nil || sb.Status != models.SandboxStatusStarted {
+			continue
+		}
+		// Sandboxes with both limits at 0 (unlimited) and counters already
+		// at 0 are still polled — operators expect /network/usage to reflect
+		// real traffic even before they set a limit. Skip empty container
+		// refs which would otherwise hit the PID lookup path uselessly.
+		ref := sb.ContainerID
+		if ref == "" {
+			ref = sb.ID
+		}
+		out = append(out, netstats.Target{SandboxID: sb.ID, ContainerRef: ref})
+	}
+	return out
+}
+
+// netstatsServiceSink adapts Service to the netstats.SampleSink interface.
+type netstatsServiceSink struct{ svc *Service }
+
+func (k netstatsServiceSink) HandleSamples(ctx context.Context, samples []netstats.Sample) {
+	if len(samples) == 0 {
+		return
+	}
+	for _, sample := range samples {
+		if sample.BytesIn == 0 && sample.BytesOut == 0 {
+			continue
+		}
+		if err := k.svc.store.UpdateSandboxNetCounters(ctx, sample.SandboxID, sample.BytesIn, sample.BytesOut); err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				continue
+			}
+			k.svc.logger.Warn("netstats: update counters failed",
+				"sandbox_id", sample.SandboxID, "error", err)
+			continue
+		}
+
+		// After persisting deltas, re-read the row so the quota check works
+		// against the post-update cumulative — including any concurrent
+		// SetNetworkLimits change to the caps. Cheap: SQLite, single row,
+		// already in cache.
+		sandbox, err := k.svc.store.Get(ctx, sample.SandboxID)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				continue
+			}
+			k.svc.logger.Warn("netstats: re-fetch sandbox failed",
+				"sandbox_id", sample.SandboxID, "error", err)
+			continue
+		}
+
+		overIn := sandbox.NetworkBytesInLimit > 0 && sandbox.NetworkBytesIn >= sandbox.NetworkBytesInLimit
+		overOut := sandbox.NetworkBytesOutLimit > 0 && sandbox.NetworkBytesOut >= sandbox.NetworkBytesOutLimit
+		if overIn || overOut || sandbox.NetworkQuotaExceeded {
+			k.svc.applyNetworkQuotaState(ctx, sandbox, overIn, overOut)
+		}
+	}
+
+	if len(samples) > 0 {
+		k.svc.netstatsLastTick.Store(samples[len(samples)-1].SampledAt.UnixNano())
+	}
+}

--- a/internal/service/netstats.go
+++ b/internal/service/netstats.go
@@ -79,7 +79,8 @@ func (s *Service) GetNetworkUsage(ctx context.Context, id string) (*models.Netwo
 		QuotaExceededAt: sandbox.NetworkQuotaExceededAt,
 	}
 	if last := s.netstatsLastTick.Load(); last > 0 {
-		usage.LastSampledAt = time.Unix(0, last).UTC()
+		t := time.Unix(0, last).UTC()
+		usage.LastSampledAt = &t
 	}
 	return usage, nil
 }

--- a/internal/service/netstats.go
+++ b/internal/service/netstats.go
@@ -54,7 +54,17 @@ func (s *Service) EnsureNetstatsReady(ctx context.Context) error {
 
 // GetNetworkUsage returns the current cumulative byte counters and
 // configured limits for a sandbox. Callers handle ErrNotFound translation.
+//
+// Best-effort lazy bootstrap of the netstats poller: if boot's
+// EnsureNetstatsReady failed (cold-start race against the docker daemon, etc.)
+// this call retries it under the same single-flight latch. Failure is logged
+// and swallowed — the caller still gets back whatever counters the store has,
+// and the next call will retry again.
 func (s *Service) GetNetworkUsage(ctx context.Context, id string) (*models.NetworkUsage, error) {
+	if err := s.EnsureNetstatsReady(ctx); err != nil {
+		s.logger.Warn("netstats lazy bootstrap failed; counters may be stale",
+			"sandbox_id", id, "error", err)
+	}
 	sandbox, err := s.store.Get(ctx, id)
 	if err != nil {
 		return nil, err
@@ -87,6 +97,16 @@ func (s *Service) SetNetworkLimits(ctx context.Context, id string, bytesInLimit,
 	if bytesInLimit < 0 || bytesOutLimit < 0 {
 		return nil, errors.New("network byte limits must be >= 0")
 	}
+	// Stronger lazy-bootstrap case than GetNetworkUsage: setting a limit
+	// implies the operator wants enforcement to start. If the poller is
+	// down, "limit set, never enforced" is silent failure of a security
+	// control. Best-effort still — the limit is persisted either way and
+	// reconcile will re-evaluate; this just shortens the window before the
+	// poller starts feeding the quota check.
+	if err := s.EnsureNetstatsReady(ctx); err != nil {
+		s.logger.Warn("netstats lazy bootstrap failed; quota enforcement may be delayed",
+			"sandbox_id", id, "error", err)
+	}
 	if err := s.store.SetNetworkLimits(ctx, id, bytesInLimit, bytesOutLimit); err != nil {
 		return nil, err
 	}
@@ -107,34 +127,44 @@ func (s *Service) SetNetworkLimits(ctx context.Context, id string, bytesInLimit,
 // both sides — called from the poller sink, the SetNetworkLimits path, and
 // the reconcile re-heal path.
 func (s *Service) applyNetworkQuotaState(ctx context.Context, sandbox *models.Sandbox, overIn, overOut bool) {
-	if sandbox == nil || sandbox.ContainerIP == "" {
+	if sandbox == nil {
 		return
 	}
 
-	// Egress: only clear when NetworkBlockAll is also off. NetworkBlockAll
-	// owns the same DOCKER-USER row, so ApplyNetworkBlockAll is the right
-	// shared installer for the quota path too.
-	if overOut {
-		if err := s.docker.ApplyNetworkBlockAll(sandbox.ContainerIP); err != nil {
-			s.logger.Warn("apply quota egress block failed",
-				"sandbox_id", sandbox.ID, "ip", sandbox.ContainerIP, "error", err)
+	// iptables reconciliation needs an IP to install rules against. A
+	// sandbox in a state with no ContainerIP (stopped, between create and
+	// runtime ready, etc.) has nothing to firewall — Start / reconcile
+	// reapplies quota state via this same function once an IP exists.
+	// Store-flag reconciliation below is intentionally NOT gated on the IP:
+	// without that, a sandbox stopped while over-quota would have its
+	// `quota_exceeded` flag stuck true even after the operator raises the
+	// limit and the over-quota condition no longer holds.
+	if sandbox.ContainerIP != "" {
+		// Egress: only clear when NetworkBlockAll is also off. NetworkBlockAll
+		// owns the same DOCKER-USER row, so ApplyNetworkBlockAll is the right
+		// shared installer for the quota path too.
+		if overOut {
+			if err := s.docker.ApplyNetworkBlockAll(sandbox.ContainerIP); err != nil {
+				s.logger.Warn("apply quota egress block failed",
+					"sandbox_id", sandbox.ID, "ip", sandbox.ContainerIP, "error", err)
+			}
+		} else if !sandbox.NetworkBlockAll {
+			if err := s.docker.ClearNetworkBlockEgress(sandbox.ContainerIP); err != nil {
+				s.logger.Warn("clear quota egress block failed",
+					"sandbox_id", sandbox.ID, "ip", sandbox.ContainerIP, "error", err)
+			}
 		}
-	} else if !sandbox.NetworkBlockAll {
-		if err := s.docker.ClearNetworkBlockEgress(sandbox.ContainerIP); err != nil {
-			s.logger.Warn("clear quota egress block failed",
-				"sandbox_id", sandbox.ID, "ip", sandbox.ContainerIP, "error", err)
-		}
-	}
 
-	if overIn {
-		if err := s.docker.ApplyNetworkBlockIngress(sandbox.ContainerIP); err != nil {
-			s.logger.Warn("apply quota ingress block failed",
-				"sandbox_id", sandbox.ID, "ip", sandbox.ContainerIP, "error", err)
-		}
-	} else {
-		if err := s.docker.ClearNetworkBlockIngress(sandbox.ContainerIP); err != nil {
-			s.logger.Warn("clear quota ingress block failed",
-				"sandbox_id", sandbox.ID, "ip", sandbox.ContainerIP, "error", err)
+		if overIn {
+			if err := s.docker.ApplyNetworkBlockIngress(sandbox.ContainerIP); err != nil {
+				s.logger.Warn("apply quota ingress block failed",
+					"sandbox_id", sandbox.ID, "ip", sandbox.ContainerIP, "error", err)
+			}
+		} else {
+			if err := s.docker.ClearNetworkBlockIngress(sandbox.ContainerIP); err != nil {
+				s.logger.Warn("clear quota ingress block failed",
+					"sandbox_id", sandbox.ID, "ip", sandbox.ContainerIP, "error", err)
+			}
 		}
 	}
 

--- a/internal/service/reconcile_destroy_test.go
+++ b/internal/service/reconcile_destroy_test.go
@@ -75,6 +75,15 @@ func (f *fakeReconcileRuntime) ClearNetworkRules(string) error {
 func (f *fakeReconcileRuntime) ApplyNetworkBlockAll(string) error {
 	return nil
 }
+func (f *fakeReconcileRuntime) ApplyNetworkBlockIngress(string) error {
+	return nil
+}
+func (f *fakeReconcileRuntime) ClearNetworkBlockIngress(string) error {
+	return nil
+}
+func (f *fakeReconcileRuntime) ClearNetworkBlockEgress(string) error {
+	return nil
+}
 
 // TestReconcileDestroyedRowFreesHostPort is the regression test required by
 // pr-review.md §5: a destroyed sandbox must free its TCP host_port reservation

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -138,6 +138,12 @@ func (s *Service) CreateSandbox(ctx context.Context, req models.CreateSandboxReq
 		}
 	}
 
+	// Mirror SetNetworkLimits: enforcement uses `limit > 0`, so a negative
+	// value would silently behave as unlimited and bypass the quota.
+	if req.NetworkBytesInLimit < 0 || req.NetworkBytesOutLimit < 0 {
+		return nil, errors.New("network byte limits must be >= 0")
+	}
+
 	sealedMounts, err := s.sealMounts(req.Mounts)
 	if err != nil {
 		return nil, err

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aerol-ai/microvm/pkg/caddy"
 	"github.com/aerol-ai/microvm/pkg/capacity"
 	"github.com/aerol-ai/microvm/pkg/docker"
+	"github.com/aerol-ai/microvm/pkg/docker/netstats"
 	"github.com/aerol-ai/microvm/pkg/models"
 	"github.com/aerol-ai/microvm/pkg/mounts"
 	"github.com/aerol-ai/microvm/pkg/secrets"
@@ -61,6 +62,16 @@ type Service struct {
 	l4Mu       sync.Mutex
 	l4Ready    atomic.Bool
 	snapshotMu sync.Mutex
+
+	// netstatsReady latches the lazy bootstrap of the per-sandbox network
+	// byte-counter poller. Same pattern as l4Ready: atomic fast-path on the
+	// hot side, single-flight Mutex on the cold-start side. The poller is
+	// kicked off either at daemon boot (best-effort) or on the first request
+	// that needs network usage data — whichever happens first.
+	netstatsMu       sync.Mutex
+	netstatsReady    atomic.Bool
+	netstatsPoller   *netstats.Poller
+	netstatsLastTick atomic.Int64 // unix nanos; last successful tick for /usage staleness reporting
 }
 
 func New(cfg config.Config, logger *slog.Logger, db *store.Store, runtimeDriver runtime.Runtime, eventsClient *docker.Client, caddyClient *caddy.Client, cipher *secrets.Cipher, mountManager *mounts.Manager, admitter *capacity.Admitter) *Service {
@@ -187,30 +198,32 @@ func (s *Service) CreateSandbox(ctx context.Context, req models.CreateSandboxReq
 
 	now := time.Now().UTC()
 	sandbox := &models.Sandbox{
-		ID:               state.SandboxID,
-		Image:            req.Image,
-		Status:           state.Status,
-		PublicURL:        s.caddy.SandboxPublicURL(state.SandboxID),
-		ContainerID:      state.ContainerID,
-		ContainerIP:      state.ContainerIP,
-		CPU:              req.CPU,
-		MemoryMB:         req.MemoryMB,
-		DiskGB:           req.DiskGB,
-		OSUser:           req.OSUser,
-		Env:              req.Env,
-		NetworkBlockAll:  req.NetworkBlockAll,
-		ToolboxEnabled:   true,
-		ToolboxToken:     toolboxToken,
-		SSHPublicKey:     authorizedKey,
-		Name:             strings.TrimSpace(req.Name),
-		Tags:             req.Tags,
-		CreatedAt:        now,
-		UpdatedAt:        now,
-		LastActiveAt:     now,
-		ContainerCommand: req.ContainerCommand,
-		Lifecycle:        lifecycle,
-		Runtime:          chosenRuntime,
-		GPUs:             req.GPUs,
+		ID:                   state.SandboxID,
+		Image:                req.Image,
+		Status:               state.Status,
+		PublicURL:            s.caddy.SandboxPublicURL(state.SandboxID),
+		ContainerID:          state.ContainerID,
+		ContainerIP:          state.ContainerIP,
+		CPU:                  req.CPU,
+		MemoryMB:             req.MemoryMB,
+		DiskGB:               req.DiskGB,
+		OSUser:               req.OSUser,
+		Env:                  req.Env,
+		NetworkBlockAll:      req.NetworkBlockAll,
+		ToolboxEnabled:       true,
+		ToolboxToken:         toolboxToken,
+		SSHPublicKey:         authorizedKey,
+		Name:                 strings.TrimSpace(req.Name),
+		Tags:                 req.Tags,
+		CreatedAt:            now,
+		UpdatedAt:            now,
+		LastActiveAt:         now,
+		ContainerCommand:     req.ContainerCommand,
+		Lifecycle:            lifecycle,
+		Runtime:              chosenRuntime,
+		GPUs:                 req.GPUs,
+		NetworkBytesInLimit:  req.NetworkBytesInLimit,
+		NetworkBytesOutLimit: req.NetworkBytesOutLimit,
 	}
 
 	if err := s.caddy.UpsertSandboxRoute(ctx, sandbox.ID, sandbox.ContainerIP, s.cfg.ToolboxPort); err != nil {
@@ -1170,6 +1183,17 @@ func (s *Service) Reconcile(ctx context.Context) error {
 						"error", err,
 					)
 				}
+			}
+			// Heal quota-driven blocks. The flag is the source of truth for
+			// "we previously decided to block"; re-evaluate against the
+			// current cumulative counters so a quota raised over the wire
+			// while sandboxd was down clears as part of the same pass.
+			if sandbox.NetworkQuotaExceeded ||
+				(sandbox.NetworkBytesInLimit > 0 && sandbox.NetworkBytesIn >= sandbox.NetworkBytesInLimit) ||
+				(sandbox.NetworkBytesOutLimit > 0 && sandbox.NetworkBytesOut >= sandbox.NetworkBytesOutLimit) {
+				overIn := sandbox.NetworkBytesInLimit > 0 && sandbox.NetworkBytesIn >= sandbox.NetworkBytesInLimit
+				overOut := sandbox.NetworkBytesOutLimit > 0 && sandbox.NetworkBytesOut >= sandbox.NetworkBytesOutLimit
+				s.applyNetworkQuotaState(ctx, sandbox, overIn, overOut)
 			}
 			if err := s.caddy.UpsertSandboxRoute(ctx, sandbox.ID, sandbox.ContainerIP, s.cfg.ToolboxPort); err != nil {
 				return err

--- a/internal/service/snapshot_test.go
+++ b/internal/service/snapshot_test.go
@@ -65,8 +65,11 @@ func (f *fakeSnapshotRuntime) RemoveImage(_ context.Context, imageRef string) er
 func (f *fakeSnapshotRuntime) PushAllowedPorts(context.Context, string, string, []int) error {
 	panic("unexpected PushAllowedPorts")
 }
-func (f *fakeSnapshotRuntime) ClearNetworkRules(string) error    { return nil }
-func (f *fakeSnapshotRuntime) ApplyNetworkBlockAll(string) error { return nil }
+func (f *fakeSnapshotRuntime) ClearNetworkRules(string) error        { return nil }
+func (f *fakeSnapshotRuntime) ApplyNetworkBlockAll(string) error     { return nil }
+func (f *fakeSnapshotRuntime) ApplyNetworkBlockIngress(string) error { return nil }
+func (f *fakeSnapshotRuntime) ClearNetworkBlockIngress(string) error { return nil }
+func (f *fakeSnapshotRuntime) ClearNetworkBlockEgress(string) error  { return nil }
 
 func TestCreateSnapshotIdempotentByName(t *testing.T) {
 	ctx := context.Background()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -81,6 +81,12 @@ func Open(path string) (*Store, error) {
 			destroy_at_age_ns INTEGER NOT NULL DEFAULT 0,
 			runtime TEXT NOT NULL DEFAULT '',
 			gpus_json TEXT NOT NULL DEFAULT '',
+			net_bytes_in INTEGER NOT NULL DEFAULT 0,
+			net_bytes_out INTEGER NOT NULL DEFAULT 0,
+			net_bytes_in_limit INTEGER NOT NULL DEFAULT 0,
+			net_bytes_out_limit INTEGER NOT NULL DEFAULT 0,
+			net_quota_exceeded INTEGER NOT NULL DEFAULT 0,
+			net_quota_exceeded_at DATETIME,
 			created_at DATETIME NOT NULL,
 			updated_at DATETIME NOT NULL,
 			last_active_at DATETIME NOT NULL
@@ -179,6 +185,26 @@ func Open(path string) (*Store, error) {
 		}
 	}
 
+	// Additive migrations for sandboxes columns introduced after the original
+	// schema landed. Each ALTER TABLE is run unconditionally; SQLite returns
+	// "duplicate column name" when the column already exists, which we
+	// swallow so cold installs (where CREATE TABLE above already includes
+	// the column) and warm upgrades (where the column is new) both succeed.
+	migrations := []string{
+		`ALTER TABLE sandboxes ADD COLUMN net_bytes_in INTEGER NOT NULL DEFAULT 0;`,
+		`ALTER TABLE sandboxes ADD COLUMN net_bytes_out INTEGER NOT NULL DEFAULT 0;`,
+		`ALTER TABLE sandboxes ADD COLUMN net_bytes_in_limit INTEGER NOT NULL DEFAULT 0;`,
+		`ALTER TABLE sandboxes ADD COLUMN net_bytes_out_limit INTEGER NOT NULL DEFAULT 0;`,
+		`ALTER TABLE sandboxes ADD COLUMN net_quota_exceeded INTEGER NOT NULL DEFAULT 0;`,
+		`ALTER TABLE sandboxes ADD COLUMN net_quota_exceeded_at DATETIME;`,
+	}
+	for _, stmt := range migrations {
+		if _, err := db.Exec(stmt); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+			db.Close()
+			return nil, fmt.Errorf("apply schema migration %q: %w", stmt, err)
+		}
+	}
+
 	// Partial unique index on host_port (only enforced when host_port > 0).
 	// This is the load-bearing primitive of the random-first allocator: two
 	// concurrent ExposePort calls race to INSERT a host_port row, and only
@@ -251,8 +277,10 @@ func (s *Store) Create(ctx context.Context, sandbox *models.Sandbox) error {
 			os_user, env_json, network_block_all, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
-			runtime, gpus_json
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			runtime, gpus_json,
+			net_bytes_in, net_bytes_out, net_bytes_in_limit, net_bytes_out_limit,
+			net_quota_exceeded, net_quota_exceeded_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		sandbox.ID,
 		sandbox.Image,
@@ -282,6 +310,12 @@ func (s *Store) Create(ctx context.Context, sandbox *models.Sandbox) error {
 		int64(sandbox.Lifecycle.DestroyAtAge),
 		sandbox.Runtime,
 		gpusJSON,
+		sandbox.NetworkBytesIn,
+		sandbox.NetworkBytesOut,
+		sandbox.NetworkBytesInLimit,
+		sandbox.NetworkBytesOutLimit,
+		boolToInt(sandbox.NetworkQuotaExceeded),
+		nullableTime(sandbox.NetworkQuotaExceededAt),
 	)
 	if err != nil {
 		if isSandboxNameConflict(err, sandbox.Name) {
@@ -319,8 +353,10 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 			os_user, env_json, network_block_all, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
-			runtime, gpus_json
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			runtime, gpus_json,
+			net_bytes_in, net_bytes_out, net_bytes_in_limit, net_bytes_out_limit,
+			net_quota_exceeded, net_quota_exceeded_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			image = excluded.image,
 			status = excluded.status,
@@ -347,7 +383,9 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 			stop_at_age_ns = excluded.stop_at_age_ns,
 			destroy_at_age_ns = excluded.destroy_at_age_ns,
 			runtime = excluded.runtime,
-			gpus_json = excluded.gpus_json
+			gpus_json = excluded.gpus_json,
+			net_bytes_in_limit = excluded.net_bytes_in_limit,
+			net_bytes_out_limit = excluded.net_bytes_out_limit
 	`,
 		sandbox.ID,
 		sandbox.Image,
@@ -377,6 +415,12 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 		int64(sandbox.Lifecycle.DestroyAtAge),
 		sandbox.Runtime,
 		gpusJSON,
+		sandbox.NetworkBytesIn,
+		sandbox.NetworkBytesOut,
+		sandbox.NetworkBytesInLimit,
+		sandbox.NetworkBytesOutLimit,
+		boolToInt(sandbox.NetworkQuotaExceeded),
+		nullableTime(sandbox.NetworkQuotaExceededAt),
 	)
 	if err != nil {
 		if isSandboxNameConflict(err, sandbox.Name) {
@@ -393,7 +437,9 @@ func (s *Store) Get(ctx context.Context, id string) (*models.Sandbox, error) {
 			os_user, env_json, network_block_all, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
-			runtime, gpus_json
+			runtime, gpus_json,
+			net_bytes_in, net_bytes_out, net_bytes_in_limit, net_bytes_out_limit,
+			net_quota_exceeded, net_quota_exceeded_at
 		FROM sandboxes
 		WHERE id = ?
 	`, id)
@@ -421,7 +467,9 @@ func (s *Store) List(ctx context.Context) ([]*models.Sandbox, error) {
 			os_user, env_json, network_block_all, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
-			runtime, gpus_json
+			runtime, gpus_json,
+			net_bytes_in, net_bytes_out, net_bytes_in_limit, net_bytes_out_limit,
+			net_quota_exceeded, net_quota_exceeded_at
 		FROM sandboxes
 		ORDER BY created_at DESC
 	`)
@@ -566,6 +614,101 @@ func (s *Store) UpdateLifecycle(ctx context.Context, id string, l models.Lifecyc
 	)
 	if err != nil {
 		return fmt.Errorf("update sandbox lifecycle: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err == nil && affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// UpdateSandboxNetCounters bumps the cumulative ingress/egress counters by
+// the given deltas. Both values are non-negative byte counts measured since
+// the last sample. Concurrent calls are serialized by SQLite's single
+// writer, and the UPDATE is atomic so a failed sample never partially
+// applies. Returns ErrNotFound if the sandbox row was deleted between the
+// poller's snapshot and this write — the netstats poller treats that as a
+// cleanup signal and drops the in-memory baseline.
+func (s *Store) UpdateSandboxNetCounters(ctx context.Context, id string, deltaIn, deltaOut int64) error {
+	if deltaIn < 0 || deltaOut < 0 {
+		return fmt.Errorf("net counter deltas must be non-negative (in=%d out=%d)", deltaIn, deltaOut)
+	}
+	if deltaIn == 0 && deltaOut == 0 {
+		return nil
+	}
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE sandboxes
+		SET net_bytes_in = net_bytes_in + ?,
+		    net_bytes_out = net_bytes_out + ?,
+		    updated_at = ?
+		WHERE id = ?
+	`, deltaIn, deltaOut, time.Now().UTC(), id)
+	if err != nil {
+		return fmt.Errorf("update sandbox net counters: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err == nil && affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// SetNetworkLimits replaces the per-sandbox network byte caps. Zero means
+// unlimited; negative values are rejected. The handler validates first so
+// the store does not re-validate. Returns ErrNotFound if no row matches id.
+func (s *Store) SetNetworkLimits(ctx context.Context, id string, bytesInLimit, bytesOutLimit int64) error {
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE sandboxes
+		SET net_bytes_in_limit = ?,
+		    net_bytes_out_limit = ?,
+		    updated_at = ?
+		WHERE id = ?
+	`, bytesInLimit, bytesOutLimit, time.Now().UTC(), id)
+	if err != nil {
+		return fmt.Errorf("set sandbox net limits: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err == nil && affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// MarkNetworkQuotaExceeded flips the flag on. detectedAt records when the
+// crossover was first observed so the API can surface it to the SDK. Calls
+// when already-exceeded preserve the original detectedAt — the trigger time
+// is the interesting one, not the most recent re-observation.
+func (s *Store) MarkNetworkQuotaExceeded(ctx context.Context, id string, detectedAt time.Time) error {
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE sandboxes
+		SET net_quota_exceeded = 1,
+		    net_quota_exceeded_at = COALESCE(net_quota_exceeded_at, ?),
+		    updated_at = ?
+		WHERE id = ?
+	`, detectedAt.UTC(), time.Now().UTC(), id)
+	if err != nil {
+		return fmt.Errorf("mark sandbox network quota exceeded: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err == nil && affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ClearNetworkQuotaExceeded resets the flag and the detection timestamp.
+// Used when an operator raises the limit (or sets it to unlimited) and the
+// counter is no longer over the new ceiling.
+func (s *Store) ClearNetworkQuotaExceeded(ctx context.Context, id string) error {
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE sandboxes
+		SET net_quota_exceeded = 0,
+		    net_quota_exceeded_at = NULL,
+		    updated_at = ?
+		WHERE id = ?
+	`, time.Now().UTC(), id)
+	if err != nil {
+		return fmt.Errorf("clear sandbox network quota exceeded: %w", err)
 	}
 	affected, err := result.RowsAffected()
 	if err == nil && affected == 0 {
@@ -1266,6 +1409,8 @@ func scanSandbox(scanner interface {
 	var tagsJSON string
 	var gpusJSON string
 	var stopIfIdleNs, destroyIfIdleNs, stopAtAgeNs, destroyAtAgeNs int64
+	var netQuotaExceeded int
+	var netQuotaExceededAt sql.NullTime
 
 	err := scanner.Scan(
 		&sandbox.ID,
@@ -1296,9 +1441,20 @@ func scanSandbox(scanner interface {
 		&destroyAtAgeNs,
 		&sandbox.Runtime,
 		&gpusJSON,
+		&sandbox.NetworkBytesIn,
+		&sandbox.NetworkBytesOut,
+		&sandbox.NetworkBytesInLimit,
+		&sandbox.NetworkBytesOutLimit,
+		&netQuotaExceeded,
+		&netQuotaExceededAt,
 	)
 	if err != nil {
 		return nil, err
+	}
+	sandbox.NetworkQuotaExceeded = netQuotaExceeded == 1
+	if netQuotaExceededAt.Valid {
+		t := netQuotaExceededAt.Time.UTC()
+		sandbox.NetworkQuotaExceededAt = &t
 	}
 
 	if envJSON != "" {
@@ -1450,6 +1606,17 @@ func marshalGPUs(g *models.GPURequest) (string, error) {
 		return "", fmt.Errorf("marshal gpus: %w", err)
 	}
 	return string(encoded), nil
+}
+
+// nullableTime maps a *time.Time to a sql.NullTime so a nil pointer becomes
+// NULL on disk. Used by columns where "absent" is a meaningful state distinct
+// from the zero time (e.g. net_quota_exceeded_at — sandboxes under quota
+// have NULL, not 0001-01-01).
+func nullableTime(t *time.Time) sql.NullTime {
+	if t == nil || t.IsZero() {
+		return sql.NullTime{}
+	}
+	return sql.NullTime{Time: t.UTC(), Valid: true}
 }
 
 func boolToInt(value bool) int {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"os"
@@ -1200,8 +1201,12 @@ func TestStoreHelperCases(t *testing.T) {
 			"{}",                        // tags_json
 			now, now, now,               // created_at, updated_at, last_active_at
 			int64(0), int64(0), int64(0), int64(0), // lifecycle ns columns
-			"", // runtime
-			"", // gpus_json
+			"",                 // runtime
+			"",                 // gpus_json
+			int64(0), int64(0), // net_bytes_in, net_bytes_out
+			int64(0), int64(0), // net_bytes_in_limit, net_bytes_out_limit
+			0,              // net_quota_exceeded
+			sql.NullTime{}, // net_quota_exceeded_at
 		}}
 		_, err := scanSandbox(row)
 		if err == nil {

--- a/pkg/api/daytona/contract_harness_test.go
+++ b/pkg/api/daytona/contract_harness_test.go
@@ -162,8 +162,11 @@ func (f *fakeDaytonaContractRuntime) PushAllowedPorts(_ context.Context, contain
 	return nil
 }
 
-func (f *fakeDaytonaContractRuntime) ClearNetworkRules(string) error    { return nil }
-func (f *fakeDaytonaContractRuntime) ApplyNetworkBlockAll(string) error { return nil }
+func (f *fakeDaytonaContractRuntime) ClearNetworkRules(string) error        { return nil }
+func (f *fakeDaytonaContractRuntime) ApplyNetworkBlockAll(string) error     { return nil }
+func (f *fakeDaytonaContractRuntime) ApplyNetworkBlockIngress(string) error { return nil }
+func (f *fakeDaytonaContractRuntime) ClearNetworkBlockIngress(string) error { return nil }
+func (f *fakeDaytonaContractRuntime) ClearNetworkBlockEgress(string) error  { return nil }
 
 func (f *fakeDaytonaContractRuntime) seedSandbox(sandbox *models.Sandbox) {
 	if sandbox == nil {

--- a/pkg/api/daytona/handlers_test.go
+++ b/pkg/api/daytona/handlers_test.go
@@ -312,8 +312,11 @@ func (f *fakeDaytonaSnapshotRuntime) PushAllowedPorts(context.Context, string, s
 	panic("unexpected PushAllowedPorts")
 }
 
-func (f *fakeDaytonaSnapshotRuntime) ClearNetworkRules(string) error    { return nil }
-func (f *fakeDaytonaSnapshotRuntime) ApplyNetworkBlockAll(string) error { return nil }
+func (f *fakeDaytonaSnapshotRuntime) ClearNetworkRules(string) error        { return nil }
+func (f *fakeDaytonaSnapshotRuntime) ApplyNetworkBlockAll(string) error     { return nil }
+func (f *fakeDaytonaSnapshotRuntime) ApplyNetworkBlockIngress(string) error { return nil }
+func (f *fakeDaytonaSnapshotRuntime) ClearNetworkBlockIngress(string) error { return nil }
+func (f *fakeDaytonaSnapshotRuntime) ClearNetworkBlockEgress(string) error  { return nil }
 
 func newSnapshotHandlerTestEnv(t *testing.T) (*service.Service, *store.Store, *fakeDaytonaSnapshotRuntime, http.Handler) {
 	t.Helper()

--- a/pkg/api/e2b/handlers.go
+++ b/pkg/api/e2b/handlers.go
@@ -1118,4 +1118,3 @@ func writeJSON(w http.ResponseWriter, status int, value any) {
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(value)
 }
-

--- a/pkg/api/e2b/handlers_test.go
+++ b/pkg/api/e2b/handlers_test.go
@@ -534,6 +534,9 @@ func (f *fakeE2BRuntime) RemoveImage(_ context.Context, imageRef string) error {
 func (f *fakeE2BRuntime) PushAllowedPorts(context.Context, string, string, []int) error { return nil }
 func (f *fakeE2BRuntime) ClearNetworkRules(string) error                                { return nil }
 func (f *fakeE2BRuntime) ApplyNetworkBlockAll(string) error                             { return nil }
+func (f *fakeE2BRuntime) ApplyNetworkBlockIngress(string) error                         { return nil }
+func (f *fakeE2BRuntime) ClearNetworkBlockIngress(string) error                         { return nil }
+func (f *fakeE2BRuntime) ClearNetworkBlockEgress(string) error                          { return nil }
 
 func (f *fakeE2BRuntime) lookup(containerRef string) (*models.SandboxRuntimeState, bool) {
 	if state, ok := f.states[containerRef]; ok {

--- a/pkg/api/v1/handlers.go
+++ b/pkg/api/v1/handlers.go
@@ -178,3 +178,43 @@ func (h *handlers) listMounts(w http.ResponseWriter, r *http.Request) {
 	}
 	apihttp.WriteJSON(w, http.StatusOK, map[string]any{"mounts": mounts})
 }
+
+func (h *handlers) getNetworkUsage(w http.ResponseWriter, r *http.Request) {
+	usage, err := h.deps.Service.GetNetworkUsage(r.Context(), r.PathValue("id"))
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	apihttp.WriteJSON(w, http.StatusOK, usage)
+}
+
+func (h *handlers) updateNetworkLimits(w http.ResponseWriter, r *http.Request) {
+	var req models.UpdateNetworkLimitsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	id := r.PathValue("id")
+	// Pointer-nil ⇒ "leave alone"; pointer-to-zero ⇒ "set to unlimited".
+	// Read the existing limits when only one direction is supplied so the
+	// other direction round-trips unchanged.
+	current, err := h.deps.Service.GetNetworkUsage(r.Context(), id)
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	in := current.BytesInLimit
+	if req.NetworkBytesInLimit != nil {
+		in = *req.NetworkBytesInLimit
+	}
+	out := current.BytesOutLimit
+	if req.NetworkBytesOutLimit != nil {
+		out = *req.NetworkBytesOutLimit
+	}
+	usage, err := h.deps.Service.SetNetworkLimits(r.Context(), id, in, out)
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	apihttp.WriteJSON(w, http.StatusOK, usage)
+}

--- a/pkg/api/v1/routes.go
+++ b/pkg/api/v1/routes.go
@@ -40,6 +40,8 @@ func RegisterRoutes(mux *http.ServeMux, d Deps) {
 	mux.Handle("POST "+PathPrefix+"/sandboxes/{id}/ports/{port}", d.Auth(http.HandlerFunc(h.exposePort)))
 	mux.Handle("DELETE "+PathPrefix+"/sandboxes/{id}/ports/{port}", d.Auth(http.HandlerFunc(h.unexposePort)))
 	mux.Handle("GET "+PathPrefix+"/sandboxes/{id}/mounts", d.Auth(http.HandlerFunc(h.listMounts)))
+	mux.Handle("GET "+PathPrefix+"/sandboxes/{id}/network/usage", d.Auth(http.HandlerFunc(h.getNetworkUsage)))
+	mux.Handle("PATCH "+PathPrefix+"/sandboxes/{id}/network/limits", d.Auth(http.HandlerFunc(h.updateNetworkLimits)))
 
 	// Explicit session routes are syntactic sugar for the toolbox proxy:
 	// /v1/sandboxes/{id}/sessions/... → toolbox /sessions/...

--- a/pkg/capacity/capacity.go
+++ b/pkg/capacity/capacity.go
@@ -68,19 +68,19 @@ type Request struct {
 // Snapshot is a read-only view of admitter state, suitable for an HTTP
 // /capacity response.
 type Snapshot struct {
-	HostCPUCores      int      `json:"host_cpu_cores"`
-	HostMemoryTotalMB int      `json:"host_memory_total_mb"`
-	ReservedCPU       float64  `json:"reserved_cpu"`
-	ReservedMemoryMB  int      `json:"reserved_memory_mb"`
-	LiveMemoryFreeMB  int      `json:"live_memory_free_mb"`
-	SandboxesActive   int      `json:"sandboxes_active"`
-	CanAdmit          bool     `json:"can_admit"`
-	Reasons           []string `json:"reasons,omitempty"`
-	CPUReservationRatio       float64 `json:"cpu_reservation_ratio"`
-	MemoryReservationRatio    float64 `json:"memory_reservation_ratio"`
-	MemoryFloorRatio          float64 `json:"memory_floor_ratio"`
-	CPUOverProvisionFactor    float64 `json:"cpu_overprovision_factor"`
-	MemoryOverProvisionFactor float64 `json:"memory_overprovision_factor"`
+	HostCPUCores              int      `json:"host_cpu_cores"`
+	HostMemoryTotalMB         int      `json:"host_memory_total_mb"`
+	ReservedCPU               float64  `json:"reserved_cpu"`
+	ReservedMemoryMB          int      `json:"reserved_memory_mb"`
+	LiveMemoryFreeMB          int      `json:"live_memory_free_mb"`
+	SandboxesActive           int      `json:"sandboxes_active"`
+	CanAdmit                  bool     `json:"can_admit"`
+	Reasons                   []string `json:"reasons,omitempty"`
+	CPUReservationRatio       float64  `json:"cpu_reservation_ratio"`
+	MemoryReservationRatio    float64  `json:"memory_reservation_ratio"`
+	MemoryFloorRatio          float64  `json:"memory_floor_ratio"`
+	CPUOverProvisionFactor    float64  `json:"cpu_overprovision_factor"`
+	MemoryOverProvisionFactor float64  `json:"memory_overprovision_factor"`
 	// MemoryFloorMB is the absolute floor derived from MemoryFloorRatio and
 	// host memory, exposed for operators reading /capacity.
 	MemoryFloorMB int `json:"memory_floor_mb"`

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -98,11 +98,16 @@ func New(logger *slog.Logger, cfg config.Config, rules *netrules.Manager) (*Clie
 // ClearNetworkRules releases any per-IP network rules previously attached to a
 // sandbox. Used by the event-driven path when a container exits or is destroyed
 // out-of-band, since Destroy() handles this for us during normal teardown.
+// Clears both egress (NetworkBlockAll / quota egress) and ingress (quota
+// ingress) rules — once the IP is gone there is nothing left to firewall on.
 func (c *Client) ClearNetworkRules(containerIP string) error {
 	if containerIP == "" {
 		return nil
 	}
-	return c.networkRules.ClearBlockAllEgress(containerIP)
+	if err := c.networkRules.ClearBlockAllEgress(containerIP); err != nil {
+		return err
+	}
+	return c.networkRules.ClearBlockAllIngress(containerIP)
 }
 
 // ApplyNetworkBlockAll installs the per-IP egress DROP rule. Idempotent —
@@ -115,6 +120,52 @@ func (c *Client) ApplyNetworkBlockAll(containerIP string) error {
 		return nil
 	}
 	return c.networkRules.BlockAllEgress(containerIP)
+}
+
+// ContainerPID returns the host PID of a running container's init process.
+// The PID is the entry point into the container's network namespace —
+// /proc/<pid>/net/dev is per-netns, so the netstats poller reads byte
+// counters straight from there with no nsenter / veth-iflink dance. Returns
+// 0 when the container is not running (Docker reports Pid:0 in that case).
+func (c *Client) ContainerPID(ctx context.Context, containerRef string) (int, error) {
+	inspect, err := c.inspectContainer(ctx, containerRef)
+	if err != nil {
+		return 0, err
+	}
+	if inspect.State == nil {
+		return 0, nil
+	}
+	return inspect.State.Pid, nil
+}
+
+// ApplyNetworkBlockIngress installs the per-IP ingress DROP rule used by the
+// network-quota enforcer when net_bytes_in_limit is crossed. Idempotent.
+func (c *Client) ApplyNetworkBlockIngress(containerIP string) error {
+	if containerIP == "" {
+		return nil
+	}
+	return c.networkRules.BlockAllIngress(containerIP)
+}
+
+// ClearNetworkBlockIngress removes the per-IP ingress DROP rule. Service layer
+// only calls this when the inbound limit is raised above current usage.
+func (c *Client) ClearNetworkBlockIngress(containerIP string) error {
+	if containerIP == "" {
+		return nil
+	}
+	return c.networkRules.ClearBlockAllIngress(containerIP)
+}
+
+// ClearNetworkBlockEgress removes the per-IP egress DROP rule. Symmetric to
+// ApplyNetworkBlockAll. The underlying rule is shared with NetworkBlockAll, so
+// the service must consult sandbox.NetworkBlockAll before invoking this on a
+// quota-clear path — otherwise it would silently undo the operator's egress
+// block.
+func (c *Client) ClearNetworkBlockEgress(containerIP string) error {
+	if containerIP == "" {
+		return nil
+	}
+	return c.networkRules.ClearBlockAllEgress(containerIP)
 }
 
 func (c *Client) Ping(ctx context.Context) error {
@@ -739,6 +790,7 @@ type containerInspect struct {
 	State *struct {
 		Running bool   `json:"Running"`
 		Status  string `json:"Status"`
+		Pid     int    `json:"Pid"`
 	} `json:"State"`
 	NetworkSettings struct {
 		Networks map[string]struct {

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -426,7 +426,9 @@ func (c *Client) Stop(ctx context.Context, containerRef string) error {
 
 func (c *Client) Destroy(ctx context.Context, sandbox *models.Sandbox) error {
 	if sandbox != nil {
-		_ = c.networkRules.ClearBlockAllEgress(sandbox.ContainerIP)
+		// Clear both directions: a stale ingress DROP would re-attach to whoever
+		// next gets this IP from Docker's IPAM pool.
+		_ = c.ClearNetworkRules(sandbox.ContainerIP)
 	}
 	if sandbox == nil {
 		return nil

--- a/pkg/docker/netrules/manager.go
+++ b/pkg/docker/netrules/manager.go
@@ -72,3 +72,43 @@ func (m *Manager) ClearBlockAllEgress(containerIP string) error {
 
 	return nil
 }
+
+// BlockAllIngress installs a DROP rule for traffic destined for containerIP,
+// the mirror of BlockAllEgress on the destination axis. Used by the network
+// quota enforcer when net_bytes_in_limit is crossed. The honest caveat (also
+// documented in plans/network-usage-tracking.md): host-side ingress is
+// counted after the NIC has accepted the packet, so the meter is "what the
+// container would have seen" rather than "bytes spent on the wire." Same
+// chain (DOCKER-USER) and idempotency check pattern as the egress mirror.
+func (m *Manager) BlockAllIngress(containerIP string) error {
+	if !m.Enabled() || containerIP == "" {
+		return nil
+	}
+
+	exists, err := m.ipt.Exists("filter", "DOCKER-USER", "-d", containerIP, "-j", "DROP")
+	if err != nil {
+		return fmt.Errorf("check existing ingress rule: %w", err)
+	}
+	if exists {
+		return nil
+	}
+
+	if err := m.ipt.Insert("filter", "DOCKER-USER", 1, "-d", containerIP, "-j", "DROP"); err != nil {
+		return fmt.Errorf("insert ingress rule: %w", err)
+	}
+
+	return nil
+}
+
+func (m *Manager) ClearBlockAllIngress(containerIP string) error {
+	if !m.Enabled() || containerIP == "" {
+		return nil
+	}
+
+	err := m.ipt.Delete("filter", "DOCKER-USER", "-d", containerIP, "-j", "DROP")
+	if err != nil && !strings.Contains(err.Error(), "No chain/target/match") {
+		return fmt.Errorf("delete ingress rule: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/docker/netrules/manager.go
+++ b/pkg/docker/netrules/manager.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+	"sync"
 
 	"github.com/coreos/go-iptables/iptables"
 )
@@ -11,6 +12,12 @@ import (
 type Manager struct {
 	enabled bool
 	ipt     *iptables.IPTables
+	// mu serializes Block/Clear pairs. iptables Exists+Insert is not atomic,
+	// and the poller, reconcile, SetNetworkLimits, and Destroy paths can all
+	// drive the same IP concurrently. Without this lock, two callers can both
+	// pass Exists and both Insert, leaving a duplicate that a single Delete
+	// in Clear* won't fully remove.
+	mu sync.Mutex
 }
 
 func New(enabled bool) (*Manager, error) {
@@ -44,6 +51,8 @@ func (m *Manager) BlockAllEgress(containerIP string) error {
 	if !m.Enabled() || containerIP == "" {
 		return nil
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	exists, err := m.ipt.Exists("filter", "DOCKER-USER", "-s", containerIP, "-j", "DROP")
 	if err != nil {
@@ -64,13 +73,21 @@ func (m *Manager) ClearBlockAllEgress(containerIP string) error {
 	if !m.Enabled() || containerIP == "" {
 		return nil
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
-	err := m.ipt.Delete("filter", "DOCKER-USER", "-s", containerIP, "-j", "DROP")
-	if err != nil && !strings.Contains(err.Error(), "No chain/target/match") {
+	// Loop in case a prior race left a duplicate row — Delete only removes
+	// one match per call. Stop on the first "no such rule" return.
+	for {
+		err := m.ipt.Delete("filter", "DOCKER-USER", "-s", containerIP, "-j", "DROP")
+		if err == nil {
+			continue
+		}
+		if strings.Contains(err.Error(), "No chain/target/match") {
+			return nil
+		}
 		return fmt.Errorf("delete egress rule: %w", err)
 	}
-
-	return nil
 }
 
 // BlockAllIngress installs a DROP rule for traffic destined for containerIP,
@@ -84,6 +101,8 @@ func (m *Manager) BlockAllIngress(containerIP string) error {
 	if !m.Enabled() || containerIP == "" {
 		return nil
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	exists, err := m.ipt.Exists("filter", "DOCKER-USER", "-d", containerIP, "-j", "DROP")
 	if err != nil {
@@ -104,11 +123,17 @@ func (m *Manager) ClearBlockAllIngress(containerIP string) error {
 	if !m.Enabled() || containerIP == "" {
 		return nil
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
-	err := m.ipt.Delete("filter", "DOCKER-USER", "-d", containerIP, "-j", "DROP")
-	if err != nil && !strings.Contains(err.Error(), "No chain/target/match") {
+	for {
+		err := m.ipt.Delete("filter", "DOCKER-USER", "-d", containerIP, "-j", "DROP")
+		if err == nil {
+			continue
+		}
+		if strings.Contains(err.Error(), "No chain/target/match") {
+			return nil
+		}
 		return fmt.Errorf("delete ingress rule: %w", err)
 	}
-
-	return nil
 }

--- a/pkg/docker/netstats/poller.go
+++ b/pkg/docker/netstats/poller.go
@@ -120,7 +120,17 @@ func (p *Poller) tick(ctx context.Context, now time.Time) {
 
 	samples := make([]Sample, 0, len(targets))
 	for _, t := range targets {
-		if t.SandboxID == "" || t.ContainerRef == "" {
+		if t.SandboxID == "" {
+			continue
+		}
+		// Per the SandboxLister contract, an empty ContainerRef means "not
+		// running this tick" — same semantics as a failed PID lookup or
+		// ErrNotRunning below. Drop the baseline so the next tick (when the
+		// container is up and the ref reappears) re-baselines from the new
+		// PID instead of diffing against a stale one. Without this, baselines
+		// for sandboxes stuck in not-yet-running states would accumulate.
+		if t.ContainerRef == "" {
+			p.dropBaseline(t.SandboxID)
 			continue
 		}
 

--- a/pkg/docker/netstats/poller.go
+++ b/pkg/docker/netstats/poller.go
@@ -1,0 +1,211 @@
+package netstats
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// PIDLookup resolves a sandbox container reference to the host PID of its
+// init process. Implemented by *docker.Client.ContainerPID.
+type PIDLookup interface {
+	ContainerPID(ctx context.Context, containerRef string) (int, error)
+}
+
+// SandboxLister returns the sandboxes that should be polled this tick.
+// Returning a fresh slice on each call is fine — the poller doesn't retain
+// it. Items must include both the sandbox ID (for callbacks) and the
+// container reference (for the PID lookup); when a container is not yet
+// running the lister can omit it or include it with empty containerRef.
+type SandboxLister interface {
+	NetstatsTargets(ctx context.Context) []Target
+}
+
+// Target is one row the poller will sample on the next tick.
+type Target struct {
+	SandboxID    string
+	ContainerRef string
+}
+
+// SampleSink receives per-tick deltas. Implementations typically call into
+// the store to add deltas to the cumulative counters and check quotas.
+// Implementations MUST be safe to call from the poller goroutine.
+type SampleSink interface {
+	HandleSamples(ctx context.Context, samples []Sample)
+}
+
+// Sample is the per-sandbox delta the poller produces each tick.
+// BytesIn/BytesOut are non-negative deltas since the last successful sample
+// for the same (sandbox, PID) pair. The first observation of any new PID
+// produces a Sample with zero deltas — the cumulative reading at that point
+// is stored as the baseline so subsequent ticks compute meaningful diffs.
+// This makes the poller restart-safe: container restart → new PID → fresh
+// baseline → no spurious giant delta from the cumulative counter resetting
+// to a small number.
+type Sample struct {
+	SandboxID string
+	BytesIn   int64
+	BytesOut  int64
+	SampledAt time.Time
+}
+
+// Poller drives the netstats loop. Construct via NewPoller and call Start
+// once; call Stop on shutdown to release the goroutine cleanly.
+type Poller struct {
+	logger   *slog.Logger
+	reader   *Reader
+	lookup   PIDLookup
+	lister   SandboxLister
+	sink     SampleSink
+	interval time.Duration
+
+	mu        sync.Mutex
+	baselines map[string]baseline // keyed by sandbox ID
+}
+
+type baseline struct {
+	pid      int
+	counters Counters
+}
+
+// NewPoller wires the dependencies together. interval <= 0 is rejected at
+// Start; the caller controls the cadence so deployments with thousands of
+// sandboxes can dial it down.
+func NewPoller(logger *slog.Logger, reader *Reader, lookup PIDLookup, lister SandboxLister, sink SampleSink, interval time.Duration) *Poller {
+	return &Poller{
+		logger:    logger,
+		reader:    reader,
+		lookup:    lookup,
+		lister:    lister,
+		sink:      sink,
+		interval:  interval,
+		baselines: make(map[string]baseline),
+	}
+}
+
+// Start launches the poll loop in a goroutine and returns immediately. The
+// goroutine exits when ctx is cancelled. Calling Start more than once on the
+// same Poller will spawn additional loops — don't do that.
+func (p *Poller) Start(ctx context.Context) error {
+	if p.interval <= 0 {
+		return errors.New("netstats: poll interval must be > 0")
+	}
+	go p.run(ctx)
+	return nil
+}
+
+func (p *Poller) run(ctx context.Context) {
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			p.tick(ctx, now)
+		}
+	}
+}
+
+// tick is exposed (lowercase but visible to test files in-package) so tests
+// can drive a deterministic sample without standing up a real ticker.
+func (p *Poller) tick(ctx context.Context, now time.Time) {
+	targets := p.lister.NetstatsTargets(ctx)
+	if len(targets) == 0 {
+		p.gcBaselines(targets)
+		return
+	}
+
+	samples := make([]Sample, 0, len(targets))
+	for _, t := range targets {
+		if t.SandboxID == "" || t.ContainerRef == "" {
+			continue
+		}
+
+		pid, err := p.lookup.ContainerPID(ctx, t.ContainerRef)
+		if err != nil {
+			p.logger.Debug("netstats: pid lookup failed", "sandbox_id", t.SandboxID, "error", err)
+			continue
+		}
+		if pid <= 0 {
+			p.dropBaseline(t.SandboxID)
+			continue
+		}
+
+		current, err := p.reader.Read(pid)
+		if err != nil {
+			if errors.Is(err, ErrNotRunning) {
+				p.dropBaseline(t.SandboxID)
+				continue
+			}
+			p.logger.Debug("netstats: read failed", "sandbox_id", t.SandboxID, "pid", pid, "error", err)
+			continue
+		}
+
+		delta := p.diffAndUpdate(t.SandboxID, pid, current)
+		samples = append(samples, Sample{
+			SandboxID: t.SandboxID,
+			BytesIn:   delta.BytesIn,
+			BytesOut:  delta.BytesOut,
+			SampledAt: now,
+		})
+	}
+
+	p.gcBaselines(targets)
+
+	if len(samples) > 0 {
+		p.sink.HandleSamples(ctx, samples)
+	}
+}
+
+// diffAndUpdate computes the delta against the stored baseline and rotates
+// the baseline forward. If PID changed (container restart) or no baseline
+// exists yet (first observation), returns a zero delta and stores `current`
+// as the new baseline — see Sample doc for why.
+func (p *Poller) diffAndUpdate(sandboxID string, pid int, current Counters) Counters {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	prev, ok := p.baselines[sandboxID]
+	p.baselines[sandboxID] = baseline{pid: pid, counters: current}
+	if !ok || prev.pid != pid {
+		return Counters{}
+	}
+	return Counters{
+		BytesIn:  nonNegative(current.BytesIn - prev.counters.BytesIn),
+		BytesOut: nonNegative(current.BytesOut - prev.counters.BytesOut),
+	}
+}
+
+// dropBaseline forgets a sandbox so a future Start (and new PID) starts
+// clean. Called when the container is no longer running this tick.
+func (p *Poller) dropBaseline(sandboxID string) {
+	p.mu.Lock()
+	delete(p.baselines, sandboxID)
+	p.mu.Unlock()
+}
+
+// gcBaselines drops any baselines whose sandbox is no longer in the target
+// list — covers Destroy, where the sandbox is gone from the store before the
+// next tick.
+func (p *Poller) gcBaselines(targets []Target) {
+	keep := make(map[string]struct{}, len(targets))
+	for _, t := range targets {
+		keep[t.SandboxID] = struct{}{}
+	}
+	p.mu.Lock()
+	for id := range p.baselines {
+		if _, ok := keep[id]; !ok {
+			delete(p.baselines, id)
+		}
+	}
+	p.mu.Unlock()
+}
+
+func nonNegative(n int64) int64 {
+	if n < 0 {
+		return 0
+	}
+	return n
+}

--- a/pkg/docker/netstats/poller_test.go
+++ b/pkg/docker/netstats/poller_test.go
@@ -1,0 +1,187 @@
+package netstats
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"log/slog"
+	"sync"
+	"testing"
+	"testing/fstest"
+	"time"
+)
+
+const sampleProcNetDev = `Inter-|   Receive                                                |  Transmit
+ face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+    lo:    1234       12    0    0    0     0          0         0     1234       12    0    0    0     0       0          0
+  eth0:    9000       18    0    0    0     0          0         0     5000       11    0    0    0     0       0          0
+`
+
+func TestParseNetDevExcludesLoopback(t *testing.T) {
+	fsys := fstest.MapFS{
+		"42/net/dev": &fstest.MapFile{Data: []byte(sampleProcNetDev)},
+	}
+	r := NewReaderFS(fsys)
+	got, err := r.Read(42)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got.BytesIn != 9000 || got.BytesOut != 5000 {
+		t.Fatalf("unexpected counters: %+v", got)
+	}
+}
+
+func TestReadMissingPIDReturnsNotRunning(t *testing.T) {
+	r := NewReaderFS(fstest.MapFS{})
+	_, err := r.Read(99)
+	if !errors.Is(err, ErrNotRunning) {
+		t.Fatalf("expected ErrNotRunning, got %v", err)
+	}
+	if _, err := r.Read(0); !errors.Is(err, ErrNotRunning) {
+		t.Fatalf("pid 0 should be ErrNotRunning, got %v", err)
+	}
+}
+
+type fakeLookup struct {
+	mu   sync.Mutex
+	pids map[string]int
+	err  error
+}
+
+func (f *fakeLookup) ContainerPID(_ context.Context, ref string) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.err != nil {
+		return 0, f.err
+	}
+	return f.pids[ref], nil
+}
+
+type fakeLister struct {
+	targets []Target
+}
+
+func (f *fakeLister) NetstatsTargets(_ context.Context) []Target { return f.targets }
+
+type fakeSink struct {
+	mu      sync.Mutex
+	batches [][]Sample
+}
+
+func (f *fakeSink) HandleSamples(_ context.Context, samples []Sample) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	cp := make([]Sample, len(samples))
+	copy(cp, samples)
+	f.batches = append(f.batches, cp)
+}
+
+func TestPollerEstablishesBaselineThenEmitsDelta(t *testing.T) {
+	mfs := fstest.MapFS{
+		"100/net/dev": &fstest.MapFile{Data: []byte(sampleProcNetDev)},
+	}
+	reader := NewReaderFS(mfs)
+	lookup := &fakeLookup{pids: map[string]int{"sb-1": 100}}
+	lister := &fakeLister{targets: []Target{{SandboxID: "sb-1", ContainerRef: "sb-1"}}}
+	sink := &fakeSink{}
+
+	p := NewPoller(slog.Default(), reader, lookup, lister, sink, time.Second)
+
+	// First tick: baseline only — Sample with zero deltas.
+	p.tick(context.Background(), time.Unix(1000, 0))
+	if len(sink.batches) != 1 || len(sink.batches[0]) != 1 {
+		t.Fatalf("expected 1 sample on first tick, got %#v", sink.batches)
+	}
+	first := sink.batches[0][0]
+	if first.BytesIn != 0 || first.BytesOut != 0 {
+		t.Fatalf("first tick should have zero deltas, got %+v", first)
+	}
+
+	// Second tick after counters grow.
+	growing := []byte(`Inter-|   Receive                                                |  Transmit
+ face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+    lo:    1234       12    0    0    0     0          0         0     1234       12    0    0    0     0       0          0
+  eth0:   12000       18    0    0    0     0          0         0     7500       11    0    0    0     0       0          0
+`)
+	mfs["100/net/dev"] = &fstest.MapFile{Data: growing}
+
+	p.tick(context.Background(), time.Unix(1001, 0))
+	if len(sink.batches) != 2 {
+		t.Fatalf("expected 2 batches, got %d", len(sink.batches))
+	}
+	second := sink.batches[1][0]
+	if second.BytesIn != 3000 || second.BytesOut != 2500 {
+		t.Fatalf("expected delta 3000/2500, got %+v", second)
+	}
+}
+
+func TestPollerResetsBaselineOnPIDChange(t *testing.T) {
+	mfs := fstest.MapFS{
+		"100/net/dev": &fstest.MapFile{Data: []byte(sampleProcNetDev)},
+	}
+	reader := NewReaderFS(mfs)
+	lookup := &fakeLookup{pids: map[string]int{"sb-1": 100}}
+	lister := &fakeLister{targets: []Target{{SandboxID: "sb-1", ContainerRef: "sb-1"}}}
+	sink := &fakeSink{}
+
+	p := NewPoller(slog.Default(), reader, lookup, lister, sink, time.Second)
+	p.tick(context.Background(), time.Unix(1000, 0)) // baseline @ pid 100
+
+	// Container restarts: new PID, fresh procfs entry with smaller cumulative.
+	delete(mfs, "100/net/dev")
+	smaller := []byte(`Inter-|   Receive                                                |  Transmit
+ face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+    lo:       0        0    0    0    0     0          0         0        0        0    0    0    0     0       0          0
+  eth0:     500        2    0    0    0     0          0         0      300        1    0    0    0     0       0          0
+`)
+	mfs["200/net/dev"] = &fstest.MapFile{Data: smaller}
+	lookup.pids["sb-1"] = 200
+
+	p.tick(context.Background(), time.Unix(1001, 0))
+	if len(sink.batches) != 2 {
+		t.Fatalf("expected 2 batches, got %d", len(sink.batches))
+	}
+	got := sink.batches[1][0]
+	if got.BytesIn != 0 || got.BytesOut != 0 {
+		t.Fatalf("PID change should reset baseline (zero delta), got %+v", got)
+	}
+}
+
+func TestPollerSkipsStoppedContainers(t *testing.T) {
+	reader := NewReaderFS(fstest.MapFS{}) // no procfs entries
+	lookup := &fakeLookup{pids: map[string]int{"sb-stopped": 0}}
+	lister := &fakeLister{targets: []Target{{SandboxID: "sb-stopped", ContainerRef: "sb-stopped"}}}
+	sink := &fakeSink{}
+	p := NewPoller(slog.Default(), reader, lookup, lister, sink, time.Second)
+
+	p.tick(context.Background(), time.Unix(1000, 0))
+	if len(sink.batches) != 0 {
+		t.Fatalf("expected no samples for stopped container, got %#v", sink.batches)
+	}
+}
+
+func TestPollerGarbageCollectsBaselines(t *testing.T) {
+	mfs := fstest.MapFS{
+		"100/net/dev": &fstest.MapFile{Data: []byte(sampleProcNetDev)},
+	}
+	reader := NewReaderFS(mfs)
+	lookup := &fakeLookup{pids: map[string]int{"sb-1": 100}}
+	lister := &fakeLister{targets: []Target{{SandboxID: "sb-1", ContainerRef: "sb-1"}}}
+	sink := &fakeSink{}
+	p := NewPoller(slog.Default(), reader, lookup, lister, sink, time.Second)
+	p.tick(context.Background(), time.Unix(1000, 0))
+	if len(p.baselines) != 1 {
+		t.Fatalf("expected baseline stored, got %d", len(p.baselines))
+	}
+
+	// Sandbox disappears from target list (Destroy path).
+	lister.targets = nil
+	p.tick(context.Background(), time.Unix(1001, 0))
+	if len(p.baselines) != 0 {
+		t.Fatalf("expected baselines pruned, got %d", len(p.baselines))
+	}
+}
+
+// guard — the test fixture must conform to fs.FS, surface errors that aren't
+// ErrNotExist as plain errors so we don't accidentally silence real bugs.
+var _ fs.FS = fstest.MapFS{}

--- a/pkg/docker/netstats/reader.go
+++ b/pkg/docker/netstats/reader.go
@@ -1,0 +1,141 @@
+// Package netstats reads per-sandbox network byte counters from
+// /proc/<pid>/net/dev. The procfs `net/` subtree is per-netns: opening it
+// through a process PID joins that PID's network namespace, so a host-side
+// reader sees the container's interfaces (eth0 etc.) and their cumulative
+// rx/tx_bytes from the container's perspective.
+//
+// rx/tx semantics here are the *container's*: rx_bytes = bytes the container
+// received (= ingress to the sandbox = NetworkBytesIn); tx_bytes = bytes the
+// container sent (= egress from the sandbox = NetworkBytesOut). This matches
+// what an operator would intuitively bill against.
+//
+// We deliberately ignore the host-side veth (the peer interface visible in
+// the host netns). That path is correct too, but discovering it requires
+// matching iflink/ifindex pairs — measurably more code than just reading
+// /proc/<pid>/net/dev for a number that is already per-netns by construction.
+//
+// The "lo" interface is skipped: pure intra-container loopback shouldn't
+// count against an external network quota.
+package netstats
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// ErrNotRunning is returned when the procfs entry for the requested PID is
+// gone — typically because the container exited between the caller obtaining
+// the PID and the read. Callers should treat it as "no sample this tick"
+// rather than a hard error, since reconcile/event paths will pick up the
+// state change shortly.
+var ErrNotRunning = errors.New("netstats: container process not present")
+
+// Counters is one snapshot of per-container byte counters. Cumulative since
+// container start — the poller computes deltas itself so it can survive
+// container restarts without double-counting.
+type Counters struct {
+	BytesIn  int64 // container rx (ingress to sandbox)
+	BytesOut int64 // container tx (egress from sandbox)
+}
+
+// Reader reads /proc/<pid>/net/dev. The fs.FS indirection exists so tests
+// can supply an in-memory fixture — the production caller passes nil to use
+// the real /proc.
+type Reader struct {
+	fsys fs.FS // when nil, reads /proc/<pid>/net/dev directly via os.Open
+}
+
+// NewReader builds a Reader against the host /proc.
+func NewReader() *Reader { return &Reader{} }
+
+// NewReaderFS builds a Reader against an injected filesystem rooted such
+// that "<pid>/net/dev" resolves correctly. Used by tests.
+func NewReaderFS(fsys fs.FS) *Reader { return &Reader{fsys: fsys} }
+
+// Read returns the cumulative per-container byte counters for the given PID.
+// PID 0 (Docker reports Pid:0 for a non-running container) yields
+// ErrNotRunning so the poller can short-circuit without a procfs lookup.
+func (r *Reader) Read(pid int) (Counters, error) {
+	if pid <= 0 {
+		return Counters{}, ErrNotRunning
+	}
+
+	data, err := r.openNetDev(pid)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, os.ErrNotExist) {
+			return Counters{}, ErrNotRunning
+		}
+		return Counters{}, err
+	}
+	defer data.Close()
+
+	return parseNetDev(data)
+}
+
+// openNetDev returns a closer-backed reader for /proc/<pid>/net/dev.
+type readCloser interface {
+	Read([]byte) (int, error)
+	Close() error
+}
+
+func (r *Reader) openNetDev(pid int) (readCloser, error) {
+	if r.fsys != nil {
+		f, err := r.fsys.Open(fmt.Sprintf("%d/net/dev", pid))
+		if err != nil {
+			return nil, err
+		}
+		return f.(readCloser), nil
+	}
+	return os.Open(fmt.Sprintf("/proc/%d/net/dev", pid))
+}
+
+// parseNetDev sums non-loopback rx/tx_bytes columns from a /proc/net/dev
+// formatted stream. Format (after a 2-line header):
+//
+//	iface: rx_bytes rx_packets rx_errs rx_drop ... tx_bytes tx_packets ...
+//
+// Columns are whitespace-separated; rx_bytes is field index 1, tx_bytes is
+// field index 9 of the post-colon tail.
+func parseNetDev(r readCloser) (Counters, error) {
+	scanner := bufio.NewScanner(r)
+	var c Counters
+	headerLines := 0
+	for scanner.Scan() {
+		if headerLines < 2 {
+			headerLines++
+			continue
+		}
+		line := scanner.Text()
+		colon := strings.Index(line, ":")
+		if colon < 0 {
+			continue
+		}
+		iface := strings.TrimSpace(line[:colon])
+		if iface == "" || iface == "lo" {
+			continue
+		}
+		fields := strings.Fields(line[colon+1:])
+		if len(fields) < 10 {
+			continue
+		}
+		rx, err := strconv.ParseInt(fields[0], 10, 64)
+		if err != nil {
+			continue
+		}
+		tx, err := strconv.ParseInt(fields[8], 10, 64)
+		if err != nil {
+			continue
+		}
+		c.BytesIn += rx
+		c.BytesOut += tx
+	}
+	if err := scanner.Err(); err != nil {
+		return Counters{}, err
+	}
+	return c, nil
+}

--- a/pkg/models/mounts_test.go
+++ b/pkg/models/mounts_test.go
@@ -95,4 +95,3 @@ func TestRedactStripsCredentials(t *testing.T) {
 		t.Errorf("Options lost: %v", r.Options)
 	}
 }
-

--- a/pkg/models/sessions.go
+++ b/pkg/models/sessions.go
@@ -7,10 +7,10 @@ import "time"
 type SessionStatus string
 
 const (
-	SessionStatusRunning  SessionStatus = "running"
-	SessionStatusExited   SessionStatus = "exited"
-	SessionStatusKilled   SessionStatus = "killed"
-	SessionStatusFailed   SessionStatus = "failed" // could not start
+	SessionStatusRunning SessionStatus = "running"
+	SessionStatusExited  SessionStatus = "exited"
+	SessionStatusKilled  SessionStatus = "killed"
+	SessionStatusFailed  SessionStatus = "failed" // could not start
 )
 
 // CreateSessionRequest is the body of POST /sessions on toolboxd (and the
@@ -43,8 +43,8 @@ type Session struct {
 	StartedAt  time.Time     `json:"started_at"`
 	ExitedAt   time.Time     `json:"exited_at,omitempty"`
 	Recording  bool          `json:"recording"`
-	Bytes      int64         `json:"bytes"`     // total stdout+stderr bytes produced
-	Attached   int           `json:"attached"`  // current number of attached clients
+	Bytes      int64         `json:"bytes"`    // total stdout+stderr bytes produced
+	Attached   int           `json:"attached"` // current number of attached clients
 }
 
 // SessionList is the GET /sessions response shape.

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -340,7 +340,10 @@ type NetworkUsage struct {
 	BytesOutLimit   int64      `json:"bytes_out_limit"`
 	QuotaExceeded   bool       `json:"quota_exceeded"`
 	QuotaExceededAt *time.Time `json:"quota_exceeded_at,omitempty"`
-	LastSampledAt   time.Time  `json:"last_sampled_at"`
+	// LastSampledAt is omitted until the netstats poller has produced at
+	// least one sample. Pointer + omitempty so we don't serialize the zero
+	// time as "0001-01-01T00:00:00Z" before the first tick.
+	LastSampledAt *time.Time `json:"last_sampled_at,omitempty"`
 }
 
 // UpdateNetworkLimitsRequest is the body for PATCH /v1/sandboxes/{id}/network/limits.

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -254,6 +254,16 @@ type CreateSandboxRequest struct {
 	// is not supported with the gVisor runtime — the API returns an error if
 	// both GPUs and runtime="gvisor" are set.
 	GPUs *GPURequest `json:"gpus,omitempty"`
+	// NetworkBytesInLimit caps lifetime ingress bytes for the sandbox. Zero
+	// means unlimited. When the cumulative counter crosses the limit, the
+	// reconcile loop installs an ingress DROP rule. The "we already paid for
+	// the bytes you see in the meter" caveat applies — host-side ingress is
+	// counted after the NIC has accepted the packet.
+	NetworkBytesInLimit int64 `json:"network_bytes_in_limit,omitempty"`
+	// NetworkBytesOutLimit caps lifetime egress bytes. Zero means unlimited.
+	// Crossing the limit installs an egress DROP rule via the same primitive
+	// NetworkBlockAll uses.
+	NetworkBytesOutLimit int64 `json:"network_bytes_out_limit,omitempty"`
 }
 
 type ResizeSandboxRequest struct {
@@ -301,6 +311,45 @@ type Sandbox struct {
 	// GPUs is the GPU configuration this sandbox was created with. Nil means
 	// no GPU was requested.
 	GPUs *GPURequest `json:"gpus,omitempty"`
+	// NetworkBytesIn / NetworkBytesOut are cumulative byte counters
+	// maintained by the netstats poller. They survive container restarts —
+	// a new veth resets in-memory baseline math but the persisted total is
+	// preserved.
+	NetworkBytesIn  int64 `json:"network_bytes_in"`
+	NetworkBytesOut int64 `json:"network_bytes_out"`
+	// NetworkBytesInLimit / NetworkBytesOutLimit are the caps the sandbox was
+	// created or patched with. Zero = unlimited.
+	NetworkBytesInLimit  int64 `json:"network_bytes_in_limit"`
+	NetworkBytesOutLimit int64 `json:"network_bytes_out_limit"`
+	// NetworkQuotaExceeded reflects whether either lifetime byte counter has
+	// crossed its limit. The reconcile loop installs DROP rules when this is
+	// true; clearing requires raising the limit (or zeroing it for unlimited).
+	NetworkQuotaExceeded bool `json:"network_quota_exceeded"`
+	// NetworkQuotaExceededAt is the wall-clock time the limit was first
+	// observed crossed. Nil while under quota.
+	NetworkQuotaExceededAt *time.Time `json:"network_quota_exceeded_at,omitempty"`
+}
+
+// NetworkUsage is the response shape for GET /v1/sandboxes/{id}/network/usage.
+// BytesInLimit / BytesOutLimit zero means unlimited.
+type NetworkUsage struct {
+	SandboxID       string     `json:"sandbox_id"`
+	BytesIn         int64      `json:"bytes_in"`
+	BytesOut        int64      `json:"bytes_out"`
+	BytesInLimit    int64      `json:"bytes_in_limit"`
+	BytesOutLimit   int64      `json:"bytes_out_limit"`
+	QuotaExceeded   bool       `json:"quota_exceeded"`
+	QuotaExceededAt *time.Time `json:"quota_exceeded_at,omitempty"`
+	LastSampledAt   time.Time  `json:"last_sampled_at"`
+}
+
+// UpdateNetworkLimitsRequest is the body for PATCH /v1/sandboxes/{id}/network/limits.
+// Each field is a pointer so the handler can distinguish "leave alone" (nil)
+// from "set to unlimited" (pointer to zero). Negative values are rejected at
+// the service layer.
+type UpdateNetworkLimitsRequest struct {
+	NetworkBytesInLimit  *int64 `json:"network_bytes_in_limit,omitempty"`
+	NetworkBytesOutLimit *int64 `json:"network_bytes_out_limit,omitempty"`
 }
 
 // CreateSandboxResponse is what the API returns from POST /v1/sandboxes.

--- a/pkg/sshgateway/gateway.go
+++ b/pkg/sshgateway/gateway.go
@@ -164,9 +164,11 @@ func (g *Gateway) handleConn(ctx context.Context, nConn net.Conn) {
 
 // parseSSHUser splits the SSH username into (sandbox_id, mode, name).
 // Forms:
-//   "<id>"           → mode="session", name="default"
-//   "<id>+<name>"    → mode="session", name=<name>
-//   "<id>+exec"      → mode="exec" (legacy one-shot via docker exec)
+//
+//	"<id>"           → mode="session", name="default"
+//	"<id>+<name>"    → mode="session", name=<name>
+//	"<id>+exec"      → mode="exec" (legacy one-shot via docker exec)
+//
 // Returns ok=false if the input is empty.
 func parseSSHUser(raw string) (sandboxID, mode, name string, ok bool) {
 	raw = strings.TrimSpace(raw)

--- a/pkg/sshgateway/gateway_test.go
+++ b/pkg/sshgateway/gateway_test.go
@@ -137,10 +137,10 @@ type fakeChannel struct {
 	stderr io.Writer
 }
 
-func (f fakeChannel) Read(p []byte) (int, error)              { return 0, io.EOF }
-func (f fakeChannel) Write(p []byte) (int, error)             { return f.stdout.Write(p) }
-func (f fakeChannel) Close() error                            { return nil }
-func (f fakeChannel) CloseWrite() error                       { return nil }
+func (f fakeChannel) Read(p []byte) (int, error)  { return 0, io.EOF }
+func (f fakeChannel) Write(p []byte) (int, error) { return f.stdout.Write(p) }
+func (f fakeChannel) Close() error                { return nil }
+func (f fakeChannel) CloseWrite() error           { return nil }
 func (f fakeChannel) SendRequest(string, bool, []byte) (bool, error) {
 	return false, nil
 }
@@ -148,5 +148,5 @@ func (f fakeChannel) Stderr() io.ReadWriter { return stderrAdapter{w: f.stderr} 
 
 type stderrAdapter struct{ w io.Writer }
 
-func (s stderrAdapter) Read([]byte) (int, error)  { return 0, io.EOF }
+func (s stderrAdapter) Read([]byte) (int, error)    { return 0, io.EOF }
 func (s stderrAdapter) Write(p []byte) (int, error) { return s.w.Write(p) }

--- a/plans/issues.md
+++ b/plans/issues.md
@@ -79,6 +79,117 @@ window reliably; opportunistic and accidental traffic mostly will not.
 
 ---
 
+## 2. Network usage poller drops bytes on the first observation
+
+### Symptom
+
+`pkg/docker/netstats/poller.go:167-173` (`diffAndUpdate`) treats the first sample for a
+new `(sandbox, PID)` pair as a baseline-only event and emits a zero delta. The current
+`/proc/<pid>/net/dev` reading is stored, the next tick's delta is computed against it,
+and only that next tick contributes to the persisted counter.
+
+For a freshly created sandbox at the default 10s poll interval, that means up to ~10s of
+traffic between container start and the first poll, plus another full interval before
+enforcement sees a non-zero delta. A workload that bursts hard at startup (large image
+pull inside the container, an exfil-on-startup script, an aggressive `wget`) can move
+tens of GB before the quota check ever fires.
+
+### Affected code
+
+- `pkg/docker/netstats/poller.go:163-179` — `diffAndUpdate` baseline rule.
+- `pkg/docker/netstats/poller.go:41-46` — comment documenting the design intent.
+- `internal/service/netstats.go:186-227` — `HandleSamples` is the only callback path,
+  so any byte not surfaced here never gets metered or quota-checked.
+
+### Why deferred
+
+The current behaviour is intentional: it makes the poller restart-safe. After a
+container restart (new PID) or a daemon restart (poller forgets baselines), `/proc`
+counters reset to small numbers, and treating the first read as "delta from zero" would
+spuriously credit terabytes against the quota.
+
+A correct fix has to *distinguish* the two cases:
+
+- **Fresh container, first observation ever:** counters start at 0 inside the new netns,
+  so the first reading IS the actual usage from 0 — credit it.
+- **Daemon restart, container already had traffic:** stored cumulative is non-zero,
+  in-PID counters are mid-run — must baseline.
+
+This needs persistent baselines, not just in-memory ones, and a slightly subtler diff
+rule. Worth doing right rather than racing a one-line patch.
+
+### Proposed fix shape
+
+- Persist `(last_observed_pid, last_observed_bytes_in, last_observed_bytes_out)` on the
+  sandbox row alongside the existing cumulative counters.
+- On poll:
+  - If the persisted PID is 0 / unset → fresh sandbox, no prior reading. Credit the
+    full current reading as the delta and store the snapshot.
+  - If the persisted PID matches the current PID → normal delta, store snapshot.
+  - If PIDs differ → container restart, baseline only (current behaviour).
+- Re-hydrate in-memory `baselines` map at `EnsureNetstatsReady` from the persisted row
+  so a daemon restart doesn't lose state.
+- Optional: tighten the default `NetstatsPollInterval` for the first ~minute of a
+  sandbox's life (a "warm-up" sub-poller) to bound the first-observation gap. Costs
+  extra `/proc` reads per new sandbox, no impact at steady state.
+
+### Severity
+
+Medium. Most workloads don't move tens of GB in their first 20 seconds, but billing
+accuracy and abuse-prevention quotas both rely on this counter being honest. Currently
+a known sub-quota leak exists at the start of every sandbox's life.
+
+### Test plan
+
+- Unit test for `diffAndUpdate` (or its persistent successor): asserts the
+  fresh-container case produces a non-zero delta on first observation, while the
+  PID-change case still baselines.
+- Restart test: create a sandbox, kill the daemon, restart, observe that the first
+  post-restart sample baselines (does not credit cumulative counter to zero).
+
+---
+
+## 3. Netstats poller scans the whole sandbox table every tick
+
+### Symptom
+
+`internal/service/netstats.go:159-181` (`netstatsServiceLister.NetstatsTargets`) calls
+`store.List(ctx)` on every poll. `Store.List` loads every sandbox row, runs
+`attachPortsBulk` (which scans all `exposed_ports`), and filters in Go. The poller only
+needs `(id, container_id WHERE status='started')`.
+
+At small scale this is invisible. As historical / running rows grow, every tick walks
+more rows through the same single-writer SQLite connection that serves API traffic.
+
+### Affected code
+
+- `internal/service/netstats.go:159-181` — caller.
+- `internal/store/store.go` — `List` is the only available query; no filtered variant.
+
+### Why deferred
+
+It's premature optimization until a host genuinely carries hundreds-to-thousands of
+running sandboxes. The poller already runs at a low cadence (default 10s) and the work
+isn't on a request-serving path. The fix is mechanical, but it adds a new store method
+that needs its own tests, and shipping it with no measured pressure isn't worth the
+diff cost.
+
+### Proposed fix shape
+
+- Add `Store.ListNetstatsTargets(ctx) ([]struct{ ID, ContainerID string }, error)` that
+  runs a single `SELECT id, container_id FROM sandboxes WHERE status = ?` (no port
+  attach, no full row hydration).
+- Switch `netstatsServiceLister.NetstatsTargets` to call it.
+- Add a regression test in `store_test.go` that verifies status filtering and that no
+  port-attach side query runs (could assert via query counter or simply scope the
+  fixture).
+
+### Severity
+
+Low until measured. Re-evaluate when single-host sandbox counts move into the hundreds.
+
+---
+
 ## What was fixed in the same pass (for context)
 
 - `pkg/docker/client.go` — `Create` now fails closed if `BlockAllEgress` errors (was a

--- a/plans/network-usage-tracking.md
+++ b/plans/network-usage-tracking.md
@@ -1,0 +1,341 @@
+# Per-sandbox Network Usage Tracking & Limits
+
+## Context
+
+AerolVM today has **zero** network metering. The only network primitive on
+sandboxes is `NetworkBlockAll` — a binary DROP rule on `DOCKER-USER` keyed by
+container source IP (`pkg/docker/netrules/manager.go`). No bytes are counted,
+no quotas exist, no limits can be expressed in `CreateSandboxRequest`, and no
+SDK method asks "how much has this sandbox transferred?".
+
+This plan adds:
+
+1. **Metering** — cumulative ingress/egress byte counters per sandbox,
+   persisted across container restarts and sandboxd restarts, queryable via
+   the SDK.
+2. **Limits** — optional caps (`net_bytes_in_limit`, `net_bytes_out_limit`)
+   that, when exceeded, freeze the sandbox's network (block all egress,
+   surface a typed error). Settable at create-time and via an update RPC.
+
+The user-facing shape mirrors the existing `cpu` / `memory_mb` / `disk_gb`
+quota fields: limits are advisory metadata held on the sandbox row, enforced
+by a background reconcile, and exposed through the same five SDKs.
+
+## Prior art — what the competitive bar actually looks like
+
+I checked what each major sandbox/microVM platform exposes today:
+
+| Platform | Per-sandbox bytes meter? | Per-sandbox bandwidth limit? | How |
+|---|---|---|---|
+| **E2B** | No | No | Limits are *concurrent egress connections* (2,500/sandbox) and request rates. Pricing is per-second compute only. |
+| **Daytona** | No | No | "Network limits" = firewall allow/block list (≤10 CIDRs), not bytes. |
+| **Modal** | No | No | Egress not on price list; no SDK call for bytes. |
+| **Fly.io Machines** | Yes (Prometheus) | No (billed, not capped) | $0.02–0.12/GB egress, exposed via managed Prometheus at `api.fly.io/prometheus/<org>`. |
+| **AWS Lambda / Fargate** | Customer-instrumented only | No | Official guidance is in-guest `/proc/net/dev` snapshots emitted as EMF. |
+| **CF Workers / DO** | No | No | Egress fees eliminated; no per-DO byte counter. |
+
+**Takeaway:** none of the direct competitors (E2B, Daytona, Modal, CF) expose
+per-sandbox bandwidth metering or quota. Only Fly meters, and only as a
+billing-driven Prometheus surface. Shipping `sandbox.getNetworkUsage()` and
+`networkBytesOutLimit` on `CreateSandboxRequest` is genuinely differentiated
+SDK surface, not catch-up.
+
+## Implementation menu — metering
+
+| Technique | Granularity | Overhead | Why we did/didn't pick it |
+|---|---|---|---|
+| **veth `/sys/class/net/<iface>/statistics/{rx,tx}_bytes`** | per-sandbox | ~zero (kernel already counts) | **Picked for v1.** Every container has a host-side veth; counter is free; pure read-side; no rules to install. |
+| **iptables/nftables byte counters** per per-source-IP chain | per-sandbox + per-rule | low | Composes with the existing `DOCKER-USER` chain, but at hundreds of sandboxes the rule list scales poorly and we'd be inventing chain naming + lifecycle. v2 if we want per-destination breakdown. |
+| **cgroup-bpf (cgroup v2, ≥4.10)** | per-cgroup, in+out | low; eBPF only on cgroup processes | Best for per-destination attribution; needs eBPF toolchain + cgroup-id → sandbox-id map. v2 path. |
+| **`/proc/net/dev` polled by toolboxd** | per-sandbox | trivial | Tenant has root; can tamper. Reject. |
+| **Caddy `/metrics`** | per-route (HTTP only) | already deployed | Misses raw TCP through L4, misses direct egress that doesn't go via Caddy. Only useful as a cross-check. |
+
+**Decision: veth statistics polling, host-side, from sandboxd.** Lowest risk,
+no new kernel features required, works with the existing single-bridge Docker
+network setup. The rx/tx semantics from the *host* side of the veth are
+inverted relative to the container (host-side `rx_bytes` = container egress),
+which we'll abstract behind a single helper.
+
+## Implementation menu — limits
+
+| Technique | What it does | Why we did/didn't pick it |
+|---|---|---|
+| **Hard cap → block egress on exceed** (DROP rule via existing netrules) | When `bytes_out > limit_out`, install the same DROP rule `BlockAllEgress` already installs | **Picked for v1.** Reuses an audited primitive. Coarse but matches "quota" semantics — the same shape as a cloud-billing cutoff. |
+| **tc TBF on veth** | Rate-shape (Mbps cap), not a quota | Different feature ("max 10 Mbps") vs. ("max 10 GB total"). Out of scope here; track separately if requested. |
+| **eBPF EDT + FQ** | Nanosecond pacing, scales past tc | Overkill for current scale. v3+. |
+| **App-layer throttle in Caddy** | HTTP-only | Misses raw TCP. Reject. |
+
+**Decision: hard quota cap.** The SDK feature the user asked for is
+"limited with the number of ingress or egress usage" — that maps to a
+total-bytes cap, not a rate cap. Rate-limiting is a separate plan.
+
+## What "ingress" enforcement actually means
+
+Egress enforcement is straightforward — drop forwarded packets in
+`DOCKER-USER` keyed on source IP, exactly like `NetworkBlockAll` already does.
+
+Ingress enforcement is harder: by the time inbound bytes have hit the host's
+NIC and been counted by the veth, we've already paid for them. Three honest
+options:
+
+1. **Count ingress, don't enforce it.** Limit applies to egress only. Ingress
+   shows as a stat. Most customers care about egress (it's what gets billed
+   upstream).
+2. **Enforce ingress by also dropping `-d <containerIP>` in `DOCKER-USER`.**
+   Wastes the bytes that already hit our NIC, but stops *application*-visible
+   ingress. Honest about its limits.
+3. **Enforce at the L7/L4 proxy (Caddy)** by tearing down published routes.
+   Only catches published-port ingress, not direct container-IP traffic
+   (which the bridge network blocks at the host firewall already, but that's
+   a different rabbit hole).
+
+**Decision: option 2.** When `bytes_in > limit_in`, install both
+`-s <ip> -j DROP` and `-d <ip> -j DROP`. Document the "we already paid for the
+bytes you see in the meter" caveat. Egress-only limits are the recommended
+default in docs.
+
+## Data model
+
+### Store changes — `internal/store/store.go`
+
+Four new columns on `sandboxes`. All `INTEGER NOT NULL DEFAULT 0`. None are
+indexed.
+
+```sql
+ALTER TABLE sandboxes ADD COLUMN net_bytes_in        INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE sandboxes ADD COLUMN net_bytes_out       INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE sandboxes ADD COLUMN net_bytes_in_limit  INTEGER NOT NULL DEFAULT 0; -- 0 = unlimited
+ALTER TABLE sandboxes ADD COLUMN net_bytes_out_limit INTEGER NOT NULL DEFAULT 0; -- 0 = unlimited
+```
+
+`net_bytes_*` are **cumulative across container restarts** — the lifetime
+total for a sandbox. `0` for limits means unlimited (matching how
+`memory_mb=0` would be treated, except we always require memory).
+
+A new dedicated method `UpdateSandboxNetCounters(id, deltaIn, deltaOut)`
+writes the deltas atomically. Limits are updated through the existing patch
+path used by `Resize`. Per `/touch-tcp-pool`-style discipline, store changes
+ship with a regression test in `internal/store/store_test.go`.
+
+### Models — `pkg/models/types.go`
+
+```go
+type CreateSandboxRequest struct {
+    // ... existing fields ...
+    NetworkBytesInLimit  int64 `json:"network_bytes_in_limit,omitempty"`
+    NetworkBytesOutLimit int64 `json:"network_bytes_out_limit,omitempty"`
+}
+
+type Sandbox struct {
+    // ... existing fields ...
+    NetworkBytesInLimit  int64 `json:"network_bytes_in_limit"`
+    NetworkBytesOutLimit int64 `json:"network_bytes_out_limit"`
+}
+
+type NetworkUsage struct {
+    SandboxID            string `json:"sandbox_id"`
+    BytesIn              int64  `json:"bytes_in"`
+    BytesOut             int64  `json:"bytes_out"`
+    BytesInLimit         int64  `json:"bytes_in_limit"`           // 0 = unlimited
+    BytesOutLimit        int64  `json:"bytes_out_limit"`          // 0 = unlimited
+    QuotaExceededAt      *time.Time `json:"quota_exceeded_at,omitempty"`
+    LastSampledAt        time.Time  `json:"last_sampled_at"`
+}
+```
+
+Validation: limit ≥ 0; reject negative. Units are bytes, not GB — match the
+disk_gb convention by *not* hiding the unit (`*_bytes` is in the field name).
+
+## Counter pipeline
+
+### New package `pkg/docker/netstats/`
+
+Three responsibilities:
+
+1. **Discover the host-side veth name** for a container. Docker doesn't
+   expose this directly. Standard trick:
+   - `docker.ContainerInspect` → `state.Pid`
+   - `/proc/<pid>/ns/net` → enter or read `/sys/class/net/eth0/iflink` from
+     the container ns to get the host ifindex
+   - Walk `/sys/class/net/*/ifindex` on the host to find the matching veth
+   - Cache the mapping `containerID → vethName` for the container lifetime
+
+2. **Sample** `/sys/class/net/<veth>/statistics/{rx_bytes,tx_bytes}` and
+   compute deltas against an in-memory baseline. From the host side: `rx` is
+   container-egress, `tx` is container-ingress (we'll abstract this).
+
+3. **Background poller** — one goroutine in `Service`, ticking every
+   `NETSTATS_POLL_INTERVAL` (default 10s). For each running sandbox: sample,
+   compute delta vs. last sample, persist via `UpdateSandboxNetCounters`,
+   then check limits.
+
+### Service hooks — `internal/service/service.go`
+
+Following the canonical lazy-bootstrap pattern documented in `CLAUDE.md`
+(`EnsureLayer4Ready` example), a netstats poller is **not** on the
+`CreateSandbox` hot path. It starts on first running sandbox via the
+`atomic.Bool` + `sync.Mutex` single-flight pattern, then runs forever.
+
+New service methods (version-agnostic, called from v1 handlers + facades):
+
+- `GetNetworkUsage(ctx, id) (NetworkUsage, error)`
+- `SetNetworkLimits(ctx, id, in, out int64) (Sandbox, error)`
+- `EnsureNetstatsReady()` — lazy bootstrap, latch + mutex
+
+The reconcile loop at `internal/service/service.go:~1160` already re-heals
+`NetworkBlockAll`; a cheap `bytes_*_limit > 0 && bytes_* >= limit` check is
+added there as the limit-enforcement trigger. Enforcement uses the existing
+`netrules.BlockAllEgress` (and a new `BlockAllIngress` mirror) so we are not
+inventing a second iptables-touching primitive.
+
+### Restart safety
+
+Two failure modes to handle:
+
+1. **Container restart.** Veth interface goes away; new one comes up with a
+   fresh counter at 0. Solution: when the `containerID → vethName` cache
+   miss occurs (or the iface disappears), reset the in-memory baseline to 0
+   for the next sample. Cumulative store value is preserved.
+2. **Sandboxd restart.** Process loses the in-memory baseline. On startup,
+   the first poll for each sandbox snapshots the *current* veth counter as
+   the baseline and records no delta. Worst case: the bytes transferred
+   during the restart window are missed. Acceptable for a 10-second poll.
+
+Document both in code comments — these are exactly the WHY-not-WHAT comments
+the codebase prefers.
+
+## API surface
+
+### `/v1` additions (additive sub-routes only)
+
+`/v1` is soft-frozen against *behavioral changes to existing routes*. Adding
+new sub-paths is allowed and is the established pattern (compare
+`/v1/sandboxes/{id}/expose-port`).
+
+```
+GET   /v1/sandboxes/{id}/network/usage   → NetworkUsage
+PATCH /v1/sandboxes/{id}/network/limits  → { network_bytes_in_limit, network_bytes_out_limit } → Sandbox
+```
+
+Plus the existing `POST /v1/sandboxes` accepts the two new optional fields
+on `CreateSandboxRequest`. New sandbox responses include the two new fields
+(zero by default — backwards-compatible).
+
+### Facade behavior
+
+- **Daytona** — Daytona has no equivalent concept; the new fields are simply
+  not surfaced by `/daytona/...` responses. No change.
+- **E2B** — Same. The existing `TrafficAccessToken` field
+  (`pkg/api/e2b/dto.go:53`) is unrelated and stays untouched.
+
+## SDK lockstep changes
+
+Per `/add-sdk-method`, all five SDKs ship together. Two new methods on the
+sandbox object:
+
+```ts
+// TypeScript example, repeated structure across all 5 SDKs.
+const usage = await sandbox.getNetworkUsage();
+// { bytesIn, bytesOut, bytesInLimit, bytesOutLimit, quotaExceededAt, lastSampledAt }
+
+await sandbox.setNetworkLimits({
+  bytesIn:  10 * 1024 * 1024 * 1024,  // 10 GB
+  bytesOut: 1  * 1024 * 1024 * 1024,  // 1  GB
+});
+```
+
+Plus two new optional fields on the create-sandbox call:
+`networkBytesInLimit`, `networkBytesOutLimit`.
+
+A new typed error `QuotaExceededError` (mirroring how `models.ErrNotFound` is
+mapped through `apihttp.WriteStoreAwareError`) is returned by any SDK call
+that hits a quota-frozen sandbox in a way that requires network (today: none
+do directly — it's the *user's* code inside the sandbox that fails). The
+sandbox's `status` does **not** change; we add a new boolean
+`network_quota_exceeded` on the response and a `quota_exceeded_at` timestamp.
+
+## Documentation
+
+Per the docs hard rules: a new top-level feature gets a new `.mdx` page, not
+a subsection. Add `docs/src/content/docs/network-usage.mdx` registered in
+`docs/src/content.config.ts`. Five-tab `<Tabs syncKey="lang">` with TS,
+Python, Go, Rust, Java examples for `getNetworkUsage()`, `setNetworkLimits()`,
+and the create-time fields. No raw `curl`.
+
+## Phasing
+
+Two ships, not three. Phase 1 is read-only and provides immediate value
+(observability) without the riskier enforcement path.
+
+### Phase 1 — Metering (read-only)
+
+- `pkg/docker/netstats/` package (veth discovery + poller).
+- Store columns `net_bytes_in`, `net_bytes_out` only.
+- Service: `GetNetworkUsage`, `EnsureNetstatsReady` lazy bootstrap.
+- API: `GET /v1/sandboxes/{id}/network/usage`.
+- SDKs: `getNetworkUsage()` across all 5.
+- Docs: new `network-usage.mdx`, metering section only.
+- Tests: store regression test for new columns; service test for poller
+  delta math; netstats unit test that mocks `/sys/class/net/...`.
+
+### Phase 2 — Limits (enforcement)
+
+- Store columns `net_bytes_in_limit`, `net_bytes_out_limit`.
+- Models: extend `CreateSandboxRequest`, `Sandbox`.
+- `pkg/docker/netrules/`: add `BlockAllIngress` mirror.
+- Service: `SetNetworkLimits`; reconcile-loop hook to enforce on exceed;
+  `network_quota_exceeded` flag.
+- API: `POST /v1/sandboxes` accepts new fields; `PATCH /v1/sandboxes/{id}/network/limits`.
+- SDKs: create-time fields + `setNetworkLimits()`.
+- Docs: extend `network-usage.mdx` with limits section.
+- Tests: service test that exceeding limit installs DROP rule; reconcile
+  test that re-heals enforcement after sandboxd restart.
+
+## What's explicitly out of scope
+
+- **Rate shaping** (Mbps caps). Different feature; if requested, ships as a
+  separate plan using tc TBF on veth.
+- **Per-destination attribution** ("how many bytes did this sandbox send to
+  github.com?"). Requires cgroup-bpf or nftables sets. Track for v3.
+- **Billing integration.** This plan exposes the meter; converting bytes to
+  invoices is a separate system.
+- **Resetting the cumulative counter.** Counters are lifetime-of-sandbox.
+  No reset RPC. (Delete the sandbox to reset.)
+- **Daytona/E2B facade exposure.** Those facades don't model this; we don't
+  invent fields for them.
+
+## Risks and call-outs (PR-description bait)
+
+Per `pr-review.md`, these get explicit call-outs in the PR description:
+
+1. **Boot-path latency.** None. The poller is lazy-started on first running
+   sandbox via the canonical latch pattern; `CreateSandbox` is unchanged.
+2. **Idempotency.** `SetNetworkLimits` is idempotent (PATCH semantics).
+   `GetNetworkUsage` is read-only. Limit enforcement is idempotent
+   (re-installing an existing DROP rule is a no-op via the existing
+   `netrules` checks).
+3. **Failure-path consistency.** Counter writes are best-effort; a write
+   failure logs and retries on the next tick. Limit-enforcement DROP rule
+   install is the same primitive as `NetworkBlockAll` and inherits its
+   rollback story.
+4. **`/v1` freeze.** Only additive — new optional fields on the create body
+   (default zero, backwards-compatible) and new sub-routes. No change to
+   existing wire bodies, status codes, or paths.
+5. **TCP host-port pool & L4 bootstrap.** Not touched.
+6. **Veth discovery is privileged.** Reading
+   `/proc/<pid>/ns/net` requires sandboxd to have `CAP_SYS_ADMIN` or root,
+   which it already has for iptables. Document the requirement.
+
+## Open questions for the user
+
+1. **Default limit?** Ship as `0 = unlimited` (recommended) or pick a
+   sensible default (e.g. 100 GB lifetime egress) so the feature is "on" by
+   default? My recommendation is unlimited — opt-in matches the rest of the
+   quota fields.
+2. **Action on quota exceeded:** drop network only (recommended), or also
+   stop the container? Dropping network only matches the "the sandbox is
+   still running, the user's code just can't reach the network" model that
+   feels closest to a billing cap.
+3. **Poll interval:** 10s default OK, or do we want it configurable per
+   sandbox? Recommend a single `NETSTATS_POLL_INTERVAL` env on sandboxd
+   (default 10s), no per-sandbox override.

--- a/plans/sandbox-abuse-prevention.md
+++ b/plans/sandbox-abuse-prevention.md
@@ -1,0 +1,541 @@
+# Sandbox Abuse Prevention (Anti-DDoS, Anti-Scanning, Anti-Spam)
+
+## Context
+
+A sandbox-as-a-service is, by construction, a "give me arbitrary code
+execution on the internet" product. The same primitive that makes it useful
+for AI agents and code interpreters makes it perfect for:
+
+- Outbound DDoS (volumetric or packet-rate)
+- Reflection / amplification attacks (DNS, NTP, memcached, SSDP)
+- Port scanning and vulnerability scanning
+- Brute-force attacks against third-party auth endpoints
+- Spam relay (outbound SMTP)
+- Crypto mining
+- Open proxy / Tor exit abuse
+- C2 traffic for unrelated malware
+
+AerolVM today has **one** anti-abuse primitive: `NetworkBlockAll` — a binary
+DROP rule on `DOCKER-USER` keyed by container source IP
+(`pkg/docker/netrules/manager.go`). That's all-or-nothing and not enabled by
+default. There is no rate limiting, no destination filtering beyond
+`networkAllowList` (≤10 CIDRs, off by default), no behavioral detection, and
+no kill-switch. The platform's reputation is currently one bad customer away
+from getting host IPs onto Spamhaus / AbuseIPDB.
+
+This plan adds a **layered defense** rather than a single mechanism. Each
+layer catches what the previous layer misses; cheap layers go first; the
+expensive layer (eBPF) only ships once we have data to tune it.
+
+A companion plan, [`network-usage-tracking.md`](./network-usage-tracking.md),
+covers per-sandbox byte metering and quotas. That plan is the **billing /
+volume backstop** layer of this one — necessary but not sufficient. The two
+plans share the `pkg/docker/netrules/` and `internal/service/` integration
+surface and should be reviewed together.
+
+## Why bytes-quota alone is insufficient
+
+DDoS is a **rate** problem, not a volume problem. A SYN flood at 100k pps
+can take down a target in 30 seconds while moving only ~6 MB total — far
+under any sane byte cap. Reflection attacks send tiny request packets and
+the *victim* eats the amplified response. Port scans use minuscule
+half-open connections. Reasoning purely in bytes/day misses every
+fast-and-small attack class.
+
+The metering plan's veth byte counter is the right tool for "did this
+sandbox use 10 GB this month." It is the wrong tool for "is this sandbox
+SYN-flooding a victim right now."
+
+## Threat model
+
+| Attack | Shape | Detection signal | Enforcement lever |
+|---|---|---|---|
+| Volumetric flood (UDP/TCP bandwidth) | Sustained high Mbps to one dst | Bandwidth meter trips per-sandbox cap | `tc` TBF rate cap on veth |
+| SYN flood / packet flood | Tiny packets, very high pps | nftables pps counter trips | nftables `limit rate over` drop |
+| Reflection / amplification (DNS, NTP, memcached, SSDP) | Spoofed-source UDP to amplifier ports | Anti-spoof + dst-port match | rp_filter + static dst port denylist |
+| L7 flood (HTTP GET, slowloris) | Many "normal" HTTP/HTTPS requests | Egress proxy request rate per tenant | Caddy/Envoy rate limit |
+| Port scanning / vuln scanning | High distinct-dst-IP count per second | eBPF fanout counter | Behavioral kill-switch |
+| Brute-force | High cps to one dst:port | nftables per-(src,dst:port) cps | nftables connlimit / hashlimit |
+| Spam relay | Outbound to SMTP ports | Static dst-port denylist | nftables drop |
+| Crypto mining | Sustained outbound to known pool IPs | Threat-intel ipset match | nftables drop |
+| Tor exit / open proxy | Wide fanout, mixed dst, sustained | Behavioral fanout + threat intel | Kill-switch |
+| C2 traffic | DNS query to DGA domains, low-rate beacon | DNS filter logs | RPZ sinkhole |
+
+## Layered defense architecture
+
+Seven layers, ordered cheapest-first. The first four are required (table
+stakes for a public sandbox service). Layers 5–7 are opt-in or paid-tier.
+
+### Layer 0 — Kernel hygiene
+
+**Cost:** hours. **What it stops:** spoofing-based reflection attacks,
+conntrack table exhaustion DoS against the host itself.
+
+- `sysctl net.ipv4.conf.all.rp_filter = 1` (strict reverse-path filter —
+  drop packets whose source IP doesn't match the route back). Stops a
+  sandbox from spoofing its source IP for reflection attacks.
+- `sysctl net.ipv4.conf.all.send_redirects = 0`,
+  `net.ipv4.conf.all.accept_redirects = 0`.
+- Per-cgroup conntrack limits via `nft ct count` so one sandbox can't
+  exhaust the host's `nf_conntrack` table.
+- Disable IPv6 forwarding in the sandbox network namespace if unused —
+  halves the attack surface.
+
+These are sandboxd startup operations. Document the sysctl assumptions in
+the install docs; refuse to start (or warn loudly) if `rp_filter != 1`.
+
+### Layer 1 — Static destination/port denylist
+
+**Cost:** ~1 day. **What it stops:** spam, amplification, lateral movement
+to internal services, traffic to known-bad IPs.
+
+Extend `pkg/docker/netrules/` with a denylist applied to every sandbox
+unconditionally:
+
+**Destination ports always blocked:**
+- 25, 465, 587 (SMTP — spam relay)
+- 23 (telnet)
+- 19 (chargen), 17 (qotd) — legacy amplifiers
+- 1900 (SSDP), 11211 (memcached), 161 (SNMP) — modern amplifiers
+- 53 (DNS) — *unless* destined for the sandbox's configured resolver (Layer 6)
+- 123 (NTP) — *unless* destined for an allowed time source
+
+**Destination CIDRs always blocked:**
+- RFC1918 (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`)
+- Link-local (`169.254.0.0/16`)
+- Carrier-grade NAT (`100.64.0.0/10`)
+- Multicast (`224.0.0.0/4`)
+- The host's own management subnet (operator-configured)
+- Localhost (`127.0.0.0/8`) and the host's primary IPs
+
+**Threat-intel denylists** (refreshed hourly via cron):
+- Spamhaus DROP and EDROP
+- FireHOL Level 1
+- Known Tor exit nodes (optional, configurable)
+- Known mining-pool IPs (optional, configurable)
+
+Implementation: maintain these as `ipset` (or nftables sets) and have
+`netrules` reference them. One DROP rule per set. Refresh job is a
+goroutine in sandboxd.
+
+A per-sandbox `networkAllowListOverride: ["smtp"]` escape hatch lets
+specific tenants opt out of specific denylist categories — required for
+legitimate use cases (e.g. a customer building a transactional-email
+service). Off by default; surface as an admin-only field.
+
+### Layer 2 — Per-sandbox rate limits (the primary lever)
+
+**Cost:** ~1 week. **What it stops:** the bulk of practical DDoS, scanning,
+and brute-force activity.
+
+nftables, with one rule per sandbox container IP:
+
+```nft
+add rule ip filter DOCKER-USER \
+  ip saddr <containerIP> ct state new \
+  limit rate over 50/second drop comment "cps cap"
+
+add rule ip filter DOCKER-USER \
+  ip saddr <containerIP> \
+  limit rate over 10000/second drop comment "pps cap"
+
+add rule ip filter DOCKER-USER \
+  ip saddr <containerIP> ct count over 1000 drop comment "concurrent cap"
+```
+
+**Default tier limits (tunable per sandbox via SDK):**
+
+| Knob | Default | Rationale |
+|---|---|---|
+| New connections / sec | 50 | Normal app: ~5 cps. Scanner: 100s cps. |
+| Packets / sec | 10,000 | Normal HTTP API: ~500 pps. Flood: 50k+ pps. |
+| Concurrent connections | 1,000 | E2B caps at 2,500; we start stricter. |
+| Outbound bandwidth (tc TBF) | 100 Mbit/s | Stops volumetric floods; doesn't slow normal app. |
+| DNS queries / sec | 30 | Normal: <5/sec. DGA / amplification: 100s/sec. |
+
+These numbers are starting points. They become per-tier defaults once we
+have production telemetry. Trip-action is `drop` (silent), not `reject` —
+attackers shouldn't get useful timing signal back.
+
+Per-sandbox overrides shipped as new fields on `CreateSandboxRequest`
+(admin-only or paid-tier; not exposed to free-tier users to override
+upward).
+
+### Layer 3 — Behavioral / fanout detection
+
+**Cost:** 1–2 weeks once we have baseline data. **What it stops:** the
+patient and the clever — slow scanners, low-rate floods, tool-assisted
+reconnaissance that stays under static thresholds.
+
+Static rate limits catch obvious abuse but not "5 cps to a victim for an
+hour" or "1 connection to each of 10,000 IPs." What gives those away is
+**pattern**:
+
+- **Fanout**: distinct destination IPs per source per minute. >N → port
+  scan or worm.
+- **Concentration**: >P% of all connections in a window go to a single
+  destination → flood.
+- **Failed-connection ratio**: high SYN-without-SYNACK ratio → scanner.
+- **DNS query rate spike or DGA pattern**: query rate or NXDOMAIN ratio
+  above baseline → DGA / C2.
+
+Right tool: **eBPF at `cgroup_skb`**, keying a hashmap on cgroup ID. This
+is the use case where eBPF earns its complexity vs. sysfs polling — `cat
+/sys/class/net/.../statistics/rx_bytes` cannot tell you "to how many
+distinct destinations." Standard library: `cilium/ebpf` (Go).
+
+A separate goroutine in sandboxd reads BPF maps every 1–5 seconds, runs
+heuristics, and on trip:
+
+1. Calls `netrules.BlockAllEgress(sandboxID)`.
+2. Sets `abuse_suspected = true`, `abuse_reason = "fanout > 200/min"`,
+   `abuse_detected_at = now` on the sandbox row.
+3. Emits an `abuse_events` row with the sample window snapshot.
+4. Sends an alert (webhook configurable; default off).
+
+No automatic unfreeze. Operator review required to clear `abuse_suspected`
+— for AI-agent workloads, "scanned 1000 IPs" is almost never a
+false-positive.
+
+**Why not ship Layer 3 first:** false-positive rate is impossible to tune
+without production traffic baselines. Shipping it before Layers 0–2 means
+either too-loose thresholds (no protection) or too-tight (legitimate users
+freezing). Layers 0–2 buy us the time to collect that baseline.
+
+### Layer 4 — Volume quota (the metering plan)
+
+**Cost:** covered by [`network-usage-tracking.md`](./network-usage-tracking.md).
+
+Last-line backstop for slow exfiltration that evades rate-domain detection.
+Also serves the billing use case. No additional work in this plan; it's
+called out here so reviewers see how the layers compose.
+
+### Layer 5 — Egress proxy (paid tier / strict mode)
+
+**Cost:** 1–2 weeks if we extend the existing Caddy; longer if we
+introduce Envoy.
+
+For tenants who want defense in depth, force outbound HTTP/HTTPS through a
+proxy. Buys:
+
+- Domain-level allowlist / denylist (much more useful than IP-level)
+- L7 request-rate limits
+- Full request log per tenant
+- TLS interception (off by default; opt-in for tenants who consent)
+
+Caddy is already in the stack as the L7 ingress proxy; reusing it as an
+**egress** proxy means a small new admin module, not a new dependency.
+For non-HTTP TCP, fall back to Layer 2. Surface as a `egressProxy: true`
+field on `CreateSandboxRequest`.
+
+### Layer 6 — DNS filtering
+
+**Cost:** ~1 week.
+
+Force all DNS through a controlled resolver (CoreDNS with the `rpz` plugin
+or Unbound with RPZ). Layer 1 already blocks dst port 53 except to the
+configured resolver, so this layer just chooses the resolver's behavior:
+
+- Sinkhole malicious domains via Spamhaus/Quad9/SURBL feeds
+- Block DGA-pattern queries (high-entropy subdomains, NXDOMAIN floods)
+- Per-source rate limit (default: 30 q/s, same as Layer 2 knob)
+- Full query log per tenant (rotated)
+
+Most C2 traffic and many attacks need DNS. Controlling DNS controls a lot
+for very little code.
+
+### Layer 7 — Kill-switch & abuse review pipeline
+
+**Cost:** ~3 days of glue work; reuses Layers 1–3 enforcement primitives.
+
+When *any* layer trips, the action path is the same:
+
+1. `netrules.BlockAllEgress(sandboxID)` — instant, idempotent.
+2. Persist `abuse_suspected, abuse_reason, abuse_detected_at` on
+   `sandboxes` row.
+3. Append to `abuse_events` table (one row per detection).
+4. Emit webhook to the operator's configured endpoint (Slack, PagerDuty,
+   their billing/CRM system).
+5. Sandbox status remains `running` (the user's code keeps running, it
+   just can't reach the network). Operator decides whether to suspend the
+   tenant entirely.
+
+**No automatic unfreeze.** Manual operator action via a new admin
+endpoint: `POST /v1/admin/sandboxes/{id}/clear-abuse-flag` with a `reason`
+field for the audit log.
+
+## Data model
+
+### Store changes — `internal/store/store.go`
+
+Three new columns on `sandboxes`:
+
+```sql
+ALTER TABLE sandboxes ADD COLUMN abuse_suspected     INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE sandboxes ADD COLUMN abuse_reason        TEXT NOT NULL DEFAULT '';
+ALTER TABLE sandboxes ADD COLUMN abuse_detected_at   INTEGER NOT NULL DEFAULT 0;
+```
+
+Per-sandbox rate-limit overrides (paid-tier; nullable means "use
+host default"):
+
+```sql
+ALTER TABLE sandboxes ADD COLUMN rate_cps_limit       INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE sandboxes ADD COLUMN rate_pps_limit       INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE sandboxes ADD COLUMN rate_concurrent_limit INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE sandboxes ADD COLUMN rate_bw_mbps_limit    INTEGER NOT NULL DEFAULT 0;
+```
+
+`0` = use host default. The host defaults live in sandboxd config
+(`SB_RATE_*` env vars).
+
+New table for the audit log:
+
+```sql
+CREATE TABLE abuse_events (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  sandbox_id  TEXT NOT NULL,
+  detected_at INTEGER NOT NULL,
+  layer       TEXT NOT NULL,        -- 'static_denylist' | 'rate_limit' | 'behavioral' | 'manual'
+  reason      TEXT NOT NULL,
+  sample_json TEXT NOT NULL,        -- snapshot of metrics at detection
+  cleared_at  INTEGER,
+  cleared_by  TEXT,
+  cleared_reason TEXT
+);
+CREATE INDEX abuse_events_sandbox_idx ON abuse_events(sandbox_id, detected_at DESC);
+```
+
+### Models — `pkg/models/types.go`
+
+```go
+type CreateSandboxRequest struct {
+    // ... existing fields ...
+    RateLimits *RateLimits `json:"rate_limits,omitempty"`
+}
+
+type RateLimits struct {
+    NewConnectionsPerSecond int `json:"new_connections_per_second,omitempty"`
+    PacketsPerSecond        int `json:"packets_per_second,omitempty"`
+    ConcurrentConnections   int `json:"concurrent_connections,omitempty"`
+    BandwidthMbps           int `json:"bandwidth_mbps,omitempty"`
+}
+
+type AbuseStatus struct {
+    Suspected   bool       `json:"suspected"`
+    Reason      string     `json:"reason,omitempty"`
+    DetectedAt  *time.Time `json:"detected_at,omitempty"`
+    Layer       string     `json:"layer,omitempty"`
+    RecentEvents []AbuseEvent `json:"recent_events,omitempty"`
+}
+```
+
+`Sandbox` gets a top-level `AbuseSuspected bool` for visibility in list
+responses.
+
+## Implementation surfaces
+
+### `pkg/docker/netrules/` — extend, don't replace
+
+The existing `Manager` is iptables-only and binary
+(`BlockAllEgress`/`ClearBlockAllEgress`). Refactor:
+
+- Migrate from `iptables` to `nft` for the new chains (the existing
+  `DOCKER-USER` rule stays iptables for compatibility — you can mix in
+  modern kernels).
+- New methods: `ApplyStaticDenylists`, `ApplyRateLimits(sandboxID, RateLimits)`,
+  `ApplyBandwidthCap(sandboxID, mbps)`, `ApplyIngressBlock`,
+  `RefreshThreatIntel`.
+- All idempotent — re-applying an existing rule is a no-op (use named
+  chains and `nft -- atomic` reload).
+
+### `pkg/docker/netstats/` — already proposed in the metering plan
+
+Extended here with **rate-domain metrics** read from BPF maps (Layer 3),
+not just sysfs counters (Layer 4). The package owns both polling cadences:
+- 10s cadence: sysfs byte counters → store deltas (metering plan)
+- 1s cadence: BPF map reads → in-memory rate samples → behavioral
+  heuristics
+
+### `internal/service/service.go`
+
+New methods (version-agnostic):
+
+- `SetRateLimits(ctx, id, RateLimits) (Sandbox, error)` — paid-tier;
+  validate against host max ceilings.
+- `GetAbuseStatus(ctx, id) (AbuseStatus, error)`
+- `ClearAbuseFlag(ctx, id, reason string) (Sandbox, error)` — admin only.
+- `EnsureAbuseDefenseReady()` — lazy bootstrap (canonical latch +
+  single-flight pattern from `EnsureLayer4Ready`). Loads denylists,
+  attaches BPF programs, starts refresh and detection goroutines.
+
+The `CreateSandbox` path applies Layers 0–2 unconditionally as part of
+container post-start (after the IP is known, before returning). Layer 3
+attaches the BPF program at the same point.
+
+### API surface — `/v1` additive only
+
+```
+GET    /v1/sandboxes/{id}/abuse-status
+POST   /v1/admin/sandboxes/{id}/clear-abuse-flag       { reason }
+PATCH  /v1/sandboxes/{id}/rate-limits                  RateLimits → Sandbox
+```
+
+Plus `POST /v1/sandboxes` accepts the new optional `rate_limits` field.
+No behavioral changes to existing v1 routes.
+
+### Facade behavior
+
+- **Daytona** — no analog; new fields not surfaced.
+- **E2B** — has the concept of rate limits (E2B's published limits are
+  org-level, not per-sandbox). Surface AerolVM's per-sandbox limits via
+  the existing E2B headers if there's a clean mapping; otherwise leave
+  the facade silent. Defer to the E2B compat owner.
+
+## SDK lockstep changes
+
+Per `/add-sdk-method`, all five SDKs:
+
+```ts
+const status = await sandbox.getAbuseStatus();
+// { suspected, reason, detectedAt, layer, recentEvents }
+
+await sandbox.setRateLimits({
+  newConnectionsPerSecond: 100,
+  packetsPerSecond: 20000,
+  concurrentConnections: 2000,
+  bandwidthMbps: 200,
+});
+```
+
+New typed error `AbuseDetectedError` returned when an SDK call against a
+flagged sandbox would be misleading (e.g. reading network usage). `clear`
+is admin-only; not exposed in the public SDKs by default.
+
+## Documentation
+
+Per the docs hard rules, two new `.mdx` pages:
+
+- `docs/src/content/docs/abuse-prevention.mdx` — operator-facing.
+  Explains the seven layers, what each catches, defaults, tuning knobs,
+  and how to respond to abuse events. No SDK code samples (this is an
+  operator concern).
+- `docs/src/content/docs/rate-limits.mdx` — developer-facing. Five-tab
+  examples for `setRateLimits` and `getAbuseStatus`. Documents the
+  default tier, what tripping looks like, and how to request a tier
+  upgrade.
+
+Register both in `docs/src/content.config.ts`.
+
+## Phasing
+
+Three ships, ordered by "stops the most abuse per week of work."
+
+### Phase 1 — Hygiene + static denylist (1 week, REQUIRED)
+
+Layers 0 and 1. Plus the kill-switch wiring (Layer 7, partial — manual
+trip from operator only).
+
+- Kernel sysctls + install-time check
+- Static dst-port and CIDR denylists
+- Threat-intel ipset refresh job (Spamhaus DROP/EDROP)
+- `abuse_suspected` column + admin clear endpoint
+- `abuse_events` table
+
+This alone cuts off spam relay, the major amplification vectors, lateral
+movement to internal services, and traffic to known-bad IPs. It is the
+table-stakes "don't get our IPs blocklisted" layer.
+
+### Phase 2 — Per-sandbox rate limits (1–2 weeks)
+
+Layer 2 in full + Layer 7 trip from rate-limit violations.
+
+- nftables per-sandbox rate / pps / concurrent / bandwidth rules
+- `RateLimits` model + store columns
+- `SetRateLimits` service method + API + SDK lockstep
+- Default tier in sandboxd config; per-sandbox overrides
+
+After Phase 2 the platform is hardened against the bulk of practical
+abuse. Phase 3 is for the patient/clever attackers.
+
+### Phase 3 — Behavioral detection (2–4 weeks, after baseline data)
+
+Layer 3 in full.
+
+- `pkg/docker/netstats/` BPF programs (cilium/ebpf)
+- 1s detection loop with fanout / concentration / DNS-rate heuristics
+- Webhook alert configuration
+- `recent_events` in `AbuseStatus`
+
+Do NOT ship Phase 3 before collecting at least a month of Phase 1+2
+production traffic. The heuristic thresholds are unknowable before that.
+
+### Future phases (uncommitted)
+
+- Layer 5: egress proxy (paid-tier feature).
+- Layer 6: DNS filtering.
+- ML-based detection (only after rule-based is well-tuned).
+
+## What's explicitly out of scope
+
+- **Inbound DDoS protection of the AerolVM control plane itself.** That's
+  a different problem (front your own host with Cloudflare / AWS Shield).
+  This plan is about preventing *outbound* abuse from sandboxes.
+- **Tenant-level rate limits / quotas.** Per-tenant aggregation across
+  many sandboxes is a different aggregation level; this plan is
+  per-sandbox. A future plan can stack tenant limits on top.
+- **Anti-fraud / payment abuse.** Out of network scope.
+- **In-sandbox software inventory / antivirus.** We don't inspect the
+  user's code; we govern its network behavior.
+- **TLS interception / DPI by default.** Layer 5 mentions opt-in TLS
+  interception but only as an explicit tenant choice with consent.
+
+## Risks and PR-description call-outs
+
+Per `pr-review.md`:
+
+1. **Boot-path latency.** Layers 0 and 1 are sandboxd-startup work, not
+   per-sandbox. Layer 2 adds 3 nftables rules per sandbox at create-time
+   (~5 ms via netlink); call out in the PR. Layer 3 BPF attach is
+   ~10–50 ms per sandbox; called out and benchmarked.
+2. **Idempotency.** Every nftables rule is keyed by sandbox ID with
+   named chains; re-apply is a no-op (`nft -- atomic` replace).
+   Threat-intel refresh swaps the set atomically.
+3. **Failure-path consistency.** If nftables apply fails during create,
+   the sandbox start is **rolled back** (DELETE container, store row to
+   `failed`). Document this explicitly — better to refuse to create than
+   to start an unprotected sandbox.
+4. **`/v1` freeze.** Only additive — new optional `rate_limits` field
+   (default null), new sub-routes. No change to existing wire bodies.
+5. **TCP host-port pool & L4 bootstrap.** Not touched.
+6. **Lazy bootstrap pattern.** `EnsureAbuseDefenseReady` follows the
+   `EnsureLayer4Ready` latch + single-flight template.
+7. **iptables ↔ nftables coexistence.** We mix iptables (existing
+   `DOCKER-USER` rule) with new nftables chains. Document the
+   compatibility constraint (kernel ≥ 4.18, both binaries present) in
+   install docs. Refuse to start if either is missing.
+8. **False-positive blast radius.** Phase 3 freezes a sandbox on
+   detection. Document the operator-clear path in the on-call runbook
+   before shipping Phase 3.
+
+## Open questions for the user
+
+1. **Default-on or opt-in for Layers 0–2?** Recommendation: default-on,
+   non-overridable for Layer 0, denylist-categories overridable for
+   Layer 1, rate limits set to permissive defaults that real apps won't
+   notice.
+2. **Webhook destination format.** Slack-style incoming webhook,
+   PagerDuty Events API, or generic JSON POST? Recommendation: generic
+   JSON POST; let operators adapt.
+3. **What action on abuse: network-block (current proposal) or
+   container-stop?** Recommendation: network-block. Stopping the
+   container loses customer state; blocking network preserves the
+   blast-radius "the user's code is still running, it just can't reach
+   out" model that matches billing-cap semantics in the metering plan.
+4. **Tier surfacing.** Should `RateLimits` defaults be hardcoded or
+   driven by a `tier` field on the sandbox? Recommendation: start
+   hardcoded via env (`SB_RATE_*`); add a tier abstraction in a later
+   plan when there's a real billing model to attach it to.
+5. **Threat-intel feeds** — Spamhaus + FireHOL is the obvious start.
+   Add Tor exit list and mining-pool list as opt-in operator config?
+   Recommendation: yes, opt-in and configurable.

--- a/sdk/go/internal/apiclient/client.go
+++ b/sdk/go/internal/apiclient/client.go
@@ -193,6 +193,22 @@ func (c *Client) Mounts(ctx context.Context, id string) ([]models.MountSpecRedac
 	return response.Mounts, nil
 }
 
+func (c *Client) GetNetworkUsage(ctx context.Context, id string) (models.NetworkUsage, error) {
+	var response models.NetworkUsage
+	if err := c.doJSON(ctx, http.MethodGet, c.versionPrefix+"/sandboxes/"+id+"/network/usage", nil, &response); err != nil {
+		return models.NetworkUsage{}, err
+	}
+	return response, nil
+}
+
+func (c *Client) SetNetworkLimits(ctx context.Context, id string, request models.UpdateNetworkLimitsRequest) (models.NetworkUsage, error) {
+	var response models.NetworkUsage
+	if err := c.doJSON(ctx, http.MethodPatch, c.versionPrefix+"/sandboxes/"+id+"/network/limits", request, &response); err != nil {
+		return models.NetworkUsage{}, err
+	}
+	return response, nil
+}
+
 func (c *Client) Exec(ctx context.Context, id string, request ExecRequest) (ExecResult, error) {
 	var response ExecResult
 	err := c.doJSON(ctx, http.MethodPost, c.versionPrefix+"/sandboxes/"+id+"/toolbox/process/execute", request, &response)

--- a/sdk/go/internal/apiclient/client_test.go
+++ b/sdk/go/internal/apiclient/client_test.go
@@ -144,6 +144,7 @@ func TestTransportClientCases(t *testing.T) {
 					if r.Method != http.MethodGet || r.URL.Path != "/v1/sandboxes/sb-net/network/usage" {
 						t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 					}
+					sampled := time.Now().UTC()
 					_ = json.NewEncoder(w).Encode(models.NetworkUsage{
 						SandboxID:     "sb-net",
 						BytesIn:       1024,
@@ -151,7 +152,7 @@ func TestTransportClientCases(t *testing.T) {
 						BytesInLimit:  1 << 20,
 						BytesOutLimit: 0,
 						QuotaExceeded: false,
-						LastSampledAt: time.Now().UTC(),
+						LastSampledAt: &sampled,
 					})
 				}))
 				defer server.Close()

--- a/sdk/go/internal/apiclient/client_test.go
+++ b/sdk/go/internal/apiclient/client_test.go
@@ -138,6 +138,70 @@ func TestTransportClientCases(t *testing.T) {
 			},
 		},
 		{
+			name: "get_network_usage_returns_counters_and_limits",
+			run: func(t *testing.T) {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method != http.MethodGet || r.URL.Path != "/v1/sandboxes/sb-net/network/usage" {
+						t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+					}
+					_ = json.NewEncoder(w).Encode(models.NetworkUsage{
+						SandboxID:     "sb-net",
+						BytesIn:       1024,
+						BytesOut:      2048,
+						BytesInLimit:  1 << 20,
+						BytesOutLimit: 0,
+						QuotaExceeded: false,
+						LastSampledAt: time.Now().UTC(),
+					})
+				}))
+				defer server.Close()
+
+				client := NewClient(server.URL, ClientOptions{PATToken: "pat-token", HTTPClient: server.Client()})
+				usage, err := client.GetNetworkUsage(ctx, "sb-net")
+				if err != nil {
+					t.Fatalf("GetNetworkUsage() error = %v", err)
+				}
+				if usage.BytesIn != 1024 || usage.BytesOutLimit != 0 || usage.QuotaExceeded {
+					t.Fatalf("unexpected usage: %+v", usage)
+				}
+			},
+		},
+		{
+			name: "set_network_limits_sends_patch_with_pointer_fields",
+			run: func(t *testing.T) {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method != http.MethodPatch || r.URL.Path != "/v1/sandboxes/sb-net/network/limits" {
+						t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+					}
+					var payload models.UpdateNetworkLimitsRequest
+					if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+						t.Fatalf("Decode() error = %v", err)
+					}
+					if payload.NetworkBytesInLimit == nil || *payload.NetworkBytesInLimit != 4096 {
+						t.Fatalf("unexpected NetworkBytesInLimit: %+v", payload.NetworkBytesInLimit)
+					}
+					if payload.NetworkBytesOutLimit != nil {
+						t.Fatalf("expected NetworkBytesOutLimit nil; got %+v", payload.NetworkBytesOutLimit)
+					}
+					_ = json.NewEncoder(w).Encode(models.NetworkUsage{
+						SandboxID:    "sb-net",
+						BytesInLimit: 4096,
+					})
+				}))
+				defer server.Close()
+
+				client := NewClient(server.URL, ClientOptions{PATToken: "pat-token", HTTPClient: server.Client()})
+				inLimit := int64(4096)
+				usage, err := client.SetNetworkLimits(ctx, "sb-net", models.UpdateNetworkLimitsRequest{NetworkBytesInLimit: &inLimit})
+				if err != nil {
+					t.Fatalf("SetNetworkLimits() error = %v", err)
+				}
+				if usage.BytesInLimit != 4096 {
+					t.Fatalf("unexpected usage: %+v", usage)
+				}
+			},
+		},
+		{
 			name: "json_error_payload_is_decoded",
 			run: func(t *testing.T) {
 				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/sdk/go/pkg/microvm/client.go
+++ b/sdk/go/pkg/microvm/client.go
@@ -114,6 +114,21 @@ func (c *Client) Mounts(ctx context.Context, id string) ([]sdktypes.MountSpecRed
 	return c.inner.Mounts(ctx, id)
 }
 
+// GetNetworkUsage returns current cumulative ingress/egress byte counters and
+// the configured per-direction caps for a sandbox. A `*Limit` of zero means
+// unlimited.
+func (c *Client) GetNetworkUsage(ctx context.Context, id string) (sdktypes.NetworkUsage, error) {
+	return c.inner.GetNetworkUsage(ctx, id)
+}
+
+// SetNetworkLimits raises or lifts the per-direction byte caps. Leave a field
+// nil to keep the current value; pass a pointer to zero to set "unlimited".
+// Raising a cap above current usage clears the per-IP iptables block on the
+// next reconcile pass (or immediately if it's already over the new cap).
+func (c *Client) SetNetworkLimits(ctx context.Context, id string, opts sdktypes.SetNetworkLimitsOptions) (sdktypes.NetworkUsage, error) {
+	return c.inner.SetNetworkLimits(ctx, id, opts)
+}
+
 func (c *Client) Start(ctx context.Context, id string) (*Sandbox, error) {
 	item, err := c.inner.Start(ctx, id)
 	if err != nil {
@@ -274,6 +289,14 @@ func (s *Sandbox) Resize(ctx context.Context, opts sdktypes.ResizeSandboxOptions
 	}
 	s.Sandbox = item.Sandbox
 	return nil
+}
+
+func (s *Sandbox) GetNetworkUsage(ctx context.Context) (sdktypes.NetworkUsage, error) {
+	return s.client.GetNetworkUsage(ctx, s.ID)
+}
+
+func (s *Sandbox) SetNetworkLimits(ctx context.Context, opts sdktypes.SetNetworkLimitsOptions) (sdktypes.NetworkUsage, error) {
+	return s.client.SetNetworkLimits(ctx, s.ID, opts)
 }
 
 func (s *Sandbox) UpdateLifecycle(ctx context.Context, lifecycle sdktypes.Lifecycle) error {

--- a/sdk/go/pkg/types/types.go
+++ b/sdk/go/pkg/types/types.go
@@ -62,6 +62,9 @@ const (
 	RuntimeKata   = models.RuntimeKata
 )
 
+type NetworkUsage = models.NetworkUsage
+type SetNetworkLimitsOptions = models.UpdateNetworkLimitsRequest
+
 type GPURequest = models.GPURequest
 type GPUVendor = models.GPUVendor
 

--- a/sdk/java/src/main/java/ai/aerol/microvm/MicroVMClient.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/MicroVMClient.java
@@ -36,11 +36,13 @@ import ai.aerol.microvm.model.ExposeResult;
 import ai.aerol.microvm.model.HealthStatus;
 import ai.aerol.microvm.model.Lifecycle;
 import ai.aerol.microvm.model.MountSpecRedacted;
+import ai.aerol.microvm.model.NetworkUsage;
 import ai.aerol.microvm.model.ResizeOptions;
 import ai.aerol.microvm.model.SandboxData;
 import ai.aerol.microvm.model.SandboxSnapshot;
 import ai.aerol.microvm.model.Session;
 import ai.aerol.microvm.model.SessionAttachOptions;
+import ai.aerol.microvm.model.SetNetworkLimitsOptions;
 
 public class MicroVMClient {
     static final String DEFAULT_API_URL = "http://127.0.0.1:21212";
@@ -156,6 +158,14 @@ public class MicroVMClient {
             return Collections.emptyList();
         }
         return response.mounts;
+    }
+
+    public NetworkUsage getNetworkUsage(String sandboxId) {
+        return doJson("GET", sandboxPath(sandboxId) + "/network/usage", null, NetworkUsage.class);
+    }
+
+    public NetworkUsage setNetworkLimits(String sandboxId, SetNetworkLimitsOptions options) {
+        return doJson("PATCH", sandboxPath(sandboxId) + "/network/limits", options, NetworkUsage.class);
     }
 
     public ExecResult exec(String sandboxId, ExecRequest request) {

--- a/sdk/java/src/main/java/ai/aerol/microvm/Sandbox.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/Sandbox.java
@@ -9,11 +9,13 @@ import ai.aerol.microvm.model.ExecStreamOptions;
 import ai.aerol.microvm.model.ExposeOptions;
 import ai.aerol.microvm.model.ExposeResult;
 import ai.aerol.microvm.model.Lifecycle;
+import ai.aerol.microvm.model.NetworkUsage;
 import ai.aerol.microvm.model.ResizeOptions;
 import ai.aerol.microvm.model.SandboxData;
 import ai.aerol.microvm.model.SandboxSnapshot;
 import ai.aerol.microvm.model.Session;
 import ai.aerol.microvm.model.SessionAttachOptions;
+import ai.aerol.microvm.model.SetNetworkLimitsOptions;
 
 public class Sandbox extends SandboxData {
     private final MicroVMClient client;
@@ -133,6 +135,14 @@ public class Sandbox extends SandboxData {
     public Sandbox updateLifecycle(Lifecycle lifecycle) {
         apply(client.updateLifecycle(id, lifecycle));
         return this;
+    }
+
+    public NetworkUsage getNetworkUsage() {
+        return client.getNetworkUsage(id);
+    }
+
+    public NetworkUsage setNetworkLimits(SetNetworkLimitsOptions options) {
+        return client.setNetworkLimits(id, options);
     }
 
     private void apply(SandboxData data) {

--- a/sdk/java/src/main/java/ai/aerol/microvm/model/CreateOptions.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/model/CreateOptions.java
@@ -17,6 +17,10 @@ public class CreateOptions {
     public Map<String, String> env;
     public String osUser;
     public Boolean networkBlockAll;
+    @JsonProperty("network_bytes_in_limit")
+    public Long networkBytesInLimit;
+    @JsonProperty("network_bytes_out_limit")
+    public Long networkBytesOutLimit;
     public RegistryAuth registry;
     public List<String> containerCommand;
     public List<MountSpec> mounts;
@@ -57,6 +61,16 @@ public class CreateOptions {
 
     public CreateOptions setNetworkBlockAll(Boolean networkBlockAll) {
         this.networkBlockAll = networkBlockAll;
+        return this;
+    }
+
+    public CreateOptions setNetworkBytesInLimit(Long networkBytesInLimit) {
+        this.networkBytesInLimit = networkBytesInLimit;
+        return this;
+    }
+
+    public CreateOptions setNetworkBytesOutLimit(Long networkBytesOutLimit) {
+        this.networkBytesOutLimit = networkBytesOutLimit;
         return this;
     }
 

--- a/sdk/java/src/main/java/ai/aerol/microvm/model/NetworkUsage.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/model/NetworkUsage.java
@@ -1,0 +1,22 @@
+package ai.aerol.microvm.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class NetworkUsage {
+    @JsonProperty("sandbox_id")
+    public String sandboxId;
+    @JsonProperty("bytes_in")
+    public long bytesIn;
+    @JsonProperty("bytes_out")
+    public long bytesOut;
+    @JsonProperty("bytes_in_limit")
+    public long bytesInLimit;
+    @JsonProperty("bytes_out_limit")
+    public long bytesOutLimit;
+    @JsonProperty("quota_exceeded")
+    public boolean quotaExceeded;
+    @JsonProperty("quota_exceeded_at")
+    public String quotaExceededAt;
+    @JsonProperty("last_sampled_at")
+    public String lastSampledAt;
+}

--- a/sdk/java/src/main/java/ai/aerol/microvm/model/NetworkUsage.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/model/NetworkUsage.java
@@ -17,6 +17,7 @@ public class NetworkUsage {
     public boolean quotaExceeded;
     @JsonProperty("quota_exceeded_at")
     public String quotaExceededAt;
+    /** Null until the netstats poller has produced at least one sample. */
     @JsonProperty("last_sampled_at")
     public String lastSampledAt;
 }

--- a/sdk/java/src/main/java/ai/aerol/microvm/model/SetNetworkLimitsOptions.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/model/SetNetworkLimitsOptions.java
@@ -1,0 +1,24 @@
+package ai.aerol.microvm.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+// Long (boxed) so unset fields serialize as missing — server reads "leave
+// alone" for nulls and "unlimited" for an explicit 0.
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SetNetworkLimitsOptions {
+    @JsonProperty("network_bytes_in_limit")
+    public Long networkBytesInLimit;
+    @JsonProperty("network_bytes_out_limit")
+    public Long networkBytesOutLimit;
+
+    public SetNetworkLimitsOptions setNetworkBytesInLimit(Long limit) {
+        this.networkBytesInLimit = limit;
+        return this;
+    }
+
+    public SetNetworkLimitsOptions setNetworkBytesOutLimit(Long limit) {
+        this.networkBytesOutLimit = limit;
+        return this;
+    }
+}

--- a/sdk/java/src/test/java/ai/aerol/microvm/MicroVMClientTest.java
+++ b/sdk/java/src/test/java/ai/aerol/microvm/MicroVMClientTest.java
@@ -36,10 +36,12 @@ import ai.aerol.microvm.model.ExecStreamOptions;
 import ai.aerol.microvm.model.Lifecycle;
 import ai.aerol.microvm.model.MountSpec;
 import ai.aerol.microvm.model.MountSpecRedacted;
+import ai.aerol.microvm.model.NetworkUsage;
 import ai.aerol.microvm.model.SandboxData;
 import ai.aerol.microvm.model.SandboxSnapshot;
 import ai.aerol.microvm.model.Session;
 import ai.aerol.microvm.model.SessionAttachOptions;
+import ai.aerol.microvm.model.SetNetworkLimitsOptions;
 
 class MicroVMClientTest {
     @Test
@@ -301,6 +303,62 @@ class MicroVMClientTest {
             assertEquals(99, session.bytes);
             assertArrayEquals("session log".getBytes(StandardCharsets.UTF_8), log);
             assertArrayEquals("{\"version\":2}".getBytes(StandardCharsets.UTF_8), recording);
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void networkUsageAndLimitsMapApiShapes() throws Exception {
+        AtomicReference<Map<String, Object>> patchBody = new AtomicReference<>();
+        AtomicReference<String> patchMethod = new AtomicReference<>();
+        HttpServer server = startServer(exchange -> {
+            String path = exchange.getRequestURI().getPath();
+            String method = exchange.getRequestMethod();
+            if ("GET".equals(method) && "/v1/sandboxes/sb-1/network/usage".equals(path)) {
+                writeJson(exchange, 200, mapOf(
+                    "sandbox_id", "sb-1",
+                    "bytes_in", 1024,
+                    "bytes_out", 2048,
+                    "bytes_in_limit", 1048576,
+                    "bytes_out_limit", 0,
+                    "quota_exceeded", false,
+                    "last_sampled_at", "2026-05-15T10:00:00Z"
+                ));
+                return;
+            }
+            if ("PATCH".equals(method) && "/v1/sandboxes/sb-1/network/limits".equals(path)) {
+                patchMethod.set(method);
+                patchBody.set(castMap(JsonSupport.read(exchange.getRequestBody().readAllBytes(), Map.class)));
+                writeJson(exchange, 200, mapOf(
+                    "sandbox_id", "sb-1",
+                    "bytes_in", 0,
+                    "bytes_out", 0,
+                    "bytes_in_limit", 4096,
+                    "bytes_out_limit", 0,
+                    "quota_exceeded", false,
+                    "last_sampled_at", "2026-05-15T10:00:00Z"
+                ));
+                return;
+            }
+            throw new AssertionError("unexpected request: " + method + " " + path);
+        });
+
+        try {
+            MicroVMClient client = clientFor(server);
+            NetworkUsage usage = client.getNetworkUsage("sb-1");
+            assertEquals("sb-1", usage.sandboxId);
+            assertEquals(1024, usage.bytesIn);
+            assertEquals(0, usage.bytesOutLimit);
+
+            NetworkUsage updated = client.setNetworkLimits(
+                "sb-1",
+                new SetNetworkLimitsOptions().setNetworkBytesInLimit(4096L)
+            );
+            assertEquals(4096, updated.bytesInLimit);
+            assertEquals("PATCH", patchMethod.get());
+            assertEquals(4096, ((Number) patchBody.get().get("network_bytes_in_limit")).longValue());
+            assertEquals(1, patchBody.get().size(), "unset fields should not be serialized");
         } finally {
             server.stop(0);
         }

--- a/sdk/python/microvm/client.py
+++ b/sdk/python/microvm/client.py
@@ -823,11 +823,13 @@ def _from_api_network_usage(payload: Dict[str, Any]) -> NetworkUsage:
         "bytesInLimit": int(_first_of(payload, "bytes_in_limit", "bytesInLimit") or 0),
         "bytesOutLimit": int(_first_of(payload, "bytes_out_limit", "bytesOutLimit") or 0),
         "quotaExceeded": bool(_first_of(payload, "quota_exceeded", "quotaExceeded") or False),
-        "lastSampledAt": str(_first_of(payload, "last_sampled_at", "lastSampledAt") or ""),
     }
     quota_exceeded_at = _first_of(payload, "quota_exceeded_at", "quotaExceededAt")
     if quota_exceeded_at not in (None, ""):
         result["quotaExceededAt"] = str(quota_exceeded_at)
+    last_sampled_at = _first_of(payload, "last_sampled_at", "lastSampledAt")
+    if last_sampled_at not in (None, ""):
+        result["lastSampledAt"] = str(last_sampled_at)
     return result
 
 

--- a/sdk/python/microvm/client.py
+++ b/sdk/python/microvm/client.py
@@ -26,11 +26,13 @@ from .types import (
     Lifecycle,
     MountSpec,
     MountSpecRedacted,
+    NetworkUsage,
     ResizeOptions,
     SandboxData,
     SandboxSnapshot,
     Session,
     SessionAttachOptions,
+    SetNetworkLimitsOptions,
 )
 
 STREAM_PREFIX_STDOUT = 0x01
@@ -342,6 +344,12 @@ class Sandbox:
         self._data = updated.to_dict()
         return self
 
+    def get_network_usage(self) -> NetworkUsage:
+        return self._client.get_network_usage(self.id)
+
+    def set_network_limits(self, options: SetNetworkLimitsOptions) -> NetworkUsage:
+        return self._client.set_network_limits(self.id, options)
+
     @property
     def id(self) -> str:
         return str(self._data.get("id", ""))
@@ -429,6 +437,15 @@ class MicroVM:
         if not isinstance(mounts, list):
             return []
         return [_from_api_mount_spec_redacted(item) for item in mounts]
+
+    def get_network_usage(self, sandbox_id: str) -> NetworkUsage:
+        payload = self._do_json("GET", f"{self._version_prefix}/sandboxes/{sandbox_id}/network/usage", None)
+        return _from_api_network_usage(payload)
+
+    def set_network_limits(self, sandbox_id: str, options: SetNetworkLimitsOptions) -> NetworkUsage:
+        body = _to_api_set_network_limits_options(options)
+        payload = self._do_json("PATCH", f"{self._version_prefix}/sandboxes/{sandbox_id}/network/limits", body)
+        return _from_api_network_usage(payload)
 
     def exec(self, sandbox_id: str, request: ExecRequest) -> ExecResult:
         response = self._do_json("POST", f"{self._version_prefix}/sandboxes/{sandbox_id}/toolbox/process/execute", _to_api_exec_request(request))
@@ -656,6 +673,8 @@ def _to_api_create_options(options: CreateOptions) -> Dict[str, Any]:
             "env": _first_of(options, "env"),
             "os_user": _first_of(options, "osUser", "os_user"),
             "network_block_all": _first_of(options, "networkBlockAll", "network_block_all"),
+            "network_bytes_in_limit": _first_of(options, "networkBytesInLimit", "network_bytes_in_limit"),
+            "network_bytes_out_limit": _first_of(options, "networkBytesOutLimit", "network_bytes_out_limit"),
             "registry": _first_of(options, "registry"),
             "container_command": _first_of(options, "containerCommand", "container_command"),
             "mounts": [_to_api_mount_spec(item) for item in (_first_of(options, "mounts") or [])],
@@ -784,6 +803,32 @@ def _to_api_mount_spec(mount: MountSpec) -> Dict[str, Any]:
             "read_only": _first_of(mount, "readOnly", "read_only"),
         }
     )
+
+
+def _to_api_set_network_limits_options(options: SetNetworkLimitsOptions) -> Dict[str, Any]:
+    # Omitted keys mean "leave unchanged" on the server. 0 means unlimited.
+    return _compact(
+        {
+            "network_bytes_in_limit": _first_of(options, "networkBytesInLimit", "network_bytes_in_limit"),
+            "network_bytes_out_limit": _first_of(options, "networkBytesOutLimit", "network_bytes_out_limit"),
+        }
+    )
+
+
+def _from_api_network_usage(payload: Dict[str, Any]) -> NetworkUsage:
+    result: NetworkUsage = {
+        "sandboxID": str(_first_of(payload, "sandbox_id", "sandboxID") or ""),
+        "bytesIn": int(_first_of(payload, "bytes_in", "bytesIn") or 0),
+        "bytesOut": int(_first_of(payload, "bytes_out", "bytesOut") or 0),
+        "bytesInLimit": int(_first_of(payload, "bytes_in_limit", "bytesInLimit") or 0),
+        "bytesOutLimit": int(_first_of(payload, "bytes_out_limit", "bytesOutLimit") or 0),
+        "quotaExceeded": bool(_first_of(payload, "quota_exceeded", "quotaExceeded") or False),
+        "lastSampledAt": str(_first_of(payload, "last_sampled_at", "lastSampledAt") or ""),
+    }
+    quota_exceeded_at = _first_of(payload, "quota_exceeded_at", "quotaExceededAt")
+    if quota_exceeded_at not in (None, ""):
+        result["quotaExceededAt"] = str(quota_exceeded_at)
+    return result
 
 
 def _from_api_mount_spec_redacted(mount: Dict[str, Any]) -> MountSpecRedacted:

--- a/sdk/python/microvm/types.py
+++ b/sdk/python/microvm/types.py
@@ -77,6 +77,11 @@ class CreateOptions(TypedDict, total=False):
     env: Dict[str, str]
     osUser: str
     networkBlockAll: bool
+    # Caps on network bytes the sandbox may receive (in) / send (out) before
+    # per-IP iptables block fires. 0 (default) means unlimited; both can be
+    # raised or lifted at runtime via set_network_limits.
+    networkBytesInLimit: int
+    networkBytesOutLimit: int
     registry: RegistryAuth
     containerCommand: List[str]
     mounts: List[MountSpec]
@@ -239,6 +244,23 @@ class SandboxData(TypedDict, total=False):
     runtime: Literal["", "docker", "gvisor", "kata"]
     # GPU configuration this sandbox was created with. Absent means no GPU.
     gpus: GPUOptions
+
+
+class NetworkUsage(TypedDict, total=False):
+    sandboxID: str
+    bytesIn: int
+    bytesOut: int
+    bytesInLimit: int
+    bytesOutLimit: int
+    quotaExceeded: bool
+    quotaExceededAt: str
+    lastSampledAt: str
+
+
+class SetNetworkLimitsOptions(TypedDict, total=False):
+    # Omit a key to leave that direction unchanged. 0 means unlimited.
+    networkBytesInLimit: int
+    networkBytesOutLimit: int
 
 
 class HealthStatus(TypedDict):

--- a/sdk/python/microvm/types.py
+++ b/sdk/python/microvm/types.py
@@ -254,6 +254,7 @@ class NetworkUsage(TypedDict, total=False):
     bytesOutLimit: int
     quotaExceeded: bool
     quotaExceededAt: str
+    # Absent until the netstats poller has produced at least one sample.
     lastSampledAt: str
 
 

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -60,6 +60,27 @@ class RecordingMicroVM(MicroVM):
                 "source_sandbox_id": "sb-1",
                 "created_at": "2026-05-14T10:00:00Z",
             }
+        if method == "GET" and path == "/v1/sandboxes/sb-1/network/usage":
+            return {
+                "sandbox_id": "sb-1",
+                "bytes_in": 1024,
+                "bytes_out": 2048,
+                "bytes_in_limit": 1048576,
+                "bytes_out_limit": 0,
+                "quota_exceeded": False,
+                "last_sampled_at": "2026-05-15T10:00:00Z",
+            }
+        if method == "PATCH" and path == "/v1/sandboxes/sb-1/network/limits":
+            return {
+                "sandbox_id": "sb-1",
+                "bytes_in": 1024,
+                "bytes_out": 2048,
+                "bytes_in_limit": payload.get("network_bytes_in_limit", 0) if payload else 0,
+                "bytes_out_limit": payload.get("network_bytes_out_limit", 0) if payload else 0,
+                "quota_exceeded": False,
+                "quota_exceeded_at": "2026-05-15T09:00:00Z",
+                "last_sampled_at": "2026-05-15T10:00:00Z",
+            }
         if method == "GET" and path == "/v1/sandboxes/sb-1/mounts":
             return {
                 "mounts": [
@@ -368,6 +389,65 @@ class ClientTests(unittest.TestCase):
                 }
             ],
         )
+
+    def test_create_with_network_byte_limits_maps_snake_case_fields(self):
+        client = RecordingMicroVM()
+        client.create(
+            {
+                "image": "ubuntu:22.04",
+                "networkBytesInLimit": 1048576,
+                "networkBytesOutLimit": 524288,
+            }
+        )
+        self.assertEqual(
+            client.calls[0],
+            (
+                "POST",
+                "/v1/sandboxes",
+                {
+                    "image": "ubuntu:22.04",
+                    "network_bytes_in_limit": 1048576,
+                    "network_bytes_out_limit": 524288,
+                    "mounts": [],
+                },
+            ),
+        )
+
+    def test_get_network_usage_maps_response_shape(self):
+        client = RecordingMicroVM()
+
+        usage = client.get_network_usage("sb-1")
+
+        self.assertEqual(client.calls[0], ("GET", "/v1/sandboxes/sb-1/network/usage", None))
+        self.assertEqual(
+            usage,
+            {
+                "sandboxID": "sb-1",
+                "bytesIn": 1024,
+                "bytesOut": 2048,
+                "bytesInLimit": 1048576,
+                "bytesOutLimit": 0,
+                "quotaExceeded": False,
+                "lastSampledAt": "2026-05-15T10:00:00Z",
+            },
+        )
+
+    def test_set_network_limits_sends_patch_and_returns_usage(self):
+        client = RecordingMicroVM()
+        sandbox = client.create({"image": "ubuntu:22.04"})
+
+        usage = sandbox.set_network_limits({"networkBytesInLimit": 2097152})
+
+        self.assertEqual(
+            client.calls[1],
+            (
+                "PATCH",
+                "/v1/sandboxes/sb-1/network/limits",
+                {"network_bytes_in_limit": 2097152},
+            ),
+        )
+        self.assertEqual(usage["bytesInLimit"], 2097152)
+        self.assertEqual(usage["quotaExceededAt"], "2026-05-15T09:00:00Z")
 
     def test_exec_stream_sends_handshake_and_control_frames(self):
         stdout_chunks = []

--- a/sdk/rust/examples/create_sandbox.rs
+++ b/sdk/rust/examples/create_sandbox.rs
@@ -19,6 +19,8 @@ fn main() {
             env: None,
             os_user: None,
             network_block_all: None,
+            network_bytes_in_limit: None,
+            network_bytes_out_limit: None,
             registry: None,
             container_command: None,
             mounts: None,

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -1348,6 +1348,24 @@ mod tests {
     }
 
     #[test]
+    fn get_network_usage_handles_absent_last_sampled_at() {
+        let body = serde_json::json!({
+            "sandbox_id": "sb-fresh",
+            "bytes_in": 0,
+            "bytes_out": 0,
+            "bytes_in_limit": 0,
+            "bytes_out_limit": 0,
+            "quota_exceeded": false
+        })
+        .to_string();
+        let (url, _rx) = spawn_json_server(body);
+
+        let client = Client::new(Some(&url), Some("pat-token")).expect("client should build");
+        let usage = client.get_network_usage("sb-fresh").expect("get_network_usage should succeed");
+        assert_eq!(usage.last_sampled_at, None);
+    }
+
+    #[test]
     fn set_network_limits_sends_patch_with_provided_fields_only() {
         let body = serde_json::json!({
             "sandbox_id": "sb-1",

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -17,7 +17,7 @@ use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::{Error as WebSocketError, Message};
 
-pub use types::{CreateOptions, CreateSessionOptions, ExecExitInfo, ExecRequest, ExecResult, ExposedPort, ExposeOptions, ExposeProtocol, ExposeResult, HealthStatus, Lifecycle, MountSpec, MountSpecRedacted, MountType, RegistryAuth, ResizeOptions, Sandbox as SandboxData, SandboxSnapshot, Session, SessionList, SessionStatus, UpdateLifecycleOptions};
+pub use types::{CreateOptions, CreateSessionOptions, ExecExitInfo, ExecRequest, ExecResult, ExposedPort, ExposeOptions, ExposeProtocol, ExposeResult, HealthStatus, Lifecycle, MountSpec, MountSpecRedacted, MountType, NetworkUsage, RegistryAuth, ResizeOptions, Sandbox as SandboxData, SandboxSnapshot, Session, SessionList, SessionStatus, SetNetworkLimitsOptions, UpdateLifecycleOptions};
 pub use types::CreateSandboxResponse;
 use types::ExposePortResponseWire;
 
@@ -390,6 +390,14 @@ impl Sandbox {
         self.data = updated.data;
         Ok(self)
     }
+
+    pub fn get_network_usage(&self) -> Result<NetworkUsage, Error> {
+        self.client.get_network_usage(&self.data.id)
+    }
+
+    pub fn set_network_limits(&self, opts: SetNetworkLimitsOptions) -> Result<NetworkUsage, Error> {
+        self.client.set_network_limits(&self.data.id, opts)
+    }
 }
 
 impl Client {
@@ -498,6 +506,14 @@ impl Client {
 
         let raw = self.do_json::<(), MountList>(Method::GET, &format!("{}/sandboxes/{}/mounts", self.version_prefix(), id), None)?;
         Ok(raw.mounts)
+    }
+
+    pub fn get_network_usage(&self, id: &str) -> Result<NetworkUsage, Error> {
+        self.do_json::<(), NetworkUsage>(Method::GET, &format!("{}/sandboxes/{}/network/usage", self.version_prefix(), id), None)
+    }
+
+    pub fn set_network_limits(&self, id: &str, opts: SetNetworkLimitsOptions) -> Result<NetworkUsage, Error> {
+        self.do_json::<SetNetworkLimitsOptions, NetworkUsage>(Method::PATCH, &format!("{}/sandboxes/{}/network/limits", self.version_prefix(), id), Some(&opts))
     }
 
     pub fn exec(&self, id: &str, request: ExecRequest) -> Result<ExecResult, Error> {
@@ -1073,6 +1089,8 @@ mod tests {
             env: None,
             os_user: None,
             network_block_all: None,
+            network_bytes_in_limit: None,
+            network_bytes_out_limit: None,
             registry: None,
             container_command: None,
             mounts: None,
@@ -1303,6 +1321,62 @@ mod tests {
                 has_credentials: true,
             }]
         );
+    }
+
+    #[test]
+    fn get_network_usage_maps_response_shape() {
+        let body = serde_json::json!({
+            "sandbox_id": "sb-1",
+            "bytes_in": 1024,
+            "bytes_out": 2048,
+            "bytes_in_limit": 1048576,
+            "bytes_out_limit": 0,
+            "quota_exceeded": false,
+            "last_sampled_at": "2026-05-15T10:00:00Z"
+        })
+        .to_string();
+        let (url, request_rx) = spawn_json_server(body);
+
+        let client = Client::new(Some(&url), Some("pat-token")).expect("client should build");
+        let usage = client.get_network_usage("sb-1").expect("get_network_usage should succeed");
+        let request = request_rx.recv().expect("request should be captured");
+
+        assert!(request.starts_with("GET /v1/sandboxes/sb-1/network/usage HTTP/1.1\r\n"), "unexpected request: {}", request);
+        assert_eq!(usage.bytes_in, 1024);
+        assert_eq!(usage.bytes_out_limit, 0);
+        assert!(!usage.quota_exceeded);
+    }
+
+    #[test]
+    fn set_network_limits_sends_patch_with_provided_fields_only() {
+        let body = serde_json::json!({
+            "sandbox_id": "sb-1",
+            "bytes_in": 0,
+            "bytes_out": 0,
+            "bytes_in_limit": 4096,
+            "bytes_out_limit": 0,
+            "quota_exceeded": false,
+            "last_sampled_at": "2026-05-15T10:00:00Z"
+        })
+        .to_string();
+        let (url, request_rx) = spawn_json_server(body);
+
+        let client = Client::new(Some(&url), Some("pat-token")).expect("client should build");
+        let usage = client
+            .set_network_limits(
+                "sb-1",
+                SetNetworkLimitsOptions {
+                    network_bytes_in_limit: Some(4096),
+                    network_bytes_out_limit: None,
+                },
+            )
+            .expect("set_network_limits should succeed");
+        let request = request_rx.recv().expect("request should be captured");
+        let body = request_json_body(&request);
+
+        assert!(request.starts_with("PATCH /v1/sandboxes/sb-1/network/limits HTTP/1.1\r\n"), "unexpected request: {}", request);
+        assert_eq!(body, serde_json::json!({"network_bytes_in_limit": 4096}));
+        assert_eq!(usage.bytes_in_limit, 4096);
     }
 
     #[test]

--- a/sdk/rust/src/types.rs
+++ b/sdk/rust/src/types.rs
@@ -94,6 +94,17 @@ pub struct CreateOptions {
     pub os_user: Option<String>,
     #[serde(rename = "network_block_all", skip_serializing_if = "Option::is_none")]
     pub network_block_all: Option<bool>,
+    /// Cap on bytes the sandbox may receive before its ingress is dropped via
+    /// per-IP iptables rule. `0` (or omit) means unlimited. Limits can be
+    /// raised or lifted at runtime via [`Client::set_network_limits`].
+    #[serde(rename = "network_bytes_in_limit", skip_serializing_if = "Option::is_none")]
+    pub network_bytes_in_limit: Option<i64>,
+    /// Cap on bytes the sandbox may send before its egress is dropped. `0`
+    /// (or omit) means unlimited. The block reuses the same iptables row as
+    /// `network_block_all`; clearing the quota does not lift an operator-set
+    /// blanket egress block.
+    #[serde(rename = "network_bytes_out_limit", skip_serializing_if = "Option::is_none")]
+    pub network_bytes_out_limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub registry: Option<RegistryAuth>,
     #[serde(rename = "container_command", skip_serializing_if = "Option::is_none")]
@@ -388,4 +399,41 @@ pub struct Session {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SessionList {
     pub sessions: Vec<Session>,
+}
+
+/// Per-sandbox network byte counters and the configured caps that drive the
+/// quota enforcer. `bytes_in` is traffic the container received (ingress);
+/// `bytes_out` is traffic the container sent (egress). A `*_limit` of `0`
+/// means unlimited. `quota_exceeded` flips true the first time the meter
+/// crosses either configured cap and stays true until the operator raises
+/// the limit.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct NetworkUsage {
+    #[serde(rename = "sandbox_id")]
+    pub sandbox_id: String,
+    #[serde(rename = "bytes_in")]
+    pub bytes_in: i64,
+    #[serde(rename = "bytes_out")]
+    pub bytes_out: i64,
+    #[serde(rename = "bytes_in_limit")]
+    pub bytes_in_limit: i64,
+    #[serde(rename = "bytes_out_limit")]
+    pub bytes_out_limit: i64,
+    #[serde(rename = "quota_exceeded")]
+    pub quota_exceeded: bool,
+    #[serde(rename = "quota_exceeded_at", skip_serializing_if = "Option::is_none")]
+    pub quota_exceeded_at: Option<String>,
+    #[serde(rename = "last_sampled_at")]
+    pub last_sampled_at: String,
+}
+
+/// Patch body for [`Client::set_network_limits`]. Each field is `Option`-wrapped
+/// so an unset key serializes as missing (server reads as "leave alone");
+/// `Some(0)` means unlimited.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct SetNetworkLimitsOptions {
+    #[serde(rename = "network_bytes_in_limit", skip_serializing_if = "Option::is_none")]
+    pub network_bytes_in_limit: Option<i64>,
+    #[serde(rename = "network_bytes_out_limit", skip_serializing_if = "Option::is_none")]
+    pub network_bytes_out_limit: Option<i64>,
 }

--- a/sdk/rust/src/types.rs
+++ b/sdk/rust/src/types.rs
@@ -423,8 +423,11 @@ pub struct NetworkUsage {
     pub quota_exceeded: bool,
     #[serde(rename = "quota_exceeded_at", skip_serializing_if = "Option::is_none")]
     pub quota_exceeded_at: Option<String>,
-    #[serde(rename = "last_sampled_at")]
-    pub last_sampled_at: String,
+    /// Absent (`None`) until the netstats poller has produced at least one
+    /// sample. `default` lets us deserialize a server response that omits the
+    /// field entirely (pre-first-tick) rather than failing.
+    #[serde(rename = "last_sampled_at", default, skip_serializing_if = "Option::is_none")]
+    pub last_sampled_at: Option<String>,
 }
 
 /// Patch body for [`Client::set_network_limits`]. Each field is `Option`-wrapped

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -18,7 +18,7 @@
     "example:create:src": "npx tsx src/examples/createSandbox.ts",
     "example:delete": "npm run build && node dist/examples/deleteSandbox.js",
     "example:delete:src": "npx tsx src/examples/deleteSandbox.ts",
-    "test": "tsc -p tsconfig.test.json --outDir dist-test && node --test dist-test/**/*.test.js"
+    "test": "tsc -p tsconfig.test.json --outDir dist-test && node --test dist-test/*.test.js dist-test/internal/*.test.js"
   },
   "devDependencies": {
     "@types/node": "^25.6.2",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -18,7 +18,7 @@
     "example:create:src": "npx tsx src/examples/createSandbox.ts",
     "example:delete": "npm run build && node dist/examples/deleteSandbox.js",
     "example:delete:src": "npx tsx src/examples/deleteSandbox.ts",
-    "test": "tsc -p tsconfig.test.json --outDir dist-test && node --test dist-test/*.test.js"
+    "test": "tsc -p tsconfig.test.json --outDir dist-test && node --test dist-test/**/*.test.js"
   },
   "devDependencies": {
     "@types/node": "^25.6.2",

--- a/sdk/typescript/src/internal/client.test.ts
+++ b/sdk/typescript/src/internal/client.test.ts
@@ -28,7 +28,12 @@ test("internal client create maps request and response", async () => {
     patToken: "pat-token",
     fetch: async (input, init) => {
       seenRequest = new Request(input, init);
-      return jsonResponse(apiSandbox("sb-create"));
+      return jsonResponse(apiSandbox("sb-create", {
+        lifecycle: {
+          stop_if_idle_for: 3_600_000_000_000,
+          destroy_at_age: 86_400_000_000_000,
+        },
+      }));
     },
   });
 

--- a/sdk/typescript/src/internal/client.test.ts
+++ b/sdk/typescript/src/internal/client.test.ts
@@ -541,6 +541,25 @@ test("internal client getNetworkUsage maps response shape", async () => {
   });
 });
 
+test("internal client getNetworkUsage handles absent last_sampled_at (pre-first-tick)", async () => {
+  const client = new APIClient({
+    baseURL: "https://api.example.com",
+    patToken: "pat-token",
+    fetch: async () =>
+      jsonResponse({
+        sandbox_id: "sb-fresh",
+        bytes_in: 0,
+        bytes_out: 0,
+        bytes_in_limit: 0,
+        bytes_out_limit: 0,
+        quota_exceeded: false,
+      }),
+  });
+
+  const usage = await client.getNetworkUsage("sb-fresh");
+  assert.equal(usage.lastSampledAt, undefined);
+});
+
 test("internal client setNetworkLimits sends PATCH with provided fields only", async () => {
   let seenRequest: Request | undefined;
   let seenBody: unknown;

--- a/sdk/typescript/src/internal/client.test.ts
+++ b/sdk/typescript/src/internal/client.test.ts
@@ -500,6 +500,73 @@ test("internal client create defaults runtime to '' when sandboxd omits the fiel
   assert.equal(sandbox.runtime, "");
 });
 
+test("internal client getNetworkUsage maps response shape", async () => {
+  let seenRequest: Request | undefined;
+  const client = new APIClient({
+    baseURL: "https://api.example.com",
+    patToken: "pat-token",
+    fetch: async (input, init) => {
+      seenRequest = new Request(input, init);
+      return jsonResponse({
+        sandbox_id: "sb-net",
+        bytes_in: 1024,
+        bytes_out: 2048,
+        bytes_in_limit: 4096,
+        bytes_out_limit: 0,
+        quota_exceeded: false,
+        quota_exceeded_at: null,
+        last_sampled_at: "2026-05-15T10:00:00Z",
+      });
+    },
+  });
+
+  const usage = await client.getNetworkUsage("sb-net");
+  assert.ok(seenRequest);
+  assert.equal(seenRequest.method, "GET");
+  assert.ok(seenRequest.url.endsWith("/v1/sandboxes/sb-net/network/usage"));
+  assert.deepEqual(usage, {
+    sandboxID: "sb-net",
+    bytesIn: 1024,
+    bytesOut: 2048,
+    bytesInLimit: 4096,
+    bytesOutLimit: 0,
+    quotaExceeded: false,
+    quotaExceededAt: undefined,
+    lastSampledAt: "2026-05-15T10:00:00Z",
+  });
+});
+
+test("internal client setNetworkLimits sends PATCH with provided fields only", async () => {
+  let seenRequest: Request | undefined;
+  let seenBody: unknown;
+  const client = new APIClient({
+    baseURL: "https://api.example.com",
+    patToken: "pat-token",
+    fetch: async (input, init) => {
+      seenRequest = new Request(input, init);
+      seenBody = await seenRequest.clone().json();
+      return jsonResponse({
+        sandbox_id: "sb-net",
+        bytes_in: 0,
+        bytes_out: 0,
+        bytes_in_limit: 4096,
+        bytes_out_limit: 0,
+        quota_exceeded: false,
+        quota_exceeded_at: null,
+        last_sampled_at: "2026-05-15T10:01:00Z",
+      });
+    },
+  });
+
+  const usage = await client.setNetworkLimits("sb-net", { networkBytesInLimit: 4096 });
+  assert.ok(seenRequest);
+  assert.equal(seenRequest.method, "PATCH");
+  assert.ok(seenRequest.url.endsWith("/v1/sandboxes/sb-net/network/limits"));
+  // Unset egress limit must be omitted entirely so the server reads "leave alone".
+  assert.deepEqual(seenBody, { network_bytes_in_limit: 4096 });
+  assert.equal(usage.bytesInLimit, 4096);
+});
+
 function jsonResponse(value: unknown, status = 200): Response {
   return new Response(JSON.stringify(value), {
     status,

--- a/sdk/typescript/src/internal/client.ts
+++ b/sdk/typescript/src/internal/client.ts
@@ -18,6 +18,8 @@ import type {
   Lifecycle,
   MountSpec,
   MountSpecRedacted,
+  NetworkUsage,
+  SetNetworkLimitsOptions,
   ResizeOptions,
   Sandbox,
   SandboxSnapshot,
@@ -169,6 +171,17 @@ interface ApiMountSpecRedacted {
 
 interface ApiMountList {
   mounts: ApiMountSpecRedacted[];
+}
+
+interface ApiNetworkUsage {
+  sandbox_id: string;
+  bytes_in: number;
+  bytes_out: number;
+  bytes_in_limit: number;
+  bytes_out_limit: number;
+  quota_exceeded: boolean;
+  quota_exceeded_at?: string;
+  last_sampled_at: string;
 }
 
 export class APIClient {
@@ -349,6 +362,20 @@ export class APIClient {
     return response.mounts.map(fromApiMountSpecRedacted);
   }
 
+  async getNetworkUsage(id: string): Promise<NetworkUsage> {
+    const response = await this.doJSON<ApiNetworkUsage>("GET", `${this.versionPrefix}/sandboxes/${id}/network/usage`);
+    return fromApiNetworkUsage(response);
+  }
+
+  async setNetworkLimits(id: string, options: SetNetworkLimitsOptions): Promise<NetworkUsage> {
+    const response = await this.doJSON<ApiNetworkUsage>(
+      "PATCH",
+      `${this.versionPrefix}/sandboxes/${id}/network/limits`,
+      toApiSetNetworkLimitsOptions(options),
+    );
+    return fromApiNetworkUsage(response);
+  }
+
   private wrap(sandbox: ApiSandbox): SandboxResource {
     return new SandboxResource(this, fromApiSandbox(sandbox));
   }
@@ -523,6 +550,14 @@ export class SandboxResource implements Sandbox {
     return this;
   }
 
+  async getNetworkUsage(): Promise<NetworkUsage> {
+    return this.client.getNetworkUsage(this.id);
+  }
+
+  async setNetworkLimits(options: SetNetworkLimitsOptions): Promise<NetworkUsage> {
+    return this.client.setNetworkLimits(this.id, options);
+  }
+
   toJSON(): Sandbox {
     return cloneSandbox(this);
   }
@@ -541,6 +576,8 @@ function toApiCreateOptions(options: CreateOptions): Record<string, unknown> {
     env: options.env,
     os_user: options.osUser,
     network_block_all: options.networkBlockAll,
+    network_bytes_in_limit: options.networkBytesInLimit,
+    network_bytes_out_limit: options.networkBytesOutLimit,
     registry: options.registry,
     container_command: options.containerCommand,
     mounts: options.mounts?.map(toApiMountSpec),
@@ -725,6 +762,26 @@ function fromApiMountSpecRedacted(mount: ApiMountSpecRedacted): MountSpecRedacte
     options: mount.options,
     readOnly: mount.read_only ?? false,
     hasCredentials: mount.has_credentials,
+  };
+}
+
+function fromApiNetworkUsage(usage: ApiNetworkUsage): NetworkUsage {
+  return {
+    sandboxID: usage.sandbox_id,
+    bytesIn: usage.bytes_in,
+    bytesOut: usage.bytes_out,
+    bytesInLimit: usage.bytes_in_limit,
+    bytesOutLimit: usage.bytes_out_limit,
+    quotaExceeded: usage.quota_exceeded,
+    quotaExceededAt: usage.quota_exceeded_at ?? undefined,
+    lastSampledAt: usage.last_sampled_at,
+  };
+}
+
+function toApiSetNetworkLimitsOptions(options: SetNetworkLimitsOptions): Record<string, unknown> {
+  return {
+    network_bytes_in_limit: options.networkBytesInLimit,
+    network_bytes_out_limit: options.networkBytesOutLimit,
   };
 }
 

--- a/sdk/typescript/src/internal/client.ts
+++ b/sdk/typescript/src/internal/client.ts
@@ -180,7 +180,7 @@ interface ApiNetworkUsage {
   bytes_in_limit: number;
   bytes_out_limit: number;
   quota_exceeded: boolean;
-  quota_exceeded_at?: string;
+  quota_exceeded_at?: string | null;
   last_sampled_at: string;
 }
 

--- a/sdk/typescript/src/internal/client.ts
+++ b/sdk/typescript/src/internal/client.ts
@@ -181,7 +181,7 @@ interface ApiNetworkUsage {
   bytes_out_limit: number;
   quota_exceeded: boolean;
   quota_exceeded_at?: string | null;
-  last_sampled_at: string;
+  last_sampled_at?: string | null;
 }
 
 export class APIClient {
@@ -774,7 +774,7 @@ function fromApiNetworkUsage(usage: ApiNetworkUsage): NetworkUsage {
     bytesOutLimit: usage.bytes_out_limit,
     quotaExceeded: usage.quota_exceeded,
     quotaExceededAt: usage.quota_exceeded_at ?? undefined,
-    lastSampledAt: usage.last_sampled_at,
+    lastSampledAt: usage.last_sampled_at ?? undefined,
   };
 }
 

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -236,7 +236,8 @@ export interface NetworkUsage {
   bytesOutLimit: number;
   quotaExceeded: boolean;
   quotaExceededAt?: string;
-  lastSampledAt: string;
+  /** Absent until the netstats poller has produced at least one sample. */
+  lastSampledAt?: string;
 }
 
 export interface SetNetworkLimitsOptions {

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -78,6 +78,19 @@ export interface CreateOptions {
   env?: Record<string, string>;
   osUser?: string;
   networkBlockAll?: boolean;
+  /**
+   * Cap on bytes the sandbox may receive from outside the container before its
+   * ingress is dropped via per-IP iptables rule. `0` (default) is unlimited.
+   * Limits can be raised or lifted at runtime via `setNetworkLimits`.
+   */
+  networkBytesInLimit?: number;
+  /**
+   * Cap on bytes the sandbox may send to outside the container before its
+   * egress is dropped. `0` (default) is unlimited. The block reuses the same
+   * iptables row as `networkBlockAll`; clearing the quota does not lift an
+   * operator-set blanket egress block.
+   */
+  networkBytesOutLimit?: number;
   registry?: RegistryAuth;
   containerCommand?: string[];
   mounts?: MountSpec[];
@@ -206,6 +219,30 @@ export interface Sandbox {
   runtime: "" | "docker" | "gvisor" | "kata";
   /** GPU configuration this sandbox was created with. Absent means no GPU. */
   gpus?: GPUOptions;
+}
+
+/**
+ * Per-sandbox network byte counters and the configured caps that drive the
+ * quota enforcer. `bytesIn` is traffic the container received (ingress);
+ * `bytesOut` is traffic the container sent (egress). A `*Limit` of `0` means
+ * unlimited. `quotaExceeded` flips true the first time the meter crosses
+ * either configured cap and stays true until the operator raises the limit.
+ */
+export interface NetworkUsage {
+  sandboxID: string;
+  bytesIn: number;
+  bytesOut: number;
+  bytesInLimit: number;
+  bytesOutLimit: number;
+  quotaExceeded: boolean;
+  quotaExceededAt?: string;
+  lastSampledAt: string;
+}
+
+export interface SetNetworkLimitsOptions {
+  /** Omit (undefined) to leave unchanged. `0` means unlimited. */
+  networkBytesInLimit?: number;
+  networkBytesOutLimit?: number;
 }
 
 export interface ExecRequest {


### PR DESCRIPTION
This pull request introduces per-sandbox network usage tracking and quota enforcement, enabling ingress/egress byte counters and configurable network caps for each sandbox. It adds both backend service logic and documentation, as well as updates to the configuration and runtime interfaces to support this feature.

**Network Usage & Quota Enforcement**

* Introduced a new `netstats` poller in the backend service (`Service`) that periodically samples network byte counters for each sandbox, persists them, and enforces ingress/egress caps by installing/removing iptables rules as needed. The poller is bootstrapped at service startup or on first use. (`internal/service/netstats.go`, `cmd/sandboxd/main.go`, `internal/service/service.go`) [[1]](diffhunk://#diff-3a53cc9f63dd4bb9d0ba7e64aa38a62f02de6b3b10e37953ce164a9179568407R1-R227) [[2]](diffhunk://#diff-e977aef3a61407d38b134a73df7978004343a347ee0b5c8cc69a57b31624e2d0R65-R74) [[3]](diffhunk://#diff-e977aef3a61407d38b134a73df7978004343a347ee0b5c8cc69a57b31624e2d0R225-R226) [[4]](diffhunk://#diff-85cd4174384a81cdbf87370531855ae87bcbd19bf68f36b611d73cd5d96cb4daR122-R127)
* Added methods to the runtime interface for applying and clearing per-IP ingress and egress DROP rules, allowing independent enforcement of ingress and egress network quotas. (`internal/runtime/runtime.go`, `internal/service/capacity_lifecycle_test.go`, `internal/service/reconcile_destroy_test.go`) [[1]](diffhunk://#diff-dfb217f99ae89452063f7bc651da92476ba387fc6de37495c98096ad67f5ba10R83-R101) [[2]](diffhunk://#diff-c9ab7fbd2d8c1877b68fd5c4144fcc85e331cd381b582254e721f0e38ee14a39R68-R70) [[3]](diffhunk://#diff-7127bb24fa117a7be549bb53fd93b6dc95c3393890ef905321afef0f580f12b6R78-R86)
* Updated the service configuration to include a configurable poll interval for network stats collection (`NetstatsPollInterval`). (`internal/config/config.go`) [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR55) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR151)
* Extended the sandbox creation process to accept optional ingress and egress byte limits, storing these in the sandbox model. (`internal/service/service.go`)

**Documentation & Developer Experience**

* Added comprehensive documentation describing the network usage and quota feature, including API usage examples for multiple languages and detailed explanations of the quota enforcement model. (`docs/src/content/docs/network-usage.mdx`)
* Updated the documentation sidebar to include a new entry for "Network Usage & Quotas." (`docs/src/content.config.ts`)

**Developer Tooling**

* Added a `Pipfile` specifying Python 3.14 for development tooling.<!--
GitHub auto-fills new PR descriptions with this template. Fill in EVERY
section below. "N/A — <one-line reason>" is a valid answer; an empty answer
is not. See pr-review.md at the repo root for what each section is asking.
-->