### PR TITLE
fix(gossip): improve NodeMeta fallback logic to preserve essential fields

### DIFF
--- a/internal/cluster/gossip.go
+++ b/internal/cluster/gossip.go
@@ -95,14 +95,28 @@ func (d *gossipDelegate) refreshMeta() {
 func (d *gossipDelegate) NodeMeta(limit int) []byte {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
+	if limit <= 0 {
+		return nil
+	}
 	if len(d.encoded) > limit {
-		// Truncated metadata is worse than minimal metadata (peers can't
-		// decode partial JSON). Fall back to ID+URL only.
-		fallback, _ := json.Marshal(nodeMeta{NodeID: d.nodeID, APIURL: d.apiURL, DataPlaneHost: d.dataPlaneHost})
-		if len(fallback) > limit {
-			return fallback[:limit]
+		// Truncated metadata is worse than minimal metadata because peers
+		// cannot decode partial JSON. Drop display/convenience fields first,
+		// but preserve raft join identity as long as it fits.
+		fallbacks := []nodeMeta{
+			{NodeID: d.nodeID, APIURL: d.apiURL, DataPlaneHost: d.dataPlaneHost, RaftAddr: d.raftAddr, InternalURL: d.internalURL, Role: d.role},
+			{NodeID: d.nodeID, APIURL: d.apiURL, DataPlaneHost: d.dataPlaneHost, RaftAddr: d.raftAddr, Role: d.role},
+			{NodeID: d.nodeID, APIURL: d.apiURL, RaftAddr: d.raftAddr, Role: d.role},
+			{NodeID: d.nodeID, RaftAddr: d.raftAddr, Role: d.role},
+			{NodeID: d.nodeID, RaftAddr: d.raftAddr},
+			{NodeID: d.nodeID},
 		}
-		return fallback
+		for _, meta := range fallbacks {
+			fallback, _ := json.Marshal(meta)
+			if len(fallback) <= limit {
+				return fallback
+			}
+		}
+		return []byte("{}")
 	}
 	return d.encoded
 }

--- a/internal/cluster/gossip_index_test.go
+++ b/internal/cluster/gossip_index_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/aerol-ai/microvm/internal/config"
@@ -45,6 +46,43 @@ func TestGossipMemberIndexStoresDecodedMemberMetadata(t *testing.T) {
 	// remote admitter decide." Asserting it here pins that contract.
 	if m.Capacity.CPUBudget != 0 || m.Capacity.MemoryBudgetMB != 0 {
 		t.Fatalf("decoded capacity = %+v, want zero (capacity is no longer gossiped)", m.Capacity)
+	}
+}
+
+func TestNodeMetaFallbackPreservesRaftJoinFields(t *testing.T) {
+	d := newGossipDelegate(
+		"ip-10-42-1-76",
+		strings.Repeat("aerolvm-node2-", 50),
+		"http://10.42.1.76:21212",
+		"10.42.1.76",
+		"10.42.1.76:7000",
+		"https://10.42.1.76:7002",
+		config.NodeRoleMixed,
+		nil,
+	)
+	if len(d.encoded) <= memberlist.MetaMaxSize {
+		t.Fatalf("test setup encoded meta len=%d, want > %d", len(d.encoded), memberlist.MetaMaxSize)
+	}
+
+	encoded := d.NodeMeta(memberlist.MetaMaxSize)
+	if len(encoded) > memberlist.MetaMaxSize {
+		t.Fatalf("NodeMeta len=%d, want <= %d", len(encoded), memberlist.MetaMaxSize)
+	}
+	var meta nodeMeta
+	if err := json.Unmarshal(encoded, &meta); err != nil {
+		t.Fatalf("fallback NodeMeta is not valid JSON: %v; %q", err, string(encoded))
+	}
+	if meta.NodeID != "ip-10-42-1-76" {
+		t.Fatalf("fallback NodeID=%q, want ip-10-42-1-76", meta.NodeID)
+	}
+	if meta.RaftAddr != "10.42.1.76:7000" {
+		t.Fatalf("fallback RaftAddr=%q, want 10.42.1.76:7000", meta.RaftAddr)
+	}
+	if meta.Role != config.NodeRoleMixed {
+		t.Fatalf("fallback Role=%q, want %s", meta.Role, config.NodeRoleMixed)
+	}
+	if meta.APIURL != "http://10.42.1.76:21212" {
+		t.Fatalf("fallback APIURL=%q, want http://10.42.1.76:21212", meta.APIURL)
 	}
 }
 


### PR DESCRIPTION
<!--
GitHub auto-fills new PR descriptions with this template. Fill in EVERY
section below. "N/A — <one-line reason>" is a valid answer; an empty answer
is not. See pr-review.md at the repo root for what each section is asking.
-->

## Summary

- Enhanced the NodeMeta fallback logic to ensure essential fields like RaftAddr and Role are preserved when metadata exceeds the size limit.
- Added a test to verify that the fallback mechanism correctly retains critical information.

## Sandbox boot impact

N/A — no work added to sandbox boot path.

## Idempotency

N/A — no API surface changed.

## Failure-path consistency

N/A — no multi-step write path changed.

## L4 / host-port-pool changes

N/A — neither touched.

## Test plan

- Verified the changes by running the new test for NodeMeta fallback.
- Ensured that the fallback preserves essential fields under size constraints.

