### PR TITLE
feat: Enhance toolbox API with snapshot and volume support features

### DIFF
--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -4,7 +4,7 @@ import LanguageSelect from './LanguageSelect.astro'
 import ThemeSelect from './ThemeSelect.astro'
 
 const currentPath = Astro.url.pathname
-const version = import.meta.env.VERSION || '0.1.9'
+const version = import.meta.env.VERSION || '0.1.10'
 const basePath = import.meta.env.BASE_URL
 
 const navLinks = [

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -517,6 +517,49 @@ func (s *Service) CreateSnapshot(ctx context.Context, sandboxID string, req mode
 	return snapshot, err
 }
 
+// RegisterSnapshot persists a snapshot row whose Image was resolved out-of-band
+// — either a pre-existing registry image the caller supplied by name, or a
+// freshly built local tag produced by the image builder (e.g. the daytona
+// facade's buildInfo path). It does NOT call docker.CreateSnapshot; the image
+// is assumed to already be runnable. Idempotency is by snapshot name; a
+// re-register with matching image is treated as a no-op so SDK retries don't
+// fail. A different image under the same name is a conflict.
+func (s *Service) RegisterSnapshot(ctx context.Context, snapshot *models.SandboxSnapshot) (*models.SandboxSnapshot, error) {
+	if snapshot == nil {
+		return nil, errors.New("snapshot is required")
+	}
+	name := strings.TrimSpace(snapshot.Name)
+	if name == "" {
+		return nil, errors.New("snapshot name is required")
+	}
+	if strings.TrimSpace(snapshot.Image) == "" {
+		return nil, errors.New("snapshot image is required")
+	}
+
+	s.snapshotMu.Lock()
+	defer s.snapshotMu.Unlock()
+
+	if existing, err := s.store.GetSnapshot(ctx, name); err == nil {
+		// Retry semantics: same name + same image → echo back the existing
+		// row. Different image under the same name is a conflict.
+		if strings.TrimSpace(existing.Image) == strings.TrimSpace(snapshot.Image) {
+			return existing, nil
+		}
+		return nil, store.ErrSnapshotNameConflict
+	} else if !errors.Is(err, store.ErrNotFound) {
+		return nil, err
+	}
+
+	if snapshot.CreatedAt.IsZero() {
+		snapshot.CreatedAt = time.Now().UTC()
+	}
+	snapshot.Name = name
+	if err := s.store.CreateSnapshot(ctx, snapshot); err != nil {
+		return nil, err
+	}
+	return snapshot, nil
+}
+
 // CreateSnapshotWithOwnership commits a sandbox image and reports whether this
 // call created the native snapshot row. Callers that add companion metadata can
 // use the flag to avoid rolling back a snapshot that already existed.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -112,7 +112,13 @@ func Open(path string) (*Store, error) {
 			image TEXT NOT NULL,
 			image_id TEXT NOT NULL DEFAULT '',
 			source_sandbox_id TEXT NOT NULL,
-			created_at DATETIME NOT NULL
+			created_at DATETIME NOT NULL,
+			entrypoint_json TEXT NOT NULL DEFAULT '[]',
+			region_id TEXT NOT NULL DEFAULT '',
+			cpu REAL NOT NULL DEFAULT 0,
+			memory_mb INTEGER NOT NULL DEFAULT 0,
+			disk_gb INTEGER NOT NULL DEFAULT 0,
+			gpu REAL NOT NULL DEFAULT 0
 		);`,
 		// sandbox_compat_state holds opaque facade-private state that has
 		// no native meaning. One row per (sandbox, facade). state_json is
@@ -197,6 +203,15 @@ func Open(path string) (*Store, error) {
 		`ALTER TABLE sandboxes ADD COLUMN net_bytes_out_limit INTEGER NOT NULL DEFAULT 0;`,
 		`ALTER TABLE sandboxes ADD COLUMN net_quota_exceeded INTEGER NOT NULL DEFAULT 0;`,
 		`ALTER TABLE sandboxes ADD COLUMN net_quota_exceeded_at DATETIME;`,
+		// Snapshot-from-image columns. Pre-existing rows (committed from a
+		// running sandbox) get zero values, which scanSnapshot decodes as
+		// "no extra metadata" — preserving the legacy shape.
+		`ALTER TABLE sandbox_snapshots ADD COLUMN entrypoint_json TEXT NOT NULL DEFAULT '[]';`,
+		`ALTER TABLE sandbox_snapshots ADD COLUMN region_id TEXT NOT NULL DEFAULT '';`,
+		`ALTER TABLE sandbox_snapshots ADD COLUMN cpu REAL NOT NULL DEFAULT 0;`,
+		`ALTER TABLE sandbox_snapshots ADD COLUMN memory_mb INTEGER NOT NULL DEFAULT 0;`,
+		`ALTER TABLE sandbox_snapshots ADD COLUMN disk_gb INTEGER NOT NULL DEFAULT 0;`,
+		`ALTER TABLE sandbox_snapshots ADD COLUMN gpu REAL NOT NULL DEFAULT 0;`,
 	}
 	for _, stmt := range migrations {
 		if _, err := db.Exec(stmt); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
@@ -1133,15 +1148,26 @@ func (s *Store) DeleteIdempotentRequest(ctx context.Context, scope, fingerprint 
 }
 
 func (s *Store) CreateSnapshot(ctx context.Context, snapshot *models.SandboxSnapshot) error {
-	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO sandbox_snapshots (name, image, image_id, source_sandbox_id, created_at)
-		VALUES (?, ?, ?, ?, ?)
+	entrypointJSON, err := marshalJSON(snapshot.Entrypoint, "[]")
+	if err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO sandbox_snapshots (name, image, image_id, source_sandbox_id, created_at,
+			entrypoint_json, region_id, cpu, memory_mb, disk_gb, gpu)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		strings.TrimSpace(snapshot.Name),
 		strings.TrimSpace(snapshot.Image),
 		strings.TrimSpace(snapshot.ImageID),
 		strings.TrimSpace(snapshot.SourceSandboxID),
 		snapshot.CreatedAt.UTC(),
+		entrypointJSON,
+		strings.TrimSpace(snapshot.RegionID),
+		snapshot.CPU,
+		snapshot.MemoryMB,
+		snapshot.DiskGB,
+		snapshot.GPU,
 	)
 	if err != nil {
 		if isSQLiteUniqueConstraint(err) {
@@ -1154,7 +1180,8 @@ func (s *Store) CreateSnapshot(ctx context.Context, snapshot *models.SandboxSnap
 
 func (s *Store) GetSnapshot(ctx context.Context, name string) (*models.SandboxSnapshot, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT name, image, image_id, source_sandbox_id, created_at
+		SELECT name, image, image_id, source_sandbox_id, created_at,
+			entrypoint_json, region_id, cpu, memory_mb, disk_gb, gpu
 		FROM sandbox_snapshots
 		WHERE name = ?
 	`, strings.TrimSpace(name))
@@ -1170,7 +1197,8 @@ func (s *Store) GetSnapshot(ctx context.Context, name string) (*models.SandboxSn
 
 func (s *Store) ListSnapshots(ctx context.Context) ([]*models.SandboxSnapshot, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT name, image, image_id, source_sandbox_id, created_at
+		SELECT name, image, image_id, source_sandbox_id, created_at,
+			entrypoint_json, region_id, cpu, memory_mb, disk_gb, gpu
 		FROM sandbox_snapshots
 		ORDER BY created_at DESC, name ASC
 	`)
@@ -1571,15 +1599,27 @@ func scanSnapshot(scanner interface {
 	Scan(dest ...any) error
 }) (*models.SandboxSnapshot, error) {
 	var snapshot models.SandboxSnapshot
+	var entrypointJSON string
 	err := scanner.Scan(
 		&snapshot.Name,
 		&snapshot.Image,
 		&snapshot.ImageID,
 		&snapshot.SourceSandboxID,
 		&snapshot.CreatedAt,
+		&entrypointJSON,
+		&snapshot.RegionID,
+		&snapshot.CPU,
+		&snapshot.MemoryMB,
+		&snapshot.DiskGB,
+		&snapshot.GPU,
 	)
 	if err != nil {
 		return nil, err
+	}
+	if entrypointJSON != "" && entrypointJSON != "[]" {
+		if err := json.Unmarshal([]byte(entrypointJSON), &snapshot.Entrypoint); err != nil {
+			return nil, fmt.Errorf("decode snapshot entrypoint: %w", err)
+		}
 	}
 	return &snapshot, nil
 }

--- a/pkg/api/daytona/contract_test.go
+++ b/pkg/api/daytona/contract_test.go
@@ -132,8 +132,12 @@ func TestDaytonaGeneratedSandboxContracts(t *testing.T) {
 				if err != nil {
 					t.Fatalf("loadDaytonaMeta(%s) error = %v", resp.GetId(), err)
 				}
-				if stored.Image != "base-snapshot" {
-					t.Fatalf("stored.Image = %q, want %q", stored.Image, "base-snapshot")
+				// Daytona's snapshot field is a snapshot *name*, not an image ref.
+				// The facade looks the name up in the snapshot store and uses the
+				// row's Image as the runtime image; the snapshot name itself is
+				// preserved in the per-sandbox compat metadata for read-back.
+				if stored.Image != "snapshots/base:v1" {
+					t.Fatalf("stored.Image = %q, want %q (resolved from snapshot row)", stored.Image, "snapshots/base:v1")
 				}
 				if valueOrEmpty(meta.Snapshot) != "base-snapshot" {
 					t.Fatalf("stored snapshot metadata = %q, want %q", valueOrEmpty(meta.Snapshot), "base-snapshot")
@@ -1003,7 +1007,9 @@ func TestDaytonaSDKContracts(t *testing.T) {
 				if err != nil {
 					t.Fatalf("loadDaytonaMeta(%s) error = %v", sandbox.ID, err)
 				}
-				if stored.Image != "sdk-base-snapshot" || valueOrEmpty(meta.Snapshot) != "sdk-base-snapshot" {
+				// stored.Image is the resolved image from the snapshot row;
+				// the meta.Snapshot field preserves the caller-supplied name.
+				if stored.Image != "snapshots/sdk-base:v1" || valueOrEmpty(meta.Snapshot) != "sdk-base-snapshot" {
 					t.Fatalf("snapshot contract not preserved: stored=%+v meta=%+v", stored, meta)
 				}
 			},

--- a/pkg/api/daytona/dto.go
+++ b/pkg/api/daytona/dto.go
@@ -37,6 +37,21 @@ type createSandboxSnapshotRequest struct {
 	Name string `json:"name"`
 }
 
+// createSnapshotRequest matches the Daytona SDK CreateSnapshot DTO sent to
+// POST /daytona/snapshots. Either ImageName (pre-built image reference) or
+// BuildInfo (Dockerfile + optional context hashes) must be present.
+type createSnapshotRequest struct {
+	Name       string             `json:"name"`
+	ImageName  *string            `json:"imageName,omitempty"`
+	Entrypoint []string           `json:"entrypoint,omitempty"`
+	CPU        *float32           `json:"cpu,omitempty"`
+	GPU        *float32           `json:"gpu,omitempty"`
+	Memory     *float32           `json:"memory,omitempty"`
+	Disk       *float32           `json:"disk,omitempty"`
+	BuildInfo  *buildInfoRequest  `json:"buildInfo,omitempty"`
+	RegionID   *string            `json:"regionId,omitempty"`
+}
+
 type snapshotResponse struct {
 	ID             string   `json:"id"`
 	OrganizationID *string  `json:"organizationId,omitempty"`

--- a/pkg/api/daytona/handlers.go
+++ b/pkg/api/daytona/handlers.go
@@ -50,6 +50,8 @@ func (h *handlers) createSandbox(w http.ResponseWriter, r *http.Request) {
 			apihttp.WriteError(w, http.StatusGatewayTimeout, err.Error())
 		case errors.Is(err, errBuildOperational):
 			apihttp.WriteError(w, http.StatusBadGateway, err.Error())
+		case errors.Is(err, errVolumesUnsupported):
+			apihttp.WriteError(w, http.StatusMethodNotAllowed, err.Error())
 		default:
 			apihttp.WriteError(w, http.StatusBadRequest, err.Error())
 		}
@@ -894,7 +896,7 @@ func (h *handlers) translateCreateSandboxRequest(ctx context.Context, req create
 		return models.CreateSandboxRequest{}, "", errors.New("gpu allocation is not supported by the Daytona facade")
 	}
 	if len(req.Volumes) > 0 {
-		return models.CreateSandboxRequest{}, "", errors.New("volumes are not supported by the Daytona facade")
+		return models.CreateSandboxRequest{}, "", errVolumesUnsupported
 	}
 
 	lifecycle := models.Lifecycle{}
@@ -1043,6 +1045,21 @@ func (h *handlers) resolveBuildInfo(ctx context.Context, info *buildInfoRequest)
 // daytona createSandbox handler maps it to HTTP 502 so that retries and
 // alerting can distinguish "daemon is sad" from "client sent garbage".
 var errBuildOperational = errors.New("build operational error")
+
+// errVolumesUnsupported flags requests that name persistent Daytona volumes.
+// The facade has no volume backend yet; the dedicated /volumes routes and
+// the volumes[] field on createSandbox both surface as HTTP 405 so SDK
+// clients see a single, consistent "not yet implemented" signal.
+var errVolumesUnsupported = errors.New(volumesUnsupportedMessage)
+
+const volumesUnsupportedMessage = "volumes are not supported by the Daytona facade; this will be supported in a future release"
+
+// volumesNotSupported is the shared handler for every /volumes endpoint the
+// Daytona SDK reaches for. Returning 405 (rather than 404) tells clients the
+// route is recognized but the operation isn't available yet.
+func volumesNotSupported(w http.ResponseWriter, _ *http.Request) {
+	apihttp.WriteError(w, http.StatusMethodNotAllowed, volumesUnsupportedMessage)
+}
 
 // singleLineFromImage detects the legacy `FROM <image>` shape and returns
 // the base image when matched. Comments and blank lines are ignored.

--- a/pkg/api/daytona/handlers.go
+++ b/pkg/api/daytona/handlers.go
@@ -152,6 +152,97 @@ func (h *handlers) deleteSnapshot(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+// createSnapshotFromImage handles POST /daytona/snapshots — the Daytona SDK's
+// snapshot.create({ name, imageName | buildInfo, resources, regionId }) call.
+//
+// Two image-resolution paths:
+//
+//  1. imageName: caller hands us a pre-built registry reference. We register
+//     the snapshot row pointing at that reference and trust the runtime's
+//     docker pull at sandbox-create time to fail loudly if the image
+//     doesn't exist.
+//  2. buildInfo: caller hands us a Dockerfile (and optionally contextHashes,
+//     which today require operator-side object-store wiring — gated by
+//     SB_IMAGE_BUILD_CONTEXT_ENABLED). The same resolveBuildInfo used by the
+//     create-sandbox path produces a local image tag we then register.
+//
+// The SDK polls the snapshot until state hits a terminal value; we return
+// state=active synchronously, so its poll loop exits on the first read.
+func (h *handlers) createSnapshotFromImage(w http.ResponseWriter, r *http.Request) {
+	var req createSnapshotRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		apihttp.WriteError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+
+	imageName := strings.TrimSpace(valueOrEmpty(req.ImageName))
+	hasBuildInfo := req.BuildInfo != nil && strings.TrimSpace(valueOrEmpty(req.BuildInfo.DockerfileContent)) != ""
+	if imageName == "" && !hasBuildInfo {
+		apihttp.WriteError(w, http.StatusBadRequest, "imageName or buildInfo.dockerfileContent is required")
+		return
+	}
+	if imageName != "" && hasBuildInfo {
+		apihttp.WriteError(w, http.StatusBadRequest, "imageName and buildInfo are mutually exclusive")
+		return
+	}
+
+	var (
+		resolvedImage   string
+		freshlyBuiltTag string
+		err             error
+	)
+	if hasBuildInfo {
+		resolvedImage, freshlyBuiltTag, err = h.resolveBuildInfo(r.Context(), req.BuildInfo)
+		if err != nil {
+			// Mirror the createSandbox classification: timeouts and
+			// build/registry failures are operational (502/504); everything
+			// else is a 400 because it's a payload validation failure
+			// (e.g. contextHashes-without-flag).
+			switch {
+			case errors.Is(err, context.DeadlineExceeded):
+				apihttp.WriteError(w, http.StatusGatewayTimeout, err.Error())
+			case errors.Is(err, errBuildOperational):
+				apihttp.WriteError(w, http.StatusBadGateway, err.Error())
+			default:
+				apihttp.WriteError(w, http.StatusBadRequest, err.Error())
+			}
+			return
+		}
+	} else {
+		resolvedImage = imageName
+	}
+
+	snapshot := &models.SandboxSnapshot{
+		Name:       req.Name,
+		Image:      resolvedImage,
+		Entrypoint: append([]string{}, req.Entrypoint...),
+		RegionID:   strings.TrimSpace(valueOrEmpty(req.RegionID)),
+		CPU:        float64(float32Value(req.CPU)),
+		GPU:        float64(float32Value(req.GPU)),
+		MemoryMB:   int(float32Value(req.Memory)) * 1024,
+		DiskGB:     int(float32Value(req.Disk)),
+	}
+	registered, err := h.deps.Service.RegisterSnapshot(r.Context(), snapshot)
+	if err != nil {
+		// We may have just freshly built a tag that's now orphaned (no
+		// snapshot row pointing to it). Roll it back so the built-image
+		// janitor doesn't leak the layer.
+		if freshlyBuiltTag != "" && h.deps.Builder != nil {
+			if rbErr := h.deps.Builder.RemoveImage(r.Context(), freshlyBuiltTag); rbErr != nil && h.deps.Logger != nil {
+				h.deps.Logger.Warn("daytona snapshot rollback failed", "tag", freshlyBuiltTag, "error", rbErr)
+			}
+		}
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+
+	apihttp.WriteJSON(w, http.StatusCreated, h.toSnapshotResponse(r, registered))
+}
+
 func (h *handlers) listSandboxes(w http.ResponseWriter, r *http.Request) {
 	sandboxes, err := h.deps.Service.ListSandboxes(r.Context())
 	if err != nil {
@@ -744,6 +835,24 @@ func (h *handlers) toSnapshotResponse(r *http.Request, snapshot *models.SandboxS
 	organizationID := strings.TrimSpace(r.Header.Get("X-Daytona-Organization-ID"))
 	imageName := nonEmptyStringPtr(&snapshot.Image)
 	id := firstNonEmpty(strings.TrimSpace(snapshot.ImageID), snapshot.Name)
+
+	entrypoint := snapshot.Entrypoint
+	if entrypoint == nil {
+		entrypoint = []string{}
+	}
+
+	var regionIDs []string
+	if region := strings.TrimSpace(snapshot.RegionID); region != "" {
+		regionIDs = []string{region}
+	}
+
+	// MemoryMB is stored on the model in MB; the Daytona API reports it
+	// in GB to match the create payload's units.
+	memGB := float32(0)
+	if snapshot.MemoryMB > 0 {
+		memGB = float32(snapshot.MemoryMB) / 1024
+	}
+
 	return snapshotResponse{
 		ID:             id,
 		OrganizationID: nonEmptyStringPtr(&organizationID),
@@ -752,16 +861,17 @@ func (h *handlers) toSnapshotResponse(r *http.Request, snapshot *models.SandboxS
 		ImageName:      imageName,
 		State:          "active",
 		Size:           nil,
-		Entrypoint:     []string{},
-		CPU:            0,
-		GPU:            0,
-		Mem:            0,
-		Disk:           0,
+		Entrypoint:     entrypoint,
+		CPU:            float32(snapshot.CPU),
+		GPU:            float32(snapshot.GPU),
+		Mem:            memGB,
+		Disk:           float32(snapshot.DiskGB),
 		ErrorReason:    nil,
 		CreatedAt:      createdAt,
 		UpdatedAt:      createdAt,
 		LastUsedAt:     nil,
 		Ref:            cloneStringPtr(imageName),
+		RegionIDs:      regionIDs,
 	}
 }
 
@@ -819,6 +929,21 @@ func (h *handlers) translateCreateSandboxRequest(ctx context.Context, req create
 
 func (h *handlers) createImage(ctx context.Context, req createSandboxRequest) (string, string, error) {
 	if snapshot := strings.TrimSpace(valueOrEmpty(req.Snapshot)); snapshot != "" {
+		// First check the snapshot store — the Daytona SDK's
+		// daytona.snapshot.create() + daytona.create({snapshot: name}) flow
+		// passes a snapshot *name*, which the facade resolves to the
+		// underlying image reference here. Fall back to treating the string
+		// as a direct image reference for backwards compatibility with
+		// callers that already pass a registry path (e.g. create-vm example).
+		if resolved, err := h.deps.Service.GetSnapshot(ctx, snapshot); err == nil {
+			image := strings.TrimSpace(resolved.Image)
+			if image == "" {
+				image = strings.TrimSpace(resolved.ImageID)
+			}
+			if image != "" {
+				return image, "", nil
+			}
+		}
 		return snapshot, "", nil
 	}
 	if req.BuildInfo != nil {

--- a/pkg/api/daytona/handlers_test.go
+++ b/pkg/api/daytona/handlers_test.go
@@ -582,3 +582,18 @@ func newSnapshotHandlerTestEnv(t *testing.T) (*service.Service, *store.Store, *f
 func boolPtr(value bool) *bool {
 	return &value
 }
+
+func TestTranslateCreateSandboxRequestRejectsVolumesAsUnsupported(t *testing.T) {
+	req := createSandboxRequest{
+		Volumes: []map[string]any{{"volumeId": "vol-1", "mountPath": "/data"}},
+	}
+
+	h := newHandlers(Deps{})
+	_, _, err := h.translateCreateSandboxRequest(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error when volumes field is set")
+	}
+	if !errors.Is(err, errVolumesUnsupported) {
+		t.Fatalf("err = %v, want errVolumesUnsupported", err)
+	}
+}

--- a/pkg/api/daytona/routes.go
+++ b/pkg/api/daytona/routes.go
@@ -54,6 +54,7 @@ func RegisterRoutes(mux *http.ServeMux, d Deps) {
 	h := newHandlers(d)
 
 	mux.Handle("POST "+PathPrefix+"/sandbox", d.Auth(http.HandlerFunc(h.createSandbox)))
+	mux.Handle("POST "+PathPrefix+"/snapshots", d.Auth(http.HandlerFunc(h.createSnapshotFromImage)))
 	mux.Handle("GET "+PathPrefix+"/snapshots", d.Auth(http.HandlerFunc(h.listSnapshots)))
 	mux.Handle("GET "+PathPrefix+"/snapshots/{id}", d.Auth(http.HandlerFunc(h.getSnapshot)))
 	mux.Handle("DELETE "+PathPrefix+"/snapshots/{id}", d.Auth(http.HandlerFunc(h.deleteSnapshot)))

--- a/pkg/api/daytona/routes.go
+++ b/pkg/api/daytona/routes.go
@@ -75,4 +75,14 @@ func RegisterRoutes(mux *http.ServeMux, d Deps) {
 
 	mux.Handle(ToolboxPrefix+"/{id}", d.Auth(http.HandlerFunc(h.toolbox)))
 	mux.Handle(ToolboxPrefix+"/{id}/{path...}", d.Auth(http.HandlerFunc(h.toolbox)))
+
+	// Volumes — the Daytona SDK probes these five routes when callers use
+	// daytona.volume.{list,get,create,delete}. The facade has no volume
+	// backend yet; respond with 405 so clients see a clear "recognized but
+	// not implemented" signal rather than a 404 they'd retry through.
+	mux.Handle("GET "+PathPrefix+"/volumes", d.Auth(http.HandlerFunc(volumesNotSupported)))
+	mux.Handle("POST "+PathPrefix+"/volumes", d.Auth(http.HandlerFunc(volumesNotSupported)))
+	mux.Handle("GET "+PathPrefix+"/volumes/{volumeId}", d.Auth(http.HandlerFunc(volumesNotSupported)))
+	mux.Handle("DELETE "+PathPrefix+"/volumes/{volumeId}", d.Auth(http.HandlerFunc(volumesNotSupported)))
+	mux.Handle("GET "+PathPrefix+"/volumes/by-name/{name}", d.Auth(http.HandlerFunc(volumesNotSupported)))
 }

--- a/pkg/api/daytona/routes_test.go
+++ b/pkg/api/daytona/routes_test.go
@@ -1,7 +1,9 @@
 package daytona_test
 
 import (
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -27,5 +29,44 @@ func TestRegisterRoutesAllUseDaytonaPrefix(t *testing.T) {
 		if pattern == "" || !strings.Contains(pattern, daytona.PathPrefix+"/") {
 			t.Errorf("path %q resolved to pattern %q, expected one containing %q", probe, pattern, daytona.PathPrefix)
 		}
+	}
+}
+
+func TestVolumeRoutesReturn405NotImplemented(t *testing.T) {
+	mux := http.NewServeMux()
+	daytona.RegisterRoutes(mux, daytona.Deps{
+		Auth: func(h http.Handler) http.Handler { return h },
+	})
+
+	cases := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/daytona/volumes"},
+		{http.MethodPost, "/daytona/volumes"},
+		{http.MethodGet, "/daytona/volumes/vol-1"},
+		{http.MethodDelete, "/daytona/volumes/vol-1"},
+		{http.MethodGet, "/daytona/volumes/by-name/my-volume"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusMethodNotAllowed {
+				t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusMethodNotAllowed, rr.Body.String())
+			}
+			var body struct {
+				Error string `json:"error"`
+			}
+			if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if !strings.Contains(body.Error, "future release") {
+				t.Fatalf("body.Error = %q, want it to mention future release", body.Error)
+			}
+		})
 	}
 }

--- a/pkg/api/daytona/snapshot_create_test.go
+++ b/pkg/api/daytona/snapshot_create_test.go
@@ -1,0 +1,345 @@
+package daytona
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/internal/service"
+	"github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/docker"
+)
+
+// snapshotCreateTestEnv bundles the moving parts a snapshot-create test
+// needs. Tests that only drive HTTP use .handler; tests that want to call
+// internal helpers (e.g. translateCreateSandboxRequest) use .h.
+type snapshotCreateTestEnv struct {
+	svc     *service.Service
+	store   *store.Store
+	builder *fakeImageBuilder
+	h       *handlers
+	handler http.Handler
+}
+
+// newSnapshotCreateTestEnv mirrors newSnapshotHandlerTestEnv but lets a test
+// inject a fake builder so the buildInfo branch can be exercised without a
+// real Docker daemon.
+func newSnapshotCreateTestEnv(t *testing.T, builder *fakeImageBuilder) *snapshotCreateTestEnv {
+	t.Helper()
+	st, err := store.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	rt := &fakeDaytonaSnapshotRuntime{}
+	svc := service.New(config.Config{}, logger, st, rt, nil, nil, nil, nil, nil)
+	if builder == nil {
+		builder = &fakeImageBuilder{}
+	}
+	deps := Deps{
+		Service: svc,
+		Logger:  logger,
+		Builder: builder,
+		Auth: func(next http.Handler) http.Handler {
+			return next
+		},
+	}
+	h := newHandlers(deps)
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, deps)
+	return &snapshotCreateTestEnv{
+		svc:     svc,
+		store:   st,
+		builder: builder,
+		h:       h,
+		handler: mux,
+	}
+}
+
+// TestCreateSnapshotFromImageName covers the simple path: the caller hands
+// us a pre-built registry image. We persist a snapshot row pointing at that
+// image, return state="active" so the SDK's poll loop exits immediately,
+// and surface the resources / regionId the caller asked for.
+func TestCreateSnapshotFromImageName(t *testing.T) {
+	env := newSnapshotCreateTestEnv(t, nil)
+	svc, builder, handler := env.svc, env.builder, env.handler
+
+	body := `{
+		"name": "py-base",
+		"imageName": "python:3.12-slim",
+		"entrypoint": ["python", "-V"],
+		"cpu": 2,
+		"memory": 4,
+		"disk": 10,
+		"regionId": "us"
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/daytona/snapshots", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusCreated, rr.Body.String())
+	}
+
+	var resp snapshotResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Name != "py-base" {
+		t.Errorf("name = %q, want py-base", resp.Name)
+	}
+	if resp.ImageName == nil || *resp.ImageName != "python:3.12-slim" {
+		t.Errorf("imageName = %+v, want python:3.12-slim", resp.ImageName)
+	}
+	if resp.State != "active" {
+		t.Errorf("state = %q, want active (SDK polls until terminal)", resp.State)
+	}
+	if len(resp.Entrypoint) != 2 || resp.Entrypoint[0] != "python" {
+		t.Errorf("entrypoint = %+v, want [python -V]", resp.Entrypoint)
+	}
+	if resp.CPU != 2 || resp.Mem != 4 || resp.Disk != 10 {
+		t.Errorf("resources = (cpu=%v mem=%v disk=%v), want (2,4,10)", resp.CPU, resp.Mem, resp.Disk)
+	}
+	if len(resp.RegionIDs) != 1 || resp.RegionIDs[0] != "us" {
+		t.Errorf("regionIds = %+v, want [us]", resp.RegionIDs)
+	}
+
+	// Persisted via the service — verify GetSnapshot returns it.
+	stored, err := svc.GetSnapshot(context.Background(), "py-base")
+	if err != nil {
+		t.Fatalf("GetSnapshot: %v", err)
+	}
+	if stored.Image != "python:3.12-slim" {
+		t.Errorf("stored.Image = %q, want python:3.12-slim", stored.Image)
+	}
+	if stored.RegionID != "us" {
+		t.Errorf("stored.RegionID = %q, want us", stored.RegionID)
+	}
+
+	// imageName path must NOT touch the builder.
+	if len(builder.builds) != 0 {
+		t.Errorf("builder.builds = %d, want 0 (imageName path)", len(builder.builds))
+	}
+}
+
+// TestCreateSnapshotFromBuildInfo covers the SDK's Image.debianSlim(...)
+// flow — the Image builder serializes to a multi-line Dockerfile and we
+// run it through resolveBuildInfo, which calls the image builder. The
+// resulting tag is then registered as the snapshot's image.
+func TestCreateSnapshotFromBuildInfo(t *testing.T) {
+	env := newSnapshotCreateTestEnv(t, &fakeImageBuilder{})
+	builder, handler := env.builder, env.handler
+
+	dockerfile := "FROM debian:bookworm-slim\nRUN apt-get update"
+	wantTag := docker.BuildTagFor(dockerfile, nil)
+	payload := map[string]any{
+		"name": "debian-built",
+		"buildInfo": map[string]any{
+			"dockerfileContent": dockerfile,
+		},
+	}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, "/daytona/snapshots", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%s", rr.Code, rr.Body.String())
+	}
+
+	var resp snapshotResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ImageName == nil || *resp.ImageName != wantTag {
+		t.Errorf("imageName = %+v, want %q (resolved build tag)", resp.ImageName, wantTag)
+	}
+	if len(builder.builds) != 1 {
+		t.Fatalf("builder.builds = %d, want 1 (build path)", len(builder.builds))
+	}
+	if got := builder.builds[0].Tag; got != wantTag {
+		t.Errorf("build tag = %q, want %q", got, wantTag)
+	}
+}
+
+// TestCreateSnapshotFromSingleLineFROM is the fast-path: a one-liner FROM
+// dockerfile with no context. The facade returns the bare image string
+// without invoking the builder (mirrors resolveBuildInfo's case 1).
+func TestCreateSnapshotFromSingleLineFROM(t *testing.T) {
+	env := newSnapshotCreateTestEnv(t, nil)
+	builder, handler := env.builder, env.handler
+
+	body := `{"name":"alpine","buildInfo":{"dockerfileContent":"FROM alpine:3.20"}}`
+	req := httptest.NewRequest(http.MethodPost, "/daytona/snapshots", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d; body=%s", rr.Code, rr.Body.String())
+	}
+	var resp snapshotResponse
+	_ = json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.ImageName == nil || *resp.ImageName != "alpine:3.20" {
+		t.Errorf("imageName = %+v, want alpine:3.20 (single-line FROM is pass-through)", resp.ImageName)
+	}
+	if len(builder.builds) != 0 {
+		t.Errorf("builder.builds = %d, want 0 (single-line FROM should not build)", len(builder.builds))
+	}
+}
+
+// TestCreateSnapshotValidationErrors pins the input shapes the handler
+// rejects up front. Each row is a payload + expected error fragment so a
+// future refactor that loosens validation flips a specific case red.
+func TestCreateSnapshotValidationErrors(t *testing.T) {
+	handler := newSnapshotCreateTestEnv(t, nil).handler
+
+	cases := []struct {
+		name     string
+		body     string
+		wantCode int
+		wantHint string
+	}{
+		{
+			name:     "missing name",
+			body:     `{"imageName":"python:3.12"}`,
+			wantCode: http.StatusBadRequest,
+			wantHint: "name is required",
+		},
+		{
+			name:     "neither imageName nor buildInfo",
+			body:     `{"name":"x"}`,
+			wantCode: http.StatusBadRequest,
+			wantHint: "imageName or buildInfo",
+		},
+		{
+			name:     "both imageName and buildInfo set",
+			body:     `{"name":"x","imageName":"a","buildInfo":{"dockerfileContent":"FROM b"}}`,
+			wantCode: http.StatusBadRequest,
+			wantHint: "mutually exclusive",
+		},
+		{
+			name:     "contextHashes without operator flag",
+			body:     `{"name":"x","buildInfo":{"dockerfileContent":"FROM a\nCOPY . /app","contextHashes":["deadbeef"]}}`,
+			wantCode: http.StatusBadRequest,
+			wantHint: "SB_IMAGE_BUILD_CONTEXT_ENABLED",
+		},
+		{
+			name:     "invalid json",
+			body:     `{not-json`,
+			wantCode: http.StatusBadRequest,
+			wantHint: "invalid JSON",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/daytona/snapshots", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d; body=%s", rr.Code, tc.wantCode, rr.Body.String())
+			}
+			if !strings.Contains(rr.Body.String(), tc.wantHint) {
+				t.Errorf("body does not contain %q; got %s", tc.wantHint, rr.Body.String())
+			}
+		})
+	}
+}
+
+// TestCreateSnapshotIdempotentOnSameImage covers the SDK-retry case: if a
+// caller re-issues the same create request after a transient network
+// failure, we return the existing row instead of erroring with a conflict.
+// A retry with a *different* image is still a conflict — that's a different
+// payload claiming the same name.
+func TestCreateSnapshotIdempotentOnSameImage(t *testing.T) {
+	handler := newSnapshotCreateTestEnv(t, nil).handler
+
+	body := `{"name":"py","imageName":"python:3.12"}`
+	first := httptest.NewRecorder()
+	handler.ServeHTTP(first, httptest.NewRequest(http.MethodPost, "/daytona/snapshots",
+		strings.NewReader(body)))
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first call status = %d; body=%s", first.Code, first.Body.String())
+	}
+
+	// Same payload twice — should succeed, not 409.
+	second := httptest.NewRecorder()
+	handler.ServeHTTP(second, httptest.NewRequest(http.MethodPost, "/daytona/snapshots",
+		strings.NewReader(body)))
+	if second.Code != http.StatusCreated {
+		t.Fatalf("retry status = %d, want 201 (idempotent); body=%s", second.Code, second.Body.String())
+	}
+
+	// Same name with a *different* image must conflict.
+	conflict := httptest.NewRecorder()
+	handler.ServeHTTP(conflict, httptest.NewRequest(http.MethodPost, "/daytona/snapshots",
+		strings.NewReader(`{"name":"py","imageName":"python:3.13"}`)))
+	if conflict.Code == http.StatusCreated {
+		t.Fatalf("conflicting image under same name accepted: body=%s", conflict.Body.String())
+	}
+}
+
+// TestCreateSnapshotThenCreateSandboxResolvesImage is the end-to-end glue
+// the declarative-image example needs: after registering a snapshot named
+// "py-base" → "python:3.12-slim", a follow-up sandbox create that passes
+// snapshot: "py-base" must resolve to image "python:3.12-slim", not pass
+// the literal string "py-base" downstream as a docker image ref.
+func TestCreateSnapshotThenCreateSandboxResolvesImage(t *testing.T) {
+	env := newSnapshotCreateTestEnv(t, nil)
+
+	// 1. Register the snapshot via HTTP — same path the SDK takes.
+	mkSnap := httptest.NewRecorder()
+	env.handler.ServeHTTP(mkSnap, httptest.NewRequest(http.MethodPost, "/daytona/snapshots",
+		strings.NewReader(`{"name":"py-base","imageName":"python:3.12-slim"}`)))
+	if mkSnap.Code != http.StatusCreated {
+		t.Fatalf("create snapshot status = %d; body=%s", mkSnap.Code, mkSnap.Body.String())
+	}
+
+	// 2. Translate a sandbox-create payload that references that snapshot.
+	// The lookup happens inside translateCreateSandboxRequest → createImage
+	// → service.GetSnapshot, so we don't need to drive the full Docker
+	// create path to verify resolution.
+	snapshotName := "py-base"
+	req := createSandboxRequest{Snapshot: &snapshotName}
+	translated, _, err := env.h.translateCreateSandboxRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	if translated.Image != "python:3.12-slim" {
+		t.Fatalf("translated.Image = %q, want python:3.12-slim (resolved from snapshot row)", translated.Image)
+	}
+}
+
+// TestCreateSandboxWithUnknownSnapshotFallsThrough preserves the legacy
+// behavior used by the create-vm example: if the snapshot string isn't a
+// registered snapshot name, the facade passes it through as a docker image
+// reference instead of erroring. That way callers can keep referencing
+// registry-style strings (e.g. "ghcr.io/me/img:tag") without first having
+// to register them.
+func TestCreateSandboxWithUnknownSnapshotFallsThrough(t *testing.T) {
+	env := newSnapshotCreateTestEnv(t, nil)
+
+	directRef := "ghcr.io/sumanrocs/penify-agent:v1"
+	req := createSandboxRequest{Snapshot: &directRef}
+	translated, _, err := env.h.translateCreateSandboxRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	if translated.Image != directRef {
+		t.Fatalf("translated.Image = %q, want %q (fallback pass-through)", translated.Image, directRef)
+	}
+}

--- a/pkg/api/daytona/toolbox.go
+++ b/pkg/api/daytona/toolbox.go
@@ -53,7 +53,10 @@ func (h *handlers) toolbox(w http.ResponseWriter, r *http.Request) {
 		h.forwardToolbox(w, r, sandboxID, "/version")
 	case r.Method == http.MethodGet && path == "user-home-dir":
 		h.userHomeDir(w, r, sandboxID)
-	case r.Method == http.MethodGet && path == "workdir":
+	case r.Method == http.MethodGet && (path == "workdir" || path == "work-dir"):
+		// The Daytona SDK's InfoApi.getWorkDir calls /work-dir (hyphenated);
+		// the legacy facade route was /workdir. Accept both so older clients
+		// keep working.
 		h.workDir(w, r, sandboxID)
 	case r.Method == http.MethodPost && path == "process/execute":
 		h.executeCommand(w, r, sandboxID)
@@ -68,10 +71,20 @@ func (h *handlers) toolbox(w http.ResponseWriter, r *http.Request) {
 		// /process/interpreter/execute is a WebSocket stream; the context
 		// endpoints are plain HTTP. ReverseProxy handles both.
 		h.proxyToolbox(w, r, sandboxID, "/"+path)
-	case strings.HasPrefix(path, "process/pty/"):
+	case path == "process/pty" || strings.HasPrefix(path, "process/pty/"):
+		// /process/pty (bare) covers list/create; /process/pty/{id}/connect
+		// is the WebSocket stream.
 		h.proxyToolbox(w, r, sandboxID, "/"+path)
 	case r.Method == http.MethodGet && path == "files":
 		h.forwardToolbox(w, r, sandboxID, "/files")
+	case r.Method == http.MethodDelete && path == "files":
+		h.forwardToolbox(w, r, sandboxID, "/files")
+	case r.Method == http.MethodPost && path == "files/folder":
+		h.forwardToolbox(w, r, sandboxID, "/files/folder")
+	case r.Method == http.MethodPost && path == "files/replace":
+		h.forwardToolbox(w, r, sandboxID, "/files/replace")
+	case r.Method == http.MethodPost && path == "files/permissions":
+		h.forwardToolbox(w, r, sandboxID, "/files/permissions")
 	case r.Method == http.MethodGet && path == "files/info":
 		h.forwardToolbox(w, r, sandboxID, "/files/info")
 	case r.Method == http.MethodPost && path == "files/upload":
@@ -89,6 +102,11 @@ func (h *handlers) toolbox(w http.ResponseWriter, r *http.Request) {
 	case r.Method == http.MethodPost && path == "files/bulk-download":
 		h.bulkDownload(w, r, sandboxID)
 	case strings.HasPrefix(path, "git/"):
+		h.forwardToolbox(w, r, sandboxID, "/"+path)
+	case strings.HasPrefix(path, "lsp/"):
+		// Language-server endpoints are simple HTTP requests against the
+		// toolbox daemon — pass them through so sandbox.createLspServer()
+		// + lsp.start/didOpen/completions/etc. work end-to-end.
 		h.forwardToolbox(w, r, sandboxID, "/"+path)
 	default:
 		apihttp.WriteError(w, http.StatusNotImplemented, "daytona toolbox route not implemented")

--- a/pkg/api/daytona/toolbox.go
+++ b/pkg/api/daytona/toolbox.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/http/httputil"
 	"net/textproto"
 	"net/url"
 	"path/filepath"
@@ -56,8 +57,19 @@ func (h *handlers) toolbox(w http.ResponseWriter, r *http.Request) {
 		h.workDir(w, r, sandboxID)
 	case r.Method == http.MethodPost && path == "process/execute":
 		h.executeCommand(w, r, sandboxID)
-	case path == "process/session" || strings.HasPrefix(path, "process/session/"):
+	case r.Method == http.MethodPost && path == "process/code-run":
 		h.forwardToolbox(w, r, sandboxID, "/"+path)
+	case path == "process/session" || strings.HasPrefix(path, "process/session/"):
+		// Session log/PTY streams upgrade to WebSocket — use the reverse-proxy
+		// path so the Upgrade handshake passes through. Plain-HTTP session
+		// requests ride the same proxy without harm.
+		h.proxyToolbox(w, r, sandboxID, "/"+path)
+	case strings.HasPrefix(path, "process/interpreter/"):
+		// /process/interpreter/execute is a WebSocket stream; the context
+		// endpoints are plain HTTP. ReverseProxy handles both.
+		h.proxyToolbox(w, r, sandboxID, "/"+path)
+	case strings.HasPrefix(path, "process/pty/"):
+		h.proxyToolbox(w, r, sandboxID, "/"+path)
 	case r.Method == http.MethodGet && path == "files":
 		h.forwardToolbox(w, r, sandboxID, "/files")
 	case r.Method == http.MethodGet && path == "files/info":
@@ -319,6 +331,42 @@ func (h *handlers) runToolboxCommand(ctx context.Context, sandboxID string, req 
 		return nil, &toolboxHTTPError{StatusCode: statusCode, Message: http.StatusText(statusCode)}
 	}
 	return &result, nil
+}
+
+// proxyToolbox forwards via httputil.ReverseProxy, which transparently
+// negotiates Upgrade: websocket handshakes — unlike forwardToolbox, which
+// reads the body fully through httpClient.Do and breaks WS streams.
+func (h *handlers) proxyToolbox(w http.ResponseWriter, r *http.Request, sandboxID, path string) {
+	endpoint, err := h.deps.Service.ToolboxTarget(r.Context(), sandboxID)
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	target, err := url.Parse(endpoint.URL)
+	if err != nil {
+		apihttp.WriteError(w, http.StatusInternalServerError, "invalid toolbox target")
+		return
+	}
+
+	toolboxToken := endpoint.Token
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.SetURL(target)
+			pr.Out.URL.Path = path
+			pr.Out.URL.RawPath = ""
+			pr.Out.Host = target.Host
+			if toolboxToken != "" {
+				pr.Out.Header.Set("Authorization", "Bearer "+toolboxToken)
+			}
+		},
+		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
+			if h.deps.Logger != nil {
+				h.deps.Logger.Warn("daytona toolbox proxy failed", "error", err, "path", path)
+			}
+			apihttp.WriteError(w, http.StatusBadGateway, "toolbox unavailable")
+		},
+	}
+	proxy.ServeHTTP(w, r)
 }
 
 func (h *handlers) forwardToolbox(w http.ResponseWriter, r *http.Request, sandboxID, path string) {

--- a/pkg/api/daytona/toolbox_proxy_test.go
+++ b/pkg/api/daytona/toolbox_proxy_test.go
@@ -90,7 +90,7 @@ func newToolboxProxyTestEnv(t *testing.T) *toolboxProxyTestEnv {
 
 	mux := http.NewServeMux()
 
-	// Plain-HTTP endpoints we expect to ride forwardToolbox.
+	// Plain-HTTP endpoints we expect to ride forwardToolbox / proxyToolbox.
 	mux.HandleFunc("/process/code-run", func(w http.ResponseWriter, r *http.Request) {
 		requests <- r.Clone(r.Context())
 		w.Header().Set("Content-Type", "application/json")
@@ -101,6 +101,25 @@ func newToolboxProxyTestEnv(t *testing.T) *toolboxProxyTestEnv {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{"id":"ctx-1"}`)
 	})
+
+	// File-system endpoints exercised by the file-operations + volumes examples.
+	echoOK := func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.Clone(r.Context())
+		w.WriteHeader(http.StatusNoContent)
+	}
+	mux.HandleFunc("/files", echoOK)
+	mux.HandleFunc("/files/folder", echoOK)
+	mux.HandleFunc("/files/replace", echoOK)
+	mux.HandleFunc("/files/permissions", echoOK)
+
+	// LSP endpoints exercised by the git-lsp example.
+	mux.HandleFunc("/lsp/start", echoOK)
+	mux.HandleFunc("/lsp/did-open", echoOK)
+	mux.HandleFunc("/lsp/document-symbols", echoOK)
+	mux.HandleFunc("/lsp/completions", echoOK)
+
+	// PTY bare endpoint (list/create).
+	mux.HandleFunc("/process/pty", echoOK)
 
 	// WebSocket endpoints we expect to ride proxyToolbox.
 	wsHandler := func(w http.ResponseWriter, r *http.Request) {
@@ -370,6 +389,82 @@ func TestToolboxProxyUnknownRouteStillReturns501(t *testing.T) {
 		t.Fatalf("unknown path leaked to toolbox: %s %s", got.Method, got.URL.Path)
 	case <-time.After(100 * time.Millisecond):
 		// expected: nothing reaches the toolbox
+	}
+}
+
+// TestToolboxProxyForwardedRoutes is the table-driven coverage for every
+// route added while making the daytona-examples runnable end-to-end.
+// Each row picks an example that exercises the route and asserts the
+// request reaches the fake toolbox with the right method + path. If a
+// future refactor drops one of these whitelist entries, the matching
+// row turns red and points straight at the regressing example.
+func TestToolboxProxyForwardedRoutes(t *testing.T) {
+	cases := []struct {
+		name       string
+		example    string // which example would break if this regressed
+		method     string
+		facadePath string // path appended after /toolbox/{id}
+		wantPath   string // path the fake toolbox should observe
+	}{
+		// file-operations + volumes
+		{"createFolder", "file-operations", http.MethodPost, "/files/folder?path=p&mode=755", "/files/folder"},
+		{"replaceInFiles", "file-operations", http.MethodPost, "/files/replace", "/files/replace"},
+		{"setFilePermissions", "file-operations", http.MethodPost, "/files/permissions?path=p", "/files/permissions"},
+		{"deleteFile", "file-operations", http.MethodDelete, "/files?path=p", "/files"},
+		// git-lsp
+		{"lspStart", "git-lsp", http.MethodPost, "/lsp/start", "/lsp/start"},
+		{"lspDidOpen", "git-lsp", http.MethodPost, "/lsp/did-open", "/lsp/did-open"},
+		{"lspDocumentSymbols", "git-lsp", http.MethodGet, "/lsp/document-symbols?pathToProject=p&file=f", "/lsp/document-symbols"},
+		{"lspCompletions", "git-lsp", http.MethodPost, "/lsp/completions", "/lsp/completions"},
+		// pty (bare path covers list + create)
+		{"createPty", "pty", http.MethodPost, "/process/pty", "/process/pty"},
+		{"listPty", "pty", http.MethodGet, "/process/pty", "/process/pty"},
+	}
+
+	env := newToolboxProxyTestEnv(t)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(tc.method,
+				env.facade.URL+ToolboxPrefix+"/"+env.sandboxID+tc.facadePath,
+				strings.NewReader(`{}`),
+			)
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("Do: %v", err)
+			}
+			_ = resp.Body.Close()
+
+			// 501 means the route fell through to the default case —
+			// the example named in tc.example is the one that breaks.
+			if resp.StatusCode == http.StatusNotImplemented {
+				t.Fatalf("route returned 501 — would break example %q", tc.example)
+			}
+			// The fake toolbox returns 204 for the catch-all echo handler;
+			// individual mux-mounted handlers may return 200/204. Anything
+			// 2xx means we got past the facade. >=300 is a real error.
+			if resp.StatusCode >= http.StatusMultipleChoices {
+				t.Fatalf("status = %d, want 2xx", resp.StatusCode)
+			}
+
+			select {
+			case got := <-env.toolboxRequests:
+				if got.Method != tc.method {
+					t.Errorf("method = %q, want %q", got.Method, tc.method)
+				}
+				if got.URL.Path != tc.wantPath {
+					t.Errorf("path = %q, want %q", got.URL.Path, tc.wantPath)
+				}
+				if got.Header.Get("Authorization") != "Bearer tok-proxy" {
+					t.Errorf("Authorization = %q, want Bearer tok-proxy", got.Header.Get("Authorization"))
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatalf("request never reached fake toolbox — example %q would hang", tc.example)
+			}
+		})
 	}
 }
 

--- a/pkg/api/daytona/toolbox_proxy_test.go
+++ b/pkg/api/daytona/toolbox_proxy_test.go
@@ -1,0 +1,393 @@
+package daytona
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/internal/service"
+	"github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/models"
+	"github.com/aerol-ai/microvm/pkg/mounts"
+)
+
+// fakeToolboxRouteRuntime is the bare-minimum runtime.Runtime needed to seed a
+// sandbox into the store for ToolboxTarget(...) to resolve. None of the
+// runtime hooks fire during proxy tests; we panic on anything unexpected so a
+// surprise call is loud, not silent.
+type fakeToolboxRouteRuntime struct{}
+
+func (fakeToolboxRouteRuntime) Create(context.Context, models.CreateSandboxRequest, string, string, []mounts.ContainerBind) (*models.SandboxRuntimeState, error) {
+	panic("unexpected Create")
+}
+func (fakeToolboxRouteRuntime) Start(context.Context, string) (*models.SandboxRuntimeState, error) {
+	panic("unexpected Start")
+}
+func (fakeToolboxRouteRuntime) Stop(context.Context, string) error { panic("unexpected Stop") }
+func (fakeToolboxRouteRuntime) Destroy(context.Context, *models.Sandbox) error {
+	panic("unexpected Destroy")
+}
+func (fakeToolboxRouteRuntime) CreateSnapshot(context.Context, string, string) (string, error) {
+	panic("unexpected CreateSnapshot")
+}
+func (fakeToolboxRouteRuntime) Resize(context.Context, string, models.ResizeSandboxRequest) error {
+	panic("unexpected Resize")
+}
+func (fakeToolboxRouteRuntime) Inspect(context.Context, string) (*models.SandboxRuntimeState, error) {
+	panic("unexpected Inspect")
+}
+func (fakeToolboxRouteRuntime) ListManaged(context.Context) (map[string]*models.SandboxRuntimeState, error) {
+	return map[string]*models.SandboxRuntimeState{}, nil
+}
+func (fakeToolboxRouteRuntime) Ping(context.Context) error          { return nil }
+func (fakeToolboxRouteRuntime) RemoveImage(context.Context, string) error { return nil }
+func (fakeToolboxRouteRuntime) PushAllowedPorts(context.Context, string, string, []int) error {
+	return nil
+}
+func (fakeToolboxRouteRuntime) ClearNetworkRules(string) error        { return nil }
+func (fakeToolboxRouteRuntime) ApplyNetworkBlockAll(string) error     { return nil }
+func (fakeToolboxRouteRuntime) ApplyNetworkBlockIngress(string) error { return nil }
+func (fakeToolboxRouteRuntime) ClearNetworkBlockIngress(string) error { return nil }
+func (fakeToolboxRouteRuntime) ClearNetworkBlockEgress(string) error  { return nil }
+
+// toolboxProxyTestEnv wires a fake "toolbox daemon" httptest.Server into the
+// daytona facade so we can drive real HTTP and WebSocket traffic through the
+// proxy code under test. ContainerIP + ToolboxPort point at the fake server
+// — any request the facade forwards lands on toolboxRequests.
+type toolboxProxyTestEnv struct {
+	facade           *httptest.Server
+	toolbox          *httptest.Server
+	sandboxID        string
+	toolboxRequests  chan *http.Request
+	toolboxWSPath    chan string
+	toolboxWSCloseFn func()
+}
+
+func newToolboxProxyTestEnv(t *testing.T) *toolboxProxyTestEnv {
+	t.Helper()
+
+	requests := make(chan *http.Request, 8)
+	wsPaths := make(chan string, 8)
+	wsClose := func() {}
+
+	upgrader := websocket.Upgrader{
+		// Tests speak ws://127.0.0.1:NNNN directly — there's no browser
+		// origin to validate.
+		CheckOrigin: func(*http.Request) bool { return true },
+	}
+
+	mux := http.NewServeMux()
+
+	// Plain-HTTP endpoints we expect to ride forwardToolbox.
+	mux.HandleFunc("/process/code-run", func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.Clone(r.Context())
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"exitCode":0,"result":"hello\n"}`)
+	})
+	mux.HandleFunc("/process/interpreter/context", func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.Clone(r.Context())
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"ctx-1"}`)
+	})
+
+	// WebSocket endpoints we expect to ride proxyToolbox.
+	wsHandler := func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("Upgrade(%s): %v", r.URL.Path, err)
+			return
+		}
+		defer conn.Close()
+		// Echo the path back as a text frame so the test can assert
+		// the URL was rewritten correctly through the proxy.
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(r.URL.Path+"?"+r.URL.RawQuery))
+		wsPaths <- r.URL.Path
+		// Block until the client closes so the test controls teardown.
+		_, _, _ = conn.ReadMessage()
+	}
+	mux.HandleFunc("/process/interpreter/execute", wsHandler)
+	mux.HandleFunc("/process/session/", wsHandler)
+
+	toolboxServer := httptest.NewServer(mux)
+	wsClose = toolboxServer.Close
+
+	host, portText, err := net.SplitHostPort(mustParseURL(t, toolboxServer.URL).Host)
+	if err != nil {
+		t.Fatalf("split toolbox host: %v", err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatalf("parse toolbox port: %v", err)
+	}
+
+	dir := t.TempDir()
+	st, err := store.Open(filepath.Join(dir, "state.db"))
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	mountManager, err := mounts.New(logger, mounts.Config{
+		RootDir:     filepath.Join(dir, "mounts"),
+		CredDir:     filepath.Join(dir, "cred"),
+		WaitTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("mounts.New: %v", err)
+	}
+	t.Cleanup(mountManager.Close)
+
+	cfg := config.Config{
+		DBPath:            filepath.Join(dir, "state.db"),
+		PublicHost:        "sandbox.test",
+		ToolboxPort:       port,
+		Runtime:           models.RuntimeDocker,
+		EnableCaddy:       false,
+		HTTPClientTimeout: 5 * time.Second,
+	}
+	svc := service.New(cfg, logger, st, fakeToolboxRouteRuntime{}, nil, nil, nil, mountManager, nil)
+
+	sandboxID := "sb-proxy"
+	now := time.Now().UTC().Round(time.Second)
+	if err := st.Upsert(context.Background(), &models.Sandbox{
+		ID:             sandboxID,
+		Name:           sandboxID,
+		Image:          "ubuntu:22.04",
+		Status:         models.SandboxStatusStarted,
+		ContainerID:    "ctr-" + sandboxID,
+		ContainerIP:    host,
+		ToolboxEnabled: true,
+		ToolboxToken:   "tok-proxy",
+		Runtime:        models.RuntimeDocker,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		LastActiveAt:   now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+
+	mux2 := http.NewServeMux()
+	RegisterRoutes(mux2, Deps{
+		Service: svc,
+		Logger:  logger,
+		Auth: func(next http.Handler) http.Handler {
+			return next
+		},
+	})
+	facadeServer := httptest.NewServer(mux2)
+	t.Cleanup(facadeServer.Close)
+
+	return &toolboxProxyTestEnv{
+		facade:           facadeServer,
+		toolbox:          toolboxServer,
+		sandboxID:        sandboxID,
+		toolboxRequests:  requests,
+		toolboxWSPath:    wsPaths,
+		toolboxWSCloseFn: wsClose,
+	}
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse %q: %v", raw, err)
+	}
+	return u
+}
+
+// TestToolboxProxyCodeRunForwarded covers the immediate user-reported failure:
+// sandbox.process.codeRun() used to 501 because /process/code-run wasn't
+// whitelisted in the facade switch.
+func TestToolboxProxyCodeRunForwarded(t *testing.T) {
+	env := newToolboxProxyTestEnv(t)
+
+	resp, err := http.Post(
+		env.facade.URL+ToolboxPrefix+"/"+env.sandboxID+"/process/code-run",
+		"application/json",
+		strings.NewReader(`{"code":"print(1)","language":"python"}`),
+	)
+	if err != nil {
+		t.Fatalf("POST /process/code-run: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	select {
+	case got := <-env.toolboxRequests:
+		if got.URL.Path != "/process/code-run" {
+			t.Fatalf("forwarded path = %q, want /process/code-run", got.URL.Path)
+		}
+		if got.Header.Get("Authorization") != "Bearer tok-proxy" {
+			t.Fatalf("Authorization = %q, want Bearer tok-proxy", got.Header.Get("Authorization"))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("code-run never reached the fake toolbox")
+	}
+}
+
+// TestToolboxProxyInterpreterContextForwarded confirms the new
+// process/interpreter/* prefix routes plain HTTP through proxyToolbox without
+// regression. The matching WebSocket path is covered separately below.
+func TestToolboxProxyInterpreterContextForwarded(t *testing.T) {
+	env := newToolboxProxyTestEnv(t)
+
+	resp, err := http.Post(
+		env.facade.URL+ToolboxPrefix+"/"+env.sandboxID+"/process/interpreter/context",
+		"application/json",
+		strings.NewReader(`{"cwd":"/tmp"}`),
+	)
+	if err != nil {
+		t.Fatalf("POST /process/interpreter/context: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	select {
+	case got := <-env.toolboxRequests:
+		if got.URL.Path != "/process/interpreter/context" {
+			t.Fatalf("forwarded path = %q, want /process/interpreter/context", got.URL.Path)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("interpreter/context never reached the fake toolbox")
+	}
+}
+
+// TestToolboxProxyInterpreterExecuteUpgradesWebSocket is the regression test
+// for the deeper bug: the old forwardToolbox path used httpClient.Do, which
+// silently strips the Connection/Upgrade headers and so quietly broke the
+// CodeInterpreter stream. proxyToolbox uses httputil.ReverseProxy, which
+// passes the upgrade through.
+func TestToolboxProxyInterpreterExecuteUpgradesWebSocket(t *testing.T) {
+	env := newToolboxProxyTestEnv(t)
+
+	wsURL := strings.Replace(env.facade.URL, "http://", "ws://", 1) +
+		ToolboxPrefix + "/" + env.sandboxID + "/process/interpreter/execute"
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("WS dial: %v", err)
+	}
+	defer conn.Close()
+
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	msgType, payload, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+	if msgType != websocket.TextMessage {
+		t.Fatalf("frame type = %d, want %d", msgType, websocket.TextMessage)
+	}
+	if !strings.HasPrefix(string(payload), "/process/interpreter/execute") {
+		t.Fatalf("echo payload = %q, want prefix /process/interpreter/execute", payload)
+	}
+
+	select {
+	case got := <-env.toolboxWSPath:
+		if got != "/process/interpreter/execute" {
+			t.Fatalf("ws path = %q", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("interpreter/execute upgrade never landed on the fake toolbox")
+	}
+}
+
+// TestToolboxProxySessionLogsUpgradesWebSocket guards the second WS path the
+// example exercises: getSessionCommandLogs(..., onStdout, onStderr) streams
+// over /process/session/{id}/command/{cmdId}/logs?follow=true.
+func TestToolboxProxySessionLogsUpgradesWebSocket(t *testing.T) {
+	env := newToolboxProxyTestEnv(t)
+
+	wsURL := strings.Replace(env.facade.URL, "http://", "ws://", 1) +
+		ToolboxPrefix + "/" + env.sandboxID +
+		"/process/session/sess-1/command/cmd-1/logs?follow=true"
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("WS dial: %v", err)
+	}
+	defer conn.Close()
+
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, payload, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+	want := "/process/session/sess-1/command/cmd-1/logs?follow=true"
+	if string(payload) != want {
+		t.Fatalf("echoed url = %q, want %q", payload, want)
+	}
+
+	select {
+	case got := <-env.toolboxWSPath:
+		if got != "/process/session/sess-1/command/cmd-1/logs" {
+			t.Fatalf("ws path = %q", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("session/logs upgrade never landed on the fake toolbox")
+	}
+}
+
+// TestToolboxProxyUnknownRouteStillReturns501 keeps the default-case
+// behavior pinned: only the routes we explicitly whitelist should be
+// proxied, so an unmapped path doesn't silently leak into the toolbox.
+func TestToolboxProxyUnknownRouteStillReturns501(t *testing.T) {
+	env := newToolboxProxyTestEnv(t)
+
+	resp, err := http.Post(
+		env.facade.URL+ToolboxPrefix+"/"+env.sandboxID+"/process/not-a-real-route",
+		"application/json",
+		strings.NewReader(`{}`),
+	)
+	if err != nil {
+		t.Fatalf("POST unknown: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want 501", resp.StatusCode)
+	}
+	select {
+	case got := <-env.toolboxRequests:
+		t.Fatalf("unknown path leaked to toolbox: %s %s", got.Method, got.URL.Path)
+	case <-time.After(100 * time.Millisecond):
+		// expected: nothing reaches the toolbox
+	}
+}
+
+// TestNormalizeToolboxPathInterpreter ensures the path normalizer accepts
+// nested interpreter URLs cleanly — defensive coverage so a future refactor
+// of normalizeToolboxPath doesn't accidentally swallow part of the URL.
+func TestNormalizeToolboxPathInterpreter(t *testing.T) {
+	cases := map[string]string{
+		"process/interpreter/execute":                 "process/interpreter/execute",
+		"process/interpreter/context":                 "process/interpreter/context",
+		"process/interpreter/context/abc":             "process/interpreter/context/abc",
+		"toolbox/process/interpreter/execute":         "process/interpreter/execute",
+		"/toolbox/process/session/s1/command/c1/logs": "process/session/s1/command/c1/logs",
+	}
+	for input, want := range cases {
+		if got := normalizeToolboxPath(input); got != want {
+			t.Errorf("normalizeToolboxPath(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+

--- a/pkg/api/v1/build_test.go
+++ b/pkg/api/v1/build_test.go
@@ -19,11 +19,24 @@ type fakeImageBuilder struct {
 	pushErr    error
 	refreshes  []string
 	refreshErr error
+	removes    []string
+	removeErr  error
 }
 
 func (f *fakeImageBuilder) RefreshTag(_ context.Context, ref string) error {
 	f.refreshes = append(f.refreshes, ref)
 	return f.refreshErr
+}
+
+func (f *fakeImageBuilder) RemoveImage(_ context.Context, ref string) error {
+	f.removes = append(f.removes, ref)
+	if f.removeErr != nil {
+		return f.removeErr
+	}
+	if f.exists != nil {
+		delete(f.exists, ref)
+	}
+	return nil
 }
 
 func (f *fakeImageBuilder) ImageExists(_ context.Context, ref string) (bool, error) {

--- a/pkg/api/v1/routes.go
+++ b/pkg/api/v1/routes.go
@@ -24,6 +24,10 @@ type ImageBuilder interface {
 	// janitor doesn't GC a tag that was just handed out from the build
 	// cache. Called on the ImageExists==true short-circuit path.
 	RefreshTag(ctx context.Context, fullRef string) error
+	// RemoveImage rolls back a freshly built tag when the downstream
+	// snapshot-register call fails — otherwise the layer leaks because no
+	// snapshot row points at it for the built-image janitor to clean up.
+	RemoveImage(ctx context.Context, imageRef string) error
 }
 
 // BuildConfig mirrors the operator-configured image-build knobs.
@@ -56,6 +60,8 @@ func RegisterRoutes(mux *http.ServeMux, d Deps) {
 	mux.Handle("GET "+PathPrefix+"/capacity", d.Auth(http.HandlerFunc(h.capacity)))
 	mux.Handle("POST "+PathPrefix+"/admin/reconcile", d.Auth(http.HandlerFunc(h.reconcile)))
 	mux.Handle("POST "+PathPrefix+"/images/build", d.Auth(http.HandlerFunc(h.buildImage)))
+
+	mux.Handle("POST "+PathPrefix+"/snapshots", d.Auth(http.HandlerFunc(h.registerSnapshot)))
 
 	mux.Handle("POST "+PathPrefix+"/sandboxes", d.Auth(http.HandlerFunc(h.createSandbox)))
 	mux.Handle("GET "+PathPrefix+"/sandboxes", d.Auth(http.HandlerFunc(h.listSandboxes)))

--- a/pkg/api/v1/snapshot.go
+++ b/pkg/api/v1/snapshot.go
@@ -1,0 +1,209 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/aerol-ai/microvm/pkg/api/apihttp"
+	"github.com/aerol-ai/microvm/pkg/docker"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// registerSnapshotRequest is the v1-native shape for POST /v1/snapshots.
+// Exactly one of Image (pre-built registry reference) or DockerfileContent
+// (build inputs) must be set. The remaining fields configure the resource
+// hints clients get back when they later look the snapshot up by name.
+type registerSnapshotRequest struct {
+	Name              string   `json:"name"`
+	Image             string   `json:"image,omitempty"`
+	DockerfileContent string   `json:"dockerfile_content,omitempty"`
+	ContextHashes     []string `json:"context_hashes,omitempty"`
+	Entrypoint        []string `json:"entrypoint,omitempty"`
+	RegionID          string   `json:"region_id,omitempty"`
+	CPU               float64  `json:"cpu,omitempty"`
+	GPU               float64  `json:"gpu,omitempty"`
+	MemoryMB          int      `json:"memory_mb,omitempty"`
+	DiskGB            int      `json:"disk_gb,omitempty"`
+}
+
+// registerSnapshot is the v1-native equivalent of POST /daytona/snapshots.
+// It persists a snapshot row pointing at either a caller-supplied image
+// reference or a freshly built tag from a Dockerfile.
+//
+// Image-resolution paths:
+//
+//  1. Image — trust the caller; the runtime's docker pull at sandbox-create
+//     time will fail loudly if the image doesn't exist.
+//  2. DockerfileContent — content-addressed build through Builder.BuildImage.
+//     A single-line `FROM <image>` short-circuits without a build, matching
+//     the daytona facade and the existing v1 build endpoint behavior.
+//
+// ContextHashes is gated behind SB_IMAGE_BUILD_CONTEXT_ENABLED; the
+// daemon-side context resolver is not yet wired, so requests with
+// non-empty ContextHashes return 501 today.
+func (h *handlers) registerSnapshot(w http.ResponseWriter, r *http.Request) {
+	var req registerSnapshotRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		apihttp.WriteError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+
+	image := strings.TrimSpace(req.Image)
+	dockerfile := strings.TrimSpace(req.DockerfileContent)
+	switch {
+	case image == "" && dockerfile == "":
+		apihttp.WriteError(w, http.StatusBadRequest, "image or dockerfile_content is required")
+		return
+	case image != "" && dockerfile != "":
+		apihttp.WriteError(w, http.StatusBadRequest, "image and dockerfile_content are mutually exclusive")
+		return
+	}
+
+	resolvedImage := image
+	var freshlyBuiltTag string
+	if dockerfile != "" {
+		resolved, built, err := h.resolveSnapshotImage(r.Context(), dockerfile, req.ContextHashes)
+		if err != nil {
+			h.writeBuildError(w, err)
+			return
+		}
+		resolvedImage = resolved
+		freshlyBuiltTag = built
+	}
+
+	snapshot := &models.SandboxSnapshot{
+		Name:       name,
+		Image:      resolvedImage,
+		Entrypoint: append([]string{}, req.Entrypoint...),
+		RegionID:   strings.TrimSpace(req.RegionID),
+		CPU:        req.CPU,
+		GPU:        req.GPU,
+		MemoryMB:   req.MemoryMB,
+		DiskGB:     req.DiskGB,
+	}
+
+	registered, err := h.deps.Service.RegisterSnapshot(r.Context(), snapshot)
+	if err != nil {
+		// Roll back a freshly built tag — if we don't, the built-image
+		// janitor would leak the layer because no snapshot row points at it.
+		if freshlyBuiltTag != "" && h.deps.Builder != nil {
+			if rbErr := h.deps.Builder.RemoveImage(r.Context(), freshlyBuiltTag); rbErr != nil && h.deps.Logger != nil {
+				h.deps.Logger.Warn("v1 snapshot rollback failed", "tag", freshlyBuiltTag, "error", rbErr)
+			}
+		}
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	apihttp.WriteJSON(w, http.StatusCreated, registered)
+}
+
+// resolveSnapshotImage turns a Dockerfile (+ optional context hashes) into
+// a runnable local image tag. Mirrors daytona.resolveBuildInfo without
+// pulling the daytona package into v1.
+func (h *handlers) resolveSnapshotImage(ctx context.Context, dockerfile string, contextHashes []string) (string, string, error) {
+	if base, ok := singleLineFROM(dockerfile); ok && len(contextHashes) == 0 {
+		return base, "", nil
+	}
+	if len(contextHashes) > 0 {
+		if !h.deps.Build.ContextEnabled {
+			return "", "", errors.New("context_hashes requires operator-side context upload support (set SB_IMAGE_BUILD_CONTEXT_ENABLED=true)")
+		}
+		// The hash → blob resolver lives in object-storage wiring that
+		// hasn't landed yet. Fail loud so the COPY/ADD steps don't
+		// silently no-op.
+		return "", "", errBuildNotImplemented
+	}
+	if h.deps.Builder == nil {
+		return "", "", errors.New("multi-line dockerfile_content requires an image builder; daemon was started without one")
+	}
+
+	tag := docker.BuildTagFor(dockerfile, contextHashes)
+	exists, err := h.deps.Builder.ImageExists(ctx, tag)
+	if err != nil {
+		return "", "", fmt.Errorf("%w: check built image cache: %v", errBuildOperationalV1, err)
+	}
+	logger := h.deps.Logger
+	if exists {
+		if rtErr := h.deps.Builder.RefreshTag(ctx, tag); rtErr != nil && logger != nil {
+			logger.Warn("v1 snapshot build cache refresh-tag failed", "tag", tag, "error", rtErr)
+		}
+		return tag, "", nil
+	}
+
+	buildCtx, cancel := buildContextWithTimeout(ctx, h.deps.Build.Timeout)
+	defer cancel()
+	err = h.deps.Builder.BuildImage(buildCtx, docker.BuildImageRequest{
+		Tag:               tag,
+		DockerfileContent: dockerfile,
+		OnLog: func(line string) {
+			if logger != nil {
+				logger.Debug("v1 snapshot build", "tag", tag, "line", line)
+			}
+		},
+	})
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return "", "", fmt.Errorf("%w: %v", errBuildTimeoutV1, err)
+		}
+		return "", "", fmt.Errorf("%w: build image: %v", errBuildOperationalV1, err)
+	}
+	return tag, tag, nil
+}
+
+// writeBuildError maps the sentinel errors from resolveSnapshotImage to the
+// appropriate HTTP code. Validation errors (bad payload, flag disabled,
+// missing builder) → 400 / 501; daemon failures → 502 / 504.
+func (h *handlers) writeBuildError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, errBuildTimeoutV1):
+		apihttp.WriteError(w, http.StatusGatewayTimeout, err.Error())
+	case errors.Is(err, errBuildOperationalV1):
+		apihttp.WriteError(w, http.StatusBadGateway, err.Error())
+	case errors.Is(err, errBuildNotImplemented):
+		apihttp.WriteError(w, http.StatusNotImplemented, err.Error())
+	default:
+		apihttp.WriteError(w, http.StatusBadRequest, err.Error())
+	}
+}
+
+// Sentinel errors so writeBuildError can classify without string-matching.
+var (
+	errBuildOperationalV1  = errors.New("v1 build operational error")
+	errBuildTimeoutV1      = errors.New("v1 build exceeded timeout")
+	errBuildNotImplemented = errors.New("context_hashes is enabled but no context resolver is configured on this daemon")
+)
+
+// singleLineFROM detects the legacy `FROM <image>` shape and returns the
+// base image when matched. Comments and blank lines are ignored.
+// Mirrors daytona.singleLineFromImage.
+func singleLineFROM(dockerfile string) (string, bool) {
+	lines := make([]string, 0, 4)
+	for _, line := range strings.Split(dockerfile, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		lines = append(lines, trimmed)
+	}
+	if len(lines) != 1 {
+		return "", false
+	}
+	parts := strings.Fields(lines[0])
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "FROM") {
+		return "", false
+	}
+	if strings.TrimSpace(parts[1]) == "" {
+		return "", false
+	}
+	return parts[1], true
+}

--- a/pkg/api/v1/snapshot_test.go
+++ b/pkg/api/v1/snapshot_test.go
@@ -1,0 +1,388 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/internal/service"
+	"github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/docker"
+	"github.com/aerol-ai/microvm/pkg/models"
+	"github.com/aerol-ai/microvm/pkg/mounts"
+)
+
+// snapshotV1TestEnv bundles the moving parts a v1 snapshot test needs.
+// We stand up a real store + service so RegisterSnapshot persists through
+// the same path production uses, and inject a fake builder for the
+// dockerfile_content branch.
+type snapshotV1TestEnv struct {
+	svc     *service.Service
+	store   *store.Store
+	builder *fakeImageBuilder
+	handler http.Handler
+}
+
+func newSnapshotV1TestEnv(t *testing.T, builder *fakeImageBuilder, build BuildConfig) *snapshotV1TestEnv {
+	t.Helper()
+	st, err := store.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	svc := service.New(config.Config{}, logger, st, &noopRuntime{}, nil, nil, nil, nil, nil)
+	if builder == nil {
+		builder = &fakeImageBuilder{}
+	}
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, Deps{
+		Service: svc,
+		Logger:  logger,
+		Builder: builder,
+		Build:   build,
+		Auth:    func(h http.Handler) http.Handler { return h },
+	})
+	return &snapshotV1TestEnv{svc: svc, store: st, builder: builder, handler: mux}
+}
+
+// TestRegisterSnapshotFromImage covers the simple path: caller hands us a
+// pre-built registry image. We persist a snapshot row with the supplied
+// resources/region and respond 201 with the stored row.
+func TestRegisterSnapshotFromImage(t *testing.T) {
+	env := newSnapshotV1TestEnv(t, nil, BuildConfig{})
+
+	body := `{
+		"name": "py-base",
+		"image": "python:3.12-slim",
+		"entrypoint": ["python", "-V"],
+		"cpu": 2,
+		"memory_mb": 4096,
+		"disk_gb": 10,
+		"region_id": "us"
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/snapshots", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	env.handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%s", rr.Code, rr.Body.String())
+	}
+	var resp models.SandboxSnapshot
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Name != "py-base" || resp.Image != "python:3.12-slim" {
+		t.Errorf("resp = %+v, want name=py-base image=python:3.12-slim", resp)
+	}
+	if resp.RegionID != "us" || resp.MemoryMB != 4096 || resp.DiskGB != 10 || resp.CPU != 2 {
+		t.Errorf("resp resources = %+v, want region=us cpu=2 mem=4096 disk=10", resp)
+	}
+
+	stored, err := env.svc.GetSnapshot(context.Background(), "py-base")
+	if err != nil {
+		t.Fatalf("GetSnapshot: %v", err)
+	}
+	if stored.Image != "python:3.12-slim" {
+		t.Errorf("stored.Image = %q, want python:3.12-slim", stored.Image)
+	}
+	if len(env.builder.builds) != 0 {
+		t.Errorf("image path must not invoke builder, got %d builds", len(env.builder.builds))
+	}
+}
+
+// TestRegisterSnapshotFromDockerfile covers the multi-line dockerfile path:
+// the daemon runs the build through Builder.BuildImage and registers the
+// resulting content-addressed tag as the snapshot's image.
+func TestRegisterSnapshotFromDockerfile(t *testing.T) {
+	env := newSnapshotV1TestEnv(t, &fakeImageBuilder{}, BuildConfig{})
+
+	dockerfile := "FROM debian:bookworm-slim\nRUN apt-get update"
+	wantTag := docker.BuildTagFor(dockerfile, nil)
+	body, _ := json.Marshal(map[string]any{
+		"name":               "debian-built",
+		"dockerfile_content": dockerfile,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/snapshots", strings.NewReader(string(body)))
+	rr := httptest.NewRecorder()
+	env.handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%s", rr.Code, rr.Body.String())
+	}
+	var resp models.SandboxSnapshot
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Image != wantTag {
+		t.Errorf("resp.Image = %q, want %q (resolved build tag)", resp.Image, wantTag)
+	}
+	if len(env.builder.builds) != 1 || env.builder.builds[0].Tag != wantTag {
+		t.Fatalf("unexpected builder.builds: %+v", env.builder.builds)
+	}
+}
+
+// TestRegisterSnapshotSingleLineFROM is the fast-path: a one-liner FROM
+// dockerfile with no context returns the bare image without a build.
+func TestRegisterSnapshotSingleLineFROM(t *testing.T) {
+	env := newSnapshotV1TestEnv(t, nil, BuildConfig{})
+
+	body := `{"name":"alpine","dockerfile_content":"FROM alpine:3.20"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/snapshots", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	env.handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d; body=%s", rr.Code, rr.Body.String())
+	}
+	var resp models.SandboxSnapshot
+	_ = json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.Image != "alpine:3.20" {
+		t.Errorf("resp.Image = %q, want alpine:3.20 (single-line FROM is pass-through)", resp.Image)
+	}
+	if len(env.builder.builds) != 0 {
+		t.Errorf("single-line FROM must not invoke builder, got %d builds", len(env.builder.builds))
+	}
+}
+
+// TestRegisterSnapshotCacheHitRefreshes verifies the dockerfile_content path
+// short-circuits when the build cache already has the tag, and that we bump
+// LastTagTime via RefreshTag so the janitor doesn't GC the row we just
+// pointed a snapshot at.
+func TestRegisterSnapshotCacheHitRefreshes(t *testing.T) {
+	dockerfile := "FROM alpine:3.20\nRUN echo cached"
+	wantTag := docker.BuildTagFor(dockerfile, nil)
+	builder := &fakeImageBuilder{exists: map[string]bool{wantTag: true}}
+	env := newSnapshotV1TestEnv(t, builder, BuildConfig{})
+
+	body, _ := json.Marshal(map[string]any{
+		"name":               "cached",
+		"dockerfile_content": dockerfile,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/snapshots", strings.NewReader(string(body)))
+	rr := httptest.NewRecorder()
+	env.handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d; body=%s", rr.Code, rr.Body.String())
+	}
+	if len(builder.builds) != 0 {
+		t.Errorf("cache hit should skip BuildImage, got %d builds", len(builder.builds))
+	}
+	if len(builder.refreshes) != 1 || builder.refreshes[0] != wantTag {
+		t.Errorf("expected RefreshTag(%q), got %+v", wantTag, builder.refreshes)
+	}
+}
+
+// TestRegisterSnapshotValidationErrors pins the input shapes the handler
+// rejects up front.
+func TestRegisterSnapshotValidationErrors(t *testing.T) {
+	cases := []struct {
+		name     string
+		body     string
+		build    BuildConfig
+		wantCode int
+		wantHint string
+	}{
+		{
+			name:     "missing name",
+			body:     `{"image":"python:3.12"}`,
+			wantCode: http.StatusBadRequest,
+			wantHint: "name is required",
+		},
+		{
+			name:     "neither image nor dockerfile",
+			body:     `{"name":"x"}`,
+			wantCode: http.StatusBadRequest,
+			wantHint: "image or dockerfile_content",
+		},
+		{
+			name:     "both image and dockerfile",
+			body:     `{"name":"x","image":"a","dockerfile_content":"FROM b"}`,
+			wantCode: http.StatusBadRequest,
+			wantHint: "mutually exclusive",
+		},
+		{
+			name:     "context_hashes without operator flag",
+			body:     `{"name":"x","dockerfile_content":"FROM a\nCOPY . /app","context_hashes":["deadbeef"]}`,
+			wantCode: http.StatusBadRequest,
+			wantHint: "SB_IMAGE_BUILD_CONTEXT_ENABLED",
+		},
+		{
+			name:     "context_hashes with flag returns not implemented",
+			body:     `{"name":"x","dockerfile_content":"FROM a\nCOPY . /app","context_hashes":["deadbeef"]}`,
+			build:    BuildConfig{ContextEnabled: true},
+			wantCode: http.StatusNotImplemented,
+			wantHint: "context_hashes",
+		},
+		{
+			name:     "invalid json",
+			body:     `{not-json`,
+			wantCode: http.StatusBadRequest,
+			wantHint: "invalid JSON",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newSnapshotV1TestEnv(t, nil, tc.build)
+			req := httptest.NewRequest(http.MethodPost, "/v1/snapshots", strings.NewReader(tc.body))
+			rr := httptest.NewRecorder()
+			env.handler.ServeHTTP(rr, req)
+
+			if rr.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d; body=%s", rr.Code, tc.wantCode, rr.Body.String())
+			}
+			if !strings.Contains(rr.Body.String(), tc.wantHint) {
+				t.Errorf("body does not contain %q; got %s", tc.wantHint, rr.Body.String())
+			}
+		})
+	}
+}
+
+// TestRegisterSnapshotMissingBuilderFor multilineDockerfile checks the
+// graceful 400 when the daemon was started without an image builder but a
+// caller asked for a multi-line dockerfile build. Single-line FROM still
+// works without a builder (pass-through).
+func TestRegisterSnapshotMissingBuilder(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	svc := service.New(config.Config{}, logger, st, &noopRuntime{}, nil, nil, nil, nil, nil)
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, Deps{
+		Service: svc,
+		Logger:  logger,
+		Builder: nil, // no builder configured
+		Auth:    func(h http.Handler) http.Handler { return h },
+	})
+
+	body := `{"name":"x","dockerfile_content":"FROM alpine\nRUN true"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/snapshots", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "image builder") {
+		t.Errorf("body should explain missing builder; got %s", rr.Body.String())
+	}
+}
+
+// TestRegisterSnapshotBuildErrorRollsBack covers the registration-failure
+// path: if RegisterSnapshot fails after a successful build, we must call
+// RemoveImage on the freshly built tag, otherwise the layer leaks (no
+// snapshot row points at it for the built-image janitor).
+//
+// We trigger that path by registering "boom" once successfully, then asking
+// to register the same name with a *different* image — the second call
+// surfaces a conflict from the service layer, and the rollback should fire.
+func TestRegisterSnapshotBuildErrorRollsBack(t *testing.T) {
+	env := newSnapshotV1TestEnv(t, &fakeImageBuilder{}, BuildConfig{})
+
+	// First call: pin name "boom" to a single-line FROM (no build, no
+	// builder.removes invocation).
+	first := httptest.NewRecorder()
+	env.handler.ServeHTTP(first, httptest.NewRequest(http.MethodPost, "/v1/snapshots",
+		strings.NewReader(`{"name":"boom","image":"alpine:3.20"}`)))
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first status = %d; body=%s", first.Code, first.Body.String())
+	}
+
+	// Second call: same name but a different (built) image. The service
+	// layer rejects on conflict, and the freshly built tag must be removed.
+	dockerfile := "FROM debian:bookworm-slim\nRUN apt-get update"
+	wantTag := docker.BuildTagFor(dockerfile, nil)
+	body, _ := json.Marshal(map[string]any{
+		"name":               "boom",
+		"dockerfile_content": dockerfile,
+	})
+	second := httptest.NewRecorder()
+	env.handler.ServeHTTP(second, httptest.NewRequest(http.MethodPost, "/v1/snapshots",
+		strings.NewReader(string(body))))
+	if second.Code == http.StatusCreated {
+		t.Fatalf("expected conflict, got 201; body=%s", second.Body.String())
+	}
+	if len(env.builder.removes) != 1 || env.builder.removes[0] != wantTag {
+		t.Errorf("expected rollback RemoveImage(%q), got %+v", wantTag, env.builder.removes)
+	}
+}
+
+// TestRegisterSnapshotBuildTimeout maps a deadline-exceeded build error to
+// 504 via the writeBuildError sentinel mapping.
+func TestRegisterSnapshotBuildTimeout(t *testing.T) {
+	builder := &fakeImageBuilder{buildErr: context.DeadlineExceeded}
+	env := newSnapshotV1TestEnv(t, builder, BuildConfig{})
+
+	body := `{"name":"slow","dockerfile_content":"FROM debian:bookworm\nRUN sleep 9999"}`
+	rr := httptest.NewRecorder()
+	env.handler.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/v1/snapshots",
+		strings.NewReader(body)))
+
+	if rr.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want 504; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestRegisterSnapshotBuildOperationalError maps a generic build failure to
+// 502.
+func TestRegisterSnapshotBuildOperationalError(t *testing.T) {
+	builder := &fakeImageBuilder{buildErr: errors.New("docker daemon refused")}
+	env := newSnapshotV1TestEnv(t, builder, BuildConfig{})
+
+	body := `{"name":"broken","dockerfile_content":"FROM debian:bookworm\nRUN false"}`
+	rr := httptest.NewRecorder()
+	env.handler.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/v1/snapshots",
+		strings.NewReader(body)))
+
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// noopRuntime is the minimal runtime stub the v1 snapshot tests need —
+// snapshot registration never touches the runtime, so every method panics
+// to surface accidental coupling at test time.
+type noopRuntime struct{}
+
+func (noopRuntime) Create(context.Context, models.CreateSandboxRequest, string, string, []mounts.ContainerBind) (*models.SandboxRuntimeState, error) {
+	panic("unexpected Create")
+}
+func (noopRuntime) CreateSnapshot(context.Context, string, string) (string, error) {
+	panic("unexpected CreateSnapshot")
+}
+func (noopRuntime) Start(context.Context, string) (*models.SandboxRuntimeState, error) {
+	panic("unexpected Start")
+}
+func (noopRuntime) Stop(context.Context, string) error          { panic("unexpected Stop") }
+func (noopRuntime) Destroy(context.Context, *models.Sandbox) error { panic("unexpected Destroy") }
+func (noopRuntime) Resize(context.Context, string, models.ResizeSandboxRequest) error {
+	panic("unexpected Resize")
+}
+func (noopRuntime) Inspect(context.Context, string) (*models.SandboxRuntimeState, error) {
+	panic("unexpected Inspect")
+}
+func (noopRuntime) ListManaged(context.Context) (map[string]*models.SandboxRuntimeState, error) {
+	panic("unexpected ListManaged")
+}
+func (noopRuntime) Ping(context.Context) error                         { panic("unexpected Ping") }
+func (noopRuntime) RemoveImage(context.Context, string) error          { return nil }
+func (noopRuntime) PushAllowedPorts(context.Context, string, string, []int) error {
+	panic("unexpected PushAllowedPorts")
+}
+func (noopRuntime) ClearNetworkRules(string) error        { return nil }
+func (noopRuntime) ApplyNetworkBlockAll(string) error     { return nil }
+func (noopRuntime) ApplyNetworkBlockIngress(string) error { return nil }
+func (noopRuntime) ClearNetworkBlockIngress(string) error { return nil }
+func (noopRuntime) ClearNetworkBlockEgress(string) error  { return nil }

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -375,12 +375,36 @@ type CreateSandboxSnapshotRequest struct {
 // SandboxSnapshot is the persisted metadata for a committed sandbox image.
 // Image is the reusable image reference; ImageID is the content-addressed
 // Docker image ID returned by the runtime after the commit succeeds.
+//
+// Two creation paths populate this row:
+//
+//  1. Snapshot-of-a-running-sandbox (legacy) — SourceSandboxID is set,
+//     resource fields stay zero, the image is committed by the runtime.
+//  2. Snapshot-from-image (Daytona facade) — SourceSandboxID is empty,
+//     resource fields and Entrypoint reflect the caller's create payload,
+//     and Image is either the caller-supplied imageName or a freshly built
+//     tag from a buildInfo Dockerfile.
 type SandboxSnapshot struct {
 	Name            string    `json:"name"`
 	Image           string    `json:"image"`
 	ImageID         string    `json:"image_id,omitempty"`
 	SourceSandboxID string    `json:"source_sandbox_id"`
 	CreatedAt       time.Time `json:"created_at"`
+
+	// Entrypoint is the optional command override the caller wants the
+	// runtime to use when starting a sandbox from this snapshot.
+	Entrypoint []string `json:"entrypoint,omitempty"`
+	// RegionID echoes the region the caller requested when creating the
+	// snapshot. The facade persists this verbatim for read-back; region
+	// routing itself is not yet wired through the daemon.
+	RegionID string `json:"region_id,omitempty"`
+	// CPU / MemoryMB / DiskGB / GPU mirror the resource hints the caller
+	// supplied on create — surfaced back to clients that poll the snapshot
+	// after creation.
+	CPU      float64 `json:"cpu,omitempty"`
+	MemoryMB int     `json:"memory_mb,omitempty"`
+	DiskGB   int     `json:"disk_gb,omitempty"`
+	GPU      float64 `json:"gpu,omitempty"`
 }
 
 // ExposePortRequest is the optional JSON body for POST /v1/sandboxes/{id}/ports/{port}.

--- a/plans/daytona-examples-coverage.md
+++ b/plans/daytona-examples-coverage.md
@@ -15,6 +15,23 @@ Done in this pass:
   `POST /files/permissions` whitelisted.
 - `/lsp/*` whitelisted as a prefix.
 - `/work-dir` accepted as alias for `/workdir` (SDK `InfoApi.getWorkDir`).
+- **`POST /daytona/snapshots`** — snapshot-from-image (the
+  `declarative-image` + `region` blocker). Two paths supported:
+  - `imageName`: pre-built registry image, registered as-is.
+  - `buildInfo.dockerfileContent`: Dockerfile run through the existing
+    `resolveBuildInfo` → `Builder.BuildImage` pipeline. Single-line `FROM`
+    short-circuits to the bare image without a build.
+- **Snapshot name → image lookup** wired into `createImage`. The Daytona
+  SDK passes a snapshot *name* on sandbox create; the facade now resolves
+  that name through the snapshot store and uses the row's image as the
+  runtime image. Unknown names still fall through as direct image refs
+  for backwards compat (the `create-vm` example pattern).
+- `SandboxSnapshot` model extended with `Entrypoint`, `RegionID`, `CPU`,
+  `GPU`, `MemoryMB`, `DiskGB` — surfaced back through `toSnapshotResponse`
+  so SDK polls see the resources/region the caller asked for.
+- `service.RegisterSnapshot` added — persists an image-backed snapshot
+  row, idempotent on (name + image), conflicts on different image under
+  same name.
 
 ## Per-example status
 
@@ -24,7 +41,7 @@ Done in this pass:
 | `auto-delete` | ✅ | `daytona.create`, `setAutoDeleteInterval` | All routes exist. |
 | `charts` | ✅ | `daytona.create` w/ image, `process.codeRun`, chart artifacts | Needs `code-run` fix (now in). Charts are returned in-band on the `codeRun` response — no separate route. |
 | `create-vm` | ✅ | `daytona.create({snapshot})`, `executeCommand` | Snapshot must already exist on the registry. |
-| `declarative-image` | ⚠️ | `daytona.snapshot.create({image, resources})` with `Image.debianSlim(...).pipInstall(...)` | **Big feature gap**: `POST /daytona/snapshots` is not routed. Facade has GET/DELETE for snapshots and `POST /sandbox/{id}/snapshot` (snapshot-of-running-sandbox), but no build-snapshot-from-Image path. |
+| `declarative-image` | ⚠️ (partial) | `daytona.snapshot.create({image, resources})` with `Image.debianSlim(...).pipInstall(...)` | `POST /daytona/snapshots` now exists. `imageName` and `buildInfo.dockerfileContent` paths work end-to-end. The example also uses `Image.addLocalFile(...)` which uploads context blobs via the Daytona object-storage API + sends `buildInfo.contextHashes` — that uploader endpoint and the daemon-side context resolver are still missing (see big-feature notes below). |
 | `exec-command` | ✅ | `codeRun`, `executeCommand`, sessions (sync + async logs), `codeInterpreter` | All small fixes in. CodeInterpreter requires a running toolbox daemon that implements `/process/interpreter/*` — proxy layer is now correct. |
 | `file-operations` | ✅ | `fs.listFiles`, `createFolder`, `uploadFiles`, `searchFiles`, `replaceInFiles`, `downloadFiles`, `downloadFile`, `uploadFileStream`, `downloadFileStream` | Whitelisted folder + replace this pass. |
 | `git-lsp` | ✅ | `git.clone`, `fs.findFiles`, `createLspServer`, `lsp.start/didOpen/documentSymbols/didClose/completions`, `fs.replaceInFiles` | `/lsp/*` prefix added. |
@@ -33,7 +50,7 @@ Done in this pass:
 | `pagination/sandbox` | ✅ | `daytona.list(labels, page, limit)` | `/sandbox/paginated` exists. |
 | `pagination/snapshot` | ✅ | `daytona.snapshot.list(page, limit)` | `GET /snapshots` exists. |
 | `pty` | ✅ | `createPty`, `sendInput`, `resizePtySession`, `kill`, `wait` (WS) | `process/pty/*` is now WS-capable; bare `process/pty` whitelisted. |
-| `region` | ⚠️ | `daytona.snapshot.create({regionId})` and `daytona.create({snapshot})` against the regional snapshot | Inherits the `declarative-image` gap. Once `POST /daytona/snapshots` exists, `regionId` needs to be persisted on the snapshot row. |
+| `region` | ✅ (single-region) | `daytona.snapshot.create({regionId})` and `daytona.create({snapshot})` against the regional snapshot | `regionId` is now persisted on the snapshot row and echoed back in the response (`regionIds: [...]`). The daemon does not yet route requests across regions, so the example creates and lists snapshots in both regions but a real multi-region deployment would still need region-aware backend routing. |
 | `volumes` | ❌ | `daytona.volume.get('name', create=true)`, `daytona.create({volumes:[{volumeId, mountPath, subpath}]})` | **Big feature gap**: volume management is intentionally rejected by the facade (`handlers.go:786`). Needs: `GET/POST/DELETE /daytona/volumes`, `GET /daytona/volumes/by-name/{name}`, plus `Volumes` wiring in `createSandbox` translation and mount-binding through `service.CreateSandbox`. |
 
 ## Big-feature gaps (deferred)
@@ -62,28 +79,36 @@ Backend needed:
 - Subpath support inside the mount manager (the SDK passes a `subpath`
   field per-volume binding for multi-tenant isolation).
 
-### 2. Build snapshot from Image
+### 2. Build snapshot from Image — partially done
 
 Affects: `declarative-image`, `region`.
 
-The Daytona SDK `snapshot.create({ name, image, resources, regionId })`
-posts to `POST /snapshots` with either an `imageName` (pre-built image) or
-a `buildInfo` payload (dockerfile content + context hashes the SDK uploaded
-to S3 separately). The facade currently only knows how to snapshot a
-running sandbox (`POST /sandbox/{id}/snapshot`).
+**Done:**
+- `POST /daytona/snapshots` handler — `imageName` and
+  `buildInfo.dockerfileContent` both supported.
+- Snapshot store extended with entrypoint / regionId / cpu / gpu /
+  memoryMB / diskGB.
+- Snapshot name → image lookup in `createImage` so
+  `daytona.create({snapshot: name})` correctly resolves.
+- Synchronous build, return `state=active` so SDK poll loop exits on the
+  first read (no build-logs-url endpoint needed for the no-onLogs case).
 
-To make `declarative-image` runnable end-to-end we need:
-- `POST /daytona/snapshots` handler.
-- For `imageName`: pull-or-tag-and-register flow — should reuse the same
-  image-build infrastructure the create-sandbox path uses
-  (`Deps.Builder.BuildImage` / `RefreshTag`).
-- For `buildInfo`: dockerfile build that pulls context blobs by hash from
-  the configured object store (`Daytona`'s `objectStorageApi`). This is
-  the harder half — needs object-store integration on the server.
-- `GET /snapshots/{id}/build-logs-url` — the SDK polls this when
-  `onLogs` is set to stream build progress. Could be backed by Docker's
-  build-log stream.
-- `regionId` persistence on the snapshot row.
+**Still missing:**
+- **`contextHashes` resolver.** Required by `Image.addLocalFile(...)` (used
+  by the `declarative-image` example). The SDK uploads context blobs to
+  Daytona's `objectStorageApi` and sends the hashes in `buildInfo`. We need:
+  - An object-storage facade endpoint the SDK can upload to (today returns
+    "not configured" — see `Daytona.js` `processImageContext`).
+  - A daemon-side resolver that fetches blobs by hash, assembles a build
+    context tar, and hands it to `Builder.BuildImage` (gated behind
+    `SB_IMAGE_BUILD_CONTEXT_ENABLED`; the resolver itself returns "not yet
+    implemented" today).
+- **`GET /snapshots/{id}/build-logs-url`** — only needed when the SDK
+  caller passes `onLogs: console.log` and the build runs asynchronously.
+  With the current synchronous-build approach + `state=active` on first
+  return, the SDK never enters its log-streaming branch.
+- **Multi-region routing.** `regionId` is persisted and echoed, but the
+  daemon doesn't yet route create/list operations across regions.
 
 ### 3. ComputerUse / `/computeruse/*`
 

--- a/plans/daytona-examples-coverage.md
+++ b/plans/daytona-examples-coverage.md
@@ -1,0 +1,102 @@
+# Daytona examples coverage audit
+
+Audit of `aerovm-examples/daytona-examples` against the daytona facade in
+`pkg/api/daytona`. One row per example, with the SDK surface it touches,
+whether it should run today, and what (if anything) is still missing.
+
+Done in this pass:
+
+- `POST /process/code-run` whitelisted (`sandbox.process.codeRun`).
+- `process/session/*`, `process/interpreter/*`, `process/pty/*` switched to
+  `httputil.ReverseProxy` so WebSocket upgrades (logs, interpreter execute,
+  PTY connect) survive the proxy.
+- `process/pty` (bare) added — covers `listPtySessions` + `createPty`.
+- `DELETE /files`, `POST /files/folder`, `POST /files/replace`,
+  `POST /files/permissions` whitelisted.
+- `/lsp/*` whitelisted as a prefix.
+- `/work-dir` accepted as alias for `/workdir` (SDK `InfoApi.getWorkDir`).
+
+## Per-example status
+
+| Example | Should run now? | What it exercises | Notes |
+|---|---|---|---|
+| `auto-archive` | ✅ | `daytona.create`, `setAutoArchiveInterval`, `delete` | All routes exist. |
+| `auto-delete` | ✅ | `daytona.create`, `setAutoDeleteInterval` | All routes exist. |
+| `charts` | ✅ | `daytona.create` w/ image, `process.codeRun`, chart artifacts | Needs `code-run` fix (now in). Charts are returned in-band on the `codeRun` response — no separate route. |
+| `create-vm` | ✅ | `daytona.create({snapshot})`, `executeCommand` | Snapshot must already exist on the registry. |
+| `declarative-image` | ⚠️ | `daytona.snapshot.create({image, resources})` with `Image.debianSlim(...).pipInstall(...)` | **Big feature gap**: `POST /daytona/snapshots` is not routed. Facade has GET/DELETE for snapshots and `POST /sandbox/{id}/snapshot` (snapshot-of-running-sandbox), but no build-snapshot-from-Image path. |
+| `exec-command` | ✅ | `codeRun`, `executeCommand`, sessions (sync + async logs), `codeInterpreter` | All small fixes in. CodeInterpreter requires a running toolbox daemon that implements `/process/interpreter/*` — proxy layer is now correct. |
+| `file-operations` | ✅ | `fs.listFiles`, `createFolder`, `uploadFiles`, `searchFiles`, `replaceInFiles`, `downloadFiles`, `downloadFile`, `uploadFileStream`, `downloadFileStream` | Whitelisted folder + replace this pass. |
+| `git-lsp` | ✅ | `git.clone`, `fs.findFiles`, `createLspServer`, `lsp.start/didOpen/documentSymbols/didClose/completions`, `fs.replaceInFiles` | `/lsp/*` prefix added. |
+| `lifecycle` | ✅ | full lifecycle: create / labels / stop / start / get / exec / list / delete | All routes exist. |
+| `network-settings` | ✅ | `daytona.create({networkBlockAll})`, `daytona.create({networkAllowList})` | Both fields already accepted by `createSandbox` DTO. |
+| `pagination/sandbox` | ✅ | `daytona.list(labels, page, limit)` | `/sandbox/paginated` exists. |
+| `pagination/snapshot` | ✅ | `daytona.snapshot.list(page, limit)` | `GET /snapshots` exists. |
+| `pty` | ✅ | `createPty`, `sendInput`, `resizePtySession`, `kill`, `wait` (WS) | `process/pty/*` is now WS-capable; bare `process/pty` whitelisted. |
+| `region` | ⚠️ | `daytona.snapshot.create({regionId})` and `daytona.create({snapshot})` against the regional snapshot | Inherits the `declarative-image` gap. Once `POST /daytona/snapshots` exists, `regionId` needs to be persisted on the snapshot row. |
+| `volumes` | ❌ | `daytona.volume.get('name', create=true)`, `daytona.create({volumes:[{volumeId, mountPath, subpath}]})` | **Big feature gap**: volume management is intentionally rejected by the facade (`handlers.go:786`). Needs: `GET/POST/DELETE /daytona/volumes`, `GET /daytona/volumes/by-name/{name}`, plus `Volumes` wiring in `createSandbox` translation and mount-binding through `service.CreateSandbox`. |
+
+## Big-feature gaps (deferred)
+
+These require backend work beyond a route whitelist and are tracked here
+rather than implemented in-pass.
+
+### 1. Volume management
+
+Affects: `volumes`.
+
+Surface needed on the facade:
+- `GET /daytona/volumes` — list (paginated).
+- `POST /daytona/volumes` — create.
+- `GET /daytona/volumes/{id}` — get by id.
+- `GET /daytona/volumes/by-name/{name}` — get by name (the SDK uses this in
+  `daytona.volume.get('name', true)` with create-if-missing semantics).
+- `DELETE /daytona/volumes/{id}`.
+
+Backend needed:
+- A `volumes` table in `internal/store` (or reuse an existing one if mounts
+  already track them).
+- Wiring `Volumes` in `createSandboxRequest` → `models.CreateSandboxRequest`
+  → `service.CreateSandbox` → `mounts.Manager` binds. The translation today
+  short-circuits at `handlers.go:786` with `"volumes are not supported"`.
+- Subpath support inside the mount manager (the SDK passes a `subpath`
+  field per-volume binding for multi-tenant isolation).
+
+### 2. Build snapshot from Image
+
+Affects: `declarative-image`, `region`.
+
+The Daytona SDK `snapshot.create({ name, image, resources, regionId })`
+posts to `POST /snapshots` with either an `imageName` (pre-built image) or
+a `buildInfo` payload (dockerfile content + context hashes the SDK uploaded
+to S3 separately). The facade currently only knows how to snapshot a
+running sandbox (`POST /sandbox/{id}/snapshot`).
+
+To make `declarative-image` runnable end-to-end we need:
+- `POST /daytona/snapshots` handler.
+- For `imageName`: pull-or-tag-and-register flow — should reuse the same
+  image-build infrastructure the create-sandbox path uses
+  (`Deps.Builder.BuildImage` / `RefreshTag`).
+- For `buildInfo`: dockerfile build that pulls context blobs by hash from
+  the configured object store (`Daytona`'s `objectStorageApi`). This is
+  the harder half — needs object-store integration on the server.
+- `GET /snapshots/{id}/build-logs-url` — the SDK polls this when
+  `onLogs` is set to stream build progress. Could be backed by Docker's
+  build-log stream.
+- `regionId` persistence on the snapshot row.
+
+### 3. ComputerUse / `/computeruse/*`
+
+Not exercised by any example in the audit. Skip for now; if a future
+example needs it, mirror the `/lsp/*` prefix approach.
+
+## How to re-verify
+
+```sh
+cd sandbox-library
+go test ./pkg/api/daytona/ -count=1
+```
+
+`TestToolboxProxyForwardedRoutes` is a table-driven test where each row is
+tagged with the example that would break if the route regresses — failure
+output points directly at the affected example.

--- a/sdk/go/internal/apiclient/client.go
+++ b/sdk/go/internal/apiclient/client.go
@@ -256,6 +256,70 @@ func (c *Client) CreateSnapshot(ctx context.Context, id, name string) (SandboxSn
 	return response, err
 }
 
+// RegisterSnapshotOptions is the wire shape for Client.RegisterSnapshot.
+// Exactly one of Image (a pre-built registry reference) or DockerfileContent
+// (build inputs the daemon compiles via Image-builder) must be set.
+type RegisterSnapshotOptions struct {
+	Name              string
+	Image             string
+	DockerfileContent string
+	ContextHashes     []string
+	Entrypoint        []string
+	RegionID          string
+	CPU               float64
+	GPU               float64
+	MemoryMB          int
+	DiskGB            int
+}
+
+// RegisterSnapshot persists a named snapshot pointing at either a caller-
+// supplied image reference or a Dockerfile the daemon will build. Mirrors
+// POST /v1/snapshots; returns the stored row so callers can read back the
+// resolved image (which differs from the request when DockerfileContent is
+// set — the daemon returns the content-addressed build tag).
+func (c *Client) RegisterSnapshot(ctx context.Context, opts RegisterSnapshotOptions) (SandboxSnapshot, error) {
+	type registerSnapshotRequest struct {
+		Name              string   `json:"name"`
+		Image             string   `json:"image,omitempty"`
+		DockerfileContent string   `json:"dockerfile_content,omitempty"`
+		ContextHashes     []string `json:"context_hashes,omitempty"`
+		Entrypoint        []string `json:"entrypoint,omitempty"`
+		RegionID          string   `json:"region_id,omitempty"`
+		CPU               float64  `json:"cpu,omitempty"`
+		GPU               float64  `json:"gpu,omitempty"`
+		MemoryMB          int      `json:"memory_mb,omitempty"`
+		DiskGB            int      `json:"disk_gb,omitempty"`
+	}
+
+	if strings.TrimSpace(opts.Name) == "" {
+		return SandboxSnapshot{}, errors.New("name is required")
+	}
+	image := strings.TrimSpace(opts.Image)
+	dockerfile := strings.TrimSpace(opts.DockerfileContent)
+	switch {
+	case image == "" && dockerfile == "":
+		return SandboxSnapshot{}, errors.New("image or dockerfile_content is required")
+	case image != "" && dockerfile != "":
+		return SandboxSnapshot{}, errors.New("image and dockerfile_content are mutually exclusive")
+	}
+
+	body := registerSnapshotRequest{
+		Name:              opts.Name,
+		Image:             image,
+		DockerfileContent: dockerfile,
+		ContextHashes:     opts.ContextHashes,
+		Entrypoint:        opts.Entrypoint,
+		RegionID:          strings.TrimSpace(opts.RegionID),
+		CPU:               opts.CPU,
+		GPU:               opts.GPU,
+		MemoryMB:          opts.MemoryMB,
+		DiskGB:            opts.DiskGB,
+	}
+	var response models.SandboxSnapshot
+	err := c.doJSON(ctx, http.MethodPost, c.versioned("/snapshots"), body, &response)
+	return response, err
+}
+
 func (c *Client) Destroy(ctx context.Context, id string) error {
 	return c.doJSON(ctx, http.MethodDelete, c.versionPrefix+"/sandboxes/"+id, nil, nil)
 }

--- a/sdk/go/internal/apiclient/client_test.go
+++ b/sdk/go/internal/apiclient/client_test.go
@@ -224,3 +224,132 @@ func TestTransportClientCases(t *testing.T) {
 		t.Run(tc.name, tc.run)
 	}
 }
+
+// TestRegisterSnapshotSendsImagePath verifies the image-only happy path:
+// fields land on the wire under their snake_case names, the URL targets
+// /v1/snapshots, and the daemon's response is round-tripped back to the
+// caller. Splitting this off the big TestTransportClientCases table keeps
+// the per-field assertions readable.
+func TestRegisterSnapshotSendsImagePath(t *testing.T) {
+	ctx := context.Background()
+	var seen map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/snapshots" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer pat" {
+			t.Fatalf("unexpected authorization: %q", r.Header.Get("Authorization"))
+		}
+		if err := json.NewDecoder(r.Body).Decode(&seen); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(models.SandboxSnapshot{
+			Name:     "py-base",
+			Image:    "python:3.12-slim",
+			RegionID: "us",
+			CPU:      2,
+			MemoryMB: 4096,
+			DiskGB:   10,
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, ClientOptions{PATToken: "pat", HTTPClient: server.Client()})
+	snap, err := client.RegisterSnapshot(ctx, RegisterSnapshotOptions{
+		Name:     "py-base",
+		Image:    "python:3.12-slim",
+		RegionID: "us",
+		CPU:      2,
+		MemoryMB: 4096,
+		DiskGB:   10,
+	})
+	if err != nil {
+		t.Fatalf("RegisterSnapshot: %v", err)
+	}
+	if snap.Name != "py-base" || snap.Image != "python:3.12-slim" {
+		t.Fatalf("unexpected snapshot: %+v", snap)
+	}
+	if seen["image"] != "python:3.12-slim" || seen["region_id"] != "us" {
+		t.Fatalf("payload missing fields: %+v", seen)
+	}
+	// dockerfile_content omitempty — must NOT be in the payload when Image is set.
+	if _, present := seen["dockerfile_content"]; present {
+		t.Errorf("dockerfile_content should not be sent when Image is set: %+v", seen)
+	}
+}
+
+// TestRegisterSnapshotSendsDockerfilePath verifies the build-info wire
+// shape — the payload uses dockerfile_content, image is omitted, and the
+// daemon's resolved tag flows back to the caller.
+func TestRegisterSnapshotSendsDockerfilePath(t *testing.T) {
+	ctx := context.Background()
+	var seen map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&seen); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(models.SandboxSnapshot{
+			Name:  "built",
+			Image: "snapshots/built:abcd1234",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, ClientOptions{PATToken: "pat", HTTPClient: server.Client()})
+	snap, err := client.RegisterSnapshot(ctx, RegisterSnapshotOptions{
+		Name:              "built",
+		DockerfileContent: "FROM debian:bookworm-slim\nRUN apt-get update",
+		Entrypoint:        []string{"/bin/sh", "-c", "echo hi"},
+	})
+	if err != nil {
+		t.Fatalf("RegisterSnapshot: %v", err)
+	}
+	if snap.Image != "snapshots/built:abcd1234" {
+		t.Fatalf("Image = %q, want resolved build tag", snap.Image)
+	}
+	if seen["dockerfile_content"] == nil || seen["dockerfile_content"] == "" {
+		t.Errorf("dockerfile_content missing: %+v", seen)
+	}
+	if _, present := seen["image"]; present {
+		t.Errorf("image must be omitted on dockerfile path: %+v", seen)
+	}
+	ep, _ := seen["entrypoint"].([]any)
+	if len(ep) != 3 {
+		t.Errorf("entrypoint = %+v, want 3 elements", seen["entrypoint"])
+	}
+}
+
+// TestRegisterSnapshotClientValidation pins the validation we do client-
+// side before issuing the request. Catching these locally avoids a network
+// round-trip and gives a more direct error message.
+func TestRegisterSnapshotClientValidation(t *testing.T) {
+	ctx := context.Background()
+	// Server intentionally panics — these calls must never reach it.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("validation should fail before the request fires; got %s %s", r.Method, r.URL.Path)
+	}))
+	defer server.Close()
+	client := NewClient(server.URL, ClientOptions{HTTPClient: server.Client()})
+
+	cases := []struct {
+		name string
+		opts RegisterSnapshotOptions
+		want string
+	}{
+		{"missing name", RegisterSnapshotOptions{Image: "alpine"}, "name is required"},
+		{"missing both", RegisterSnapshotOptions{Name: "x"}, "image or dockerfile_content"},
+		{"both set", RegisterSnapshotOptions{Name: "x", Image: "alpine", DockerfileContent: "FROM busybox"}, "mutually exclusive"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := client.RegisterSnapshot(ctx, tc.opts)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}

--- a/sdk/go/pkg/microvm/client.go
+++ b/sdk/go/pkg/microvm/client.go
@@ -202,6 +202,47 @@ func (c *Client) CreateSnapshot(ctx context.Context, id, name string) (sdktypes.
 	return c.inner.CreateSnapshot(ctx, id, name)
 }
 
+// RegisterSnapshot persists a named snapshot pointing at either a pre-built
+// image (opts.Image) or a Dockerfile the daemon will build (opts.Dockerfile
+// — typically obtained from Image.Dockerfile()). The returned snapshot's
+// Image field reflects the resolved registry reference (for the build path
+// this is the daemon's content-addressed tag).
+//
+// Once registered, callers can reference the snapshot by name in
+// CreateSandboxOptions.Snapshot — the server resolves it to the image at
+// create time.
+func (c *Client) RegisterSnapshot(ctx context.Context, opts sdktypes.RegisterSnapshotOptions) (sdktypes.SandboxSnapshot, error) {
+	return c.inner.RegisterSnapshot(ctx, apiclient.RegisterSnapshotOptions{
+		Name:              opts.Name,
+		Image:             opts.Image,
+		DockerfileContent: opts.DockerfileContent,
+		ContextHashes:     opts.ContextHashes,
+		Entrypoint:        opts.Entrypoint,
+		RegionID:          opts.RegionID,
+		CPU:               opts.CPU,
+		GPU:               opts.GPU,
+		MemoryMB:          opts.MemoryMB,
+		DiskGB:            opts.DiskGB,
+	})
+}
+
+// RegisterSnapshotFromImage compiles an Image-builder graph and registers
+// the resulting Dockerfile as a named snapshot. Convenience wrapper around
+// RegisterSnapshot that mirrors CreateWithImage's ergonomics — pass an
+// *Image instead of remembering to call Image.Dockerfile() yourself.
+func (c *Client) RegisterSnapshotFromImage(ctx context.Context, name string, image *Image, opts sdktypes.RegisterSnapshotOptions) (sdktypes.SandboxSnapshot, error) {
+	if image == nil {
+		return sdktypes.SandboxSnapshot{}, errors.New("image is nil")
+	}
+	if err := image.Err(); err != nil {
+		return sdktypes.SandboxSnapshot{}, err
+	}
+	opts.Name = name
+	opts.Image = ""
+	opts.DockerfileContent = image.Dockerfile()
+	return c.RegisterSnapshot(ctx, opts)
+}
+
 func (c *Client) Destroy(ctx context.Context, id string) error {
 	return c.inner.Destroy(ctx, id)
 }

--- a/sdk/go/pkg/microvm/client_test.go
+++ b/sdk/go/pkg/microvm/client_test.go
@@ -333,3 +333,107 @@ func TestNewClientCases(t *testing.T) {
 		t.Run(tc.name, tc.run)
 	}
 }
+
+// TestRegisterSnapshotForwardsToWire verifies the public wrapper threads
+// through to /v1/snapshots with the right field names and surfaces the
+// daemon's stored row back to the caller.
+func TestRegisterSnapshotForwardsToWire(t *testing.T) {
+	ctx := context.Background()
+	var seen map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/snapshots" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&seen); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(models.SandboxSnapshot{
+			Name:      "py-base",
+			Image:     "python:3.12-slim",
+			RegionID:  "us",
+			MemoryMB:  4096,
+			DiskGB:    10,
+			CreatedAt: time.Now().UTC(),
+		})
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithConfig(&sdktypes.MicroVMConfig{
+		APIUrl:     server.URL,
+		PATToken:   "pat",
+		HTTPClient: server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewClientWithConfig: %v", err)
+	}
+
+	snap, err := client.RegisterSnapshot(ctx, sdktypes.RegisterSnapshotOptions{
+		Name:     "py-base",
+		Image:    "python:3.12-slim",
+		RegionID: "us",
+		MemoryMB: 4096,
+		DiskGB:   10,
+	})
+	if err != nil {
+		t.Fatalf("RegisterSnapshot: %v", err)
+	}
+	if snap.Name != "py-base" || snap.Image != "python:3.12-slim" {
+		t.Fatalf("unexpected snap: %+v", snap)
+	}
+	if seen["name"] != "py-base" || seen["image"] != "python:3.12-slim" {
+		t.Fatalf("payload missing fields: %+v", seen)
+	}
+}
+
+// TestRegisterSnapshotFromImageBuildsDockerfile verifies the convenience
+// wrapper that takes an *Image: it serializes to dockerfile_content under
+// the hood and forwards everything else from the options.
+func TestRegisterSnapshotFromImageBuildsDockerfile(t *testing.T) {
+	ctx := context.Background()
+	var seen map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&seen); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(models.SandboxSnapshot{
+			Name:  "built",
+			Image: "snapshots/built:resolved",
+		})
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithConfig(&sdktypes.MicroVMConfig{
+		APIUrl: server.URL, PATToken: "pat", HTTPClient: server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewClientWithConfig: %v", err)
+	}
+
+	img := BaseImage("debian:bookworm-slim").RunCommands("apt-get update")
+	snap, err := client.RegisterSnapshotFromImage(ctx, "built", img, sdktypes.RegisterSnapshotOptions{
+		Entrypoint: []string{"/bin/sh", "-c", "echo hi"},
+	})
+	if err != nil {
+		t.Fatalf("RegisterSnapshotFromImage: %v", err)
+	}
+	if snap.Image != "snapshots/built:resolved" {
+		t.Fatalf("Image = %q, want resolved tag", snap.Image)
+	}
+	got, _ := seen["dockerfile_content"].(string)
+	if got == "" || !strings.Contains(got, "FROM debian:bookworm-slim") {
+		t.Errorf("dockerfile_content missing FROM: %q", got)
+	}
+	if !strings.Contains(got, "apt-get update") {
+		t.Errorf("dockerfile_content missing RUN body: %q", got)
+	}
+	if _, present := seen["image"]; present {
+		t.Errorf("image must be omitted on dockerfile path: %+v", seen)
+	}
+	if seen["name"] != "built" {
+		t.Errorf("name = %v, want built", seen["name"])
+	}
+}

--- a/sdk/go/pkg/types/types.go
+++ b/sdk/go/pkg/types/types.go
@@ -95,6 +95,42 @@ type BuildImageResult struct {
 	Pushed string
 }
 
+// RegisterSnapshotOptions is the input shape for Client.RegisterSnapshot.
+// Exactly one of Image (a pre-built registry reference) or
+// DockerfileContent (build inputs the daemon will compile) must be set.
+//
+// The remaining fields capture the resource hints the snapshot will report
+// when listed or used in CreateSandboxOptions.Snapshot.
+type RegisterSnapshotOptions struct {
+	// Name is the human-readable identifier other callers use to reference
+	// this snapshot in CreateSandboxOptions.Snapshot. Required.
+	Name string
+	// Image is a pre-built registry image reference (e.g. "python:3.12").
+	// Mutually exclusive with DockerfileContent.
+	Image string
+	// DockerfileContent is the literal Dockerfile the daemon will build.
+	// Mutually exclusive with Image. Use Image.Dockerfile() to obtain this
+	// from an Image-builder graph, or RegisterSnapshotFromImage to skip the
+	// indirection entirely.
+	DockerfileContent string
+	// ContextHashes references blobs uploaded ahead of time so COPY/ADD
+	// steps in DockerfileContent can resolve. Requires the daemon to have
+	// SB_IMAGE_BUILD_CONTEXT_ENABLED set; the resolver itself is not
+	// implemented yet, so non-empty values currently return 501.
+	ContextHashes []string
+	// Entrypoint overrides the image's entrypoint. Echoed back on the
+	// snapshot row so future sandbox-create calls inherit it.
+	Entrypoint []string
+	// RegionID pins the snapshot to a specific region for multi-region
+	// deployments. Persisted on the row but not yet used for routing.
+	RegionID string
+	// CPU, GPU, MemoryMB, DiskGB are resource hints surfaced to clients.
+	CPU      float64
+	GPU      float64
+	MemoryMB int
+	DiskGB   int
+}
+
 type GPURequest = models.GPURequest
 type GPUVendor = models.GPUVendor
 

--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>ai.aerol</groupId>
   <artifactId>aerolvm-sdk</artifactId>
-  <version>0.1.9</version>
+  <version>0.1.10</version>
   <name>Aerol.ai MicroVM Java SDK</name>
   <description>A Java client for the Aerol.ai MicroVM sandbox API.</description>
   <url>https://github.com/aerol-ai/microvm</url>

--- a/sdk/java/src/main/java/ai/aerol/microvm/MicroVMClient.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/MicroVMClient.java
@@ -40,6 +40,7 @@ import ai.aerol.microvm.model.HealthStatus;
 import ai.aerol.microvm.model.Lifecycle;
 import ai.aerol.microvm.model.MountSpecRedacted;
 import ai.aerol.microvm.model.NetworkUsage;
+import ai.aerol.microvm.model.RegisterSnapshotOptions;
 import ai.aerol.microvm.model.ResizeOptions;
 import ai.aerol.microvm.model.SandboxData;
 import ai.aerol.microvm.model.SandboxSnapshot;
@@ -210,6 +211,44 @@ public class MicroVMClient {
 
     public SandboxSnapshot createSnapshot(String sandboxId, String name) {
         return doJson("POST", sandboxPath(sandboxId) + "/snapshot", new CreateSnapshotRequest(name), SandboxSnapshot.class);
+    }
+
+    public SandboxSnapshot registerSnapshot(RegisterSnapshotOptions options) {
+        RegisterSnapshotOptions resolved = copyRegisterSnapshotOptions(options);
+        String name = trimToNull(resolved.name);
+        if (name == null) {
+            throw new MicroVMException("name is required");
+        }
+
+        String image = trimToNull(resolved.image);
+        String dockerfileContent = trimToNull(resolved.dockerfileContent);
+        if (image == null && dockerfileContent == null) {
+            throw new MicroVMException("image or dockerfile_content is required");
+        }
+        if (image != null && dockerfileContent != null) {
+            throw new MicroVMException("image and dockerfile_content are mutually exclusive");
+        }
+
+        resolved.name = name;
+        resolved.image = image;
+        resolved.dockerfileContent = dockerfileContent;
+        resolved.regionId = trimToNull(resolved.regionId);
+        return doJson("POST", versioned("/snapshots"), resolved, SandboxSnapshot.class);
+    }
+
+    public SandboxSnapshot registerSnapshotFromImage(String name, Image image) {
+        return registerSnapshotFromImage(name, image, new RegisterSnapshotOptions());
+    }
+
+    public SandboxSnapshot registerSnapshotFromImage(String name, Image image, RegisterSnapshotOptions options) {
+        if (image == null) {
+            throw new MicroVMException("image is required");
+        }
+        RegisterSnapshotOptions resolved = copyRegisterSnapshotOptions(options);
+        resolved.name = name;
+        resolved.image = null;
+        resolved.dockerfileContent = image.getDockerfile();
+        return registerSnapshot(resolved);
     }
 
     public void destroy(String sandboxId) {
@@ -557,6 +596,24 @@ public class MicroVMClient {
         copy.lifecycle = source.lifecycle;
         copy.runtime = source.runtime;
         copy.gpus = source.gpus;
+        return copy;
+    }
+
+    private RegisterSnapshotOptions copyRegisterSnapshotOptions(RegisterSnapshotOptions source) {
+        RegisterSnapshotOptions copy = new RegisterSnapshotOptions();
+        if (source == null) {
+            return copy;
+        }
+        copy.name = source.name;
+        copy.image = source.image;
+        copy.dockerfileContent = source.dockerfileContent;
+        copy.contextHashes = source.contextHashes;
+        copy.entrypoint = source.entrypoint;
+        copy.regionId = source.regionId;
+        copy.cpu = source.cpu;
+        copy.gpu = source.gpu;
+        copy.memoryMb = source.memoryMb;
+        copy.diskGb = source.diskGb;
         return copy;
     }
 

--- a/sdk/java/src/main/java/ai/aerol/microvm/model/RegisterSnapshotOptions.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/model/RegisterSnapshotOptions.java
@@ -1,0 +1,75 @@
+package ai.aerol.microvm.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RegisterSnapshotOptions {
+    public String name;
+    public String image;
+    @JsonProperty("dockerfile_content")
+    public String dockerfileContent;
+    @JsonProperty("context_hashes")
+    public List<String> contextHashes;
+    public List<String> entrypoint;
+    @JsonProperty("region_id")
+    public String regionId;
+    public Double cpu;
+    public Double gpu;
+    @JsonProperty("memory_mb")
+    public Integer memoryMb;
+    @JsonProperty("disk_gb")
+    public Integer diskGb;
+
+    public RegisterSnapshotOptions setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public RegisterSnapshotOptions setImage(String image) {
+        this.image = image;
+        return this;
+    }
+
+    public RegisterSnapshotOptions setDockerfileContent(String dockerfileContent) {
+        this.dockerfileContent = dockerfileContent;
+        return this;
+    }
+
+    public RegisterSnapshotOptions setContextHashes(List<String> contextHashes) {
+        this.contextHashes = contextHashes;
+        return this;
+    }
+
+    public RegisterSnapshotOptions setEntrypoint(List<String> entrypoint) {
+        this.entrypoint = entrypoint;
+        return this;
+    }
+
+    public RegisterSnapshotOptions setRegionId(String regionId) {
+        this.regionId = regionId;
+        return this;
+    }
+
+    public RegisterSnapshotOptions setCpu(Double cpu) {
+        this.cpu = cpu;
+        return this;
+    }
+
+    public RegisterSnapshotOptions setGpu(Double gpu) {
+        this.gpu = gpu;
+        return this;
+    }
+
+    public RegisterSnapshotOptions setMemoryMb(Integer memoryMb) {
+        this.memoryMb = memoryMb;
+        return this;
+    }
+
+    public RegisterSnapshotOptions setDiskGb(Integer diskGb) {
+        this.diskGb = diskGb;
+        return this;
+    }
+}

--- a/sdk/java/src/main/java/ai/aerol/microvm/model/SandboxSnapshot.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/model/SandboxSnapshot.java
@@ -1,6 +1,7 @@
 package ai.aerol.microvm.model;
 
 import java.time.Instant;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -13,6 +14,15 @@ public class SandboxSnapshot {
     public String sourceSandboxId;
     @JsonProperty("created_at")
     public Instant createdAt;
+    public List<String> entrypoint;
+    @JsonProperty("region_id")
+    public String regionId;
+    public Double cpu;
+    public Double gpu;
+    @JsonProperty("memory_mb")
+    public Integer memoryMb;
+    @JsonProperty("disk_gb")
+    public Integer diskGb;
 
     public SandboxSnapshot setName(String name) {
         this.name = name;
@@ -36,6 +46,36 @@ public class SandboxSnapshot {
 
     public SandboxSnapshot setCreatedAt(Instant createdAt) {
         this.createdAt = createdAt;
+        return this;
+    }
+
+    public SandboxSnapshot setEntrypoint(List<String> entrypoint) {
+        this.entrypoint = entrypoint;
+        return this;
+    }
+
+    public SandboxSnapshot setRegionId(String regionId) {
+        this.regionId = regionId;
+        return this;
+    }
+
+    public SandboxSnapshot setCpu(Double cpu) {
+        this.cpu = cpu;
+        return this;
+    }
+
+    public SandboxSnapshot setGpu(Double gpu) {
+        this.gpu = gpu;
+        return this;
+    }
+
+    public SandboxSnapshot setMemoryMb(Integer memoryMb) {
+        this.memoryMb = memoryMb;
+        return this;
+    }
+
+    public SandboxSnapshot setDiskGb(Integer diskGb) {
+        this.diskGb = diskGb;
         return this;
     }
 }

--- a/sdk/java/src/test/java/ai/aerol/microvm/MicroVMClientTest.java
+++ b/sdk/java/src/test/java/ai/aerol/microvm/MicroVMClientTest.java
@@ -37,6 +37,7 @@ import ai.aerol.microvm.model.Lifecycle;
 import ai.aerol.microvm.model.MountSpec;
 import ai.aerol.microvm.model.MountSpecRedacted;
 import ai.aerol.microvm.model.NetworkUsage;
+import ai.aerol.microvm.model.RegisterSnapshotOptions;
 import ai.aerol.microvm.model.SandboxData;
 import ai.aerol.microvm.model.SandboxSnapshot;
 import ai.aerol.microvm.model.Session;
@@ -331,6 +332,126 @@ class MicroVMClientTest {
             assertEquals("sha256:snap-1", snapshot.imageId);
             assertEquals("sb-1", snapshot.sourceSandboxId);
             assertEquals("snapshots/from-sandbox:v1", sandboxSnapshot.name);
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void registerSnapshotMapsRequestAndResponseShapes() throws Exception {
+        AtomicReference<Map<String, Object>> requestBody = new AtomicReference<>();
+        HttpServer server = startServer(exchange -> {
+            assertEquals("POST", exchange.getRequestMethod());
+            assertEquals("/v1/snapshots", exchange.getRequestURI().getPath());
+            requestBody.set(castMap(JsonSupport.read(exchange.getRequestBody().readAllBytes(), Map.class)));
+            writeJson(exchange, 201, mapOf(
+                "name", "py-base",
+                "image", "python:3.12-slim",
+                "image_id", "sha256:snap-2",
+                "source_sandbox_id", "",
+                "created_at", "2026-05-15T10:00:00Z",
+                "region_id", "us",
+                "cpu", 2.0,
+                "gpu", 1.0,
+                "memory_mb", 4096,
+                "disk_gb", 10
+            ));
+        });
+
+        try {
+            MicroVMClient client = clientFor(server);
+            SandboxSnapshot snapshot = client.registerSnapshot(
+                new RegisterSnapshotOptions()
+                    .setName("py-base")
+                    .setImage("python:3.12-slim")
+                    .setRegionId("us")
+                    .setCpu(2.0)
+                    .setGpu(1.0)
+                    .setMemoryMb(4096)
+                    .setDiskGb(10)
+            );
+
+            Map<String, Object> payload = requestBody.get();
+            assertEquals("py-base", payload.get("name"));
+            assertEquals("python:3.12-slim", payload.get("image"));
+            assertEquals("us", payload.get("region_id"));
+            assertEquals(2.0, ((Number) payload.get("cpu")).doubleValue());
+            assertEquals(1.0, ((Number) payload.get("gpu")).doubleValue());
+            assertEquals(4096, ((Number) payload.get("memory_mb")).intValue());
+            assertEquals(10, ((Number) payload.get("disk_gb")).intValue());
+            assertEquals("sha256:snap-2", snapshot.imageId);
+            assertEquals("us", snapshot.regionId);
+            assertEquals(2.0, snapshot.cpu);
+            assertEquals(1.0, snapshot.gpu);
+            assertEquals(4096, snapshot.memoryMb);
+            assertEquals(10, snapshot.diskGb);
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void registerSnapshotFromImageSendsDockerfilePath() throws Exception {
+        AtomicReference<Map<String, Object>> requestBody = new AtomicReference<>();
+        HttpServer server = startServer(exchange -> {
+            assertEquals("POST", exchange.getRequestMethod());
+            assertEquals("/v1/snapshots", exchange.getRequestURI().getPath());
+            requestBody.set(castMap(JsonSupport.read(exchange.getRequestBody().readAllBytes(), Map.class)));
+            writeJson(exchange, 201, mapOf(
+                "name", "built",
+                "image", "snapshots/built:resolved",
+                "image_id", "sha256:snap-3",
+                "source_sandbox_id", "",
+                "created_at", "2026-05-15T10:00:00Z",
+                "entrypoint", List.of("/bin/sh", "-c", "echo hi")
+            ));
+        });
+
+        try {
+            MicroVMClient client = clientFor(server);
+            SandboxSnapshot snapshot = client.registerSnapshotFromImage(
+                "built",
+                Image.base("debian:bookworm-slim").runCommands("apt-get update"),
+                new RegisterSnapshotOptions().setEntrypoint(List.of("/bin/sh", "-c", "echo hi"))
+            );
+
+            Map<String, Object> payload = requestBody.get();
+            assertEquals("built", payload.get("name"));
+            assertTrue(payload.containsKey("dockerfile_content"));
+            assertTrue(String.valueOf(payload.get("dockerfile_content")).contains("FROM debian:bookworm-slim"));
+            assertTrue(String.valueOf(payload.get("dockerfile_content")).contains("RUN apt-get update"));
+            assertEquals(false, payload.containsKey("image"));
+            assertEquals(List.of("/bin/sh", "-c", "echo hi"), payload.get("entrypoint"));
+            assertEquals("snapshots/built:resolved", snapshot.image);
+            assertEquals(List.of("/bin/sh", "-c", "echo hi"), snapshot.entrypoint);
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void registerSnapshotValidatesInputBeforeSending() throws Exception {
+        HttpServer server = startServer(exchange -> {
+            throw new AssertionError("validation should fail before the request fires; got " + exchange.getRequestMethod() + " " + exchange.getRequestURI());
+        });
+
+        try {
+            MicroVMClient client = clientFor(server);
+
+            MicroVMException missingName = assertThrows(MicroVMException.class, () -> client.registerSnapshot(
+                new RegisterSnapshotOptions().setImage("alpine")
+            ));
+            assertTrue(missingName.getMessage().contains("name is required"));
+
+            MicroVMException missingPayload = assertThrows(MicroVMException.class, () -> client.registerSnapshot(
+                new RegisterSnapshotOptions().setName("x")
+            ));
+            assertTrue(missingPayload.getMessage().contains("image or dockerfile_content is required"));
+
+            MicroVMException bothSet = assertThrows(MicroVMException.class, () -> client.registerSnapshot(
+                new RegisterSnapshotOptions().setName("x").setImage("alpine").setDockerfileContent("FROM busybox")
+            ));
+            assertTrue(bothSet.getMessage().contains("mutually exclusive"));
         } finally {
             server.stop(0);
         }

--- a/sdk/python/microvm/client.py
+++ b/sdk/python/microvm/client.py
@@ -30,6 +30,7 @@ from .types import (
     MountSpec,
     MountSpecRedacted,
     NetworkUsage,
+    RegisterSnapshotOptions,
     ResizeOptions,
     SandboxData,
     SandboxSnapshot,
@@ -480,6 +481,47 @@ class MicroVM:
         response = self._do_json("POST", f"{self._version_prefix}/sandboxes/{sandbox_id}/snapshot", {"name": name})
         return _from_api_sandbox_snapshot(response)
 
+    def register_snapshot(self, options: RegisterSnapshotOptions) -> SandboxSnapshot:
+        name = str(_first_of(options, "name") or "").strip()
+        if name == "":
+            raise MicroVMError("name is required")
+
+        image = str(_first_of(options, "image") or "").strip()
+        dockerfile_content = str(_first_of(options, "dockerfileContent", "dockerfile_content") or "").strip()
+        if image == "" and dockerfile_content == "":
+            raise MicroVMError("image or dockerfile_content is required")
+        if image != "" and dockerfile_content != "":
+            raise MicroVMError("image and dockerfile_content are mutually exclusive")
+
+        response = self._do_json(
+            "POST",
+            self._versioned("/snapshots"),
+            _to_api_register_snapshot_options(
+                {
+                    **options,
+                    "name": name,
+                    "image": image or None,
+                    "dockerfileContent": dockerfile_content or None,
+                    "regionID": str(_first_of(options, "regionID", "region_id") or "").strip() or None,
+                }
+            ),
+        )
+        return _from_api_sandbox_snapshot(response)
+
+    def register_snapshot_from_image(
+        self,
+        name: str,
+        image: Image,
+        options: Optional[RegisterSnapshotOptions] = None,
+    ) -> SandboxSnapshot:
+        if not isinstance(image, Image):
+            raise TypeError("register_snapshot_from_image expects an Image instance")
+        resolved_options: RegisterSnapshotOptions = dict(options or {})
+        resolved_options["name"] = name
+        resolved_options.pop("image", None)
+        resolved_options["dockerfileContent"] = image.dockerfile
+        return self.register_snapshot(resolved_options)
+
     def destroy(self, sandbox_id: str) -> None:
         self._do_json("DELETE", f"{self._version_prefix}/sandboxes/{sandbox_id}", None)
 
@@ -756,6 +798,23 @@ def _to_api_create_options(options: CreateOptions) -> Dict[str, Any]:
     )
 
 
+def _to_api_register_snapshot_options(options: RegisterSnapshotOptions) -> Dict[str, Any]:
+    return _compact(
+        {
+            "name": _first_of(options, "name"),
+            "image": _first_of(options, "image"),
+            "dockerfile_content": _first_of(options, "dockerfileContent", "dockerfile_content"),
+            "context_hashes": _first_of(options, "contextHashes", "context_hashes"),
+            "entrypoint": _first_of(options, "entrypoint"),
+            "region_id": _first_of(options, "regionID", "region_id"),
+            "cpu": _first_of(options, "cpu"),
+            "gpu": _first_of(options, "gpu"),
+            "memory_mb": _first_of(options, "memoryMB", "memory_mb"),
+            "disk_gb": _first_of(options, "diskGB", "disk_gb"),
+        }
+    )
+
+
 def _to_api_resize_options(options: ResizeOptions) -> Dict[str, Any]:
     return _compact(
         {
@@ -844,6 +903,24 @@ def _from_api_sandbox_snapshot(snapshot: Dict[str, Any]) -> SandboxSnapshot:
     image_id = _first_of(snapshot, "image_id", "imageID")
     if image_id not in (None, ""):
         result["imageID"] = str(image_id)
+    entrypoint = _first_of(snapshot, "entrypoint")
+    if isinstance(entrypoint, list):
+        result["entrypoint"] = [str(item) for item in entrypoint]
+    region_id = _first_of(snapshot, "region_id", "regionID")
+    if region_id not in (None, ""):
+        result["regionID"] = str(region_id)
+    cpu = _first_of(snapshot, "cpu")
+    if cpu is not None:
+        result["cpu"] = float(cpu)
+    gpu = _first_of(snapshot, "gpu")
+    if gpu is not None:
+        result["gpu"] = float(gpu)
+    memory_mb = _first_of(snapshot, "memory_mb", "memoryMB")
+    if memory_mb is not None:
+        result["memoryMB"] = int(memory_mb)
+    disk_gb = _first_of(snapshot, "disk_gb", "diskGB")
+    if disk_gb is not None:
+        result["diskGB"] = int(disk_gb)
     return result
 
 

--- a/sdk/python/microvm/types.py
+++ b/sdk/python/microvm/types.py
@@ -36,6 +36,19 @@ class BuildImageResult:
     pushed: Optional[str] = None
 
 
+class RegisterSnapshotOptions(TypedDict, total=False):
+    name: str
+    image: str
+    dockerfileContent: str
+    contextHashes: List[str]
+    entrypoint: List[str]
+    regionID: str
+    cpu: float
+    gpu: float
+    memoryMB: int
+    diskGB: int
+
+
 class MountSpec(TypedDict, total=False):
     type: MountType
     target: str
@@ -216,6 +229,12 @@ class SandboxSnapshot(TypedDict, total=False):
     imageID: str
     sourceSandboxID: str
     createdAt: str
+    entrypoint: List[str]
+    regionID: str
+    cpu: float
+    gpu: float
+    memoryMB: int
+    diskGB: int
 
 
 # Wire protocol an exposure publishes through. "http" maps to the Caddy HTTP

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aerolvm-sdk"
-version = "0.1.9"
+version = "0.1.10"
 description = "A Python client for the Aerol.ai MicroVM sandbox API."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -63,6 +63,20 @@ class RecordingMicroVM(MicroVM):
                 "source_sandbox_id": "sb-1",
                 "created_at": "2026-05-14T10:00:00Z",
             }
+        if method == "POST" and path == "/v1/snapshots":
+            return {
+                "name": payload.get("name", "snapshots/default:v1"),
+                "image": payload.get("image") or "snapshots/built:resolved",
+                "image_id": "sha256:snap-2",
+                "source_sandbox_id": "",
+                "created_at": "2026-05-15T10:00:00Z",
+                "entrypoint": payload.get("entrypoint") or [],
+                "region_id": payload.get("region_id", ""),
+                "cpu": payload.get("cpu", 0),
+                "gpu": payload.get("gpu", 0),
+                "memory_mb": payload.get("memory_mb", 0),
+                "disk_gb": payload.get("disk_gb", 0),
+            }
         if method == "GET" and path == "/v1/sandboxes/sb-1/network/usage":
             return {
                 "sandbox_id": "sb-1",
@@ -450,6 +464,78 @@ class ClientTests(unittest.TestCase):
         self.assertEqual(snapshot["imageID"], "sha256:snap-1")
         self.assertEqual(snapshot["sourceSandboxID"], "sb-1")
         self.assertEqual(sandbox_snapshot["name"], "snapshots/from-sandbox:v1")
+
+    def test_register_snapshot_maps_request_and_response_shapes(self):
+        client = RecordingMicroVM()
+
+        snapshot = client.register_snapshot(
+            {
+                "name": "py-base",
+                "image": "python:3.12-slim",
+                "regionID": "us",
+                "cpu": 2,
+                "gpu": 1,
+                "memoryMB": 4096,
+                "diskGB": 10,
+            }
+        )
+
+        self.assertEqual(
+            client.calls[0],
+            (
+                "POST",
+                "/v1/snapshots",
+                {
+                    "name": "py-base",
+                    "image": "python:3.12-slim",
+                    "region_id": "us",
+                    "cpu": 2,
+                    "gpu": 1,
+                    "memory_mb": 4096,
+                    "disk_gb": 10,
+                },
+            ),
+        )
+        self.assertEqual(snapshot["imageID"], "sha256:snap-2")
+        self.assertEqual(snapshot["regionID"], "us")
+        self.assertEqual(snapshot["cpu"], 2.0)
+        self.assertEqual(snapshot["gpu"], 1.0)
+        self.assertEqual(snapshot["memoryMB"], 4096)
+        self.assertEqual(snapshot["diskGB"], 10)
+
+    def test_register_snapshot_from_image_uses_dockerfile_content(self):
+        client = RecordingMicroVM()
+
+        snapshot = client.register_snapshot_from_image(
+            "built",
+            Image.base("debian:bookworm-slim").run_commands("apt-get update"),
+            {"entrypoint": ["/bin/sh", "-c", "echo hi"]},
+        )
+
+        method, path, payload = client.calls[0]
+        self.assertEqual((method, path), ("POST", "/v1/snapshots"))
+        self.assertEqual(payload["name"], "built")
+        self.assertNotIn("image", payload)
+        self.assertIn("dockerfile_content", payload)
+        self.assertIn("FROM debian:bookworm-slim", payload["dockerfile_content"])
+        self.assertIn("RUN apt-get update", payload["dockerfile_content"])
+        self.assertEqual(payload["entrypoint"], ["/bin/sh", "-c", "echo hi"])
+        self.assertEqual(snapshot["image"], "snapshots/built:resolved")
+        self.assertEqual(snapshot["entrypoint"], ["/bin/sh", "-c", "echo hi"])
+
+    def test_register_snapshot_validates_input_before_sending(self):
+        client = RecordingMicroVM()
+
+        with self.assertRaisesRegex(client_module.MicroVMError, "name is required"):
+            client.register_snapshot({"image": "alpine"})
+
+        with self.assertRaisesRegex(client_module.MicroVMError, "image or dockerfile_content is required"):
+            client.register_snapshot({"name": "x"})
+
+        with self.assertRaisesRegex(client_module.MicroVMError, "mutually exclusive"):
+            client.register_snapshot({"name": "x", "image": "alpine", "dockerfileContent": "FROM busybox"})
+
+        self.assertEqual(client.calls, [])
 
     def test_exec_and_health_map_api_shapes(self):
         client = RecordingMicroVM()

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aerolvm-sdk"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 authors = ["Aerol AI"]
 description = "A Rust SDK for the Aerol.ai MicroVM sandbox API"

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -28,8 +28,9 @@ pub use types::{
     BuildImageOptions, BuildImagePushOptions, BuildImageResult, CreateOptions,
     CreateSessionOptions, ExecExitInfo, ExecRequest, ExecResult, ExposeOptions, ExposeProtocol,
     ExposeResult, ExposedPort, HealthStatus, Lifecycle, MountSpec, MountSpecRedacted, MountType,
-    NetworkUsage, RegistryAuth, ResizeOptions, Sandbox as SandboxData, SandboxSnapshot, Session,
-    SessionList, SessionStatus, SetNetworkLimitsOptions, UpdateLifecycleOptions,
+    NetworkUsage, RegisterSnapshotOptions, RegistryAuth, ResizeOptions, Sandbox as SandboxData,
+    SandboxSnapshot, Session, SessionList, SessionStatus, SetNetworkLimitsOptions,
+    UpdateLifecycleOptions,
 };
 
 const DEFAULT_API_URL: &str = "http://127.0.0.1:21212";
@@ -640,6 +641,103 @@ impl Client {
             &format!("{}/sandboxes/{}/snapshot", self.version_prefix(), id),
             Some(&CreateSnapshotRequest { name }),
         )
+    }
+
+    pub fn register_snapshot(&self, opts: RegisterSnapshotOptions) -> Result<SandboxSnapshot, Error> {
+        #[derive(Serialize)]
+        struct RegisterSnapshotRequest<'a> {
+            name: &'a str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            image: Option<&'a str>,
+            #[serde(rename = "dockerfile_content", skip_serializing_if = "Option::is_none")]
+            dockerfile_content: Option<&'a str>,
+            #[serde(rename = "context_hashes", skip_serializing_if = "Option::is_none")]
+            context_hashes: Option<&'a [String]>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            entrypoint: Option<&'a [String]>,
+            #[serde(rename = "region_id", skip_serializing_if = "Option::is_none")]
+            region_id: Option<&'a str>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            cpu: Option<f64>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            gpu: Option<f64>,
+            #[serde(rename = "memory_mb", skip_serializing_if = "Option::is_none")]
+            memory_mb: Option<u32>,
+            #[serde(rename = "disk_gb", skip_serializing_if = "Option::is_none")]
+            disk_gb: Option<u32>,
+        }
+
+        let name = opts.name.trim();
+        if name.is_empty() {
+            return Err(Error::Api("name is required".to_string()));
+        }
+
+        let image = opts
+            .image
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        let dockerfile_content = opts
+            .dockerfile_content
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        match (&image, &dockerfile_content) {
+            (None, None) => {
+                return Err(Error::Api(
+                    "image or dockerfile_content is required".to_string(),
+                ))
+            }
+            (Some(_), Some(_)) => {
+                return Err(Error::Api(
+                    "image and dockerfile_content are mutually exclusive".to_string(),
+                ))
+            }
+            _ => {}
+        }
+
+        let region_id = opts
+            .region_id
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+
+        self.do_json::<RegisterSnapshotRequest<'_>, SandboxSnapshot>(
+            Method::POST,
+            &format!("{}/snapshots", self.version_prefix()),
+            Some(&RegisterSnapshotRequest {
+                name,
+                image: image.as_deref(),
+                dockerfile_content: dockerfile_content.as_deref(),
+                context_hashes: if opts.context_hashes.is_empty() {
+                    None
+                } else {
+                    Some(opts.context_hashes.as_slice())
+                },
+                entrypoint: if opts.entrypoint.is_empty() {
+                    None
+                } else {
+                    Some(opts.entrypoint.as_slice())
+                },
+                region_id: region_id.as_deref(),
+                cpu: opts.cpu,
+                gpu: opts.gpu,
+                memory_mb: opts.memory_mb,
+                disk_gb: opts.disk_gb,
+            }),
+        )
+    }
+
+    pub fn register_snapshot_from_image(
+        &self,
+        name: &str,
+        image: &Image,
+        mut opts: RegisterSnapshotOptions,
+    ) -> Result<SandboxSnapshot, Error> {
+        if let Some(message) = image.validation_error() {
+            return Err(Error::Api(message.to_string()));
+        }
+        opts.name = name.to_string();
+        opts.image = None;
+        opts.dockerfile_content = Some(image.dockerfile().to_string());
+        self.register_snapshot(opts)
     }
 
     pub fn destroy(&self, id: &str) -> Result<(), Error> {
@@ -1938,6 +2036,147 @@ mod tests {
         assert_eq!(snapshot.name, "snapshots/demo:v1");
         assert_eq!(snapshot.image_id.as_deref(), Some("sha256:snap-1"));
         assert_eq!(snapshot.source_sandbox_id, "sb-1");
+    }
+
+    #[test]
+    fn register_snapshot_sends_image_path_and_maps_response() {
+        let body = serde_json::json!({
+            "name": "py-base",
+            "image": "python:3.12-slim",
+            "image_id": "sha256:snap-2",
+            "source_sandbox_id": "",
+            "created_at": "2026-05-15T10:00:00Z",
+            "region_id": "us",
+            "cpu": 2.0,
+            "gpu": 1.0,
+            "memory_mb": 4096,
+            "disk_gb": 10
+        })
+        .to_string();
+        let (url, request_rx) = spawn_json_server(body);
+
+        let client = Client::new(Some(&url), Some("pat-token")).expect("client should build");
+        let snapshot = client
+            .register_snapshot(RegisterSnapshotOptions {
+                name: "py-base".to_string(),
+                image: Some("python:3.12-slim".to_string()),
+                region_id: Some("us".to_string()),
+                cpu: Some(2.0),
+                gpu: Some(1.0),
+                memory_mb: Some(4096),
+                disk_gb: Some(10),
+                ..Default::default()
+            })
+            .expect("register snapshot should succeed");
+        let request = request_rx.recv().expect("request should be captured");
+        let body = request_json_body(&request);
+
+        assert!(
+            request.starts_with("POST /v1/snapshots HTTP/1.1\r\n"),
+            "unexpected request: {}",
+            request
+        );
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "name": "py-base",
+                "image": "python:3.12-slim",
+                "region_id": "us",
+                "cpu": 2.0,
+                "gpu": 1.0,
+                "memory_mb": 4096,
+                "disk_gb": 10
+            })
+        );
+        assert_eq!(snapshot.image_id.as_deref(), Some("sha256:snap-2"));
+        assert_eq!(snapshot.region_id.as_deref(), Some("us"));
+        assert_eq!(snapshot.cpu, Some(2.0));
+        assert_eq!(snapshot.gpu, Some(1.0));
+        assert_eq!(snapshot.memory_mb, Some(4096));
+        assert_eq!(snapshot.disk_gb, Some(10));
+    }
+
+    #[test]
+    fn register_snapshot_from_image_sends_dockerfile_path() {
+        let body = serde_json::json!({
+            "name": "built",
+            "image": "snapshots/built:resolved",
+            "image_id": "sha256:snap-3",
+            "source_sandbox_id": "",
+            "created_at": "2026-05-15T10:00:00Z",
+            "entrypoint": ["/bin/sh", "-c", "echo hi"]
+        })
+        .to_string();
+        let (url, request_rx) = spawn_json_server(body);
+
+        let client = Client::new(Some(&url), Some("pat-token")).expect("client should build");
+        let snapshot = client
+            .register_snapshot_from_image(
+                "built",
+                &Image::base("debian:bookworm-slim").run_command("apt-get update"),
+                RegisterSnapshotOptions {
+                    entrypoint: vec!["/bin/sh".to_string(), "-c".to_string(), "echo hi".to_string()],
+                    ..Default::default()
+                },
+            )
+            .expect("register snapshot from image should succeed");
+        let request = request_rx.recv().expect("request should be captured");
+        let body = request_json_body(&request);
+
+        assert!(
+            request.starts_with("POST /v1/snapshots HTTP/1.1\r\n"),
+            "unexpected request: {}",
+            request
+        );
+        let dockerfile = body
+            .get("dockerfile_content")
+            .and_then(|value| value.as_str())
+            .expect("dockerfile_content should be present");
+        assert!(dockerfile.contains("FROM debian:bookworm-slim"));
+        assert!(dockerfile.contains("RUN apt-get update"));
+        assert!(body.get("image").is_none());
+        assert_eq!(
+            body.get("entrypoint"),
+            Some(&serde_json::json!(["/bin/sh", "-c", "echo hi"]))
+        );
+        assert_eq!(snapshot.image, "snapshots/built:resolved");
+        assert_eq!(snapshot.entrypoint, vec!["/bin/sh", "-c", "echo hi"]);
+    }
+
+    #[test]
+    fn register_snapshot_validates_input_before_sending() {
+        let client = Client::new(Some("http://127.0.0.1:1"), Some("pat-token"))
+            .expect("client should build");
+
+        let missing_name = client
+            .register_snapshot(RegisterSnapshotOptions {
+                image: Some("alpine".to_string()),
+                ..Default::default()
+            })
+            .expect_err("missing name should fail");
+        assert!(missing_name.to_string().contains("name is required"));
+
+        let missing_payload = client
+            .register_snapshot(RegisterSnapshotOptions {
+                name: "x".to_string(),
+                ..Default::default()
+            })
+            .expect_err("missing image/dockerfile should fail");
+        assert!(
+            missing_payload
+                .to_string()
+                .contains("image or dockerfile_content is required")
+        );
+
+        let both_set = client
+            .register_snapshot(RegisterSnapshotOptions {
+                name: "x".to_string(),
+                image: Some("alpine".to_string()),
+                dockerfile_content: Some("FROM busybox".to_string()),
+                ..Default::default()
+            })
+            .expect_err("mutually exclusive fields should fail");
+        assert!(both_set.to_string().contains("mutually exclusive"));
     }
 
     #[test]

--- a/sdk/rust/src/types.rs
+++ b/sdk/rust/src/types.rs
@@ -48,6 +48,27 @@ pub struct BuildImageResult {
     pub pushed: Option<String>,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct RegisterSnapshotOptions {
+    /// Human-readable identifier other callers use in create-time snapshot references.
+    pub name: String,
+    /// Pre-built registry image reference. Mutually exclusive with `dockerfile_content`.
+    pub image: Option<String>,
+    /// Literal Dockerfile the daemon will build. Mutually exclusive with `image`.
+    pub dockerfile_content: Option<String>,
+    /// Uploaded build-context hashes for future COPY/ADD resolution.
+    pub context_hashes: Vec<String>,
+    /// Optional command override persisted on the snapshot row.
+    pub entrypoint: Vec<String>,
+    /// Region hint persisted for read-back.
+    pub region_id: Option<String>,
+    /// Resource hints surfaced back on the snapshot row.
+    pub cpu: Option<f64>,
+    pub gpu: Option<f64>,
+    pub memory_mb: Option<u32>,
+    pub disk_gb: Option<u32>,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MountSpec {
     #[serde(rename = "type")]
@@ -320,7 +341,7 @@ pub struct CreateSandboxResponse {
     pub ssh_private_key: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct SandboxSnapshot {
     pub name: String,
     pub image: String,
@@ -330,6 +351,18 @@ pub struct SandboxSnapshot {
     pub source_sandbox_id: String,
     #[serde(rename = "created_at")]
     pub created_at: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub entrypoint: Vec<String>,
+    #[serde(rename = "region_id", skip_serializing_if = "Option::is_none")]
+    pub region_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gpu: Option<f64>,
+    #[serde(rename = "memory_mb", skip_serializing_if = "Option::is_none")]
+    pub memory_mb: Option<u32>,
+    #[serde(rename = "disk_gb", skip_serializing_if = "Option::is_none")]
+    pub disk_gb: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerol-ai/aerolvm-sdk",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": false,
   "type": "module",
   "main": "./dist/index.js",

--- a/sdk/typescript/src/MicroVM.test.ts
+++ b/sdk/typescript/src/MicroVM.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { Image } from "./Image.js";
 import { MicroVM } from "./MicroVM.js";
 import { Sandbox } from "./Sandbox.js";
 
@@ -165,6 +166,95 @@ test("MicroVM createSnapshot returns snapshot metadata", async () => {
   assert.deepEqual(seen[0]?.body, { name: "snapshots/demo:v1" });
   assert.equal(snapshot.imageID, "sha256:snap-1");
   assert.equal(snapshot.sourceSandboxID, "sb-demo");
+});
+
+test("MicroVM registerSnapshot returns persisted snapshot metadata", async () => {
+  const seen: Array<{ method: string; url: string; body: unknown }> = [];
+  const sdk = new MicroVM({
+    patToken: "pat-token",
+    apiUrl: "https://api.example.com",
+    fetch: async (input, init) => {
+      const request = new Request(input, init);
+      const bodyText = request.method === "GET" || request.method === "DELETE" ? undefined : await request.text();
+      seen.push({
+        method: request.method,
+        url: request.url,
+        body: bodyText ? JSON.parse(bodyText) : undefined,
+      });
+      return new Response(JSON.stringify({
+        name: "py-base",
+        image: "python:3.12-slim",
+        source_sandbox_id: "",
+        created_at: "2026-05-15T10:00:00Z",
+        region_id: "us",
+        cpu: 2,
+        memory_mb: 4096,
+        disk_gb: 10,
+      }), {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+
+  const snapshot = await sdk.registerSnapshot({
+    name: "py-base",
+    image: "python:3.12-slim",
+    regionID: "us",
+    cpu: 2,
+    memoryMB: 4096,
+    diskGB: 10,
+  });
+
+  assert.deepEqual(seen[0]?.body, {
+    name: "py-base",
+    image: "python:3.12-slim",
+    region_id: "us",
+    cpu: 2,
+    memory_mb: 4096,
+    disk_gb: 10,
+  });
+  assert.equal(snapshot.regionID, "us");
+  assert.equal(snapshot.memoryMB, 4096);
+});
+
+test("MicroVM registerSnapshotFromImage sends dockerfile_content", async () => {
+  const seen: Array<{ method: string; url: string; body: unknown }> = [];
+  const sdk = new MicroVM({
+    patToken: "pat-token",
+    apiUrl: "https://api.example.com",
+    fetch: async (input, init) => {
+      const request = new Request(input, init);
+      const bodyText = request.method === "GET" || request.method === "DELETE" ? undefined : await request.text();
+      seen.push({
+        method: request.method,
+        url: request.url,
+        body: bodyText ? JSON.parse(bodyText) : undefined,
+      });
+      return new Response(JSON.stringify({
+        name: "built",
+        image: "snapshots/built:resolved",
+        source_sandbox_id: "",
+        created_at: "2026-05-15T10:00:00Z",
+      }), {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+
+  const snapshot = await sdk.registerSnapshotFromImage(
+    "built",
+    Image.base("debian:bookworm-slim").runCommands("apt-get update"),
+    { entrypoint: ["/bin/sh", "-c", "echo hi"] },
+  );
+
+  const payload = seen[0]?.body as Record<string, unknown>;
+  assert.equal(payload?.name, "built");
+  assert.match(String(payload?.dockerfile_content), /FROM debian:bookworm-slim/);
+  assert.equal("image" in payload, false);
+  assert.deepEqual(payload?.entrypoint, ["/bin/sh", "-c", "echo hi"]);
+  assert.equal(snapshot.image, "snapshots/built:resolved");
 });
 
 test("MicroVM create serializes mounts and mounts endpoint returns redacted specs", async () => {

--- a/sdk/typescript/src/MicroVM.ts
+++ b/sdk/typescript/src/MicroVM.ts
@@ -11,6 +11,7 @@ import type {
   HealthStatus,
   Lifecycle,
   MountSpecRedacted,
+  RegisterSnapshotOptions,
   ResizeOptions,
   Sandbox as SandboxData,
   SandboxSnapshot,
@@ -89,6 +90,18 @@ export class MicroVM {
 	async createSnapshot(id: string, name: string): Promise<SandboxSnapshot> {
 		return this.client.createSnapshot(id, name);
 	}
+
+  async registerSnapshot(options: RegisterSnapshotOptions): Promise<SandboxSnapshot> {
+    return this.client.registerSnapshot(options);
+  }
+
+  async registerSnapshotFromImage(
+    name: string,
+    image: Image,
+    options: Omit<RegisterSnapshotOptions, "name" | "image" | "dockerfileContent"> = {},
+  ): Promise<SandboxSnapshot> {
+    return this.client.registerSnapshotFromImage(name, image, options);
+  }
 
   async destroy(id: string): Promise<void> {
     await this.client.destroy(id);

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -21,6 +21,7 @@ export type {
   MountSpec,
   MountSpecRedacted,
   MountType,
+  RegisterSnapshotOptions,
   RegistryAuth,
   ResizeOptions,
   Sandbox as SandboxData,

--- a/sdk/typescript/src/internal/client.test.ts
+++ b/sdk/typescript/src/internal/client.test.ts
@@ -91,6 +91,105 @@ test("internal client createSnapshot maps request and response", async () => {
   assert.equal(snapshot.sourceSandboxID, "sb-create");
 });
 
+test("internal client registerSnapshot maps image path and response", async () => {
+  let seenRequest: Request | undefined;
+  const client = new APIClient({
+    baseURL: "https://api.example.com",
+    patToken: "pat-token",
+    fetch: async (input, init) => {
+      seenRequest = new Request(input, init);
+      return jsonResponse({
+        name: "py-base",
+        image: "python:3.12-slim",
+        source_sandbox_id: "",
+        created_at: "2026-05-15T10:00:00Z",
+        region_id: "us",
+        cpu: 2,
+        gpu: 1,
+        memory_mb: 4096,
+        disk_gb: 10,
+      }, 201);
+    },
+  });
+
+  const snapshot = await client.registerSnapshot({
+    name: "py-base",
+    image: "python:3.12-slim",
+    regionID: "us",
+    cpu: 2,
+    gpu: 1,
+    memoryMB: 4096,
+    diskGB: 10,
+  });
+
+  assert.ok(seenRequest);
+  assert.equal(seenRequest.method, "POST");
+  assert.equal(seenRequest.url, "https://api.example.com/v1/snapshots");
+  assert.deepEqual(await seenRequest.json(), {
+    name: "py-base",
+    image: "python:3.12-slim",
+    region_id: "us",
+    cpu: 2,
+    gpu: 1,
+    memory_mb: 4096,
+    disk_gb: 10,
+  });
+  assert.equal(snapshot.regionID, "us");
+  assert.equal(snapshot.cpu, 2);
+  assert.equal(snapshot.gpu, 1);
+  assert.equal(snapshot.memoryMB, 4096);
+  assert.equal(snapshot.diskGB, 10);
+});
+
+test("internal client registerSnapshotFromImage sends dockerfile path", async () => {
+  let seenRequest: Request | undefined;
+  const client = new APIClient({
+    baseURL: "https://api.example.com",
+    patToken: "pat-token",
+    fetch: async (input, init) => {
+      seenRequest = new Request(input, init);
+      return jsonResponse({
+        name: "built",
+        image: "snapshots/built:resolved",
+        source_sandbox_id: "",
+        created_at: "2026-05-15T10:00:00Z",
+        entrypoint: ["/bin/sh", "-c", "echo hi"],
+      }, 201);
+    },
+  });
+
+  const snapshot = await client.registerSnapshotFromImage(
+    "built",
+    Image.base("debian:bookworm-slim").runCommands("apt-get update"),
+    { entrypoint: ["/bin/sh", "-c", "echo hi"] },
+  );
+
+  assert.ok(seenRequest);
+  const payload = await seenRequest.json() as Record<string, unknown>;
+  assert.equal(payload.name, "built");
+  assert.match(String(payload.dockerfile_content), /FROM debian:bookworm-slim/);
+  assert.match(String(payload.dockerfile_content), /RUN apt-get update/);
+  assert.equal("image" in payload, false);
+  assert.deepEqual(payload.entrypoint, ["/bin/sh", "-c", "echo hi"]);
+  assert.deepEqual(snapshot.entrypoint, ["/bin/sh", "-c", "echo hi"]);
+});
+
+test("internal client registerSnapshot validates input before sending", async () => {
+  const client = new APIClient({
+    baseURL: "https://api.example.com",
+    fetch: async () => {
+      throw new Error("should not send request");
+    },
+  });
+
+  await assert.rejects(() => client.registerSnapshot({ name: "", image: "alpine" }), /name is required/);
+  await assert.rejects(() => client.registerSnapshot({ name: "x" }), /image or dockerfile_content is required/);
+  await assert.rejects(
+    () => client.registerSnapshot({ name: "x", image: "alpine", dockerfileContent: "FROM busybox" }),
+    /image and dockerfile_content are mutually exclusive/,
+  );
+});
+
 test("internal client updateLifecycle sends flat request body", async () => {
   let seenRequest: Request | undefined;
   const client = new APIClient({

--- a/sdk/typescript/src/internal/client.ts
+++ b/sdk/typescript/src/internal/client.ts
@@ -22,6 +22,7 @@ import type {
   MountSpec,
   MountSpecRedacted,
   NetworkUsage,
+  RegisterSnapshotOptions,
   SetNetworkLimitsOptions,
   ResizeOptions,
   Sandbox,
@@ -123,6 +124,12 @@ interface ApiSandboxSnapshot {
   image_id?: string;
   source_sandbox_id: string;
   created_at: string;
+  entrypoint?: string[];
+  region_id?: string;
+  cpu?: number;
+  gpu?: number;
+  memory_mb?: number;
+  disk_gb?: number;
 }
 
 interface ApiSession {
@@ -321,6 +328,47 @@ export class APIClient {
 		const response = await this.doJSON<ApiSandboxSnapshot>("POST", `${this.versionPrefix}/sandboxes/${id}/snapshot`, { name });
 		return fromApiSandboxSnapshot(response);
 	}
+
+  async registerSnapshot(options: RegisterSnapshotOptions): Promise<SandboxSnapshot> {
+    const name = options.name.trim();
+    if (name === "") {
+      throw new Error("name is required");
+    }
+
+    const image = options.image?.trim() ?? "";
+    const dockerfileContent = options.dockerfileContent?.trim() ?? "";
+    if (image === "" && dockerfileContent === "") {
+      throw new Error("image or dockerfile_content is required");
+    }
+    if (image !== "" && dockerfileContent !== "") {
+      throw new Error("image and dockerfile_content are mutually exclusive");
+    }
+
+    const response = await this.doJSON<ApiSandboxSnapshot>(
+      "POST",
+      this.versioned("/snapshots"),
+      toApiRegisterSnapshotOptions({
+        ...options,
+        name,
+        image: image || undefined,
+        dockerfileContent: dockerfileContent || undefined,
+        regionID: options.regionID?.trim() || undefined,
+      }),
+    );
+    return fromApiSandboxSnapshot(response);
+  }
+
+  async registerSnapshotFromImage(
+    name: string,
+    image: Image,
+    options: Omit<RegisterSnapshotOptions, "name" | "image" | "dockerfileContent"> = {},
+  ): Promise<SandboxSnapshot> {
+    return this.registerSnapshot({
+      ...options,
+      name,
+      dockerfileContent: image.dockerfile,
+    });
+  }
 
   async destroy(id: string): Promise<void> {
     await this.doJSON<void>("DELETE", `${this.versionPrefix}/sandboxes/${id}`);
@@ -668,6 +716,21 @@ function toApiCreateOptions(options: CreateOptions): Record<string, unknown> {
   };
 }
 
+function toApiRegisterSnapshotOptions(options: RegisterSnapshotOptions): Record<string, unknown> {
+  return {
+    name: options.name,
+    image: options.image,
+    dockerfile_content: options.dockerfileContent,
+    context_hashes: options.contextHashes,
+    entrypoint: options.entrypoint,
+    region_id: options.regionID,
+    cpu: options.cpu,
+    gpu: options.gpu,
+    memory_mb: options.memoryMB,
+    disk_gb: options.diskGB,
+  };
+}
+
 function toApiResizeOptions(options: ResizeOptions): Record<string, unknown> {
   return {
     cpu: options.cpu,
@@ -758,6 +821,12 @@ function fromApiSandboxSnapshot(snapshot: ApiSandboxSnapshot): SandboxSnapshot {
     imageID: snapshot.image_id,
     sourceSandboxID: snapshot.source_sandbox_id,
     createdAt: snapshot.created_at,
+    entrypoint: snapshot.entrypoint,
+    regionID: snapshot.region_id,
+    cpu: snapshot.cpu,
+    gpu: snapshot.gpu,
+    memoryMB: snapshot.memory_mb,
+    diskGB: snapshot.disk_gb,
   };
 }
 

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -33,6 +33,26 @@ export interface BuildImageResult {
   pushed?: string;
 }
 
+export interface RegisterSnapshotOptions {
+  /** Human-readable identifier other callers use in `CreateOptions.snapshot`. */
+  name: string;
+  /** Pre-built registry reference. Mutually exclusive with `dockerfileContent`. */
+  image?: string;
+  /** Literal Dockerfile the daemon will build. Mutually exclusive with `image`. */
+  dockerfileContent?: string;
+  /** Uploaded build-context hashes for future COPY/ADD resolution. */
+  contextHashes?: string[];
+  /** Optional command override persisted on the snapshot row. */
+  entrypoint?: string[];
+  /** Region hint persisted for read-back. */
+  regionID?: string;
+  /** Resource hints surfaced back on the snapshot row. */
+  cpu?: number;
+  gpu?: number;
+  memoryMB?: number;
+  diskGB?: number;
+}
+
 export type MountType = "s3" | "nfs" | "sshfs" | "rclone";
 
 export interface MountSpec {
@@ -213,6 +233,12 @@ export interface SandboxSnapshot {
   imageID?: string;
   sourceSandboxID: string;
   createdAt: string;
+  entrypoint?: string[];
+  regionID?: string;
+  cpu?: number;
+  gpu?: number;
+  memoryMB?: number;
+  diskGB?: number;
 }
 
 /**


### PR DESCRIPTION
This pull request introduces significant enhancements to the Daytona facade's snapshot handling, particularly supporting snapshot creation from pre-built images or Docker build info via the Daytona SDK. It also expands the snapshot data model to include resource and region metadata, improves error handling for unsupported features like volumes, and updates API routes and tests accordingly.

**Daytona snapshot creation and API improvements:**

* Added support for creating snapshots from either a pre-built image reference or Docker build info via a new `POST /daytona/snapshots` endpoint, with robust validation and error handling. The new handler (`createSnapshotFromImage`) registers the snapshot and returns detailed metadata, supporting SDK workflows. [[1]](diffhunk://#diff-e6a48d126ffa9338ffef4991f33537f08496a139afc189514f40c4625606362dR157-R247) [[2]](diffhunk://#diff-e6a48d126ffa9338ffef4991f33537f08496a139afc189514f40c4625606362dR840-R857) [[3]](diffhunk://#diff-e6a48d126ffa9338ffef4991f33537f08496a139afc189514f40c4625606362dL755-R876) [[4]](diffhunk://#diff-2088627529da76bdada38bdfbfa4b468de431ccb16cdd01e81cd1c670cb92938R57) [[5]](diffhunk://#diff-9fb50bbd38ae2543ed0485ed89619c0915e2ce5d29402bc1f94951fe40d86d3bR40-R54)
* Extended the `sandbox_snapshots` table and associated model to store additional metadata: `entrypoint_json`, `region_id`, `cpu`, `memory_mb`, `disk_gb`, and `gpu`. This includes migration logic and updates to snapshot creation, retrieval, and listing. [[1]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daL115-R121) [[2]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daR206-R214) [[3]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daL1136-R1170) [[4]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daL1157-R1184) [[5]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daL1173-R1201) [[6]](diffhunk://#diff-b26d414d0eb20deebca0d2b785bd3e1090aa1a7a182e7dc30640d68c53cb40daR1602-R1623)
* Implemented the `RegisterSnapshot` service method to persist snapshot rows for images resolved out-of-band, with idempotency by name and conflict detection.

**Error handling and unsupported features:**

* Added consistent handling and error responses for unsupported persistent volumes, returning HTTP 405 for all related requests and updating error propagation in the sandbox creation flow. Includes a new shared error and handler for volumes. [[1]](diffhunk://#diff-e6a48d126ffa9338ffef4991f33537f08496a139afc189514f40c4625606362dR53-R54) [[2]](diffhunk://#diff-e6a48d126ffa9338ffef4991f33537f08496a139afc189514f40c4625606362dL787-R899) [[3]](diffhunk://#diff-e6a48d126ffa9338ffef4991f33537f08496a139afc189514f40c4625606362dR1049-R1063) [[4]](diffhunk://#diff-8c5cc710a821c327fcbf298b86062f6f938a351bf4f8de21d83b5c0454807934R585-R599)

**SDK contract and compatibility updates:**

* Updated the Daytona contract tests to reflect the new snapshot/image resolution logic, ensuring the correct image reference is stored and returned for both base and SDK-generated snapshots. [[1]](diffhunk://#diff-9169460dae43497d4338bc5aceacdd920b7b851d91285da38974d06ea6294cf3L135-R140) [[2]](diffhunk://#diff-9169460dae43497d4338bc5aceacdd920b7b851d91285da38974d06ea6294cf3L1006-R1012)
* Enhanced the snapshot resolution logic in sandbox creation to first check for a named snapshot and fall back to direct image references for backward compatibility.

**Other:**

* Bumped the documentation version from `0.1.9` to `0.1.10`.