### PR TITLE
feat: Enhance node identification with node-name support in scripts

### DIFF
--- a/Terraform/nodes.tf
+++ b/Terraform/nodes.tf
@@ -36,8 +36,10 @@ resource "aws_instance" "seed" {
     http_put_response_hop_limit = 2
   }
 
+  user_data_replace_on_change = true
+
   user_data = templatefile("${path.module}/templates/bootstrap.sh.tftpl", {
-    node_name               = local.seed_node.name
+    node_name               = "${var.cluster_name}-${local.seed_node.name}"
     role                    = local.seed_node.role
     is_seed                 = true
     domain                  = var.domain_name
@@ -98,8 +100,10 @@ resource "aws_instance" "joiner" {
     http_put_response_hop_limit = 2
   }
 
+  user_data_replace_on_change = true
+
   user_data = templatefile("${path.module}/templates/bootstrap.sh.tftpl", {
-    node_name               = each.value.name
+    node_name               = "${var.cluster_name}-${each.value.name}"
     role                    = each.value.role
     is_seed                 = false
     domain                  = var.domain_name

--- a/Terraform/templates/bootstrap.sh.tftpl
+++ b/Terraform/templates/bootstrap.sh.tftpl
@@ -38,7 +38,7 @@ apt-get install -y curl jq awscli openssl ca-certificates
 curl -fsSL '${install_script_url}' -o /tmp/install.sh
 chmod +x /tmp/install.sh
 
-INSTALL_ARGS=(--pat-token '${pat_token}')
+INSTALL_ARGS=(--pat-token '${pat_token}' --node-name '${node_name}')
 if [ -n '${domain}' ]; then
   INSTALL_ARGS+=(
     --domain '${domain}'
@@ -60,16 +60,6 @@ INSTALL_ARGS+=(--idle-timeout-min '${idle_timeout_min}')
 %{ endif ~}
 
 sudo /tmp/install.sh "$${INSTALL_ARGS[@]}"
-
-# Inject SB_NODE_NAME so the dashboard's CLUSTER table shows the Terraform
-# name (node1/srv1/wrk2/...) alongside the hostname-derived node_id. Restart
-# is best-effort — cluster-init/join below restart sandboxd anyway, but on
-# re-applies that skip those (already-joined) the explicit restart guarantees
-# the env reaches the running daemon.
-if [ -f /etc/sandboxd/sandboxd.env ] && ! grep -q '^SB_NODE_NAME=' /etc/sandboxd/sandboxd.env; then
-  echo "SB_NODE_NAME=${node_name}" | sudo tee -a /etc/sandboxd/sandboxd.env >/dev/null
-  sudo systemctl restart sandboxd || true
-fi
 
 %{ if is_seed ~}
 ###############################################################################

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -21,6 +21,7 @@ RUNSC_PATH=""
 WITH_NVIDIA_GPU="false"
 WITH_AMD_GPU="false"
 LOCAL_MODE="false"
+NODE_NAME=""
 
 usage() {
 	cat <<'EOF'
@@ -73,6 +74,12 @@ Options:
                                Requires the amdgpu kernel module loaded on the
                                host (the GPU must already be recognized by the
                                OS — /dev/kfd must exist).
+  --node-name <name>           Human-readable identifier broadcast to the
+                               cluster (shown in the dashboard's CLUSTER
+                               table). Persisted as SB_NODE_NAME in
+                               sandboxd.env. Defaults to empty, in which
+                               case the dashboard falls back to the
+                               hostname-derived node_id.
   --local                      Local development mode. The server binds to
                                127.0.0.1:21212 with no Caddy or TLS. Supported
                                on both macOS and Linux. Docker Desktop (macOS)
@@ -256,6 +263,10 @@ while [[ $# -gt 0 ]]; do
 		--local)
 			LOCAL_MODE="true"
 			shift
+			;;
+		--node-name)
+			NODE_NAME="$2"
+			shift 2
 			;;
 		--help)
 			usage
@@ -507,6 +518,7 @@ write_environment() {
 	chmod 0700 /var/lib/sandboxd /var/lib/sandboxd/mounts /run/sandboxd
 	cat > /etc/sandboxd/sandboxd.env <<EOF
 SB_PAT_TOKEN=$PAT_TOKEN
+SB_NODE_NAME=$NODE_NAME
 SB_API_HOST=0.0.0.0
 SB_API_PORT=21212
 SB_DOMAIN=$DOMAIN
@@ -940,6 +952,7 @@ write_local_environment() {
 	chmod 0700 /var/lib/sandboxd /var/lib/sandboxd/mounts /run/sandboxd
 	cat > /etc/sandboxd/sandboxd.env <<EOF
 SB_PAT_TOKEN=$PAT_TOKEN
+SB_NODE_NAME=$NODE_NAME
 SB_API_HOST=127.0.0.1
 SB_API_PORT=21212
 SB_PUBLIC_HOST=127.0.0.1


### PR DESCRIPTION
This pull request improves how node names are handled and propagated throughout the Terraform and install scripts, making node identification more robust and consistent across the cluster. The changes ensure that node names are explicitly set, passed through all relevant scripts, and correctly persisted in environment files for use by the dashboard and other services.

**Node name propagation and consistency:**

* The Terraform `aws_instance` resources for both seed and joiner nodes now prepend the cluster name to the node name, ensuring unique and descriptive identifiers for each node (`Terraform/nodes.tf`). [[1]](diffhunk://#diff-27284210e9c845fb0bd0438ee58839db7687dc87b81265e01f31135740489dccR39-R42) [[2]](diffhunk://#diff-27284210e9c845fb0bd0438ee58839db7687dc87b81265e01f31135740489dccR103-R106)
* The `bootstrap.sh.tftpl` template now passes the composed node name as a `--node-name` argument to the install script, ensuring that the install process is aware of the intended node identity (`Terraform/templates/bootstrap.sh.tftpl`).

**Install script enhancements:**

* The `install.sh` script introduces a new `--node-name` argument, which is documented in the usage output and parsed as an option. This value is used to set the `SB_NODE_NAME` environment variable (`scripts/install.sh`). [[1]](diffhunk://#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09ccR24) [[2]](diffhunk://#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09ccR77-R82) [[3]](diffhunk://#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09ccR267-R270)
* The install script now writes `SB_NODE_NAME` to `/etc/sandboxd/sandboxd.env` in both standard and local environment setups, making the node name available to the running daemon and dashboard (`scripts/install.sh`). [[1]](diffhunk://#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09ccR521) [[2]](diffhunk://#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09ccR955)

**Cleanup and simplification:**

* The previous workaround in `bootstrap.sh.tftpl` for injecting `SB_NODE_NAME` and restarting the service is removed, as this is now handled directly by the install script (`Terraform/templates/bootstrap.sh.tftpl`).