### PR TITLE
feat: Enhance cluster management with capacity heartbeats and recovery support

### DIFF
--- a/Ansible/README.md
+++ b/Ansible/README.md
@@ -107,6 +107,11 @@ ansible-playbook playbooks/update-sandboxd.yml \
 
 # Tail recent sandboxd logs from every node:
 ansible-playbook playbooks/tail-logs.yml -e lines=200
+
+# Configure OTEL/image-pull hardening and deploy backup/recovery helpers:
+ansible-playbook playbooks/configure-ops.yml \
+  -e sandboxd_otel_metrics_endpoint=http://otel-collector:4318/v1/metrics \
+  -e sandboxd_backup_enabled=true
 ```
 
 `update-sandboxd.yml` runs `serial: 1` — one host at a time, with
@@ -152,6 +157,7 @@ inventory/
 playbooks/
   ping.yml             # connectivity smoke test
   update-sandboxd.yml  # rolling binary push + restart + healthcheck
+  configure-ops.yml    # OTEL env, image-pull knobs, backup/recovery helpers
   tail-logs.yml        # journalctl across the fleet
 ```
 
@@ -162,6 +168,8 @@ playbooks/
 | Add / remove / resize nodes                     | Terraform   |
 | Change SG rules, DNS, AMI                       | Terraform   |
 | Push a new `sandboxd` binary                    | Ansible     |
+| Change OTEL/image-pull env on running nodes     | Ansible     |
+| Deploy backup/recovery helpers or backup cron   | Ansible     |
 | Restart a service, rotate a PAT, tail logs      | Ansible     |
 | Run one-off shell commands across many nodes    | Ansible     |
 

--- a/Ansible/README.md
+++ b/Ansible/README.md
@@ -108,7 +108,8 @@ ansible-playbook playbooks/update-sandboxd.yml \
 # Tail recent sandboxd logs from every node:
 ansible-playbook playbooks/tail-logs.yml -e lines=200
 
-# Configure OTEL/image-pull hardening and deploy backup/recovery helpers:
+# Configure OTEL/image-pull hardening and deploy backup/recovery,
+# Grafana, Prometheus, and Alertmanager artifacts:
 ansible-playbook playbooks/configure-ops.yml \
   -e sandboxd_otel_metrics_endpoint=http://otel-collector:4318/v1/metrics \
   -e sandboxd_backup_enabled=true
@@ -157,7 +158,7 @@ inventory/
 playbooks/
   ping.yml             # connectivity smoke test
   update-sandboxd.yml  # rolling binary push + restart + healthcheck
-  configure-ops.yml    # OTEL env, image-pull knobs, backup/recovery helpers
+  configure-ops.yml    # OTEL env, image-pull knobs, ops alert/dashboard files
   tail-logs.yml        # journalctl across the fleet
 ```
 
@@ -170,6 +171,7 @@ playbooks/
 | Push a new `sandboxd` binary                    | Ansible     |
 | Change OTEL/image-pull env on running nodes     | Ansible     |
 | Deploy backup/recovery helpers or backup cron   | Ansible     |
+| Deploy Grafana/Prometheus/Alertmanager artifacts | Ansible     |
 | Restart a service, rotate a PAT, tail logs      | Ansible     |
 | Run one-off shell commands across many nodes    | Ansible     |
 

--- a/Ansible/README.md
+++ b/Ansible/README.md
@@ -116,6 +116,7 @@ ansible-playbook playbooks/prepare-role-change.yml --limit aerolvm-worker-17
 # node lifecycle, Grafana, Prometheus, Alertmanager, and runbook artifacts:
 ansible-playbook playbooks/configure-ops.yml \
   -e sandboxd_otel_metrics_endpoint=http://otel-collector:4318/v1/metrics \
+  -e sandboxd_otel_traces_endpoint=http://otel-collector:4318/v1/traces \
   -e sandboxd_backup_enabled=true
 ```
 

--- a/Ansible/README.md
+++ b/Ansible/README.md
@@ -108,8 +108,12 @@ ansible-playbook playbooks/update-sandboxd.yml \
 # Tail recent sandboxd logs from every node:
 ansible-playbook playbooks/tail-logs.yml -e lines=200
 
+# Drain a node and wait until it owns zero placements before a Terraform
+# role change or instance replacement:
+ansible-playbook playbooks/prepare-role-change.yml --limit aerolvm-worker-17
+
 # Configure OTEL/image-pull hardening and deploy backup/recovery,
-# Grafana, Prometheus, Alertmanager, and runbook artifacts:
+# node lifecycle, Grafana, Prometheus, Alertmanager, and runbook artifacts:
 ansible-playbook playbooks/configure-ops.yml \
   -e sandboxd_otel_metrics_endpoint=http://otel-collector:4318/v1/metrics \
   -e sandboxd_backup_enabled=true
@@ -158,6 +162,7 @@ inventory/
 playbooks/
   ping.yml             # connectivity smoke test
   update-sandboxd.yml  # rolling binary push + restart + healthcheck
+  prepare-role-change.yml # drain + wait-empty guard before Terraform role changes
   configure-ops.yml    # OTEL env, image-pull knobs, ops alert/dashboard/runbook files
   tail-logs.yml        # journalctl across the fleet
 ```
@@ -168,6 +173,7 @@ playbooks/
 |-------------------------------------------------|-------------|
 | Add / remove / resize nodes                     | Terraform   |
 | Change SG rules, DNS, AMI                       | Terraform   |
+| Drain a node before Terraform role changes      | Ansible     |
 | Push a new `sandboxd` binary                    | Ansible     |
 | Change OTEL/image-pull env on running nodes     | Ansible     |
 | Deploy backup/recovery helpers or backup cron   | Ansible     |

--- a/Ansible/README.md
+++ b/Ansible/README.md
@@ -109,7 +109,7 @@ ansible-playbook playbooks/update-sandboxd.yml \
 ansible-playbook playbooks/tail-logs.yml -e lines=200
 
 # Configure OTEL/image-pull hardening and deploy backup/recovery,
-# Grafana, Prometheus, and Alertmanager artifacts:
+# Grafana, Prometheus, Alertmanager, and runbook artifacts:
 ansible-playbook playbooks/configure-ops.yml \
   -e sandboxd_otel_metrics_endpoint=http://otel-collector:4318/v1/metrics \
   -e sandboxd_backup_enabled=true
@@ -158,7 +158,7 @@ inventory/
 playbooks/
   ping.yml             # connectivity smoke test
   update-sandboxd.yml  # rolling binary push + restart + healthcheck
-  configure-ops.yml    # OTEL env, image-pull knobs, ops alert/dashboard files
+  configure-ops.yml    # OTEL env, image-pull knobs, ops alert/dashboard/runbook files
   tail-logs.yml        # journalctl across the fleet
 ```
 
@@ -172,6 +172,7 @@ playbooks/
 | Change OTEL/image-pull env on running nodes     | Ansible     |
 | Deploy backup/recovery helpers or backup cron   | Ansible     |
 | Deploy Grafana/Prometheus/Alertmanager artifacts | Ansible     |
+| Deploy operational runbooks                     | Ansible     |
 | Restart a service, rotate a PAT, tail logs      | Ansible     |
 | Run one-off shell commands across many nodes    | Ansible     |
 

--- a/Ansible/inventory/group_vars/all.yml
+++ b/Ansible/inventory/group_vars/all.yml
@@ -18,6 +18,9 @@ sandboxd_runbook_dir: /etc/sandboxd/runbooks
 sandboxd_otel_metrics_enabled: false
 sandboxd_otel_metrics_endpoint: ""
 sandboxd_otel_metrics_interval: "30s"
+sandboxd_otel_traces_enabled: false
+sandboxd_otel_traces_endpoint: ""
+sandboxd_otel_traces_sample_ratio: 0.05
 sandboxd_otel_service_name: "sandboxd"
 sandboxd_image_pull_max_concurrent: 4
 sandboxd_image_pull_failure_backoff: "30s"

--- a/Ansible/inventory/group_vars/all.yml
+++ b/Ansible/inventory/group_vars/all.yml
@@ -4,5 +4,24 @@
 sandboxd_binary_path:   /usr/local/bin/sandboxd
 sandboxd_service_name:  sandboxd
 sandboxd_env_file:      /etc/sandboxd/sandboxd.env
+sandboxd_cluster_env_file: /etc/sandboxd/cluster.env
 sandboxd_health_url:    "http://127.0.0.1:21212/health"
 sandboxd_health_wait_s: 30
+sandboxd_ops_script_dir: /usr/local/sbin
+sandboxd_grafana_dashboard_dir: /etc/sandboxd/grafana
+
+# Observability / pull-storm controls managed by playbooks/configure-ops.yml.
+sandboxd_otel_metrics_enabled: false
+sandboxd_otel_metrics_endpoint: ""
+sandboxd_otel_metrics_interval: "30s"
+sandboxd_otel_service_name: "sandboxd"
+sandboxd_image_pull_max_concurrent: 4
+sandboxd_image_pull_failure_backoff: "30s"
+sandboxd_restart_after_ops_config: true
+
+# Optional local backup schedule managed by playbooks/configure-ops.yml.
+sandboxd_backup_enabled: false
+sandboxd_backup_output_dir: /var/backups/sandboxd
+sandboxd_backup_cron_minute: "17"
+sandboxd_backup_cron_hour: "2"
+sandboxd_backup_retention_days: 7

--- a/Ansible/inventory/group_vars/all.yml
+++ b/Ansible/inventory/group_vars/all.yml
@@ -9,6 +9,8 @@ sandboxd_health_url:    "http://127.0.0.1:21212/health"
 sandboxd_health_wait_s: 30
 sandboxd_ops_script_dir: /usr/local/sbin
 sandboxd_grafana_dashboard_dir: /etc/sandboxd/grafana
+sandboxd_prometheus_rules_dir: /etc/sandboxd/prometheus
+sandboxd_alertmanager_config_dir: /etc/sandboxd/alertmanager
 
 # Observability / pull-storm controls managed by playbooks/configure-ops.yml.
 sandboxd_otel_metrics_enabled: false

--- a/Ansible/inventory/group_vars/all.yml
+++ b/Ansible/inventory/group_vars/all.yml
@@ -11,6 +11,7 @@ sandboxd_ops_script_dir: /usr/local/sbin
 sandboxd_grafana_dashboard_dir: /etc/sandboxd/grafana
 sandboxd_prometheus_rules_dir: /etc/sandboxd/prometheus
 sandboxd_alertmanager_config_dir: /etc/sandboxd/alertmanager
+sandboxd_runbook_dir: /etc/sandboxd/runbooks
 
 # Observability / pull-storm controls managed by playbooks/configure-ops.yml.
 sandboxd_otel_metrics_enabled: false

--- a/Ansible/inventory/group_vars/all.yml
+++ b/Ansible/inventory/group_vars/all.yml
@@ -8,6 +8,7 @@ sandboxd_cluster_env_file: /etc/sandboxd/cluster.env
 sandboxd_health_url:    "http://127.0.0.1:21212/health"
 sandboxd_health_wait_s: 30
 sandboxd_ops_script_dir: /usr/local/sbin
+sandboxd_lifecycle_script_path: /usr/local/sbin/sandboxd-node-lifecycle.sh
 sandboxd_grafana_dashboard_dir: /etc/sandboxd/grafana
 sandboxd_prometheus_rules_dir: /etc/sandboxd/prometheus
 sandboxd_alertmanager_config_dir: /etc/sandboxd/alertmanager
@@ -28,3 +29,6 @@ sandboxd_backup_output_dir: /var/backups/sandboxd
 sandboxd_backup_cron_minute: "17"
 sandboxd_backup_cron_hour: "2"
 sandboxd_backup_retention_days: 7
+
+# Node lifecycle defaults used by playbooks/prepare-role-change.yml.
+sandboxd_role_change_drain_timeout_s: 3600

--- a/Ansible/playbooks/configure-ops.yml
+++ b/Ansible/playbooks/configure-ops.yml
@@ -4,6 +4,7 @@
 # Usage:
 #   ansible-playbook playbooks/configure-ops.yml \
 #     -e sandboxd_otel_metrics_endpoint=http://otel-collector:4318/v1/metrics \
+#     -e sandboxd_otel_traces_endpoint=http://otel-collector:4318/v1/traces \
 #     -e sandboxd_backup_enabled=true
 
 - name: Configure sandboxd observability and operations
@@ -18,6 +19,9 @@
       SB_OTEL_METRICS_ENABLED: "{{ ((sandboxd_otel_metrics_enabled | bool) or (sandboxd_otel_metrics_endpoint | length > 0)) | string | lower }}"
       SB_OTEL_METRICS_ENDPOINT: "{{ sandboxd_otel_metrics_endpoint }}"
       SB_OTEL_METRICS_INTERVAL: "{{ sandboxd_otel_metrics_interval }}"
+      SB_OTEL_TRACES_ENABLED: "{{ ((sandboxd_otel_traces_enabled | bool) or (sandboxd_otel_traces_endpoint | length > 0)) | string | lower }}"
+      SB_OTEL_TRACES_ENDPOINT: "{{ sandboxd_otel_traces_endpoint }}"
+      SB_OTEL_TRACES_SAMPLE_RATIO: "{{ sandboxd_otel_traces_sample_ratio }}"
       OTEL_SERVICE_NAME: "{{ sandboxd_otel_service_name }}"
       SB_IMAGE_PULL_MAX_CONCURRENT: "{{ sandboxd_image_pull_max_concurrent }}"
       SB_IMAGE_PULL_FAILURE_BACKOFF: "{{ sandboxd_image_pull_failure_backoff }}"

--- a/Ansible/playbooks/configure-ops.yml
+++ b/Ansible/playbooks/configure-ops.yml
@@ -104,6 +104,28 @@
         owner: root
         group: root
 
+    - name: Create runbook artifact directory
+      ansible.builtin.file:
+        path: "{{ sandboxd_runbook_dir }}"
+        state: directory
+        mode: "0755"
+        owner: root
+        group: root
+
+    - name: Deploy sandboxd operational runbooks
+      ansible.builtin.copy:
+        src: "{{ item }}"
+        dest: "{{ sandboxd_runbook_dir }}/{{ item | basename }}"
+        mode: "0644"
+        owner: root
+        group: root
+      loop:
+        - "../../setup/runbooks/README.md"
+        - "../../setup/runbooks/backup-restore.md"
+        - "../../setup/runbooks/lost-quorum-recovery.md"
+        - "../../setup/runbooks/image-pull-storm.md"
+        - "../../setup/runbooks/slo-breach.md"
+
     - name: Write sandboxd operational env vars
       ansible.builtin.lineinfile:
         path: "{{ sandboxd_ops_env_file }}"

--- a/Ansible/playbooks/configure-ops.yml
+++ b/Ansible/playbooks/configure-ops.yml
@@ -55,6 +55,7 @@
         - { src: "../../scripts/sandboxd-backup.sh", dest: "sandboxd-backup.sh" }
         - { src: "../../scripts/sandboxd-restore.sh", dest: "sandboxd-restore.sh" }
         - { src: "../../scripts/raft-lost-quorum-recover.sh", dest: "raft-lost-quorum-recover.sh" }
+        - { src: "../../scripts/sandboxd-node-lifecycle.sh", dest: "sandboxd-node-lifecycle.sh" }
 
     - name: Create Grafana dashboard artifact directory
       ansible.builtin.file:

--- a/Ansible/playbooks/configure-ops.yml
+++ b/Ansible/playbooks/configure-ops.yml
@@ -1,0 +1,135 @@
+---
+# Configure sandboxd operational hardening across the fleet.
+#
+# Usage:
+#   ansible-playbook playbooks/configure-ops.yml \
+#     -e sandboxd_otel_metrics_endpoint=http://otel-collector:4318/v1/metrics \
+#     -e sandboxd_backup_enabled=true
+
+- name: Configure sandboxd observability and operations
+  hosts: all
+  become: true
+  serial: 1
+  any_errors_fatal: true
+  gather_facts: false
+
+  vars:
+    sandboxd_ops_env:
+      SB_OTEL_METRICS_ENABLED: "{{ ((sandboxd_otel_metrics_enabled | bool) or (sandboxd_otel_metrics_endpoint | length > 0)) | string | lower }}"
+      SB_OTEL_METRICS_ENDPOINT: "{{ sandboxd_otel_metrics_endpoint }}"
+      SB_OTEL_METRICS_INTERVAL: "{{ sandboxd_otel_metrics_interval }}"
+      OTEL_SERVICE_NAME: "{{ sandboxd_otel_service_name }}"
+      SB_IMAGE_PULL_MAX_CONCURRENT: "{{ sandboxd_image_pull_max_concurrent }}"
+      SB_IMAGE_PULL_FAILURE_BACKOFF: "{{ sandboxd_image_pull_failure_backoff }}"
+
+  pre_tasks:
+    - name: Check base sandboxd env file
+      ansible.builtin.stat:
+        path: "{{ sandboxd_env_file }}"
+      register: sandboxd_base_env
+
+    - name: Refuse when base sandboxd env file is missing
+      ansible.builtin.assert:
+        that:
+          - sandboxd_base_env.stat.exists
+        fail_msg: "{{ sandboxd_env_file }} is missing; run install.sh/bootstrap first."
+
+    - name: Check cluster env file
+      ansible.builtin.stat:
+        path: "{{ sandboxd_cluster_env_file }}"
+      register: sandboxd_cluster_env
+
+    - name: Pick env file to manage
+      ansible.builtin.set_fact:
+        sandboxd_ops_env_file: "{{ sandboxd_cluster_env_file if sandboxd_cluster_env.stat.exists else sandboxd_env_file }}"
+
+  tasks:
+    - name: Deploy sandboxd backup/recovery helpers
+      ansible.builtin.copy:
+        src: "{{ item.src }}"
+        dest: "{{ sandboxd_ops_script_dir }}/{{ item.dest }}"
+        mode: "0755"
+        owner: root
+        group: root
+      loop:
+        - { src: "../../scripts/sandboxd-backup.sh", dest: "sandboxd-backup.sh" }
+        - { src: "../../scripts/sandboxd-restore.sh", dest: "sandboxd-restore.sh" }
+        - { src: "../../scripts/raft-lost-quorum-recover.sh", dest: "raft-lost-quorum-recover.sh" }
+
+    - name: Create Grafana dashboard artifact directory
+      ansible.builtin.file:
+        path: "{{ sandboxd_grafana_dashboard_dir }}"
+        state: directory
+        mode: "0755"
+        owner: root
+        group: root
+
+    - name: Deploy Grafana SLO dashboard JSON
+      ansible.builtin.copy:
+        src: "../../setup/grafana/sandboxd-slo-dashboard.json"
+        dest: "{{ sandboxd_grafana_dashboard_dir }}/sandboxd-slo-dashboard.json"
+        mode: "0644"
+        owner: root
+        group: root
+
+    - name: Write sandboxd operational env vars
+      ansible.builtin.lineinfile:
+        path: "{{ sandboxd_ops_env_file }}"
+        regexp: "^{{ item.key }}="
+        line: "{{ item.key }}={{ item.value }}"
+        create: false
+        mode: "0600"
+        owner: root
+        group: root
+      loop: "{{ sandboxd_ops_env | dict2items }}"
+      notify: Apply sandboxd ops config
+
+    - name: Create backup output directory
+      when: sandboxd_backup_enabled | bool
+      ansible.builtin.file:
+        path: "{{ sandboxd_backup_output_dir }}"
+        state: directory
+        mode: "0700"
+        owner: root
+        group: root
+
+    - name: Configure local sandboxd backup cron
+      when: sandboxd_backup_enabled | bool
+      ansible.builtin.cron:
+        name: sandboxd local backup
+        minute: "{{ sandboxd_backup_cron_minute }}"
+        hour: "{{ sandboxd_backup_cron_hour }}"
+        user: root
+        job: >-
+          {{ sandboxd_ops_script_dir }}/sandboxd-backup.sh
+          --output {{ sandboxd_backup_output_dir }}/sandboxd-$(hostname)-$(date +\%F-\%H\%M\%S).tar.gz
+          && find {{ sandboxd_backup_output_dir }} -type f -name 'sandboxd-*.tar.gz'
+          -mtime +{{ sandboxd_backup_retention_days }} -delete
+
+    - name: Remove local sandboxd backup cron
+      when: not (sandboxd_backup_enabled | bool)
+      ansible.builtin.cron:
+        name: sandboxd local backup
+        user: root
+        state: absent
+
+  handlers:
+    - name: Restart sandboxd
+      listen: Apply sandboxd ops config
+      when: sandboxd_restart_after_ops_config | bool
+      ansible.builtin.systemd:
+        name: "{{ sandboxd_service_name }}"
+        state: restarted
+        daemon_reload: false
+
+    - name: Wait for sandboxd health
+      listen: Apply sandboxd ops config
+      when: sandboxd_restart_after_ops_config | bool
+      ansible.builtin.uri:
+        url: "{{ sandboxd_health_url }}"
+        status_code: 200
+        return_content: false
+      register: health
+      until: health.status == 200
+      retries: "{{ sandboxd_health_wait_s }}"
+      delay: 1

--- a/Ansible/playbooks/configure-ops.yml
+++ b/Ansible/playbooks/configure-ops.yml
@@ -72,6 +72,38 @@
         owner: root
         group: root
 
+    - name: Create Prometheus alert rule artifact directory
+      ansible.builtin.file:
+        path: "{{ sandboxd_prometheus_rules_dir }}"
+        state: directory
+        mode: "0755"
+        owner: root
+        group: root
+
+    - name: Deploy Prometheus alert rules
+      ansible.builtin.copy:
+        src: "../../setup/prometheus/sandboxd-alerts.yml"
+        dest: "{{ sandboxd_prometheus_rules_dir }}/sandboxd-alerts.yml"
+        mode: "0644"
+        owner: root
+        group: root
+
+    - name: Create Alertmanager example artifact directory
+      ansible.builtin.file:
+        path: "{{ sandboxd_alertmanager_config_dir }}"
+        state: directory
+        mode: "0755"
+        owner: root
+        group: root
+
+    - name: Deploy Alertmanager example config
+      ansible.builtin.copy:
+        src: "../../setup/alertmanager/sandboxd-alertmanager-example.yml"
+        dest: "{{ sandboxd_alertmanager_config_dir }}/sandboxd-alertmanager-example.yml"
+        mode: "0644"
+        owner: root
+        group: root
+
     - name: Write sandboxd operational env vars
       ansible.builtin.lineinfile:
         path: "{{ sandboxd_ops_env_file }}"

--- a/Ansible/playbooks/prepare-role-change.yml
+++ b/Ansible/playbooks/prepare-role-change.yml
@@ -16,6 +16,21 @@
   gather_facts: false
 
   tasks:
+    - name: Refuse to run without an explicit --limit (or confirm_drain_all=true)
+      # `hosts: all` is intentional so an operator can target any single node
+      # with --limit, but forgetting --limit would serially drain every host
+      # in the inventory. Require either --limit, or an opt-in override for
+      # the rare case where draining the whole inventory is the actual goal.
+      run_once: true
+      ansible.builtin.assert:
+        that:
+          - (ansible_limit is defined and ansible_limit | length > 0)
+            or (confirm_drain_all | default(false) | bool)
+        fail_msg: >-
+          Refusing to run without --limit. Pass --limit <host> to drain a
+          single node, or -e confirm_drain_all=true to drain every host in
+          the inventory on purpose.
+
     - name: Deploy sandboxd node lifecycle helper
       ansible.builtin.copy:
         src: "../../scripts/sandboxd-node-lifecycle.sh"

--- a/Ansible/playbooks/prepare-role-change.yml
+++ b/Ansible/playbooks/prepare-role-change.yml
@@ -1,0 +1,62 @@
+---
+# Drain a node before a Terraform role change or instance replacement.
+#
+# Usage:
+#   ansible-playbook playbooks/prepare-role-change.yml --limit aerolvm-worker-17
+#
+# The playbook marks the node drained in the cluster FSM and waits until the
+# node owns zero placements. If long-lived sandboxes remain, it fails before
+# Terraform can recreate the instance and lose those workloads.
+
+- name: Prepare sandboxd nodes for role change
+  hosts: all
+  become: true
+  serial: 1
+  any_errors_fatal: true
+  gather_facts: false
+
+  tasks:
+    - name: Deploy sandboxd node lifecycle helper
+      ansible.builtin.copy:
+        src: "../../scripts/sandboxd-node-lifecycle.sh"
+        dest: "{{ sandboxd_lifecycle_script_path }}"
+        mode: "0755"
+        owner: root
+        group: root
+
+    - name: Check sandboxd base env file
+      ansible.builtin.stat:
+        path: "{{ sandboxd_env_file }}"
+      register: sandboxd_base_env
+
+    - name: Refuse when sandboxd base env file is missing
+      ansible.builtin.assert:
+        that:
+          - sandboxd_base_env.stat.exists
+        fail_msg: "{{ sandboxd_env_file }} is missing; run install.sh/bootstrap first."
+
+    - name: Check sandboxd cluster env file
+      ansible.builtin.stat:
+        path: "{{ sandboxd_cluster_env_file }}"
+      register: sandboxd_cluster_env
+
+    - name: Refuse when sandboxd cluster env file is missing
+      ansible.builtin.assert:
+        that:
+          - sandboxd_cluster_env.stat.exists
+        fail_msg: "{{ sandboxd_cluster_env_file }} is missing; this playbook is only for cluster nodes."
+
+    - name: Drain node and wait for owned placements to leave
+      ansible.builtin.command:
+        cmd: >-
+          {{ sandboxd_lifecycle_script_path }}
+          pre-role-change
+          --env-file {{ sandboxd_env_file }}
+          --env-file {{ sandboxd_cluster_env_file }}
+          --timeout {{ sandboxd_role_change_drain_timeout_s }}
+      register: drain_result
+      changed_when: "'drained node' in drain_result.stdout"
+
+    - name: Report drain result
+      ansible.builtin.debug:
+        msg: "{{ drain_result.stdout_lines }}"

--- a/Terraform/README.md
+++ b/Terraform/README.md
@@ -135,6 +135,8 @@ for a Prometheus running inside the VPC:
 ```hcl
 otel_metrics_endpoint = "http://otel-collector.internal:4318/v1/metrics"
 otel_metrics_interval = "30s"
+otel_traces_endpoint = "http://otel-collector.internal:4318/v1/traces"
+otel_traces_sample_ratio = 0.05
 otel_service_name     = "sandboxd"
 
 image_pull_max_concurrent  = 4

--- a/Terraform/README.md
+++ b/Terraform/README.md
@@ -146,6 +146,7 @@ The repo-local observability artifacts to import are:
 - Grafana dashboard: `../setup/grafana/sandboxd-slo-dashboard.json`
 - Prometheus alerts: `../setup/prometheus/sandboxd-alerts.yml`
 - Alertmanager example: `../setup/alertmanager/sandboxd-alertmanager-example.yml`
+- Operational runbooks: `../setup/runbooks/`
 
 ## Cloudflare DNS
 

--- a/Terraform/README.md
+++ b/Terraform/README.md
@@ -36,7 +36,9 @@ terraform apply
 ```
 
 Outputs include every node's public IP, the seed's SSH command, and the
-verify-cluster `curl`. Watch one node's bootstrap with:
+verify-cluster `curl`. They also include Prometheus scrape targets for
+`/v1/metrics` on every node's private API address. Watch one node's bootstrap
+with:
 
 ```bash
 ssh ubuntu@<public-ip> sudo tail -f /var/log/aerolvm-bootstrap.log
@@ -116,10 +118,31 @@ phases:
    runs `cluster-join.sh --role <its-role> --ingress-advertise-host
    <domain_name> --gossip-key <…> --peers <seed-private-ip>:7001 --tls-bundle
    /tmp/aerolvm-tls-bundle.tar.gz`.
+4. **Operational env** is appended to `/etc/sandboxd/cluster.env` on every
+   node: OTEL metrics settings and image-pull storm controls. The bootstrap
+   then restarts sandboxd once so those env vars are active immediately.
 
 The S3 bucket is private, SSE-encrypted, and `force_destroy = true` by
 default so `terraform destroy` doesn't fail on leftover objects. Flip
 `bundle_bucket_force_destroy = false` if you want belt-and-braces.
+
+## Observability and pull-storm controls
+
+Prometheus scraping is always available at `GET /v1/metrics` on each node's
+API port. The `prometheus_scrape_targets` output returns private-IP targets
+for a Prometheus running inside the VPC:
+
+```hcl
+otel_metrics_endpoint = "http://otel-collector.internal:4318/v1/metrics"
+otel_metrics_interval = "30s"
+otel_service_name     = "sandboxd"
+
+image_pull_max_concurrent  = 4
+image_pull_failure_backoff = "30s"
+```
+
+The Grafana dashboard JSON to import is
+`../setup/grafana/sandboxd-slo-dashboard.json`.
 
 ## Cloudflare DNS
 

--- a/Terraform/README.md
+++ b/Terraform/README.md
@@ -141,8 +141,11 @@ image_pull_max_concurrent  = 4
 image_pull_failure_backoff = "30s"
 ```
 
-The Grafana dashboard JSON to import is
-`../setup/grafana/sandboxd-slo-dashboard.json`.
+The repo-local observability artifacts to import are:
+
+- Grafana dashboard: `../setup/grafana/sandboxd-slo-dashboard.json`
+- Prometheus alerts: `../setup/prometheus/sandboxd-alerts.yml`
+- Alertmanager example: `../setup/alertmanager/sandboxd-alertmanager-example.yml`
 
 ## Cloudflare DNS
 

--- a/Terraform/nodes.tf
+++ b/Terraform/nodes.tf
@@ -59,6 +59,9 @@ resource "aws_instance" "seed" {
     otel_metrics_enabled       = var.otel_metrics_enabled || var.otel_metrics_endpoint != ""
     otel_metrics_endpoint      = var.otel_metrics_endpoint
     otel_metrics_interval      = var.otel_metrics_interval
+    otel_traces_enabled        = var.otel_traces_enabled || var.otel_traces_endpoint != ""
+    otel_traces_endpoint       = var.otel_traces_endpoint
+    otel_traces_sample_ratio   = var.otel_traces_sample_ratio
     otel_service_name          = var.otel_service_name
     image_pull_max_concurrent  = var.image_pull_max_concurrent
     image_pull_failure_backoff = var.image_pull_failure_backoff
@@ -129,6 +132,9 @@ resource "aws_instance" "joiner" {
     otel_metrics_enabled       = var.otel_metrics_enabled || var.otel_metrics_endpoint != ""
     otel_metrics_endpoint      = var.otel_metrics_endpoint
     otel_metrics_interval      = var.otel_metrics_interval
+    otel_traces_enabled        = var.otel_traces_enabled || var.otel_traces_endpoint != ""
+    otel_traces_endpoint       = var.otel_traces_endpoint
+    otel_traces_sample_ratio   = var.otel_traces_sample_ratio
     otel_service_name          = var.otel_service_name
     image_pull_max_concurrent  = var.image_pull_max_concurrent
     image_pull_failure_backoff = var.image_pull_failure_backoff

--- a/Terraform/nodes.tf
+++ b/Terraform/nodes.tf
@@ -39,24 +39,30 @@ resource "aws_instance" "seed" {
   user_data_replace_on_change = true
 
   user_data = templatefile("${path.module}/templates/bootstrap.sh.tftpl", {
-    node_name               = "${var.cluster_name}-${local.seed_node.name}"
-    role                    = local.seed_node.role
-    is_seed                 = true
-    domain                  = var.domain_name
-    pat_token               = var.pat_token
-    cloudflare_api_token    = var.cloudflare_api_token
-    with_gvisor             = local.seed_node.with_gvisor
-    with_nvidia_gpu         = local.seed_node.with_nvidia_gpu
-    with_amd_gpu            = local.seed_node.with_amd_gpu
-    idle_timeout_min        = local.seed_node.idle_timeout_min
-    bundle_bucket           = aws_s3_bucket.bundle.bucket
-    aws_region              = var.aws_region
-    seed_private_ip         = ""
-    install_script_url      = var.install_script_url
-    cluster_init_script_url = var.cluster_init_script_url
-    cluster_join_script_url = var.cluster_join_script_url
-    seed_wait_max_seconds   = var.seed_wait_max_seconds
-    extra_user_data         = local.seed_node.extra_user_data
+    node_name                  = "${var.cluster_name}-${local.seed_node.name}"
+    role                       = local.seed_node.role
+    is_seed                    = true
+    domain                     = var.domain_name
+    pat_token                  = var.pat_token
+    cloudflare_api_token       = var.cloudflare_api_token
+    with_gvisor                = local.seed_node.with_gvisor
+    with_nvidia_gpu            = local.seed_node.with_nvidia_gpu
+    with_amd_gpu               = local.seed_node.with_amd_gpu
+    idle_timeout_min           = local.seed_node.idle_timeout_min
+    bundle_bucket              = aws_s3_bucket.bundle.bucket
+    aws_region                 = var.aws_region
+    seed_private_ip            = ""
+    install_script_url         = var.install_script_url
+    cluster_init_script_url    = var.cluster_init_script_url
+    cluster_join_script_url    = var.cluster_join_script_url
+    seed_wait_max_seconds      = var.seed_wait_max_seconds
+    otel_metrics_enabled       = var.otel_metrics_enabled || var.otel_metrics_endpoint != ""
+    otel_metrics_endpoint      = var.otel_metrics_endpoint
+    otel_metrics_interval      = var.otel_metrics_interval
+    otel_service_name          = var.otel_service_name
+    image_pull_max_concurrent  = var.image_pull_max_concurrent
+    image_pull_failure_backoff = var.image_pull_failure_backoff
+    extra_user_data            = local.seed_node.extra_user_data
   })
 
   tags = merge(
@@ -103,24 +109,30 @@ resource "aws_instance" "joiner" {
   user_data_replace_on_change = true
 
   user_data = templatefile("${path.module}/templates/bootstrap.sh.tftpl", {
-    node_name               = "${var.cluster_name}-${each.value.name}"
-    role                    = each.value.role
-    is_seed                 = false
-    domain                  = var.domain_name
-    pat_token               = var.pat_token
-    cloudflare_api_token    = var.cloudflare_api_token
-    with_gvisor             = each.value.with_gvisor
-    with_nvidia_gpu         = each.value.with_nvidia_gpu
-    with_amd_gpu            = each.value.with_amd_gpu
-    idle_timeout_min        = each.value.idle_timeout_min
-    bundle_bucket           = aws_s3_bucket.bundle.bucket
-    aws_region              = var.aws_region
-    seed_private_ip         = aws_instance.seed.private_ip
-    install_script_url      = var.install_script_url
-    cluster_init_script_url = var.cluster_init_script_url
-    cluster_join_script_url = var.cluster_join_script_url
-    seed_wait_max_seconds   = var.seed_wait_max_seconds
-    extra_user_data         = each.value.extra_user_data
+    node_name                  = "${var.cluster_name}-${each.value.name}"
+    role                       = each.value.role
+    is_seed                    = false
+    domain                     = var.domain_name
+    pat_token                  = var.pat_token
+    cloudflare_api_token       = var.cloudflare_api_token
+    with_gvisor                = each.value.with_gvisor
+    with_nvidia_gpu            = each.value.with_nvidia_gpu
+    with_amd_gpu               = each.value.with_amd_gpu
+    idle_timeout_min           = each.value.idle_timeout_min
+    bundle_bucket              = aws_s3_bucket.bundle.bucket
+    aws_region                 = var.aws_region
+    seed_private_ip            = aws_instance.seed.private_ip
+    install_script_url         = var.install_script_url
+    cluster_init_script_url    = var.cluster_init_script_url
+    cluster_join_script_url    = var.cluster_join_script_url
+    seed_wait_max_seconds      = var.seed_wait_max_seconds
+    otel_metrics_enabled       = var.otel_metrics_enabled || var.otel_metrics_endpoint != ""
+    otel_metrics_endpoint      = var.otel_metrics_endpoint
+    otel_metrics_interval      = var.otel_metrics_interval
+    otel_service_name          = var.otel_service_name
+    image_pull_max_concurrent  = var.image_pull_max_concurrent
+    image_pull_failure_backoff = var.image_pull_failure_backoff
+    extra_user_data            = each.value.extra_user_data
   })
 
   depends_on = [aws_instance.seed]

--- a/Terraform/outputs.tf
+++ b/Terraform/outputs.tf
@@ -64,3 +64,8 @@ output "alertmanager_example_file" {
   description = "Repo-local Alertmanager example route/receiver config."
   value       = "setup/alertmanager/sandboxd-alertmanager-example.yml"
 }
+
+output "operational_runbooks_dir" {
+  description = "Repo-local operator runbooks for restore, lost quorum, image-pull storms, and SLO breaches."
+  value       = "setup/runbooks"
+}

--- a/Terraform/outputs.tf
+++ b/Terraform/outputs.tf
@@ -44,3 +44,13 @@ output "verify_cluster_command" {
   description = "Run this from any node (after bootstrap) to confirm membership."
   value       = "curl -s -H 'Authorization: Bearer <PAT>' http://127.0.0.1:21212/v1/cluster/members | jq ."
 }
+
+output "prometheus_scrape_targets" {
+  description = "Private-IP sandboxd API targets for Prometheus scraping with metrics_path=/v1/metrics and bearer_token=<PAT>."
+  value       = [for n, inst in local.all_instances : "${inst.private_ip}:21212"]
+}
+
+output "grafana_dashboard_file" {
+  description = "Repo-local dashboard JSON to import into Grafana."
+  value       = "setup/grafana/sandboxd-slo-dashboard.json"
+}

--- a/Terraform/outputs.tf
+++ b/Terraform/outputs.tf
@@ -54,3 +54,13 @@ output "grafana_dashboard_file" {
   description = "Repo-local dashboard JSON to import into Grafana."
   value       = "setup/grafana/sandboxd-slo-dashboard.json"
 }
+
+output "prometheus_alert_rules_file" {
+  description = "Repo-local Prometheus alert rule file for sandboxd SLOs."
+  value       = "setup/prometheus/sandboxd-alerts.yml"
+}
+
+output "alertmanager_example_file" {
+  description = "Repo-local Alertmanager example route/receiver config."
+  value       = "setup/alertmanager/sandboxd-alertmanager-example.yml"
+}

--- a/Terraform/templates/bootstrap.sh.tftpl
+++ b/Terraform/templates/bootstrap.sh.tftpl
@@ -130,6 +130,26 @@ sudo /tmp/cluster-join.sh \
   --tls-bundle /tmp/aerolvm-tls-bundle.tar.gz
 %{ endif ~}
 
+###############################################################################
+# 3. Operational hardening env
+#
+# cluster-init/join writes /etc/sandboxd/cluster.env and the systemd drop-in
+# already includes it. Append the observability and image-pull storm controls
+# Terraform owns, then restart so the just-bootstrapped daemon picks them up.
+###############################################################################
+cat > /tmp/aerolvm-ops.env <<'EOF'
+
+# Managed by Terraform bootstrap: observability and operational hardening.
+SB_OTEL_METRICS_ENABLED=${otel_metrics_enabled}
+SB_OTEL_METRICS_ENDPOINT=${otel_metrics_endpoint}
+SB_OTEL_METRICS_INTERVAL=${otel_metrics_interval}
+OTEL_SERVICE_NAME=${otel_service_name}
+SB_IMAGE_PULL_MAX_CONCURRENT=${image_pull_max_concurrent}
+SB_IMAGE_PULL_FAILURE_BACKOFF=${image_pull_failure_backoff}
+EOF
+sudo tee -a /etc/sandboxd/cluster.env < /tmp/aerolvm-ops.env >/dev/null
+sudo systemctl restart sandboxd
+
 ${extra_user_data}
 
 echo "[bootstrap] complete"

--- a/Terraform/templates/bootstrap.sh.tftpl
+++ b/Terraform/templates/bootstrap.sh.tftpl
@@ -143,6 +143,9 @@ cat > /tmp/aerolvm-ops.env <<'EOF'
 SB_OTEL_METRICS_ENABLED=${otel_metrics_enabled}
 SB_OTEL_METRICS_ENDPOINT=${otel_metrics_endpoint}
 SB_OTEL_METRICS_INTERVAL=${otel_metrics_interval}
+SB_OTEL_TRACES_ENABLED=${otel_traces_enabled}
+SB_OTEL_TRACES_ENDPOINT=${otel_traces_endpoint}
+SB_OTEL_TRACES_SAMPLE_RATIO=${otel_traces_sample_ratio}
 OTEL_SERVICE_NAME=${otel_service_name}
 SB_IMAGE_PULL_MAX_CONCURRENT=${image_pull_max_concurrent}
 SB_IMAGE_PULL_FAILURE_BACKOFF=${image_pull_failure_backoff}

--- a/Terraform/terraform.tfvars.example
+++ b/Terraform/terraform.tfvars.example
@@ -45,6 +45,22 @@ default_volume_type       = "gp3"
 # default_with_amd_gpu     = false   # adds --with-amd-gpu (x86_64 only)
 # default_idle_timeout_min = 0       # sandbox auto-stop minutes; 0 disables
 
+# --- Observability / operational hardening ----------------------------------
+
+# Prometheus scrapes every node at /v1/metrics with the shared PAT. Terraform
+# outputs private-IP scrape targets after apply.
+#
+# Native OTEL metrics export is optional. Setting otel_metrics_endpoint enables
+# SB_OTEL_METRICS_ENABLED and writes SB_OTEL_METRICS_ENDPOINT into cluster.env.
+# otel_metrics_endpoint = "http://otel-collector.internal:4318/v1/metrics"
+# otel_metrics_interval = "30s"
+# otel_service_name     = "sandboxd"
+
+# Docker image-pull storm controls. These are written into cluster.env on every
+# node; defaults match sandboxd's runtime defaults.
+# image_pull_max_concurrent  = 4
+# image_pull_failure_backoff = "30s"
+
 # --- Cloudflare DNS behavior ------------------------------------------------
 
 # create_wildcard_record = true   # *.<domain_name> in addition to the apex

--- a/Terraform/terraform.tfvars.example
+++ b/Terraform/terraform.tfvars.example
@@ -50,10 +50,12 @@ default_volume_type       = "gp3"
 # Prometheus scrapes every node at /v1/metrics with the shared PAT. Terraform
 # outputs private-IP scrape targets after apply.
 #
-# Native OTEL metrics export is optional. Setting otel_metrics_endpoint enables
-# SB_OTEL_METRICS_ENABLED and writes SB_OTEL_METRICS_ENDPOINT into cluster.env.
+# Native OTEL export is optional. Setting an endpoint enables the matching
+# exporter and writes the SB_OTEL_* values into cluster.env.
 # otel_metrics_endpoint = "http://otel-collector.internal:4318/v1/metrics"
 # otel_metrics_interval = "30s"
+# otel_traces_endpoint = "http://otel-collector.internal:4318/v1/traces"
+# otel_traces_sample_ratio = 0.05
 # otel_service_name     = "sandboxd"
 
 # Docker image-pull storm controls. These are written into cluster.env on every

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -278,6 +278,61 @@ variable "default_idle_timeout_min" {
 }
 
 ###############################################################################
+# Observability and operational hardening
+###############################################################################
+
+variable "otel_metrics_enabled" {
+  description = "Enable sandboxd's native OTLP/HTTP metrics exporter. Automatically true when otel_metrics_endpoint is non-empty."
+  type        = bool
+  default     = false
+}
+
+variable "otel_metrics_endpoint" {
+  description = "OTLP/HTTP metrics endpoint written as SB_OTEL_METRICS_ENDPOINT, for example http://otel-collector:4318/v1/metrics. Empty disables endpoint-specific config."
+  type        = string
+  default     = ""
+}
+
+variable "otel_metrics_interval" {
+  description = "sandboxd OTEL metrics export interval written as SB_OTEL_METRICS_INTERVAL."
+  type        = string
+  default     = "30s"
+
+  validation {
+    condition     = can(regex("^[0-9]+(ns|us|ms|s|m|h)$", var.otel_metrics_interval))
+    error_message = "otel_metrics_interval must be a Go duration such as 30s, 1m, or 500ms."
+  }
+}
+
+variable "otel_service_name" {
+  description = "OTEL_SERVICE_NAME written into sandboxd env."
+  type        = string
+  default     = "sandboxd"
+}
+
+variable "image_pull_max_concurrent" {
+  description = "Per-worker cap on concurrent Docker image pulls. 0 disables the cap."
+  type        = number
+  default     = 4
+
+  validation {
+    condition     = var.image_pull_max_concurrent >= 0
+    error_message = "image_pull_max_concurrent must be >= 0."
+  }
+}
+
+variable "image_pull_failure_backoff" {
+  description = "Per-image/auth retry suppression after a failed pull, written as SB_IMAGE_PULL_FAILURE_BACKOFF. Use 0s to disable."
+  type        = string
+  default     = "30s"
+
+  validation {
+    condition     = can(regex("^[0-9]+(ns|us|ms|s|m|h)$", var.image_pull_failure_backoff))
+    error_message = "image_pull_failure_backoff must be a Go duration such as 30s, 1m, or 0s."
+  }
+}
+
+###############################################################################
 # Cloudflare DNS
 ###############################################################################
 

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -304,6 +304,29 @@ variable "otel_metrics_interval" {
   }
 }
 
+variable "otel_traces_enabled" {
+  description = "Enable sandboxd's native OTLP/HTTP trace exporter. Automatically true when otel_traces_endpoint is non-empty."
+  type        = bool
+  default     = false
+}
+
+variable "otel_traces_endpoint" {
+  description = "OTLP/HTTP traces endpoint written as SB_OTEL_TRACES_ENDPOINT, for example http://otel-collector:4318/v1/traces. Empty disables endpoint-specific config."
+  type        = string
+  default     = ""
+}
+
+variable "otel_traces_sample_ratio" {
+  description = "Parent-based trace sample ratio written as SB_OTEL_TRACES_SAMPLE_RATIO. 0 disables local sampling; 1 samples every root trace."
+  type        = number
+  default     = 0.05
+
+  validation {
+    condition     = var.otel_traces_sample_ratio >= 0 && var.otel_traces_sample_ratio <= 1
+    error_message = "otel_traces_sample_ratio must be between 0 and 1."
+  }
+}
+
 variable "otel_service_name" {
   description = "OTEL_SERVICE_NAME written into sandboxd env."
   type        = string

--- a/cmd/sandboxd/main.go
+++ b/cmd/sandboxd/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aerol-ai/microvm/internal/cluster"
 	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/internal/observability"
 	"github.com/aerol-ai/microvm/internal/service"
 	"github.com/aerol-ai/microvm/internal/store"
 	"github.com/aerol-ai/microvm/internal/version"
@@ -37,6 +38,26 @@ func main() {
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
+
+	otelShutdown, err := observability.StartOTELMetrics(ctx, logger, observability.OTELMetricsConfig{
+		Enabled:     cfg.OTELMetricsEnabled,
+		Endpoint:    cfg.OTELMetricsEndpoint,
+		Interval:    cfg.OTELMetricsInterval,
+		ServiceName: cfg.OTELServiceName,
+		NodeID:      cfg.NodeID,
+		NodeRole:    cfg.NodeRole,
+	})
+	if err != nil {
+		logger.Warn("failed to start otel metrics exporter", "error", err)
+	} else if otelShutdown != nil {
+		defer func() {
+			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer shutdownCancel()
+			if err := otelShutdown(shutdownCtx); err != nil {
+				logger.Warn("otel metrics shutdown failed", "error", err)
+			}
+		}()
+	}
 
 	db, err := store.Open(cfg.DBPath)
 	if err != nil {

--- a/cmd/sandboxd/main.go
+++ b/cmd/sandboxd/main.go
@@ -39,6 +39,26 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
+	otelTracesShutdown, err := observability.StartOTELTraces(ctx, logger, observability.OTELTracesConfig{
+		Enabled:     cfg.OTELTracesEnabled,
+		Endpoint:    cfg.OTELTracesEndpoint,
+		SampleRatio: cfg.OTELTracesSampleRatio,
+		ServiceName: cfg.OTELServiceName,
+		NodeID:      cfg.NodeID,
+		NodeRole:    cfg.NodeRole,
+	})
+	if err != nil {
+		logger.Warn("failed to start otel trace exporter", "error", err)
+	} else if otelTracesShutdown != nil {
+		defer func() {
+			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer shutdownCancel()
+			if err := otelTracesShutdown(shutdownCtx); err != nil {
+				logger.Warn("otel trace shutdown failed", "error", err)
+			}
+		}()
+	}
+
 	otelShutdown, err := observability.StartOTELMetrics(ctx, logger, observability.OTELMetricsConfig{
 		Enabled:     cfg.OTELMetricsEnabled,
 		Endpoint:    cfg.OTELMetricsEndpoint,

--- a/cmd/sandboxd/main.go
+++ b/cmd/sandboxd/main.go
@@ -378,6 +378,7 @@ func specFromSandbox(svc *service.Service, sb *models.Sandbox, logger *slog.Logg
 		ContainerCommand: sb.ContainerCommand,
 		Runtime:          sb.Runtime,
 		GPUs:             sb.GPUs,
+		Failover:         sb.Failover,
 	}
 	// Lifecycle on Sandbox is value-typed; spec wants a pointer so the JSON
 	// "omitempty" stays meaningful for fresh creates that didn't pass one.

--- a/cmd/sandboxd/main.go
+++ b/cmd/sandboxd/main.go
@@ -125,15 +125,18 @@ func main() {
 			"error", err,
 		)
 	}
+	// Keep the detected disk total separate from the admission budget so we
+	// can log it for observability without changing placement behavior on
+	// deployments that never configured SB_HOST_DISK_GB. Disk admission stays
+	// opt-in: DiskTotalGB only carries the operator's declared budget.
+	detectedDiskTotalGB := host.DiskTotalGB
 	if cfg.HostCPUCoresOverride > 0 {
 		host.CPUCores = cfg.HostCPUCoresOverride
 	}
 	if cfg.HostMemoryMBOverride > 0 {
 		host.MemoryTotalMB = cfg.HostMemoryMBOverride
 	}
-	if cfg.HostDiskGB > 0 {
-		host.DiskTotalGB = cfg.HostDiskGB
-	}
+	host.DiskTotalGB = max(cfg.HostDiskGB, 0)
 	host.GPUCount = cfg.HostGPUCount
 	host.GPUVendor = cfg.HostGPUVendor
 	host.SupportedRuntimes = cfg.HostSupportedRuntimes
@@ -149,6 +152,7 @@ func main() {
 		"host_cpu_cores", host.CPUCores,
 		"host_memory_mb", host.MemoryTotalMB,
 		"host_disk_gb", host.DiskTotalGB,
+		"host_disk_detected_gb", detectedDiskTotalGB,
 		"host_disk_free_gb", host.DiskFreeGB,
 		"host_gpu_count", host.GPUCount,
 		"host_gpu_vendor", host.GPUVendor,

--- a/cmd/sandboxd/main.go
+++ b/cmd/sandboxd/main.go
@@ -90,7 +90,9 @@ func main() {
 	if cfg.HostMemoryMBOverride > 0 {
 		host.MemoryTotalMB = cfg.HostMemoryMBOverride
 	}
-	host.DiskTotalGB = cfg.HostDiskGB
+	if cfg.HostDiskGB > 0 {
+		host.DiskTotalGB = cfg.HostDiskGB
+	}
 	host.GPUCount = cfg.HostGPUCount
 	host.GPUVendor = cfg.HostGPUVendor
 	host.SupportedRuntimes = cfg.HostSupportedRuntimes
@@ -106,6 +108,7 @@ func main() {
 		"host_cpu_cores", host.CPUCores,
 		"host_memory_mb", host.MemoryTotalMB,
 		"host_disk_gb", host.DiskTotalGB,
+		"host_disk_free_gb", host.DiskFreeGB,
 		"host_gpu_count", host.GPUCount,
 		"host_gpu_vendor", host.GPUVendor,
 		"host_supported_runtimes", host.SupportedRuntimes,

--- a/docs/network-isolation.md
+++ b/docs/network-isolation.md
@@ -119,25 +119,37 @@ the rule isn't firing. Common causes:
   scale; not worth the complexity until you're at >1000 concurrent
   blocked sandboxes.
 
+## Reconcile and reboot recovery
+
+`networkBlockAll` is stored on the sandbox row and reconciled from Docker's
+current runtime view. On every boot reconcile and periodic reconcile pass,
+`sandboxd`:
+
+1. Lists the managed containers Docker currently has.
+2. Refreshes each sandbox row with the container's current ID and IP.
+3. Re-applies `BlockAllEgress(<current container IP>)` for every running
+   sandbox with `networkBlockAll=true`.
+
+This means host reboot, Docker chain rebuild, `iptables` flush, or a missed
+create/start rule install is healed by the next reconcile pass. The reapply is
+idempotent: the netrules manager checks for an existing `DOCKER-USER` rule
+before inserting, so running reconcile repeatedly does not create duplicate
+rules.
+
+You can force the same repair immediately:
+
+```bash
+curl -fsS -X POST -H "Authorization: Bearer $SB_PAT_TOKEN" \
+  http://127.0.0.1:21212/v1/admin/reconcile
+```
+
 ## Cleanup
 
-`ClearBlockAllEgress` is called in two places:
-
-1. `Destroy` (always) - removes the DROP rule when the sandbox is
-   destroyed.
-2. Reconcile (boot) - currently no-op for blocked containers (we don't
-   re-apply rules during reconcile because Docker's IPs may have
-   changed; the rule survives reboots only if iptables is persisted by
-   the host).
-
-⚠️ **iptables rules do not survive a host reboot by default**. If
-`networkBlockAll` is critical for security on your host, install
-`iptables-persistent` (Debian/Ubuntu) and persist after each
-sandbox change, OR run a periodic re-apply in `sandboxd`. The current
-implementation does the former - when the host reboots, the rules are
-gone until a new sandbox is created or destroyed.
-
-This is a real gap for production hardening; track in TODO.
+`ClearBlockAllEgress` is called when the sandbox is destroyed or when the
+runtime reports a stop/die/destroy event for that container IP. The stop path
+clears the per-IP rule because Docker may later assign that IP to an unrelated
+container. A later `Start` or reconcile pass re-applies the rule if the sandbox
+is still configured with `networkBlockAll=true`.
 
 ## File map
 
@@ -145,4 +157,5 @@ This is a real gap for production hardening; track in TODO.
 | --- | --- |
 | `pkg/docker/netrules/manager.go` | `Manager`, `BlockAllEgress`, `ClearBlockAllEgress` |
 | `pkg/docker/client.go` | calls `BlockAllEgress` after container start when `req.NetworkBlockAll` is set |
+| `internal/service/service.go` | re-applies `networkBlockAll` during start and reconcile using Docker's current container IP |
 | `internal/config/config.go` | `EnableNetworkRules` (env: `SB_ENABLE_NETWORK_RULES`, default `true`) |

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -256,6 +256,12 @@ const getDocsSidebarConfig = (): NavigationGroup[] => [
         label: 'Dashboard',
         description: 'Built-in operator dashboard for cluster, capacity, placements, and metrics — sign in with your PAT.',
       },
+      {
+        type: 'link',
+        href: '/operational-runbooks',
+        label: 'Operational Runbooks',
+        description: 'Incident procedures for restore, lost quorum, image-pull storms, and SLO breaches.',
+      },
     ],
   },
 ]

--- a/docs/src/content/docs/cluster-ingress.mdx
+++ b/docs/src/content/docs/cluster-ingress.mdx
@@ -85,7 +85,7 @@ AerolVM does not build, run, or manage any of the three. The ingress nodes thems
 
 | Cluster size | Suggested layout |
 |---|---|
-| <= 10 nodes | `mixed` or a small split. Hybrid roles are allowed here for constrained deployments. |
+| &lt;= 10 nodes | `mixed` or a small split. Hybrid roles are allowed here for constrained deployments. |
 | 11+ nodes | Mandatory split: 3 or 5 `server` + N `worker` + 2+ dedicated `ingress`. Mixed and hybrid roles are rejected for placement/create. |
 | 1000-worker target | 3 or 5 `server`, 1000 `worker`, and a separately scaled `ingress` tier behind your LB. |
 

--- a/docs/src/content/docs/cluster-ingress.mdx
+++ b/docs/src/content/docs/cluster-ingress.mdx
@@ -3,7 +3,9 @@ title: Cluster Ingress
 description: Split an AerolVM cluster into server / worker / ingress roles and front it with a single advertised load-balancer endpoint.
 ---
 
-In single-node and small-cluster deployments, every AerolVM node does three jobs at once: it votes in Raft (the control plane), it runs sandbox containers (the worker), and it accepts public traffic and routes it to the correct sandbox owner (the ingress). That topology is fine through about ten nodes. Beyond it, every additional node adds a Raft voter and another copy of the cluster-wide route table - the same fan-out problem Kubernetes solves by separating control-plane masters from worker nodes and ingress controllers.
+In single-node and small-cluster deployments, every AerolVM node does three jobs at once: it votes in Raft (the control plane), it runs sandbox containers (the worker), and it accepts public traffic and routes it to the correct sandbox owner (the ingress). That topology is fine through ten live nodes. Beyond it, every additional mixed node adds a Raft voter and another copy of the cluster-wide route table - the same fan-out problem Kubernetes solves by separating control-plane masters from worker nodes and ingress controllers.
+
+AerolVM now enforces that split at runtime. When a cluster has more than 10 live nodes, placement and local creates fail with `503` if any live member is `mixed` or a comma-separated hybrid role, or if the live membership is missing one of the dedicated `server`, `worker`, or `ingress` tiers.
 
 `SB_NODE_ROLE` is the switch that splits those three jobs across different nodes. The cluster-init and cluster-join scripts accept `--role` so operators can opt into the split when they need it, without changing anything for clusters that don't.
 
@@ -16,11 +18,11 @@ In single-node and small-cluster deployments, every AerolVM node does three jobs
 | `ingress` | no (non-voter only) | no | yes |
 | `mixed` (default) | yes | yes | yes |
 
-`mixed` is the default and preserves every existing deployment's behaviour bit-for-bit. The split only kicks in when an operator passes `--role` (or sets `SB_NODE_ROLE` in the env file).
+`mixed` is the default and preserves existing single-node and small-cluster behaviour. It is not a production topology for clusters above 10 live nodes.
 
 ## Hybrid roles
 
-`SB_NODE_ROLE` also accepts a **comma-separated combination** of `server`, `worker`, and `ingress` for nodes that should run more than one job - but not all three. This is the middle ground between a single-purpose node and a full `mixed` node.
+`SB_NODE_ROLE` also accepts a **comma-separated combination** of `server`, `worker`, and `ingress` for small clusters that should run more than one job - but not all three. This is the middle ground between a single-purpose node and a full `mixed` node while the cluster has 10 or fewer live nodes.
 
 | Hybrid value | Voter? | Runs sandboxes? | Holds route table? | Use case |
 |---|---|---|---|---|
@@ -35,6 +37,7 @@ Notes:
 - Token order does not matter and the value is normalised: `SB_NODE_ROLE=ingress,worker` and `SB_NODE_ROLE=worker,ingress` both parse to the same canonical form.
 - `mixed` may not be combined with other tokens. `SB_NODE_ROLE=mixed,worker` is rejected at boot - `mixed` is already the all-three shorthand and combining it is almost always a misconfiguration.
 - A hybrid value that does **not** include `server` (e.g. `worker,ingress`) cannot bootstrap a fresh cluster - same rule as the single `worker` / `ingress` roles. Pick a node with `server` (or `mixed`) for `cluster-init.sh`.
+- Any hybrid value is a small-cluster convenience only. Above 10 live nodes, the scheduler rejects mixed and hybrid-role members so production clusters stay on dedicated server, worker, and ingress tiers.
 
 A small production cluster looks like this:
 
@@ -82,10 +85,9 @@ AerolVM does not build, run, or manage any of the three. The ingress nodes thems
 
 | Cluster size | Suggested layout |
 |---|---|
-| ≤ 5 nodes | All `mixed`. No reason to split. |
-| 5–20 nodes | 3 `server` + the rest `worker` + 2 `ingress`. Workers stop weighing on Raft quorum. |
-| 20+ nodes | 3 or 5 `server` + N `worker` + 3 `ingress` (scaled to expected bandwidth). |
-| 5–20 nodes, hardware-constrained | 3 `server` + the rest `worker,ingress`. Each data-plane node both owns sandboxes and serves public ingress, so you don't need a separate ingress tier. |
+| <= 10 nodes | `mixed` or a small split. Hybrid roles are allowed here for constrained deployments. |
+| 11+ nodes | Mandatory split: 3 or 5 `server` + N `worker` + 2+ dedicated `ingress`. Mixed and hybrid roles are rejected for placement/create. |
+| 1000-worker target | 3 or 5 `server`, 1000 `worker`, and a separately scaled `ingress` tier behind your LB. |
 
 The voter-cap setting (`SB_CLUSTER_MAX_AUTO_VOTERS`, default 5) is still in effect, but the role split is the real control: any node whose role-set lacks `server` (single `worker`, single `ingress`, or any hybrid like `worker,ingress`) never becomes a Raft voter regardless of the cap.
 
@@ -124,7 +126,7 @@ sudo ./cluster-join.sh \
 
 Point your wildcard DNS (`*.sandbox.example.com`) at the ingress nodes (or at the LB in front of them) and `ingress.sandbox.example.com` at the same target. The SDK will return sandbox URLs that resolve there; the ingress nodes' caddy-l4 will SNI-route each request to the worker that owns the sandbox.
 
-### Hybrid bootstrap example
+### Hybrid bootstrap example (10 nodes or fewer)
 
 Three-server + five `worker,ingress` edge nodes (no separate ingress tier):
 
@@ -151,7 +153,7 @@ sudo ./cluster-join.sh \
     --peers '<seed-ip>:7001'
 ```
 
-The LB / DNS in front of `ingress.sandbox.example.com` should target every edge node - they all hold the public route table and can answer for any sandbox in the cluster.
+The LB / DNS in front of `ingress.sandbox.example.com` should target every edge node - they all hold the public route table and can answer for any sandbox in the cluster. Do not use this shape once the cluster grows beyond 10 live nodes; at that point, move to dedicated `worker` and `ingress` tiers first.
 
 ## What lives where after the split
 

--- a/docs/src/content/docs/cluster-ingress.mdx
+++ b/docs/src/content/docs/cluster-ingress.mdx
@@ -171,12 +171,12 @@ The placement FSM is replicated to every node so any node can answer "where does
 
 ## Failure semantics
 
-- **Worker dies:** the sandboxes it owned are orphaned after `SB_DEAD_OWNER_GRACE`. Clients see `410 Gone` and must call `Create` again on the surviving fleet. See [Durability and Failover](/durability) for the full story.
+- **Worker dies:** default sandboxes are orphaned after `SB_DEAD_OWNER_GRACE`; clients see `410 Gone` and must call `Create` again. Sandboxes created with `failover.policy="recreate"` are reassigned to a surviving worker and recreated from the replicated spec. See [Durability and Failover](/durability) for the full story.
 - **Ingress node dies:** the LB in front of the ingress tier sheds it. Public URLs continue through the surviving ingress nodes. No effect on Raft quorum.
 - **Server node dies:** as long as a majority of `server` nodes remain, the cluster continues writing to the FSM. Below quorum, writes pause until a majority returns.
 
 ## Limitations
 
-- Cluster mode does not yet auto-recreate sandboxes after worker death (see [Durability and Failover](/durability)). The placement spec, sealed credentials, and exposed-port intents are replicated through Raft so a future opt-in failover policy can recover specific sandboxes, but the auto-recreate code path is gated off today.
+- Sandbox HA is opt-in per sandbox (see [Durability and Failover](/durability)). The placement spec, sealed credentials, and exposed-port intents are replicated through Raft; only sandboxes created with `failover.policy="recreate"` are auto-recreated after worker death.
 - Route convergence is currently driven by a 5-second poll, not a watch. In steady state this is well within the 2-second p95 target stated in the release plan; immediately after a placement change, expect up to one tick of `503 placement in flux` before ingress reconciles.
 - UDP is not supported. caddy-l4 can carry TCP and TLS/SNI; UDP exposure needs a separate design.

--- a/docs/src/content/docs/cluster-setup.md
+++ b/docs/src/content/docs/cluster-setup.md
@@ -12,7 +12,7 @@ Single-node installs ([Server Setup](/getting-started)) handle every workload th
 - Per-node failure isolation - the loss of one node only affects the sandboxes it owned, and survivors keep serving traffic.
 - Geographic distribution across multiple data centers behind one logical API.
 
-Cluster mode adds two new pieces on top of the single-node binaries: a Raft quorum (placement decisions) and a SWIM gossip ring (membership + capacity). See [Durability and Failover](/durability) for what survives node loss.
+Cluster mode adds three pieces on top of the single-node binaries: a Raft quorum (placement decisions), a SWIM gossip ring (membership), and authenticated worker capacity heartbeats used by the scheduler. See [Durability and Failover](/durability) for what survives node loss.
 
 ## Prerequisites
 
@@ -88,10 +88,10 @@ Both require the same `Authorization: Bearer $SB_PAT_TOKEN` header as the rest o
 
 When a create lands on a node (call it `A`):
 
-1. `A` runs placement scoring against the gossiped capacity snapshot, biased
-   by any pending reservations it knows about, and picks a target `T`. If
-   `A == T`, `A` runs the create locally and commits a placement to the raft
-   log on success.
+1. `A` runs placement scoring against fresh worker capacity heartbeats,
+   biased by any pending reservations it knows about, and picks a target `T`.
+   If `A == T`, `A` runs the create locally and commits a placement to the
+   raft log on success.
 2. If `T` is a different node, `A` mints a sandbox ID, seals + redacts the
    request secrets, and writes a **reservation** for `T` to the raft log
    *before* forwarding. The reservation holds the requested capacity and the

--- a/docs/src/content/docs/dashboard.mdx
+++ b/docs/src/content/docs/dashboard.mdx
@@ -167,3 +167,7 @@ at `setup/alertmanager/sandboxd-alertmanager-example.yml`. The alert file
 covers Raft apply/snapshot health, stale worker leases, create queue backlog,
 worker pressure, ingress route lag, Caddy/admin errors, owner-forward errors,
 image-pull storms, and secret decrypt failures.
+
+Incident runbooks are checked in under `setup/runbooks/` for backup/restore,
+lost-quorum recovery, image-pull storms, and general SLO breaches. The
+Prometheus alerts link directly to these runbooks.

--- a/docs/src/content/docs/dashboard.mdx
+++ b/docs/src/content/docs/dashboard.mdx
@@ -134,6 +134,29 @@ scrape_configs:
 ```
 
 Useful first alerts are `aerolvm_raft_apply_errors_total`,
-`aerolvm_ingress_route_lag_versions`, `aerolvm_create_queue_depth`,
-`aerolvm_worker_lease_max_age_nanos`, and the `aerolvm_host_pressure_*`
-gauges.
+`aerolvm_ingress_route_desired_revision - aerolvm_ingress_route_applied_revision`,
+`aerolvm_create_queue_depth`, `aerolvm_worker_lease_max_age_nanos`,
+`aerolvm_image_pull_backoff_rejects_total`, and the
+`aerolvm_host_pressure_*` gauges.
+
+## Prometheus, OTEL, and Grafana
+
+Prometheus is pull-based through `GET /v1/metrics`. Native OTEL metrics
+are push-based over OTLP/HTTP and are enabled by either setting
+`SB_OTEL_METRICS_ENABLED=true` or by setting an OTLP endpoint:
+
+```bash
+SB_OTEL_METRICS_ENDPOINT=http://otel-collector:4318/v1/metrics
+SB_OTEL_METRICS_INTERVAL=30s
+OTEL_SERVICE_NAME=sandboxd
+```
+
+The OTEL bridge exports the same `aerolvm_*` expvars as observations under
+`aerolvm.expvar.int64` and `aerolvm.expvar.float64`; the original expvar
+name is attached as the `metric` attribute, with expvar map keys attached
+as `key`, `key2`, and so on.
+
+A starter Grafana dashboard is checked in at
+`setup/grafana/sandboxd-slo-dashboard.json`. It covers create queue depth,
+worker pressure, route lag, shard health, Raft errors, data-plane errors,
+and image-pull storm signals.

--- a/docs/src/content/docs/dashboard.mdx
+++ b/docs/src/content/docs/dashboard.mdx
@@ -31,7 +31,8 @@ INFO dashboard available url=http://0.0.0.0:8080/ui
 
 The dashboard works on every node — server, worker, or ingress. Cluster
 status endpoints already forward to the right node internally, so opening
-the dashboard against any node gives you the cluster-wide view.
+the dashboard against any node gives you the cluster-wide view instead of
+only the node your DNS record happened to pick.
 
 ## Signing in
 
@@ -55,8 +56,8 @@ exposes.
 | Panel | Endpoint | What it shows |
 |---|---|---|
 | **Health** | `GET /health` | Docker / Caddy / SSH gateway probes, overall status, sandboxd version, live sandbox count. |
-| **Local capacity** | `GET /v1/capacity` | CPU / memory / disk / GPU reservation ratios, post-overcommit budgets, whether the node currently admits new sandboxes, and any rejection reasons. |
-| **Cluster** | `GET /v1/cluster/leader` and `GET /v1/cluster/members` | Current Raft leader and every gossiped peer with its role, alive bit, drain state, and capacity summary. |
+| **Local capacity** | `GET /v1/capacity` | CPU / memory / disk / GPU reservation ratios, available capacity, post-overcommit budgets, whether the node currently admits new sandboxes, and any rejection reasons. |
+| **Cluster** | `GET /v1/cluster/leader` and `GET /v1/cluster/members` | Current Raft leader, aggregate cluster CPU / memory / disk / GPU availability from fresh worker capacity heartbeats, and every peer with its role, alive bit, drain state, and capacity freshness. |
 | **Placements** | `GET /v1/cluster/sandbox-index` (paginated) | One row per cluster-replicated sandbox: ID, owning node, state (`placed` / `reserved` / `orphaned`), version, and timestamps. |
 | **Metrics (expvar)** | `GET /debug/vars` | Curated picks from the `aerolvm_*` counter set (Raft apply latency, owner forward count, worker lease health, etc.). A raw view is collapsed below the grid. |
 

--- a/docs/src/content/docs/dashboard.mdx
+++ b/docs/src/content/docs/dashboard.mdx
@@ -160,3 +160,10 @@ A starter Grafana dashboard is checked in at
 `setup/grafana/sandboxd-slo-dashboard.json`. It covers create queue depth,
 worker pressure, route lag, shard health, Raft errors, data-plane errors,
 and image-pull storm signals.
+
+Prometheus alert rules are checked in at
+`setup/prometheus/sandboxd-alerts.yml`, with an Alertmanager routing example
+at `setup/alertmanager/sandboxd-alertmanager-example.yml`. The alert file
+covers Raft apply/snapshot health, stale worker leases, create queue backlog,
+worker pressure, ingress route lag, Caddy/admin errors, owner-forward errors,
+image-pull storms, and secret decrypt failures.

--- a/docs/src/content/docs/dashboard.mdx
+++ b/docs/src/content/docs/dashboard.mdx
@@ -60,6 +60,7 @@ exposes.
 | **Cluster** | `GET /v1/cluster/leader` and `GET /v1/cluster/members` | Current Raft leader, aggregate cluster CPU / memory / disk / GPU availability from fresh worker capacity heartbeats, and every peer with its role, alive bit, drain state, and capacity freshness. |
 | **Placements** | `GET /v1/cluster/sandbox-index` (paginated) | One row per cluster-replicated sandbox: ID, owning node, state (`placed` / `reserved` / `orphaned`), version, and timestamps. |
 | **Metrics (expvar)** | `GET /debug/vars` | Curated picks from the `aerolvm_*` counter set (Raft apply latency, owner forward count, worker lease health, etc.). A raw view is collapsed below the grid. |
+| **Metrics (Prometheus)** | `GET /v1/metrics` | Prometheus text-format export of the same `aerolvm_*` counters and gauges for scrapers and alerting. |
 
 The whole page auto-refreshes every five seconds while the tab is
 visible. Refresh pauses automatically when the tab is hidden so it does
@@ -92,7 +93,7 @@ A short summary, because there are two related but distinct surfaces:
   sign-in form prompts for the PAT before any API call fires. This
   matches how every standard login page works.
 - Every API call the page makes — `GET /health`, `GET /v1/...`,
-  `GET /debug/vars`, the action endpoints — sends the PAT as
+  `GET /debug/vars`, `GET /v1/metrics`, the action endpoints — sends the PAT as
   `Authorization: Bearer <token>` and goes through the same
   middleware as a curl or SDK call. Including `/debug/vars`: the
   expvar counters carry operational shape (lease state, queue depths,
@@ -117,3 +118,22 @@ The metrics panel is intentionally local to the node you opened the
 dashboard against — it reads the in-process expvar counters of *that*
 sandboxd process. To compare nodes side-by-side, open one tab per
 node.
+
+Prometheus scraping is local in the same way. Scrape every server, worker,
+and ingress node independently:
+
+```yaml
+scrape_configs:
+  - job_name: sandboxd
+    metrics_path: /v1/metrics
+    bearer_token: "<SB_PAT_TOKEN>"
+    static_configs:
+      - targets:
+          - server-1.example.com:8080
+          - worker-1.example.com:8080
+```
+
+Useful first alerts are `aerolvm_raft_apply_errors_total`,
+`aerolvm_ingress_route_lag_versions`, `aerolvm_create_queue_depth`,
+`aerolvm_worker_lease_max_age_nanos`, and the `aerolvm_host_pressure_*`
+gauges.

--- a/docs/src/content/docs/dashboard.mdx
+++ b/docs/src/content/docs/dashboard.mdx
@@ -141,13 +141,15 @@ Useful first alerts are `aerolvm_raft_apply_errors_total`,
 
 ## Prometheus, OTEL, and Grafana
 
-Prometheus is pull-based through `GET /v1/metrics`. Native OTEL metrics
-are push-based over OTLP/HTTP and are enabled by either setting
-`SB_OTEL_METRICS_ENABLED=true` or by setting an OTLP endpoint:
+Prometheus is pull-based through `GET /v1/metrics`. Native OTEL metrics and
+traces are push-based over OTLP/HTTP and are enabled by either setting
+`SB_OTEL_*_ENABLED=true` or by setting the matching OTLP endpoint:
 
 ```bash
 SB_OTEL_METRICS_ENDPOINT=http://otel-collector:4318/v1/metrics
 SB_OTEL_METRICS_INTERVAL=30s
+SB_OTEL_TRACES_ENDPOINT=http://otel-collector:4318/v1/traces
+SB_OTEL_TRACES_SAMPLE_RATIO=0.05
 OTEL_SERVICE_NAME=sandboxd
 ```
 
@@ -156,10 +158,17 @@ The OTEL bridge exports the same `aerolvm_*` expvars as observations under
 name is attached as the `metric` attribute, with expvar map keys attached
 as `key`, `key2`, and so on.
 
+The trace exporter emits server spans for API requests, extracts incoming
+W3C trace context, and tags spans with `http.route`, status code, node ID,
+node role, service name, and daemon version. The default local root sampling
+ratio is `0.05` so large clusters can send traces without turning every burst
+into telemetry load.
+
 A starter Grafana dashboard is checked in at
 `setup/grafana/sandboxd-slo-dashboard.json`. It covers create queue depth,
-worker pressure, route lag, shard health, Raft errors, data-plane errors,
-and image-pull storm signals.
+create latency buckets, worker pressure, worker lease coverage, route lag,
+shard health, Raft errors and snapshot size, data-plane errors, secret
+decrypt health, and image-pull storm signals.
 
 Prometheus alert rules are checked in at
 `setup/prometheus/sandboxd-alerts.yml`, with an Alertmanager routing example

--- a/docs/src/content/docs/durability.mdx
+++ b/docs/src/content/docs/durability.mdx
@@ -4,7 +4,7 @@ title: Durability and Failover
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-A sandbox's container is ephemeral. Files written into the container's writable layer (`/tmp`, the working directory, anywhere not on a mount) live only as long as the container itself. If the container is destroyed - by an explicit `Destroy`, by a host crash, or by the loss of the owner node in cluster mode - that data is gone, **and the sandbox itself is gone too**: the current release does not auto-recreate a sandbox after the owner dies.
+A sandbox's container is ephemeral. Files written into the container's writable layer (`/tmp`, the working directory, anywhere not on a mount) live only as long as the container itself. If the container is destroyed - by an explicit `Destroy`, by a host crash, or by the loss of the owner node in cluster mode - that data is gone. By default the sandbox placement is gone too: the API returns `410 Gone`. Sandboxes that opt into `failover.policy = "recreate"` are best-effort recreated on another worker from their replicated create spec.
 
 This is the same model used by GitHub Codespaces, Daytona workspaces, and Coder workspaces. Persistent state lives on a separate, declared volume; the container is treated as cattle. Add cluster mode and *the sandbox* is also treated as cattle - a fresh `Create` is the way to recover.
 
@@ -14,13 +14,13 @@ This is the same model used by GitHub Codespaces, Daytona workspaces, and Coder 
 |---|---|---|---|
 | Container writable layer | Lost | Lost | Lost |
 | Mounted volumes (S3, NFS, SSHFS, rclone) | Survive (external) | Survive (external) | Survive (external) - a *new* sandbox can re-mount them |
-| Sandbox ID | Reused on next `Create` | Preserved if record persisted | **Lost** - API returns `410 Gone`; create a new sandbox |
-| Environment variables, image, resource limits | N/A | Restored on `Start` | Lost (spec is replicated in the FSM but not rematerialized) |
-| Idle lifecycle policy | N/A | Restored on `Start` | Lost |
-| Exposed ports (preview, TCP, TLS) | Removed | Restored on `Start` | Lost - the new sandbox declares its own |
-| Caddy routes | Removed | Restored on `Start` | Lost - ingress routes are torn down when the placement orphans |
-| Host port number | N/A | Same host, same port | Lost |
-| Public URL | Removed | Restored on `Start` | Lost - a new sandbox gets a new URL |
+| Sandbox ID | Reused on next `Create` | Preserved if record persisted | Default: lost (`410 Gone`). With `failover.policy="recreate"`: preserved if recreation succeeds |
+| Environment variables, image, resource limits | N/A | Restored on `Start` | Default: lost. With recreate: restored from replicated spec |
+| Idle lifecycle policy | N/A | Restored on `Start` | Default: lost. With recreate: restored |
+| Exposed ports (preview, TCP, TLS) | Removed | Restored on `Start` | Default: lost. With recreate: replayed when possible |
+| Caddy routes | Removed | Restored on `Start` | Default: lost. With recreate: rebuilt by the new owner and ingress reconciler |
+| Host port number | N/A | Same host, same port | Default: lost. With recreate: preferred raw TCP host ports are replayed when available |
+| Public URL | Removed | Restored on `Start` | Default: lost. With recreate: stable ingress host remains, owner route changes underneath |
 
 ## Make workspace state durable
 
@@ -129,15 +129,62 @@ Anything written under `/workspace` outlives the container. Anything written els
 
 ## Cluster-mode owner death
 
-When `SB_ENABLE_CLUSTER=true` and a sandbox's owner node dies, the current product policy is:
+When `SB_ENABLE_CLUSTER=true` and a sandbox's owner node dies, the default policy is:
 
 1. After `SB_DEAD_OWNER_GRACE` (default 30s) the cluster leader **orphans** every placement that the dead node owned (`OwnerNodeID = ""` in the replicated FSM) and removes the node from the raft configuration.
 2. Any further API call for one of those sandboxes returns `410 Gone`.
-3. The sandbox is not auto-recreated on a different node. Clients should issue a fresh `Create` to land a new sandbox on the surviving fleet.
+3. Clients should issue a fresh `Create` to land a new sandbox on the surviving fleet.
 
-The cluster *does* still replicate each sandbox's create spec (image, env, resource limits, mounts, lifecycle), the sealed registry/mount credential bag, and every exposed-port route intent into the raft log. That replication is preserved deliberately so a future opt-in lifecycle policy can recover specific sandboxes; the auto-recreate code path is present in the codebase but gated off (`clusterRecreateOnFailoverEnabled` in `internal/cluster/dead_owner.go`).
+For workloads that can tolerate losing writable-layer state but need the same sandbox ID and route intents, opt in at create time:
 
-For now: design your application around the assumption that a sandbox is a session, not a service. Put durable state on a mount, and recreate the sandbox on top of that mount when the old one goes away.
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    const sandbox = await client.create({
+      image: 'ubuntu:22.04',
+      failover: { policy: 'recreate' },
+    })
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    sandbox = client.create({
+        'image': 'ubuntu:22.04',
+        'failover': {'policy': 'recreate'},
+    })
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    sandbox, err := client.Create(ctx, sdktypes.CreateSandboxOptions{
+        Image: "ubuntu:22.04",
+        Failover: &sdktypes.Failover{Policy: sdktypes.FailoverPolicyRecreate},
+    })
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let sandbox = client.create(CreateOptions {
+        image: "ubuntu:22.04".to_string(),
+        failover: Some(aerolvm_sdk::Failover { policy: "recreate".to_string() }),
+        ..Default::default()
+    })?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    Sandbox sandbox = client.create(
+        new CreateOptions()
+            .setImage("ubuntu:22.04")
+            .setFailover(new Failover().setPolicy("recreate"))
+    );
+    ```
+  </TabItem>
+</Tabs>
+
+The cluster replicates each sandbox's create spec (image, env, resource limits, mounts, lifecycle, failover policy), the sealed registry/mount credential bag, and every exposed-port route intent. When an opted-in owner dies, the leader reassigns that placement to a live worker that satisfies the spec; the new worker recreates the sandbox with the original ID and replays exposed ports.
+
+`failover.policy="recreate"` is rejected for local-only images because no other worker can pull them. Writable-layer state is still lost, so put durable state on a mount.
 
 If you ever need to re-expose a port manually (for example, the original `ExposePort` call landed during a network partition and was dropped), the API is idempotent:
 
@@ -204,7 +251,7 @@ When `SB_GOSSIP_SECRET_KEY` is unset, the daemon logs a warning at boot. Raft it
 
 ## Limitations
 
-- **Sandboxes are not highly available.** Owner-node death orphans the placement; clients see `410 Gone` and must create a fresh sandbox. Spec, sealed creds, and port intents are still replicated through raft for a future opt-in failover policy, but no auto-recreate runs in this release.
+- **Sandbox HA is opt-in.** Owner-node death orphans default placements; clients see `410 Gone` and must create a fresh sandbox. Only sandboxes created with `failover.policy="recreate"` are reassigned and recreated.
 - **Ingress has a convergence window.** Public HTTP/TLS URLs and raw TCP host ports for *live* sandboxes are replicated through the cluster route map, but non-owner ingress routes refresh periodically. Immediately after a new `ExposePort` call, a backend can briefly return 404/502 until it has reconciled.
 - **Writable-layer state is not replicated.** Treat anything outside a mount as cache. If you need it after a crash, write it to a mount.
 - **Single-node deployments inherit the same model.** A host crash loses the writable layer just as owner death does. Mount external storage for anything that must survive.

--- a/docs/src/content/docs/durability.mdx
+++ b/docs/src/content/docs/durability.mdx
@@ -184,7 +184,8 @@ If you ever need to re-expose a port manually (for example, the original `Expose
 
 Cluster traffic uses two transports:
 
-- **Gossip** (`SB_GOSSIP_BIND_ADDR`, default `:7001`) - SWIM membership and capacity dissemination.
+- **Gossip** (`SB_GOSSIP_BIND_ADDR`, default `:7001`) - SWIM membership and role/identity metadata.
+- **Capacity heartbeats** (`GET /v1/capacity`) - authenticated worker capacity snapshots used by server-role schedulers.
 - **Raft** (`SB_RAFT_BIND_ADDR`, default `:7000`) - placement-map consensus.
 
 When a node successfully joins gossip, it is added to the Raft configuration as a voter until `SB_CLUSTER_MAX_AUTO_VOTERS` is reached, then as a non-voter. **Anyone who can reach these ports can still join the cluster and influence placement replication.** Run them on a private network the operator controls (VPC peering, WireGuard mesh, dedicated cluster subnet); never expose them to the public internet.

--- a/docs/src/content/docs/operational-runbooks.mdx
+++ b/docs/src/content/docs/operational-runbooks.mdx
@@ -1,0 +1,39 @@
+---
+title: Operational Runbooks
+---
+
+sandboxd ships checked-in production runbooks under `setup/runbooks/`. They are
+the procedures used by the Prometheus alert rules and by the deployment
+artifacts installed through Ansible.
+
+## Runbooks
+
+| Runbook | Incident |
+|---|---|
+| `setup/runbooks/backup-restore.md` | Restore a node, prove backup usability, or recover local state. |
+| `setup/runbooks/lost-quorum-recovery.md` | Recover when too many Raft voters are gone and no leader can be elected. |
+| `setup/runbooks/image-pull-storm.md` | Respond to queued, failing, rate-limited, or backoff-suppressed image pulls. |
+| `setup/runbooks/slo-breach.md` | First-response procedure for Raft, scheduler, create, ingress, data-plane, image, and secret SLO alerts. |
+
+## Deployment
+
+Runbooks are deployed by:
+
+```bash
+ansible-playbook Ansible/playbooks/configure-ops.yml
+```
+
+The playbook copies them to `/etc/sandboxd/runbooks` by default, alongside the
+Grafana dashboard, Prometheus alert rules, and Alertmanager example.
+
+## Drill Expectation
+
+Each runbook includes a drill checklist. Run these drills in staging monthly:
+
+- backup restore
+- lost-quorum tabletop
+- image-pull storm
+- SLO breach response
+
+The goal is to prove the commands, access, metrics, and escalation path before
+an outage.

--- a/go.mod
+++ b/go.mod
@@ -57,11 +57,11 @@ require (
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
+	go.opentelemetry.io/otel/trace v1.43.0
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.53.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/google/btree v1.1.3 // indirect
+	github.com/google/btree v1.1.3
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -54,13 +54,13 @@ require (
 	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
 	go.etcd.io/bbolt v1.3.5 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel v1.43.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0 // indirect
+	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0 // indirect
-	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/metric v1.43.0
+	go.opentelemetry.io/otel/sdk v1.43.0
+	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	golang.org/x/mod v0.35.0 // indirect

--- a/internal/cluster/agent.go
+++ b/internal/cluster/agent.go
@@ -58,8 +58,9 @@ type DrainStateResponse struct {
 
 // Agent is the worker/ingress-side cluster client. It deliberately does not
 // start Raft, does not create a placement FSM, and never joins the raft
-// configuration as a non-voter. It only gossips local capacity/addresses and
-// delegates every authoritative placement read/write to server-role nodes.
+// configuration as a non-voter. It gossips identity/addresses, serves local
+// capacity heartbeats, and delegates every authoritative placement read/write
+// to server-role nodes.
 type Agent struct {
 	cfg           config.Config
 	logger        *slog.Logger
@@ -465,6 +466,14 @@ func (a *Agent) AttachInternalHandler(h http.Handler) {
 func (a *Agent) Members() []Member {
 	if a.gossip == nil {
 		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var resp struct {
+		Members []Member `json:"members"`
+	}
+	if err := a.doControlPlaneJSON(ctx, http.MethodGet, "/v1/cluster/members", "/v1/cluster/members", nil, &resp); err == nil && resp.Members != nil {
+		return resp.Members
 	}
 	return a.gossip.members()
 }

--- a/internal/cluster/agent.go
+++ b/internal/cluster/agent.go
@@ -701,14 +701,24 @@ func (a *Agent) doHTTPRequest(ctx context.Context, client *http.Client, endpoint
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		if resp.StatusCode == http.StatusServiceUnavailable && strings.Contains(string(msg), ErrNotLeader.Error()) {
-			return ErrNotLeader
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			msg, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+			message := strings.TrimSpace(string(msg))
+			if resp.StatusCode == http.StatusTooManyRequests && strings.Contains(message, ErrCreateBackpressure.Error()) {
+				return fmt.Errorf("%w: %s", ErrCreateBackpressure, message)
+			}
+			if resp.StatusCode == http.StatusServiceUnavailable && strings.Contains(message, ErrNotLeader.Error()) {
+				return ErrNotLeader
+			}
+			if resp.StatusCode == http.StatusServiceUnavailable && strings.Contains(message, ErrCapacityExceeded.Error()) {
+				return fmt.Errorf("%w: %s", ErrCapacityExceeded, message)
+			}
+			if resp.StatusCode == http.StatusServiceUnavailable && strings.Contains(message, ErrNoPlacementTarget.Error()) {
+				return fmt.Errorf("%w: %s", ErrNoPlacementTarget, message)
+			}
+			return statusError{status: resp.StatusCode, message: message}
 		}
-		return statusError{status: resp.StatusCode, message: strings.TrimSpace(string(msg))}
-	}
 	if out == nil {
 		io.Copy(io.Discard, resp.Body)
 		return nil

--- a/internal/cluster/agent.go
+++ b/internal/cluster/agent.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/aerol-ai/microvm/internal/config"
@@ -83,6 +84,10 @@ type Agent struct {
 	cacheMu        sync.RWMutex
 	placementCache []Placement
 	shardCache     map[string][]Placement
+	// placementVersion tracks the highest placement version observed via
+	// shard/page/point reads. It keeps PlacementVersion() off the full-map
+	// endpoint on worker/ingress-only agents.
+	placementVersion atomic.Uint64
 }
 
 func NewAgent(cfg config.Config, logger *slog.Logger, admitter *capacity.Admitter) (*Agent, error) {
@@ -511,6 +516,7 @@ func (a *Agent) PlacementsForShards(filter PlacementShardFilter) []Placement {
 	a.shardCache[placementShardFilterCacheKey(filter)] = clonePlacements(out)
 	shardEntries := len(a.shardCache)
 	a.cacheMu.Unlock()
+	a.observePlacementVersions(out)
 	recordPlacementCacheRefresh(time.Since(start), len(out), shardEntries, nil)
 	return out
 }
@@ -530,6 +536,7 @@ func (a *Agent) PlacementPage(req PlacementPageRequest) PlacementPageResponse {
 		a.logger.Warn("cluster agent: placement page lookup failed", "err", err, "limit", req.Limit, "page_token", req.PageToken)
 		return PlacementPageResponse{}
 	}
+	a.observePlacementVersions(out.Placements)
 	return out
 }
 
@@ -538,17 +545,12 @@ func (a *Agent) PlacementOf(sandboxID string) (Placement, bool) {
 	if err != nil || !ok {
 		return Placement{}, false
 	}
+	a.observePlacementVersion(lookup.Placement.Version)
 	return lookup.Placement, true
 }
 
 func (a *Agent) PlacementVersion() uint64 {
-	var max uint64
-	for _, p := range a.Placements() {
-		if p.Version > max {
-			max = p.Version
-		}
-	}
-	return max
+	return a.placementVersion.Load()
 }
 
 func (a *Agent) SubscribePlacement(context.Context) <-chan struct{} { return nil }
@@ -589,7 +591,33 @@ func (a *Agent) lookupPlacement(ctx context.Context, sandboxID string) (Placemen
 		}
 		return PlacementLookupResponse{}, false, err
 	}
+	a.observePlacementVersion(lookup.Placement.Version)
 	return lookup, true, nil
+}
+
+func (a *Agent) observePlacementVersions(placements []Placement) {
+	var max uint64
+	for _, p := range placements {
+		if p.Version > max {
+			max = p.Version
+		}
+	}
+	a.observePlacementVersion(max)
+}
+
+func (a *Agent) observePlacementVersion(version uint64) {
+	if version == 0 {
+		return
+	}
+	for {
+		cur := a.placementVersion.Load()
+		if version <= cur {
+			return
+		}
+		if a.placementVersion.CompareAndSwap(cur, version) {
+			return
+		}
+	}
 }
 
 func (a *Agent) applyCommand(ctx context.Context, cmd command) error {

--- a/internal/cluster/agent.go
+++ b/internal/cluster/agent.go
@@ -231,6 +231,9 @@ func (a *Agent) SelectPlacement(req capacity.Request) (PlacementTarget, error) {
 		if resp.Error == ErrNoPlacementTarget.Error() {
 			return PlacementTarget{}, ErrNoPlacementTarget
 		}
+		if err := invalidTopologyFromMessage(resp.Error); err != nil {
+			return PlacementTarget{}, err
+		}
 		return PlacementTarget{}, errors.New(resp.Error)
 	}
 	if resp.Target.NodeID == a.nodeID {

--- a/internal/cluster/agent.go
+++ b/internal/cluster/agent.go
@@ -30,6 +30,7 @@ const (
 	PublicInternalPlacementsPath        = "/v1/cluster/internal/placements"
 	PublicInternalPlacementsQueryPath   = "/v1/cluster/internal/placements/query"
 	PublicInternalPlacementsPagePath    = "/v1/cluster/internal/placements/page"
+	PublicInternalRecoveryPath          = "/v1/cluster/internal/recovery/"
 	PublicInternalSelectPlacementPath   = "/v1/cluster/internal/select-placement"
 	PublicInternalDrainStatePath        = "/v1/cluster/internal/drain/"
 	PublicInternalClusterLeaderPath     = "/v1/cluster/leader"
@@ -621,7 +622,11 @@ func (a *Agent) observePlacementVersion(version uint64) {
 }
 
 func (a *Agent) applyCommand(ctx context.Context, cmd command) error {
-	payload, err := encodeCommand(cmd)
+	raftCmd, err := a.externalizeCommandRecovery(ctx, cmd)
+	if err != nil {
+		return fmt.Errorf("cluster agent: externalize recovery: %w", err)
+	}
+	payload, err := encodeCommand(raftCmd)
 	if err != nil {
 		return fmt.Errorf("cluster: encode command: %w", err)
 	}
@@ -701,24 +706,24 @@ func (a *Agent) doHTTPRequest(ctx context.Context, client *http.Client, endpoint
 	if err != nil {
 		return err
 	}
-		defer resp.Body.Close()
-		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			msg, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-			message := strings.TrimSpace(string(msg))
-			if resp.StatusCode == http.StatusTooManyRequests && strings.Contains(message, ErrCreateBackpressure.Error()) {
-				return fmt.Errorf("%w: %s", ErrCreateBackpressure, message)
-			}
-			if resp.StatusCode == http.StatusServiceUnavailable && strings.Contains(message, ErrNotLeader.Error()) {
-				return ErrNotLeader
-			}
-			if resp.StatusCode == http.StatusServiceUnavailable && strings.Contains(message, ErrCapacityExceeded.Error()) {
-				return fmt.Errorf("%w: %s", ErrCapacityExceeded, message)
-			}
-			if resp.StatusCode == http.StatusServiceUnavailable && strings.Contains(message, ErrNoPlacementTarget.Error()) {
-				return fmt.Errorf("%w: %s", ErrNoPlacementTarget, message)
-			}
-			return statusError{status: resp.StatusCode, message: message}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		message := strings.TrimSpace(string(msg))
+		if resp.StatusCode == http.StatusTooManyRequests && strings.Contains(message, ErrCreateBackpressure.Error()) {
+			return fmt.Errorf("%w: %s", ErrCreateBackpressure, message)
 		}
+		if resp.StatusCode == http.StatusServiceUnavailable && strings.Contains(message, ErrNotLeader.Error()) {
+			return ErrNotLeader
+		}
+		if resp.StatusCode == http.StatusServiceUnavailable && strings.Contains(message, ErrCapacityExceeded.Error()) {
+			return fmt.Errorf("%w: %s", ErrCapacityExceeded, message)
+		}
+		if resp.StatusCode == http.StatusServiceUnavailable && strings.Contains(message, ErrNoPlacementTarget.Error()) {
+			return fmt.Errorf("%w: %s", ErrNoPlacementTarget, message)
+		}
+		return statusError{status: resp.StatusCode, message: message}
+	}
 	if out == nil {
 		io.Copy(io.Discard, resp.Body)
 		return nil

--- a/internal/cluster/agent.go
+++ b/internal/cluster/agent.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"math/rand"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -378,6 +379,17 @@ func (a *Agent) SetNodeDrainState(ctx context.Context, nodeID string, drained bo
 	return a.applyCommand(ctx, command{Op: opSetNodeDrainState, NodeID: nodeID, Drained: drained})
 }
 
+func (a *Agent) RemoveMember(ctx context.Context, nodeID string, force bool) error {
+	if nodeID == "" {
+		return fmt.Errorf("cluster: RemoveMember requires non-empty nodeID")
+	}
+	path := "/v1/cluster/members/" + url.PathEscape(nodeID)
+	if force {
+		path += "?force=true"
+	}
+	return a.doControlPlaneBytes(ctx, http.MethodDelete, path, path, nil, nil)
+}
+
 func (a *Agent) IsNodeDrained(nodeID string) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), controlPlaneRequestTimeout)
 	defer cancel()
@@ -713,7 +725,7 @@ func (a *Agent) doHTTPRequest(ctx context.Context, client *http.Client, endpoint
 		if resp.StatusCode == http.StatusTooManyRequests && strings.Contains(message, ErrCreateBackpressure.Error()) {
 			return fmt.Errorf("%w: %s", ErrCreateBackpressure, message)
 		}
-		if resp.StatusCode == http.StatusServiceUnavailable && strings.Contains(message, ErrNotLeader.Error()) {
+		if resp.StatusCode == http.StatusServiceUnavailable && (strings.Contains(message, ErrNotLeader.Error()) || strings.Contains(message, "not leader")) {
 			return ErrNotLeader
 		}
 		if resp.StatusCode == http.StatusServiceUnavailable && strings.Contains(message, ErrCapacityExceeded.Error()) {
@@ -721,6 +733,15 @@ func (a *Agent) doHTTPRequest(ctx context.Context, client *http.Client, endpoint
 		}
 		if resp.StatusCode == http.StatusServiceUnavailable && strings.Contains(message, ErrNoPlacementTarget.Error()) {
 			return fmt.Errorf("%w: %s", ErrNoPlacementTarget, message)
+		}
+		if resp.StatusCode == http.StatusNotFound && strings.Contains(message, ErrUnknownMember.Error()) {
+			return ErrUnknownMember
+		}
+		if resp.StatusCode == http.StatusConflict && strings.Contains(message, ErrMemberStillAlive.Error()) {
+			return ErrMemberStillAlive
+		}
+		if resp.StatusCode == http.StatusConflict && strings.Contains(message, ErrLastVoter.Error()) {
+			return ErrLastVoter
 		}
 		return statusError{status: resp.StatusCode, message: message}
 	}

--- a/internal/cluster/agent_test.go
+++ b/internal/cluster/agent_test.go
@@ -61,6 +61,22 @@ func TestAgentDelegatesPlacementReadWriteToServerControlPlane(t *testing.T) {
 	}
 }
 
+func TestAgentPlacementVersionUsesObservedReads(t *testing.T) {
+	agent := &Agent{}
+	agent.observePlacementVersions([]Placement{{SandboxID: "a", Version: 3}, {SandboxID: "b", Version: 2}})
+	if got := agent.PlacementVersion(); got != 3 {
+		t.Fatalf("PlacementVersion after shard read = %d, want 3", got)
+	}
+	agent.observePlacementVersion(1)
+	if got := agent.PlacementVersion(); got != 3 {
+		t.Fatalf("PlacementVersion regressed to %d, want 3", got)
+	}
+	agent.observePlacementVersion(5)
+	if got := agent.PlacementVersion(); got != 5 {
+		t.Fatalf("PlacementVersion after point read = %d, want 5", got)
+	}
+}
+
 func startAgentControlPlaneServer(t *testing.T, c *Cluster, ln net.Listener) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()

--- a/internal/cluster/capacity_lease.go
+++ b/internal/cluster/capacity_lease.go
@@ -1,0 +1,211 @@
+package cluster
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/capacity"
+)
+
+const capacityLeaseFetchConcurrency = 32
+
+type capacityLease struct {
+	snapshot capacity.Snapshot
+	updated  time.Time
+}
+
+type capacityLeaseCache struct {
+	selfID   string
+	admitter *capacity.Admitter
+	ttl      time.Duration
+	logger   *slog.Logger
+
+	mu     sync.RWMutex
+	leases map[string]capacityLease
+}
+
+func newCapacityLeaseCache(selfID string, admitter *capacity.Admitter, interval time.Duration, logger *slog.Logger) *capacityLeaseCache {
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	ttl := interval * 3
+	if ttl < 15*time.Second {
+		ttl = 15 * time.Second
+	}
+	return &capacityLeaseCache{
+		selfID:   selfID,
+		admitter: admitter,
+		ttl:      ttl,
+		logger:   logger,
+		leases:   make(map[string]capacityLease),
+	}
+}
+
+func (c *capacityLeaseCache) refreshLocal(now time.Time) {
+	if c == nil || c.admitter == nil || c.selfID == "" {
+		return
+	}
+	c.set(c.selfID, c.admitter.Snapshot(), now)
+}
+
+func (c *capacityLeaseCache) set(nodeID string, snap capacity.Snapshot, updated time.Time) {
+	if c == nil || nodeID == "" {
+		return
+	}
+	c.mu.Lock()
+	if c.leases == nil {
+		c.leases = make(map[string]capacityLease)
+	}
+	c.leases[nodeID] = capacityLease{snapshot: snap, updated: updated}
+	c.mu.Unlock()
+}
+
+func (c *capacityLeaseCache) apply(members []Member, now time.Time) []Member {
+	if c == nil {
+		return members
+	}
+	c.refreshLocal(now)
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	out := make([]Member, 0, len(members))
+	for _, m := range members {
+		if !m.Alive || !CanOwnSandboxRole(m.Role) {
+			out = append(out, m)
+			continue
+		}
+		lease, ok := c.leases[m.NodeID]
+		if !ok {
+			m.CapacityStale = true
+			out = append(out, m)
+			continue
+		}
+		m.Capacity = lease.snapshot
+		m.CapacityUpdatedUnix = lease.updated.Unix()
+		m.CapacityStale = now.Sub(lease.updated) > c.ttl
+		out = append(out, m)
+	}
+	return out
+}
+
+func (c *Cluster) startCapacityLeaseLoop(interval time.Duration) {
+	if c.capacityLeases == nil || c.gossip == nil {
+		return
+	}
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	c.capacityLeaseStop = cancel
+	go c.runCapacityLeaseLoop(ctx, interval)
+}
+
+func (c *Cluster) runCapacityLeaseLoop(ctx context.Context, interval time.Duration) {
+	c.refreshCapacityLeases(ctx)
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			c.refreshCapacityLeases(ctx)
+		}
+	}
+}
+
+func (c *Cluster) refreshCapacityLeases(ctx context.Context) {
+	if c == nil || c.capacityLeases == nil || c.gossip == nil {
+		return
+	}
+	now := time.Now()
+	c.capacityLeases.refreshLocal(now)
+
+	members := c.gossip.members()
+	jobs := make(chan Member)
+	var wg sync.WaitGroup
+	for i := 0; i < capacityLeaseFetchConcurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for m := range jobs {
+				snap, err := c.fetchMemberCapacity(ctx, m)
+				if err != nil {
+					if c.logger != nil {
+						c.logger.Debug("cluster: capacity heartbeat fetch failed", "node_id", m.NodeID, "error", err)
+					}
+					continue
+				}
+				c.capacityLeases.set(m.NodeID, snap, time.Now())
+			}
+		}()
+	}
+
+	for _, m := range members {
+		if ctx.Err() != nil {
+			break
+		}
+		if m.NodeID == "" || m.NodeID == c.nodeID || !m.Alive || !CanOwnSandboxRole(m.Role) {
+			continue
+		}
+		if m.APIURL == "" && m.InternalURL == "" {
+			continue
+		}
+		jobs <- m
+	}
+	close(jobs)
+	wg.Wait()
+}
+
+func (c *Cluster) fetchMemberCapacity(ctx context.Context, m Member) (capacity.Snapshot, error) {
+	reqCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	if c.internalClient != nil && m.InternalURL != "" {
+		snap, err := fetchCapacitySnapshot(reqCtx, c.internalClient, strings.TrimRight(m.InternalURL, "/")+"/v1/capacity", c.patToken)
+		if err == nil {
+			return snap, nil
+		}
+		if !isStatus(err, http.StatusServiceUnavailable) || m.APIURL == "" {
+			return capacity.Snapshot{}, err
+		}
+	}
+	if m.APIURL == "" {
+		return capacity.Snapshot{}, fmt.Errorf("node %s has no API URL for capacity heartbeat", m.NodeID)
+	}
+	return fetchCapacitySnapshot(reqCtx, c.httpClient, strings.TrimRight(m.APIURL, "/")+"/v1/capacity", c.patToken)
+}
+
+func fetchCapacitySnapshot(ctx context.Context, client *http.Client, endpoint, patToken string) (capacity.Snapshot, error) {
+	var snap capacity.Snapshot
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return snap, err
+	}
+	req.Header.Set("Accept", "application/json")
+	if patToken != "" {
+		req.Header.Set("Authorization", "Bearer "+patToken)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return snap, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return snap, statusError{status: resp.StatusCode, message: strings.TrimSpace(string(msg))}
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&snap); err != nil {
+		return snap, err
+	}
+	return snap, nil
+}
+
+func hasCapacitySnapshot(s capacity.Snapshot) bool {
+	return s.HostCPUCores > 0 || s.HostMemoryTotalMB > 0
+}

--- a/internal/cluster/capacity_lease_test.go
+++ b/internal/cluster/capacity_lease_test.go
@@ -1,0 +1,52 @@
+package cluster
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/pkg/capacity"
+)
+
+func TestCapacityLeaseCacheMarksMissingAndStaleWorkers(t *testing.T) {
+	now := time.Unix(1000, 0)
+	cache := newCapacityLeaseCache("self", nil, 5*time.Second, nil)
+	cache.set("fresh", capacity.Snapshot{HostCPUCores: 8, HostMemoryTotalMB: 16000}, now.Add(-5*time.Second))
+	cache.set("old", capacity.Snapshot{HostCPUCores: 8, HostMemoryTotalMB: 16000}, now.Add(-30*time.Second))
+
+	got := cache.apply([]Member{
+		{NodeID: "fresh", Role: config.NodeRoleWorker, Alive: true},
+		{NodeID: "old", Role: config.NodeRoleWorker, Alive: true},
+		{NodeID: "missing", Role: config.NodeRoleWorker, Alive: true},
+		{NodeID: "server", Role: config.NodeRoleServer, Alive: true},
+	}, now)
+
+	byID := make(map[string]Member, len(got))
+	for _, m := range got {
+		byID[m.NodeID] = m
+	}
+	if byID["fresh"].CapacityStale {
+		t.Fatalf("fresh lease marked stale: %+v", byID["fresh"])
+	}
+	if !byID["old"].CapacityStale {
+		t.Fatalf("old lease not marked stale: %+v", byID["old"])
+	}
+	if !byID["missing"].CapacityStale {
+		t.Fatalf("missing lease not marked stale: %+v", byID["missing"])
+	}
+	if byID["server"].CapacityStale {
+		t.Fatalf("pure server should not require worker capacity: %+v", byID["server"])
+	}
+}
+
+func TestHasCapacitySnapshot(t *testing.T) {
+	if hasCapacitySnapshot(capacity.Snapshot{}) {
+		t.Fatal("zero snapshot should be unknown")
+	}
+	if !hasCapacitySnapshot(capacity.Snapshot{HostCPUCores: 1}) {
+		t.Fatal("snapshot with CPU should be known")
+	}
+	if !hasCapacitySnapshot(capacity.Snapshot{HostMemoryTotalMB: 1}) {
+		t.Fatal("snapshot with memory should be known")
+	}
+}

--- a/internal/cluster/client.go
+++ b/internal/cluster/client.go
@@ -133,7 +133,10 @@ func New(cfg config.Config, logger *slog.Logger, admitter *capacity.Admitter) (*
 		return nil, errors.New("cluster.New: SelfAPIAdvertiseURL required in cluster mode")
 	}
 
-	fsm := newPlacementFSM()
+	fsm, err := newPlacementFSMWithFileRecovery(cfg.RaftDataDir)
+	if err != nil {
+		return nil, fmt.Errorf("cluster.New: recovery store: %w", err)
+	}
 
 	// Load cluster TLS material first — both raft transport and the internal
 	// HTTPS listener need it. Empty SB_CLUSTER_TLS_DIR keeps the legacy

--- a/internal/cluster/client.go
+++ b/internal/cluster/client.go
@@ -88,6 +88,12 @@ type Cluster struct {
 	// fresh lease before a worker can receive new sandboxes.
 	capacityLeases    *capacityLeaseCache
 	capacityLeaseStop context.CancelFunc
+	// reservationAdmissionMu serializes leader-side reservation admission.
+	// Capacity leases are outside the Raft FSM, so the leader must check
+	// target capacity + per-worker pending caps under one queue before
+	// appending opReserve/opReserveBatch. Otherwise two routers can both
+	// validate against the same pending snapshot and overfill a worker.
+	reservationAdmissionMu sync.Mutex
 
 	// recreator is the service-layer hook the owner watcher uses to bring up
 	// a sandbox the FSM says we own but the local store doesn't have. Set via
@@ -558,6 +564,36 @@ func (c *Cluster) ReserveOnTarget(ctx context.Context, sandboxID string, target 
 	return c.applyCommand(ctx, cmd)
 }
 
+// ReserveBatchOnTargets commits multiple reservation intents in one Raft entry.
+// It is intended for create-burst frontends that have already selected targets
+// and want the leader to admit the whole chunk against the same capacity view.
+// The public one-create API still uses ReserveOnTarget, but scale harnesses and
+// bulk create callers use this to avoid one Raft log entry per sandbox.
+func (c *Cluster) ReserveBatchOnTargets(ctx context.Context, reservations []PlacementReservation) error {
+	if len(reservations) == 0 {
+		return nil
+	}
+	cmd := command{Op: opReserveBatch, Reservations: make([]reservationCommand, 0, len(reservations))}
+	now := time.Now()
+	for _, r := range reservations {
+		if r.TTL <= 0 {
+			return fmt.Errorf("cluster: reservation ttl must be > 0")
+		}
+		cmd.Reservations = append(cmd.Reservations, reservationCommand{
+			SandboxID:          r.SandboxID,
+			OwnerNodeID:        r.Target.NodeID,
+			OwnerAPIURL:        r.Target.APIURL,
+			OwnerDataPlaneHost: r.Target.DataPlaneHost,
+			Spec:               r.Redacted,
+			SecretRef:          r.Secrets.Ref,
+			SecretVersion:      r.Secrets.Version,
+			SealedSecrets:      cloneBytes(r.Secrets.LegacySealed),
+			ExpiresUnix:        now.Add(r.TTL).Unix(),
+		})
+	}
+	return c.applyCommand(ctx, cmd)
+}
+
 // CancelReservation deletes a pending reservation for sandboxID. Safe to
 // call at any rollback point: opCancelReserve only fires when the row is
 // State == Reserved, so a stale cancel after a successful promote is a
@@ -723,6 +759,9 @@ func (c *Cluster) applyCommand(ctx context.Context, cmd command) error {
 		return fmt.Errorf("cluster: encode command: %w", err)
 	}
 	if c.raft.raft.State() == raft.Leader {
+		if cmd.Op == opReserve || cmd.Op == opReserveBatch {
+			return c.applyReservationEncodedLocal(ctx, payload, cmd)
+		}
 		return c.applyEncodedLocal(ctx, payload)
 	}
 	return c.forwardApplyToLeader(ctx, payload)
@@ -733,11 +772,27 @@ func (c *Cluster) applyCommand(ctx context.Context, cmd command) error {
 // and applies it locally. Returns ErrNotLeader if leadership has changed
 // since the forwarder picked us — the caller is expected to retry.
 func (c *Cluster) ApplyEncoded(ctx context.Context, payload []byte) error {
-	if _, err := decodeCommand(payload); err != nil {
+	cmd, err := decodeCommand(payload)
+	if err != nil {
 		return fmt.Errorf("cluster: decode forwarded command: %w", err)
 	}
 	if c.raft.raft.State() != raft.Leader {
 		return ErrNotLeader
+	}
+	if cmd.Op == opReserve || cmd.Op == opReserveBatch {
+		return c.applyReservationEncodedLocal(ctx, payload, cmd)
+	}
+	return c.applyEncodedLocal(ctx, payload)
+}
+
+func (c *Cluster) applyReservationEncodedLocal(ctx context.Context, payload []byte, cmd command) error {
+	c.reservationAdmissionMu.Lock()
+	defer c.reservationAdmissionMu.Unlock()
+	if c.raft.raft.State() != raft.Leader {
+		return ErrNotLeader
+	}
+	if err := c.admitReservationCommand(cmd); err != nil {
+		return err
 	}
 	return c.applyEncodedLocal(ctx, payload)
 }
@@ -832,10 +887,23 @@ func (c *Cluster) doLeaderApply(ctx context.Context, client *http.Client, endpoi
 		return nil
 	}
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+	message := strings.TrimSpace(string(body))
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return fmt.Errorf("%w: %s", ErrCreateBackpressure, message)
+	}
 	if resp.StatusCode == http.StatusServiceUnavailable {
+		if strings.Contains(message, ErrCapacityExceeded.Error()) {
+			return fmt.Errorf("%w: %s", ErrCapacityExceeded, message)
+		}
+		if strings.Contains(message, ErrNoPlacementTarget.Error()) {
+			return fmt.Errorf("%w: %s", ErrNoPlacementTarget, message)
+		}
+		if strings.Contains(message, ErrCreateBackpressure.Error()) {
+			return fmt.Errorf("%w: %s", ErrCreateBackpressure, message)
+		}
 		return ErrNotLeader
 	}
-	return fmt.Errorf("cluster: leader-forward apply: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	return fmt.Errorf("cluster: leader-forward apply: status %d: %s", resp.StatusCode, message)
 }
 
 // waitForLeader blocks until raft reports a leader or the deadline passes.

--- a/internal/cluster/client.go
+++ b/internal/cluster/client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -622,6 +623,142 @@ func (c *Cluster) SetNodeDrainState(ctx context.Context, nodeID string, drained 
 	}
 	cmd := command{Op: opSetNodeDrainState, NodeID: nodeID, Drained: drained}
 	return c.applyCommand(ctx, cmd)
+}
+
+// RemoveMember explicitly retires nodeID from the raft configuration. It is an
+// operator lifecycle command, not gossip failure detection: the caller should
+// drain the node first, then stop/terminate it, then remove it from raft.
+//
+// Before RemoveServer, we persist a drain mark and orphan any placements owned
+// by the retiring node so surviving nodes stop routing new work there and
+// clients get a clear 410 for lost sandboxes under the current non-HA policy.
+func (c *Cluster) RemoveMember(ctx context.Context, nodeID string, force bool) error {
+	if nodeID == "" {
+		return fmt.Errorf("cluster: RemoveMember requires non-empty nodeID")
+	}
+	if c.raft == nil || c.raft.raft == nil {
+		return ErrUnknownMember
+	}
+	if c.raft.raft.State() != raft.Leader {
+		return c.forwardRemoveMemberToLeader(ctx, nodeID, force)
+	}
+	return c.removeMemberLocal(ctx, nodeID, force)
+}
+
+func (c *Cluster) removeMemberLocal(ctx context.Context, nodeID string, force bool) error {
+	srv, ok := c.configuredServer(nodeID)
+	if !ok {
+		return ErrUnknownMember
+	}
+	if srv.Suffrage == raft.Voter {
+		voters, ok := c.currentVoterCount()
+		if !ok {
+			return fmt.Errorf("cluster: read raft configuration")
+		}
+		if voters <= 1 {
+			return ErrLastVoter
+		}
+	}
+	if !force && c.memberAlive(nodeID) {
+		return ErrMemberStillAlive
+	}
+	if err := c.SetNodeDrainState(ctx, nodeID, true); err != nil {
+		return err
+	}
+	if err := c.orphanOwner(ctx, nodeID); err != nil {
+		return err
+	}
+	timeout := c.commitTimeout
+	if dl, ok := ctx.Deadline(); ok {
+		if remaining := time.Until(dl); remaining > 0 && remaining < timeout {
+			timeout = remaining
+		}
+	}
+	f := c.raft.raft.RemoveServer(raft.ServerID(nodeID), 0, timeout)
+	if err := f.Error(); err != nil {
+		if errors.Is(err, raft.ErrNotLeader) || errors.Is(err, raft.ErrLeadershipLost) {
+			return ErrNotLeader
+		}
+		return fmt.Errorf("cluster: remove raft member: %w", err)
+	}
+	c.deadOwners.clear(nodeID)
+	c.logger.Info("cluster: removed raft member", "node_id", nodeID, "force", force)
+	return nil
+}
+
+func (c *Cluster) memberAlive(nodeID string) bool {
+	if c.gossip == nil {
+		return false
+	}
+	for _, m := range c.gossip.members() {
+		if m.NodeID == nodeID {
+			return m.Alive
+		}
+	}
+	return false
+}
+
+func (c *Cluster) forwardRemoveMemberToLeader(ctx context.Context, nodeID string, force bool) error {
+	leader := c.Leader()
+	if leader == "" {
+		return ErrNotLeader
+	}
+	path := "/v1/cluster/members/" + url.PathEscape(nodeID)
+	if force {
+		path += "?force=true"
+	}
+	if c.internalClient != nil && c.gossip != nil {
+		if peerInternal := c.gossip.peerInternalURL(leader); peerInternal != "" {
+			return c.doLeaderLifecycle(ctx, c.internalClient, strings.TrimRight(peerInternal, "/")+path, http.MethodDelete, nil)
+		}
+	}
+	leaderURL := c.LeaderAPIURL()
+	if leaderURL == "" {
+		return ErrNotLeader
+	}
+	return c.doLeaderLifecycle(ctx, c.httpClient, strings.TrimRight(leaderURL, "/")+path, http.MethodDelete, nil)
+}
+
+func (c *Cluster) doLeaderLifecycle(ctx context.Context, client *http.Client, endpoint, method string, body []byte) error {
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("cluster: build lifecycle request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.patToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.patToken)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("cluster: lifecycle request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+	msg, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+	message := strings.TrimSpace(string(msg))
+	switch resp.StatusCode {
+	case http.StatusServiceUnavailable:
+		if strings.Contains(message, ErrNotLeader.Error()) || strings.Contains(message, "not leader") {
+			return ErrNotLeader
+		}
+	case http.StatusNotFound:
+		if strings.Contains(message, ErrUnknownMember.Error()) {
+			return ErrUnknownMember
+		}
+	case http.StatusConflict:
+		if strings.Contains(message, ErrMemberStillAlive.Error()) {
+			return ErrMemberStillAlive
+		}
+		if strings.Contains(message, ErrLastVoter.Error()) {
+			return ErrLastVoter
+		}
+	}
+	return fmt.Errorf("cluster: lifecycle request: status %d: %s", resp.StatusCode, message)
 }
 
 // IsNodeDrained reports the FSM's view of nodeID's drain state. Read from the

--- a/internal/cluster/client.go
+++ b/internal/cluster/client.go
@@ -83,6 +83,11 @@ type Cluster struct {
 	// opReserve rows. Followers run no loop because every CancelReservation
 	// has to land via raft anyway. See dead_owner.go for the loop body.
 	reservationGCStop context.CancelFunc
+	// capacityLeases holds authenticated worker capacity heartbeats used by
+	// SelectPlacement. Gossip carries identity only; placement requires a
+	// fresh lease before a worker can receive new sandboxes.
+	capacityLeases    *capacityLeaseCache
+	capacityLeaseStop context.CancelFunc
 
 	// recreator is the service-layer hook the owner watcher uses to bring up
 	// a sandbox the FSM says we own but the local store doesn't have. Set via
@@ -246,6 +251,8 @@ func New(cfg config.Config, logger *slog.Logger, admitter *capacity.Admitter) (*
 		return nil, fmt.Errorf("cluster.New: gossip: %w", err)
 	}
 	c.gossip = gn
+	c.capacityLeases = newCapacityLeaseCache(c.nodeID, admitter, cfg.ClusterCapacityGossipInterval, logger)
+	c.startCapacityLeaseLoop(cfg.ClusterCapacityGossipInterval)
 
 	// Slow reconcile loop: catches the "joined too fast" race where the
 	// memberlist event fires before the joiner's nodeMeta has propagated. The
@@ -849,8 +856,22 @@ func (c *Cluster) waitForLeader(ctx context.Context, max time.Duration) error {
 	}
 }
 
-// Members returns gossip-known members (self included).
-func (c *Cluster) Members() []Member { return c.gossip.members() }
+// Members returns gossip-known members (self included), enriched with fresh
+// capacity heartbeats where available.
+func (c *Cluster) Members() []Member {
+	if c.gossip == nil {
+		return nil
+	}
+	return c.membersWithCapacity()
+}
+
+func (c *Cluster) membersWithCapacity() []Member {
+	members := c.gossip.members()
+	if c.capacityLeases == nil {
+		return members
+	}
+	return c.capacityLeases.apply(members, time.Now())
+}
 
 func (c *Cluster) Placements() []Placement {
 	return c.PlacementsForShards(PlacementShardFilter{})
@@ -941,6 +962,9 @@ func (c *Cluster) Close() error {
 	}
 	if c.reservationGCStop != nil {
 		c.reservationGCStop()
+	}
+	if c.capacityLeaseStop != nil {
+		c.capacityLeaseStop()
 	}
 	if c.ownerWatcherStop != nil {
 		c.ownerWatcherStop()

--- a/internal/cluster/client.go
+++ b/internal/cluster/client.go
@@ -178,6 +178,7 @@ func New(cfg config.Config, logger *slog.Logger, admitter *capacity.Admitter) (*
 		tls:           clusterTLS,
 		publicProxies: newProxyCache(defaultPublicTransport),
 	}
+	fsm.recoveryResolver = c.fetchRecoveryBlob
 
 	// Build the cluster-internal HTTPS client + listener when TLS is loaded.
 	// Both ride on the same CA + node keypair as raft, so a peer's cert can
@@ -757,12 +758,16 @@ func placementCanBeClaimedBy(p Placement, nodeID string) bool {
 // DeletePlacement) safe to call from any node — without it, every owner-side
 // caller would have to know whether it's the leader and forward by hand.
 func (c *Cluster) applyCommand(ctx context.Context, cmd command) error {
-	payload, err := encodeCommand(cmd)
+	raftCmd, err := c.externalizeCommandRecovery(ctx, cmd)
+	if err != nil {
+		return fmt.Errorf("cluster: externalize recovery: %w", err)
+	}
+	payload, err := encodeCommand(raftCmd)
 	if err != nil {
 		return fmt.Errorf("cluster: encode command: %w", err)
 	}
 	if c.raft.raft.State() == raft.Leader {
-		if cmd.Op == opReserve || cmd.Op == opReserveBatch {
+		if raftCmd.Op == opReserve || raftCmd.Op == opReserveBatch {
 			return c.applyReservationEncodedLocal(ctx, payload, cmd)
 		}
 		return c.applyEncodedLocal(ctx, payload)
@@ -782,10 +787,21 @@ func (c *Cluster) ApplyEncoded(ctx context.Context, payload []byte) error {
 	if c.raft.raft.State() != raft.Leader {
 		return ErrNotLeader
 	}
-	if cmd.Op == opReserve || cmd.Op == opReserveBatch {
-		return c.applyReservationEncodedLocal(ctx, payload, cmd)
+	if err := c.fsm.hydrateCommandRecovery(&cmd); err != nil {
+		return err
 	}
-	return c.applyEncodedLocal(ctx, payload)
+	raftCmd, err := c.externalizeCommandRecovery(ctx, cmd)
+	if err != nil {
+		return fmt.Errorf("cluster: externalize recovery: %w", err)
+	}
+	raftPayload, err := encodeCommand(raftCmd)
+	if err != nil {
+		return fmt.Errorf("cluster: encode command: %w", err)
+	}
+	if raftCmd.Op == opReserve || raftCmd.Op == opReserveBatch {
+		return c.applyReservationEncodedLocal(ctx, raftPayload, cmd)
+	}
+	return c.applyEncodedLocal(ctx, raftPayload)
 }
 
 func (c *Cluster) applyReservationEncodedLocal(ctx context.Context, payload []byte, cmd command) error {

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -93,6 +93,12 @@ var ErrReservationConflict = errors.New("cluster: sandbox already placed or rese
 // ingress node must not silently fall back to local Docker ownership.
 var ErrNoPlacementTarget = errors.New("cluster: no worker placement target available")
 
+// ErrInvalidTopology is returned when the live cluster shape violates a
+// production topology invariant. API layers translate this to 503 so clients
+// retry after the operator fixes membership instead of treating it as a
+// malformed request.
+var ErrInvalidTopology = errors.New("cluster: invalid topology")
+
 // PlacementState distinguishes a reservation (capacity held, no docker yet)
 // from a placement (sandbox materialized). Empty defaults to Placed so
 // pre-reservation snapshots restore correctly: every old row is a real

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -86,6 +86,12 @@ var ErrOrphanClaimConflict = errors.New("cluster: orphaned placement belongs to 
 // will see the new reservation and pick a different node.
 var ErrCapacityExceeded = errors.New("cluster: target capacity exceeded after pending reservations")
 
+// ErrCreateBackpressure is returned when the leader-side create queue for a
+// worker is full. This is intentionally distinct from ErrCapacityExceeded:
+// capacity means "pick another worker or wait for resources"; backpressure means
+// "too many creates are already in-flight to this worker, retry shortly."
+var ErrCreateBackpressure = errors.New("cluster: create backpressure")
+
 // ErrReservationConflict is returned when opReserve tries to reserve a
 // sandbox ID that already has a non-expired placement (placed or actively
 // reserved by a different owner). Indicates either a router racing a
@@ -102,6 +108,14 @@ var ErrNoPlacementTarget = errors.New("cluster: no worker placement target avail
 // retry after the operator fixes membership instead of treating it as a
 // malformed request.
 var ErrInvalidTopology = errors.New("cluster: invalid topology")
+
+const (
+	// CreateBackpressureRetryAfterSeconds is the public Retry-After hint for
+	// queue/concurrency backpressure. Keep it short: these rejects are caused by
+	// transient in-flight create fan-in, not by a long operator action.
+	CreateBackpressureRetryAfterSeconds = 5
+	CapacityRetryAfterSeconds           = 30
+)
 
 // PlacementState distinguishes a reservation (capacity held, no docker yet)
 // from a placement (sandbox materialized). Empty defaults to Placed so
@@ -269,6 +283,17 @@ type PlacementTarget struct {
 	// preference to APIURL so the hop rides the cert-pinned channel.
 	InternalURL string
 	IsSelf      bool
+}
+
+// PlacementReservation is one item in a leader-side batch reservation request.
+// Redacted MUST have plaintext credentials stripped before the caller passes it
+// in; Secrets carries only a provider handle or legacy sealed bytes.
+type PlacementReservation struct {
+	SandboxID string
+	Target    PlacementTarget
+	Redacted  *models.CreateSandboxRequest
+	Secrets   PlacementSecrets
+	TTL       time.Duration
 }
 
 // OwnerInfo is returned by OwnerOf.

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -68,9 +68,9 @@ var ErrNameConflict = errors.New("cluster: sandbox name already in use")
 
 // ErrOrphaned is returned by OwnerOf when a placement exists but its owner has
 // been auto-evicted and the dead-owner reconciler has cleared the pointer.
-// Under the current product policy this is a terminal manual-recovery state:
-// callers should surface 410 Gone. If auto-recreation is enabled later, the
-// owner watcher may converge it by reassigning the placement to a live node.
+// This is the terminal state for default non-HA sandboxes; callers should
+// surface 410 Gone. Sandboxes that opted into failover.policy=recreate are
+// reassigned before the remaining dead-owner placements are orphaned.
 var ErrOrphaned = errors.New("cluster: sandbox owner is dead, placement orphaned")
 
 // ErrOrphanClaimConflict is returned when a node tries to reclaim an orphaned

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -460,21 +460,23 @@ type Client interface {
 	// Members returns a snapshot of all known cluster members.
 	Members() []Member
 
-	// Placements returns the local FSM's placement snapshot. Used by each node
-	// to reconcile owner-aware public ingress routes.
+	// Placements returns the local FSM's hot placement snapshot. Recovery
+	// payloads (Spec/secrets) are omitted; use PlacementOf/SpecOf for point
+	// lookups that need them.
 	Placements() []Placement
 
 	// PlacementsForShards returns only placements whose sandbox ID belongs to
 	// one of the requested placement shards. Ingress nodes use this instead of
 	// pulling the full global placement map; server nodes serve it from the
 	// FSM shard index and agent nodes delegate it to a server-role control
-	// plane peer. Empty Shards means "all placements."
+	// plane peer. Empty Shards means "all placements." Returned rows are hot
+	// rows without Spec/secrets.
 	PlacementsForShards(filter PlacementShardFilter) []Placement
 
 	// PlacementPage returns a bounded global placement-index page sorted by
 	// sandbox ID. It is the scalable read path for operators/control planes
-	// that need to enumerate 100k sandboxes without asking every worker for
-	// its local DB.
+	// that need to enumerate large clusters without asking every worker for
+	// its local DB. Returned rows are hot rows without Spec/secrets.
 	PlacementPage(req PlacementPageRequest) PlacementPageResponse
 
 	// PlacementOf returns the full Placement record for sandboxID and true,

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -2,14 +2,18 @@
 //
 // Architecture (Phase 1):
 //
-//   - Membership and capacity dissemination: SWIM gossip via hashicorp/memberlist.
-//     Every node periodically advertises a capacity.Snapshot in its memberlist
-//     metadata; placement decisions read these advertised snapshots.
+//   - Membership: SWIM gossip via hashicorp/memberlist. Gossip carries
+//     identity and role metadata only so memberlist's 512-byte NodeMeta limit
+//     cannot strip Raft addresses.
+//
+//   - Capacity heartbeats: server-role nodes fetch authenticated
+//     capacity.Snapshot payloads from worker-capable peers and require a fresh
+//     heartbeat before placement can target that worker.
 //
 //   - Placement map: server-role nodes run a small Raft FSM (hashicorp/raft)
 //     holding sandbox_id -> owner_node_id plus replicated recovery metadata.
 //     Mutations happen on the leader; server reads are local from the FSM.
-//     Worker/ingress-only nodes run Agent instead: they gossip capacity and
+//     Worker/ingress-only nodes run Agent instead: they gossip identity and
 //     receive owner API forwards, but all placement reads/writes go to the
 //     server quorum over authenticated RPC. They do not store the FSM and do
 //     not join Raft as non-voters.
@@ -227,6 +231,11 @@ type Member struct {
 	Role     string            `json:"role,omitempty"`
 	Alive    bool              `json:"alive"`
 	Capacity capacity.Snapshot `json:"capacity"`
+	// CapacityUpdatedUnix is when this node's last capacity heartbeat was
+	// observed by the scheduler. CapacityStale means the last heartbeat is
+	// missing or too old for placement admission.
+	CapacityUpdatedUnix int64 `json:"capacity_updated_unix,omitempty"`
+	CapacityStale       bool  `json:"capacity_stale,omitempty"`
 }
 
 // LocalSandboxState is one entry in the boot-time AssertOwnership payload.

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -200,22 +200,29 @@ type ExposedPortRoute struct {
 // ingress nodes can install owner-aware data-plane routes. Both fields are kept
 // so older snapshots still restore cleanly.
 type Placement struct {
-	SandboxID           string                       `json:"sandbox_id"`
-	OwnerNodeID         string                       `json:"owner_node_id"`
-	OwnerAPIURL         string                       `json:"owner_api_url"`
-	OwnerDataPlaneHost  string                       `json:"owner_data_plane_host,omitempty"`
-	OwnerState          PlacementOwnerState          `json:"owner_state,omitempty"`
-	OrphanedOwnerNodeID string                       `json:"orphaned_owner_node_id,omitempty"`
-	OrphanedUnix        int64                        `json:"orphaned_unix,omitempty"`
-	Version             uint64                       `json:"version"`
-	CreatedUnix         int64                        `json:"created_unix"`
-	UpdatedUnix         int64                        `json:"updated_unix"`
-	Spec                *models.CreateSandboxRequest `json:"spec,omitempty"`
-	SecretRef           string                       `json:"secret_ref,omitempty"`
-	SecretVersion       int                          `json:"secret_version,omitempty"`
-	SealedSecrets       []byte                       `json:"sealed_secrets,omitempty"`
-	ExposedPorts        map[int]string               `json:"exposed_ports,omitempty"`
-	ExposedPortRoutes   map[int]ExposedPortRoute     `json:"exposed_port_routes,omitempty"`
+	SandboxID           string              `json:"sandbox_id"`
+	OwnerNodeID         string              `json:"owner_node_id"`
+	OwnerAPIURL         string              `json:"owner_api_url"`
+	OwnerDataPlaneHost  string              `json:"owner_data_plane_host,omitempty"`
+	OwnerState          PlacementOwnerState `json:"owner_state,omitempty"`
+	OrphanedOwnerNodeID string              `json:"orphaned_owner_node_id,omitempty"`
+	OrphanedUnix        int64               `json:"orphaned_unix,omitempty"`
+	Version             uint64              `json:"version"`
+	CreatedUnix         int64               `json:"created_unix"`
+	UpdatedUnix         int64               `json:"updated_unix"`
+	// Name is the small, hot copy of Spec.Name used to rebuild the cluster-wide
+	// uniqueness index without loading the larger recovery spec payload.
+	Name string `json:"name,omitempty"`
+	// RecoveryRef points at the out-of-snapshot recovery payload for this row.
+	// Spec/secret fields are hydrated from that store only for point lookups and
+	// recreate flows.
+	RecoveryRef       string                       `json:"-"`
+	Spec              *models.CreateSandboxRequest `json:"spec,omitempty"`
+	SecretRef         string                       `json:"secret_ref,omitempty"`
+	SecretVersion     int                          `json:"secret_version,omitempty"`
+	SealedSecrets     []byte                       `json:"sealed_secrets,omitempty"`
+	ExposedPorts      map[int]string               `json:"exposed_ports,omitempty"`
+	ExposedPortRoutes map[int]ExposedPortRoute     `json:"exposed_port_routes,omitempty"`
 	// State is empty for materialized placements (the historical schema) and
 	// PlacementStateReserved for capacity-only intents that have not yet been
 	// promoted by a successful local create. Reservations are eligible for

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -128,6 +128,11 @@ const (
 	// transient in-flight create fan-in, not by a long operator action.
 	CreateBackpressureRetryAfterSeconds = 5
 	CapacityRetryAfterSeconds           = 30
+	// InvalidTopologyRetryAfterSeconds is the hint for ErrInvalidTopology
+	// rejects, which only clear when an operator reshapes the cluster
+	// (promoting servers or adding workers). A long back-off keeps clients
+	// from busy-retrying while the human change is in flight.
+	InvalidTopologyRetryAfterSeconds = 300
 )
 
 // PlacementState distinguishes a reservation (capacity held, no docker yet)

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -109,6 +109,19 @@ var ErrNoPlacementTarget = errors.New("cluster: no worker placement target avail
 // malformed request.
 var ErrInvalidTopology = errors.New("cluster: invalid topology")
 
+// ErrUnknownMember is returned when an operator asks to remove a node that is
+// not present in the current raft configuration.
+var ErrUnknownMember = errors.New("cluster: unknown raft member")
+
+// ErrMemberStillAlive protects operators from accidentally removing a live
+// control-plane node. Stop the node first, or pass force through the public
+// lifecycle API when intentionally retiring a live member.
+var ErrMemberStillAlive = errors.New("cluster: raft member is still alive")
+
+// ErrLastVoter prevents an explicit removal from deleting the last voting raft
+// server and leaving the cluster with no quorum path.
+var ErrLastVoter = errors.New("cluster: cannot remove last raft voter")
+
 const (
 	// CreateBackpressureRetryAfterSeconds is the public Retry-After hint for
 	// queue/concurrency backpressure. Keep it short: these rejects are caused by
@@ -455,6 +468,12 @@ type Client interface {
 	// going away — the operator's intent must outlast the process they're
 	// about to stop.
 	SetNodeDrainState(ctx context.Context, nodeID string, drained bool) error
+
+	// RemoveMember explicitly removes nodeID from the raft configuration after
+	// marking it drained and orphaning any placements it owned. Unknown raft
+	// members return ErrUnknownMember. Live members require force=true so an
+	// operator cannot accidentally cut out a healthy server by typo.
+	RemoveMember(ctx context.Context, nodeID string, force bool) error
 
 	// IsNodeDrained reports whether nodeID is currently marked drained.
 	// Reads the local FSM (no network hop). Used by observability endpoints

--- a/internal/cluster/dead_owner.go
+++ b/internal/cluster/dead_owner.go
@@ -9,23 +9,6 @@ import (
 	"github.com/hashicorp/raft"
 )
 
-// clusterRecreateOnFailoverEnabled is the product-policy gate for automatic
-// sandbox failover-recreate. When false (current policy), a dead owner's
-// placements are orphaned and clients see 410 Gone — sandboxes do not survive
-// node death.
-//
-// The reassign + recreate code paths in this file (pickRecreationTarget,
-// evictDeadOwner's spec-driven branch) and in owner_watcher.go
-// (recreateOwnedSandboxes, tryReassignStuckPlacement) are intentionally
-// preserved rather than deleted: spec/sealed-secret replication is cheap, the
-// failure-mode tests are still useful, and a future opt-in lifecycle policy
-// (e.g. Lifecycle.RecreateOnFailover) is expected to flip this gate.
-//
-// To re-enable: change to true here. Before exposing to users, decide whether
-// recreate should be opt-in per sandbox so it does not silently revive user
-// work that the operator intended to leave dead.
-const clusterRecreateOnFailoverEnabled = false
-
 // deadOwnerTracker holds per-node "first observed dead at" timestamps so the
 // reconciler can decide which nodes have outlasted the grace period.
 type deadOwnerTracker struct {
@@ -169,50 +152,32 @@ func (c *Cluster) reconcileDeadOwners(ctx context.Context) {
 	}
 }
 
-// evictDeadOwner orphans every placement owned by nodeID and removes the dead
-// node from the raft configuration. Orphan = OwnerNodeID set to "", so the API
-// surfaces ErrOrphaned (410 Gone) for any subsequent request against that
-// sandbox. This matches the product policy that sandboxes do not survive node
-// death (see clusterRecreateOnFailoverEnabled at the top of this file).
-//
-// When clusterRecreateOnFailoverEnabled flips to true, pickRecreationTarget
-// returns a live peer scored against the replicated spec and the placement is
-// reassigned (rather than orphaned) — the owner watcher on the new owner then
-// re-materializes the container. That code path is preserved here for the
-// future opt-in failover behavior.
+// evictDeadOwner handles every placement owned by nodeID and removes the dead
+// node from the raft configuration. Sandboxes that opted into
+// failover.policy=recreate are reassigned to a live peer scored against their
+// replicated spec; the owner watcher on that peer re-materializes the
+// container. All remaining placements are orphaned (OwnerNodeID="") so the API
+// surfaces ErrOrphaned (410 Gone).
 //
 // All steps are idempotent so a partial failure is safe to retry on the next
 // tick: a placement already orphaned stays orphaned, and RemoveServer is a
 // no-op once the dead node is gone.
 func (c *Cluster) evictDeadOwner(ctx context.Context, nodeID string) {
-	if !clusterRecreateOnFailoverEnabled {
-		orphaned := len(c.fsm.idsOwnedBy(nodeID))
-		if err := c.orphanOwner(ctx, nodeID); err != nil {
-			c.logger.Warn("cluster: orphan dead-owner placements failed; will retry next tick",
-				"dead_node", nodeID, "err", err)
-			return
-		}
-		if orphaned > 0 {
-			c.logger.Warn("cluster: orphaned placements after owner death",
-				"dead_node", nodeID, "orphaned", orphaned)
-		}
-		c.removeDeadOwnerServer(nodeID)
-		return
-	}
-
 	ids := c.fsm.idsOwnedBy(nodeID)
-	var reassigned, orphaned int
+	var reassigned int
 	for _, id := range ids {
 		p, ok := c.fsm.get(id)
 		if !ok {
 			continue
 		}
-		// Default to the orphan path. The reassign branch is gated off in
-		// product policy; keeping pickRecreationTarget callable preserves the
-		// future opt-in path and the existing tests that exercise it.
-		var newOwnerID, newOwnerURL, newOwnerDataPlaneHost string
-		if clusterRecreateOnFailoverEnabled {
-			newOwnerID, newOwnerURL, newOwnerDataPlaneHost = c.pickRecreationTarget(p.Spec)
+		if !placementWantsFailoverRecreate(p) {
+			continue
+		}
+		newOwnerID, newOwnerURL, newOwnerDataPlaneHost := c.pickRecreationTarget(p.Spec)
+		if newOwnerID == "" {
+			c.logger.Warn("cluster: no failover recreation target; placement will be orphaned",
+				"sandbox_id", id, "dead_node", nodeID)
+			continue
 		}
 		cmd := command{
 			Op:                 opReassign,
@@ -226,15 +191,17 @@ func (c *Cluster) evictDeadOwner(ctx context.Context, nodeID string) {
 				"sandbox_id", id, "dead_node", nodeID, "new_owner", newOwnerID, "err", err)
 			return
 		}
-		if newOwnerID == "" {
-			orphaned++
-		} else {
-			reassigned++
-		}
+		reassigned++
+	}
+	orphaned := len(c.fsm.idsOwnedBy(nodeID))
+	if err := c.orphanOwner(ctx, nodeID); err != nil {
+		c.logger.Warn("cluster: orphan dead-owner placements failed; will retry next tick",
+			"dead_node", nodeID, "err", err)
+		return
 	}
 	if reassigned > 0 || orphaned > 0 {
 		c.logger.Warn("cluster: handled placements after owner death",
-			"dead_node", nodeID, "reassigned", reassigned, "orphaned_no_spec", orphaned)
+			"dead_node", nodeID, "reassigned", reassigned, "orphaned", orphaned)
 	}
 	c.removeDeadOwnerServer(nodeID)
 }

--- a/internal/cluster/dead_owner.go
+++ b/internal/cluster/dead_owner.go
@@ -284,7 +284,7 @@ func (c *Cluster) startReservationGCLoop() {
 
 // reconcileReservations cancels any reservation whose expiry has passed.
 // Cancel is best-effort + idempotent: a reservation that was promoted to
-// Placed between snapshot and Apply is left alone (opCancelReserve is a no-op
+// Placed between enumeration and Apply is left alone (opCancelReserve is a no-op
 // on placed rows), and a reservation already cancelled by the router's
 // rollback path is also a no-op. So a partial sweep on leader-flap re-runs
 // safely on the next tick.
@@ -293,14 +293,8 @@ func (c *Cluster) reconcileReservations(ctx context.Context) {
 		return
 	}
 	now := time.Now().Unix()
-	snapshot := c.fsm.snapshot()
-	for id, p := range snapshot {
-		if p.State != PlacementStateReserved {
-			continue
-		}
-		if p.ExpiresUnix == 0 || now <= p.ExpiresUnix {
-			continue
-		}
+	for _, id := range c.fsm.expiredReservationIDs(now) {
+		p, _ := c.fsm.get(id)
 		if err := c.CancelReservation(ctx, id); err != nil {
 			c.logger.Warn("cluster: cancel expired reservation failed; will retry next tick",
 				"sandbox_id", id, "owner", p.OwnerNodeID, "err", err)

--- a/internal/cluster/dead_owner_test.go
+++ b/internal/cluster/dead_owner_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/pkg/capacity"
 	"github.com/aerol-ai/microvm/pkg/models"
 )
 
@@ -114,31 +115,29 @@ func TestReconcileDeadOwnersRespectsGrace(t *testing.T) {
 	}
 }
 
-// TestEvictDeadOwnerReassignsWhenSpecExists drives the spec-replication
-// codepath: a placement carrying a Spec gets reassigned to a live node (the
-// only candidate is self/leader) instead of being marked orphan. This is the
-// behaviour change behind auto-recreation — the owner watcher on the new
+// TestEvictDeadOwnerReassignsWhenSpecOptsIn drives the opt-in
+// failover-recreate path: a placement carrying a portable Spec with
+// failover.policy=recreate gets reassigned to a live node (the only candidate
+// is self/leader) instead of being marked orphan. The owner watcher on the new
 // owner picks up from there.
-//
-// Skipped under the current product policy (clusterRecreateOnFailoverEnabled
-// is false): evictDeadOwner always orphans, regardless of spec. The test is
-// kept so the reassign path is still validated whenever the gate flips back
-// on.
-func TestEvictDeadOwnerReassignsWhenSpecExists(t *testing.T) {
-	if !clusterRecreateOnFailoverEnabled {
-		t.Skip("failover recreate is gated off; flip clusterRecreateOnFailoverEnabled to exercise")
-	}
+func TestEvictDeadOwnerReassignsWhenSpecOptsIn(t *testing.T) {
 	if testing.Short() {
 		t.Skip("integration test: requires real raft socket")
 	}
 	c, cleanup := newTestCluster(t, "leader", true, nil)
 	defer cleanup()
 	waitForLeader(t, c, 10*time.Second)
+	seedSelfFailoverCapacity(c)
 
 	// Placement with a non-nil spec belongs to a phantom dead node.
 	cmd := command{
 		Op: opPlace, SandboxID: "sb-reassign", OwnerNodeID: "dead-node", OwnerAPIURL: "http://gone",
-		Spec: &models.CreateSandboxRequest{Image: "alpine", CPU: 0.5, MemoryMB: 256},
+		Spec: &models.CreateSandboxRequest{
+			Image:    "alpine",
+			CPU:      0.5,
+			MemoryMB: 256,
+			Failover: &models.Failover{Policy: models.FailoverPolicyRecreate},
+		},
 	}
 	payload, _ := encodeCommand(cmd)
 	if err := c.raft.raft.Apply(payload, 2*time.Second).Error(); err != nil {
@@ -158,6 +157,32 @@ func TestEvictDeadOwnerReassignsWhenSpecExists(t *testing.T) {
 	}
 }
 
+func TestEvictDeadOwnerOrphansSpecWithoutFailoverOptIn(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test: requires real raft socket")
+	}
+	c, cleanup := newTestCluster(t, "leader", true, nil)
+	defer cleanup()
+	waitForLeader(t, c, 10*time.Second)
+
+	cmd := command{
+		Op: opPlace, SandboxID: "sb-no-ha", OwnerNodeID: "dead-node", OwnerAPIURL: "http://gone",
+		Spec: &models.CreateSandboxRequest{Image: "alpine", CPU: 0.5, MemoryMB: 256},
+	}
+	payload, _ := encodeCommand(cmd)
+	if err := c.raft.raft.Apply(payload, 2*time.Second).Error(); err != nil {
+		t.Fatalf("raft Apply: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	c.evictDeadOwner(ctx, "dead-node")
+
+	if _, err := c.OwnerOf("sb-no-ha"); err != ErrOrphaned {
+		t.Fatalf("post-evict OwnerOf err = %v, want ErrOrphaned", err)
+	}
+}
+
 // newTestClusterWithCfg is newTestCluster but with a hook to mutate the
 // generated config before it's handed to New. Used by tests that need to
 // shorten time-based knobs.
@@ -168,4 +193,22 @@ func newTestClusterWithCfg(t *testing.T, nodeID string, bootstrap bool, gossipPe
 		mutate(&c.cfg)
 	}
 	return c, cleanup
+}
+
+func seedSelfFailoverCapacity(c *Cluster) {
+	if c == nil || c.capacityLeases == nil {
+		return
+	}
+	c.capacityLeases.set(c.nodeID, capacity.Snapshot{
+		HostCPUCores:      16,
+		HostMemoryTotalMB: 65536,
+		HostDiskTotalGB:   1024,
+		CPUBudget:         16,
+		MemoryBudgetMB:    65536,
+		DiskBudgetGB:      1024,
+		AvailableCPU:      16,
+		AvailableMemoryMB: 65536,
+		AvailableDiskGB:   1024,
+		CanAdmit:          true,
+	}, time.Now())
 }

--- a/internal/cluster/failover_policy.go
+++ b/internal/cluster/failover_policy.go
@@ -1,0 +1,11 @@
+package cluster
+
+import "github.com/aerol-ai/microvm/pkg/models"
+
+func placementWantsFailoverRecreate(p Placement) bool {
+	return specWantsFailoverRecreate(p.Spec)
+}
+
+func specWantsFailoverRecreate(spec *models.CreateSandboxRequest) bool {
+	return spec != nil && spec.ShouldRecreateOnFailover()
+}

--- a/internal/cluster/fsm.go
+++ b/internal/cluster/fsm.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/aerol-ai/microvm/pkg/capacity"
 	"github.com/aerol-ai/microvm/pkg/models"
+	"github.com/google/btree"
 	"github.com/hashicorp/raft"
 )
 
@@ -110,13 +111,17 @@ func applyCommandSecretUpdate(existing Placement, exists bool, cmd command) Plac
 	return PlacementSecrets{LegacySealed: cloneBytes(cmd.SealedSecrets)}
 }
 
-// placementFSM is the raft.FSM implementation. It holds the entire placement
-// map in-memory; persistence is provided by the raft log + snapshots. The map
-// is small (one row per sandbox; row size ~150 bytes), so even a 10K-node
-// fleet with 100 sandboxes/node fits comfortably in RAM.
+// placementFSM is the raft.FSM implementation. It keeps hot routing/admission
+// fields separate from larger recovery payloads so ingress/page reads do not
+// clone specs or secret handles for every sandbox.
 type placementFSM struct {
-	mu         sync.RWMutex
+	mu sync.RWMutex
+	// placements is the hot row map. Values deliberately keep Placement.Spec,
+	// SecretRef, SecretVersion, and SealedSecrets empty; those larger recovery
+	// fields live in recovery and are attached only for point lookups, snapshots,
+	// and failover/recreate flows.
 	placements map[string]Placement
+	recovery   map[string]placementRecovery
 	version    uint64
 	// nameIndex maps sandbox Name → SandboxID for cluster-wide name uniqueness.
 	// Empty names are NOT indexed (anonymous sandboxes don't conflict, matching
@@ -131,6 +136,9 @@ type placementFSM struct {
 	// The shard ID derives only from SandboxID, so ownership/spec/port changes
 	// update the placement row without touching this index.
 	shardIndex map[int]map[string]struct{}
+	// placementIDs is a sorted sandbox ID index used by PlacementPage so a
+	// bounded page does not allocate/sort the full placement map.
+	placementIDs *btree.BTreeG[string]
 	// hostPortIndex maps a raw-TCP public host port to the placement exposure
 	// that owns it. This is the cluster-wide raw TCP capacity index: AddPort
 	// rejects collisions in O(1) under the FSM lock instead of scanning every
@@ -150,6 +158,10 @@ type placementFSM struct {
 	pendingReservationCapacity   map[string]capacity.Request
 	pendingReservationIDsByOwner map[string]map[string]struct{}
 	pendingReservationExpiries   pendingReservationExpiryHeap
+	// reservedIndex tracks rows that are still State=Reserved even after their
+	// capacity claim has been pruned as expired. The leader GC uses it to find
+	// expired reservation rows without scanning every placed sandbox.
+	reservedIndex map[string]struct{}
 	// drainedNodes holds the set of nodeIDs an operator has marked as
 	// "exclude from SelectPlacement candidate set". Stored in the FSM (not in
 	// gossip) so the state survives the drained node going away — operators
@@ -164,6 +176,13 @@ type placementFSM struct {
 	// then takes subMu to fan out.
 	subMu       sync.Mutex
 	subscribers []chan<- struct{}
+}
+
+type placementRecovery struct {
+	Spec          *models.CreateSandboxRequest
+	SecretRef     string
+	SecretVersion int
+	SealedSecrets []byte
 }
 
 type hostPortClaim struct {
@@ -205,15 +224,22 @@ func (h *pendingReservationExpiryHeap) Pop() any {
 func newPlacementFSM() *placementFSM {
 	return &placementFSM{
 		placements:                   make(map[string]Placement),
+		recovery:                     make(map[string]placementRecovery),
 		nameIndex:                    make(map[string]string),
 		shardIndex:                   make(map[int]map[string]struct{}),
+		placementIDs:                 newPlacementIDIndex(),
 		hostPortIndex:                make(map[int]hostPortClaim),
 		ownerIndex:                   make(map[string]map[string]struct{}),
 		pendingReservationClaims:     make(map[string]pendingReservationClaim),
 		pendingReservationCapacity:   make(map[string]capacity.Request),
 		pendingReservationIDsByOwner: make(map[string]map[string]struct{}),
+		reservedIndex:                make(map[string]struct{}),
 		drainedNodes:                 make(map[string]bool),
 	}
+}
+
+func newPlacementIDIndex() *btree.BTreeG[string] {
+	return btree.NewG[string](32, func(a, b string) bool { return a < b })
 }
 
 // Apply is invoked by raft for every committed log entry on every node.
@@ -253,7 +279,7 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 		// transition + UpdatedUnix bump even when Spec/Secrets are empty
 		// (the reservation already holds them) — so we fall through to the
 		// write path below in that case.
-		existing, exists := f.placements[cmd.SandboxID]
+		existing, exists := f.fullPlacementLocked(cmd.SandboxID)
 		if exists && existing.OwnerNodeID == cmd.OwnerNodeID && cmd.Spec == nil && !cmd.hasSecretUpdate() && !existing.IsReserved() {
 			return nil
 		}
@@ -310,7 +336,7 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 				f.releasePendingReservationOwnerLocked(cmd.SandboxID, existing.OwnerNodeID)
 			}
 		}
-		f.placements[cmd.SandboxID] = Placement{
+		p := Placement{
 			SandboxID:          cmd.SandboxID,
 			OwnerNodeID:        cmd.OwnerNodeID,
 			OwnerAPIURL:        cmd.OwnerAPIURL,
@@ -331,11 +357,10 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 			State:       PlacementStatePlaced,
 			ExpiresUnix: 0,
 		}
+		f.storePlacementLocked(cmd.SandboxID, p)
 		f.claimNameLocked(cmd.SandboxID, specName(spec))
 		f.claimShardLocked(cmd.SandboxID)
-		if p, ok := f.placements[cmd.SandboxID]; ok {
-			f.claimOwnerLocked(cmd.SandboxID, p)
-		}
+		f.claimOwnerLocked(cmd.SandboxID, p)
 		return nil
 	case opReserve:
 		// Reservations are the first-half of the two-step create: the router
@@ -348,7 +373,7 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 		if cmd.SandboxID == "" || cmd.OwnerNodeID == "" {
 			return fmt.Errorf("placementFSM: opReserve requires sandbox_id and owner_node_id")
 		}
-		existing, exists := f.placements[cmd.SandboxID]
+		existing, exists := f.fullPlacementLocked(cmd.SandboxID)
 		if exists {
 			// Reject when the slot is already materialized — a router racing
 			// a completed sandbox should back off and let the caller see 409.
@@ -361,7 +386,7 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 				existing.ExpiresUnix = cmd.ExpiresUnix
 				existing.Version = f.version
 				existing.UpdatedUnix = now
-				f.placements[cmd.SandboxID] = existing
+				f.storePlacementLocked(cmd.SandboxID, existing)
 				f.refreshPendingReservationExpiryLocked(cmd.SandboxID, cmd.ExpiresUnix)
 				return nil
 			}
@@ -398,7 +423,7 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 			State:              PlacementStateReserved,
 			ExpiresUnix:        cmd.ExpiresUnix,
 		}
-		f.placements[cmd.SandboxID] = p
+		f.storePlacementLocked(cmd.SandboxID, p)
 		f.claimNameLocked(cmd.SandboxID, specName(cmd.Spec))
 		f.claimShardLocked(cmd.SandboxID)
 		f.claimPendingReservationLocked(cmd.SandboxID, p)
@@ -409,7 +434,7 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 		// the safety property that lets the router fire CancelReservation
 		// freely on any failure without worrying about a racing successful
 		// promote.
-		existing, exists := f.placements[cmd.SandboxID]
+		existing, exists := f.fullPlacementLocked(cmd.SandboxID)
 		if !exists || !existing.IsReserved() {
 			return nil
 		}
@@ -419,9 +444,10 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 		f.releasePendingReservationLocked(cmd.SandboxID)
 		f.releasePendingReservationOwnerLocked(cmd.SandboxID, existing.OwnerNodeID)
 		delete(f.placements, cmd.SandboxID)
+		delete(f.recovery, cmd.SandboxID)
 		return nil
 	case opDelete:
-		if existing, ok := f.placements[cmd.SandboxID]; ok {
+		if existing, ok := f.fullPlacementLocked(cmd.SandboxID); ok {
 			f.releaseNameLocked(cmd.SandboxID, specName(existing.Spec))
 			f.releaseShardLocked(cmd.SandboxID)
 			f.releaseAllHostPortsLocked(cmd.SandboxID, existing)
@@ -432,9 +458,10 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 			}
 		}
 		delete(f.placements, cmd.SandboxID)
+		delete(f.recovery, cmd.SandboxID)
 		return nil
 	case opReassign:
-		existing, exists := f.placements[cmd.SandboxID]
+		existing, exists := f.fullPlacementLocked(cmd.SandboxID)
 		if !exists {
 			// Reassigning a non-existent placement is a no-op (could happen
 			// if a delete and a reassign race; delete wins).
@@ -465,7 +492,7 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 		}
 		existing.Version = f.version
 		existing.UpdatedUnix = now
-		f.placements[cmd.SandboxID] = existing
+		f.storePlacementLocked(cmd.SandboxID, existing)
 		if wasReserved {
 			f.claimPendingReservationLocked(cmd.SandboxID, existing)
 		} else {
@@ -477,7 +504,7 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 			return fmt.Errorf("placementFSM: opOrphanOwner requires node_id")
 		}
 		for _, id := range f.ownedPlacementIDsLocked(cmd.NodeID) {
-			existing, ok := f.placements[id]
+			existing, ok := f.fullPlacementLocked(id)
 			if !ok || existing.IsReserved() || existing.OwnerNodeID != cmd.NodeID {
 				continue
 			}
@@ -490,10 +517,10 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 			existing.OrphanedUnix = now
 			existing.Version = f.version
 			existing.UpdatedUnix = now
-			f.placements[id] = existing
+			f.storePlacementLocked(id, existing)
 		}
 		for _, id := range f.pendingReservationIDsLocked(cmd.NodeID) {
-			existing, ok := f.placements[id]
+			existing, ok := f.fullPlacementLocked(id)
 			if !ok || !existing.IsReserved() || existing.OwnerNodeID != cmd.NodeID {
 				continue
 			}
@@ -502,13 +529,14 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 			f.releasePendingReservationLocked(id)
 			f.releasePendingReservationOwnerLocked(id, existing.OwnerNodeID)
 			delete(f.placements, id)
+			delete(f.recovery, id)
 		}
 		return nil
 	case opClaimOrphan:
 		if cmd.SandboxID == "" || cmd.OwnerNodeID == "" {
 			return fmt.Errorf("placementFSM: opClaimOrphan requires sandbox_id and owner_node_id")
 		}
-		existing, exists := f.placements[cmd.SandboxID]
+		existing, exists := f.fullPlacementLocked(cmd.SandboxID)
 		if !exists {
 			return ErrUnknownSandbox
 		}
@@ -550,11 +578,11 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 		existing.OrphanedUnix = 0
 		existing.Version = f.version
 		existing.UpdatedUnix = now
-		f.placements[cmd.SandboxID] = existing
+		f.storePlacementLocked(cmd.SandboxID, existing)
 		f.claimOwnerLocked(cmd.SandboxID, existing)
 		return nil
 	case opUpsertSpec:
-		existing, exists := f.placements[cmd.SandboxID]
+		existing, exists := f.fullPlacementLocked(cmd.SandboxID)
 		if !exists {
 			// No placement to attach the spec to. Treat as no-op: the
 			// mutating handler that produced this entry will have already
@@ -592,13 +620,13 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 		}
 		existing.Version = f.version
 		existing.UpdatedUnix = now
-		f.placements[cmd.SandboxID] = existing
+		f.storePlacementLocked(cmd.SandboxID, existing)
 		if wasReserved {
 			f.claimPendingReservationLocked(cmd.SandboxID, existing)
 		}
 		return nil
 	case opAddExposedPort:
-		existing, exists := f.placements[cmd.SandboxID]
+		existing, exists := f.fullPlacementLocked(cmd.SandboxID)
 		if !exists || cmd.Port <= 0 {
 			return nil
 		}
@@ -630,10 +658,10 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 		f.claimHostPortLocked(cmd.SandboxID, cmd.Port, route)
 		existing.Version = f.version
 		existing.UpdatedUnix = now
-		f.placements[cmd.SandboxID] = existing
+		f.storePlacementLocked(cmd.SandboxID, existing)
 		return nil
 	case opRemoveExposedPort:
-		existing, exists := f.placements[cmd.SandboxID]
+		existing, exists := f.fullPlacementLocked(cmd.SandboxID)
 		if !exists || cmd.Port <= 0 {
 			return nil
 		}
@@ -651,7 +679,7 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 		}
 		existing.Version = f.version
 		existing.UpdatedUnix = now
-		f.placements[cmd.SandboxID] = existing
+		f.storePlacementLocked(cmd.SandboxID, existing)
 		return nil
 	case opSetNodeDrainState:
 		// Drain marks live in the FSM so an operator-issued drain persists past
@@ -783,20 +811,28 @@ func (f *placementFSM) claimShardLocked(sandboxID string) {
 		f.shardIndex[shard] = ids
 	}
 	ids[sandboxID] = struct{}{}
+	if f.placementIDs == nil {
+		f.placementIDs = newPlacementIDIndex()
+	}
+	f.placementIDs.ReplaceOrInsert(sandboxID)
 }
 
 func (f *placementFSM) releaseShardLocked(sandboxID string) {
-	if sandboxID == "" || f.shardIndex == nil {
+	if sandboxID == "" {
 		return
 	}
-	shard := PlacementShardForSandbox(sandboxID, DefaultPlacementShardCount)
-	ids := f.shardIndex[shard]
-	if ids == nil {
-		return
+	if f.shardIndex != nil {
+		shard := PlacementShardForSandbox(sandboxID, DefaultPlacementShardCount)
+		ids := f.shardIndex[shard]
+		if ids != nil {
+			delete(ids, sandboxID)
+			if len(ids) == 0 {
+				delete(f.shardIndex, shard)
+			}
+		}
 	}
-	delete(ids, sandboxID)
-	if len(ids) == 0 {
-		delete(f.shardIndex, shard)
+	if f.placementIDs != nil {
+		f.placementIDs.Delete(sandboxID)
 	}
 }
 
@@ -859,6 +895,9 @@ func (f *placementFSM) claimPendingReservationLocked(sandboxID string, p Placeme
 	if f.pendingReservationIDsByOwner == nil {
 		f.pendingReservationIDsByOwner = make(map[string]map[string]struct{})
 	}
+	if f.reservedIndex == nil {
+		f.reservedIndex = make(map[string]struct{})
+	}
 	if old, ok := f.pendingReservationClaims[sandboxID]; ok {
 		f.subtractPendingCapacityLocked(old.OwnerNodeID, old.Request)
 		if old.OwnerNodeID != p.OwnerNodeID {
@@ -874,12 +913,18 @@ func (f *placementFSM) claimPendingReservationLocked(sandboxID string, p Placeme
 	f.pendingReservationClaims[sandboxID] = claim
 	f.addPendingCapacityLocked(claim.OwnerNodeID, claim.Request)
 	f.claimPendingReservationOwnerLocked(sandboxID, claim.OwnerNodeID)
+	f.reservedIndex[sandboxID] = struct{}{}
 	if claim.ExpiresUnix > 0 {
 		heap.Push(&f.pendingReservationExpiries, pendingReservationExpiry{SandboxID: sandboxID, ExpiresUnix: claim.ExpiresUnix})
 	}
 }
 
 func (f *placementFSM) releasePendingReservationLocked(sandboxID string) {
+	f.releasePendingReservationClaimLocked(sandboxID)
+	delete(f.reservedIndex, sandboxID)
+}
+
+func (f *placementFSM) releasePendingReservationClaimLocked(sandboxID string) {
 	if f.pendingReservationClaims == nil {
 		return
 	}
@@ -965,7 +1010,7 @@ func (f *placementFSM) pruneExpiredPendingReservationsLocked(now int64) {
 		if !ok || claim.ExpiresUnix != next.ExpiresUnix {
 			continue
 		}
-		f.releasePendingReservationLocked(next.SandboxID)
+		f.releasePendingReservationClaimLocked(next.SandboxID)
 	}
 }
 
@@ -997,11 +1042,56 @@ func (f *placementFSM) subtractPendingCapacityLocked(owner string, req capacity.
 	f.pendingReservationCapacity[owner] = cur
 }
 
+func (f *placementFSM) fullPlacementLocked(id string) (Placement, bool) {
+	p, ok := f.placements[id]
+	if !ok {
+		return Placement{}, false
+	}
+	if rec, ok := f.recovery[id]; ok {
+		p.Spec = rec.Spec
+		p.SecretRef = rec.SecretRef
+		p.SecretVersion = rec.SecretVersion
+		p.SealedSecrets = rec.SealedSecrets
+	}
+	return p, true
+}
+
+func (f *placementFSM) storePlacementLocked(id string, p Placement) {
+	hot, rec := splitPlacement(p)
+	f.placements[id] = hot
+	if rec.empty() {
+		delete(f.recovery, id)
+		return
+	}
+	if f.recovery == nil {
+		f.recovery = make(map[string]placementRecovery)
+	}
+	f.recovery[id] = rec
+}
+
+func splitPlacement(p Placement) (Placement, placementRecovery) {
+	rec := placementRecovery{
+		Spec:          p.Spec,
+		SecretRef:     p.SecretRef,
+		SecretVersion: p.SecretVersion,
+		SealedSecrets: p.SealedSecrets,
+	}
+	p.Spec = nil
+	p.SecretRef = ""
+	p.SecretVersion = 0
+	p.SealedSecrets = nil
+	return p, rec
+}
+
+func (r placementRecovery) empty() bool {
+	return r.Spec == nil && r.SecretRef == "" && r.SecretVersion == 0 && len(r.SealedSecrets) == 0
+}
+
 // get returns the placement for id, or zero-value + false if absent.
 func (f *placementFSM) get(id string) (Placement, bool) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
-	p, ok := f.placements[id]
+	p, ok := f.fullPlacementLocked(id)
 	if !ok {
 		return Placement{}, false
 	}
@@ -1063,30 +1153,62 @@ func (f *placementFSM) pendingReservationsByNode(now int64) map[string]capacity.
 	return out
 }
 
-// snapshot copies the placement map for use by Snapshot().
+func (f *placementFSM) expiredReservationIDs(now int64) []string {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	if now <= 0 || len(f.reservedIndex) == 0 {
+		return nil
+	}
+	out := make([]string, 0)
+	for id := range f.reservedIndex {
+		p, ok := f.placements[id]
+		if !ok || !p.IsReserved() || p.ExpiresUnix == 0 || now <= p.ExpiresUnix {
+			continue
+		}
+		out = append(out, id)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (f *placementFSM) fullPlacementsForOwner(nodeID string) map[string]Placement {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	ids := f.ownedPlacementIDsLocked(nodeID)
+	out := make(map[string]Placement, len(ids))
+	for _, id := range ids {
+		if p, ok := f.fullPlacementLocked(id); ok {
+			out[id] = clonePlacement(p)
+		}
+	}
+	return out
+}
+
+// snapshot copies the full placement map for correctness-sensitive tests and
+// recovery paths. Ingress/list reads use placementsForShards and placementPage,
+// which intentionally return hot rows without recovery payloads.
 func (f *placementFSM) snapshot() map[string]Placement {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 	out := make(map[string]Placement, len(f.placements))
-	for k, v := range f.placements {
-		out[k] = clonePlacement(v)
+	for k := range f.placements {
+		p, _ := f.fullPlacementLocked(k)
+		out[k] = clonePlacement(p)
 	}
 	return out
 }
 
 func (f *placementFSM) placementsForShards(filter PlacementShardFilter) []Placement {
 	filter = filter.Normalize()
+	f.mu.RLock()
+	defer f.mu.RUnlock()
 	if filter.allShards() {
-		snap := f.snapshot()
-		out := make([]Placement, 0, len(snap))
-		for _, p := range snap {
-			out = append(out, p)
+		out := make([]Placement, 0, len(f.placements))
+		for _, p := range f.placements {
+			out = append(out, cloneHotPlacement(p))
 		}
 		return out
 	}
-
-	f.mu.RLock()
-	defer f.mu.RUnlock()
 
 	// The in-memory shard index is built for the default shard space. If an
 	// operator ever asks for a different count, fall back to a scan rather
@@ -1099,7 +1221,7 @@ func (f *placementFSM) placementsForShards(filter PlacementShardFilter) []Placem
 		out := make([]Placement, 0)
 		for id, p := range f.placements {
 			if _, ok := want[PlacementShardForSandbox(id, filter.ShardCount)]; ok {
-				out = append(out, clonePlacement(p))
+				out = append(out, cloneHotPlacement(p))
 			}
 		}
 		return out
@@ -1109,7 +1231,7 @@ func (f *placementFSM) placementsForShards(filter PlacementShardFilter) []Placem
 	for _, shard := range filter.Shards {
 		for id := range f.shardIndex[shard] {
 			if p, ok := f.placements[id]; ok {
-				out = append(out, clonePlacement(p))
+				out = append(out, cloneHotPlacement(p))
 			}
 		}
 	}
@@ -1128,16 +1250,53 @@ func (f *placementFSM) placementPage(req PlacementPageRequest) PlacementPageResp
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
+	ids := f.pagePlacementIDsLocked(req, shardFilter, allShards, wantShards)
+	out := make([]Placement, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, cloneHotPlacement(f.placements[id]))
+	}
+	next := ""
+	if len(ids) == req.Limit {
+		next = ids[len(ids)-1]
+	}
+	return PlacementPageResponse{Placements: out, NextPageToken: next}
+}
+
+func (f *placementFSM) pagePlacementIDsLocked(req PlacementPageRequest, shardFilter PlacementShardFilter, allShards bool, wantShards map[int]struct{}) []string {
+	if f.placementIDs == nil {
+		return f.pagePlacementIDsByScanLocked(req, shardFilter, allShards, wantShards)
+	}
+	if allShards || shardFilter.ShardCount != DefaultPlacementShardCount || len(shardFilter.Shards) > 1024 {
+		return f.pagePlacementIDsFromTreeLocked(req, shardFilter, allShards, wantShards)
+	}
+
+	ids := make([]string, 0, req.Limit)
+	for _, shard := range shardFilter.Shards {
+		for id := range f.shardIndex[shard] {
+			if req.PageToken != "" && id <= req.PageToken {
+				continue
+			}
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	if len(ids) > req.Limit {
+		ids = ids[:req.Limit]
+	}
+	return ids
+}
+
+func (f *placementFSM) pagePlacementIDsByScanLocked(req PlacementPageRequest, shardFilter PlacementShardFilter, allShards bool, wantShards map[int]struct{}) []string {
 	ids := make([]string, 0, len(f.placements))
+	shardCount := shardFilter.ShardCount
+	if shardCount <= 0 {
+		shardCount = DefaultPlacementShardCount
+	}
 	for id := range f.placements {
 		if req.PageToken != "" && id <= req.PageToken {
 			continue
 		}
 		if !allShards {
-			shardCount := shardFilter.ShardCount
-			if shardCount <= 0 {
-				shardCount = DefaultPlacementShardCount
-			}
 			if _, ok := wantShards[PlacementShardForSandbox(id, shardCount)]; !ok {
 				continue
 			}
@@ -1148,15 +1307,28 @@ func (f *placementFSM) placementPage(req PlacementPageRequest) PlacementPageResp
 	if len(ids) > req.Limit {
 		ids = ids[:req.Limit]
 	}
-	out := make([]Placement, 0, len(ids))
-	for _, id := range ids {
-		out = append(out, clonePlacement(f.placements[id]))
+	return ids
+}
+
+func (f *placementFSM) pagePlacementIDsFromTreeLocked(req PlacementPageRequest, shardFilter PlacementShardFilter, allShards bool, wantShards map[int]struct{}) []string {
+	ids := make([]string, 0, req.Limit)
+	shardCount := shardFilter.ShardCount
+	if shardCount <= 0 {
+		shardCount = DefaultPlacementShardCount
 	}
-	next := ""
-	if len(ids) == req.Limit {
-		next = ids[len(ids)-1]
-	}
-	return PlacementPageResponse{Placements: out, NextPageToken: next}
+	f.placementIDs.AscendGreaterOrEqual(req.PageToken, func(id string) bool {
+		if req.PageToken != "" && id <= req.PageToken {
+			return true
+		}
+		if !allShards {
+			if _, ok := wantShards[PlacementShardForSandbox(id, shardCount)]; !ok {
+				return true
+			}
+		}
+		ids = append(ids, id)
+		return len(ids) < req.Limit
+	})
+	return ids
 }
 
 // isNodeDrained reports whether nodeID has been marked drained via
@@ -1185,30 +1357,43 @@ func (f *placementFSM) drainedNodesSnapshot() map[string]bool {
 	return out
 }
 
-// fsmSnapshotPayload is the on-disk envelope for an FSM snapshot. Wrapping
-// the map in a struct lets the snapshot carry the FSM version alongside the
-// placement state — without this, version reset to 0 on every cold restart
-// (B9). Legacy snapshots (pre-envelope) decoded as a bare map[string]Placement;
-// Restore detects that shape and reconstructs the version from the highest
-// Placement.Version it sees. DrainedNodes is an optional addition — older
-// snapshots that pre-date the field decode it as nil and the FSM treats that
-// as "no drains," matching the empty-map steady state.
+// fsmSnapshotPayload is the on-disk envelope for an FSM snapshot. Rows is the
+// compact current format: hot placement fields plus optional recovery payload
+// without duplicating the sandbox ID in separate maps. Placements/Recovery are
+// retained for older envelope snapshots, and Restore also accepts the original
+// bare map[string]Placement format. DrainedNodes is optional; older snapshots
+// decode it as nil and the FSM treats that as "no drains."
 type fsmSnapshotPayload struct {
 	Version      uint64
+	Rows         []placementSnapshotRow
 	Placements   map[string]Placement
+	Recovery     map[string]placementRecovery
 	DrainedNodes map[string]bool
+}
+
+type placementSnapshotRow struct {
+	Placement Placement
+	Recovery  placementRecovery
 }
 
 // Snapshot returns a raft.FSMSnapshot capturing current placement state.
 func (f *placementFSM) Snapshot() (raft.FSMSnapshot, error) {
 	f.mu.RLock()
+	defer f.mu.RUnlock()
 	version := f.version
+	rows := make([]placementSnapshotRow, 0, len(f.placements))
+	for id, p := range f.placements {
+		row := placementSnapshotRow{Placement: cloneHotPlacement(p)}
+		if rec, ok := f.recovery[id]; ok && !rec.empty() {
+			row.Recovery = clonePlacementRecovery(rec)
+		}
+		rows = append(rows, row)
+	}
 	drained := make(map[string]bool, len(f.drainedNodes))
 	for k, v := range f.drainedNodes {
 		drained[k] = v
 	}
-	f.mu.RUnlock()
-	return &fsmSnapshot{version: version, placements: f.snapshot(), drainedNodes: drained}, nil
+	return &fsmSnapshot{version: version, rows: rows, drainedNodes: drained}, nil
 }
 
 // Restore loads state from a previously written snapshot. Replaces in-memory
@@ -1244,34 +1429,68 @@ func (f *placementFSM) Restore(rc io.ReadCloser) (err error) {
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if payload.Placements == nil {
+	if len(payload.Rows) > 0 {
+		payload.Placements = make(map[string]Placement, len(payload.Rows))
+		payload.Recovery = make(map[string]placementRecovery, len(payload.Rows))
+		for _, row := range payload.Rows {
+			id := row.Placement.SandboxID
+			if id == "" {
+				continue
+			}
+			payload.Placements[id] = row.Placement
+			if !row.Recovery.empty() {
+				payload.Recovery[id] = row.Recovery
+			}
+		}
+	} else if payload.Placements == nil {
 		payload.Placements = make(map[string]Placement)
 	}
-	f.placements = payload.Placements
+	f.placements = make(map[string]Placement, len(payload.Placements))
+	f.recovery = make(map[string]placementRecovery, len(payload.Recovery))
 	f.version = payload.Version
 	// Rebuild nameIndex from placements. Snapshots don't carry the index
 	// (older snapshots predate it), and rebuilding keeps the FSM the single
 	// source of truth even after a cold restart.
 	f.nameIndex = make(map[string]string, len(payload.Placements))
 	f.shardIndex = make(map[int]map[string]struct{})
+	f.placementIDs = newPlacementIDIndex()
 	f.hostPortIndex = make(map[int]hostPortClaim)
 	f.ownerIndex = make(map[string]map[string]struct{})
 	f.pendingReservationClaims = make(map[string]pendingReservationClaim)
 	f.pendingReservationCapacity = make(map[string]capacity.Request)
 	f.pendingReservationIDsByOwner = make(map[string]map[string]struct{})
 	f.pendingReservationExpiries = nil
+	f.reservedIndex = make(map[string]struct{})
 	for id, p := range payload.Placements {
-		if name := specName(p.Spec); name != "" {
+		hot, legacyRec := splitPlacement(p)
+		rec := legacyRec
+		if payload.Recovery != nil {
+			if payloadRec, ok := payload.Recovery[id]; ok {
+				rec = payloadRec
+			}
+		}
+		f.placements[id] = cloneHotPlacement(hot)
+		if !rec.empty() {
+			f.recovery[id] = clonePlacementRecovery(rec)
+		}
+		full := hot
+		if !rec.empty() {
+			full.Spec = rec.Spec
+			full.SecretRef = rec.SecretRef
+			full.SecretVersion = rec.SecretVersion
+			full.SealedSecrets = rec.SealedSecrets
+		}
+		if name := specName(full.Spec); name != "" {
 			f.nameIndex[name] = id
 		}
 		f.claimShardLocked(id)
-		for port, route := range exposedPortRoutesForPlacement(p) {
+		for port, route := range exposedPortRoutesForPlacement(full) {
 			f.claimHostPortLocked(id, port, route)
 		}
-		if p.IsReserved() {
-			f.claimPendingReservationLocked(id, p)
+		if full.IsReserved() {
+			f.claimPendingReservationLocked(id, full)
 		} else {
-			f.claimOwnerLocked(id, p)
+			f.claimOwnerLocked(id, full)
 		}
 	}
 	// Pre-drain snapshots have a nil DrainedNodes — initialize empty so the
@@ -1288,7 +1507,7 @@ func (f *placementFSM) Restore(rc io.ReadCloser) (err error) {
 
 type fsmSnapshot struct {
 	version      uint64
-	placements   map[string]Placement
+	rows         []placementSnapshotRow
 	drainedNodes map[string]bool
 }
 
@@ -1296,10 +1515,10 @@ func (s *fsmSnapshot) Persist(sink raft.SnapshotSink) (err error) {
 	start := time.Now()
 	counting := &countingSnapshotSink{SnapshotSink: sink}
 	defer func() {
-		recordSnapshotPersist(time.Since(start), counting.bytes, len(s.placements), err)
+		recordSnapshotPersist(time.Since(start), counting.bytes, len(s.rows), err)
 	}()
 	enc := gob.NewEncoder(counting)
-	if err := enc.Encode(fsmSnapshotPayload{Version: s.version, Placements: s.placements, DrainedNodes: s.drainedNodes}); err != nil {
+	if err := enc.Encode(fsmSnapshotPayload{Version: s.version, Rows: s.rows, DrainedNodes: s.drainedNodes}); err != nil {
 		_ = sink.Cancel()
 		return fmt.Errorf("fsmSnapshot: encode: %w", err)
 	}
@@ -1317,6 +1536,34 @@ func (s *countingSnapshotSink) Write(p []byte) (int, error) {
 	n, err := s.SnapshotSink.Write(p)
 	s.bytes += int64(n)
 	return n, err
+}
+
+func cloneHotPlacement(p Placement) Placement {
+	p.Spec = nil
+	p.SecretRef = ""
+	p.SecretVersion = 0
+	p.SealedSecrets = nil
+	if len(p.ExposedPorts) > 0 {
+		ports := make(map[int]string, len(p.ExposedPorts))
+		for k, v := range p.ExposedPorts {
+			ports[k] = v
+		}
+		p.ExposedPorts = ports
+	}
+	if len(p.ExposedPortRoutes) > 0 {
+		routes := make(map[int]ExposedPortRoute, len(p.ExposedPortRoutes))
+		for k, v := range p.ExposedPortRoutes {
+			routes[k] = v
+		}
+		p.ExposedPortRoutes = routes
+	}
+	return p
+}
+
+func clonePlacementRecovery(r placementRecovery) placementRecovery {
+	r.Spec = cloneCreateSandboxRequest(r.Spec)
+	r.SealedSecrets = cloneBytes(r.SealedSecrets)
+	return r
 }
 
 func clonePlacement(p Placement) Placement {

--- a/internal/cluster/fsm.go
+++ b/internal/cluster/fsm.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"bytes"
 	"container/heap"
+	"context"
 	"encoding/gob"
 	"encoding/json"
 	"fmt"
@@ -36,12 +37,11 @@ const (
 	opReserveBatch      opCode = 12 // hold capacity + names for a create burst in one raft entry
 )
 
-// command is the wire format for one raft log entry. Spec is non-nil for
-// opPlace (records the original creation request alongside the owner pointer)
-// and opUpsertSpec (records mutations like resize/lifecycle that must survive
-// failover). Spec MUST be redacted of plaintext credentials before encoding.
-// SecretRef/SecretVersion carry only the provider handle; SealedSecrets is a
-// legacy fallback for log entries written before secret refs existed.
+// command is the wire format for one raft log entry. New writers externalize
+// recovery payloads before encoding, so raft carries Name + RecoveryRef instead
+// of full Spec/secret bytes. Spec/SecretRef/SealedSecrets remain in the struct
+// for legacy log entries and direct FSM tests; any Spec MUST be redacted of
+// plaintext credentials before encoding.
 // Port/Protocol carry one (port, protocol) tuple for opAddExposedPort and
 // opRemoveExposedPort — replicated as intent-only so the new owner picks a
 // fresh host port from its own pool.
@@ -58,6 +58,8 @@ type command struct {
 	OwnerNodeID        string                       `json:"owner_node_id,omitempty"`
 	OwnerAPIURL        string                       `json:"owner_api_url,omitempty"`
 	OwnerDataPlaneHost string                       `json:"owner_data_plane_host,omitempty"`
+	Name               string                       `json:"name,omitempty"`
+	RecoveryRef        string                       `json:"recovery_ref,omitempty"`
 	Spec               *models.CreateSandboxRequest `json:"spec,omitempty"`
 	SecretRef          string                       `json:"secret_ref,omitempty"`
 	SecretVersion      int                          `json:"secret_version,omitempty"`
@@ -87,6 +89,8 @@ type reservationCommand struct {
 	OwnerNodeID        string                       `json:"owner_node_id,omitempty"`
 	OwnerAPIURL        string                       `json:"owner_api_url,omitempty"`
 	OwnerDataPlaneHost string                       `json:"owner_data_plane_host,omitempty"`
+	Name               string                       `json:"name,omitempty"`
+	RecoveryRef        string                       `json:"recovery_ref,omitempty"`
 	Spec               *models.CreateSandboxRequest `json:"spec,omitempty"`
 	SecretRef          string                       `json:"secret_ref,omitempty"`
 	SecretVersion      int                          `json:"secret_version,omitempty"`
@@ -120,6 +124,8 @@ func reservationFromCommand(c command) reservationCommand {
 		OwnerNodeID:        c.OwnerNodeID,
 		OwnerAPIURL:        c.OwnerAPIURL,
 		OwnerDataPlaneHost: c.OwnerDataPlaneHost,
+		Name:               c.Name,
+		RecoveryRef:        c.RecoveryRef,
 		Spec:               c.Spec,
 		SecretRef:          c.SecretRef,
 		SecretVersion:      c.SecretVersion,
@@ -135,6 +141,8 @@ func commandFromReservation(r reservationCommand) command {
 		OwnerNodeID:        r.OwnerNodeID,
 		OwnerAPIURL:        r.OwnerAPIURL,
 		OwnerDataPlaneHost: r.OwnerDataPlaneHost,
+		Name:               r.Name,
+		RecoveryRef:        r.RecoveryRef,
 		Spec:               r.Spec,
 		SecretRef:          r.SecretRef,
 		SecretVersion:      r.SecretVersion,
@@ -178,7 +186,11 @@ type placementFSM struct {
 	// contained inline recovery payloads. New snapshots do not persist it.
 	recovery      map[string]placementRecovery
 	recoveryStore placementRecoveryStore
-	version       uint64
+	// recoveryResolver fetches missing content-addressed recovery blobs from
+	// peer servers during log replay or point lookup. It is optional so unit
+	// tests and single-process FSM use can stay local-only.
+	recoveryResolver func(context.Context, string) (RecoveryBlob, bool, error)
+	version          uint64
 	// nameIndex maps sandbox Name → SandboxID for cluster-wide name uniqueness.
 	// Empty names are NOT indexed (anonymous sandboxes don't conflict, matching
 	// the local SQLite partial unique index that allows many empty names but
@@ -319,6 +331,9 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 	if err != nil {
 		return fmt.Errorf("placementFSM: decode: %w", err)
 	}
+	if err := f.hydrateCommandRecovery(&cmd); err != nil {
+		return err
+	}
 
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -357,7 +372,7 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 		// Done before any state mutation so a conflict leaves the FSM
 		// untouched and the leader's apply path returns the sentinel for the
 		// API handler to roll back the local create.
-		name := specName(cmd.Spec)
+		name := commandName(cmd)
 		if cmd.Spec == nil && exists {
 			name = placementName(existing)
 		}
@@ -755,6 +770,20 @@ func specName(spec *models.CreateSandboxRequest) string {
 	return strings.TrimSpace(spec.Name)
 }
 
+func commandName(cmd command) string {
+	if name := strings.TrimSpace(cmd.Name); name != "" {
+		return name
+	}
+	return specName(cmd.Spec)
+}
+
+func reservationName(r reservationCommand) string {
+	if name := strings.TrimSpace(r.Name); name != "" {
+		return name
+	}
+	return specName(r.Spec)
+}
+
 func placementName(p Placement) string {
 	if name := strings.TrimSpace(p.Name); name != "" {
 		return name
@@ -783,7 +812,7 @@ func (f *placementFSM) validateReservationBatchLocked(reservations []reservation
 			}
 		}
 
-		name := specName(r.Spec)
+		name := reservationName(r)
 		if name == "" {
 			continue
 		}
@@ -831,7 +860,8 @@ func (f *placementFSM) reservePlacementLocked(cmd command, now int64) error {
 			return fmt.Errorf("%w: %s reserved by %s", ErrReservationConflict, cmd.SandboxID, existing.OwnerNodeID)
 		}
 	}
-	if err := f.validateNameUniqueLocked(cmd.SandboxID, specName(cmd.Spec)); err != nil {
+	name := commandName(cmd)
+	if err := f.validateNameUniqueLocked(cmd.SandboxID, name); err != nil {
 		return err
 	}
 	secrets := applyCommandSecretUpdate(Placement{}, false, cmd)
@@ -843,7 +873,7 @@ func (f *placementFSM) reservePlacementLocked(cmd command, now int64) error {
 		Version:            f.version,
 		CreatedUnix:        now,
 		UpdatedUnix:        now,
-		Name:               specName(cmd.Spec),
+		Name:               name,
 		Spec:               cmd.Spec,
 		SecretRef:          secrets.Ref,
 		SecretVersion:      secrets.Version,
@@ -854,7 +884,7 @@ func (f *placementFSM) reservePlacementLocked(cmd command, now int64) error {
 	if err := f.storePlacementLocked(cmd.SandboxID, p); err != nil {
 		return err
 	}
-	f.claimNameLocked(cmd.SandboxID, placementName(p))
+	f.claimNameLocked(cmd.SandboxID, name)
 	f.claimShardLocked(cmd.SandboxID)
 	f.claimPendingReservationLocked(cmd.SandboxID, p)
 	return nil
@@ -1223,23 +1253,93 @@ func (f *placementFSM) fullPlacementLocked(id string) (Placement, bool) {
 	if !ok {
 		return Placement{}, false
 	}
-	if p.RecoveryRef != "" && f.recoveryStore != nil {
-		rec, ok, err := f.recoveryStore.Get(p.RecoveryRef)
-		if err == nil && ok {
-			p.Spec = rec.Spec
-			p.SecretRef = rec.SecretRef
-			p.SecretVersion = rec.SecretVersion
-			p.SealedSecrets = rec.SealedSecrets
-			return p, true
+	if p.RecoveryRef != "" {
+		if rec, ok, err := f.resolveRecoveryRef(p.RecoveryRef); err == nil && ok {
+			return attachPlacementRecovery(p, rec), true
 		}
 	}
 	if rec, ok := f.recovery[id]; ok {
-		p.Spec = rec.Spec
-		p.SecretRef = rec.SecretRef
-		p.SecretVersion = rec.SecretVersion
-		p.SealedSecrets = rec.SealedSecrets
+		p = attachPlacementRecovery(p, rec)
 	}
 	return p, true
+}
+
+func attachPlacementRecovery(p Placement, rec placementRecovery) Placement {
+	p.Spec = rec.Spec
+	p.SecretRef = rec.SecretRef
+	p.SecretVersion = rec.SecretVersion
+	p.SealedSecrets = rec.SealedSecrets
+	return p
+}
+
+func (f *placementFSM) hydrateCommandRecovery(cmd *command) error {
+	if err := f.hydrateCommandRecoveryFields(cmd.SandboxID, cmd.RecoveryRef, &cmd.Spec, &cmd.SecretRef, &cmd.SecretVersion, &cmd.SealedSecrets); err != nil {
+		return err
+	}
+	for i := range cmd.Reservations {
+		r := &cmd.Reservations[i]
+		if err := f.hydrateCommandRecoveryFields(r.SandboxID, r.RecoveryRef, &r.Spec, &r.SecretRef, &r.SecretVersion, &r.SealedSecrets); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *placementFSM) hydrateCommandRecoveryFields(sandboxID, ref string, spec **models.CreateSandboxRequest, secretRef *string, secretVersion *int, sealed *[]byte) error {
+	if ref == "" {
+		return nil
+	}
+	rec, ok, err := f.resolveRecoveryRef(ref)
+	if err != nil {
+		return fmt.Errorf("placementFSM: load recovery %s for %s: %w", ref, sandboxID, err)
+	}
+	if !ok {
+		return fmt.Errorf("placementFSM: missing recovery blob %s for %s", ref, sandboxID)
+	}
+	*spec = rec.Spec
+	*secretRef = rec.SecretRef
+	*secretVersion = rec.SecretVersion
+	*sealed = rec.SealedSecrets
+	return nil
+}
+
+func (f *placementFSM) resolveRecoveryRef(ref string) (placementRecovery, bool, error) {
+	if f.recoveryStore != nil {
+		rec, ok, err := f.recoveryStore.Get(ref)
+		if err != nil {
+			return placementRecovery{}, false, err
+		}
+		if ok {
+			return rec, true, nil
+		}
+	}
+	if f.recoveryResolver == nil {
+		return placementRecovery{}, false, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), controlPlanePlacementRequestTimeout)
+	defer cancel()
+	blob, ok, err := f.recoveryResolver(ctx, ref)
+	if err != nil || !ok {
+		return placementRecovery{}, ok, err
+	}
+	if err := f.storeRecoveryBlob(blob); err != nil {
+		return placementRecovery{}, false, err
+	}
+	return blob.recovery(), true, nil
+}
+
+func (f *placementFSM) storeRecoveryBlob(blob RecoveryBlob) error {
+	if f.recoveryStore == nil {
+		return nil
+	}
+	ref, err := f.recoveryStore.Put(blob.SandboxID, blob.recovery())
+	if err != nil {
+		return err
+	}
+	if ref != blob.Ref {
+		return fmt.Errorf("placement recovery blob ref mismatch: got %s want %s", ref, blob.Ref)
+	}
+	return nil
 }
 
 func (f *placementFSM) storePlacementLocked(id string, p Placement) error {
@@ -1591,14 +1691,18 @@ func (f *placementFSM) Snapshot() (raft.FSMSnapshot, error) {
 	defer f.mu.RUnlock()
 	version := f.version
 	rows := make([]placementSnapshotRow, 0, len(f.placements))
+	recoveryRefs := make([]string, 0, len(f.placements))
 	for _, p := range f.placements {
 		rows = append(rows, placementSnapshotRow{Placement: cloneHotPlacement(p)})
+		if p.RecoveryRef != "" {
+			recoveryRefs = append(recoveryRefs, p.RecoveryRef)
+		}
 	}
 	drained := make(map[string]bool, len(f.drainedNodes))
 	for k, v := range f.drainedNodes {
 		drained[k] = v
 	}
-	return &fsmSnapshot{version: version, rows: rows, drainedNodes: drained}, nil
+	return &fsmSnapshot{version: version, rows: rows, drainedNodes: drained, recoveryStore: f.recoveryStore, recoveryRefs: recoveryRefs}, nil
 }
 
 // Restore loads state from a previously written snapshot. Replaces in-memory
@@ -1714,9 +1818,11 @@ func (f *placementFSM) Restore(rc io.ReadCloser) (err error) {
 }
 
 type fsmSnapshot struct {
-	version      uint64
-	rows         []placementSnapshotRow
-	drainedNodes map[string]bool
+	version       uint64
+	rows          []placementSnapshotRow
+	drainedNodes  map[string]bool
+	recoveryStore placementRecoveryStore
+	recoveryRefs  []string
 }
 
 func (s *fsmSnapshot) Persist(sink raft.SnapshotSink) (err error) {
@@ -1730,7 +1836,13 @@ func (s *fsmSnapshot) Persist(sink raft.SnapshotSink) (err error) {
 		_ = sink.Cancel()
 		return fmt.Errorf("fsmSnapshot: encode: %w", err)
 	}
-	return sink.Close()
+	if err := sink.Close(); err != nil {
+		return err
+	}
+	if s.recoveryStore != nil {
+		_ = s.recoveryStore.RetainSnapshotRefs(s.recoveryRefs)
+	}
+	return nil
 }
 
 func (s *fsmSnapshot) Release() {}

--- a/internal/cluster/fsm.go
+++ b/internal/cluster/fsm.go
@@ -1932,6 +1932,10 @@ func cloneCreateSandboxRequest(in *models.CreateSandboxRequest) *models.CreateSa
 		lifecycle := *in.Lifecycle
 		out.Lifecycle = &lifecycle
 	}
+	if in.Failover != nil {
+		failover := *in.Failover
+		out.Failover = &failover
+	}
 	if in.GPUs != nil {
 		gpus := *in.GPUs
 		if len(in.GPUs.DeviceIDs) > 0 {

--- a/internal/cluster/fsm.go
+++ b/internal/cluster/fsm.go
@@ -171,11 +171,14 @@ type placementFSM struct {
 	mu sync.RWMutex
 	// placements is the hot row map. Values deliberately keep Placement.Spec,
 	// SecretRef, SecretVersion, and SealedSecrets empty; those larger recovery
-	// fields live in recovery and are attached only for point lookups, snapshots,
-	// and failover/recreate flows.
+	// fields live behind Placement.RecoveryRef and are attached only for point
+	// lookups and failover/recreate flows.
 	placements map[string]Placement
-	recovery   map[string]placementRecovery
-	version    uint64
+	// recovery is a legacy/in-memory fallback for tests and old snapshots that
+	// contained inline recovery payloads. New snapshots do not persist it.
+	recovery      map[string]placementRecovery
+	recoveryStore placementRecoveryStore
+	version       uint64
 	// nameIndex maps sandbox Name → SandboxID for cluster-wide name uniqueness.
 	// Empty names are NOT indexed (anonymous sandboxes don't conflict, matching
 	// the local SQLite partial unique index that allows many empty names but
@@ -275,9 +278,14 @@ func (h *pendingReservationExpiryHeap) Pop() any {
 }
 
 func newPlacementFSM() *placementFSM {
+	return newPlacementFSMWithRecoveryStore(newPlacementRecoveryMemoryStore())
+}
+
+func newPlacementFSMWithRecoveryStore(store placementRecoveryStore) *placementFSM {
 	return &placementFSM{
 		placements:                   make(map[string]Placement),
 		recovery:                     make(map[string]placementRecovery),
+		recoveryStore:                store,
 		nameIndex:                    make(map[string]string),
 		shardIndex:                   make(map[int]map[string]struct{}),
 		placementIDs:                 newPlacementIDIndex(),
@@ -349,7 +357,11 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 		// Done before any state mutation so a conflict leaves the FSM
 		// untouched and the leader's apply path returns the sentinel for the
 		// API handler to roll back the local create.
-		if err := f.validateNameUniqueLocked(cmd.SandboxID, specName(cmd.Spec)); err != nil {
+		name := specName(cmd.Spec)
+		if cmd.Spec == nil && exists {
+			name = placementName(existing)
+		}
+		if err := f.validateNameUniqueLocked(cmd.SandboxID, name); err != nil {
 			return err
 		}
 		created := now
@@ -382,7 +394,7 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 		// otherwise a re-place with a renamed spec would leave a phantom
 		// nameIndex entry pointing at this sandbox under its previous name.
 		if exists {
-			f.releaseNameLocked(cmd.SandboxID, specName(existing.Spec))
+			f.releaseNameLocked(cmd.SandboxID, placementName(existing))
 			f.releaseOwnerLocked(cmd.SandboxID, existing)
 			if existing.IsReserved() {
 				f.releasePendingReservationLocked(cmd.SandboxID)
@@ -397,6 +409,7 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 			Version:            f.version,
 			CreatedUnix:        created,
 			UpdatedUnix:        now,
+			Name:               name,
 			Spec:               spec,
 			SecretRef:          secrets.Ref,
 			SecretVersion:      secrets.Version,
@@ -410,8 +423,10 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 			State:       PlacementStatePlaced,
 			ExpiresUnix: 0,
 		}
-		f.storePlacementLocked(cmd.SandboxID, p)
-		f.claimNameLocked(cmd.SandboxID, specName(spec))
+		if err := f.storePlacementLocked(cmd.SandboxID, p); err != nil {
+			return err
+		}
+		f.claimNameLocked(cmd.SandboxID, name)
 		f.claimShardLocked(cmd.SandboxID)
 		f.claimOwnerLocked(cmd.SandboxID, p)
 		return nil
@@ -450,17 +465,17 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 		if !exists || !existing.IsReserved() {
 			return nil
 		}
-		f.releaseNameLocked(cmd.SandboxID, specName(existing.Spec))
+		f.releaseNameLocked(cmd.SandboxID, placementName(existing))
 		f.releaseShardLocked(cmd.SandboxID)
 		f.releaseAllHostPortsLocked(cmd.SandboxID, existing)
 		f.releasePendingReservationLocked(cmd.SandboxID)
 		f.releasePendingReservationOwnerLocked(cmd.SandboxID, existing.OwnerNodeID)
+		f.deletePlacementRecoveryLocked(cmd.SandboxID)
 		delete(f.placements, cmd.SandboxID)
-		delete(f.recovery, cmd.SandboxID)
 		return nil
 	case opDelete:
 		if existing, ok := f.fullPlacementLocked(cmd.SandboxID); ok {
-			f.releaseNameLocked(cmd.SandboxID, specName(existing.Spec))
+			f.releaseNameLocked(cmd.SandboxID, placementName(existing))
 			f.releaseShardLocked(cmd.SandboxID)
 			f.releaseAllHostPortsLocked(cmd.SandboxID, existing)
 			f.releaseOwnerLocked(cmd.SandboxID, existing)
@@ -469,8 +484,8 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 				f.releasePendingReservationOwnerLocked(cmd.SandboxID, existing.OwnerNodeID)
 			}
 		}
+		f.deletePlacementRecoveryLocked(cmd.SandboxID)
 		delete(f.placements, cmd.SandboxID)
-		delete(f.recovery, cmd.SandboxID)
 		return nil
 	case opReassign:
 		existing, exists := f.fullPlacementLocked(cmd.SandboxID)
@@ -504,7 +519,9 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 		}
 		existing.Version = f.version
 		existing.UpdatedUnix = now
-		f.storePlacementLocked(cmd.SandboxID, existing)
+		if err := f.storePlacementLocked(cmd.SandboxID, existing); err != nil {
+			return err
+		}
 		if wasReserved {
 			f.claimPendingReservationLocked(cmd.SandboxID, existing)
 		} else {
@@ -529,19 +546,21 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 			existing.OrphanedUnix = now
 			existing.Version = f.version
 			existing.UpdatedUnix = now
-			f.storePlacementLocked(id, existing)
+			if err := f.storePlacementLocked(id, existing); err != nil {
+				return err
+			}
 		}
 		for _, id := range f.pendingReservationIDsLocked(cmd.NodeID) {
 			existing, ok := f.fullPlacementLocked(id)
 			if !ok || !existing.IsReserved() || existing.OwnerNodeID != cmd.NodeID {
 				continue
 			}
-			f.releaseNameLocked(id, specName(existing.Spec))
+			f.releaseNameLocked(id, placementName(existing))
 			f.releaseShardLocked(id)
 			f.releasePendingReservationLocked(id)
 			f.releasePendingReservationOwnerLocked(id, existing.OwnerNodeID)
+			f.deletePlacementRecoveryLocked(id)
 			delete(f.placements, id)
-			delete(f.recovery, id)
 		}
 		return nil
 	case opClaimOrphan:
@@ -565,7 +584,7 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 			return fmt.Errorf("%w: %s orphaned from %s", ErrOrphanClaimConflict, cmd.SandboxID, existing.OrphanedOwnerNodeID)
 		}
 		if cmd.Spec != nil {
-			oldName := specName(existing.Spec)
+			oldName := placementName(existing)
 			newName := specName(cmd.Spec)
 			if newName != oldName {
 				if err := f.validateNameUniqueLocked(cmd.SandboxID, newName); err != nil {
@@ -574,6 +593,7 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 				f.releaseNameLocked(cmd.SandboxID, oldName)
 				f.claimNameLocked(cmd.SandboxID, newName)
 			}
+			existing.Name = newName
 			existing.Spec = cmd.Spec
 		}
 		if cmd.hasSecretUpdate() {
@@ -590,7 +610,9 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 		existing.OrphanedUnix = 0
 		existing.Version = f.version
 		existing.UpdatedUnix = now
-		f.storePlacementLocked(cmd.SandboxID, existing)
+		if err := f.storePlacementLocked(cmd.SandboxID, existing); err != nil {
+			return err
+		}
 		f.claimOwnerLocked(cmd.SandboxID, existing)
 		return nil
 	case opUpsertSpec:
@@ -605,7 +627,7 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 			return nil
 		}
 		if cmd.Spec != nil {
-			oldName := specName(existing.Spec)
+			oldName := placementName(existing)
 			newName := specName(cmd.Spec)
 			if newName != oldName {
 				if err := f.validateNameUniqueLocked(cmd.SandboxID, newName); err != nil {
@@ -614,6 +636,7 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 				f.releaseNameLocked(cmd.SandboxID, oldName)
 				f.claimNameLocked(cmd.SandboxID, newName)
 			}
+			existing.Name = newName
 			existing.Spec = cmd.Spec
 		}
 		// Replace the provider handle only when the caller supplied one.
@@ -632,7 +655,9 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 		}
 		existing.Version = f.version
 		existing.UpdatedUnix = now
-		f.storePlacementLocked(cmd.SandboxID, existing)
+		if err := f.storePlacementLocked(cmd.SandboxID, existing); err != nil {
+			return err
+		}
 		if wasReserved {
 			f.claimPendingReservationLocked(cmd.SandboxID, existing)
 		}
@@ -670,7 +695,9 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 		f.claimHostPortLocked(cmd.SandboxID, cmd.Port, route)
 		existing.Version = f.version
 		existing.UpdatedUnix = now
-		f.storePlacementLocked(cmd.SandboxID, existing)
+		if err := f.storePlacementLocked(cmd.SandboxID, existing); err != nil {
+			return err
+		}
 		return nil
 	case opRemoveExposedPort:
 		existing, exists := f.fullPlacementLocked(cmd.SandboxID)
@@ -691,7 +718,9 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 		}
 		existing.Version = f.version
 		existing.UpdatedUnix = now
-		f.storePlacementLocked(cmd.SandboxID, existing)
+		if err := f.storePlacementLocked(cmd.SandboxID, existing); err != nil {
+			return err
+		}
 		return nil
 	case opSetNodeDrainState:
 		// Drain marks live in the FSM so an operator-issued drain persists past
@@ -724,6 +753,13 @@ func specName(spec *models.CreateSandboxRequest) string {
 		return ""
 	}
 	return strings.TrimSpace(spec.Name)
+}
+
+func placementName(p Placement) string {
+	if name := strings.TrimSpace(p.Name); name != "" {
+		return name
+	}
+	return specName(p.Spec)
 }
 
 func (f *placementFSM) validateReservationBatchLocked(reservations []reservationCommand, now int64) error {
@@ -779,7 +815,9 @@ func (f *placementFSM) reservePlacementLocked(cmd command, now int64) error {
 			existing.ExpiresUnix = cmd.ExpiresUnix
 			existing.Version = f.version
 			existing.UpdatedUnix = now
-			f.storePlacementLocked(cmd.SandboxID, existing)
+			if err := f.storePlacementLocked(cmd.SandboxID, existing); err != nil {
+				return err
+			}
 			f.refreshPendingReservationExpiryLocked(cmd.SandboxID, cmd.ExpiresUnix)
 			return nil
 		}
@@ -787,7 +825,7 @@ func (f *placementFSM) reservePlacementLocked(cmd command, now int64) error {
 		if now > existing.ExpiresUnix {
 			f.releasePendingReservationLocked(cmd.SandboxID)
 			f.releasePendingReservationOwnerLocked(cmd.SandboxID, existing.OwnerNodeID)
-			f.releaseNameLocked(cmd.SandboxID, specName(existing.Spec))
+			f.releaseNameLocked(cmd.SandboxID, placementName(existing))
 			f.releaseShardLocked(cmd.SandboxID)
 		} else {
 			return fmt.Errorf("%w: %s reserved by %s", ErrReservationConflict, cmd.SandboxID, existing.OwnerNodeID)
@@ -805,6 +843,7 @@ func (f *placementFSM) reservePlacementLocked(cmd command, now int64) error {
 		Version:            f.version,
 		CreatedUnix:        now,
 		UpdatedUnix:        now,
+		Name:               specName(cmd.Spec),
 		Spec:               cmd.Spec,
 		SecretRef:          secrets.Ref,
 		SecretVersion:      secrets.Version,
@@ -812,8 +851,10 @@ func (f *placementFSM) reservePlacementLocked(cmd command, now int64) error {
 		State:              PlacementStateReserved,
 		ExpiresUnix:        cmd.ExpiresUnix,
 	}
-	f.storePlacementLocked(cmd.SandboxID, p)
-	f.claimNameLocked(cmd.SandboxID, specName(cmd.Spec))
+	if err := f.storePlacementLocked(cmd.SandboxID, p); err != nil {
+		return err
+	}
+	f.claimNameLocked(cmd.SandboxID, placementName(p))
 	f.claimShardLocked(cmd.SandboxID)
 	f.claimPendingReservationLocked(cmd.SandboxID, p)
 	return nil
@@ -823,6 +864,7 @@ func (f *placementFSM) reservePlacementLocked(cmd command, now int64) error {
 // name. Empty name is always allowed (anonymous sandboxes don't conflict);
 // matches the local SQLite partial-unique-index behavior.
 func (f *placementFSM) validateNameUniqueLocked(sandboxID, name string) error {
+	name = strings.TrimSpace(name)
 	if name == "" {
 		return nil
 	}
@@ -835,6 +877,7 @@ func (f *placementFSM) validateNameUniqueLocked(sandboxID, name string) error {
 // claimNameLocked records sandboxID as the owner of name. Empty name is a
 // no-op — anonymous sandboxes don't enter the index.
 func (f *placementFSM) claimNameLocked(sandboxID, name string) {
+	name = strings.TrimSpace(name)
 	if name == "" {
 		return
 	}
@@ -849,6 +892,7 @@ func (f *placementFSM) claimNameLocked(sandboxID, name string) {
 // order: if the rename's claim already wrote the new owner, a stale release
 // for the old name could otherwise unmap the new placement.
 func (f *placementFSM) releaseNameLocked(sandboxID, name string) {
+	name = strings.TrimSpace(name)
 	if name == "" {
 		return
 	}
@@ -1179,6 +1223,16 @@ func (f *placementFSM) fullPlacementLocked(id string) (Placement, bool) {
 	if !ok {
 		return Placement{}, false
 	}
+	if p.RecoveryRef != "" && f.recoveryStore != nil {
+		rec, ok, err := f.recoveryStore.Get(p.RecoveryRef)
+		if err == nil && ok {
+			p.Spec = rec.Spec
+			p.SecretRef = rec.SecretRef
+			p.SecretVersion = rec.SecretVersion
+			p.SealedSecrets = rec.SealedSecrets
+			return p, true
+		}
+	}
 	if rec, ok := f.recovery[id]; ok {
 		p.Spec = rec.Spec
 		p.SecretRef = rec.SecretRef
@@ -1188,17 +1242,34 @@ func (f *placementFSM) fullPlacementLocked(id string) (Placement, bool) {
 	return p, true
 }
 
-func (f *placementFSM) storePlacementLocked(id string, p Placement) {
+func (f *placementFSM) storePlacementLocked(id string, p Placement) error {
 	hot, rec := splitPlacement(p)
-	f.placements[id] = hot
 	if rec.empty() {
+		if hot.RecoveryRef == "" {
+			delete(f.recovery, id)
+		}
+		f.placements[id] = hot
+		return nil
+	}
+	if f.recoveryStore != nil {
+		ref, err := f.recoveryStore.Put(id, rec)
+		if err != nil {
+			return err
+		}
+		hot.RecoveryRef = ref
 		delete(f.recovery, id)
-		return
+	} else {
+		if f.recovery == nil {
+			f.recovery = make(map[string]placementRecovery)
+		}
+		f.recovery[id] = clonePlacementRecovery(rec)
 	}
-	if f.recovery == nil {
-		f.recovery = make(map[string]placementRecovery)
-	}
-	f.recovery[id] = rec
+	f.placements[id] = hot
+	return nil
+}
+
+func (f *placementFSM) deletePlacementRecoveryLocked(id string) {
+	delete(f.recovery, id)
 }
 
 func splitPlacement(p Placement) (Placement, placementRecovery) {
@@ -1207,6 +1278,9 @@ func splitPlacement(p Placement) (Placement, placementRecovery) {
 		SecretRef:     p.SecretRef,
 		SecretVersion: p.SecretVersion,
 		SealedSecrets: p.SealedSecrets,
+	}
+	if p.Name == "" {
+		p.Name = specName(p.Spec)
 	}
 	p.Spec = nil
 	p.SecretRef = ""
@@ -1490,11 +1564,12 @@ func (f *placementFSM) drainedNodesSnapshot() map[string]bool {
 }
 
 // fsmSnapshotPayload is the on-disk envelope for an FSM snapshot. Rows is the
-// compact current format: hot placement fields plus optional recovery payload
-// without duplicating the sandbox ID in separate maps. Placements/Recovery are
-// retained for older envelope snapshots, and Restore also accepts the original
-// bare map[string]Placement format. DrainedNodes is optional; older snapshots
-// decode it as nil and the FSM treats that as "no drains."
+// compact current format: hot placement fields plus a small RecoveryRef. The
+// bulky recovery spec/secret payload lives in the local recovery store, not in
+// snapshot bytes. Placements/Recovery are retained for older envelope snapshots,
+// and Restore also accepts the original bare map[string]Placement format.
+// DrainedNodes is optional; older snapshots decode it as nil and the FSM treats
+// that as "no drains."
 type fsmSnapshotPayload struct {
 	Version      uint64
 	Rows         []placementSnapshotRow
@@ -1505,7 +1580,9 @@ type fsmSnapshotPayload struct {
 
 type placementSnapshotRow struct {
 	Placement Placement
-	Recovery  placementRecovery
+	// Recovery is retained only so Restore can read snapshots produced by the
+	// previous hot/cold FSM format. New snapshots leave it empty.
+	Recovery placementRecovery
 }
 
 // Snapshot returns a raft.FSMSnapshot capturing current placement state.
@@ -1514,12 +1591,8 @@ func (f *placementFSM) Snapshot() (raft.FSMSnapshot, error) {
 	defer f.mu.RUnlock()
 	version := f.version
 	rows := make([]placementSnapshotRow, 0, len(f.placements))
-	for id, p := range f.placements {
-		row := placementSnapshotRow{Placement: cloneHotPlacement(p)}
-		if rec, ok := f.recovery[id]; ok && !rec.empty() {
-			row.Recovery = clonePlacementRecovery(rec)
-		}
-		rows = append(rows, row)
+	for _, p := range f.placements {
+		rows = append(rows, placementSnapshotRow{Placement: cloneHotPlacement(p)})
 	}
 	drained := make(map[string]bool, len(f.drainedNodes))
 	for k, v := range f.drainedNodes {
@@ -1594,35 +1667,38 @@ func (f *placementFSM) Restore(rc io.ReadCloser) (err error) {
 	f.pendingReservationExpiries = nil
 	f.reservedIndex = make(map[string]struct{})
 	for id, p := range payload.Placements {
-		hot, legacyRec := splitPlacement(p)
+		full := p
+		if full.SandboxID == "" {
+			full.SandboxID = id
+		}
+		_, legacyRec := splitPlacement(p)
 		rec := legacyRec
 		if payload.Recovery != nil {
 			if payloadRec, ok := payload.Recovery[id]; ok {
 				rec = payloadRec
 			}
 		}
-		f.placements[id] = cloneHotPlacement(hot)
-		if !rec.empty() {
-			f.recovery[id] = clonePlacementRecovery(rec)
-		}
-		full := hot
 		if !rec.empty() {
 			full.Spec = rec.Spec
 			full.SecretRef = rec.SecretRef
 			full.SecretVersion = rec.SecretVersion
 			full.SealedSecrets = rec.SealedSecrets
 		}
-		if name := specName(full.Spec); name != "" {
+		if err := f.storePlacementLocked(id, full); err != nil {
+			return err
+		}
+		indexed, _ := f.fullPlacementLocked(id)
+		if name := placementName(indexed); name != "" {
 			f.nameIndex[name] = id
 		}
 		f.claimShardLocked(id)
-		for port, route := range exposedPortRoutesForPlacement(full) {
+		for port, route := range exposedPortRoutesForPlacement(indexed) {
 			f.claimHostPortLocked(id, port, route)
 		}
-		if full.IsReserved() {
-			f.claimPendingReservationLocked(id, full)
+		if indexed.IsReserved() {
+			f.claimPendingReservationLocked(id, indexed)
 		} else {
-			f.claimOwnerLocked(id, full)
+			f.claimOwnerLocked(id, indexed)
 		}
 	}
 	// Pre-drain snapshots have a nil DrainedNodes — initialize empty so the

--- a/internal/cluster/fsm.go
+++ b/internal/cluster/fsm.go
@@ -33,6 +33,7 @@ const (
 	opSetNodeDrainState opCode = 9  // operator-set "exclude from placement" mark for a node
 	opOrphanOwner       opCode = 10 // atomically orphan all placements owned by a dead node
 	opClaimOrphan       opCode = 11 // reclaim an orphaned placement back to its previous owner
+	opReserveBatch      opCode = 12 // hold capacity + names for a create burst in one raft entry
 )
 
 // command is the wire format for one raft log entry. Spec is non-nil for
@@ -75,6 +76,22 @@ type command struct {
 	// from SelectPlacement, false = uncordon). All other ops leave them zero.
 	NodeID  string `json:"node_id,omitempty"`
 	Drained bool   `json:"drained,omitempty"`
+
+	// Reservations is populated by opReserveBatch. The single opReserve fields
+	// above are retained for wire compatibility and the normal one-create path.
+	Reservations []reservationCommand `json:"reservations,omitempty"`
+}
+
+type reservationCommand struct {
+	SandboxID          string                       `json:"sandbox_id"`
+	OwnerNodeID        string                       `json:"owner_node_id,omitempty"`
+	OwnerAPIURL        string                       `json:"owner_api_url,omitempty"`
+	OwnerDataPlaneHost string                       `json:"owner_data_plane_host,omitempty"`
+	Spec               *models.CreateSandboxRequest `json:"spec,omitempty"`
+	SecretRef          string                       `json:"secret_ref,omitempty"`
+	SecretVersion      int                          `json:"secret_version,omitempty"`
+	SealedSecrets      []byte                       `json:"sealed_secrets,omitempty"`
+	ExpiresUnix        int64                        `json:"expires_unix,omitempty"`
 }
 
 func encodeCommand(c command) ([]byte, error) {
@@ -95,6 +112,42 @@ func (c command) placementSecrets() PlacementSecrets {
 		Version:      c.SecretVersion,
 		LegacySealed: c.SealedSecrets,
 	}
+}
+
+func reservationFromCommand(c command) reservationCommand {
+	return reservationCommand{
+		SandboxID:          c.SandboxID,
+		OwnerNodeID:        c.OwnerNodeID,
+		OwnerAPIURL:        c.OwnerAPIURL,
+		OwnerDataPlaneHost: c.OwnerDataPlaneHost,
+		Spec:               c.Spec,
+		SecretRef:          c.SecretRef,
+		SecretVersion:      c.SecretVersion,
+		SealedSecrets:      cloneBytes(c.SealedSecrets),
+		ExpiresUnix:        c.ExpiresUnix,
+	}
+}
+
+func commandFromReservation(r reservationCommand) command {
+	return command{
+		Op:                 opReserve,
+		SandboxID:          r.SandboxID,
+		OwnerNodeID:        r.OwnerNodeID,
+		OwnerAPIURL:        r.OwnerAPIURL,
+		OwnerDataPlaneHost: r.OwnerDataPlaneHost,
+		Spec:               r.Spec,
+		SecretRef:          r.SecretRef,
+		SecretVersion:      r.SecretVersion,
+		SealedSecrets:      cloneBytes(r.SealedSecrets),
+		ExpiresUnix:        r.ExpiresUnix,
+	}
+}
+
+func reservationCommands(c command) []reservationCommand {
+	if c.Op == opReserveBatch {
+		return c.Reservations
+	}
+	return []reservationCommand{reservationFromCommand(c)}
 }
 
 func (c command) hasSecretUpdate() bool {
@@ -370,63 +423,22 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 		// TTL-expired-then-reclaimed reservation can be promoted by a future
 		// re-attempt without re-sealing. The FSM-side name uniqueness check
 		// uses the redacted spec's Name.
-		if cmd.SandboxID == "" || cmd.OwnerNodeID == "" {
-			return fmt.Errorf("placementFSM: opReserve requires sandbox_id and owner_node_id")
-		}
-		existing, exists := f.fullPlacementLocked(cmd.SandboxID)
-		if exists {
-			// Reject when the slot is already materialized — a router racing
-			// a completed sandbox should back off and let the caller see 409.
-			if !existing.IsReserved() {
-				return fmt.Errorf("%w: %s already placed by %s", ErrReservationConflict, cmd.SandboxID, existing.OwnerNodeID)
-			}
-			// Re-reserve from the same owner before expiry is an idempotent
-			// retry — refresh the TTL and treat it as a no-op otherwise.
-			if existing.OwnerNodeID == cmd.OwnerNodeID && now <= existing.ExpiresUnix {
-				existing.ExpiresUnix = cmd.ExpiresUnix
-				existing.Version = f.version
-				existing.UpdatedUnix = now
-				f.storePlacementLocked(cmd.SandboxID, existing)
-				f.refreshPendingReservationExpiryLocked(cmd.SandboxID, cmd.ExpiresUnix)
-				return nil
-			}
-			// Expired reservations are eligible for overwrite by a fresh
-			// reservation (the GC sweep racing the new opReserve is harmless
-			// because the GC's opCancelReserve only fires for State==Reserved
-			// AND a different SandboxID is never reused for the same intent).
-			if now > existing.ExpiresUnix {
-				f.releasePendingReservationLocked(cmd.SandboxID)
-				f.releasePendingReservationOwnerLocked(cmd.SandboxID, existing.OwnerNodeID)
-				f.releaseNameLocked(cmd.SandboxID, specName(existing.Spec))
-				f.releaseShardLocked(cmd.SandboxID)
-			} else {
-				// Live reservation held by a different owner — conflict.
-				return fmt.Errorf("%w: %s reserved by %s", ErrReservationConflict, cmd.SandboxID, existing.OwnerNodeID)
-			}
-		}
-		if err := f.validateNameUniqueLocked(cmd.SandboxID, specName(cmd.Spec)); err != nil {
+		if err := f.reservePlacementLocked(cmd, now); err != nil {
 			return err
 		}
-		secrets := applyCommandSecretUpdate(Placement{}, false, cmd)
-		p := Placement{
-			SandboxID:          cmd.SandboxID,
-			OwnerNodeID:        cmd.OwnerNodeID,
-			OwnerAPIURL:        cmd.OwnerAPIURL,
-			OwnerDataPlaneHost: cmd.OwnerDataPlaneHost,
-			Version:            f.version,
-			CreatedUnix:        now,
-			UpdatedUnix:        now,
-			Spec:               cmd.Spec,
-			SecretRef:          secrets.Ref,
-			SecretVersion:      secrets.Version,
-			SealedSecrets:      secrets.LegacySealed,
-			State:              PlacementStateReserved,
-			ExpiresUnix:        cmd.ExpiresUnix,
+		return nil
+	case opReserveBatch:
+		if len(cmd.Reservations) == 0 {
+			return fmt.Errorf("placementFSM: opReserveBatch requires at least one reservation")
 		}
-		f.storePlacementLocked(cmd.SandboxID, p)
-		f.claimNameLocked(cmd.SandboxID, specName(cmd.Spec))
-		f.claimShardLocked(cmd.SandboxID)
-		f.claimPendingReservationLocked(cmd.SandboxID, p)
+		if err := f.validateReservationBatchLocked(cmd.Reservations, now); err != nil {
+			return err
+		}
+		for _, r := range cmd.Reservations {
+			if err := f.reservePlacementLocked(commandFromReservation(r), now); err != nil {
+				return err
+			}
+		}
 		return nil
 	case opCancelReserve:
 		// Only cancel reservations — never delete a placed sandbox, even if a
@@ -714,6 +726,99 @@ func specName(spec *models.CreateSandboxRequest) string {
 	return strings.TrimSpace(spec.Name)
 }
 
+func (f *placementFSM) validateReservationBatchLocked(reservations []reservationCommand, now int64) error {
+	seenIDs := make(map[string]struct{}, len(reservations))
+	seenNames := make(map[string]string, len(reservations))
+	for _, r := range reservations {
+		if r.SandboxID == "" || r.OwnerNodeID == "" {
+			return fmt.Errorf("placementFSM: opReserveBatch requires sandbox_id and owner_node_id")
+		}
+		if _, dup := seenIDs[r.SandboxID]; dup {
+			return fmt.Errorf("%w: duplicate reservation for %s in batch", ErrReservationConflict, r.SandboxID)
+		}
+		seenIDs[r.SandboxID] = struct{}{}
+
+		if existing, exists := f.fullPlacementLocked(r.SandboxID); exists {
+			if !existing.IsReserved() {
+				return fmt.Errorf("%w: %s already placed by %s", ErrReservationConflict, r.SandboxID, existing.OwnerNodeID)
+			}
+			if existing.OwnerNodeID != r.OwnerNodeID && now <= existing.ExpiresUnix {
+				return fmt.Errorf("%w: %s reserved by %s", ErrReservationConflict, r.SandboxID, existing.OwnerNodeID)
+			}
+		}
+
+		name := specName(r.Spec)
+		if name == "" {
+			continue
+		}
+		if prior, ok := seenNames[name]; ok && prior != r.SandboxID {
+			return fmt.Errorf("%w: %q appears more than once in reservation batch", ErrNameConflict, name)
+		}
+		seenNames[name] = r.SandboxID
+		if err := f.validateNameUniqueLocked(r.SandboxID, name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *placementFSM) reservePlacementLocked(cmd command, now int64) error {
+	if cmd.SandboxID == "" || cmd.OwnerNodeID == "" {
+		return fmt.Errorf("placementFSM: opReserve requires sandbox_id and owner_node_id")
+	}
+	existing, exists := f.fullPlacementLocked(cmd.SandboxID)
+	if exists {
+		// Reject when the slot is already materialized — a router racing a
+		// completed sandbox should back off and let the caller see 409.
+		if !existing.IsReserved() {
+			return fmt.Errorf("%w: %s already placed by %s", ErrReservationConflict, cmd.SandboxID, existing.OwnerNodeID)
+		}
+		// Re-reserve from the same owner before expiry is an idempotent retry —
+		// refresh the TTL and treat it as a no-op otherwise.
+		if existing.OwnerNodeID == cmd.OwnerNodeID && now <= existing.ExpiresUnix {
+			existing.ExpiresUnix = cmd.ExpiresUnix
+			existing.Version = f.version
+			existing.UpdatedUnix = now
+			f.storePlacementLocked(cmd.SandboxID, existing)
+			f.refreshPendingReservationExpiryLocked(cmd.SandboxID, cmd.ExpiresUnix)
+			return nil
+		}
+		// Expired reservations are eligible for overwrite by a fresh reservation.
+		if now > existing.ExpiresUnix {
+			f.releasePendingReservationLocked(cmd.SandboxID)
+			f.releasePendingReservationOwnerLocked(cmd.SandboxID, existing.OwnerNodeID)
+			f.releaseNameLocked(cmd.SandboxID, specName(existing.Spec))
+			f.releaseShardLocked(cmd.SandboxID)
+		} else {
+			return fmt.Errorf("%w: %s reserved by %s", ErrReservationConflict, cmd.SandboxID, existing.OwnerNodeID)
+		}
+	}
+	if err := f.validateNameUniqueLocked(cmd.SandboxID, specName(cmd.Spec)); err != nil {
+		return err
+	}
+	secrets := applyCommandSecretUpdate(Placement{}, false, cmd)
+	p := Placement{
+		SandboxID:          cmd.SandboxID,
+		OwnerNodeID:        cmd.OwnerNodeID,
+		OwnerAPIURL:        cmd.OwnerAPIURL,
+		OwnerDataPlaneHost: cmd.OwnerDataPlaneHost,
+		Version:            f.version,
+		CreatedUnix:        now,
+		UpdatedUnix:        now,
+		Spec:               cmd.Spec,
+		SecretRef:          secrets.Ref,
+		SecretVersion:      secrets.Version,
+		SealedSecrets:      secrets.LegacySealed,
+		State:              PlacementStateReserved,
+		ExpiresUnix:        cmd.ExpiresUnix,
+	}
+	f.storePlacementLocked(cmd.SandboxID, p)
+	f.claimNameLocked(cmd.SandboxID, specName(cmd.Spec))
+	f.claimShardLocked(cmd.SandboxID)
+	f.claimPendingReservationLocked(cmd.SandboxID, p)
+	return nil
+}
+
 // validateNameUniqueLocked checks that no other placement currently claims
 // name. Empty name is always allowed (anonymous sandboxes don't conflict);
 // matches the local SQLite partial-unique-index behavior.
@@ -979,6 +1084,33 @@ func (f *placementFSM) pendingReservationIDsLocked(owner string) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+func (f *placementFSM) livePendingReservationCount(owner string, now int64) int {
+	if owner == "" {
+		return 0
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.pendingReservationIDsByOwner == nil {
+		return 0
+	}
+	f.pruneExpiredPendingReservationsLocked(now)
+	ids := f.pendingReservationIDsByOwner[owner]
+	if len(ids) == 0 {
+		return 0
+	}
+	count := 0
+	for id := range ids {
+		claim, ok := f.pendingReservationClaims[id]
+		if !ok {
+			continue
+		}
+		if claim.ExpiresUnix <= 0 || now <= claim.ExpiresUnix {
+			count++
+		}
+	}
+	return count
 }
 
 func (f *placementFSM) refreshPendingReservationExpiryLocked(sandboxID string, expiresUnix int64) {

--- a/internal/cluster/fsm_reserve_test.go
+++ b/internal/cluster/fsm_reserve_test.go
@@ -379,6 +379,31 @@ func TestFSMPendingReservationsByNodeSumsAndExcludesExpired(t *testing.T) {
 	}
 }
 
+func TestFSMExpiredReservationIDsSurviveCapacityPrune(t *testing.T) {
+	fsm := newPlacementFSM()
+	now := time.Now()
+	applyOp(t, fsm, command{
+		Op:          opReserve,
+		SandboxID:   "sb-expired",
+		OwnerNodeID: "B",
+		Spec:        &models.CreateSandboxRequest{CPU: 2},
+		ExpiresUnix: now.Add(-time.Second).Unix(),
+	})
+
+	if got := fsm.pendingReservationsByNode(now.Unix()); len(got) != 0 {
+		t.Fatalf("expired reservation counted as pending capacity: %+v", got)
+	}
+	ids := fsm.expiredReservationIDs(now.Unix())
+	if len(ids) != 1 || ids[0] != "sb-expired" {
+		t.Fatalf("expiredReservationIDs = %+v, want [sb-expired]", ids)
+	}
+
+	applyOp(t, fsm, command{Op: opCancelReserve, SandboxID: "sb-expired"})
+	if ids := fsm.expiredReservationIDs(now.Unix()); len(ids) != 0 {
+		t.Fatalf("expired reservation remained after cancel: %+v", ids)
+	}
+}
+
 func TestFSMPendingReservationIndexReleasesOnStateTransitions(t *testing.T) {
 	fsm := newPlacementFSM()
 	expiry := time.Now().Add(60 * time.Second).Unix()

--- a/internal/cluster/fsm_reserve_test.go
+++ b/internal/cluster/fsm_reserve_test.go
@@ -356,7 +356,7 @@ func TestFSMSnapshotRoundTripPreservesReservedState(t *testing.T) {
 		t.Fatalf("persist: %v", err)
 	}
 
-	dst := newPlacementFSM()
+	dst := newPlacementFSMWithRecoveryStore(src.recoveryStore)
 	if err := dst.Restore(io.NopCloser(sink.Buffer)); err != nil {
 		t.Fatalf("restore: %v", err)
 	}

--- a/internal/cluster/fsm_reserve_test.go
+++ b/internal/cluster/fsm_reserve_test.go
@@ -162,6 +162,52 @@ func TestFSMReserveRejectsNameCollision(t *testing.T) {
 	}
 }
 
+func TestFSMReserveBatchWritesReservationsAtomically(t *testing.T) {
+	fsm := newPlacementFSM()
+	expiry := time.Now().Add(60 * time.Second).Unix()
+	got := applyOp(t, fsm, command{
+		Op: opReserveBatch,
+		Reservations: []reservationCommand{
+			{SandboxID: "sb-batch-1", OwnerNodeID: "worker-a", Spec: &models.CreateSandboxRequest{Name: "batch-a", CPU: 1}, ExpiresUnix: expiry},
+			{SandboxID: "sb-batch-2", OwnerNodeID: "worker-a", Spec: &models.CreateSandboxRequest{Name: "batch-b", CPU: 2}, ExpiresUnix: expiry},
+		},
+	})
+	if got != nil {
+		t.Fatalf("opReserveBatch returned %v, want nil", got)
+	}
+	if p, ok := fsm.get("sb-batch-1"); !ok || !p.IsReserved() || p.OwnerNodeID != "worker-a" {
+		t.Fatalf("sb-batch-1 = %+v ok=%v, want reserved on worker-a", p, ok)
+	}
+	if p, ok := fsm.get("sb-batch-2"); !ok || !p.IsReserved() || p.OwnerNodeID != "worker-a" {
+		t.Fatalf("sb-batch-2 = %+v ok=%v, want reserved on worker-a", p, ok)
+	}
+	if got := fsm.pendingReservationsByNode(time.Now().Unix())["worker-a"].CPU; got != 3 {
+		t.Fatalf("pending CPU after batch = %v, want 3", got)
+	}
+}
+
+func TestFSMReserveBatchRejectsDuplicateNameWithoutPartialWrite(t *testing.T) {
+	fsm := newPlacementFSM()
+	expiry := time.Now().Add(60 * time.Second).Unix()
+	got := applyOp(t, fsm, command{
+		Op: opReserveBatch,
+		Reservations: []reservationCommand{
+			{SandboxID: "sb-batch-1", OwnerNodeID: "worker-a", Spec: &models.CreateSandboxRequest{Name: "same"}, ExpiresUnix: expiry},
+			{SandboxID: "sb-batch-2", OwnerNodeID: "worker-a", Spec: &models.CreateSandboxRequest{Name: "same"}, ExpiresUnix: expiry},
+		},
+	})
+	err, ok := got.(error)
+	if !ok || !errors.Is(err, ErrNameConflict) {
+		t.Fatalf("opReserveBatch duplicate name = %v, want ErrNameConflict", got)
+	}
+	if _, ok := fsm.get("sb-batch-1"); ok {
+		t.Fatal("first batch row was written despite duplicate-name rejection")
+	}
+	if _, ok := fsm.get("sb-batch-2"); ok {
+		t.Fatal("second batch row was written despite duplicate-name rejection")
+	}
+}
+
 // TestFSMPlacePromotesReservationInheritsSpec pins the central invariant of
 // the reservation→placed transition: opPlace with nil Spec/SealedSecrets must
 // (a) clear State and ExpiresUnix and (b) preserve the Spec + SealedSecrets

--- a/internal/cluster/fsm_test.go
+++ b/internal/cluster/fsm_test.go
@@ -215,6 +215,50 @@ func TestFSMUpsertSpec(t *testing.T) {
 	}
 }
 
+func TestFSMHotPlacementReadsOmitRecoveryPayload(t *testing.T) {
+	fsm := newPlacementFSM()
+	place, _ := encodeCommand(command{
+		Op:            opPlace,
+		SandboxID:     "sb-hot",
+		OwnerNodeID:   "node-a",
+		OwnerAPIURL:   "http://node-a",
+		Spec:          &models.CreateSandboxRequest{Image: "alpine", Name: "demo", Env: map[string]string{"K": "V"}},
+		SecretRef:     "cluster-secret://sandbox/sb-hot/v1",
+		SecretVersion: 1,
+	})
+	if got := fsm.Apply(&raft.Log{Index: 1, Data: place}); got != nil {
+		t.Fatalf("opPlace: %v", got)
+	}
+	add, _ := encodeCommand(command{Op: opAddExposedPort, SandboxID: "sb-hot", Port: 8080, Protocol: "http"})
+	if got := fsm.Apply(&raft.Log{Index: 2, Data: add}); got != nil {
+		t.Fatalf("opAddExposedPort: %v", got)
+	}
+
+	full, ok := fsm.get("sb-hot")
+	if !ok || full.Spec == nil || full.Spec.Image != "alpine" || full.SecretRef == "" {
+		t.Fatalf("point lookup lost recovery payload: %+v ok=%v", full, ok)
+	}
+
+	shardRows := fsm.placementsForShards(PlacementShardFilter{})
+	if len(shardRows) != 1 {
+		t.Fatalf("placementsForShards len=%d, want 1", len(shardRows))
+	}
+	if shardRows[0].Spec != nil || shardRows[0].SecretRef != "" || shardRows[0].SecretVersion != 0 || len(shardRows[0].SealedSecrets) != 0 {
+		t.Fatalf("hot shard read included recovery payload: %+v", shardRows[0])
+	}
+	if shardRows[0].ExposedPorts[8080] != "http" {
+		t.Fatalf("hot shard read lost route fields: %+v", shardRows[0].ExposedPorts)
+	}
+
+	page := fsm.placementPage(PlacementPageRequest{Limit: 10})
+	if len(page.Placements) != 1 {
+		t.Fatalf("placementPage len=%d, want 1", len(page.Placements))
+	}
+	if page.Placements[0].Spec != nil || page.Placements[0].SecretRef != "" {
+		t.Fatalf("hot page read included recovery payload: %+v", page.Placements[0])
+	}
+}
+
 func TestFSMNameLookupTracksPlaceRenameAndDelete(t *testing.T) {
 	fsm := newPlacementFSM()
 	place, _ := encodeCommand(command{Op: opPlace, SandboxID: "sb1", OwnerNodeID: "A",

--- a/internal/cluster/fsm_test.go
+++ b/internal/cluster/fsm_test.go
@@ -453,7 +453,7 @@ func TestFSMSnapshotRestoreRoundTrip(t *testing.T) {
 		t.Fatal("sink should not have been cancelled on success")
 	}
 
-	dst := newPlacementFSM()
+	dst := newPlacementFSMWithRecoveryStore(src.recoveryStore)
 	if err := dst.Restore(io.NopCloser(sink.Buffer)); err != nil {
 		t.Fatalf("restore: %v", err)
 	}
@@ -472,6 +472,37 @@ func TestFSMSnapshotRestoreRoundTrip(t *testing.T) {
 	}
 	if got := dst.idsOwnedBy("owner-a"); len(got) != 1 || got[0] != "a" {
 		t.Fatalf("owner index was not rebuilt on restore: %+v", got)
+	}
+}
+
+func TestFSMSnapshotOmitsRecoveryPayload(t *testing.T) {
+	fsm := newPlacementFSM()
+	payload, _ := encodeCommand(command{
+		Op:            opPlace,
+		SandboxID:     "sb-secret",
+		OwnerNodeID:   "node-a",
+		Spec:          &models.CreateSandboxRequest{Image: "unique-image-only-in-recovery"},
+		SealedSecrets: []byte("unique-sealed-secret-only-in-recovery"),
+	})
+	if got := fsm.Apply(&raft.Log{Data: payload}); got != nil {
+		t.Fatalf("place: %v", got)
+	}
+	snap, err := fsm.Snapshot()
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	sink := &fakeSnapshotSink{Buffer: &bytes.Buffer{}}
+	if err := snap.Persist(sink); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+	raw := sink.Buffer.Bytes()
+	for _, forbidden := range [][]byte{
+		[]byte("unique-image-only-in-recovery"),
+		[]byte("unique-sealed-secret-only-in-recovery"),
+	} {
+		if bytes.Contains(raw, forbidden) {
+			t.Fatalf("snapshot persisted recovery payload %q", forbidden)
+		}
 	}
 }
 
@@ -755,7 +786,7 @@ func TestFSMRestoreRebuildsNameIndex(t *testing.T) {
 	if err := snap.Persist(sink); err != nil {
 		t.Fatalf("persist: %v", err)
 	}
-	dst := newPlacementFSM()
+	dst := newPlacementFSMWithRecoveryStore(src.recoveryStore)
 	if err := dst.Restore(io.NopCloser(sink.Buffer)); err != nil {
 		t.Fatalf("restore: %v", err)
 	}
@@ -882,7 +913,7 @@ func TestFSMSnapshotPreservesVersion(t *testing.T) {
 		t.Fatalf("persist: %v", err)
 	}
 
-	dst := newPlacementFSM()
+	dst := newPlacementFSMWithRecoveryStore(src.recoveryStore)
 	if err := dst.Restore(io.NopCloser(sink.Buffer)); err != nil {
 		t.Fatalf("restore: %v", err)
 	}
@@ -963,7 +994,7 @@ func TestFSMSnapshotIsolatedFromLaterApplies(t *testing.T) {
 		t.Fatalf("persist: %v", err)
 	}
 
-	dst := newPlacementFSM()
+	dst := newPlacementFSMWithRecoveryStore(src.recoveryStore)
 	if err := dst.Restore(io.NopCloser(sink.Buffer)); err != nil {
 		t.Fatalf("restore: %v", err)
 	}
@@ -972,7 +1003,7 @@ func TestFSMSnapshotIsolatedFromLaterApplies(t *testing.T) {
 		t.Fatal("sb1 missing after restore")
 	}
 	if got.Spec == nil || got.Spec.Image != "alpine:before" {
-		t.Fatalf("snapshot leaked post-snapshot Spec mutation: image=%q", got.Spec.Image)
+		t.Fatalf("snapshot leaked post-snapshot Spec mutation: spec=%+v", got.Spec)
 	}
 	if got.Spec.Env["K"] != "before" {
 		t.Fatalf("snapshot leaked post-snapshot Env mutation: K=%q", got.Spec.Env["K"])

--- a/internal/cluster/gossip.go
+++ b/internal/cluster/gossip.go
@@ -19,10 +19,9 @@ import (
 // so this struct must stay small. Capacity used to live here but pushed the
 // encoded blob past 512 bytes, which triggered NodeMeta()'s fallback path and
 // stripped RaftAddr from peers' view — breaking voter auto-join entirely
-// (see voter_autojoin.go which gates on peerRaftAddr != ""). Capacity is now
-// surfaced per-node via /v1/capacity; peer Capacity in Member is left
-// zero-valued, and placement.go.nodeFits / headroomScore already handle the
-// unknown-capacity case (forward and let the remote admitter decide).
+// (see voter_autojoin.go which gates on peerRaftAddr != ""). Capacity now
+// travels as authenticated /v1/capacity heartbeats into capacityLeaseCache;
+// placement rejects worker candidates without a fresh heartbeat.
 type nodeMeta struct {
 	NodeID string `json:"node_id"`
 	// NodeName is the operator-friendly label (SB_NODE_NAME). Empty for
@@ -45,7 +44,7 @@ type nodeMeta struct {
 }
 
 // gossipDelegate implements memberlist.Delegate. Its job is to publish this
-// node's metadata (which includes the capacity snapshot) and accept others'.
+// node's identity metadata and accept others'.
 type gossipDelegate struct {
 	mu            sync.RWMutex
 	selfMeta      nodeMeta
@@ -396,7 +395,7 @@ func setupGossip(cfg gossipSetupConfig, admitter *capacity.Admitter, logger *slo
 // metadata itself is now static (identity-only — see nodeMeta), so we no
 // longer call refreshMeta()+UpdateNode() here; the original purpose of that
 // pair was to disseminate live capacity, which is now fetched per-peer via
-// /v1/capacity instead.
+// authenticated /v1/capacity heartbeats instead.
 func (g *gossipNode) runRefreshLoop(ctx context.Context, interval time.Duration) {
 	t := time.NewTicker(interval)
 	defer t.Stop()
@@ -460,9 +459,9 @@ func memberFromMemberlistNode(n *memberlist.Node) Member {
 			m.RaftAddr = meta.RaftAddr
 			m.InternalURL = meta.InternalURL
 			m.Role = meta.Role
-			// m.Capacity stays zero — capacity no longer travels in nodeMeta
-			// (see the type comment). Callers needing peer capacity must hit
-			// the peer's /v1/capacity endpoint.
+			// m.Capacity stays zero here — capacity no longer travels in
+			// nodeMeta (see the type comment). Cluster.Members and
+			// SelectPlacement overlay fresh capacity leases later.
 		}
 	}
 	return m

--- a/internal/cluster/internal_server.go
+++ b/internal/cluster/internal_server.go
@@ -67,6 +67,16 @@ func startInternalServer(bindAddr string, ct *ClusterTLS, applyHandler func(cont
 				http.Error(w, applyErr.Error(), http.StatusServiceUnavailable)
 				return
 			}
+			if errors.Is(applyErr, ErrCreateBackpressure) {
+				w.Header().Set("Retry-After", fmt.Sprint(CreateBackpressureRetryAfterSeconds))
+				http.Error(w, applyErr.Error(), http.StatusTooManyRequests)
+				return
+			}
+			if errors.Is(applyErr, ErrCapacityExceeded) || errors.Is(applyErr, ErrNoPlacementTarget) {
+				w.Header().Set("Retry-After", fmt.Sprint(CapacityRetryAfterSeconds))
+				http.Error(w, applyErr.Error(), http.StatusServiceUnavailable)
+				return
+			}
 			http.Error(w, applyErr.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/internal/cluster/noop.go
+++ b/internal/cluster/noop.go
@@ -66,6 +66,9 @@ func (n *Noop) CancelReservation(ctx context.Context, sandboxID string) error { 
 func (n *Noop) SetNodeDrainState(ctx context.Context, nodeID string, drained bool) error {
 	return nil
 }
+func (n *Noop) RemoveMember(ctx context.Context, nodeID string, force bool) error {
+	return ErrUnknownMember
+}
 func (n *Noop) IsNodeDrained(nodeID string) bool                       { return false }
 func (n *Noop) ApplyEncoded(ctx context.Context, payload []byte) error { return nil }
 

--- a/internal/cluster/owner_watcher.go
+++ b/internal/cluster/owner_watcher.go
@@ -94,11 +94,8 @@ func (c *Cluster) recreateOwnedSandboxes(ctx context.Context) {
 	if r == nil {
 		return
 	}
-	placements := c.fsm.snapshot()
+	placements := c.fsm.fullPlacementsForOwner(c.nodeID)
 	for id, p := range placements {
-		if p.OwnerNodeID != c.nodeID {
-			continue
-		}
 		if p.Spec == nil {
 			// Pre-cluster sandbox or never-replicated spec. Without a spec we
 			// can't reconstruct the container; leave it unhandled. The

--- a/internal/cluster/owner_watcher.go
+++ b/internal/cluster/owner_watcher.go
@@ -27,25 +27,11 @@ const maxRecreateFailuresBeforeReassign = 5
 // startOwnerWatcher spawns the per-node loop that bridges FSM placements into
 // the service layer. It runs on every node (not just the leader): each node
 // is responsible for materializing the sandboxes it owns. The loop is a no-op
-// until AttachRecreator wires in the service hook.
-//
-// Gated by clusterRecreateOnFailoverEnabled (see dead_owner.go). When the gate
-// is off (current product policy), the loop is never started so a placement
-// owned by self is never materialized into a container after failover —
-// dead_owner.evictDeadOwner orphans placements instead of reassigning them, so
-// no FSM row should ever name self as the owner without a matching local
-// sandbox under the current policy. The tracker and loop body remain intact so
-// the existing tests can drive recreateOwnedSandboxes directly, and so a
-// future opt-in flip of the gate re-enables failover without re-implementing
-// it.
+// until AttachRecreator wires in the service hook. Only placements whose spec
+// opts into failover.policy=recreate are materialized; all others remain
+// ordinary non-HA sandboxes and are orphaned when their owner dies.
 func (c *Cluster) startOwnerWatcher() {
 	c.recreateFailures = &recreateFailureTracker{counts: make(map[string]int)}
-	if !clusterRecreateOnFailoverEnabled {
-		// Product policy: sandboxes are not highly available. Do not start
-		// the recreate loop. Keep the tracker non-nil so callers (and tests
-		// that hit recreateOwnedSandboxes directly) don't deref nil.
-		return
-	}
 	ctx, cancel := context.WithCancel(context.Background())
 	c.ownerWatcherStop = cancel
 	go func() {
@@ -96,6 +82,9 @@ func (c *Cluster) recreateOwnedSandboxes(ctx context.Context) {
 	}
 	placements := c.fsm.fullPlacementsForOwner(c.nodeID)
 	for id, p := range placements {
+		if !placementWantsFailoverRecreate(p) {
+			continue
+		}
 		if p.Spec == nil {
 			// Pre-cluster sandbox or never-replicated spec. Without a spec we
 			// can't reconstruct the container; leave it unhandled. The
@@ -127,6 +116,9 @@ func (c *Cluster) recreateOwnedSandboxes(ctx context.Context) {
 // recoverable placement). The failure counter resets on a successful
 // reassign so the new owner gets a fresh window.
 func (c *Cluster) tryReassignStuckPlacement(ctx context.Context, id string, p Placement) {
+	if !placementWantsFailoverRecreate(p) {
+		return
+	}
 	target, ok := c.selectRecreationTargetExcluding(p.Spec, c.nodeID)
 	if !ok {
 		c.logger.Warn("cluster: no alternate node available for stuck placement; will keep retrying locally",

--- a/internal/cluster/owner_watcher_test.go
+++ b/internal/cluster/owner_watcher_test.go
@@ -77,11 +77,12 @@ func TestOwnerWatcherRecreatesOwnedSandbox(t *testing.T) {
 	c, cleanup := newTestCluster(t, "leader", true, nil)
 	defer cleanup()
 	waitForLeader(t, c, 10*time.Second)
+	seedSelfFailoverCapacity(c)
 
 	rec := newRecordingRecreator()
 	c.AttachRecreator(rec)
 
-	spec := &models.CreateSandboxRequest{Image: "alpine", CPU: 1, MemoryMB: 512}
+	spec := failoverRecreateSpec()
 	cmd := command{Op: opPlace, SandboxID: "sb-failover", OwnerNodeID: "leader", Spec: spec}
 	payload, _ := encodeCommand(cmd)
 	if err := c.raft.raft.Apply(payload, 2*time.Second).Error(); err != nil {
@@ -95,6 +96,30 @@ func TestOwnerWatcherRecreatesOwnedSandbox(t *testing.T) {
 	}
 	if got.spec.Image != "alpine" || got.spec.CPU != 1 || got.spec.MemoryMB != 512 {
 		t.Fatalf("recreator received wrong spec: %+v", got)
+	}
+}
+
+func TestOwnerWatcherSkipsSandboxWithoutFailoverOptIn(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test: requires real raft socket")
+	}
+	c, cleanup := newTestCluster(t, "leader", true, nil)
+	defer cleanup()
+	waitForLeader(t, c, 10*time.Second)
+
+	rec := newRecordingRecreator()
+	c.AttachRecreator(rec)
+
+	spec := &models.CreateSandboxRequest{Image: "alpine", CPU: 1, MemoryMB: 512}
+	cmd := command{Op: opPlace, SandboxID: "sb-no-ha", OwnerNodeID: "leader", Spec: spec}
+	payload, _ := encodeCommand(cmd)
+	if err := c.raft.raft.Apply(payload, 2*time.Second).Error(); err != nil {
+		t.Fatalf("raft Apply: %v", err)
+	}
+
+	c.recreateOwnedSandboxes(context.Background())
+	if _, ok := rec.get("sb-no-ha"); ok {
+		t.Fatal("recreator was invoked for a sandbox without failover opt-in")
 	}
 }
 
@@ -113,7 +138,7 @@ func TestOwnerWatcherReplaysExposedPorts(t *testing.T) {
 	rec := newRecordingRecreator()
 	c.AttachRecreator(rec)
 
-	spec := &models.CreateSandboxRequest{Image: "alpine", CPU: 1, MemoryMB: 512}
+	spec := failoverRecreateSpec()
 	place := command{Op: opPlace, SandboxID: "sb-with-ports", OwnerNodeID: "leader", Spec: spec}
 	payload, _ := encodeCommand(place)
 	if err := c.raft.raft.Apply(payload, 2*time.Second).Error(); err != nil {
@@ -148,30 +173,29 @@ func TestOwnerWatcherReplaysExposedPorts(t *testing.T) {
 }
 
 // TestEvictThenWatcherEndToEnd is the end-to-end pipeline: a placement on a
-// dead node carries a spec; eviction reassigns it to the live leader; the
-// next watcher tick recreates it via the mock recreator. This is the
+// dead node carries an opt-in spec; eviction reassigns it to the live leader;
+// the next watcher tick recreates it via the mock recreator. This is the
 // failover-recreation scenario expressed against a single-node test cluster
 // (the leader picks itself as the recreation target via SelectPlacement's
 // fallback-to-self).
-//
-// Skipped under the current product policy (clusterRecreateOnFailoverEnabled
-// is false): evictDeadOwner orphans the placement, so the watcher never sees
-// it as owned-by-self. Kept for the future opt-in flip.
 func TestEvictThenWatcherEndToEnd(t *testing.T) {
-	if !clusterRecreateOnFailoverEnabled {
-		t.Skip("failover recreate is gated off; flip clusterRecreateOnFailoverEnabled to exercise")
-	}
 	if testing.Short() {
 		t.Skip("integration test: requires real raft socket")
 	}
 	c, cleanup := newTestCluster(t, "leader", true, nil)
 	defer cleanup()
 	waitForLeader(t, c, 10*time.Second)
+	seedSelfFailoverCapacity(c)
 
 	rec := newRecordingRecreator()
 	c.AttachRecreator(rec)
 
-	spec := &models.CreateSandboxRequest{Image: "alpine", CPU: 0.5, MemoryMB: 256}
+	spec := &models.CreateSandboxRequest{
+		Image:    "alpine",
+		CPU:      0.5,
+		MemoryMB: 256,
+		Failover: &models.Failover{Policy: models.FailoverPolicyRecreate},
+	}
 	cmd := command{
 		Op: opPlace, SandboxID: "sb-e2e", OwnerNodeID: "dead-node", OwnerAPIURL: "http://gone",
 		Spec: spec,
@@ -197,5 +221,14 @@ func TestEvictThenWatcherEndToEnd(t *testing.T) {
 	}
 	if got.spec.Image != "alpine" {
 		t.Fatalf("recreator received wrong spec: %+v", got)
+	}
+}
+
+func failoverRecreateSpec() *models.CreateSandboxRequest {
+	return &models.CreateSandboxRequest{
+		Image:    "alpine",
+		CPU:      1,
+		MemoryMB: 512,
+		Failover: &models.Failover{Policy: models.FailoverPolicyRecreate},
 	}
 }

--- a/internal/cluster/placement.go
+++ b/internal/cluster/placement.go
@@ -59,6 +59,11 @@ func capacityRequestFromSpec(spec *models.CreateSandboxRequest) capacity.Request
 func (c *Cluster) SelectPlacement(req capacity.Request) (PlacementTarget, error) {
 	all := c.gossip.members()
 	rejects := make(map[string]int64)
+	if err := LargeClusterTopologyError(all); err != nil {
+		rejects["topology"] = 1
+		recordSchedulerDecision("invalid_topology", 0, rejects)
+		return PlacementTarget{}, err
+	}
 	// Subtract still-in-flight reservations (router wrote opReserve but the
 	// target hasn't yet promoted via opPlace, so the gossip ledger doesn't
 	// reflect them) from each peer's headroom. Without this, two creates that

--- a/internal/cluster/placement.go
+++ b/internal/cluster/placement.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"errors"
+	"fmt"
 	"math/rand"
 	"strings"
 	"time"
@@ -229,6 +230,66 @@ func pickTwo(c []Member) (Member, Member) {
 }
 
 func sameNode(a, b Member) bool { return a.NodeID == b.NodeID }
+
+func (c *Cluster) admitReservationCommand(cmd command) error {
+	reservations := reservationCommands(cmd)
+	if len(reservations) == 0 {
+		return nil
+	}
+	now := time.Now().Unix()
+	pending := c.fsm.pendingReservationsByNode(now)
+	pendingCounts := make(map[string]int, len(reservations))
+	for _, r := range reservations {
+		if _, ok := pendingCounts[r.OwnerNodeID]; !ok {
+			pendingCounts[r.OwnerNodeID] = c.fsm.livePendingReservationCount(r.OwnerNodeID, now)
+		}
+	}
+	return admitReservationCommands(c.membersWithCapacity(), pending, pendingCounts, c.cfg.ClusterCreateMaxPendingPerWorker, reservations)
+}
+
+func admitReservationCommands(members []Member, pending map[string]capacity.Request, pendingCounts map[string]int, maxPendingPerWorker int, reservations []reservationCommand) error {
+	byID := make(map[string]Member, len(members))
+	for _, m := range members {
+		if m.NodeID != "" {
+			byID[m.NodeID] = m
+		}
+	}
+	batchPending := make(map[string]capacity.Request)
+	batchCounts := make(map[string]int)
+	for _, r := range reservations {
+		if r.SandboxID == "" || r.OwnerNodeID == "" {
+			return fmt.Errorf("%w: reservation missing sandbox_id or owner_node_id", ErrReservationConflict)
+		}
+		m, ok := byID[r.OwnerNodeID]
+		if !ok || !m.Alive || !CanOwnSandboxRole(m.Role) {
+			return fmt.Errorf("%w: worker %s is not an alive placement target", ErrNoPlacementTarget, r.OwnerNodeID)
+		}
+		if m.CapacityStale || !hasCapacitySnapshot(m.Capacity) {
+			return fmt.Errorf("%w: worker %s has no fresh capacity heartbeat", ErrNoPlacementTarget, r.OwnerNodeID)
+		}
+		if maxPendingPerWorker > 0 && pendingCounts[r.OwnerNodeID]+batchCounts[r.OwnerNodeID] >= maxPendingPerWorker {
+			return fmt.Errorf("%w: worker %s has %d pending creates (cap %d)",
+				ErrCreateBackpressure, r.OwnerNodeID, pendingCounts[r.OwnerNodeID]+batchCounts[r.OwnerNodeID], maxPendingPerWorker)
+		}
+		req := capacityRequestFromSpec(r.Spec)
+		extra := pending[r.OwnerNodeID]
+		batchExtra := batchPending[r.OwnerNodeID]
+		extra.CPU += batchExtra.CPU
+		extra.MemoryMB += batchExtra.MemoryMB
+		extra.DiskGB += batchExtra.DiskGB
+		extra.GPUs += batchExtra.GPUs
+		if !nodeFits(m, req, extra) {
+			return fmt.Errorf("%w: worker %s cannot fit sandbox %s", ErrCapacityExceeded, r.OwnerNodeID, r.SandboxID)
+		}
+		batchExtra.CPU += req.CPU
+		batchExtra.MemoryMB += req.MemoryMB
+		batchExtra.DiskGB += req.DiskGB
+		batchExtra.GPUs += req.GPUs
+		batchPending[r.OwnerNodeID] = batchExtra
+		batchCounts[r.OwnerNodeID]++
+	}
+	return nil
+}
 
 // CanOwnSandboxRole reports whether a gossiped node role may own sandboxes.
 // Empty is treated as worker-capable for rolling upgrades from builds that

--- a/internal/cluster/placement.go
+++ b/internal/cluster/placement.go
@@ -57,7 +57,7 @@ func capacityRequestFromSpec(spec *models.CreateSandboxRequest) capacity.Request
 // "place locally" is the existing single-node behavior; we only forward when
 // a peer is genuinely better.
 func (c *Cluster) SelectPlacement(req capacity.Request) (PlacementTarget, error) {
-	all := c.gossip.members()
+	all := c.membersWithCapacity()
 	rejects := make(map[string]int64)
 	if err := LargeClusterTopologyError(all); err != nil {
 		rejects["topology"] = 1
@@ -91,6 +91,10 @@ func (c *Cluster) SelectPlacement(req capacity.Request) (PlacementTarget, error)
 		// be partially-joined and forwarding to them would 502.
 		if m.APIURL == "" && m.NodeID != c.nodeID {
 			rejects["missing_api_url"]++
+			continue
+		}
+		if m.CapacityStale || !hasCapacitySnapshot(m.Capacity) {
+			rejects["capacity_heartbeat"]++
 			continue
 		}
 		if drained[m.NodeID] {
@@ -132,17 +136,17 @@ func (c *Cluster) SelectPlacement(req capacity.Request) (PlacementTarget, error)
 }
 
 // nodeFits returns true if the member could plausibly accept req based on its
-// gossiped capacity snapshot. We use the budget numbers (post-overcommit)
+// latest capacity heartbeat. We use the budget numbers (post-overcommit)
 // because that's what the remote admitter will check. extraReserved is the sum
-// of in-flight reservations the cluster has against this node but the gossip
-// ledger doesn't yet reflect (zero value when none).
+// of in-flight reservations the cluster has against this node but the
+// heartbeat doesn't yet reflect (zero value when none).
 func nodeFits(m Member, req capacity.Request, extraReserved capacity.Request) bool {
 	cap := m.Capacity
-	// If the snapshot is zero-valued (no advertisement yet), treat as
-	// unknown-but-allowed: better to forward and let the remote admitter
-	// reject than to skip a viable peer.
-	if cap.HostCPUCores == 0 && cap.HostMemoryTotalMB == 0 {
-		return true
+	if m.CapacityStale || !hasCapacitySnapshot(cap) {
+		return false
+	}
+	if !cap.CanAdmit && len(cap.Reasons) > 0 {
+		return false
 	}
 	if cap.CPUBudget > 0 && cap.ReservedCPU+extraReserved.CPU+req.CPU > cap.CPUBudget {
 		return false

--- a/internal/cluster/placement_test.go
+++ b/internal/cluster/placement_test.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"errors"
 	"math"
 	"testing"
 
@@ -255,5 +256,45 @@ func TestHeadroomScoreSymmetricNeutral(t *testing.T) {
 	score := headroomScore(unknown, capacity.Request{CPU: 1, MemoryMB: 1024}, capacity.Request{})
 	if math.Abs(score-0.5) > 1e-9 {
 		t.Fatalf("expected neutral 0.5 score for unknown capacity, got %v", score)
+	}
+}
+
+func TestAdmitReservationCommandsRejectsMissingCapacityHeartbeat(t *testing.T) {
+	err := admitReservationCommands([]Member{
+		{NodeID: "worker-a", APIURL: "http://worker-a", Alive: true, Role: "worker"},
+	}, nil, nil, 32, []reservationCommand{
+		{SandboxID: "sb1", OwnerNodeID: "worker-a", Spec: &models.CreateSandboxRequest{CPU: 1, MemoryMB: 128}},
+	})
+	if !errors.Is(err, ErrNoPlacementTarget) {
+		t.Fatalf("admitReservationCommands error = %v, want ErrNoPlacementTarget", err)
+	}
+}
+
+func TestAdmitReservationCommandsAppliesPerWorkerBackpressure(t *testing.T) {
+	err := admitReservationCommands([]Member{
+		{NodeID: "worker-a", APIURL: "http://worker-a", Alive: true, Role: "worker", Capacity: capacity.Snapshot{
+			HostCPUCores: 16, HostMemoryTotalMB: 32000,
+			CPUBudget: 16, MemoryBudgetMB: 32000,
+		}},
+	}, nil, map[string]int{"worker-a": 2}, 2, []reservationCommand{
+		{SandboxID: "sb1", OwnerNodeID: "worker-a", Spec: &models.CreateSandboxRequest{CPU: 1, MemoryMB: 128}},
+	})
+	if !errors.Is(err, ErrCreateBackpressure) {
+		t.Fatalf("admitReservationCommands error = %v, want ErrCreateBackpressure", err)
+	}
+}
+
+func TestAdmitReservationCommandsAccountsForBatchCapacity(t *testing.T) {
+	err := admitReservationCommands([]Member{
+		{NodeID: "worker-a", APIURL: "http://worker-a", Alive: true, Role: "worker", Capacity: capacity.Snapshot{
+			HostCPUCores: 4, HostMemoryTotalMB: 4096,
+			CPUBudget: 2, MemoryBudgetMB: 4096,
+		}},
+	}, nil, nil, 32, []reservationCommand{
+		{SandboxID: "sb1", OwnerNodeID: "worker-a", Spec: &models.CreateSandboxRequest{CPU: 1, MemoryMB: 128}},
+		{SandboxID: "sb2", OwnerNodeID: "worker-a", Spec: &models.CreateSandboxRequest{CPU: 1.5, MemoryMB: 128}},
+	})
+	if !errors.Is(err, ErrCapacityExceeded) {
+		t.Fatalf("admitReservationCommands error = %v, want ErrCapacityExceeded", err)
 	}
 }

--- a/internal/cluster/placement_test.go
+++ b/internal/cluster/placement_test.go
@@ -32,13 +32,29 @@ func TestNodeFitsRespectsBudget(t *testing.T) {
 	}
 }
 
-// TestNodeFitsUnknownCapacity asserts that a peer with no advertised capacity
-// snapshot is treated as candidate (better to forward and be rejected by the
-// remote admitter than to skip a viable node).
-func TestNodeFitsUnknownCapacity(t *testing.T) {
+// TestNodeFitsRejectsUnknownCapacity asserts that a peer with no capacity
+// heartbeat is not a candidate. Forwarding unknown-capacity creates causes
+// avoidable remote 503s and retry storms.
+func TestNodeFitsRejectsUnknownCapacity(t *testing.T) {
 	unknown := Member{NodeID: "u", APIURL: "http://u", Alive: true}
-	if !nodeFits(unknown, capacity.Request{CPU: 1, MemoryMB: 1024}, capacity.Request{}) {
-		t.Fatal("unknown-capacity node should be treated as candidate")
+	if nodeFits(unknown, capacity.Request{CPU: 1, MemoryMB: 1024}, capacity.Request{}) {
+		t.Fatal("unknown-capacity node should not be treated as candidate")
+	}
+}
+
+func TestNodeFitsRejectsStaleCapacityHeartbeat(t *testing.T) {
+	stale := Member{
+		NodeID:        "stale",
+		APIURL:        "http://stale",
+		Alive:         true,
+		CapacityStale: true,
+		Capacity: capacity.Snapshot{
+			HostCPUCores: 8, HostMemoryTotalMB: 8000,
+			CPUBudget: 8, MemoryBudgetMB: 8000,
+		},
+	}
+	if nodeFits(stale, capacity.Request{CPU: 1, MemoryMB: 1024}, capacity.Request{}) {
+		t.Fatal("stale-capacity node should not be treated as candidate")
 	}
 }
 
@@ -163,9 +179,9 @@ func TestNodeFitsRejectsUnsupportedRuntime(t *testing.T) {
 }
 
 // TestNodeFitsLegacyEmptyRuntimesAllowsAny: a peer that pre-dates the
-// SupportedRuntimes field (empty list, but non-zero CPU/memory so the
-// "unknown capacity" early-return doesn't fire) must remain a candidate
-// for any runtime — otherwise a rolling upgrade would freeze placements.
+// SupportedRuntimes field (empty list, but with a fresh non-zero capacity
+// heartbeat) must remain a candidate for any runtime — otherwise a rolling
+// upgrade would freeze placements.
 func TestNodeFitsLegacyEmptyRuntimesAllowsAny(t *testing.T) {
 	legacy := Member{NodeID: "l", APIURL: "http://l", Alive: true, Capacity: capacity.Snapshot{
 		HostCPUCores: 8, HostMemoryTotalMB: 8000,
@@ -231,8 +247,9 @@ func TestCapacityRequestFromSpecGPUCountDefaults(t *testing.T) {
 	}
 }
 
-// TestHeadroomScoreSymmetricNeutral verifies the unknown-capacity path
-// returns a neutral 0.5 score so it ties with peers that haven't reported.
+// TestHeadroomScoreSymmetricNeutral verifies the scoring helper's defensive
+// unknown-capacity path returns a neutral 0.5. SelectPlacement filters unknown
+// capacity before scoring; this keeps direct helper use deterministic.
 func TestHeadroomScoreSymmetricNeutral(t *testing.T) {
 	unknown := Member{}
 	score := headroomScore(unknown, capacity.Request{CPU: 1, MemoryMB: 1024}, capacity.Request{})

--- a/internal/cluster/raft.go
+++ b/internal/cluster/raft.go
@@ -111,6 +111,13 @@ func setupRaft(cfg raftSetupConfig, fsm *placementFSM, logger *slog.Logger) (*ra
 		}
 	}
 
+	if err := maybeRecoverRaftClusterFromPeersFile(cfg, rcfg, fsm, logStore, stableStore, snaps, transport, logger); err != nil {
+		_ = transport.Close()
+		_ = logStore.Close()
+		_ = stableStore.Close()
+		return nil, err
+	}
+
 	r, err := raft.NewRaft(rcfg, fsm, logStore, stableStore, snaps, transport)
 	if err != nil {
 		_ = transport.Close()

--- a/internal/cluster/raft_recovery.go
+++ b/internal/cluster/raft_recovery.go
@@ -1,0 +1,117 @@
+package cluster
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/raft"
+	raftboltdb "github.com/hashicorp/raft-boltdb/v2"
+)
+
+const raftRecoveryPeersFilename = "peers.json"
+
+type raftRecoveryPeer struct {
+	ID       string `json:"id"`
+	Address  string `json:"address"`
+	NonVoter bool   `json:"non_voter"`
+	Suffrage string `json:"suffrage"`
+}
+
+func maybeRecoverRaftClusterFromPeersFile(
+	cfg raftSetupConfig,
+	rcfg *raft.Config,
+	fsm *placementFSM,
+	logStore *raftboltdb.BoltStore,
+	stableStore *raftboltdb.BoltStore,
+	snaps raft.SnapshotStore,
+	transport raft.Transport,
+	logger *slog.Logger,
+) error {
+	path := raftRecoveryPeersPath(cfg.DataDir)
+	payload, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("raft recovery: read %s: %w", path, err)
+	}
+	configuration, err := raftConfigurationFromPeersJSON(payload)
+	if err != nil {
+		return fmt.Errorf("raft recovery: parse %s: %w", path, err)
+	}
+	recoveryFSM := newPlacementFSMWithRecoveryStore(fsm.recoveryStore)
+	if err := raft.RecoverCluster(rcfg, recoveryFSM, logStore, stableStore, snaps, transport, configuration); err != nil {
+		return fmt.Errorf("raft recovery: recover cluster from %s: %w", path, err)
+	}
+	appliedPath := path + ".applied." + strconv.FormatInt(time.Now().Unix(), 10)
+	if err := os.Rename(path, appliedPath); err != nil {
+		return fmt.Errorf("raft recovery: mark %s applied: %w", path, err)
+	}
+	if logger != nil {
+		logger.Warn("raft lost-quorum recovery peers file applied",
+			"path", path,
+			"applied_path", appliedPath,
+			"servers", len(configuration.Servers),
+		)
+	}
+	return nil
+}
+
+func raftRecoveryPeersPath(dataDir string) string {
+	return filepath.Join(dataDir, raftRecoveryPeersFilename)
+}
+
+func raftConfigurationFromPeersJSON(payload []byte) (raft.Configuration, error) {
+	var peers []raftRecoveryPeer
+	if err := json.Unmarshal(payload, &peers); err != nil {
+		return raft.Configuration{}, err
+	}
+	if len(peers) == 0 {
+		return raft.Configuration{}, fmt.Errorf("no peers in recovery file")
+	}
+	servers := make([]raft.Server, 0, len(peers))
+	seen := make(map[raft.ServerID]struct{}, len(peers))
+	for _, peer := range peers {
+		id := raft.ServerID(strings.TrimSpace(peer.ID))
+		address := raft.ServerAddress(strings.TrimSpace(peer.Address))
+		if id == "" || address == "" {
+			return raft.Configuration{}, fmt.Errorf("peer id and address are required")
+		}
+		if _, ok := seen[id]; ok {
+			return raft.Configuration{}, fmt.Errorf("duplicate peer id %q", id)
+		}
+		seen[id] = struct{}{}
+		suffrage, err := peerSuffrage(peer)
+		if err != nil {
+			return raft.Configuration{}, err
+		}
+		servers = append(servers, raft.Server{
+			ID:       id,
+			Address:  address,
+			Suffrage: suffrage,
+		})
+	}
+	return raft.Configuration{Servers: servers}, nil
+}
+
+func peerSuffrage(peer raftRecoveryPeer) (raft.ServerSuffrage, error) {
+	if peer.NonVoter {
+		return raft.Nonvoter, nil
+	}
+	switch strings.ToLower(strings.TrimSpace(peer.Suffrage)) {
+	case "", "voter":
+		return raft.Voter, nil
+	case "nonvoter", "non_voter", "non-voter":
+		return raft.Nonvoter, nil
+	case "staging":
+		return raft.Staging, nil
+	default:
+		return raft.Voter, fmt.Errorf("invalid suffrage %q for peer %q", peer.Suffrage, peer.ID)
+	}
+}

--- a/internal/cluster/raft_recovery_test.go
+++ b/internal/cluster/raft_recovery_test.go
@@ -1,0 +1,48 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/hashicorp/raft"
+)
+
+func TestRaftConfigurationFromPeersJSON(t *testing.T) {
+	cfg, err := raftConfigurationFromPeersJSON([]byte(`[
+		{"id":"server-a","address":"10.0.0.1:7000","suffrage":"Voter"},
+		{"id":"server-b","address":"10.0.0.2:7000","non_voter":true}
+	]`))
+	if err != nil {
+		t.Fatalf("raftConfigurationFromPeersJSON error = %v", err)
+	}
+	if len(cfg.Servers) != 2 {
+		t.Fatalf("servers = %d, want 2", len(cfg.Servers))
+	}
+	if cfg.Servers[0].ID != "server-a" || cfg.Servers[0].Address != "10.0.0.1:7000" || cfg.Servers[0].Suffrage != raft.Voter {
+		t.Fatalf("unexpected first server: %+v", cfg.Servers[0])
+	}
+	if cfg.Servers[1].ID != "server-b" || cfg.Servers[1].Suffrage != raft.Nonvoter {
+		t.Fatalf("unexpected second server: %+v", cfg.Servers[1])
+	}
+}
+
+func TestRaftConfigurationFromPeersJSONRejectsBadInput(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "empty", body: `[]`},
+		{name: "missing_address", body: `[{"id":"server-a"}]`},
+		{name: "duplicate_id", body: `[
+			{"id":"server-a","address":"10.0.0.1:7000"},
+			{"id":"server-a","address":"10.0.0.2:7000"}
+		]`},
+		{name: "bad_suffrage", body: `[{"id":"server-a","address":"10.0.0.1:7000","suffrage":"leader"}]`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := raftConfigurationFromPeersJSON([]byte(tc.body)); err == nil {
+				t.Fatalf("expected error")
+			}
+		})
+	}
+}

--- a/internal/cluster/recovery_replication.go
+++ b/internal/cluster/recovery_replication.go
@@ -1,0 +1,260 @@
+package cluster
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func (c *Cluster) externalizeCommandRecovery(ctx context.Context, cmd command) (command, error) {
+	return externalizeCommandRecovery(ctx, cmd, c.storeAndReplicateRecoveryBlob)
+}
+
+func (a *Agent) externalizeCommandRecovery(ctx context.Context, cmd command) (command, error) {
+	return externalizeCommandRecovery(ctx, cmd, a.replicateRecoveryBlob)
+}
+
+func externalizeCommandRecovery(ctx context.Context, cmd command, put func(context.Context, RecoveryBlob) error) (command, error) {
+	switch cmd.Op {
+	case opPlace, opClaimOrphan, opUpsertSpec, opReserve:
+		return externalizeSingleCommandRecovery(ctx, cmd, put)
+	case opReserveBatch:
+		for i := range cmd.Reservations {
+			r, err := externalizeReservationRecovery(ctx, cmd.Reservations[i], put)
+			if err != nil {
+				return command{}, err
+			}
+			cmd.Reservations[i] = r
+		}
+	}
+	return cmd, nil
+}
+
+func externalizeSingleCommandRecovery(ctx context.Context, cmd command, put func(context.Context, RecoveryBlob) error) (command, error) {
+	if !commandCarriesRecoveryPayload(cmd.Spec, cmd.SecretRef, cmd.SecretVersion, cmd.SealedSecrets) {
+		return cmd, nil
+	}
+	blob, err := newRecoveryBlob(cmd.SandboxID, placementRecovery{
+		Spec:          cmd.Spec,
+		SecretRef:     cmd.SecretRef,
+		SecretVersion: cmd.SecretVersion,
+		SealedSecrets: cloneBytes(cmd.SealedSecrets),
+	})
+	if err != nil {
+		return command{}, err
+	}
+	if err := put(ctx, blob); err != nil {
+		return command{}, err
+	}
+	cmd.Name = commandName(cmd)
+	cmd.RecoveryRef = blob.Ref
+	cmd.Spec = nil
+	cmd.SecretRef = ""
+	cmd.SecretVersion = 0
+	cmd.SealedSecrets = nil
+	return cmd, nil
+}
+
+func externalizeReservationRecovery(ctx context.Context, r reservationCommand, put func(context.Context, RecoveryBlob) error) (reservationCommand, error) {
+	if !commandCarriesRecoveryPayload(r.Spec, r.SecretRef, r.SecretVersion, r.SealedSecrets) {
+		return r, nil
+	}
+	blob, err := newRecoveryBlob(r.SandboxID, placementRecovery{
+		Spec:          r.Spec,
+		SecretRef:     r.SecretRef,
+		SecretVersion: r.SecretVersion,
+		SealedSecrets: cloneBytes(r.SealedSecrets),
+	})
+	if err != nil {
+		return reservationCommand{}, err
+	}
+	if err := put(ctx, blob); err != nil {
+		return reservationCommand{}, err
+	}
+	r.Name = reservationName(r)
+	r.RecoveryRef = blob.Ref
+	r.Spec = nil
+	r.SecretRef = ""
+	r.SecretVersion = 0
+	r.SealedSecrets = nil
+	return r, nil
+}
+
+func commandCarriesRecoveryPayload(spec *models.CreateSandboxRequest, secretRef string, secretVersion int, sealed []byte) bool {
+	return spec != nil || secretRef != "" || secretVersion != 0 || len(sealed) > 0
+}
+
+func (c *Cluster) storeAndReplicateRecoveryBlob(ctx context.Context, blob RecoveryBlob) error {
+	if err := c.StoreRecoveryBlob(ctx, blob); err != nil {
+		return err
+	}
+	var firstErr error
+	for _, m := range c.recoveryServerMembers() {
+		if m.NodeID == "" || m.NodeID == c.nodeID {
+			continue
+		}
+		if err := c.putRecoveryBlobToMember(ctx, m, blob); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if firstErr != nil {
+		return firstErr
+	}
+	return nil
+}
+
+func (a *Agent) replicateRecoveryBlob(ctx context.Context, blob RecoveryBlob) error {
+	members := a.controlPlaneMembers()
+	if len(members) == 0 {
+		return errors.New("cluster agent: no live server-role control-plane members for recovery blob")
+	}
+	var firstErr error
+	for _, m := range members {
+		if err := a.putRecoveryBlobToMember(ctx, m, blob); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if firstErr != nil {
+		return firstErr
+	}
+	return nil
+}
+
+func (c *Cluster) StoreRecoveryBlob(ctx context.Context, blob RecoveryBlob) error {
+	_ = ctx
+	return c.fsm.storeRecoveryBlob(blob)
+}
+
+func (c *Cluster) RecoveryBlob(ctx context.Context, ref string) (RecoveryBlob, bool, error) {
+	_ = ctx
+	if c.fsm == nil || c.fsm.recoveryStore == nil {
+		return RecoveryBlob{}, false, nil
+	}
+	record, ok, err := c.fsm.recoveryStore.GetRecord(ref)
+	if err != nil || !ok {
+		return RecoveryBlob{}, ok, err
+	}
+	return recoveryBlobFromRecord(ref, record), true, nil
+}
+
+func (c *Cluster) fetchRecoveryBlob(ctx context.Context, ref string) (RecoveryBlob, bool, error) {
+	for _, m := range c.recoveryServerMembers() {
+		if m.NodeID == "" || m.NodeID == c.nodeID {
+			continue
+		}
+		blob, ok, err := c.getRecoveryBlobFromMember(ctx, m, ref)
+		if err == nil && ok {
+			return blob, true, nil
+		}
+		if err != nil && !isStatus(err, http.StatusNotFound) {
+			continue
+		}
+	}
+	return RecoveryBlob{}, false, nil
+}
+
+func (c *Cluster) recoveryServerMembers() []Member {
+	if c.gossip == nil {
+		return nil
+	}
+	members := c.gossip.members()
+	out := make([]Member, 0, len(members))
+	for _, m := range members {
+		if m.NodeID == "" || !m.Alive || !CanServeControlPlaneRole(m.Role) {
+			continue
+		}
+		if m.NodeID != c.nodeID && m.APIURL == "" && m.InternalURL == "" {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func (c *Cluster) putRecoveryBlobToMember(ctx context.Context, m Member, blob RecoveryBlob) error {
+	body, err := json.Marshal(blob)
+	if err != nil {
+		return err
+	}
+	path := recoveryBlobPath(blob.Ref)
+	if c.internalClient != nil && m.InternalURL != "" {
+		return doRecoveryHTTPRequest(ctx, c.internalClient, strings.TrimRight(m.InternalURL, "/")+path, http.MethodPut, c.patToken, body, nil)
+	}
+	if m.APIURL == "" {
+		return errors.New("cluster: recovery blob peer API URL unknown for " + m.NodeID)
+	}
+	return doRecoveryHTTPRequest(ctx, c.httpClient, strings.TrimRight(m.APIURL, "/")+path, http.MethodPut, c.patToken, body, nil)
+}
+
+func (a *Agent) putRecoveryBlobToMember(ctx context.Context, m Member, blob RecoveryBlob) error {
+	body, err := json.Marshal(blob)
+	if err != nil {
+		return err
+	}
+	path := recoveryBlobPath(blob.Ref)
+	if a.internalClient != nil && m.InternalURL != "" {
+		return doRecoveryHTTPRequest(ctx, a.internalClient, strings.TrimRight(m.InternalURL, "/")+path, http.MethodPut, a.patToken, body, nil)
+	}
+	if m.APIURL == "" {
+		return errors.New("cluster agent: recovery blob peer API URL unknown for " + m.NodeID)
+	}
+	return doRecoveryHTTPRequest(ctx, a.httpClient, strings.TrimRight(m.APIURL, "/")+path, http.MethodPut, a.patToken, body, nil)
+}
+
+func (c *Cluster) getRecoveryBlobFromMember(ctx context.Context, m Member, ref string) (RecoveryBlob, bool, error) {
+	var out RecoveryBlob
+	path := recoveryBlobPath(ref)
+	var err error
+	if c.internalClient != nil && m.InternalURL != "" {
+		err = doRecoveryHTTPRequest(ctx, c.internalClient, strings.TrimRight(m.InternalURL, "/")+path, http.MethodGet, c.patToken, nil, &out)
+	} else if m.APIURL != "" {
+		err = doRecoveryHTTPRequest(ctx, c.httpClient, strings.TrimRight(m.APIURL, "/")+path, http.MethodGet, c.patToken, nil, &out)
+	} else {
+		err = errors.New("cluster: recovery blob peer API URL unknown for " + m.NodeID)
+	}
+	if err != nil {
+		if isStatus(err, http.StatusNotFound) {
+			return RecoveryBlob{}, false, nil
+		}
+		return RecoveryBlob{}, false, err
+	}
+	return out, true, nil
+}
+
+func recoveryBlobPath(ref string) string {
+	return PublicInternalRecoveryPath + url.PathEscape(ref)
+}
+
+func doRecoveryHTTPRequest(ctx context.Context, client *http.Client, endpoint, method, pat string, body []byte, out any) error {
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if pat != "" {
+		req.Header.Set("Authorization", "Bearer "+pat)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return statusError{status: resp.StatusCode, message: strings.TrimSpace(string(msg))}
+	}
+	if out == nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}

--- a/internal/cluster/recovery_replication_test.go
+++ b/internal/cluster/recovery_replication_test.go
@@ -1,0 +1,67 @@
+package cluster
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+	"github.com/hashicorp/raft"
+)
+
+func TestExternalizedRecoveryDoesNotEnterRaftCommand(t *testing.T) {
+	store := newPlacementRecoveryMemoryStore()
+	put := func(ctx context.Context, blob RecoveryBlob) error {
+		_ = ctx
+		ref, err := store.Put(blob.SandboxID, blob.recovery())
+		if err != nil {
+			return err
+		}
+		if ref != blob.Ref {
+			t.Fatalf("stored ref=%q want %q", ref, blob.Ref)
+		}
+		return nil
+	}
+	cmd := command{
+		Op:            opReserve,
+		SandboxID:     "sb-externalized",
+		OwnerNodeID:   "node-a",
+		Spec:          &models.CreateSandboxRequest{Name: "named", Image: "image-only-in-recovery"},
+		SealedSecrets: []byte("sealed-only-in-recovery"),
+		ExpiresUnix:   9999999999,
+	}
+	raftCmd, err := externalizeCommandRecovery(context.Background(), cmd, put)
+	if err != nil {
+		t.Fatalf("externalize: %v", err)
+	}
+	if raftCmd.Spec != nil || len(raftCmd.SealedSecrets) != 0 || raftCmd.SecretRef != "" || raftCmd.SecretVersion != 0 {
+		t.Fatalf("raft command still carries recovery payload: %+v", raftCmd)
+	}
+	if raftCmd.Name != "named" || raftCmd.RecoveryRef == "" {
+		t.Fatalf("raft command missing hot recovery fields: %+v", raftCmd)
+	}
+	payload, err := encodeCommand(raftCmd)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	for _, forbidden := range [][]byte{[]byte("image-only-in-recovery"), []byte("sealed-only-in-recovery")} {
+		if bytes.Contains(payload, forbidden) {
+			t.Fatalf("raft payload contained recovery bytes %q", forbidden)
+		}
+	}
+
+	fsm := newPlacementFSMWithRecoveryStore(store)
+	if got := fsm.Apply(&raft.Log{Index: 1, Data: payload}); got != nil {
+		t.Fatalf("apply externalized command: %v", got)
+	}
+	placement, ok := fsm.get("sb-externalized")
+	if !ok {
+		t.Fatal("placement missing after externalized apply")
+	}
+	if placement.Spec == nil || placement.Spec.Image != "image-only-in-recovery" {
+		t.Fatalf("externalized spec was not hydrated: %+v", placement.Spec)
+	}
+	if string(placement.SealedSecrets) != "sealed-only-in-recovery" {
+		t.Fatalf("externalized sealed secrets were not hydrated: %q", placement.SealedSecrets)
+	}
+}

--- a/internal/cluster/recovery_store.go
+++ b/internal/cluster/recovery_store.go
@@ -8,21 +8,46 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/models"
 )
 
 const placementRecoveryRefPrefix = "recovery:v1:"
+const placementRecoverySnapshotRefSets = 3
 
 type placementRecoveryStore interface {
 	Put(sandboxID string, rec placementRecovery) (string, error)
 	Get(ref string) (placementRecovery, bool, error)
+	GetRecord(ref string) (placementRecoveryStoreRecord, bool, error)
 	Delete(ref string) error
+	RetainSnapshotRefs(refs []string) error
 }
 
 type placementRecoveryStoreRecord struct {
 	SandboxID string            `json:"sandbox_id"`
 	Recovery  placementRecovery `json:"recovery"`
+}
+
+type RecoveryBlob struct {
+	Ref           string                       `json:"ref"`
+	SandboxID     string                       `json:"sandbox_id"`
+	Spec          *models.CreateSandboxRequest `json:"spec,omitempty"`
+	SecretRef     string                       `json:"secret_ref,omitempty"`
+	SecretVersion int                          `json:"secret_version,omitempty"`
+	SealedSecrets []byte                       `json:"sealed_secrets,omitempty"`
+}
+
+type placementRecoveryGCManifest struct {
+	Snapshots []placementRecoverySnapshotRefs `json:"snapshots"`
+}
+
+type placementRecoverySnapshotRefs struct {
+	CreatedUnix int64    `json:"created_unix"`
+	Refs        []string `json:"refs"`
 }
 
 func newPlacementFSMWithFileRecovery(raftDataDir string) (*placementFSM, error) {
@@ -34,6 +59,47 @@ func newPlacementFSMWithFileRecovery(raftDataDir string) (*placementFSM, error) 
 		return nil, err
 	}
 	return newPlacementFSMWithRecoveryStore(store), nil
+}
+
+func newRecoveryBlob(sandboxID string, rec placementRecovery) (RecoveryBlob, error) {
+	record := placementRecoveryStoreRecord{
+		SandboxID: sandboxID,
+		Recovery:  clonePlacementRecovery(rec),
+	}
+	ref, _, err := encodePlacementRecoveryRecord(record)
+	if err != nil {
+		return RecoveryBlob{}, err
+	}
+	return recoveryBlobFromRecord(ref, record), nil
+}
+
+func recoveryBlobFromRecord(ref string, record placementRecoveryStoreRecord) RecoveryBlob {
+	return RecoveryBlob{
+		Ref:           ref,
+		SandboxID:     record.SandboxID,
+		Spec:          cloneCreateSandboxRequest(record.Recovery.Spec),
+		SecretRef:     record.Recovery.SecretRef,
+		SecretVersion: record.Recovery.SecretVersion,
+		SealedSecrets: cloneBytes(record.Recovery.SealedSecrets),
+	}
+}
+
+func (b RecoveryBlob) recovery() placementRecovery {
+	return placementRecovery{
+		Spec:          cloneCreateSandboxRequest(b.Spec),
+		SecretRef:     b.SecretRef,
+		SecretVersion: b.SecretVersion,
+		SealedSecrets: cloneBytes(b.SealedSecrets),
+	}
+}
+
+func encodePlacementRecoveryRecord(record placementRecoveryStoreRecord) (string, []byte, error) {
+	payload, err := json.Marshal(record)
+	if err != nil {
+		return "", nil, fmt.Errorf("placement recovery store: marshal: %w", err)
+	}
+	sum := sha256.Sum256(payload)
+	return placementRecoveryRefPrefix + hex.EncodeToString(sum[:]), payload, nil
 }
 
 type placementRecoveryFileStore struct {
@@ -58,12 +124,10 @@ func (s *placementRecoveryFileStore) Put(sandboxID string, rec placementRecovery
 		SandboxID: sandboxID,
 		Recovery:  clonePlacementRecovery(rec),
 	}
-	payload, err := json.Marshal(record)
+	ref, payload, err := encodePlacementRecoveryRecord(record)
 	if err != nil {
-		return "", fmt.Errorf("placement recovery store: marshal: %w", err)
+		return "", err
 	}
-	sum := sha256.Sum256(payload)
-	ref := placementRecoveryRefPrefix + hex.EncodeToString(sum[:])
 	path, err := s.pathForRef(ref)
 	if err != nil {
 		return "", err
@@ -95,22 +159,30 @@ func (s *placementRecoveryFileStore) Put(sandboxID string, rec placementRecovery
 }
 
 func (s *placementRecoveryFileStore) Get(ref string) (placementRecovery, bool, error) {
+	record, ok, err := s.GetRecord(ref)
+	if err != nil || !ok {
+		return placementRecovery{}, ok, err
+	}
+	return clonePlacementRecovery(record.Recovery), true, nil
+}
+
+func (s *placementRecoveryFileStore) GetRecord(ref string) (placementRecoveryStoreRecord, bool, error) {
 	path, err := s.pathForRef(ref)
 	if err != nil {
-		return placementRecovery{}, false, err
+		return placementRecoveryStoreRecord{}, false, err
 	}
 	payload, err := os.ReadFile(path)
 	if errors.Is(err, os.ErrNotExist) {
-		return placementRecovery{}, false, nil
+		return placementRecoveryStoreRecord{}, false, nil
 	}
 	if err != nil {
-		return placementRecovery{}, false, fmt.Errorf("placement recovery store: read: %w", err)
+		return placementRecoveryStoreRecord{}, false, fmt.Errorf("placement recovery store: read: %w", err)
 	}
 	var record placementRecoveryStoreRecord
 	if err := json.Unmarshal(payload, &record); err != nil {
-		return placementRecovery{}, false, fmt.Errorf("placement recovery store: decode: %w", err)
+		return placementRecoveryStoreRecord{}, false, fmt.Errorf("placement recovery store: decode: %w", err)
 	}
-	return clonePlacementRecovery(record.Recovery), true, nil
+	return record, true, nil
 }
 
 func (s *placementRecoveryFileStore) Delete(ref string) error {
@@ -138,13 +210,131 @@ func (s *placementRecoveryFileStore) pathForRef(ref string) (string, error) {
 	return filepath.Join(s.dir, sum+".json"), nil
 }
 
+func (s *placementRecoveryFileStore) RetainSnapshotRefs(refs []string) error {
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+		return fmt.Errorf("placement recovery store: mkdir: %w", err)
+	}
+	manifest, err := s.readGCManifest()
+	if err != nil {
+		return err
+	}
+	manifest.Snapshots = append(manifest.Snapshots, placementRecoverySnapshotRefs{
+		CreatedUnix: time.Now().Unix(),
+		Refs:        normalizeRecoveryRefs(refs),
+	})
+	if len(manifest.Snapshots) > placementRecoverySnapshotRefSets {
+		manifest.Snapshots = manifest.Snapshots[len(manifest.Snapshots)-placementRecoverySnapshotRefSets:]
+	}
+	if err := s.writeGCManifest(manifest); err != nil {
+		return err
+	}
+	keep := make(map[string]struct{})
+	for _, snap := range manifest.Snapshots {
+		for _, ref := range snap.Refs {
+			keep[ref] = struct{}{}
+		}
+	}
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return fmt.Errorf("placement recovery store: list: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !isRecoveryBlobFilename(entry.Name()) {
+			continue
+		}
+		ref := placementRecoveryRefPrefix + strings.TrimSuffix(entry.Name(), ".json")
+		if _, ok := keep[ref]; ok {
+			continue
+		}
+		if err := os.Remove(filepath.Join(s.dir, entry.Name())); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("placement recovery store: gc: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *placementRecoveryFileStore) gcManifestPath() string {
+	return filepath.Join(s.dir, "snapshots.json")
+}
+
+func (s *placementRecoveryFileStore) readGCManifest() (placementRecoveryGCManifest, error) {
+	payload, err := os.ReadFile(s.gcManifestPath())
+	if errors.Is(err, os.ErrNotExist) {
+		return placementRecoveryGCManifest{}, nil
+	}
+	if err != nil {
+		return placementRecoveryGCManifest{}, fmt.Errorf("placement recovery store: read gc manifest: %w", err)
+	}
+	var manifest placementRecoveryGCManifest
+	if err := json.Unmarshal(payload, &manifest); err != nil {
+		return placementRecoveryGCManifest{}, fmt.Errorf("placement recovery store: decode gc manifest: %w", err)
+	}
+	return manifest, nil
+}
+
+func (s *placementRecoveryFileStore) writeGCManifest(manifest placementRecoveryGCManifest) error {
+	payload, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("placement recovery store: encode gc manifest: %w", err)
+	}
+	tmp, err := os.CreateTemp(s.dir, ".tmp-recovery-gc-*")
+	if err != nil {
+		return fmt.Errorf("placement recovery store: create gc temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.Write(payload); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("placement recovery store: write gc manifest: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("placement recovery store: sync gc manifest: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("placement recovery store: close gc manifest: %w", err)
+	}
+	if err := os.Rename(tmpName, s.gcManifestPath()); err != nil {
+		return fmt.Errorf("placement recovery store: rename gc manifest: %w", err)
+	}
+	return nil
+}
+
+func normalizeRecoveryRefs(refs []string) []string {
+	seen := make(map[string]struct{}, len(refs))
+	for _, ref := range refs {
+		if strings.TrimSpace(ref) == "" {
+			continue
+		}
+		seen[ref] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for ref := range seen {
+		out = append(out, ref)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func isRecoveryBlobFilename(name string) bool {
+	if !strings.HasSuffix(name, ".json") {
+		return false
+	}
+	sum := strings.TrimSuffix(name, ".json")
+	if len(sum) != sha256.Size*2 {
+		return false
+	}
+	_, err := hex.DecodeString(sum)
+	return err == nil
+}
+
 type placementRecoveryMemoryStore struct {
 	mu   sync.RWMutex
-	rows map[string]placementRecovery
+	rows map[string]placementRecoveryStoreRecord
 }
 
 func newPlacementRecoveryMemoryStore() *placementRecoveryMemoryStore {
-	return &placementRecoveryMemoryStore{rows: make(map[string]placementRecovery)}
+	return &placementRecoveryMemoryStore{rows: make(map[string]placementRecoveryStoreRecord)}
 }
 
 func (s *placementRecoveryMemoryStore) Put(sandboxID string, rec placementRecovery) (string, error) {
@@ -155,26 +345,33 @@ func (s *placementRecoveryMemoryStore) Put(sandboxID string, rec placementRecove
 		SandboxID: sandboxID,
 		Recovery:  clonePlacementRecovery(rec),
 	}
-	payload, err := json.Marshal(record)
+	ref, _, err := encodePlacementRecoveryRecord(record)
 	if err != nil {
-		return "", fmt.Errorf("placement recovery store: marshal: %w", err)
+		return "", err
 	}
-	sum := sha256.Sum256(payload)
-	ref := placementRecoveryRefPrefix + hex.EncodeToString(sum[:])
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.rows[ref] = clonePlacementRecovery(rec)
+	s.rows[ref] = record
 	return ref, nil
 }
 
 func (s *placementRecoveryMemoryStore) Get(ref string) (placementRecovery, bool, error) {
+	record, ok, err := s.GetRecord(ref)
+	if err != nil || !ok {
+		return placementRecovery{}, ok, err
+	}
+	return clonePlacementRecovery(record.Recovery), true, nil
+}
+
+func (s *placementRecoveryMemoryStore) GetRecord(ref string) (placementRecoveryStoreRecord, bool, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	rec, ok := s.rows[ref]
+	record, ok := s.rows[ref]
 	if !ok {
-		return placementRecovery{}, false, nil
+		return placementRecoveryStoreRecord{}, false, nil
 	}
-	return clonePlacementRecovery(rec), true, nil
+	record.Recovery = clonePlacementRecovery(record.Recovery)
+	return record, true, nil
 }
 
 func (s *placementRecoveryMemoryStore) Delete(ref string) error {
@@ -183,3 +380,5 @@ func (s *placementRecoveryMemoryStore) Delete(ref string) error {
 	delete(s.rows, ref)
 	return nil
 }
+
+func (s *placementRecoveryMemoryStore) RetainSnapshotRefs([]string) error { return nil }

--- a/internal/cluster/recovery_store.go
+++ b/internal/cluster/recovery_store.go
@@ -1,0 +1,185 @@
+package cluster
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+const placementRecoveryRefPrefix = "recovery:v1:"
+
+type placementRecoveryStore interface {
+	Put(sandboxID string, rec placementRecovery) (string, error)
+	Get(ref string) (placementRecovery, bool, error)
+	Delete(ref string) error
+}
+
+type placementRecoveryStoreRecord struct {
+	SandboxID string            `json:"sandbox_id"`
+	Recovery  placementRecovery `json:"recovery"`
+}
+
+func newPlacementFSMWithFileRecovery(raftDataDir string) (*placementFSM, error) {
+	if strings.TrimSpace(raftDataDir) == "" {
+		return newPlacementFSM(), nil
+	}
+	store, err := newPlacementRecoveryFileStore(filepath.Join(raftDataDir, "recovery"))
+	if err != nil {
+		return nil, err
+	}
+	return newPlacementFSMWithRecoveryStore(store), nil
+}
+
+type placementRecoveryFileStore struct {
+	dir string
+}
+
+func newPlacementRecoveryFileStore(dir string) (*placementRecoveryFileStore, error) {
+	if strings.TrimSpace(dir) == "" {
+		return nil, errors.New("placement recovery store: empty dir")
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("placement recovery store: mkdir: %w", err)
+	}
+	return &placementRecoveryFileStore{dir: dir}, nil
+}
+
+func (s *placementRecoveryFileStore) Put(sandboxID string, rec placementRecovery) (string, error) {
+	if strings.TrimSpace(sandboxID) == "" {
+		return "", errors.New("placement recovery store: empty sandbox id")
+	}
+	record := placementRecoveryStoreRecord{
+		SandboxID: sandboxID,
+		Recovery:  clonePlacementRecovery(rec),
+	}
+	payload, err := json.Marshal(record)
+	if err != nil {
+		return "", fmt.Errorf("placement recovery store: marshal: %w", err)
+	}
+	sum := sha256.Sum256(payload)
+	ref := placementRecoveryRefPrefix + hex.EncodeToString(sum[:])
+	path, err := s.pathForRef(ref)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+		return "", fmt.Errorf("placement recovery store: mkdir: %w", err)
+	}
+	tmp, err := os.CreateTemp(s.dir, ".tmp-recovery-*")
+	if err != nil {
+		return "", fmt.Errorf("placement recovery store: create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.Write(payload); err != nil {
+		_ = tmp.Close()
+		return "", fmt.Errorf("placement recovery store: write: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return "", fmt.Errorf("placement recovery store: sync: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return "", fmt.Errorf("placement recovery store: close: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return "", fmt.Errorf("placement recovery store: rename: %w", err)
+	}
+	return ref, nil
+}
+
+func (s *placementRecoveryFileStore) Get(ref string) (placementRecovery, bool, error) {
+	path, err := s.pathForRef(ref)
+	if err != nil {
+		return placementRecovery{}, false, err
+	}
+	payload, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return placementRecovery{}, false, nil
+	}
+	if err != nil {
+		return placementRecovery{}, false, fmt.Errorf("placement recovery store: read: %w", err)
+	}
+	var record placementRecoveryStoreRecord
+	if err := json.Unmarshal(payload, &record); err != nil {
+		return placementRecovery{}, false, fmt.Errorf("placement recovery store: decode: %w", err)
+	}
+	return clonePlacementRecovery(record.Recovery), true, nil
+}
+
+func (s *placementRecoveryFileStore) Delete(ref string) error {
+	if strings.TrimSpace(ref) == "" {
+		return nil
+	}
+	path, err := s.pathForRef(ref)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("placement recovery store: delete: %w", err)
+	}
+	return nil
+}
+
+func (s *placementRecoveryFileStore) pathForRef(ref string) (string, error) {
+	sum := strings.TrimPrefix(ref, placementRecoveryRefPrefix)
+	if sum == ref || len(sum) != sha256.Size*2 {
+		return "", fmt.Errorf("placement recovery store: invalid ref %q", ref)
+	}
+	if _, err := hex.DecodeString(sum); err != nil {
+		return "", fmt.Errorf("placement recovery store: invalid ref %q: %w", ref, err)
+	}
+	return filepath.Join(s.dir, sum+".json"), nil
+}
+
+type placementRecoveryMemoryStore struct {
+	mu   sync.RWMutex
+	rows map[string]placementRecovery
+}
+
+func newPlacementRecoveryMemoryStore() *placementRecoveryMemoryStore {
+	return &placementRecoveryMemoryStore{rows: make(map[string]placementRecovery)}
+}
+
+func (s *placementRecoveryMemoryStore) Put(sandboxID string, rec placementRecovery) (string, error) {
+	if strings.TrimSpace(sandboxID) == "" {
+		return "", errors.New("placement recovery store: empty sandbox id")
+	}
+	record := placementRecoveryStoreRecord{
+		SandboxID: sandboxID,
+		Recovery:  clonePlacementRecovery(rec),
+	}
+	payload, err := json.Marshal(record)
+	if err != nil {
+		return "", fmt.Errorf("placement recovery store: marshal: %w", err)
+	}
+	sum := sha256.Sum256(payload)
+	ref := placementRecoveryRefPrefix + hex.EncodeToString(sum[:])
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.rows[ref] = clonePlacementRecovery(rec)
+	return ref, nil
+}
+
+func (s *placementRecoveryMemoryStore) Get(ref string) (placementRecovery, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	rec, ok := s.rows[ref]
+	if !ok {
+		return placementRecovery{}, false, nil
+	}
+	return clonePlacementRecovery(rec), true, nil
+}
+
+func (s *placementRecoveryMemoryStore) Delete(ref string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.rows, ref)
+	return nil
+}

--- a/internal/cluster/role_split_test.go
+++ b/internal/cluster/role_split_test.go
@@ -79,8 +79,8 @@ func newTestAgentWithRole(t *testing.T, nodeID, role string, gossipPeers []strin
 
 // TestRoleSplitWorkerDoesNotJoinRaft is the headline gate: a worker must not
 // start raft at all and therefore must not appear in the raft configuration as
-// either voter or non-voter. It still joins gossip so servers can see capacity
-// and route ownership to it.
+// either voter or non-voter. It still joins gossip so servers can discover it
+// and fetch authenticated capacity heartbeats from it.
 func TestRoleSplitWorkerDoesNotJoinRaft(t *testing.T) {
 	if testing.Short() {
 		t.Skip("integration test: requires real raft/memberlist sockets")

--- a/internal/cluster/scale_harness_test.go
+++ b/internal/cluster/scale_harness_test.go
@@ -1,0 +1,158 @@
+package cluster
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/pkg/capacity"
+	"github.com/aerol-ai/microvm/pkg/models"
+	"github.com/hashicorp/raft"
+)
+
+func TestScaleHarness1000NodeCreateBurstCapacityAndWorkerDeath(t *testing.T) {
+	requireScaleGates(t)
+
+	const (
+		servers          = 3
+		workers          = 990
+		ingress          = 7
+		perWorkerCreates = 50
+	)
+	now := time.Unix(1_800_000_000, 0)
+	members := scaleHarnessMembers(servers, workers, ingress)
+	leases := newCapacityLeaseCache("", nil, 5*time.Second, nil)
+	for i := 0; i < workers; i++ {
+		leases.set(fmt.Sprintf("worker-%04d", i), scaleWorkerCapacity(), now)
+	}
+	members = leases.apply(members, now)
+
+	if got := LiveMemberCount(members); got != servers+workers+ingress {
+		t.Fatalf("live members=%d, want %d", got, servers+workers+ingress)
+	}
+	if err := LargeClusterTopologyError(members); err != nil {
+		t.Fatalf("1000-node dedicated topology rejected: %v", err)
+	}
+
+	fsm := newPlacementFSM()
+	expiry := now.Add(10 * time.Minute).Unix()
+	logIndex := uint64(1)
+	for worker := 0; worker < workers; worker++ {
+		owner := fmt.Sprintf("worker-%04d", worker)
+		batch := make([]reservationCommand, 0, perWorkerCreates)
+		for create := 0; create < perWorkerCreates; create++ {
+			batch = append(batch, reservationCommand{
+				SandboxID:   fmt.Sprintf("burst-%04d-%02d", worker, create),
+				OwnerNodeID: owner,
+				OwnerAPIURL: fmt.Sprintf("http://%s:21212", owner),
+				Spec:        &models.CreateSandboxRequest{Image: "alpine", CPU: 1, MemoryMB: 256, DiskGB: 1},
+				ExpiresUnix: expiry,
+			})
+		}
+		pending := fsm.pendingReservationsByNode(expiry - 1)
+		counts := map[string]int{owner: fsm.livePendingReservationCount(owner, expiry-1)}
+		if err := admitReservationCommands(members, pending, counts, perWorkerCreates, batch); err != nil {
+			t.Fatalf("admit batch for %s: %v", owner, err)
+		}
+		payload, err := encodeCommand(command{Op: opReserveBatch, Reservations: batch})
+		if err != nil {
+			t.Fatalf("encode batch for %s: %v", owner, err)
+		}
+		if got := fsm.Apply(&raft.Log{Index: logIndex, Data: payload}); got != nil {
+			t.Fatalf("apply batch for %s: %v", owner, got)
+		}
+		logIndex++
+	}
+
+	if got := len(fsm.pendingReservationClaims); got != workers*perWorkerCreates {
+		t.Fatalf("pending claims=%d, want %d", got, workers*perWorkerCreates)
+	}
+	if got := fsm.pendingReservationsByNode(expiry - 1)["worker-0000"].CPU; got != perWorkerCreates {
+		t.Fatalf("worker-0000 pending CPU=%v, want %d", got, perWorkerCreates)
+	}
+	err := admitReservationCommands(members, fsm.pendingReservationsByNode(expiry-1),
+		map[string]int{"worker-0000": fsm.livePendingReservationCount("worker-0000", expiry-1)},
+		perWorkerCreates,
+		[]reservationCommand{{
+			SandboxID:   "burst-over-cap",
+			OwnerNodeID: "worker-0000",
+			Spec:        &models.CreateSandboxRequest{Image: "alpine", CPU: 1, MemoryMB: 256, DiskGB: 1},
+			ExpiresUnix: expiry,
+		}},
+	)
+	if !errors.Is(err, ErrCreateBackpressure) {
+		t.Fatalf("extra create admission error=%v, want ErrCreateBackpressure", err)
+	}
+
+	missingLease := scaleHarnessMembers(servers, workers, ingress)
+	missingLease = leases.apply(missingLease, now.Add(30*time.Second))
+	err = admitReservationCommands(missingLease, nil, nil, perWorkerCreates,
+		[]reservationCommand{{
+			SandboxID:   "stale-worker-create",
+			OwnerNodeID: "worker-0001",
+			Spec:        &models.CreateSandboxRequest{Image: "alpine", CPU: 1, MemoryMB: 256, DiskGB: 1},
+			ExpiresUnix: expiry,
+		}},
+	)
+	if !errors.Is(err, ErrNoPlacementTarget) {
+		t.Fatalf("stale capacity admission error=%v, want ErrNoPlacementTarget", err)
+	}
+
+	for i := 0; i < perWorkerCreates; i++ {
+		payload, err := encodeCommand(command{
+			Op:          opPlace,
+			SandboxID:   fmt.Sprintf("dead-owned-%02d", i),
+			OwnerNodeID: "worker-dead",
+			OwnerAPIURL: "http://worker-dead:21212",
+			Spec:        &models.CreateSandboxRequest{Image: "alpine", CPU: 1, MemoryMB: 256, DiskGB: 1},
+		})
+		if err != nil {
+			t.Fatalf("encode dead placement: %v", err)
+		}
+		if got := fsm.Apply(&raft.Log{Index: logIndex, Data: payload}); got != nil {
+			t.Fatalf("apply dead placement: %v", got)
+		}
+		logIndex++
+	}
+	if got := len(fsm.idsOwnedBy("worker-dead")); got != perWorkerCreates {
+		t.Fatalf("worker-dead owned ids=%d, want %d", got, perWorkerCreates)
+	}
+	orphan, _ := encodeCommand(command{Op: opOrphanOwner, NodeID: "worker-dead"})
+	if got := fsm.Apply(&raft.Log{Index: logIndex, Data: orphan}); got != nil {
+		t.Fatalf("orphan dead worker: %v", got)
+	}
+	if got := len(fsm.idsOwnedBy("worker-dead")); got != 0 {
+		t.Fatalf("worker-dead still owns %d placements after orphan", got)
+	}
+}
+
+func scaleHarnessMembers(servers, workers, ingress int) []Member {
+	out := make([]Member, 0, servers+workers+ingress)
+	for i := 0; i < servers; i++ {
+		out = append(out, Member{NodeID: fmt.Sprintf("server-%02d", i), APIURL: fmt.Sprintf("http://server-%02d:21212", i), Alive: true, Role: config.NodeRoleServer})
+	}
+	for i := 0; i < workers; i++ {
+		out = append(out, Member{NodeID: fmt.Sprintf("worker-%04d", i), APIURL: fmt.Sprintf("http://worker-%04d:21212", i), Alive: true, Role: config.NodeRoleWorker})
+	}
+	for i := 0; i < ingress; i++ {
+		out = append(out, Member{NodeID: fmt.Sprintf("ingress-%02d", i), APIURL: fmt.Sprintf("http://ingress-%02d:21212", i), Alive: true, Role: config.NodeRoleIngress})
+	}
+	return out
+}
+
+func scaleWorkerCapacity() capacity.Snapshot {
+	return capacity.Snapshot{
+		HostCPUCores:      64,
+		HostMemoryTotalMB: 262144,
+		HostDiskTotalGB:   4096,
+		CPUBudget:         64,
+		MemoryBudgetMB:    262144,
+		DiskBudgetGB:      4096,
+		AvailableCPU:      64,
+		AvailableMemoryMB: 262144,
+		AvailableDiskGB:   4096,
+		CanAdmit:          true,
+	}
+}

--- a/internal/cluster/topology.go
+++ b/internal/cluster/topology.go
@@ -1,0 +1,146 @@
+package cluster
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aerol-ai/microvm/internal/config"
+)
+
+// MaxMixedClusterNodes is the largest live cluster size allowed to keep the
+// legacy mixed/hybrid convenience topology. Above this, production clusters
+// must run dedicated server, worker, and ingress tiers.
+const MaxMixedClusterNodes = 10
+
+type topologyRoleSet struct {
+	server      bool
+	worker      bool
+	ingress     bool
+	legacyMixed bool
+}
+
+func topologyRoles(role string) topologyRoleSet {
+	trimmed := strings.TrimSpace(role)
+	if trimmed == "" {
+		return topologyRoleSet{server: true, worker: true, ingress: true, legacyMixed: true}
+	}
+	var out topologyRoleSet
+	for raw := range strings.SplitSeq(trimmed, ",") {
+		switch strings.ToLower(strings.TrimSpace(raw)) {
+		case config.NodeRoleServer:
+			out.server = true
+		case config.NodeRoleWorker:
+			out.worker = true
+		case config.NodeRoleIngress:
+			out.ingress = true
+		case config.NodeRoleMixed:
+			out.server = true
+			out.worker = true
+			out.ingress = true
+			out.legacyMixed = true
+		}
+	}
+	return out
+}
+
+func (r topologyRoleSet) roleCount() int {
+	n := 0
+	if r.server {
+		n++
+	}
+	if r.worker {
+		n++
+	}
+	if r.ingress {
+		n++
+	}
+	return n
+}
+
+func (r topologyRoleSet) dedicated() bool {
+	return !r.legacyMixed && r.roleCount() == 1
+}
+
+// IsMixedArchitectureRole reports whether a role value runs more than one
+// production tier. Empty legacy metadata is treated as mixed because old nodes
+// behaved as server+worker+ingress.
+func IsMixedArchitectureRole(role string) bool {
+	return !topologyRoles(role).dedicated()
+}
+
+// LiveMemberCount counts live members with a usable node ID.
+func LiveMemberCount(members []Member) int {
+	live := 0
+	for _, m := range members {
+		if m.Alive && strings.TrimSpace(m.NodeID) != "" {
+			live++
+		}
+	}
+	return live
+}
+
+// LargeClusterTopologyError enforces the production topology contract:
+// clusters above MaxMixedClusterNodes must have dedicated server, worker, and
+// ingress tiers. Small clusters keep the legacy convenience behavior.
+func LargeClusterTopologyError(members []Member) error {
+	live := 0
+	server := 0
+	worker := 0
+	ingress := 0
+	mixedNodes := make([]string, 0)
+
+	for _, m := range members {
+		nodeID := strings.TrimSpace(m.NodeID)
+		if !m.Alive || nodeID == "" {
+			continue
+		}
+		live++
+		roles := topologyRoles(m.Role)
+		if roles.server {
+			server++
+		}
+		if roles.worker {
+			worker++
+		}
+		if roles.ingress {
+			ingress++
+		}
+		if !roles.dedicated() {
+			mixedNodes = append(mixedNodes, nodeID)
+		}
+	}
+
+	if live <= MaxMixedClusterNodes {
+		return nil
+	}
+	if len(mixedNodes) > 0 {
+		return fmt.Errorf("%w: clusters with more than %d live nodes cannot include mixed or hybrid-role nodes (live=%d nodes=%s); use dedicated server, worker, and ingress roles",
+			ErrInvalidTopology, MaxMixedClusterNodes, live, strings.Join(mixedNodes, ","))
+	}
+	missing := make([]string, 0, 3)
+	if server == 0 {
+		missing = append(missing, config.NodeRoleServer)
+	}
+	if worker == 0 {
+		missing = append(missing, config.NodeRoleWorker)
+	}
+	if ingress == 0 {
+		missing = append(missing, config.NodeRoleIngress)
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("%w: clusters with more than %d live nodes require dedicated server, worker, and ingress tiers (live=%d missing=%s)",
+			ErrInvalidTopology, MaxMixedClusterNodes, live, strings.Join(missing, ","))
+	}
+	return nil
+}
+
+func invalidTopologyFromMessage(message string) error {
+	if message == ErrInvalidTopology.Error() {
+		return ErrInvalidTopology
+	}
+	prefix := ErrInvalidTopology.Error() + ": "
+	if strings.HasPrefix(message, prefix) {
+		return fmt.Errorf("%w: %s", ErrInvalidTopology, strings.TrimPrefix(message, prefix))
+	}
+	return nil
+}

--- a/internal/cluster/topology_test.go
+++ b/internal/cluster/topology_test.go
@@ -1,0 +1,137 @@
+package cluster
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aerol-ai/microvm/internal/config"
+)
+
+func TestIsMixedArchitectureRole(t *testing.T) {
+	for _, tc := range []struct {
+		role string
+		want bool
+	}{
+		{"", true},
+		{config.NodeRoleMixed, true},
+		{"server,worker,ingress", true},
+		{"worker,ingress", true},
+		{"server,worker", true},
+		{"server,ingress", true},
+		{config.NodeRoleServer, false},
+		{config.NodeRoleWorker, false},
+		{config.NodeRoleIngress, false},
+	} {
+		if got := IsMixedArchitectureRole(tc.role); got != tc.want {
+			t.Fatalf("IsMixedArchitectureRole(%q) = %v, want %v", tc.role, got, tc.want)
+		}
+	}
+}
+
+func TestLargeClusterTopologyAllowsSmallMixedCluster(t *testing.T) {
+	members := makeTopologyMembers(
+		config.NodeRoleMixed,
+		config.NodeRoleMixed,
+		config.NodeRoleMixed,
+		config.NodeRoleMixed,
+		config.NodeRoleMixed,
+		config.NodeRoleMixed,
+		config.NodeRoleMixed,
+		config.NodeRoleMixed,
+		config.NodeRoleMixed,
+		config.NodeRoleMixed,
+	)
+
+	if err := LargeClusterTopologyError(members); err != nil {
+		t.Fatalf("LargeClusterTopologyError small mixed cluster = %v, want nil", err)
+	}
+}
+
+func TestLargeClusterTopologyAllowsDedicatedProductionShape(t *testing.T) {
+	members := makeTopologyMembers(
+		config.NodeRoleServer,
+		config.NodeRoleServer,
+		config.NodeRoleServer,
+		config.NodeRoleWorker,
+		config.NodeRoleWorker,
+		config.NodeRoleWorker,
+		config.NodeRoleWorker,
+		config.NodeRoleWorker,
+		config.NodeRoleWorker,
+		config.NodeRoleIngress,
+		config.NodeRoleIngress,
+	)
+
+	if err := LargeClusterTopologyError(members); err != nil {
+		t.Fatalf("LargeClusterTopologyError dedicated production cluster = %v, want nil", err)
+	}
+}
+
+func TestLargeClusterTopologyRejectsMixedOrHybridNodes(t *testing.T) {
+	members := makeTopologyMembers(
+		config.NodeRoleServer,
+		config.NodeRoleServer,
+		config.NodeRoleServer,
+		config.NodeRoleWorker,
+		config.NodeRoleWorker,
+		config.NodeRoleWorker,
+		config.NodeRoleWorker,
+		config.NodeRoleWorker,
+		config.NodeRoleWorker,
+		config.NodeRoleIngress,
+		"worker,ingress",
+	)
+
+	err := LargeClusterTopologyError(members)
+	if !errors.Is(err, ErrInvalidTopology) {
+		t.Fatalf("LargeClusterTopologyError hybrid cluster = %v, want ErrInvalidTopology", err)
+	}
+	if !strings.Contains(err.Error(), "mixed or hybrid-role nodes") {
+		t.Fatalf("error = %q, want mixed/hybrid explanation", err.Error())
+	}
+}
+
+func TestLargeClusterTopologyRequiresAllDedicatedTiers(t *testing.T) {
+	members := makeTopologyMembers(
+		config.NodeRoleServer,
+		config.NodeRoleServer,
+		config.NodeRoleServer,
+		config.NodeRoleWorker,
+		config.NodeRoleWorker,
+		config.NodeRoleWorker,
+		config.NodeRoleWorker,
+		config.NodeRoleWorker,
+		config.NodeRoleWorker,
+		config.NodeRoleWorker,
+		config.NodeRoleWorker,
+	)
+
+	err := LargeClusterTopologyError(members)
+	if !errors.Is(err, ErrInvalidTopology) {
+		t.Fatalf("LargeClusterTopologyError missing ingress = %v, want ErrInvalidTopology", err)
+	}
+	if !strings.Contains(err.Error(), "missing=ingress") {
+		t.Fatalf("error = %q, want missing ingress", err.Error())
+	}
+}
+
+func TestInvalidTopologyFromMessageWrapsSentinel(t *testing.T) {
+	err := invalidTopologyFromMessage(ErrInvalidTopology.Error() + ": live cluster contains mixed nodes")
+	if !errors.Is(err, ErrInvalidTopology) {
+		t.Fatalf("invalidTopologyFromMessage = %v, want ErrInvalidTopology", err)
+	}
+}
+
+func makeTopologyMembers(roles ...string) []Member {
+	members := make([]Member, 0, len(roles))
+	for i, role := range roles {
+		members = append(members, Member{
+			NodeID: fmt.Sprintf("node-%02d", i+1),
+			Role:   role,
+			Alive:  true,
+		})
+	}
+	return members
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -141,7 +141,13 @@ type Config struct {
 	OTELMetricsEnabled  bool
 	OTELMetricsEndpoint string
 	OTELMetricsInterval time.Duration
-	OTELServiceName     string
+	// OTELTracesEnabled starts a native OTLP/HTTP trace exporter for API
+	// request spans. It is also enabled automatically when
+	// SB_OTEL_TRACES_ENDPOINT is set.
+	OTELTracesEnabled     bool
+	OTELTracesEndpoint    string
+	OTELTracesSampleRatio float64
+	OTELServiceName       string
 
 	// Admission control. Admission is purely resource-math: CPU/memory
 	// reservation ratios plus a live memory floor. There is no fixed sandbox
@@ -424,8 +430,11 @@ func Load() (Config, error) {
 		NetstatsPollInterval:        getEnvDuration("SB_NETSTATS_POLL_INTERVAL", 10*time.Second),
 		UploadMaxBytes:              int64(getEnvInt("SB_UPLOAD_MAX_BYTES", 256*1024*1024)),
 		OTELMetricsEnabled:          getEnvBool("SB_OTEL_METRICS_ENABLED", false),
-		OTELMetricsEndpoint:         firstNonEmpty(os.Getenv("SB_OTEL_METRICS_ENDPOINT"), os.Getenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"), os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")),
+		OTELMetricsEndpoint:         firstNonEmpty(os.Getenv("SB_OTEL_METRICS_ENDPOINT"), os.Getenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT")),
 		OTELMetricsInterval:         getEnvDuration("SB_OTEL_METRICS_INTERVAL", 30*time.Second),
+		OTELTracesEnabled:           getEnvBool("SB_OTEL_TRACES_ENABLED", false),
+		OTELTracesEndpoint:          firstNonEmpty(os.Getenv("SB_OTEL_TRACES_ENDPOINT"), os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")),
+		OTELTracesSampleRatio:       getEnvFloat("SB_OTEL_TRACES_SAMPLE_RATIO", 0.05),
 		OTELServiceName:             getEnv("OTEL_SERVICE_NAME", "sandboxd"),
 
 		CPUReservationRatio:       getEnvFloat("SB_CPU_RESERVATION_RATIO", 0.9),
@@ -480,8 +489,11 @@ func Load() (Config, error) {
 		ImagePullMaxConcurrent:           getEnvInt("SB_IMAGE_PULL_MAX_CONCURRENT", 4),
 		ImagePullFailureBackoff:          getEnvDuration("SB_IMAGE_PULL_FAILURE_BACKOFF", 30*time.Second),
 	}
-	if cfg.OTELMetricsEndpoint != "" {
+	if cfg.OTELMetricsEndpoint != "" || strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")) != "" {
 		cfg.OTELMetricsEnabled = true
+	}
+	if cfg.OTELTracesEndpoint != "" || strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")) != "" {
+		cfg.OTELTracesEnabled = true
 	}
 
 	if cfg.PATToken == "" {
@@ -493,6 +505,9 @@ func Load() (Config, error) {
 	}
 	if cfg.OTELMetricsEnabled && cfg.OTELMetricsInterval <= 0 {
 		return Config{}, errors.New("SB_OTEL_METRICS_INTERVAL must be > 0 when OTEL metrics are enabled")
+	}
+	if cfg.OTELTracesEnabled && (cfg.OTELTracesSampleRatio < 0 || cfg.OTELTracesSampleRatio > 1) {
+		return Config{}, errors.New("SB_OTEL_TRACES_SAMPLE_RATIO must be between 0 and 1 when OTEL traces are enabled")
 	}
 	if cfg.ImagePullMaxConcurrent < 0 {
 		return Config{}, errors.New("SB_IMAGE_PULL_MAX_CONCURRENT must be >= 0")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -155,11 +155,10 @@ type Config struct {
 	HostCPUCoresOverride      int
 	HostMemoryMBOverride      int
 	// DiskReservationRatio gates total per-sandbox disk reservations against
-	// HostDiskGB. 0 disables disk admission entirely (legacy behaviour).
-	// HostDiskGB is operator-declared because robust auto-detection of the
-	// docker-data-root volume is filesystem-specific (overlay2, devicemapper,
-	// btrfs all report differently); we'd rather operators set the number
-	// they trust than guess wrong.
+	// HostDiskGB, or the auto-detected host disk size when HostDiskGB is not
+	// set. 0 disables disk admission while still reporting disk observability.
+	// HostDiskGB remains the operator override for a stricter Docker-volume
+	// budget when the host filesystem is larger than the sandbox pool.
 	DiskReservationRatio float64
 	HostDiskGB           int
 	// HostGPUCount and HostGPUVendor describe the GPU inventory wired into

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,7 +29,9 @@ const defaultToolboxPort = 2280
 // of base roles, e.g. "worker,ingress" for a data-plane edge node or
 // "server,ingress" for a control + ingress node. NodeRoleMixed remains the
 // shorthand for "server,worker,ingress" and may not be combined with anything
-// else.
+// else. Runtime topology validation keeps mixed and hybrid-role nodes as a
+// small-cluster convenience only; clusters above 10 live nodes must use
+// dedicated server, worker, and ingress roles.
 const (
 	NodeRoleServer  = "server"
 	NodeRoleWorker  = "worker"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -135,6 +135,13 @@ type Config struct {
 	ReconcileInterval           time.Duration
 	NetstatsPollInterval        time.Duration
 	UploadMaxBytes              int64
+	// OTELMetricsEnabled starts a native OTLP/HTTP metric exporter that bridges
+	// the daemon's aerolvm_* expvars into OpenTelemetry observations. It is
+	// also enabled automatically when SB_OTEL_METRICS_ENDPOINT is set.
+	OTELMetricsEnabled  bool
+	OTELMetricsEndpoint string
+	OTELMetricsInterval time.Duration
+	OTELServiceName     string
 
 	// Admission control. Admission is purely resource-math: CPU/memory
 	// reservation ratios plus a live memory floor. There is no fixed sandbox
@@ -364,6 +371,15 @@ type Config struct {
 	// managed AOCR image-distribution provider. Empty configs constructed in
 	// tests fall back to the product default in the service layer.
 	ImageDistributionAOCRHost string
+	// ImagePullMaxConcurrent caps simultaneous Docker /images/create streams
+	// per worker. Pulls for the same image/auth key are still deduplicated; this
+	// cap protects the daemon and registry when many different cold images are
+	// requested at once. 0 disables the cap.
+	ImagePullMaxConcurrent int
+	// ImagePullFailureBackoff suppresses immediate retries for the same
+	// image/auth key after Docker or the registry returns an error. This keeps a
+	// bad tag or rate-limit response from turning into a per-create retry storm.
+	ImagePullFailureBackoff time.Duration
 }
 
 func Load() (Config, error) {
@@ -407,6 +423,10 @@ func Load() (Config, error) {
 		ReconcileInterval:           getEnvDuration("SB_RECONCILE_INTERVAL", 5*time.Minute),
 		NetstatsPollInterval:        getEnvDuration("SB_NETSTATS_POLL_INTERVAL", 10*time.Second),
 		UploadMaxBytes:              int64(getEnvInt("SB_UPLOAD_MAX_BYTES", 256*1024*1024)),
+		OTELMetricsEnabled:          getEnvBool("SB_OTEL_METRICS_ENABLED", false),
+		OTELMetricsEndpoint:         firstNonEmpty(os.Getenv("SB_OTEL_METRICS_ENDPOINT"), os.Getenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"), os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")),
+		OTELMetricsInterval:         getEnvDuration("SB_OTEL_METRICS_INTERVAL", 30*time.Second),
+		OTELServiceName:             getEnv("OTEL_SERVICE_NAME", "sandboxd"),
 
 		CPUReservationRatio:       getEnvFloat("SB_CPU_RESERVATION_RATIO", 0.9),
 		MemoryReservationRatio:    getEnvFloat("SB_MEMORY_RESERVATION_RATIO", 0.85),
@@ -457,6 +477,11 @@ func Load() (Config, error) {
 		ImageBuildGCInterval:             getEnvDuration("SB_IMAGE_BUILD_GC_INTERVAL", 10*time.Minute),
 		ImageBuildGCTTL:                  getEnvDuration("SB_IMAGE_BUILD_GC_TTL", time.Hour),
 		ImageDistributionAOCRHost:        strings.TrimSpace(getEnv("SB_IMAGE_DISTRIBUTION_AOCR_HOST", "aocr.aerol.ai")),
+		ImagePullMaxConcurrent:           getEnvInt("SB_IMAGE_PULL_MAX_CONCURRENT", 4),
+		ImagePullFailureBackoff:          getEnvDuration("SB_IMAGE_PULL_FAILURE_BACKOFF", 30*time.Second),
+	}
+	if cfg.OTELMetricsEndpoint != "" {
+		cfg.OTELMetricsEnabled = true
 	}
 
 	if cfg.PATToken == "" {
@@ -465,6 +490,15 @@ func Load() (Config, error) {
 
 	if cfg.DBPath == "" {
 		return Config{}, errors.New("SB_DB_PATH is required")
+	}
+	if cfg.OTELMetricsEnabled && cfg.OTELMetricsInterval <= 0 {
+		return Config{}, errors.New("SB_OTEL_METRICS_INTERVAL must be > 0 when OTEL metrics are enabled")
+	}
+	if cfg.ImagePullMaxConcurrent < 0 {
+		return Config{}, errors.New("SB_IMAGE_PULL_MAX_CONCURRENT must be >= 0")
+	}
+	if cfg.ImagePullFailureBackoff < 0 {
+		return Config{}, errors.New("SB_IMAGE_PULL_FAILURE_BACKOFF must be >= 0")
 	}
 
 	if cfg.ToolboxMountPath == "" || !strings.HasPrefix(cfg.ToolboxMountPath, "/") {
@@ -603,6 +637,15 @@ func splitAndTrim(s, sep string) []string {
 		}
 	}
 	return out
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }
 
 func (c Config) ListenAddr() string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -262,6 +262,13 @@ type Config struct {
 	// without increasing quorum size. 0 means unlimited, preserving the old
 	// behavior for tests or intentionally small fully-voting clusters.
 	ClusterMaxAutoVoters int
+	// ClusterCreateMaxPendingPerWorker caps reservation-stage creates per
+	// worker. This is a leader-side queue guard: when a burst tries to send
+	// more than this many not-yet-promoted creates to one worker, the leader
+	// rejects with Retry-After instead of letting that worker absorb an
+	// unbounded image-pull/docker-create storm. 0 disables the cap.
+	// SB_CLUSTER_CREATE_MAX_PENDING_PER_WORKER.
+	ClusterCreateMaxPendingPerWorker int
 	// ClusterDeadOwnerGrace is how long the leader waits after memberlist marks
 	// a node dead before orphaning its placements and removing it from the
 	// raft configuration. Long enough to absorb transient gossip flap
@@ -419,36 +426,37 @@ func Load() (Config, error) {
 		L4TLSListen:      strings.TrimSpace(os.Getenv("SB_L4_TLS_LISTEN")),
 		L4TLSFallback:    getEnv("SB_L4_TLS_FALLBACK", "127.0.0.1:8443"),
 
-		EnableCluster:                 getEnvBool("SB_ENABLE_CLUSTER", false),
-		NodeRole:                      os.Getenv("SB_NODE_ROLE"),
-		NodeID:                        strings.TrimSpace(os.Getenv("SB_NODE_ID")),
-		NodeName:                      strings.TrimSpace(os.Getenv("SB_NODE_NAME")),
-		RaftBindAddr:                  getEnv("SB_RAFT_BIND_ADDR", "0.0.0.0:7000"),
-		RaftAdvertiseAddr:             strings.TrimSpace(os.Getenv("SB_RAFT_ADVERTISE_ADDR")),
-		RaftDataDir:                   strings.TrimSpace(os.Getenv("SB_RAFT_DATA_DIR")),
-		GossipBindAddr:                getEnv("SB_GOSSIP_BIND_ADDR", "0.0.0.0:7001"),
-		GossipAdvertiseAddr:           strings.TrimSpace(os.Getenv("SB_GOSSIP_ADVERTISE_ADDR")),
-		BootstrapPeers:                splitAndTrim(os.Getenv("SB_BOOTSTRAP_PEERS"), ","),
-		ClusterBootstrap:              getEnvBool("SB_CLUSTER_BOOTSTRAP", false),
-		SelfAPIAdvertiseURL:           strings.TrimSpace(os.Getenv("SB_API_ADVERTISE_URL")),
-		DataPlaneAdvertiseHost:        normalizeAdvertiseHost(os.Getenv("SB_DATA_PLANE_ADVERTISE_HOST")),
-		IngressAdvertiseHost:          normalizeAdvertiseHost(os.Getenv("SB_INGRESS_ADVERTISE_HOST")),
-		ClusterRaftCommitTimeout:      getEnvDuration("SB_RAFT_COMMIT_TIMEOUT", 5*time.Second),
-		ClusterCapacityGossipInterval: getEnvDuration("SB_CAPACITY_GOSSIP_INTERVAL", 5*time.Second),
-		ClusterMaxAutoVoters:          getEnvInt("SB_CLUSTER_MAX_AUTO_VOTERS", 5),
-		ClusterDeadOwnerGrace:         getEnvDuration("SB_DEAD_OWNER_GRACE", 30*time.Second),
-		ClusterGossipSecretKey:        strings.TrimSpace(os.Getenv("SB_GOSSIP_SECRET_KEY")),
-		ClusterInsecureGossip:         getEnvBool("SB_CLUSTER_INSECURE_GOSSIP", false),
-		ClusterInsecureCredentials:    getEnvBool("SB_CLUSTER_INSECURE_CREDENTIALS", false),
-		ClusterTLSDir:                 strings.TrimSpace(os.Getenv("SB_CLUSTER_TLS_DIR")),
-		ClusterInternalListenAddr:     getEnv("SB_CLUSTER_INTERNAL_LISTEN", "0.0.0.0:7002"),
-		ClusterInternalAdvertiseURL:   strings.TrimSpace(os.Getenv("SB_CLUSTER_INTERNAL_ADVERTISE")),
-		ImageBuildContextEnabled:      getEnvBool("SB_IMAGE_BUILD_CONTEXT_ENABLED", false),
-		ImageBuildTimeout:             getEnvDuration("SB_IMAGE_BUILD_TIMEOUT", 10*time.Minute),
-		ImageBuildGCEnabled:           getEnvBool("SB_IMAGE_BUILD_GC_ENABLED", true),
-		ImageBuildGCInterval:          getEnvDuration("SB_IMAGE_BUILD_GC_INTERVAL", 10*time.Minute),
-		ImageBuildGCTTL:               getEnvDuration("SB_IMAGE_BUILD_GC_TTL", time.Hour),
-		ImageDistributionAOCRHost:     strings.TrimSpace(getEnv("SB_IMAGE_DISTRIBUTION_AOCR_HOST", "aocr.aerol.ai")),
+		EnableCluster:                    getEnvBool("SB_ENABLE_CLUSTER", false),
+		NodeRole:                         os.Getenv("SB_NODE_ROLE"),
+		NodeID:                           strings.TrimSpace(os.Getenv("SB_NODE_ID")),
+		NodeName:                         strings.TrimSpace(os.Getenv("SB_NODE_NAME")),
+		RaftBindAddr:                     getEnv("SB_RAFT_BIND_ADDR", "0.0.0.0:7000"),
+		RaftAdvertiseAddr:                strings.TrimSpace(os.Getenv("SB_RAFT_ADVERTISE_ADDR")),
+		RaftDataDir:                      strings.TrimSpace(os.Getenv("SB_RAFT_DATA_DIR")),
+		GossipBindAddr:                   getEnv("SB_GOSSIP_BIND_ADDR", "0.0.0.0:7001"),
+		GossipAdvertiseAddr:              strings.TrimSpace(os.Getenv("SB_GOSSIP_ADVERTISE_ADDR")),
+		BootstrapPeers:                   splitAndTrim(os.Getenv("SB_BOOTSTRAP_PEERS"), ","),
+		ClusterBootstrap:                 getEnvBool("SB_CLUSTER_BOOTSTRAP", false),
+		SelfAPIAdvertiseURL:              strings.TrimSpace(os.Getenv("SB_API_ADVERTISE_URL")),
+		DataPlaneAdvertiseHost:           normalizeAdvertiseHost(os.Getenv("SB_DATA_PLANE_ADVERTISE_HOST")),
+		IngressAdvertiseHost:             normalizeAdvertiseHost(os.Getenv("SB_INGRESS_ADVERTISE_HOST")),
+		ClusterRaftCommitTimeout:         getEnvDuration("SB_RAFT_COMMIT_TIMEOUT", 5*time.Second),
+		ClusterCapacityGossipInterval:    getEnvDuration("SB_CAPACITY_GOSSIP_INTERVAL", 5*time.Second),
+		ClusterMaxAutoVoters:             getEnvInt("SB_CLUSTER_MAX_AUTO_VOTERS", 5),
+		ClusterCreateMaxPendingPerWorker: getEnvInt("SB_CLUSTER_CREATE_MAX_PENDING_PER_WORKER", 32),
+		ClusterDeadOwnerGrace:            getEnvDuration("SB_DEAD_OWNER_GRACE", 30*time.Second),
+		ClusterGossipSecretKey:           strings.TrimSpace(os.Getenv("SB_GOSSIP_SECRET_KEY")),
+		ClusterInsecureGossip:            getEnvBool("SB_CLUSTER_INSECURE_GOSSIP", false),
+		ClusterInsecureCredentials:       getEnvBool("SB_CLUSTER_INSECURE_CREDENTIALS", false),
+		ClusterTLSDir:                    strings.TrimSpace(os.Getenv("SB_CLUSTER_TLS_DIR")),
+		ClusterInternalListenAddr:        getEnv("SB_CLUSTER_INTERNAL_LISTEN", "0.0.0.0:7002"),
+		ClusterInternalAdvertiseURL:      strings.TrimSpace(os.Getenv("SB_CLUSTER_INTERNAL_ADVERTISE")),
+		ImageBuildContextEnabled:         getEnvBool("SB_IMAGE_BUILD_CONTEXT_ENABLED", false),
+		ImageBuildTimeout:                getEnvDuration("SB_IMAGE_BUILD_TIMEOUT", 10*time.Minute),
+		ImageBuildGCEnabled:              getEnvBool("SB_IMAGE_BUILD_GC_ENABLED", true),
+		ImageBuildGCInterval:             getEnvDuration("SB_IMAGE_BUILD_GC_INTERVAL", 10*time.Minute),
+		ImageBuildGCTTL:                  getEnvDuration("SB_IMAGE_BUILD_GC_TTL", time.Hour),
+		ImageDistributionAOCRHost:        strings.TrimSpace(getEnv("SB_IMAGE_DISTRIBUTION_AOCR_HOST", "aocr.aerol.ai")),
 	}
 
 	if cfg.PATToken == "" {
@@ -539,6 +547,9 @@ func Load() (Config, error) {
 		}
 		if cfg.ClusterMaxAutoVoters < 0 {
 			return Config{}, errors.New("SB_CLUSTER_MAX_AUTO_VOTERS must be >= 0")
+		}
+		if cfg.ClusterCreateMaxPendingPerWorker < 0 {
+			return Config{}, errors.New("SB_CLUSTER_CREATE_MAX_PENDING_PER_WORKER must be >= 0")
 		}
 		if !cfg.ClusterBootstrap && len(cfg.BootstrapPeers) == 0 {
 			return Config{}, errors.New("SB_BOOTSTRAP_PEERS is required when SB_ENABLE_CLUSTER=true and SB_CLUSTER_BOOTSTRAP=false")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -35,8 +35,16 @@ func TestLoadCases(t *testing.T) {
 			"SB_LOG_LEVEL",
 			"SB_SHUTDOWN_TIMEOUT",
 			"SB_HTTP_CLIENT_TIMEOUT",
+			"SB_OTEL_METRICS_ENABLED",
+			"SB_OTEL_METRICS_ENDPOINT",
+			"SB_OTEL_METRICS_INTERVAL",
+			"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+			"OTEL_EXPORTER_OTLP_ENDPOINT",
+			"OTEL_SERVICE_NAME",
 			"SB_CLUSTER_MAX_AUTO_VOTERS",
 			"SB_CLUSTER_CREATE_MAX_PENDING_PER_WORKER",
+			"SB_IMAGE_PULL_MAX_CONCURRENT",
+			"SB_IMAGE_PULL_FAILURE_BACKOFF",
 			"SB_DATA_PLANE_ADVERTISE_HOST",
 			"SB_NODE_ROLE",
 			"SB_ENABLE_CLUSTER",
@@ -93,6 +101,12 @@ func TestLoadCases(t *testing.T) {
 				}
 				if cfg.ClusterCreateMaxPendingPerWorker != 32 {
 					t.Fatalf("expected default ClusterCreateMaxPendingPerWorker=32, got %d", cfg.ClusterCreateMaxPendingPerWorker)
+				}
+				if cfg.OTELMetricsEnabled || cfg.OTELMetricsEndpoint != "" || cfg.OTELMetricsInterval != 30*time.Second || cfg.OTELServiceName != "sandboxd" {
+					t.Fatalf("unexpected otel defaults: %+v", cfg)
+				}
+				if cfg.ImagePullMaxConcurrent != 4 || cfg.ImagePullFailureBackoff != 30*time.Second {
+					t.Fatalf("unexpected image pull defaults: %+v", cfg)
 				}
 				if cfg.NodeRole != NodeRoleMixed {
 					t.Fatalf("expected default NodeRole=%q, got %q", NodeRoleMixed, cfg.NodeRole)
@@ -177,6 +191,11 @@ func TestLoadCases(t *testing.T) {
 				t.Setenv("SB_LOG_LEVEL", "DEBUG")
 				t.Setenv("SB_SHUTDOWN_TIMEOUT", "25s")
 				t.Setenv("SB_HTTP_CLIENT_TIMEOUT", "12s")
+				t.Setenv("SB_OTEL_METRICS_ENDPOINT", "http://otel.example.test:4318/v1/metrics")
+				t.Setenv("SB_OTEL_METRICS_INTERVAL", "45s")
+				t.Setenv("OTEL_SERVICE_NAME", "sandboxd-prod")
+				t.Setenv("SB_IMAGE_PULL_MAX_CONCURRENT", "8")
+				t.Setenv("SB_IMAGE_PULL_FAILURE_BACKOFF", "2m")
 				cfg, err := Load()
 				if err != nil {
 					t.Fatalf("Load() error = %v", err)
@@ -198,6 +217,12 @@ func TestLoadCases(t *testing.T) {
 				}
 				if cfg.LogLevel != "debug" || cfg.ShutdownTimeout != 25*time.Second || cfg.HTTPClientTimeout != 12*time.Second {
 					t.Fatalf("unexpected log/duration overrides: %+v", cfg)
+				}
+				if !cfg.OTELMetricsEnabled || cfg.OTELMetricsEndpoint != "http://otel.example.test:4318/v1/metrics" || cfg.OTELMetricsInterval != 45*time.Second || cfg.OTELServiceName != "sandboxd-prod" {
+					t.Fatalf("unexpected otel overrides: %+v", cfg)
+				}
+				if cfg.ImagePullMaxConcurrent != 8 || cfg.ImagePullFailureBackoff != 2*time.Minute {
+					t.Fatalf("unexpected image pull overrides: %+v", cfg)
 				}
 			},
 		},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -38,7 +38,11 @@ func TestLoadCases(t *testing.T) {
 			"SB_OTEL_METRICS_ENABLED",
 			"SB_OTEL_METRICS_ENDPOINT",
 			"SB_OTEL_METRICS_INTERVAL",
+			"SB_OTEL_TRACES_ENABLED",
+			"SB_OTEL_TRACES_ENDPOINT",
+			"SB_OTEL_TRACES_SAMPLE_RATIO",
 			"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+			"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
 			"OTEL_EXPORTER_OTLP_ENDPOINT",
 			"OTEL_SERVICE_NAME",
 			"SB_CLUSTER_MAX_AUTO_VOTERS",
@@ -102,7 +106,7 @@ func TestLoadCases(t *testing.T) {
 				if cfg.ClusterCreateMaxPendingPerWorker != 32 {
 					t.Fatalf("expected default ClusterCreateMaxPendingPerWorker=32, got %d", cfg.ClusterCreateMaxPendingPerWorker)
 				}
-				if cfg.OTELMetricsEnabled || cfg.OTELMetricsEndpoint != "" || cfg.OTELMetricsInterval != 30*time.Second || cfg.OTELServiceName != "sandboxd" {
+				if cfg.OTELMetricsEnabled || cfg.OTELMetricsEndpoint != "" || cfg.OTELMetricsInterval != 30*time.Second || cfg.OTELTracesEnabled || cfg.OTELTracesEndpoint != "" || cfg.OTELTracesSampleRatio != 0.05 || cfg.OTELServiceName != "sandboxd" {
 					t.Fatalf("unexpected otel defaults: %+v", cfg)
 				}
 				if cfg.ImagePullMaxConcurrent != 4 || cfg.ImagePullFailureBackoff != 30*time.Second {
@@ -193,6 +197,8 @@ func TestLoadCases(t *testing.T) {
 				t.Setenv("SB_HTTP_CLIENT_TIMEOUT", "12s")
 				t.Setenv("SB_OTEL_METRICS_ENDPOINT", "http://otel.example.test:4318/v1/metrics")
 				t.Setenv("SB_OTEL_METRICS_INTERVAL", "45s")
+				t.Setenv("SB_OTEL_TRACES_ENDPOINT", "http://otel.example.test:4318/v1/traces")
+				t.Setenv("SB_OTEL_TRACES_SAMPLE_RATIO", "0.25")
 				t.Setenv("OTEL_SERVICE_NAME", "sandboxd-prod")
 				t.Setenv("SB_IMAGE_PULL_MAX_CONCURRENT", "8")
 				t.Setenv("SB_IMAGE_PULL_FAILURE_BACKOFF", "2m")
@@ -218,11 +224,26 @@ func TestLoadCases(t *testing.T) {
 				if cfg.LogLevel != "debug" || cfg.ShutdownTimeout != 25*time.Second || cfg.HTTPClientTimeout != 12*time.Second {
 					t.Fatalf("unexpected log/duration overrides: %+v", cfg)
 				}
-				if !cfg.OTELMetricsEnabled || cfg.OTELMetricsEndpoint != "http://otel.example.test:4318/v1/metrics" || cfg.OTELMetricsInterval != 45*time.Second || cfg.OTELServiceName != "sandboxd-prod" {
+				if !cfg.OTELMetricsEnabled || cfg.OTELMetricsEndpoint != "http://otel.example.test:4318/v1/metrics" || cfg.OTELMetricsInterval != 45*time.Second || !cfg.OTELTracesEnabled || cfg.OTELTracesEndpoint != "http://otel.example.test:4318/v1/traces" || cfg.OTELTracesSampleRatio != 0.25 || cfg.OTELServiceName != "sandboxd-prod" {
 					t.Fatalf("unexpected otel overrides: %+v", cfg)
 				}
 				if cfg.ImagePullMaxConcurrent != 8 || cfg.ImagePullFailureBackoff != 2*time.Minute {
 					t.Fatalf("unexpected image pull overrides: %+v", cfg)
+				}
+			},
+		},
+		{
+			name: "generic_otel_endpoint_enables_exporters_without_endpoint_override",
+			run: func(t *testing.T) {
+				clearEnv(t)
+				t.Setenv("SB_PAT_TOKEN", "token")
+				t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel.example.test:4318")
+				cfg, err := Load()
+				if err != nil {
+					t.Fatalf("Load() error = %v", err)
+				}
+				if !cfg.OTELMetricsEnabled || cfg.OTELMetricsEndpoint != "" || !cfg.OTELTracesEnabled || cfg.OTELTracesEndpoint != "" {
+					t.Fatalf("unexpected generic otel config: %+v", cfg)
 				}
 			},
 		},
@@ -248,6 +269,19 @@ func TestLoadCases(t *testing.T) {
 				}
 				if cfg.ShutdownTimeout != 10*time.Second {
 					t.Fatalf("expected invalid duration fallback, got %s", cfg.ShutdownTimeout)
+				}
+			},
+		},
+		{
+			name: "rejects_invalid_otel_trace_sample_ratio",
+			run: func(t *testing.T) {
+				clearEnv(t)
+				t.Setenv("SB_PAT_TOKEN", "token")
+				t.Setenv("SB_OTEL_TRACES_ENABLED", "true")
+				t.Setenv("SB_OTEL_TRACES_SAMPLE_RATIO", "1.25")
+				_, err := Load()
+				if err == nil || !strings.Contains(err.Error(), "SB_OTEL_TRACES_SAMPLE_RATIO") {
+					t.Fatalf("expected trace sample ratio error, got %v", err)
 				}
 			},
 		},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -36,6 +36,7 @@ func TestLoadCases(t *testing.T) {
 			"SB_SHUTDOWN_TIMEOUT",
 			"SB_HTTP_CLIENT_TIMEOUT",
 			"SB_CLUSTER_MAX_AUTO_VOTERS",
+			"SB_CLUSTER_CREATE_MAX_PENDING_PER_WORKER",
 			"SB_DATA_PLANE_ADVERTISE_HOST",
 			"SB_NODE_ROLE",
 			"SB_ENABLE_CLUSTER",
@@ -89,6 +90,9 @@ func TestLoadCases(t *testing.T) {
 				}
 				if cfg.ClusterMaxAutoVoters != 5 {
 					t.Fatalf("expected default ClusterMaxAutoVoters=5, got %d", cfg.ClusterMaxAutoVoters)
+				}
+				if cfg.ClusterCreateMaxPendingPerWorker != 32 {
+					t.Fatalf("expected default ClusterCreateMaxPendingPerWorker=32, got %d", cfg.ClusterCreateMaxPendingPerWorker)
 				}
 				if cfg.NodeRole != NodeRoleMixed {
 					t.Fatalf("expected default NodeRole=%q, got %q", NodeRoleMixed, cfg.NodeRole)

--- a/internal/observability/expvar.go
+++ b/internal/observability/expvar.go
@@ -1,0 +1,72 @@
+package observability
+
+import (
+	"expvar"
+	"math"
+	"strconv"
+	"strings"
+)
+
+type ExpvarSample struct {
+	Name   string
+	Labels []ExpvarLabel
+	Int64  *int64
+	Float  *float64
+}
+
+type ExpvarLabel struct {
+	Name  string
+	Value string
+}
+
+func CollectAerolVMExpvars() []ExpvarSample {
+	var samples []ExpvarSample
+	expvar.Do(func(kv expvar.KeyValue) {
+		if !strings.HasPrefix(kv.Key, "aerolvm_") {
+			return
+		}
+		collectExpvarSamples(kv.Key, kv.Value, nil, &samples)
+	})
+	return samples
+}
+
+func collectExpvarSamples(name string, v expvar.Var, labels []ExpvarLabel, samples *[]ExpvarSample) {
+	if m, ok := v.(*expvar.Map); ok {
+		depth := len(labels)
+		labelName := "key"
+		if depth > 0 {
+			labelName = "key" + strconv.Itoa(depth+1)
+		}
+		m.Do(func(kv expvar.KeyValue) {
+			childLabels := append(append([]ExpvarLabel(nil), labels...), ExpvarLabel{Name: labelName, Value: kv.Key})
+			collectExpvarSamples(name, kv.Value, childLabels, samples)
+		})
+		return
+	}
+	if sample, ok := sampleFromExpvar(name, labels, v); ok {
+		*samples = append(*samples, sample)
+	}
+}
+
+func sampleFromExpvar(name string, labels []ExpvarLabel, v expvar.Var) (ExpvarSample, bool) {
+	switch typed := v.(type) {
+	case *expvar.Int:
+		value := typed.Value()
+		return ExpvarSample{Name: name, Labels: append([]ExpvarLabel(nil), labels...), Int64: &value}, true
+	case *expvar.Float:
+		value := typed.Value()
+		if math.IsNaN(value) || math.IsInf(value, 0) {
+			return ExpvarSample{}, false
+		}
+		return ExpvarSample{Name: name, Labels: append([]ExpvarLabel(nil), labels...), Float: &value}, true
+	default:
+		raw := strings.TrimSpace(v.String())
+		if i, err := strconv.ParseInt(raw, 10, 64); err == nil {
+			return ExpvarSample{Name: name, Labels: append([]ExpvarLabel(nil), labels...), Int64: &i}, true
+		}
+		if f, err := strconv.ParseFloat(raw, 64); err == nil && !math.IsNaN(f) && !math.IsInf(f, 0) {
+			return ExpvarSample{Name: name, Labels: append([]ExpvarLabel(nil), labels...), Float: &f}, true
+		}
+		return ExpvarSample{}, false
+	}
+}

--- a/internal/observability/expvar_test.go
+++ b/internal/observability/expvar_test.go
@@ -1,0 +1,49 @@
+package observability
+
+import (
+	"expvar"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestCollectAerolVMExpvarsFiltersAndFlattens(t *testing.T) {
+	suffix := time.Now().UnixNano()
+	scalarName := fmt.Sprintf("aerolvm_observability_test_scalar_%d", suffix)
+	expvar.NewInt(scalarName).Set(99)
+	mapName := fmt.Sprintf("aerolvm_observability_test_map_%d", suffix)
+	mapped := expvar.NewMap(mapName)
+	mapped.Add("worker-a", 3)
+	ignoredName := fmt.Sprintf("not_aerolvm_observability_test_%d", suffix)
+	expvar.NewInt(ignoredName).Set(1)
+
+	samples := CollectAerolVMExpvars()
+	if !hasIntSample(samples, scalarName, "", "", 99) {
+		t.Fatalf("missing scalar sample %q in %+v", scalarName, samples)
+	}
+	if !hasIntSample(samples, mapName, "key", "worker-a", 3) {
+		t.Fatalf("missing map sample %q in %+v", mapName, samples)
+	}
+	for _, sample := range samples {
+		if sample.Name == ignoredName {
+			t.Fatalf("collector included non-aerolvm expvar %q", ignoredName)
+		}
+	}
+}
+
+func hasIntSample(samples []ExpvarSample, name, labelName, labelValue string, want int64) bool {
+	for _, sample := range samples {
+		if sample.Name != name || sample.Int64 == nil || *sample.Int64 != want {
+			continue
+		}
+		if labelName == "" {
+			return len(sample.Labels) == 0
+		}
+		for _, label := range sample.Labels {
+			if label.Name == labelName && label.Value == labelValue {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/observability/otel.go
+++ b/internal/observability/otel.go
@@ -1,0 +1,109 @@
+package observability
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/version"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	otelmetric "go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+type OTELMetricsConfig struct {
+	Enabled     bool
+	Endpoint    string
+	Interval    time.Duration
+	ServiceName string
+	NodeID      string
+	NodeRole    string
+}
+
+const defaultOTELMetricsInterval = 30 * time.Second
+
+type MetricsShutdown func(context.Context) error
+
+func StartOTELMetrics(ctx context.Context, logger *slog.Logger, cfg OTELMetricsConfig) (MetricsShutdown, error) {
+	if !cfg.Enabled {
+		return nil, nil
+	}
+	opts := []otlpmetrichttp.Option{}
+	if cfg.Endpoint != "" {
+		opts = append(opts, otlpmetrichttp.WithEndpointURL(cfg.Endpoint))
+	}
+	exporter, err := otlpmetrichttp.New(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+	interval := defaultOTELMetricsInterval
+	if cfg.Interval > 0 {
+		interval = cfg.Interval
+	}
+	serviceName := cfg.ServiceName
+	if serviceName == "" {
+		serviceName = "sandboxd"
+	}
+	reader := sdkmetric.NewPeriodicReader(exporter, sdkmetric.WithInterval(interval))
+	provider := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(reader),
+		sdkmetric.WithResource(resource.NewWithAttributes("",
+			attribute.String("service.name", serviceName),
+			attribute.String("service.version", version.Version),
+			attribute.String("aerolvm.node.id", cfg.NodeID),
+			attribute.String("aerolvm.node.role", cfg.NodeRole),
+		)),
+	)
+	meter := provider.Meter("github.com/aerol-ai/microvm/sandboxd")
+	intGauge, err := meter.Int64ObservableGauge(
+		"aerolvm.expvar.int64",
+		otelmetric.WithDescription("Current AerolVM expvar int64 value. The original expvar name is in the metric attribute."),
+	)
+	if err != nil {
+		_ = provider.Shutdown(ctx)
+		return nil, err
+	}
+	floatGauge, err := meter.Float64ObservableGauge(
+		"aerolvm.expvar.float64",
+		otelmetric.WithDescription("Current AerolVM expvar float64 value. The original expvar name is in the metric attribute."),
+	)
+	if err != nil {
+		_ = provider.Shutdown(ctx)
+		return nil, err
+	}
+	if _, err := meter.RegisterCallback(func(ctx context.Context, observer otelmetric.Observer) error {
+		for _, sample := range CollectAerolVMExpvars() {
+			attrs := expvarAttributes(sample)
+			if sample.Int64 != nil {
+				observer.ObserveInt64(intGauge, *sample.Int64, otelmetric.WithAttributes(attrs...))
+			}
+			if sample.Float != nil {
+				observer.ObserveFloat64(floatGauge, *sample.Float, otelmetric.WithAttributes(attrs...))
+			}
+		}
+		return ctx.Err()
+	}, intGauge, floatGauge); err != nil {
+		_ = provider.Shutdown(ctx)
+		return nil, err
+	}
+	otel.SetMeterProvider(provider)
+	if logger != nil {
+		logger.Info("otel metrics exporter enabled", "endpoint", cfg.Endpoint, "interval", interval.String())
+	}
+	return provider.Shutdown, nil
+}
+
+func expvarAttributes(sample ExpvarSample) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, len(sample.Labels)+1)
+	attrs = append(attrs, attribute.String("metric", sample.Name))
+	for _, label := range sample.Labels {
+		if label.Name == "" {
+			continue
+		}
+		attrs = append(attrs, attribute.String(label.Name, label.Value))
+	}
+	return attrs
+}

--- a/internal/observability/otel.go
+++ b/internal/observability/otel.go
@@ -79,6 +79,12 @@ func StartOTELMetrics(ctx context.Context, logger *slog.Logger, cfg OTELMetricsC
 		return nil, err
 	}
 	if _, err := meter.RegisterCallback(func(ctx context.Context, observer otelmetric.Observer) error {
+		// Bail out without surfacing the cancellation as a callback error:
+		// the OTEL SDK logs non-nil callback returns on every cycle, which
+		// turns routine periodic-reader timeouts into log noise.
+		if err := ctx.Err(); err != nil {
+			return nil
+		}
 		for _, sample := range CollectAerolVMExpvars() {
 			attrs := expvarAttributes(sample)
 			if sample.Int64 != nil {
@@ -88,7 +94,7 @@ func StartOTELMetrics(ctx context.Context, logger *slog.Logger, cfg OTELMetricsC
 				observer.ObserveFloat64(floatGauge, *sample.Float, otelmetric.WithAttributes(attrs...))
 			}
 		}
-		return ctx.Err()
+		return nil
 	}, intGauge, floatGauge); err != nil {
 		_ = provider.Shutdown(ctx)
 		return nil, err

--- a/internal/observability/otel.go
+++ b/internal/observability/otel.go
@@ -9,9 +9,12 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	otelmetric "go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/propagation"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 type OTELMetricsConfig struct {
@@ -23,9 +26,19 @@ type OTELMetricsConfig struct {
 	NodeRole    string
 }
 
+type OTELTracesConfig struct {
+	Enabled     bool
+	Endpoint    string
+	SampleRatio float64
+	ServiceName string
+	NodeID      string
+	NodeRole    string
+}
+
 const defaultOTELMetricsInterval = 30 * time.Second
 
 type MetricsShutdown func(context.Context) error
+type TracesShutdown func(context.Context) error
 
 func StartOTELMetrics(ctx context.Context, logger *slog.Logger, cfg OTELMetricsConfig) (MetricsShutdown, error) {
 	if !cfg.Enabled {
@@ -43,19 +56,10 @@ func StartOTELMetrics(ctx context.Context, logger *slog.Logger, cfg OTELMetricsC
 	if cfg.Interval > 0 {
 		interval = cfg.Interval
 	}
-	serviceName := cfg.ServiceName
-	if serviceName == "" {
-		serviceName = "sandboxd"
-	}
 	reader := sdkmetric.NewPeriodicReader(exporter, sdkmetric.WithInterval(interval))
 	provider := sdkmetric.NewMeterProvider(
 		sdkmetric.WithReader(reader),
-		sdkmetric.WithResource(resource.NewWithAttributes("",
-			attribute.String("service.name", serviceName),
-			attribute.String("service.version", version.Version),
-			attribute.String("aerolvm.node.id", cfg.NodeID),
-			attribute.String("aerolvm.node.role", cfg.NodeRole),
-		)),
+		sdkmetric.WithResource(otelResource(cfg.ServiceName, cfg.NodeID, cfg.NodeRole)),
 	)
 	meter := provider.Meter("github.com/aerol-ai/microvm/sandboxd")
 	intGauge, err := meter.Int64ObservableGauge(
@@ -94,6 +98,52 @@ func StartOTELMetrics(ctx context.Context, logger *slog.Logger, cfg OTELMetricsC
 		logger.Info("otel metrics exporter enabled", "endpoint", cfg.Endpoint, "interval", interval.String())
 	}
 	return provider.Shutdown, nil
+}
+
+func StartOTELTraces(ctx context.Context, logger *slog.Logger, cfg OTELTracesConfig) (TracesShutdown, error) {
+	if !cfg.Enabled {
+		return nil, nil
+	}
+	opts := []otlptracehttp.Option{}
+	if cfg.Endpoint != "" {
+		opts = append(opts, otlptracehttp.WithEndpointURL(cfg.Endpoint))
+	}
+	exporter, err := otlptracehttp.New(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+	sampleRatio := cfg.SampleRatio
+	if sampleRatio < 0 {
+		sampleRatio = 0
+	} else if sampleRatio > 1 {
+		sampleRatio = 1
+	}
+	provider := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.TraceIDRatioBased(sampleRatio))),
+		sdktrace.WithResource(otelResource(cfg.ServiceName, cfg.NodeID, cfg.NodeRole)),
+	)
+	otel.SetTracerProvider(provider)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+	if logger != nil {
+		logger.Info("otel trace exporter enabled", "endpoint", cfg.Endpoint, "sample_ratio", sampleRatio)
+	}
+	return provider.Shutdown, nil
+}
+
+func otelResource(serviceName, nodeID, nodeRole string) *resource.Resource {
+	if serviceName == "" {
+		serviceName = "sandboxd"
+	}
+	return resource.NewWithAttributes("",
+		attribute.String("service.name", serviceName),
+		attribute.String("service.version", version.Version),
+		attribute.String("aerolvm.node.id", nodeID),
+		attribute.String("aerolvm.node.role", nodeRole),
+	)
 }
 
 func expvarAttributes(sample ExpvarSample) []attribute.KeyValue {

--- a/internal/service/capacity_request_test.go
+++ b/internal/service/capacity_request_test.go
@@ -40,3 +40,41 @@ func TestCreateSandboxRejectsPureServerClusterNode(t *testing.T) {
 		t.Fatalf("CreateSandbox error = %v, want ErrNoPlacementTarget", err)
 	}
 }
+
+func TestCreateSandboxRejectsInvalidLargeClusterTopology(t *testing.T) {
+	svc := New(
+		config.Config{EnableCluster: true, NodeRole: config.NodeRoleWorker},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		nil, nil, nil, nil, nil, nil, nil,
+	)
+	svc.AttachCluster(&topologyCluster{
+		Noop: cluster.NewNoop("node-01", "http://node-01"),
+		members: []cluster.Member{
+			{NodeID: "server-1", Role: config.NodeRoleServer, Alive: true},
+			{NodeID: "server-2", Role: config.NodeRoleServer, Alive: true},
+			{NodeID: "server-3", Role: config.NodeRoleServer, Alive: true},
+			{NodeID: "worker-1", Role: config.NodeRoleWorker, Alive: true},
+			{NodeID: "worker-2", Role: config.NodeRoleWorker, Alive: true},
+			{NodeID: "worker-3", Role: config.NodeRoleWorker, Alive: true},
+			{NodeID: "worker-4", Role: config.NodeRoleWorker, Alive: true},
+			{NodeID: "worker-5", Role: config.NodeRoleWorker, Alive: true},
+			{NodeID: "worker-6", Role: config.NodeRoleWorker, Alive: true},
+			{NodeID: "ingress-1", Role: config.NodeRoleIngress, Alive: true},
+			{NodeID: "edge-1", Role: "worker,ingress", Alive: true},
+		},
+	})
+
+	_, err := svc.CreateSandbox(context.Background(), models.CreateSandboxRequest{Image: "alpine"})
+	if !errors.Is(err, cluster.ErrInvalidTopology) {
+		t.Fatalf("CreateSandbox error = %v, want ErrInvalidTopology", err)
+	}
+}
+
+type topologyCluster struct {
+	*cluster.Noop
+	members []cluster.Member
+}
+
+func (c *topologyCluster) Members() []cluster.Member {
+	return c.members
+}

--- a/internal/service/cluster_secrets.go
+++ b/internal/service/cluster_secrets.go
@@ -238,6 +238,10 @@ func RedactClusterSecrets(req models.CreateSandboxRequest) models.CreateSandboxR
 		}
 		out.Env = env
 	}
+	if out.Failover != nil {
+		failover := *out.Failover
+		out.Failover = &failover
+	}
 	return out
 }
 

--- a/internal/service/cluster_secrets.go
+++ b/internal/service/cluster_secrets.go
@@ -11,11 +11,42 @@ import (
 	"io"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/aerol-ai/microvm/internal/cluster"
 	"github.com/aerol-ai/microvm/internal/store"
 	"github.com/aerol-ai/microvm/pkg/models"
 )
+
+// replicateSpecPatch keeps the FSM-replicated spec in sync after a local
+// mutation (resize, lifecycle update). It is a best-effort write-through that
+// mirrors the v1 wrapper of the same name: on failure it warns and returns
+// without surfacing the error to the caller, because the local sandbox is
+// already authoritative and the next mutation will refresh the FSM.
+//
+// No-op when the cluster doesn't carry a spec for this sandbox yet
+// (pre-cluster sandbox; Noop client in single-node mode also returns nil).
+// Same-sandbox concurrent mutations can clobber each other in the FSM, but
+// the worst case is a stale spec on a node that hasn't died — the next
+// mutating call fixes it. Single-sandbox mutations serialize at the docker
+// layer anyway.
+func (s *Service) replicateSpecPatch(ctx context.Context, id string, patch func(*models.CreateSandboxRequest)) {
+	c := s.Cluster()
+	if c == nil {
+		return
+	}
+	spec := c.SpecOf(id)
+	if spec == nil {
+		return
+	}
+	patch(spec)
+	commitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := c.UpsertSpec(commitCtx, id, spec, cluster.PlacementSecrets{}); err != nil && s.logger != nil {
+		s.logger.Warn("cluster: spec write-through failed; FSM spec stale until next mutation",
+			"sandbox_id", id, "err", err)
+	}
+}
 
 // clusterSealedSecrets is the cleartext schema stored behind a cluster secret
 // ref. It only carries the parts of CreateSandboxRequest that are actually

--- a/internal/service/cluster_spec_replicate_test.go
+++ b/internal/service/cluster_spec_replicate_test.go
@@ -1,0 +1,166 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/cluster"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// specWriteThroughCluster records UpsertSpec calls so a test can assert that
+// the FSM-replicated spec saw a given mutation. Embeds cluster.Noop so any
+// surface this test doesn't care about returns the standalone defaults.
+type specWriteThroughCluster struct {
+	*cluster.Noop
+
+	mu       sync.Mutex
+	spec     *models.CreateSandboxRequest
+	upserted []models.CreateSandboxRequest
+}
+
+func (s *specWriteThroughCluster) SpecOf(string) *models.CreateSandboxRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.spec == nil {
+		return nil
+	}
+	cp := *s.spec
+	return &cp
+}
+
+func (s *specWriteThroughCluster) UpsertSpec(_ context.Context, _ string, spec *models.CreateSandboxRequest, _ cluster.PlacementSecrets) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := *spec
+	s.spec = &cp
+	s.upserted = append(s.upserted, cp)
+	return nil
+}
+
+func (s *specWriteThroughCluster) calls() []models.CreateSandboxRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]models.CreateSandboxRequest, len(s.upserted))
+	copy(out, s.upserted)
+	return out
+}
+
+// TestResizeSandboxWritesThroughToClusterSpec pins stage-4 issue I2: the
+// FSM-replicated spec must be refreshed after a resize regardless of which
+// HTTP wrapper made the call. Previously this lived in the v1 handler only,
+// so Daytona/E2B resizes left the cluster spec stale — invisible today
+// because failover=recreate is opt-in, but a latent bug the moment a user
+// flips that policy on. The fix moves the write-through into the service
+// layer; this test guards against a regression that re-introduces the
+// per-handler duplication.
+func TestResizeSandboxWritesThroughToClusterSpec(t *testing.T) {
+	ctx := context.Background()
+	svc, _, st := newCapacityHarness(t, nil, nil)
+	stub := &specWriteThroughCluster{
+		Noop: cluster.NewNoop("self", "http://self"),
+		spec: &models.CreateSandboxRequest{Image: "alpine", CPU: 1, MemoryMB: 512, DiskGB: 1},
+	}
+	svc.AttachCluster(stub)
+
+	now := time.Now().UTC()
+	const sandboxID = "sb-resize-replicate"
+	if err := st.Create(ctx, &models.Sandbox{
+		ID: sandboxID, Image: "alpine", Status: models.SandboxStatusStarted,
+		ContainerID: "ctr-resize-replicate", ContainerIP: "10.0.0.30",
+		CPU: 1, MemoryMB: 512, DiskGB: 1, Runtime: models.RuntimeDocker,
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+
+	if _, err := svc.ResizeSandbox(ctx, sandboxID, models.ResizeSandboxRequest{CPU: 4, MemoryMB: 2048}); err != nil {
+		t.Fatalf("ResizeSandbox: %v", err)
+	}
+
+	calls := stub.calls()
+	if len(calls) != 1 {
+		t.Fatalf("UpsertSpec calls = %d, want 1 (one per resize, regardless of v1/Daytona/E2B caller)", len(calls))
+	}
+	got := calls[0]
+	if got.CPU != 4 || got.MemoryMB != 2048 {
+		t.Fatalf("replicated spec = {CPU:%v MemoryMB:%v}, want {CPU:4 MemoryMB:2048}", got.CPU, got.MemoryMB)
+	}
+	if got.DiskGB != 1 {
+		t.Fatalf("replicated spec DiskGB = %d, want 1 (unchanged field must round-trip)", got.DiskGB)
+	}
+}
+
+// TestUpdateLifecycleWritesThroughToClusterSpec is the symmetric guard for
+// stage-4 I2 on lifecycle updates. Daytona's setAutoStopInterval and E2B's
+// updateTimeout / pauseSandbox both go through Service.UpdateLifecycle, so
+// asserting the service-level write-through is what proves both facades
+// inherit the contract without per-handler duplication.
+func TestUpdateLifecycleWritesThroughToClusterSpec(t *testing.T) {
+	ctx := context.Background()
+	svc, _, st := newCapacityHarness(t, nil, nil)
+	stub := &specWriteThroughCluster{
+		Noop: cluster.NewNoop("self", "http://self"),
+		spec: &models.CreateSandboxRequest{Image: "alpine"},
+	}
+	svc.AttachCluster(stub)
+
+	now := time.Now().UTC()
+	const sandboxID = "sb-lifecycle-replicate"
+	if err := st.Create(ctx, &models.Sandbox{
+		ID: sandboxID, Image: "alpine", Status: models.SandboxStatusStarted,
+		ContainerID: "ctr-lifecycle-replicate", ContainerIP: "10.0.0.31",
+		CPU: 1, MemoryMB: 512, Runtime: models.RuntimeDocker,
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+
+	want := models.Lifecycle{StopIfIdleFor: 5 * time.Minute, DestroyIfIdleFor: time.Hour}
+	if _, err := svc.UpdateLifecycle(ctx, sandboxID, want); err != nil {
+		t.Fatalf("UpdateLifecycle: %v", err)
+	}
+
+	calls := stub.calls()
+	if len(calls) != 1 {
+		t.Fatalf("UpsertSpec calls = %d, want 1", len(calls))
+	}
+	got := calls[0].Lifecycle
+	if got == nil {
+		t.Fatal("replicated spec.Lifecycle = nil, want lifecycle to be carried into FSM")
+	}
+	if got.StopIfIdleFor != want.StopIfIdleFor || got.DestroyIfIdleFor != want.DestroyIfIdleFor {
+		t.Fatalf("replicated lifecycle = %+v, want %+v", *got, want)
+	}
+}
+
+// TestResizeSandboxSkipsWriteThroughWhenSpecNotRecorded covers the pre-cluster
+// sandbox case: SpecOf returns nil for placements that predate cluster mode
+// (or for sandboxes never written through the cluster path). The service must
+// not crash and must not invent a spec to upsert — silent no-op is correct.
+func TestResizeSandboxSkipsWriteThroughWhenSpecNotRecorded(t *testing.T) {
+	ctx := context.Background()
+	svc, _, st := newCapacityHarness(t, nil, nil)
+	stub := &specWriteThroughCluster{Noop: cluster.NewNoop("self", "http://self")}
+	svc.AttachCluster(stub)
+
+	now := time.Now().UTC()
+	const sandboxID = "sb-resize-no-spec"
+	if err := st.Create(ctx, &models.Sandbox{
+		ID: sandboxID, Image: "alpine", Status: models.SandboxStatusStarted,
+		ContainerID: "ctr-resize-no-spec", ContainerIP: "10.0.0.32",
+		CPU: 1, MemoryMB: 512, Runtime: models.RuntimeDocker,
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+
+	if _, err := svc.ResizeSandbox(ctx, sandboxID, models.ResizeSandboxRequest{CPU: 2}); err != nil {
+		t.Fatalf("ResizeSandbox: %v", err)
+	}
+	if calls := stub.calls(); len(calls) != 0 {
+		t.Fatalf("UpsertSpec was called %d times for a pre-cluster sandbox; want 0", len(calls))
+	}
+}

--- a/internal/service/image_distribution_test.go
+++ b/internal/service/image_distribution_test.go
@@ -78,6 +78,29 @@ func TestRegisterSnapshotClassifiesImageDistribution(t *testing.T) {
 	}
 }
 
+func TestNormalizeCreateFailover(t *testing.T) {
+	req := models.CreateSandboxRequest{
+		Image:                 "ubuntu:22.04",
+		ImageDistributionMode: models.ImageDistributionExternalRegistry,
+		Failover:              &models.Failover{Policy: "ReCreate"},
+	}
+	if err := NormalizeCreateFailover(&req); err != nil {
+		t.Fatalf("NormalizeCreateFailover() error = %v", err)
+	}
+	if req.Failover == nil || req.Failover.Policy != models.FailoverPolicyRecreate {
+		t.Fatalf("normalized failover = %+v, want recreate", req.Failover)
+	}
+
+	req = models.CreateSandboxRequest{
+		Image:                 docker.BuiltImageNamespace + "/abc123:latest",
+		ImageDistributionMode: models.ImageDistributionLocalOnly,
+		Failover:              &models.Failover{Policy: models.FailoverPolicyRecreate},
+	}
+	if err := NormalizeCreateFailover(&req); err == nil {
+		t.Fatal("expected local-only failover recreate to be rejected")
+	}
+}
+
 func TestCreateSnapshotWithOwnershipMarksLocalOnly(t *testing.T) {
 	ctx := context.Background()
 	st := openImageDistributionStore(t)

--- a/internal/service/reconcile_destroy_test.go
+++ b/internal/service/reconcile_destroy_test.go
@@ -25,8 +25,10 @@ import (
 // if reached, so a future refactor that starts calling them in reconcile fails
 // the test instead of silently passing.
 type fakeReconcileRuntime struct {
-	managed         map[string]*models.SandboxRuntimeState
-	removeImageHits atomic.Int32
+	managed               map[string]*models.SandboxRuntimeState
+	removeImageHits       atomic.Int32
+	networkBlockAllCalls  []string
+	allowPushAllowedPorts bool
 }
 
 func (f *fakeReconcileRuntime) ListManaged(_ context.Context) (map[string]*models.SandboxRuntimeState, error) {
@@ -67,12 +69,16 @@ func (f *fakeReconcileRuntime) Ping(context.Context) error {
 	panic("unexpected Ping on reconcile destroyed path")
 }
 func (f *fakeReconcileRuntime) PushAllowedPorts(context.Context, string, string, []int) error {
-	panic("unexpected PushAllowedPorts on reconcile destroyed path")
+	if !f.allowPushAllowedPorts {
+		panic("unexpected PushAllowedPorts on reconcile destroyed path")
+	}
+	return nil
 }
 func (f *fakeReconcileRuntime) ClearNetworkRules(string) error {
 	return nil
 }
-func (f *fakeReconcileRuntime) ApplyNetworkBlockAll(string) error {
+func (f *fakeReconcileRuntime) ApplyNetworkBlockAll(containerIP string) error {
+	f.networkBlockAllCalls = append(f.networkBlockAllCalls, containerIP)
 	return nil
 }
 func (f *fakeReconcileRuntime) ApplyNetworkBlockIngress(string) error {
@@ -83,6 +89,87 @@ func (f *fakeReconcileRuntime) ClearNetworkBlockIngress(string) error {
 }
 func (f *fakeReconcileRuntime) ClearNetworkBlockEgress(string) error {
 	return nil
+}
+
+func TestReconcileReappliesNetworkBlockAllWithCurrentContainerIP(t *testing.T) {
+	ctx := context.Background()
+
+	dbPath := filepath.Join(t.TempDir(), "state.db")
+	st, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	mgr, err := mounts.New(slog.New(slog.NewTextHandler(io.Discard, nil)), mounts.Config{
+		RootDir:     filepath.Join(t.TempDir(), "mounts"),
+		CredDir:     filepath.Join(t.TempDir(), "cred"),
+		WaitTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("mounts.New: %v", err)
+	}
+	t.Cleanup(mgr.Close)
+
+	caddyClient := caddy.New(config.Config{
+		EnableCaddy:       false,
+		HTTPClientTimeout: time.Second,
+	})
+	rt := &fakeReconcileRuntime{
+		allowPushAllowedPorts: true,
+		managed: map[string]*models.SandboxRuntimeState{
+			"sb-blocked": {
+				SandboxID:   "sb-blocked",
+				ContainerID: "ctr-current",
+				ContainerIP: "10.0.0.42",
+				Status:      models.SandboxStatusStarted,
+			},
+		},
+	}
+	svc := &Service{
+		cfg:    config.Config{},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		store:  st,
+		docker: rt,
+		caddy:  caddyClient,
+		mounts: mgr,
+	}
+
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{
+		ID:              "sb-blocked",
+		Image:           "ubuntu:22.04",
+		Status:          models.SandboxStatusStarted,
+		ContainerID:     "ctr-stale",
+		ContainerIP:     "10.0.0.7",
+		CPU:             1,
+		MemoryMB:        512,
+		Runtime:         models.RuntimeDocker,
+		NetworkBlockAll: true,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		LastActiveAt:    now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+
+	if err := svc.Reconcile(ctx); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	if got, want := rt.networkBlockAllCalls, []string{"10.0.0.42"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("ApplyNetworkBlockAll calls = %v, want %v", got, want)
+	}
+	refreshed, err := st.Get(ctx, "sb-blocked")
+	if err != nil {
+		t.Fatalf("Get refreshed sandbox: %v", err)
+	}
+	if refreshed.ContainerID != "ctr-current" || refreshed.ContainerIP != "10.0.0.42" {
+		t.Fatalf("reconcile did not persist current runtime identity: id=%q ip=%q", refreshed.ContainerID, refreshed.ContainerIP)
+	}
+	if !refreshed.NetworkBlockAll {
+		t.Fatal("NetworkBlockAll flag was lost during reconcile")
+	}
 }
 
 // TestReconcileDestroyedRowFreesHostPort is the regression test required by

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1085,6 +1085,22 @@ func (s *Service) ResizeSandbox(ctx context.Context, id string, req models.Resiz
 	if err := s.store.Upsert(ctx, sandbox); err != nil {
 		return nil, err
 	}
+	// Mirror the resize into the FSM-replicated spec so a future failover
+	// recreate uses the post-resize footprint, not the create-time one. Lives
+	// in the service layer so v1, Daytona, and E2B all inherit the write-
+	// through; previously this was duplicated in the v1 handler and silently
+	// missing from the facades.
+	s.replicateSpecPatch(ctx, id, func(spec *models.CreateSandboxRequest) {
+		if req.CPU > 0 {
+			spec.CPU = req.CPU
+		}
+		if req.MemoryMB > 0 {
+			spec.MemoryMB = req.MemoryMB
+		}
+		if req.DiskGB > 0 {
+			spec.DiskGB = req.DiskGB
+		}
+	})
 	return s.store.Get(ctx, id)
 }
 
@@ -1099,6 +1115,10 @@ func (s *Service) UpdateLifecycle(ctx context.Context, id string, l models.Lifec
 	if err := s.store.UpdateLifecycle(ctx, id, l); err != nil {
 		return nil, err
 	}
+	lc := l
+	s.replicateSpecPatch(ctx, id, func(spec *models.CreateSandboxRequest) {
+		spec.Lifecycle = &lc
+	})
 	return s.store.Get(ctx, id)
 }
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -278,12 +278,8 @@ func (s *Service) reconcileStaleOwnership(ctx context.Context) {
 // the owner watcher keeps retrying and can eventually reassign the placement.
 // ExposePort is idempotent, so a partial replay is safe to resume.
 //
-// Currently unreachable in production: cluster.startOwnerWatcher is gated off
-// by cluster.clusterRecreateOnFailoverEnabled (product policy: sandboxes are
-// not highly available; a dead owner's placements are orphaned). The method is
-// preserved here so a future opt-in failover flag can re-enable the watcher
-// without re-implementing recreate. Cluster-package tests still drive the
-// inner recreate paths through a mock recreator, not this implementation.
+// Only placements whose create spec opted into failover.policy=recreate reach
+// this path; default sandboxes remain non-HA and are orphaned on owner death.
 func (s *Service) RecreateSandbox(ctx context.Context, id string, spec models.CreateSandboxRequest, secrets cluster.PlacementSecrets, exposedPorts map[int]cluster.ExposedPortRoute) error {
 	if existing, err := s.store.Get(ctx, id); err == nil && existing != nil {
 		return s.replayClusterExposedPorts(ctx, id, exposedPorts)
@@ -375,6 +371,9 @@ func (s *Service) createSandbox(ctx context.Context, req models.CreateSandboxReq
 
 	req = normalizeCreateRequest(req)
 	if err := s.NormalizeCreateImageDistribution(ctx, &req); err != nil {
+		return nil, err
+	}
+	if err := NormalizeCreateFailover(&req); err != nil {
 		return nil, err
 	}
 	if req.Image == "" {
@@ -529,6 +528,7 @@ func (s *Service) createSandbox(ctx context.Context, req models.CreateSandboxReq
 		LastActiveAt:         now,
 		ContainerCommand:     req.ContainerCommand,
 		Lifecycle:            lifecycle,
+		Failover:             req.Failover,
 		Runtime:              chosenRuntime,
 		GPUs:                 req.GPUs,
 		RegistryAuthSealed:   sealedRegistry,
@@ -2417,6 +2417,25 @@ func normalizeCreateRequest(req models.CreateSandboxRequest) models.CreateSandbo
 		req.Env = map[string]string{}
 	}
 	return req
+}
+
+func NormalizeCreateFailover(req *models.CreateSandboxRequest) error {
+	if req == nil || req.Failover == nil {
+		return nil
+	}
+	policy, err := models.NormalizeFailoverPolicy(req.Failover.Policy)
+	if err != nil {
+		return fmt.Errorf("invalid failover: %w", err)
+	}
+	if policy == models.FailoverPolicyNone {
+		req.Failover = nil
+		return nil
+	}
+	if policy == models.FailoverPolicyRecreate && ImageRequiresLocalPlacement(*req) {
+		return errors.New("failover.policy=recreate requires a portable image; local-only images cannot be recreated on another node")
+	}
+	req.Failover = &models.Failover{Policy: policy}
+	return nil
 }
 
 func sandboxContainerRef(sandbox *models.Sandbox) string {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -148,6 +148,21 @@ func (s *Service) Cluster() cluster.Client {
 	return s.cluster
 }
 
+// ClusterTopologyError returns a production-topology violation for the current
+// live member set. It is intentionally a runtime check so rolling membership,
+// old nodes that still gossip empty roles, and explicit hybrid roles are all
+// evaluated from the same source of truth the scheduler uses.
+func (s *Service) ClusterTopologyError() error {
+	if !s.cfg.EnableCluster {
+		return nil
+	}
+	c := s.Cluster()
+	if c == nil {
+		return nil
+	}
+	return cluster.LargeClusterTopologyError(c.Members())
+}
+
 // EnsureClusterReady blocks until the cluster has elected a leader, mirroring
 // the EnsureLayer4Ready single-flight latch shape. Single-node mode latches
 // immediately. The API wrapper calls this before any RecordPlacement so a
@@ -351,6 +366,9 @@ func gpuVendorForCapacity(req *models.GPURequest) string {
 func (s *Service) createSandbox(ctx context.Context, req models.CreateSandboxRequest, idOverride string) (resp *models.CreateSandboxResponse, err error) {
 	done := beginSandboxCreateMetric()
 	defer func() { done(err) }()
+	if err := s.ClusterTopologyError(); err != nil {
+		return nil, err
+	}
 	if s.cfg.EnableCluster && !s.cfg.IsWorker() {
 		return nil, cluster.ErrNoPlacementTarget
 	}
@@ -1577,13 +1595,29 @@ func (s *Service) Health(ctx context.Context) (models.HealthStatus, error) {
 		status = "degraded"
 	}
 
+	clusterTopology := ""
+	clusterNodes := 0
+	if s.cfg.EnableCluster {
+		clusterTopology = "ok"
+		if c := s.Cluster(); c != nil {
+			members := c.Members()
+			clusterNodes = cluster.LiveMemberCount(members)
+			if err := cluster.LargeClusterTopologyError(members); err != nil {
+				clusterTopology = err.Error()
+				status = "degraded"
+			}
+		}
+	}
+
 	return models.HealthStatus{
-		Status:     status,
-		Sandboxes:  live,
-		Docker:     dockerStatus,
-		Caddy:      caddyStatus,
-		SSHGateway: sshStatus,
-		Version:    version.Version,
+		Status:          status,
+		Sandboxes:       live,
+		Docker:          dockerStatus,
+		Caddy:           caddyStatus,
+		SSHGateway:      sshStatus,
+		ClusterTopology: clusterTopology,
+		ClusterNodes:    clusterNodes,
+		Version:         version.Version,
 	}, nil
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -79,6 +79,7 @@ func Open(path string) (*Store, error) {
 			destroy_if_idle_for_ns INTEGER NOT NULL DEFAULT 0,
 			stop_at_age_ns INTEGER NOT NULL DEFAULT 0,
 			destroy_at_age_ns INTEGER NOT NULL DEFAULT 0,
+			failover_policy TEXT NOT NULL DEFAULT '',
 			runtime TEXT NOT NULL DEFAULT '',
 			gpus_json TEXT NOT NULL DEFAULT '',
 			net_bytes_in INTEGER NOT NULL DEFAULT 0,
@@ -223,6 +224,9 @@ func Open(path string) (*Store, error) {
 		`ALTER TABLE sandboxes ADD COLUMN destroy_if_idle_for_ns INTEGER NOT NULL DEFAULT 0;`,
 		`ALTER TABLE sandboxes ADD COLUMN stop_at_age_ns INTEGER NOT NULL DEFAULT 0;`,
 		`ALTER TABLE sandboxes ADD COLUMN destroy_at_age_ns INTEGER NOT NULL DEFAULT 0;`,
+		// Per-sandbox owner-death policy. Empty/none means orphan on owner
+		// death; "recreate" opts into best-effort cluster recreation.
+		`ALTER TABLE sandboxes ADD COLUMN failover_policy TEXT NOT NULL DEFAULT '';`,
 		// Per-sandbox OCI runtime selector (runc / runsc). Pre-migration rows
 		// get '' and resolve to the host default at start time; new sandboxes
 		// always store the resolved value so the choice cannot drift across
@@ -345,11 +349,12 @@ func (s *Store) Create(ctx context.Context, sandbox *models.Sandbox) error {
 			os_user, env_json, network_block_all, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
+			failover_policy,
 			runtime, gpus_json,
 			net_bytes_in, net_bytes_out, net_bytes_in_limit, net_bytes_out_limit,
 			net_quota_exceeded, net_quota_exceeded_at,
 			registry_auth_sealed
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		sandbox.ID,
 		sandbox.Image,
@@ -377,6 +382,7 @@ func (s *Store) Create(ctx context.Context, sandbox *models.Sandbox) error {
 		int64(sandbox.Lifecycle.DestroyIfIdleFor),
 		int64(sandbox.Lifecycle.StopAtAge),
 		int64(sandbox.Lifecycle.DestroyAtAge),
+		sandboxFailoverPolicy(sandbox),
 		sandbox.Runtime,
 		gpusJSON,
 		sandbox.NetworkBytesIn,
@@ -403,6 +409,17 @@ func nullableBlob(b []byte) []byte {
 		return []byte{}
 	}
 	return b
+}
+
+func sandboxFailoverPolicy(sandbox *models.Sandbox) string {
+	if sandbox == nil || sandbox.Failover == nil {
+		return ""
+	}
+	policy, err := models.NormalizeFailoverPolicy(sandbox.Failover.Policy)
+	if err != nil || policy == models.FailoverPolicyNone {
+		return ""
+	}
+	return policy
 }
 
 func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
@@ -432,11 +449,12 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 			os_user, env_json, network_block_all, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
+			failover_policy,
 			runtime, gpus_json,
 			net_bytes_in, net_bytes_out, net_bytes_in_limit, net_bytes_out_limit,
 			net_quota_exceeded, net_quota_exceeded_at,
 			registry_auth_sealed
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			image = excluded.image,
 			status = excluded.status,
@@ -462,6 +480,7 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 			destroy_if_idle_for_ns = excluded.destroy_if_idle_for_ns,
 			stop_at_age_ns = excluded.stop_at_age_ns,
 			destroy_at_age_ns = excluded.destroy_at_age_ns,
+			failover_policy = excluded.failover_policy,
 			runtime = excluded.runtime,
 			gpus_json = excluded.gpus_json,
 			net_bytes_in_limit = excluded.net_bytes_in_limit,
@@ -494,6 +513,7 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 		int64(sandbox.Lifecycle.DestroyIfIdleFor),
 		int64(sandbox.Lifecycle.StopAtAge),
 		int64(sandbox.Lifecycle.DestroyAtAge),
+		sandboxFailoverPolicy(sandbox),
 		sandbox.Runtime,
 		gpusJSON,
 		sandbox.NetworkBytesIn,
@@ -519,6 +539,7 @@ func (s *Store) Get(ctx context.Context, id string) (*models.Sandbox, error) {
 			os_user, env_json, network_block_all, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
+			failover_policy,
 			runtime, gpus_json,
 			net_bytes_in, net_bytes_out, net_bytes_in_limit, net_bytes_out_limit,
 			net_quota_exceeded, net_quota_exceeded_at,
@@ -550,6 +571,7 @@ func (s *Store) List(ctx context.Context) ([]*models.Sandbox, error) {
 			os_user, env_json, network_block_all, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
+			failover_policy,
 			runtime, gpus_json,
 			net_bytes_in, net_bytes_out, net_bytes_in_limit, net_bytes_out_limit,
 			net_quota_exceeded, net_quota_exceeded_at,
@@ -1516,6 +1538,7 @@ func scanSandbox(scanner interface {
 	var commandJSON string
 	var tagsJSON string
 	var gpusJSON string
+	var failoverPolicy string
 	var stopIfIdleNs, destroyIfIdleNs, stopAtAgeNs, destroyAtAgeNs int64
 	var netQuotaExceeded int
 	var netQuotaExceededAt sql.NullTime
@@ -1548,6 +1571,7 @@ func scanSandbox(scanner interface {
 		&destroyIfIdleNs,
 		&stopAtAgeNs,
 		&destroyAtAgeNs,
+		&failoverPolicy,
 		&sandbox.Runtime,
 		&gpusJSON,
 		&sandbox.NetworkBytesIn,
@@ -1598,6 +1622,9 @@ func scanSandbox(scanner interface {
 		DestroyIfIdleFor: time.Duration(destroyIfIdleNs),
 		StopAtAge:        time.Duration(stopAtAgeNs),
 		DestroyAtAge:     time.Duration(destroyAtAgeNs),
+	}
+	if policy, err := models.NormalizeFailoverPolicy(failoverPolicy); err == nil && policy == models.FailoverPolicyRecreate {
+		sandbox.Failover = &models.Failover{Policy: policy}
 	}
 
 	return &sandbox, nil

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1079,6 +1079,24 @@ func TestStoreCases(t *testing.T) {
 			},
 		},
 		{
+			name: "failover_policy_persists_through_create_and_get",
+			run: func(t *testing.T) {
+				st := newTestStore(t)
+				sandbox := sampleSandbox("sb-failover")
+				sandbox.Failover = &models.Failover{Policy: models.FailoverPolicyRecreate}
+				if err := st.Create(ctx, sandbox); err != nil {
+					t.Fatalf("Create() error = %v", err)
+				}
+				got, err := st.Get(ctx, sandbox.ID)
+				if err != nil {
+					t.Fatalf("Get() error = %v", err)
+				}
+				if got.Failover == nil || got.Failover.Policy != models.FailoverPolicyRecreate {
+					t.Fatalf("Failover roundtrip mismatch: got %+v", got.Failover)
+				}
+			},
+		},
+		{
 			name: "update_lifecycle_replaces_fields",
 			run: func(t *testing.T) {
 				st := newTestStore(t)
@@ -1206,6 +1224,7 @@ func TestStoreHelperCases(t *testing.T) {
 			"{}",                        // tags_json
 			now, now, now,               // created_at, updated_at, last_active_at
 			int64(0), int64(0), int64(0), int64(0), // lifecycle ns columns
+			"",                 // failover_policy
 			"",                 // runtime
 			"",                 // gpus_json
 			int64(0), int64(0), // net_bytes_in, net_bytes_out

--- a/pkg/api/apihttp/apihttp.go
+++ b/pkg/api/apihttp/apihttp.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strconv"
 
 	"github.com/aerol-ai/microvm/internal/cluster"
 	"github.com/aerol-ai/microvm/internal/store"
@@ -49,7 +50,7 @@ func WriteStoreAwareError(logger *slog.Logger, w http.ResponseWriter, err error)
 	// reasons from the admitter.
 	if errors.Is(err, capacity.ErrCapacityExceeded) || errors.Is(err, cluster.ErrCapacityExceeded) {
 		logger.Info("capacity rejected", "error", err)
-		w.Header().Set("Retry-After", "30")
+		w.Header().Set("Retry-After", strconv.Itoa(cluster.CapacityRetryAfterSeconds))
 		msg := err.Error()
 		if len(msg) > 200 {
 			msg = msg[:200]
@@ -58,13 +59,13 @@ func WriteStoreAwareError(logger *slog.Logger, w http.ResponseWriter, err error)
 		return
 	}
 	if errors.Is(err, cluster.ErrCreateBackpressure) {
-		w.Header().Set("Retry-After", "5")
+		w.Header().Set("Retry-After", strconv.Itoa(cluster.CreateBackpressureRetryAfterSeconds))
 		WriteError(w, http.StatusTooManyRequests, err.Error())
 		return
 	}
 	if errors.Is(err, cluster.ErrNoPlacementTarget) || errors.Is(err, cluster.ErrInvalidTopology) {
 		if errors.Is(err, cluster.ErrInvalidTopology) {
-			w.Header().Set("Retry-After", "300")
+			w.Header().Set("Retry-After", strconv.Itoa(cluster.InvalidTopologyRetryAfterSeconds))
 		}
 		WriteError(w, http.StatusServiceUnavailable, err.Error())
 		return

--- a/pkg/api/apihttp/apihttp.go
+++ b/pkg/api/apihttp/apihttp.go
@@ -47,7 +47,7 @@ func WriteStoreAwareError(logger *slog.Logger, w http.ResponseWriter, err error)
 	// clients (and load balancers) back off instead of treating it as a
 	// permanent 4xx. The error string already carries human-readable
 	// reasons from the admitter.
-	if errors.Is(err, capacity.ErrCapacityExceeded) {
+	if errors.Is(err, capacity.ErrCapacityExceeded) || errors.Is(err, cluster.ErrCapacityExceeded) {
 		logger.Info("capacity rejected", "error", err)
 		w.Header().Set("Retry-After", "30")
 		msg := err.Error()
@@ -55,6 +55,11 @@ func WriteStoreAwareError(logger *slog.Logger, w http.ResponseWriter, err error)
 			msg = msg[:200]
 		}
 		WriteError(w, http.StatusServiceUnavailable, msg)
+		return
+	}
+	if errors.Is(err, cluster.ErrCreateBackpressure) {
+		w.Header().Set("Retry-After", "5")
+		WriteError(w, http.StatusTooManyRequests, err.Error())
 		return
 	}
 	if errors.Is(err, cluster.ErrNoPlacementTarget) || errors.Is(err, cluster.ErrInvalidTopology) {

--- a/pkg/api/apihttp/apihttp.go
+++ b/pkg/api/apihttp/apihttp.go
@@ -30,10 +30,10 @@ func WriteError(w http.ResponseWriter, status int, message string) {
 }
 
 // WriteStoreAwareError maps the small set of well-known service-layer error
-// kinds to HTTP responses. The mapping (404 for missing sandboxes, 503 +
-// Retry-After for capacity, 400 for everything else) is a contract clients
-// depend on regardless of API version, so it lives here in the shared helper
-// package.
+// kinds to HTTP responses. The mapping (404 for missing sandboxes, 503 for
+// capacity/topology admission failures, 400 for everything else) is a contract
+// clients depend on regardless of API version, so it lives here in the shared
+// helper package.
 func WriteStoreAwareError(logger *slog.Logger, w http.ResponseWriter, err error) {
 	if errors.Is(err, store.ErrNotFound) {
 		WriteError(w, http.StatusNotFound, "sandbox not found")
@@ -57,7 +57,10 @@ func WriteStoreAwareError(logger *slog.Logger, w http.ResponseWriter, err error)
 		WriteError(w, http.StatusServiceUnavailable, msg)
 		return
 	}
-	if errors.Is(err, cluster.ErrNoPlacementTarget) {
+	if errors.Is(err, cluster.ErrNoPlacementTarget) || errors.Is(err, cluster.ErrInvalidTopology) {
+		if errors.Is(err, cluster.ErrInvalidTopology) {
+			w.Header().Set("Retry-After", "300")
+		}
 		WriteError(w, http.StatusServiceUnavailable, err.Error())
 		return
 	}

--- a/pkg/api/capacity_error_test.go
+++ b/pkg/api/capacity_error_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aerol-ai/microvm/internal/cluster"
 	"github.com/aerol-ai/microvm/pkg/capacity"
 )
 
@@ -31,5 +32,23 @@ func TestWriteStoreAwareErrorMapsCapacityTo503(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "cpu reservation exceeded") {
 		t.Fatalf("body should include reasons, got %q", rec.Body.String())
+	}
+}
+
+func TestWriteStoreAwareErrorMapsInvalidTopologyTo503(t *testing.T) {
+	server := &Server{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	rec := httptest.NewRecorder()
+
+	err := fmt.Errorf("%w: clusters with more than 10 live nodes cannot include mixed-role nodes", cluster.ErrInvalidTopology)
+	server.writeStoreAwareError(rec, err)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+	if got := rec.Header().Get("Retry-After"); got != "300" {
+		t.Fatalf("Retry-After = %q, want 300", got)
+	}
+	if !strings.Contains(rec.Body.String(), cluster.ErrInvalidTopology.Error()) {
+		t.Fatalf("body should include topology error, got %q", rec.Body.String())
 	}
 }

--- a/pkg/api/clustercreate/clustercreate.go
+++ b/pkg/api/clustercreate/clustercreate.go
@@ -64,6 +64,10 @@ func Prepare(w http.ResponseWriter, r *http.Request, svc *service.Service, req m
 		writeError(w, http.StatusBadRequest, err.Error())
 		return Decision{}, false
 	}
+	if err := service.NormalizeCreateFailover(&req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return Decision{}, false
+	}
 	if service.ImageRequiresLocalPlacement(req) {
 		if c.IsNodeDrained(c.SelfNodeID()) {
 			writeError(w, http.StatusServiceUnavailable, cluster.ErrNoPlacementTarget.Error())
@@ -169,6 +173,9 @@ type CreateOptions struct {
 
 func CreateOnSelectedNode(ctx context.Context, svc *service.Service, logger *slog.Logger, req models.CreateSandboxRequest, reservationID string, opts CreateOptions) (*models.CreateSandboxResponse, error) {
 	if err := svc.NormalizeCreateImageDistribution(ctx, &req); err != nil {
+		return nil, err
+	}
+	if err := service.NormalizeCreateFailover(&req); err != nil {
 		return nil, err
 	}
 	c := svc.Cluster()

--- a/pkg/api/clustercreate/clustercreate.go
+++ b/pkg/api/clustercreate/clustercreate.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -76,6 +77,8 @@ func Prepare(w http.ResponseWriter, r *http.Request, svc *service.Service, req m
 		if errors.Is(err, cluster.ErrNoPlacementTarget) || errors.Is(err, cluster.ErrInvalidTopology) {
 			if errors.Is(err, cluster.ErrInvalidTopology) {
 				w.Header().Set("Retry-After", "300")
+			} else {
+				w.Header().Set("Retry-After", strconv.Itoa(cluster.CapacityRetryAfterSeconds))
 			}
 			writeError(w, http.StatusServiceUnavailable, err.Error())
 			return Decision{}, false
@@ -83,10 +86,6 @@ func Prepare(w http.ResponseWriter, r *http.Request, svc *service.Service, req m
 		writeError(w, http.StatusInternalServerError, "placement: "+err.Error())
 		return Decision{}, false
 	}
-	if target.IsSelf {
-		return Decision{}, true
-	}
-
 	sandboxID := strings.TrimSpace(opts.PreferredSandboxID)
 	if sandboxID == "" {
 		var err error
@@ -121,13 +120,26 @@ func Prepare(w http.ResponseWriter, r *http.Request, svc *service.Service, req m
 			writeError(w, http.StatusConflict, "cluster: reservation conflict on sandbox id")
 			return Decision{}, false
 		}
+		if errors.Is(err, cluster.ErrCreateBackpressure) {
+			w.Header().Set("Retry-After", strconv.Itoa(cluster.CreateBackpressureRetryAfterSeconds))
+			writeError(w, http.StatusTooManyRequests, err.Error())
+			return Decision{}, false
+		}
+		if errors.Is(err, cluster.ErrCapacityExceeded) || errors.Is(err, cluster.ErrNoPlacementTarget) {
+			w.Header().Set("Retry-After", strconv.Itoa(cluster.CapacityRetryAfterSeconds))
+			writeError(w, http.StatusServiceUnavailable, err.Error())
+			return Decision{}, false
+		}
 		writeError(w, http.StatusServiceUnavailable, "cluster: reserve placement failed: "+err.Error())
 		return Decision{}, false
 	}
-	service.RecordCreateReservationState("reserve_remote")
-
 	r.Header.Set(HeaderTarget, target.NodeID)
 	r.Header.Set(HeaderID, sandboxID)
+	if target.IsSelf {
+		service.RecordCreateReservationState("reserve_local")
+		return Decision{ReservationID: sandboxID}, true
+	}
+	service.RecordCreateReservationState("reserve_remote")
 	c.ForwardHTTP(cluster.Endpoint{InternalURL: target.InternalURL, APIURL: target.APIURL}, w, r)
 	return Decision{}, false
 }

--- a/pkg/api/clustercreate/clustercreate.go
+++ b/pkg/api/clustercreate/clustercreate.go
@@ -73,7 +73,10 @@ func Prepare(w http.ResponseWriter, r *http.Request, svc *service.Service, req m
 
 	target, err := c.SelectPlacement(CapacityRequestFromCreate(req))
 	if err != nil {
-		if errors.Is(err, cluster.ErrNoPlacementTarget) {
+		if errors.Is(err, cluster.ErrNoPlacementTarget) || errors.Is(err, cluster.ErrInvalidTopology) {
+			if errors.Is(err, cluster.ErrInvalidTopology) {
+				w.Header().Set("Retry-After", "300")
+			}
 			writeError(w, http.StatusServiceUnavailable, err.Error())
 			return Decision{}, false
 		}

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -13,16 +13,18 @@ import (
 //go:embed dashboard.html
 var dashboardHTML []byte
 
-// registerDashboard mounts the dashboard page at /ui and the expvar metrics
-// at /debug/vars. The page itself is served without auth (it carries no
+// registerDashboard mounts the dashboard page at /ui, expvar JSON metrics at
+// /debug/vars, and Prometheus-compatible metrics at /v1/metrics. The page
+// itself is served without auth (it carries no
 // secrets; auth happens client-side when the user pastes their PAT into the
-// sign-in form). The metrics endpoint IS PAT-gated because the aerolvm_*
+// sign-in form). Metrics endpoints ARE PAT-gated because the aerolvm_*
 // counters carry operational shape (lease state, queue depths, secret
 // decrypt failures) we do not want exposed unauthenticated.
 func (s *Server) registerDashboard() {
 	s.mux.HandleFunc("GET /ui", s.serveDashboard)
 	s.mux.HandleFunc("GET /ui/", s.serveDashboard)
 	s.mux.Handle("GET /debug/vars", s.requireAuth(expvar.Handler()))
+	s.mux.Handle("GET /v1/metrics", s.requireAuth(http.HandlerFunc(s.servePrometheusMetrics)))
 }
 
 func (s *Server) serveDashboard(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/api/dashboard.html
+++ b/pkg/api/dashboard.html
@@ -132,6 +132,9 @@ details > summary { cursor: pointer; color: var(--muted); padding: 6px 0; }
         <div class="kv"><span class="k">Leader</span><span class="v" id="cluster-leader">—</span></div>
         <div class="kv"><span class="k">Members</span><span class="v" id="cluster-count">—</span></div>
       </div>
+      <div class="row" id="cluster-capacity-row" style="margin-bottom: 10px;">
+        <span class="muted">loading…</span>
+      </div>
       <table>
         <thead>
           <tr>
@@ -292,6 +295,11 @@ function fmtPct(n) {
   return (Number(n) * 100).toFixed(1) + "%";
 }
 
+function fmtCapacityPct(used, total) {
+  if (!total || total <= 0) { return "—"; }
+  return ((Number(used || 0) / Number(total)) * 100).toFixed(1) + "%";
+}
+
 function fmtUnix(u) {
   if (!u) { return "—"; }
   try { return new Date(Number(u) * 1000).toISOString().replace("T", " ").replace("Z", "Z"); }
@@ -314,6 +322,42 @@ function hostFromURL(s) {
   try { return new URL(s).hostname; } catch (_) { /* not a full URL */ }
   const i = s.lastIndexOf(":");
   return i > 0 ? s.slice(0, i) : s;
+}
+
+function aggregateCapacity(members) {
+  const agg = {
+    nodes: 0, stale: 0, sandboxes: 0,
+    hostCPU: 0, cpuBudget: 0, reservedCPU: 0, availableCPU: 0,
+    hostMem: 0, memBudget: 0, reservedMem: 0, availableMem: 0,
+    hostDisk: 0, diskFree: 0, diskBudget: 0, reservedDisk: 0, availableDisk: 0,
+    gpuCount: 0, reservedGPUs: 0, availableGPUs: 0,
+  };
+  (members || []).forEach((m) => {
+    const c = m.capacity || {};
+    if (!m.alive || !(c.host_cpu_cores > 0 || c.host_memory_total_mb > 0)) {
+      return;
+    }
+    agg.nodes += 1;
+    if (m.capacity_stale) { agg.stale += 1; }
+    agg.sandboxes += Number(c.sandboxes_active || 0);
+    agg.hostCPU += Number(c.host_cpu_cores || 0);
+    agg.cpuBudget += Number(c.cpu_budget || 0);
+    agg.reservedCPU += Number(c.reserved_cpu || 0);
+    agg.availableCPU += Number(c.available_cpu != null ? c.available_cpu : Math.max((c.cpu_budget || 0) - (c.reserved_cpu || 0), 0));
+    agg.hostMem += Number(c.host_memory_total_mb || 0);
+    agg.memBudget += Number(c.memory_budget_mb || 0);
+    agg.reservedMem += Number(c.reserved_memory_mb || 0);
+    agg.availableMem += Number(c.available_memory_mb != null ? c.available_memory_mb : Math.max((c.memory_budget_mb || 0) - (c.reserved_memory_mb || 0), 0));
+    agg.hostDisk += Number(c.host_disk_total_gb || 0);
+    agg.diskFree += Number(c.host_disk_free_gb || 0);
+    agg.diskBudget += Number(c.disk_budget_gb || 0);
+    agg.reservedDisk += Number(c.reserved_disk_gb || 0);
+    agg.availableDisk += Number(c.available_disk_gb != null ? c.available_disk_gb : Math.max((c.disk_budget_gb || 0) - (c.reserved_disk_gb || 0), 0));
+    agg.gpuCount += Number(c.gpu_count || 0);
+    agg.reservedGPUs += Number(c.reserved_gpus || 0);
+    agg.availableGPUs += Number(c.available_gpus != null ? c.available_gpus : Math.max((c.gpu_count || 0) - (c.reserved_gpus || 0), 0));
+  });
+  return agg;
 }
 
 // ---------- panels ----------
@@ -348,15 +392,15 @@ async function loadCapacity() {
     const cpuBreakdown = `${fmtNum(c.host_cpu_cores)} cores × ${fmtPct(c.cpu_reservation_ratio)}${cpuFactor > 1 ? " × " + fmtFloat(cpuFactor) + "× overcommit" : ""}`;
     const memBreakdown = `${fmtNum(c.host_memory_total_mb)} MB × ${fmtPct(c.memory_reservation_ratio)}${memFactor > 1 ? " × " + fmtFloat(memFactor) + "× overcommit" : ""}`;
     const diskBreakdown = c.host_disk_total_gb
-      ? `${fmtNum(c.host_disk_total_gb)} GB × ${fmtPct(c.disk_reservation_ratio || 0)}`
+      ? `${fmtNum(c.host_disk_total_gb)} GB total${c.host_disk_free_gb ? " · " + fmtNum(c.host_disk_free_gb) + " GB free" : ""} × ${fmtPct(c.disk_reservation_ratio || 0)}`
       : "disk accounting disabled";
     el("capacity-row").innerHTML = `
       <div class="kv"><span class="k">can_admit</span><span class="v">${pill(c.can_admit ? "yes" : "no", admitKind)}</span></div>
       <div class="kv"><span class="k">live sandboxes</span><span class="v">${fmtNum(c.sandboxes_active)}</span></div>
       <div class="kv" style="grid-column: 1 / -1;"><span class="k">host hardware</span><span class="v">${fmtNum(c.host_cpu_cores)} cores · ${fmtNum(c.host_memory_total_mb)} MB ram${c.host_disk_total_gb ? " · " + fmtNum(c.host_disk_total_gb) + " GB disk" : ""}</span></div>
-      <div class="kv" style="grid-column: 1 / -1;"><span class="k">cpu reserved</span><span class="v">${fmtFloat(c.reserved_cpu)} / ${fmtFloat(c.cpu_budget)} budget <span class="muted">(${cpuBreakdown})</span></span></div>
-      <div class="kv" style="grid-column: 1 / -1;"><span class="k">memory reserved</span><span class="v">${fmtNum(c.reserved_memory_mb)} / ${fmtNum(c.memory_budget_mb)} MB budget <span class="muted">(${memBreakdown})</span></span></div>
-      <div class="kv" style="grid-column: 1 / -1;"><span class="k">disk reserved</span><span class="v">${fmtNum(c.reserved_disk_gb)} / ${fmtNum(c.disk_budget_gb)} GB budget <span class="muted">(${diskBreakdown})</span></span></div>
+      <div class="kv" style="grid-column: 1 / -1;"><span class="k">cpu reserved / available</span><span class="v">${fmtFloat(c.reserved_cpu)} / ${fmtFloat(c.available_cpu)} available / ${fmtFloat(c.cpu_budget)} budget <span class="muted">(${cpuBreakdown})</span></span></div>
+      <div class="kv" style="grid-column: 1 / -1;"><span class="k">memory reserved / available</span><span class="v">${fmtNum(c.reserved_memory_mb)} / ${fmtNum(c.available_memory_mb)} MB available / ${fmtNum(c.memory_budget_mb)} MB budget <span class="muted">(${memBreakdown})</span></span></div>
+      <div class="kv" style="grid-column: 1 / -1;"><span class="k">disk reserved / available</span><span class="v">${fmtNum(c.reserved_disk_gb)} / ${fmtNum(c.available_disk_gb)} GB available / ${fmtNum(c.disk_budget_gb)} GB budget <span class="muted">(${diskBreakdown})</span></span></div>
       <div class="kv"><span class="k">memory free (live)</span><span class="v">${fmtNum(c.live_memory_free_mb)} MB${c.memory_floor_mb ? " <span class='muted'>(floor " + fmtNum(c.memory_floor_mb) + " MB)</span>" : ""}</span></div>
       <div class="kv"><span class="k">gpus</span><span class="v">${c.gpu_count ? fmtNum(c.reserved_gpus) + " / " + fmtNum(c.gpu_count) + " (" + escapeHTML(c.gpu_vendor || "?") + ")" : "—"}</span></div>
       <div class="kv"><span class="k">runtimes</span><span class="v">${escapeHTML((c.supported_runtimes || []).join(", ") || "—")}</span></div>
@@ -376,6 +420,19 @@ async function loadCluster() {
     el("cluster-leader").textContent = leader.leader || "(single-node or no leader)";
     const ms = members.members || [];
     el("cluster-count").textContent = fmtNum(ms.length);
+    const agg = aggregateCapacity(ms);
+    if (agg.nodes === 0) {
+      el("cluster-capacity-row").innerHTML = `<span class="muted">no capacity heartbeats yet</span>`;
+    } else {
+      el("cluster-capacity-row").innerHTML = `
+        <div class="kv"><span class="k">capacity heartbeats</span><span class="v">${fmtNum(agg.nodes)} nodes${agg.stale ? " · " + fmtNum(agg.stale) + " stale" : ""}</span></div>
+        <div class="kv"><span class="k">sandboxes</span><span class="v">${fmtNum(agg.sandboxes)}</span></div>
+        <div class="kv"><span class="k">cpu available</span><span class="v">${fmtFloat(agg.availableCPU)} / ${fmtFloat(agg.cpuBudget)} cores <span class="muted">(${fmtCapacityPct(agg.reservedCPU, agg.cpuBudget)} used)</span></span></div>
+        <div class="kv"><span class="k">memory available</span><span class="v">${fmtNum(agg.availableMem)} / ${fmtNum(agg.memBudget)} MB <span class="muted">(${fmtCapacityPct(agg.reservedMem, agg.memBudget)} used)</span></span></div>
+        <div class="kv"><span class="k">disk available</span><span class="v">${fmtNum(agg.availableDisk)} / ${fmtNum(agg.diskBudget)} GB budget <span class="muted">${agg.hostDisk ? "· " + fmtNum(agg.diskFree) + " / " + fmtNum(agg.hostDisk) + " GB host free" : ""}</span></span></div>
+        <div class="kv"><span class="k">gpu available</span><span class="v">${agg.gpuCount ? fmtNum(agg.availableGPUs) + " / " + fmtNum(agg.gpuCount) : "—"}</span></div>
+      `;
+    }
     if (ms.length === 0) {
       el("members-tbody").innerHTML = `<tr><td colspan="9" class="muted">no peers gossiped</td></tr>`;
       return;
@@ -386,9 +443,10 @@ async function loadCluster() {
       const cap = m.capacity || {};
       const cpuUse = cap.cpu_budget > 0 ? (cap.reserved_cpu || 0) / cap.cpu_budget : 0;
       const memUse = cap.memory_budget_mb > 0 ? (cap.reserved_memory_mb || 0) / cap.memory_budget_mb : 0;
-      const capSummary = (cap.host_cpu_cores != null)
-        ? `${fmtNum(cap.sandboxes_active || 0)} sb · cpu ${fmtFloat(cap.reserved_cpu || 0)}/${fmtFloat(cap.cpu_budget || 0)} (${fmtPct(cpuUse)}) · mem ${fmtNum(cap.reserved_memory_mb || 0)}/${fmtNum(cap.memory_budget_mb || 0)} MB (${fmtPct(memUse)})`
-        : "—";
+      const diskUse = cap.disk_budget_gb > 0 ? (cap.reserved_disk_gb || 0) / cap.disk_budget_gb : 0;
+      const capSummary = (cap.host_cpu_cores > 0 || cap.host_memory_total_mb > 0)
+        ? `${m.capacity_stale ? "STALE · " : ""}${fmtNum(cap.sandboxes_active || 0)} sb · cpu ${fmtFloat(cap.available_cpu || 0)} free/${fmtFloat(cap.cpu_budget || 0)} (${fmtPct(cpuUse)} used) · mem ${fmtNum(cap.available_memory_mb || 0)} MB free/${fmtNum(cap.memory_budget_mb || 0)} (${fmtPct(memUse)} used) · disk ${fmtNum(cap.available_disk_gb || 0)} GB free/${fmtNum(cap.disk_budget_gb || 0)} (${fmtPct(diskUse)} used)${cap.gpu_count ? " · gpu " + fmtNum(cap.available_gpus || 0) + "/" + fmtNum(cap.gpu_count) : ""}`
+        : (m.capacity_stale ? "STALE / missing heartbeat" : "—");
       const drainBtn = m.drained
         ? `<button data-action="uncordon" data-id="${escapeHTML(m.node_id)}">Uncordon</button>`
         : `<button class="danger" data-action="drain" data-id="${escapeHTML(m.node_id)}">Drain</button>`;
@@ -409,6 +467,7 @@ async function loadCluster() {
       `;
     }).join("");
   } catch (err) {
+    el("cluster-capacity-row").innerHTML = `<span class="error">${escapeHTML(err.message)}</span>`;
     el("members-tbody").innerHTML = `<tr><td colspan="9" class="error">${escapeHTML(err.message)}</td></tr>`;
   }
 }

--- a/pkg/api/e2b/errors.go
+++ b/pkg/api/e2b/errors.go
@@ -79,7 +79,10 @@ func writeStoreAwareError(logger *slog.Logger, w http.ResponseWriter, err error)
 		WriteError(w, http.StatusServiceUnavailable, message)
 		return
 	}
-	if errors.Is(err, cluster.ErrNoPlacementTarget) {
+	if errors.Is(err, cluster.ErrNoPlacementTarget) || errors.Is(err, cluster.ErrInvalidTopology) {
+		if errors.Is(err, cluster.ErrInvalidTopology) {
+			w.Header().Set("Retry-After", "300")
+		}
 		WriteError(w, http.StatusServiceUnavailable, err.Error())
 		return
 	}

--- a/pkg/api/e2b/errors.go
+++ b/pkg/api/e2b/errors.go
@@ -67,7 +67,7 @@ func writeStoreAwareError(logger *slog.Logger, w http.ResponseWriter, err error)
 		WriteError(w, http.StatusConflict, "Snapshot name already in use")
 		return
 	}
-	if errors.Is(err, capacity.ErrCapacityExceeded) {
+	if errors.Is(err, capacity.ErrCapacityExceeded) || errors.Is(err, cluster.ErrCapacityExceeded) {
 		if logger != nil {
 			logger.Info("capacity rejected", "error", err)
 		}
@@ -77,6 +77,11 @@ func writeStoreAwareError(logger *slog.Logger, w http.ResponseWriter, err error)
 			message = message[:200]
 		}
 		WriteError(w, http.StatusServiceUnavailable, message)
+		return
+	}
+	if errors.Is(err, cluster.ErrCreateBackpressure) {
+		w.Header().Set("Retry-After", "5")
+		WriteError(w, http.StatusTooManyRequests, err.Error())
 		return
 	}
 	if errors.Is(err, cluster.ErrNoPlacementTarget) || errors.Is(err, cluster.ErrInvalidTopology) {

--- a/pkg/api/middleware.go
+++ b/pkg/api/middleware.go
@@ -11,6 +11,11 @@ import (
 
 	"github.com/aerol-ai/microvm/pkg/api/apihttp"
 	apie2b "github.com/aerol-ai/microvm/pkg/api/e2b"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 // extractBearerToken returns the caller's bearer token from either:
@@ -64,17 +69,45 @@ func (s *Server) requireE2BAuth(next http.Handler) http.Handler {
 func loggingMiddleware(logger *slog.Logger, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
+		ctx := otel.GetTextMapPropagator().Extract(r.Context(), propagation.HeaderCarrier(r.Header))
+		ctx, span := otel.Tracer("github.com/aerol-ai/microvm/pkg/api").Start(ctx, r.Method+" "+r.URL.Path,
+			oteltrace.WithSpanKind(oteltrace.SpanKindServer),
+			oteltrace.WithAttributes(
+				attribute.String("http.request.method", r.Method),
+				attribute.String("url.path", r.URL.Path),
+				attribute.String("network.protocol.name", r.Proto),
+			),
+		)
+		defer span.End()
+		r = r.WithContext(ctx)
 		// Wrap the writer so we can record the status code and whether the
 		// connection was hijacked (i.e. WebSocket upgrade succeeded). The
 		// wrapper proxies http.Hijacker / http.Flusher so the toolbox proxy
 		// can still upgrade through this middleware.
 		rec := &statusRecorder{ResponseWriter: w}
 		next.ServeHTTP(rec, r)
+		duration := time.Since(start)
+		status := rec.statusCode()
+		if r.Pattern != "" {
+			route := strings.TrimPrefix(r.Pattern, r.Method+" ")
+			span.SetName(r.Method + " " + route)
+			span.SetAttributes(attribute.String("http.route", route))
+		}
+		span.SetAttributes(
+			attribute.Int("http.response.status_code", status),
+			attribute.Int64("http.server.duration_ms", duration.Milliseconds()),
+		)
+		if rec.hijacked {
+			span.SetAttributes(attribute.Bool("aerolvm.http.hijacked", true))
+		}
+		if status >= http.StatusInternalServerError {
+			span.SetStatus(codes.Error, http.StatusText(status))
+		}
 		fields := []any{
 			"method", r.Method,
 			"path", r.URL.Path,
-			"duration", time.Since(start),
-			"status", rec.statusCode(),
+			"duration", duration,
+			"status", status,
 		}
 		if rec.hijacked {
 			fields = append(fields, "hijacked", true)

--- a/pkg/api/middleware_test.go
+++ b/pkg/api/middleware_test.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestLoggingMiddlewareCreatesHTTPServerSpan(t *testing.T) {
+	oldTracerProvider := otel.GetTracerProvider()
+	oldPropagator := otel.GetTextMapPropagator()
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(recorder),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	otel.SetTracerProvider(provider)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() {
+		otel.SetTracerProvider(oldTracerProvider)
+		otel.SetTextMapPropagator(oldPropagator)
+		_ = provider.Shutdown(context.Background())
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /v1/sandboxes/{id}", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusServiceUnavailable)
+	})
+	handler := loggingMiddleware(slog.New(slog.NewTextHandler(io.Discard, nil)), mux)
+
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/v1/sandboxes/sb-1", nil))
+
+	spans := recorder.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	span := spans[0]
+	if span.Name() != "GET /v1/sandboxes/{id}" {
+		t.Fatalf("unexpected span name: %q", span.Name())
+	}
+	if got := spanStringAttr(span, "http.route"); got != "/v1/sandboxes/{id}" {
+		t.Fatalf("unexpected route attr: %q", got)
+	}
+	if got := spanStringAttr(span, "http.request.method"); got != http.MethodGet {
+		t.Fatalf("unexpected method attr: %q", got)
+	}
+	if got := spanIntAttr(span, "http.response.status_code"); got != http.StatusServiceUnavailable {
+		t.Fatalf("unexpected status attr: %d", got)
+	}
+	if span.Status().Code != codes.Error {
+		t.Fatalf("expected error status for 503, got %v", span.Status().Code)
+	}
+}
+
+func spanStringAttr(span sdktrace.ReadOnlySpan, key string) string {
+	for _, attr := range span.Attributes() {
+		if string(attr.Key) == key {
+			return attr.Value.AsString()
+		}
+	}
+	return ""
+}
+
+func spanIntAttr(span sdktrace.ReadOnlySpan, key string) int64 {
+	for _, attr := range span.Attributes() {
+		if string(attr.Key) == key {
+			return attr.Value.AsInt64()
+		}
+	}
+	return 0
+}

--- a/pkg/api/prometheus.go
+++ b/pkg/api/prometheus.go
@@ -116,7 +116,15 @@ func isFinite(v float64) bool {
 }
 
 func prometheusMetricType(name string) string {
-	if strings.HasSuffix(name, "_total") {
+	// Histogram families publish three monotonically non-decreasing series
+	// (_bucket, _count, _sum) alongside their _total counters. Prometheus
+	// tooling (rate(), histogram_quantile()) requires all of them to be
+	// declared as counters; tagging them as gauges silently breaks queries.
+	switch {
+	case strings.HasSuffix(name, "_total"),
+		strings.HasSuffix(name, "_bucket"),
+		strings.HasSuffix(name, "_count"),
+		strings.HasSuffix(name, "_sum"):
 		return "counter"
 	}
 	return "gauge"

--- a/pkg/api/prometheus.go
+++ b/pkg/api/prometheus.go
@@ -1,0 +1,166 @@
+package api
+
+import (
+	"expvar"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+const prometheusContentType = "text/plain; version=0.0.4; charset=utf-8"
+
+type prometheusSample struct {
+	name   string
+	labels []prometheusLabel
+	value  string
+	typ    string
+}
+
+type prometheusLabel struct {
+	name  string
+	value string
+}
+
+func (s *Server) servePrometheusMetrics(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", prometheusContentType)
+	w.Header().Set("Cache-Control", "no-store")
+	if err := writePrometheusExpvars(w); err != nil {
+		s.logger.Warn("prometheus metrics render failed", "error", err)
+	}
+}
+
+func writePrometheusExpvars(w io.Writer) error {
+	var samples []prometheusSample
+	expvar.Do(func(kv expvar.KeyValue) {
+		if !strings.HasPrefix(kv.Key, "aerolvm_") {
+			return
+		}
+		collectPrometheusSamples(prometheusMetricName(kv.Key), kv.Value, nil, &samples)
+	})
+	sort.Slice(samples, func(i, j int) bool {
+		if samples[i].name != samples[j].name {
+			return samples[i].name < samples[j].name
+		}
+		return prometheusLabelsString(samples[i].labels) < prometheusLabelsString(samples[j].labels)
+	})
+	seen := make(map[string]struct{})
+	for _, s := range samples {
+		if _, ok := seen[s.name]; !ok {
+			seen[s.name] = struct{}{}
+			if _, err := fmt.Fprintf(w, "# HELP %s AerolVM expvar metric %s.\n", s.name, s.name); err != nil {
+				return err
+			}
+			if _, err := fmt.Fprintf(w, "# TYPE %s %s\n", s.name, s.typ); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintf(w, "%s%s %s\n", s.name, prometheusLabelsString(s.labels), s.value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func collectPrometheusSamples(name string, v expvar.Var, labels []prometheusLabel, samples *[]prometheusSample) {
+	if m, ok := v.(*expvar.Map); ok {
+		index := len(labels) + 1
+		labelName := "key"
+		if index > 1 {
+			labelName = "key" + strconv.Itoa(index)
+		}
+		m.Do(func(kv expvar.KeyValue) {
+			childLabels := append(append([]prometheusLabel(nil), labels...), prometheusLabel{name: labelName, value: kv.Key})
+			collectPrometheusSamples(name, kv.Value, childLabels, samples)
+		})
+		return
+	}
+	value, ok := prometheusValue(v)
+	if !ok {
+		return
+	}
+	*samples = append(*samples, prometheusSample{
+		name:   name,
+		labels: append([]prometheusLabel(nil), labels...),
+		value:  value,
+		typ:    prometheusMetricType(name),
+	})
+}
+
+func prometheusValue(v expvar.Var) (string, bool) {
+	switch typed := v.(type) {
+	case *expvar.Int:
+		return strconv.FormatInt(typed.Value(), 10), true
+	case *expvar.Float:
+		value := typed.Value()
+		if !isFinite(value) {
+			return "", false
+		}
+		return strconv.FormatFloat(value, 'g', -1, 64), true
+	default:
+		raw := strings.TrimSpace(v.String())
+		value, err := strconv.ParseFloat(raw, 64)
+		if err != nil || !isFinite(value) {
+			return "", false
+		}
+		return strconv.FormatFloat(value, 'g', -1, 64), true
+	}
+}
+
+func isFinite(v float64) bool {
+	return !math.IsNaN(v) && !math.IsInf(v, 0)
+}
+
+func prometheusMetricType(name string) string {
+	if strings.HasSuffix(name, "_total") {
+		return "counter"
+	}
+	return "gauge"
+}
+
+func prometheusMetricName(name string) string {
+	var b strings.Builder
+	for i, r := range name {
+		valid := r == '_' || r == ':' || unicode.IsLetter(r) || (i > 0 && unicode.IsDigit(r))
+		if !valid {
+			b.WriteByte('_')
+			continue
+		}
+		b.WriteRune(r)
+	}
+	out := b.String()
+	if out == "" || unicode.IsDigit(rune(out[0])) {
+		return "_" + out
+	}
+	return out
+}
+
+func prometheusLabelsString(labels []prometheusLabel) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteByte('{')
+	for i, label := range labels {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(label.name)
+		b.WriteString("=\"")
+		b.WriteString(escapePrometheusLabel(label.value))
+		b.WriteByte('"')
+	}
+	b.WriteByte('}')
+	return b.String()
+}
+
+func escapePrometheusLabel(value string) string {
+	value = strings.ReplaceAll(value, "\\", "\\\\")
+	value = strings.ReplaceAll(value, "\n", "\\n")
+	value = strings.ReplaceAll(value, "\"", "\\\"")
+	return value
+}

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -2,12 +2,15 @@ package api
 
 import (
 	"encoding/json"
+	"expvar"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aerol-ai/microvm/internal/config"
 )
@@ -116,6 +119,8 @@ func TestRequireAuthCases(t *testing.T) {
 //     correct bearer token. The stdlib expvar handler always publishes
 //     "cmdline" and "memstats" so the JSON shape is stable even with a
 //     nil service.
+//  3. GET /v1/metrics is PAT-gated and renders aerolvm_* expvars in
+//     Prometheus text format for production scrapers.
 func TestDashboardEndpoints(t *testing.T) {
 	server := NewServer(slog.New(slog.NewTextHandler(io.Discard, nil)), nil, nil, config.Config{}, "pat-token")
 
@@ -161,6 +166,46 @@ func TestDashboardEndpoints(t *testing.T) {
 		// cmdline to prove we got the real handler and not an empty body.
 		if _, ok := parsed["cmdline"]; !ok {
 			t.Fatalf("expvar body missing standard \"cmdline\" key; got keys: %v", keysOf(parsed))
+		}
+	})
+
+	t.Run("prometheus_metrics_requires_auth", func(t *testing.T) {
+		request := httptest.NewRequest(http.MethodGet, "/v1/metrics", nil)
+		response := httptest.NewRecorder()
+		server.Handler().ServeHTTP(response, request)
+		if response.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", response.Code)
+		}
+	})
+
+	t.Run("prometheus_metrics_returns_aerolvm_expvars_with_pat", func(t *testing.T) {
+		scalarName := fmt.Sprintf("aerolvm_api_prometheus_test_scalar_%d", time.Now().UnixNano())
+		expvar.NewInt(scalarName).Set(42)
+		mapName := fmt.Sprintf("aerolvm_api_prometheus_test_map_%d", time.Now().UnixNano())
+		mapped := expvar.NewMap(mapName)
+		mapped.Add("route lag", 7)
+
+		request := httptest.NewRequest(http.MethodGet, "/v1/metrics", nil)
+		request.Header.Set("Authorization", "Bearer pat-token")
+		response := httptest.NewRecorder()
+		server.Handler().ServeHTTP(response, request)
+		if response.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", response.Code)
+		}
+		ct := response.Header().Get("Content-Type")
+		if !strings.HasPrefix(ct, "text/plain") {
+			t.Fatalf("Content-Type = %q, want text/plain prefix", ct)
+		}
+		body := response.Body.String()
+		if !strings.Contains(body, "# TYPE "+scalarName+" gauge\n"+scalarName+" 42\n") {
+			t.Fatalf("body missing scalar metric %q:\n%s", scalarName, body)
+		}
+		wantMapLine := mapName + "{key=\"route lag\"} 7\n"
+		if !strings.Contains(body, wantMapLine) {
+			t.Fatalf("body missing map metric line %q:\n%s", wantMapLine, body)
+		}
+		if strings.Contains(body, "cmdline") || strings.Contains(body, "memstats") {
+			t.Fatalf("prometheus endpoint should only expose aerolvm_* expvars; body contains stdlib vars:\n%s", body)
 		}
 	})
 }

--- a/pkg/api/v1/cluster_handler.go
+++ b/pkg/api/v1/cluster_handler.go
@@ -647,6 +647,49 @@ func (h *handlers) clusterMembers(w http.ResponseWriter, r *http.Request) {
 	apihttp.WriteJSON(w, http.StatusOK, map[string]any{"members": view})
 }
 
+// clusterRemoveMember explicitly removes a node from the raft configuration.
+// It is the operator path for decommissioned control-plane members; worker
+// role changes should use /cluster/nodes/{id}/drain before the infrastructure
+// replacement, not this endpoint.
+func (h *handlers) clusterRemoveMember(w http.ResponseWriter, r *http.Request) {
+	if h.deps.Service == nil {
+		apihttp.WriteError(w, http.StatusServiceUnavailable, "cluster: not enabled on this node")
+		return
+	}
+	c := h.deps.Service.Cluster()
+	if c == nil {
+		apihttp.WriteError(w, http.StatusServiceUnavailable, "cluster: not enabled on this node")
+		return
+	}
+	id := strings.TrimSpace(r.PathValue("id"))
+	if id == "" {
+		apihttp.WriteError(w, http.StatusBadRequest, "node id required")
+		return
+	}
+	force := parseBoolQuery(r, "force")
+	commitCtx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	if err := c.RemoveMember(commitCtx, id, force); err != nil {
+		switch {
+		case errors.Is(err, cluster.ErrNotLeader):
+			apihttp.WriteError(w, http.StatusServiceUnavailable, "cluster: not leader")
+		case errors.Is(err, cluster.ErrUnknownMember):
+			apihttp.WriteError(w, http.StatusNotFound, err.Error())
+		case errors.Is(err, cluster.ErrMemberStillAlive), errors.Is(err, cluster.ErrLastVoter):
+			apihttp.WriteError(w, http.StatusConflict, err.Error())
+		default:
+			apihttp.WriteError(w, http.StatusInternalServerError, err.Error())
+		}
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func parseBoolQuery(r *http.Request, key string) bool {
+	raw := strings.ToLower(strings.TrimSpace(r.URL.Query().Get(key)))
+	return raw == "1" || raw == "true" || raw == "yes"
+}
+
 // clusterLeader returns the current Raft leader's node ID.
 func (h *handlers) clusterLeader(w http.ResponseWriter, r *http.Request) {
 	c := h.deps.Service.Cluster()

--- a/pkg/api/v1/cluster_handler.go
+++ b/pkg/api/v1/cluster_handler.go
@@ -191,7 +191,10 @@ func (h *handlers) clusterCreateWrap(w http.ResponseWriter, r *http.Request) {
 
 	target, err := c.SelectPlacement(capacityRequestFromCreate(req))
 	if err != nil {
-		if errors.Is(err, cluster.ErrNoPlacementTarget) {
+		if errors.Is(err, cluster.ErrNoPlacementTarget) || errors.Is(err, cluster.ErrInvalidTopology) {
+			if errors.Is(err, cluster.ErrInvalidTopology) {
+				w.Header().Set("Retry-After", "300")
+			}
 			apihttp.WriteError(w, http.StatusServiceUnavailable, err.Error())
 			return
 		}

--- a/pkg/api/v1/cluster_handler.go
+++ b/pkg/api/v1/cluster_handler.go
@@ -961,6 +961,64 @@ func (h *handlers) clusterInternalPlacementsPage(w http.ResponseWriter, r *http.
 	apihttp.WriteJSON(w, http.StatusOK, resp)
 }
 
+type clusterRecoveryBlobStore interface {
+	StoreRecoveryBlob(context.Context, cluster.RecoveryBlob) error
+	RecoveryBlob(context.Context, string) (cluster.RecoveryBlob, bool, error)
+}
+
+func (h *handlers) clusterInternalRecoveryPut(w http.ResponseWriter, r *http.Request) {
+	ref := strings.TrimSpace(r.PathValue("ref"))
+	if ref == "" {
+		apihttp.WriteError(w, http.StatusBadRequest, "recovery ref required")
+		return
+	}
+	c, ok := h.deps.Service.Cluster().(clusterRecoveryBlobStore)
+	if !ok {
+		apihttp.WriteError(w, http.StatusServiceUnavailable, "cluster: recovery store unavailable on this node")
+		return
+	}
+	var blob cluster.RecoveryBlob
+	if err := json.NewDecoder(r.Body).Decode(&blob); err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if blob.Ref == "" {
+		blob.Ref = ref
+	}
+	if blob.Ref != ref {
+		apihttp.WriteError(w, http.StatusBadRequest, "recovery ref mismatch")
+		return
+	}
+	if err := c.StoreRecoveryBlob(r.Context(), blob); err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *handlers) clusterInternalRecoveryGet(w http.ResponseWriter, r *http.Request) {
+	ref := strings.TrimSpace(r.PathValue("ref"))
+	if ref == "" {
+		apihttp.WriteError(w, http.StatusBadRequest, "recovery ref required")
+		return
+	}
+	c, ok := h.deps.Service.Cluster().(clusterRecoveryBlobStore)
+	if !ok {
+		apihttp.WriteError(w, http.StatusServiceUnavailable, "cluster: recovery store unavailable on this node")
+		return
+	}
+	blob, found, err := c.RecoveryBlob(r.Context(), ref)
+	if err != nil {
+		apihttp.WriteError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if !found {
+		apihttp.WriteError(w, http.StatusNotFound, "recovery blob not found")
+		return
+	}
+	apihttp.WriteJSON(w, http.StatusOK, blob)
+}
+
 func (h *handlers) clusterInternalSelectPlacement(w http.ResponseWriter, r *http.Request) {
 	c := h.deps.Service.Cluster()
 	if c == nil {

--- a/pkg/api/v1/cluster_handler.go
+++ b/pkg/api/v1/cluster_handler.go
@@ -1194,45 +1194,6 @@ func (h *handlers) clusterPlacement(w http.ResponseWriter, r *http.Request) {
 	apihttp.WriteJSON(w, http.StatusOK, resp)
 }
 
-// replicateSpecPatch is the write-through used by mutating handlers (resize,
-// lifecycle) to keep the FSM-replicated spec in sync with the local sandbox.
-// It reads the current spec from the cluster, applies patch, and writes back
-// via UpsertSpec. No-op when:
-//   - cluster is nil (single-node mode handled by Noop returning nil from SpecOf)
-//   - no spec is recorded yet (pre-cluster sandbox; recreate is impossible
-//     until a future write-through bumps the spec — known limitation)
-//
-// Failures are logged at warn rather than failing the response: the local
-// mutation already succeeded and was confirmed to the user. A stale FSM spec
-// only matters if this owner dies before the next successful write-through;
-// the next mutating call (or an explicit reconcile) will refresh it.
-//
-// Race: two concurrent mutations for the same sandbox can clobber each other
-// in the FSM, but the local sandbox is already authoritative — the worst case
-// is a stale spec on a node that hasn't died yet, which the next mutation
-// fixes. Same-sandbox mutations are rare and serialize at the docker layer
-// anyway.
-func (h *handlers) replicateSpecPatch(ctx context.Context, id string, patch func(*models.CreateSandboxRequest)) {
-	c := h.deps.Service.Cluster()
-	if c == nil {
-		return
-	}
-	spec := c.SpecOf(id)
-	if spec == nil {
-		// Pre-cluster sandbox or never-recorded spec; nothing to patch.
-		return
-	}
-	patch(spec)
-	commitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	// Pass an empty secret handle — resize / lifecycle never touch
-	// credentials, so preserving the existing ref is correct.
-	if err := c.UpsertSpec(commitCtx, id, spec, cluster.PlacementSecrets{}); err != nil {
-		h.deps.Logger.Warn("cluster: spec write-through failed; FSM spec stale until next mutation",
-			"sandbox_id", id, "err", err)
-	}
-}
-
 // replicateAddExposedPort write-throughs an expose-port intent to the FSM. The
 // failure profile is identical to replicateSpecPatch: log warn, don't fail the
 // response. The local store already has the exposure recorded; a stale FSM

--- a/pkg/api/v1/cluster_handler.go
+++ b/pkg/api/v1/cluster_handler.go
@@ -194,6 +194,8 @@ func (h *handlers) clusterCreateWrap(w http.ResponseWriter, r *http.Request) {
 		if errors.Is(err, cluster.ErrNoPlacementTarget) || errors.Is(err, cluster.ErrInvalidTopology) {
 			if errors.Is(err, cluster.ErrInvalidTopology) {
 				w.Header().Set("Retry-After", "300")
+			} else {
+				w.Header().Set("Retry-After", strconv.Itoa(cluster.CapacityRetryAfterSeconds))
 			}
 			apihttp.WriteError(w, http.StatusServiceUnavailable, err.Error())
 			return
@@ -201,20 +203,9 @@ func (h *handlers) clusterCreateWrap(w http.ResponseWriter, r *http.Request) {
 		apihttp.WriteError(w, http.StatusInternalServerError, "placement: "+err.Error())
 		return
 	}
-	if target.IsSelf {
-		// Self wins: no reservation needed. There's no network hop where
-		// intermediate state could be lost, so the existing single-commit
-		// flow (CreateSandbox → RecordPlacement) stays correct and avoids
-		// an extra raft round-trip on the local-create critical path.
-		h.createSandboxOnSelectedNode(w, r, req, "")
-		return
-	}
-
-	// Cross-node create: write the reservation BEFORE forwarding so the
-	// cluster has intent the instant Node A loses ownership of the request.
-	// This fixes B2 (intent-before-side-effect) and prevents the multi-node
-	// admission race where two routers both pass T's local admitter before
-	// either's placement is replicated.
+	// Cluster create: write the reservation BEFORE any Docker side effect.
+	// Remote targets need intent before forwarding; self targets need the
+	// same leader-side capacity/backpressure accounting at large scale.
 	sandboxID, err := service.GenerateSandboxID()
 	if err != nil {
 		apihttp.WriteError(w, http.StatusInternalServerError, "cluster: generate sandbox id: "+err.Error())
@@ -239,11 +230,25 @@ func (h *handlers) clusterCreateWrap(w http.ResponseWriter, r *http.Request) {
 			apihttp.WriteError(w, http.StatusConflict, "cluster: reservation conflict on sandbox id")
 			return
 		}
+		if errors.Is(err, cluster.ErrCreateBackpressure) {
+			w.Header().Set("Retry-After", strconv.Itoa(cluster.CreateBackpressureRetryAfterSeconds))
+			apihttp.WriteError(w, http.StatusTooManyRequests, err.Error())
+			return
+		}
+		if errors.Is(err, cluster.ErrCapacityExceeded) || errors.Is(err, cluster.ErrNoPlacementTarget) {
+			w.Header().Set("Retry-After", strconv.Itoa(cluster.CapacityRetryAfterSeconds))
+			apihttp.WriteError(w, http.StatusServiceUnavailable, err.Error())
+			return
+		}
 		apihttp.WriteError(w, http.StatusServiceUnavailable, "cluster: reserve placement failed: "+err.Error())
 		return
 	}
+	if target.IsSelf {
+		service.RecordCreateReservationState("reserve_local")
+		h.createSandboxOnSelectedNode(w, r, req, sandboxID)
+		return
+	}
 	service.RecordCreateReservationState("reserve_remote")
-
 	r.Header.Set(clusterCreateTargetHeader, target.NodeID)
 	r.Header.Set(clusterCreateIDHeader, sandboxID)
 	c.ForwardHTTP(cluster.Endpoint{InternalURL: target.InternalURL, APIURL: target.APIURL}, w, r)
@@ -252,14 +257,14 @@ func (h *handlers) clusterCreateWrap(w http.ResponseWriter, r *http.Request) {
 // createSandboxOnSelectedNode performs the local side effect once placement has
 // already selected this node. Two entry points:
 //
-//   - reservationID == "": self won SelectPlacement on this node. No
-//     reservation was written; run the existing single-commit flow
-//     (CreateSandbox → seal/redact → RecordPlacement).
-//   - reservationID != "": cross-node forward. The router already wrote the
-//     reservation with our redacted spec. Use CreateSandboxWithID against the
-//     reserved ID, store a local secret ref, then RecordPlacement with the
-//     redacted spec + ref — opPlace transitions State=Reserved → Placed
-//     atomically while keeping secret material out of Raft.
+//   - reservationID == "": local-only image path. No cluster reservation was
+//     written because the image cannot be moved to another worker.
+//   - reservationID != "": normal cluster create. The router already wrote
+//     the reservation with our redacted spec, even when this node is the
+//     selected worker. Use CreateSandboxWithID against the reserved ID, store
+//     a local secret ref, then RecordPlacement with the redacted spec + ref —
+//     opPlace transitions State=Reserved → Placed atomically while keeping
+//     secret material out of Raft.
 func (h *handlers) createSandboxOnSelectedNode(w http.ResponseWriter, r *http.Request, req models.CreateSandboxRequest, reservationID string) {
 	if err := h.deps.Service.NormalizeCreateImageDistribution(r.Context(), &req); err != nil {
 		apihttp.WriteError(w, http.StatusBadRequest, err.Error())
@@ -820,6 +825,16 @@ func (h *handlers) clusterInternalApply(w http.ResponseWriter, r *http.Request) 
 	if err := c.ApplyEncoded(r.Context(), body); err != nil {
 		if errors.Is(err, cluster.ErrNotLeader) {
 			apihttp.WriteError(w, http.StatusServiceUnavailable, "cluster: not leader")
+			return
+		}
+		if errors.Is(err, cluster.ErrCreateBackpressure) {
+			w.Header().Set("Retry-After", strconv.Itoa(cluster.CreateBackpressureRetryAfterSeconds))
+			apihttp.WriteError(w, http.StatusTooManyRequests, err.Error())
+			return
+		}
+		if errors.Is(err, cluster.ErrCapacityExceeded) || errors.Is(err, cluster.ErrNoPlacementTarget) {
+			w.Header().Set("Retry-After", strconv.Itoa(cluster.CapacityRetryAfterSeconds))
+			apihttp.WriteError(w, http.StatusServiceUnavailable, err.Error())
 			return
 		}
 		apihttp.WriteError(w, http.StatusInternalServerError, err.Error())

--- a/pkg/api/v1/cluster_handler.go
+++ b/pkg/api/v1/cluster_handler.go
@@ -172,6 +172,10 @@ func (h *handlers) clusterCreateWrap(w http.ResponseWriter, r *http.Request) {
 		apihttp.WriteError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	if err := service.NormalizeCreateFailover(&req); err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	normalizedRaw, err := json.Marshal(req)
 	if err != nil {
 		apihttp.WriteError(w, http.StatusInternalServerError, "cluster: normalize create body: "+err.Error())
@@ -267,6 +271,10 @@ func (h *handlers) clusterCreateWrap(w http.ResponseWriter, r *http.Request) {
 //     secret material out of Raft.
 func (h *handlers) createSandboxOnSelectedNode(w http.ResponseWriter, r *http.Request, req models.CreateSandboxRequest, reservationID string) {
 	if err := h.deps.Service.NormalizeCreateImageDistribution(r.Context(), &req); err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := service.NormalizeCreateFailover(&req); err != nil {
 		apihttp.WriteError(w, http.StatusBadRequest, err.Error())
 		return
 	}

--- a/pkg/api/v1/cluster_handler_test.go
+++ b/pkg/api/v1/cluster_handler_test.go
@@ -765,6 +765,8 @@ type drainStubCluster struct {
 	*cluster.Noop
 	setCalls    []drainSetCall
 	setErr      error
+	removeCalls []removeMemberCall
+	removeErr   error
 	drainedView map[string]bool
 }
 
@@ -773,9 +775,19 @@ type drainSetCall struct {
 	drained bool
 }
 
+type removeMemberCall struct {
+	nodeID string
+	force  bool
+}
+
 func (c *drainStubCluster) SetNodeDrainState(_ context.Context, nodeID string, drained bool) error {
 	c.setCalls = append(c.setCalls, drainSetCall{nodeID, drained})
 	return c.setErr
+}
+
+func (c *drainStubCluster) RemoveMember(_ context.Context, nodeID string, force bool) error {
+	c.removeCalls = append(c.removeCalls, removeMemberCall{nodeID: nodeID, force: force})
+	return c.removeErr
 }
 
 func (c *drainStubCluster) IsNodeDrained(nodeID string) bool {
@@ -879,6 +891,51 @@ func TestClusterDrainNodeRejectsEmptyID(t *testing.T) {
 	}
 	if len(stub.setCalls) != 0 {
 		t.Fatalf("setCalls = %+v, want zero — FSM must not see the empty drain", stub.setCalls)
+	}
+}
+
+func TestClusterRemoveMemberReturns204AndCallsRemove(t *testing.T) {
+	stub := &drainStubCluster{Noop: cluster.NewNoop("node-a", "http://node-a")}
+	h := drainTestHandler(t, stub)
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/cluster/members/node-b?force=true", nil)
+	req.SetPathValue("id", "node-b")
+	rr := httptest.NewRecorder()
+	h.clusterRemoveMember(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d (body=%q)", rr.Code, http.StatusNoContent, rr.Body.String())
+	}
+	if len(stub.removeCalls) != 1 || stub.removeCalls[0].nodeID != "node-b" || !stub.removeCalls[0].force {
+		t.Fatalf("removeCalls = %+v, want one forced node-b removal", stub.removeCalls)
+	}
+}
+
+func TestClusterRemoveMemberMapsLifecycleErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "not leader", err: cluster.ErrNotLeader, want: http.StatusServiceUnavailable},
+		{name: "unknown", err: cluster.ErrUnknownMember, want: http.StatusNotFound},
+		{name: "alive", err: cluster.ErrMemberStillAlive, want: http.StatusConflict},
+		{name: "last voter", err: cluster.ErrLastVoter, want: http.StatusConflict},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := &drainStubCluster{Noop: cluster.NewNoop("node-a", "http://node-a"), removeErr: tc.err}
+			h := drainTestHandler(t, stub)
+
+			req := httptest.NewRequest(http.MethodDelete, "/v1/cluster/members/node-b", nil)
+			req.SetPathValue("id", "node-b")
+			rr := httptest.NewRecorder()
+			h.clusterRemoveMember(rr, req)
+
+			if rr.Code != tc.want {
+				t.Fatalf("status = %d, want %d (body=%q)", rr.Code, tc.want, rr.Body.String())
+			}
+		})
 	}
 }
 

--- a/pkg/api/v1/cluster_handler_test.go
+++ b/pkg/api/v1/cluster_handler_test.go
@@ -223,6 +223,32 @@ func TestClusterCreateWrapReturns409OnReservationNameConflict(t *testing.T) {
 	}
 }
 
+func TestClusterCreateWrapReturns429OnCreateBackpressure(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	svc := service.New(config.Config{}, logger, nil, nil, nil, nil, nil, nil, nil)
+	fakeCluster := &createForwardCluster{
+		Noop:       cluster.NewNoop("node-a", "http://node-a"),
+		target:     cluster.PlacementTarget{NodeID: "node-b", APIURL: "http://node-b:21212", IsSelf: false},
+		reserveErr: cluster.ErrCreateBackpressure,
+	}
+	svc.AttachCluster(fakeCluster)
+	h := &handlers{deps: Deps{Service: svc, Logger: logger}}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/sandboxes", strings.NewReader(`{"image":"alpine"}`))
+	rr := httptest.NewRecorder()
+	h.clusterCreateWrap(rr, req)
+
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusTooManyRequests)
+	}
+	if got := rr.Header().Get("Retry-After"); got != strconv.Itoa(cluster.CreateBackpressureRetryAfterSeconds) {
+		t.Fatalf("Retry-After = %q, want %d", got, cluster.CreateBackpressureRetryAfterSeconds)
+	}
+	if fakeCluster.forwardedPeer != "" {
+		t.Fatalf("ForwardHTTP fired; must not forward on create backpressure")
+	}
+}
+
 func TestClusterCreateWrapReturns503WhenNoWorkerCanOwnSandbox(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	svc := service.New(config.Config{}, logger, nil, nil, nil, nil, nil, nil, nil)

--- a/pkg/api/v1/handlers.go
+++ b/pkg/api/v1/handlers.go
@@ -135,17 +135,8 @@ func (h *handlers) resizeSandbox(w http.ResponseWriter, r *http.Request) {
 		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
 		return
 	}
-	h.replicateSpecPatch(r.Context(), id, func(s *models.CreateSandboxRequest) {
-		if req.CPU > 0 {
-			s.CPU = req.CPU
-		}
-		if req.MemoryMB > 0 {
-			s.MemoryMB = req.MemoryMB
-		}
-		if req.DiskGB > 0 {
-			s.DiskGB = req.DiskGB
-		}
-	})
+	// FSM spec write-through now lives in Service.ResizeSandbox so Daytona and
+	// E2B inherit the same contract.
 	apihttp.WriteJSON(w, http.StatusOK, sandbox)
 }
 
@@ -161,10 +152,7 @@ func (h *handlers) updateLifecycle(w http.ResponseWriter, r *http.Request) {
 		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
 		return
 	}
-	lc := req.Lifecycle
-	h.replicateSpecPatch(r.Context(), id, func(s *models.CreateSandboxRequest) {
-		s.Lifecycle = &lc
-	})
+	// FSM spec write-through now lives in Service.UpdateLifecycle.
 	apihttp.WriteJSON(w, http.StatusOK, sandbox)
 }
 

--- a/pkg/api/v1/routes.go
+++ b/pkg/api/v1/routes.go
@@ -104,6 +104,7 @@ func RegisterRoutes(mux *http.ServeMux, d Deps) {
 	// the v1 surface without violating the v1 freeze (these are net-new
 	// paths, not changes to existing wire format).
 	mux.Handle("GET "+PathPrefix+"/cluster/members", d.Auth(http.HandlerFunc(h.clusterMembers)))
+	mux.Handle("DELETE "+PathPrefix+"/cluster/members/{id}", d.Auth(http.HandlerFunc(h.clusterRemoveMember)))
 	mux.Handle("GET "+PathPrefix+"/cluster/leader", d.Auth(http.HandlerFunc(h.clusterLeader)))
 	mux.Handle("GET "+PathPrefix+"/cluster/placements/{id}", d.Auth(http.HandlerFunc(h.clusterPlacement)))
 	mux.Handle("GET "+PathPrefix+"/cluster/sandbox-index", d.Auth(http.HandlerFunc(h.clusterSandboxIndex)))

--- a/pkg/api/v1/routes.go
+++ b/pkg/api/v1/routes.go
@@ -126,6 +126,8 @@ func RegisterRoutes(mux *http.ServeMux, d Deps) {
 	mux.Handle("GET "+cluster.PublicInternalPlacementsPath, d.Auth(http.HandlerFunc(h.clusterInternalPlacements)))
 	mux.Handle("POST "+cluster.PublicInternalPlacementsQueryPath, d.Auth(http.HandlerFunc(h.clusterInternalPlacementsQuery)))
 	mux.Handle("POST "+cluster.PublicInternalPlacementsPagePath, d.Auth(http.HandlerFunc(h.clusterInternalPlacementsPage)))
+	mux.Handle("PUT "+cluster.PublicInternalRecoveryPath+"{ref}", d.Auth(http.HandlerFunc(h.clusterInternalRecoveryPut)))
+	mux.Handle("GET "+cluster.PublicInternalRecoveryPath+"{ref}", d.Auth(http.HandlerFunc(h.clusterInternalRecoveryGet)))
 	mux.Handle("POST "+cluster.PublicInternalSelectPlacementPath, d.Auth(http.HandlerFunc(h.clusterInternalSelectPlacement)))
 	mux.Handle("GET "+cluster.PublicInternalDrainStatePath+"{id}", d.Auth(http.HandlerFunc(h.clusterInternalDrainState)))
 }

--- a/pkg/api/v1/routes_test.go
+++ b/pkg/api/v1/routes_test.go
@@ -37,6 +37,7 @@ func TestRegisterRoutesAllUseV1Prefix(t *testing.T) {
 		{method: http.MethodGet, path: "/v1/sandboxes/abc"},
 		{method: http.MethodGet, path: "/v1/cluster/sandbox-index"},
 		{method: http.MethodGet, path: "/v1/cluster/ingress-route/abc"},
+		{method: http.MethodDelete, path: "/v1/cluster/members/node-a"},
 		{method: http.MethodPost, path: "/v1/sandboxes/abc/snapshot"},
 		{method: http.MethodGet, path: "/v1/sandboxes/abc/sessions"},
 		{method: http.MethodGet, path: "/v1/sandboxes/abc/toolbox/foo"},

--- a/pkg/capacity/capacity.go
+++ b/pkg/capacity/capacity.go
@@ -20,8 +20,10 @@ package capacity
 import (
 	"errors"
 	"fmt"
+	"os"
 	"runtime"
 	"sync"
+	"syscall"
 )
 
 // ErrCapacityExceeded is returned by Admit when the host cannot accept a new
@@ -79,19 +81,23 @@ type Request struct {
 }
 
 // Snapshot is a read-only view of admitter state, suitable for an HTTP
-// /capacity response. It is also the payload that placement scoring reads
-// off gossip — every field that is needed to decide "can this peer host
-// this request?" must be present here, otherwise placement scores against
-// stale assumptions and the caller fans out to a node that can't actually
-// admit. See nodeMeta in internal/cluster/gossip.go for the size budget.
+// /capacity response. It is also the payload in cluster capacity heartbeats:
+// every field needed to decide "can this peer host this request?" must be
+// present here, otherwise placement scores against stale assumptions and the
+// caller fans out to a node that can't actually admit.
 type Snapshot struct {
 	HostCPUCores              int      `json:"host_cpu_cores"`
 	HostMemoryTotalMB         int      `json:"host_memory_total_mb"`
 	HostDiskTotalGB           int      `json:"host_disk_total_gb,omitempty"`
+	HostDiskFreeGB            int      `json:"host_disk_free_gb,omitempty"`
 	ReservedCPU               float64  `json:"reserved_cpu"`
 	ReservedMemoryMB          int      `json:"reserved_memory_mb"`
 	ReservedDiskGB            int      `json:"reserved_disk_gb,omitempty"`
 	ReservedGPUs              int      `json:"reserved_gpus,omitempty"`
+	AvailableCPU              float64  `json:"available_cpu"`
+	AvailableMemoryMB         int      `json:"available_memory_mb"`
+	AvailableDiskGB           int      `json:"available_disk_gb,omitempty"`
+	AvailableGPUs             int      `json:"available_gpus,omitempty"`
 	LiveMemoryFreeMB          int      `json:"live_memory_free_mb"`
 	SandboxesActive           int      `json:"sandboxes_active"`
 	CanAdmit                  bool     `json:"can_admit"`
@@ -133,11 +139,14 @@ type MemProbe interface {
 type HostInfo struct {
 	CPUCores      int
 	MemoryTotalMB int
-	// DiskTotalGB is the disk budget the operator declares for sandbox
-	// storage (the volume backing Docker's data root). Auto-detection is
-	// out of scope for Phase 1 — operators set SB_HOST_DISK_GB. 0 means
-	// no disk accounting.
+	// DiskTotalGB is the disk budget for sandbox storage. It is auto-detected
+	// from the host filesystem by default and can be overridden by
+	// SB_HOST_DISK_GB when the sandbox pool is smaller than the filesystem.
 	DiskTotalGB int
+	// DiskFreeGB is the currently available space on the detected sandbox
+	// storage filesystem. It is an observability signal; reservation
+	// admission uses DiskTotalGB × DiskReservationRatio.
+	DiskFreeGB int
 	// GPUCount and GPUVendor describe the GPU inventory the operator has
 	// wired up to Docker. Operator-declared (SB_HOST_GPU_COUNT /
 	// SB_HOST_GPU_VENDOR); 0 means no GPUs available.
@@ -190,10 +199,13 @@ func DetectHost() (HostInfo, error) {
 	if err != nil {
 		return HostInfo{}, fmt.Errorf("read host memory: %w", err)
 	}
+	diskTotal, diskFree, diskErr := detectDiskGB(defaultDiskPath())
 	return HostInfo{
 		CPUCores:      runtime.NumCPU(),
 		MemoryTotalMB: mem,
-	}, nil
+		DiskTotalGB:   diskTotal,
+		DiskFreeGB:    diskFree,
+	}, diskErr
 }
 
 // Admit decides whether a new sandbox with the given resource request can be
@@ -363,15 +375,24 @@ func (a *Admitter) Snapshot() Snapshot {
 			free = v
 		}
 	}
+	diskFree := a.host.DiskFreeGB
+	if _, v, err := detectDiskGB(defaultDiskPath()); err == nil {
+		diskFree = v
+	}
 
 	snap := Snapshot{
 		HostCPUCores:              a.host.CPUCores,
 		HostMemoryTotalMB:         a.host.MemoryTotalMB,
 		HostDiskTotalGB:           a.host.DiskTotalGB,
+		HostDiskFreeGB:            diskFree,
 		ReservedCPU:               totalCPU,
 		ReservedMemoryMB:          totalMem,
 		ReservedDiskGB:            totalDisk,
 		ReservedGPUs:              totalGPUs,
+		AvailableCPU:              maxFloat(a.cpuBudget()-totalCPU, 0),
+		AvailableMemoryMB:         maxInt(a.memBudgetMB()-totalMem, 0),
+		AvailableDiskGB:           maxInt(a.diskBudgetGB()-totalDisk, 0),
+		AvailableGPUs:             maxInt(a.host.GPUCount-totalGPUs, 0),
 		LiveMemoryFreeMB:          free,
 		SandboxesActive:           count,
 		CPUReservationRatio:       a.limits.CPUReservationRatio,
@@ -513,4 +534,51 @@ func (a *Admitter) runtimeSupported(runtime string) bool {
 		}
 	}
 	return false
+}
+
+func defaultDiskPath() string {
+	if _, err := os.Stat("/var/lib/docker"); err == nil {
+		return "/var/lib/docker"
+	}
+	return "/"
+}
+
+func detectDiskGB(path string) (int, int, error) {
+	if path == "" {
+		path = "/"
+	}
+	var st syscall.Statfs_t
+	if err := syscall.Statfs(path, &st); err != nil {
+		return 0, 0, fmt.Errorf("read host disk: %w", err)
+	}
+	blockSize := uint64(st.Bsize)
+	total := bytesToGB(uint64(st.Blocks) * blockSize)
+	free := bytesToGB(uint64(st.Bavail) * blockSize)
+	return total, free, nil
+}
+
+func bytesToGB(bytes uint64) int {
+	if bytes == 0 {
+		return 0
+	}
+	const gib = uint64(1024 * 1024 * 1024)
+	gb := bytes / gib
+	if gb == 0 {
+		return 1
+	}
+	return int(gb)
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func maxFloat(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/pkg/capacity/capacity_test.go
+++ b/pkg/capacity/capacity_test.go
@@ -691,7 +691,8 @@ func TestNewDefaultsSupportedRuntimes(t *testing.T) {
 }
 
 // TestSnapshotReportsDiskGPURuntime: placement scoring on a peer reads these
-// fields off gossip, so they must round-trip through Snapshot accurately.
+// fields off capacity heartbeats, so they must round-trip through Snapshot
+// accurately.
 func TestSnapshotReportsDiskGPURuntime(t *testing.T) {
 	a := New(HostInfo{
 		CPUCores: 8, MemoryTotalMB: 8000,
@@ -709,6 +710,12 @@ func TestSnapshotReportsDiskGPURuntime(t *testing.T) {
 	snap := a.Snapshot()
 	if snap.HostDiskTotalGB != 200 || snap.DiskBudgetGB != 100 || snap.ReservedDiskGB != 30 {
 		t.Fatalf("disk fields wrong: %+v", snap)
+	}
+	if snap.AvailableDiskGB != 70 {
+		t.Fatalf("AvailableDiskGB = %d, want 70", snap.AvailableDiskGB)
+	}
+	if snap.AvailableCPU != 7 || snap.AvailableMemoryMB != 7900 || snap.AvailableGPUs != 2 {
+		t.Fatalf("available fields wrong: %+v", snap)
 	}
 	if snap.GPUCount != 4 || snap.GPUVendor != "nvidia" {
 		t.Fatalf("gpu inventory wrong: %+v", snap)

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -61,11 +61,20 @@ type Client struct {
 	toolboxWaitTimeout time.Duration
 	pullMu             sync.Mutex
 	pulls              map[string]*imagePull
+	pullSlots          chan struct{}
+	pullBackoff        time.Duration
+	pullFailures       map[string]imagePullFailure
 }
 
 type imagePull struct {
 	done chan struct{}
 	err  error
+}
+
+type imagePullFailure struct {
+	err       error
+	retryAt   time.Time
+	createdAt time.Time
 }
 
 func New(logger *slog.Logger, cfg config.Config, rules *netrules.Manager) (*Client, error) {
@@ -84,6 +93,10 @@ func New(logger *slog.Logger, cfg config.Config, rules *netrules.Manager) (*Clie
 		},
 	}
 
+	var pullSlots chan struct{}
+	if cfg.ImagePullMaxConcurrent > 0 {
+		pullSlots = make(chan struct{}, cfg.ImagePullMaxConcurrent)
+	}
 	return &Client{
 		logger:             logger,
 		socketPath:         socketPath,
@@ -101,6 +114,9 @@ func New(logger *slog.Logger, cfg config.Config, rules *netrules.Manager) (*Clie
 		waitTimeout:        cfg.DockerRuntimeWaitTimeout,
 		toolboxWaitTimeout: cfg.ToolboxWaitTimeout,
 		pulls:              make(map[string]*imagePull),
+		pullSlots:          pullSlots,
+		pullBackoff:        cfg.ImagePullFailureBackoff,
+		pullFailures:       make(map[string]imagePullFailure),
 	}, nil
 }
 
@@ -663,28 +679,118 @@ func (c *Client) pullImage(ctx context.Context, imageRef string, auth *models.Re
 }
 
 func (c *Client) pullImageDedup(ctx context.Context, imageRef string, auth *models.RegistryAuth) error {
+	finishMetric := beginImagePullMetric()
+	var resultErr error
+	defer func() { finishMetric(resultErr) }()
+
 	key := imagePullKey(imageRef, auth)
 	c.pullMu.Lock()
 	if inFlight := c.pulls[key]; inFlight != nil {
+		recordImagePullDedupWaiter()
 		c.pullMu.Unlock()
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			resultErr = ctx.Err()
+			return resultErr
 		case <-inFlight.done:
-			return inFlight.err
+			resultErr = inFlight.err
+			return resultErr
 		}
+	}
+	if failure, blocked := c.pullBackoffFailureLocked(key, time.Now()); blocked {
+		recordImagePullBackoffReject()
+		c.pullMu.Unlock()
+		resultErr = fmt.Errorf("pull image %s suppressed by failure backoff until %s: %w", imageRef, failure.retryAt.Format(time.RFC3339), failure.err)
+		return resultErr
 	}
 	inFlight := &imagePull{done: make(chan struct{})}
 	c.pulls[key] = inFlight
 	c.pullMu.Unlock()
 
-	inFlight.err = c.pullImage(ctx, imageRef, auth)
+	slotAcquired, err := c.acquirePullSlot(ctx)
+	if err != nil {
+		inFlight.err = err
+	} else {
+		inFlight.err = c.pullImage(ctx, imageRef, auth)
+		if slotAcquired {
+			c.releasePullSlot()
+		}
+	}
 
 	c.pullMu.Lock()
 	delete(c.pulls, key)
+	c.recordPullFailureLocked(key, inFlight.err)
 	c.pullMu.Unlock()
 	close(inFlight.done)
-	return inFlight.err
+	resultErr = inFlight.err
+	return resultErr
+}
+
+func (c *Client) pullBackoffFailureLocked(key string, now time.Time) (imagePullFailure, bool) {
+	if c.pullBackoff <= 0 || c.pullFailures == nil {
+		return imagePullFailure{}, false
+	}
+	failure, ok := c.pullFailures[key]
+	if !ok {
+		return imagePullFailure{}, false
+	}
+	if now.Before(failure.retryAt) {
+		return failure, true
+	}
+	delete(c.pullFailures, key)
+	return imagePullFailure{}, false
+}
+
+func (c *Client) recordPullFailureLocked(key string, err error) {
+	if c.pullFailures == nil {
+		c.pullFailures = make(map[string]imagePullFailure)
+	}
+	if err == nil || c.pullBackoff <= 0 {
+		delete(c.pullFailures, key)
+		return
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		delete(c.pullFailures, key)
+		return
+	}
+	now := time.Now()
+	c.pullFailures[key] = imagePullFailure{
+		err:       err,
+		createdAt: now,
+		retryAt:   now.Add(c.pullBackoff),
+	}
+}
+
+func (c *Client) acquirePullSlot(ctx context.Context) (bool, error) {
+	if c.pullSlots == nil {
+		return false, nil
+	}
+	select {
+	case c.pullSlots <- struct{}{}:
+		imagePullInflight.Add(1)
+		return true, nil
+	default:
+	}
+	imagePullQueued.Add(1)
+	defer imagePullQueued.Add(-1)
+	select {
+	case c.pullSlots <- struct{}{}:
+		imagePullInflight.Add(1)
+		return true, nil
+	case <-ctx.Done():
+		return false, ctx.Err()
+	}
+}
+
+func (c *Client) releasePullSlot() {
+	if c.pullSlots == nil {
+		return
+	}
+	select {
+	case <-c.pullSlots:
+		imagePullInflight.Add(-1)
+	default:
+	}
 }
 
 func imagePullKey(imageRef string, auth *models.RegistryAuth) string {

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -759,6 +759,32 @@ func (c *Client) recordPullFailureLocked(key string, err error) {
 		createdAt: now,
 		retryAt:   now.Add(c.pullBackoff),
 	}
+	// Opportunistically prune entries whose backoff window has already
+	// elapsed: they would normally be deleted lazily on the next pull of the
+	// same key, but a unique image/auth combination that fails once and is
+	// never retried would otherwise sit in the map forever. We bound the
+	// per-call work so the lock stays cheap even with a large map.
+	pruneExpiredPullFailuresLocked(c.pullFailures, now, pullFailureMaxPrunePerCall)
+}
+
+// pullFailureMaxPrunePerCall caps how many expired entries a single
+// recordPullFailureLocked call evicts. The bound keeps the critical section
+// short under pull-storm conditions; subsequent calls keep draining the map.
+const pullFailureMaxPrunePerCall = 32
+
+func pruneExpiredPullFailuresLocked(failures map[string]imagePullFailure, now time.Time, budget int) {
+	if budget <= 0 || len(failures) == 0 {
+		return
+	}
+	for key, failure := range failures {
+		if budget == 0 {
+			return
+		}
+		if !now.Before(failure.retryAt) {
+			delete(failures, key)
+			budget--
+		}
+	}
 }
 
 func (c *Client) acquirePullSlot(ctx context.Context) (bool, error) {

--- a/pkg/docker/client_test.go
+++ b/pkg/docker/client_test.go
@@ -1,6 +1,15 @@
 package docker
 
-import "testing"
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
 
 func TestSandboxIDFromContainerNameCases(t *testing.T) {
 	tests := []struct {
@@ -57,5 +66,80 @@ func TestSplitSnapshotImageRefCases(t *testing.T) {
 				t.Fatalf("splitSnapshotImageRef(%q) = (%q, %q), want (%q, %q)", tc.input, repo, tag, tc.wantRepo, tc.wantTag)
 			}
 		})
+	}
+}
+
+func TestPullImageDedupSharesInflightPull(t *testing.T) {
+	var calls atomic.Int64
+	release := make(chan struct{})
+	client := &Client{
+		logger: slog.Default(),
+		streamClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			calls.Add(1)
+			<-release
+			return pullResponse(`{"status":"done"}`), nil
+		})},
+		pulls:        make(map[string]*imagePull),
+		pullFailures: make(map[string]imagePullFailure),
+		pullBackoff:  time.Minute,
+	}
+
+	errs := make(chan error, 2)
+	go func() { errs <- client.pullImageDedup(context.Background(), "busybox:latest", nil) }()
+	for deadline := time.Now().Add(time.Second); calls.Load() == 0 && time.Now().Before(deadline); {
+		time.Sleep(10 * time.Millisecond)
+	}
+	go func() { errs <- client.pullImageDedup(context.Background(), "busybox:latest", nil) }()
+
+	time.Sleep(25 * time.Millisecond)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("pull calls while first in-flight = %d, want 1", got)
+	}
+	close(release)
+	for i := 0; i < 2; i++ {
+		if err := <-errs; err != nil {
+			t.Fatalf("pullImageDedup error = %v", err)
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("pull calls after waiters completed = %d, want 1", got)
+	}
+}
+
+func TestPullImageDedupBacksOffAfterFailure(t *testing.T) {
+	var calls atomic.Int64
+	client := &Client{
+		logger: slog.Default(),
+		streamClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			calls.Add(1)
+			return pullResponse(`{"error":"too many requests"}`), nil
+		})},
+		pulls:        make(map[string]*imagePull),
+		pullFailures: make(map[string]imagePullFailure),
+		pullBackoff:  time.Minute,
+	}
+
+	if err := client.pullImageDedup(context.Background(), "registry.example/app:bad", nil); err == nil {
+		t.Fatalf("first pull expected error")
+	}
+	if err := client.pullImageDedup(context.Background(), "registry.example/app:bad", nil); err == nil || !strings.Contains(err.Error(), "backoff") {
+		t.Fatalf("second pull expected backoff error, got %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("pull calls = %d, want 1 while backoff is active", got)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func pullResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
 	}
 }

--- a/pkg/docker/metrics.go
+++ b/pkg/docker/metrics.go
@@ -1,0 +1,72 @@
+package docker
+
+import (
+	"context"
+	"errors"
+	"expvar"
+	"strings"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/scaleobs"
+)
+
+var (
+	imagePullRequestsTotal     = expvar.NewInt("aerolvm_image_pull_requests_total")
+	imagePullDedupWaitersTotal = expvar.NewInt("aerolvm_image_pull_dedup_waiters_total")
+	imagePullInflight          = expvar.NewInt("aerolvm_image_pull_inflight")
+	imagePullQueued            = expvar.NewInt("aerolvm_image_pull_queued")
+	imagePullBackoffRejects    = expvar.NewInt("aerolvm_image_pull_backoff_rejects_total")
+	imagePullErrors            = expvar.NewMap("aerolvm_image_pull_errors_total")
+	imagePullLastNanos         = expvar.NewInt("aerolvm_image_pull_last_nanos")
+	imagePullLatency           = scaleobs.NewDurationBuckets("aerolvm_image_pull_latency_seconds_bucket")
+)
+
+func beginImagePullMetric() func(error) {
+	imagePullRequestsTotal.Add(1)
+	start := time.Now()
+	return func(err error) {
+		elapsed := time.Since(start)
+		imagePullLastNanos.Set(elapsed.Nanoseconds())
+		imagePullLatency.Observe(elapsed)
+		if err != nil {
+			scaleobs.Add(imagePullErrors, classifyImagePullError(err), 1)
+		}
+	}
+}
+
+func recordImagePullDedupWaiter() {
+	imagePullDedupWaitersTotal.Add(1)
+}
+
+func recordImagePullBackoffReject() {
+	imagePullBackoffRejects.Add(1)
+}
+
+func classifyImagePullError(err error) string {
+	if err == nil {
+		return ""
+	}
+	if errors.Is(err, context.Canceled) {
+		return "canceled"
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "context canceled"):
+		return "canceled"
+	case strings.Contains(msg, "deadline exceeded"), strings.Contains(msg, "timeout"), strings.Contains(msg, "timed out"):
+		return "timeout"
+	case strings.Contains(msg, "unauthorized"), strings.Contains(msg, "authentication required"), strings.Contains(msg, "denied"):
+		return "auth"
+	case strings.Contains(msg, "manifest unknown"), strings.Contains(msg, "not found"), strings.Contains(msg, "no such image"):
+		return "not_found"
+	case strings.Contains(msg, "too many requests"), strings.Contains(msg, "rate limit"):
+		return "rate_limited"
+	case strings.Contains(msg, "backoff"):
+		return "backoff"
+	default:
+		return "error"
+	}
+}

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -238,6 +238,47 @@ const (
 	ImageDistributionLocalOnly        = "local_only"
 )
 
+const (
+	FailoverPolicyNone     = "none"
+	FailoverPolicyRecreate = "recreate"
+)
+
+// Failover controls what the cluster should do if the sandbox's owner node is
+// declared dead. Empty or omitted means "none": orphan the placement and return
+// 410 Gone. "recreate" opts the sandbox into best-effort recreation from its
+// replicated create spec on another worker.
+type Failover struct {
+	Policy string `json:"policy,omitempty"`
+}
+
+func NormalizeFailoverPolicy(policy string) (string, error) {
+	switch normalized := strings.ToLower(strings.TrimSpace(policy)); normalized {
+	case "", FailoverPolicyNone:
+		return FailoverPolicyNone, nil
+	case FailoverPolicyRecreate:
+		return FailoverPolicyRecreate, nil
+	default:
+		return "", fmt.Errorf("invalid failover policy %q", policy)
+	}
+}
+
+func (f Failover) NormalizedPolicy() string {
+	policy, err := NormalizeFailoverPolicy(f.Policy)
+	if err != nil {
+		return ""
+	}
+	return policy
+}
+
+func (f Failover) ShouldRecreate() bool {
+	return f.NormalizedPolicy() == FailoverPolicyRecreate
+}
+
+func (f Failover) Validate() error {
+	_, err := NormalizeFailoverPolicy(f.Policy)
+	return err
+}
+
 // ImageDistributionMetadata describes whether an image can be materialized on
 // an arbitrary worker. It is deliberately metadata only: registries, AOCR, and
 // cache services remain pluggable deployment choices outside the core daemon.
@@ -289,6 +330,7 @@ type CreateSandboxRequest struct {
 	ContainerCommand []string          `json:"container_command,omitempty"`
 	Mounts           []MountSpec       `json:"mounts,omitempty"`
 	Lifecycle        *Lifecycle        `json:"lifecycle,omitempty"`
+	Failover         *Failover         `json:"failover,omitempty"`
 	// Name is an optional human-readable identifier. When set, it must be
 	// unique across all sandboxes — the store enforces this with a partial
 	// unique index. Empty means no name; the sandbox can only be referenced
@@ -340,6 +382,10 @@ func (r *CreateSandboxRequest) ApplyImageDistribution(meta ImageDistributionMeta
 	r.ImageVerifiedAt = meta.VerifiedAt
 }
 
+func (r CreateSandboxRequest) ShouldRecreateOnFailover() bool {
+	return r.Failover != nil && r.Failover.ShouldRecreate()
+}
+
 type ResizeSandboxRequest struct {
 	CPU      float64 `json:"cpu"`
 	MemoryMB int     `json:"memory_mb"`
@@ -369,6 +415,7 @@ type Sandbox struct {
 	LastError        string            `json:"last_error,omitempty"`
 	ContainerCommand []string          `json:"container_command,omitempty"`
 	Lifecycle        Lifecycle         `json:"lifecycle"`
+	Failover         *Failover         `json:"failover,omitempty"`
 	// Name is the optional unique identifier set at create time. Empty when
 	// the sandbox was created without one (the common path on /v1 today).
 	Name string `json:"name,omitempty"`

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -574,12 +574,14 @@ func ValidExposedPortProtocol(value string) (string, error) {
 }
 
 type HealthStatus struct {
-	Status     string `json:"status"`
-	Sandboxes  int    `json:"sandboxes"`
-	Docker     string `json:"docker"`
-	Caddy      string `json:"caddy"`
-	SSHGateway string `json:"ssh_gateway"`
-	Version    string `json:"version"`
+	Status          string `json:"status"`
+	Sandboxes       int    `json:"sandboxes"`
+	Docker          string `json:"docker"`
+	Caddy           string `json:"caddy"`
+	SSHGateway      string `json:"ssh_gateway"`
+	ClusterTopology string `json:"cluster_topology,omitempty"`
+	ClusterNodes    int    `json:"cluster_nodes,omitempty"`
+	Version         string `json:"version"`
 }
 
 type ExecRequest struct {

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -91,12 +91,15 @@ Options:
                                 comma-separated combination of server / worker
                                 / ingress (e.g. "server,worker") for hybrid
                                 nodes. Default mixed (every component on every
-                                node — fine for small clusters; split at 10+
-                                nodes). "mixed" cannot be combined with other
-                                tokens. The bootstrap node's role set must
-                                contain "server" (or be "mixed"); pure worker
-                                / ingress / worker,ingress refuse to bootstrap
-                                a fresh cluster.
+                                node — fine through 10 live nodes only).
+                                Clusters above 10 live nodes must use
+                                dedicated server, worker, and ingress roles;
+                                mixed and hybrid-role members block placement.
+                                "mixed" cannot be combined with other tokens.
+                                The bootstrap node's role set must contain
+                                "server" (or be "mixed"); pure worker /
+                                ingress / worker,ingress refuse to bootstrap a
+                                fresh cluster.
   --ingress-advertise-host <h>  SB_INGRESS_ADVERTISE_HOST — the public host
                                 in SDK-returned sandbox URLs. Defaults to
                                 empty (URLs use SB_PUBLIC_HOST or

--- a/scripts/cluster-join.sh
+++ b/scripts/cluster-join.sh
@@ -91,7 +91,11 @@ Optional:
                                 "worker,ingress" for a data-plane edge node
                                 that owns sandboxes AND fans out public
                                 ingress without joining the raft quorum).
-                                Default mixed. A role set without "server" /
+                                Default mixed, for clusters through 10 live
+                                nodes only. Clusters above 10 live nodes must
+                                use dedicated server, worker, and ingress
+                                roles; mixed and hybrid-role members block
+                                placement. A role set without "server" /
                                 "mixed" never becomes a raft voter even after
                                 gossip join. "mixed" cannot be combined with
                                 other tokens.

--- a/scripts/raft-lost-quorum-recover.sh
+++ b/scripts/raft-lost-quorum-recover.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: raft-lost-quorum-recover.sh --raft-dir /var/lib/sandboxd/raft --node-id NODE --raft-address HOST:7000 [--force]
+
+Writes peers.json for sandboxd's startup-time lost-quorum recovery path. Run
+only after stopping sandboxd on every survivor and choosing the survivor with
+the most advanced Raft log.
+
+Options:
+  --raft-dir PATH       Raft data directory. Default: /var/lib/sandboxd/raft
+  --node-id ID          Survivor node ID to make the sole voter. Required.
+  --raft-address ADDR   Survivor Raft advertise address. Required.
+  --force              Overwrite an existing peers.json.
+  -h, --help           Show this help.
+USAGE
+}
+
+raft_dir="/var/lib/sandboxd/raft"
+node_id=""
+raft_address=""
+force="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --raft-dir) raft_dir="${2:?missing --raft-dir value}"; shift 2 ;;
+    --node-id) node_id="${2:?missing --node-id value}"; shift 2 ;;
+    --raft-address) raft_address="${2:?missing --raft-address value}"; shift 2 ;;
+    --force) force="true"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$node_id" || -z "$raft_address" ]]; then
+  echo "--node-id and --raft-address are required" >&2
+  usage >&2
+  exit 2
+fi
+
+mkdir -p "$raft_dir"
+peers="$raft_dir/peers.json"
+if [[ -e "$peers" && "$force" != "true" ]]; then
+  echo "$peers already exists; pass --force to overwrite" >&2
+  exit 1
+fi
+
+tmp="$(mktemp "$raft_dir/.peers.json.XXXXXX")"
+cat > "$tmp" <<JSON
+[
+  {
+    "id": "$node_id",
+    "address": "$raft_address",
+    "non_voter": false,
+    "suffrage": "Voter"
+  }
+]
+JSON
+chmod 0600 "$tmp"
+mv "$tmp" "$peers"
+echo "wrote $peers"
+echo "start sandboxd on this node only; successful recovery renames the file to peers.json.applied.<unix>"

--- a/scripts/sandboxd-backup.sh
+++ b/scripts/sandboxd-backup.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: sandboxd-backup.sh --output /path/sandboxd-backup.tar.gz [options]
+
+Options:
+  --state-db PATH        SQLite state DB. Default: /var/lib/sandboxd/state.db
+  --raft-dir PATH        Raft data directory. Default: /var/lib/sandboxd/raft
+  --config-dir PATH      sandboxd config directory. Default: /etc/sandboxd
+  --output PATH          Destination .tar.gz archive. Required.
+  -h, --help             Show this help.
+USAGE
+}
+
+state_db="/var/lib/sandboxd/state.db"
+raft_dir="/var/lib/sandboxd/raft"
+config_dir="/etc/sandboxd"
+output=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --state-db) state_db="${2:?missing --state-db value}"; shift 2 ;;
+    --raft-dir) raft_dir="${2:?missing --raft-dir value}"; shift 2 ;;
+    --config-dir) config_dir="${2:?missing --config-dir value}"; shift 2 ;;
+    --output) output="${2:?missing --output value}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$output" ]]; then
+  echo "--output is required" >&2
+  usage >&2
+  exit 2
+fi
+
+tmpdir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+mkdir -p "$tmpdir/root"
+manifest="$tmpdir/root/MANIFEST.txt"
+{
+  echo "created_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "hostname=$(hostname)"
+  echo "state_db=$state_db"
+  echo "raft_dir=$raft_dir"
+  echo "config_dir=$config_dir"
+} > "$manifest"
+
+copy_if_exists() {
+  local src="$1"
+  local dst="$2"
+  if [[ -e "$src" ]]; then
+    mkdir -p "$(dirname "$dst")"
+    cp -a "$src" "$dst"
+    echo "included=$src" >> "$manifest"
+  else
+    echo "missing=$src" >> "$manifest"
+  fi
+}
+
+copy_if_exists "$state_db" "$tmpdir/root/var/lib/sandboxd/state.db"
+copy_if_exists "$raft_dir" "$tmpdir/root/var/lib/sandboxd/raft"
+copy_if_exists "$config_dir" "$tmpdir/root/etc/sandboxd"
+
+mkdir -p "$(dirname "$output")"
+tar -C "$tmpdir/root" -czf "$output" .
+chmod 0600 "$output"
+echo "wrote $output"

--- a/scripts/sandboxd-node-lifecycle.sh
+++ b/scripts/sandboxd-node-lifecycle.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+	cat >&2 <<'EOF'
+Usage:
+  sandboxd-node-lifecycle.sh drain [NODE] [--wait-empty] [--timeout SECONDS]
+  sandboxd-node-lifecycle.sh uncordon [NODE]
+  sandboxd-node-lifecycle.sh remove-member [NODE] [--force]
+  sandboxd-node-lifecycle.sh pre-role-change [NODE] [--timeout SECONDS]
+
+Options:
+  --node NODE       Node ID. Defaults to SB_NODE_ID from env files.
+  --api-url URL     sandboxd API URL. Defaults to http://127.0.0.1:${SB_API_PORT:-21212}.
+  --env-file PATH   Env file to source. May be repeated.
+  --wait-empty      After drain, wait until the node owns zero placements.
+  --timeout SEC     Wait timeout. pre-role-change defaults to 3600; drain defaults to 0.
+  --force           remove-member may remove a live raft member.
+
+The script reads SB_PAT_TOKEN from /etc/sandboxd/sandboxd.env by default and
+SB_NODE_ID from /etc/sandboxd/cluster.env by default.
+EOF
+	exit 2
+}
+
+if [[ $# -lt 1 ]]; then
+	usage
+fi
+
+cmd="$1"
+shift
+
+env_files=(/etc/sandboxd/sandboxd.env /etc/sandboxd/cluster.env)
+node_arg=""
+api_url_arg=""
+wait_empty=false
+force=false
+timeout_s=0
+
+case "$cmd" in
+	drain) ;;
+	uncordon) ;;
+	remove-member) ;;
+	pre-role-change)
+		wait_empty=true
+		timeout_s=3600
+		;;
+	*) usage ;;
+esac
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--node)
+			node_arg="${2:-}"
+			shift 2
+			;;
+		--api-url)
+			api_url_arg="${2:-}"
+			shift 2
+			;;
+		--env-file)
+			env_files+=("${2:-}")
+			shift 2
+			;;
+		--wait-empty)
+			wait_empty=true
+			shift
+			;;
+		--timeout)
+			timeout_s="${2:-}"
+			shift 2
+			;;
+		--force)
+			force=true
+			shift
+			;;
+		-*)
+			usage
+			;;
+		*)
+			if [[ -n "$node_arg" ]]; then
+				usage
+			fi
+			node_arg="$1"
+			shift
+			;;
+	esac
+done
+
+for env_file in "${env_files[@]}"; do
+	if [[ -f "$env_file" ]]; then
+		set -a
+		# shellcheck disable=SC1090
+		. "$env_file"
+		set +a
+	fi
+done
+
+node_id="${node_arg:-${SB_NODE_ID:-}}"
+api_url="${api_url_arg:-http://127.0.0.1:${SB_API_PORT:-21212}}"
+api_url="${api_url%/}"
+
+if [[ -z "$node_id" ]]; then
+	echo "node id required: pass NODE/--node or set SB_NODE_ID" >&2
+	exit 2
+fi
+if [[ -z "${SB_PAT_TOKEN:-}" ]]; then
+	echo "SB_PAT_TOKEN required in environment or env file" >&2
+	exit 2
+fi
+if ! [[ "$timeout_s" =~ ^[0-9]+$ ]]; then
+	echo "--timeout must be a non-negative integer" >&2
+	exit 2
+fi
+
+urlencode() {
+	python3 - "$1" <<'PY'
+import sys
+from urllib.parse import quote
+print(quote(sys.argv[1], safe=""))
+PY
+}
+
+request() {
+	local method="$1"
+	local path="$2"
+	curl -fsS -X "$method" \
+		-H "Authorization: Bearer ${SB_PAT_TOKEN}" \
+		"${api_url}${path}" >/dev/null
+}
+
+owned_count() {
+	python3 - "$api_url" "$SB_PAT_TOKEN" "$node_id" <<'PY'
+import json
+import sys
+import urllib.parse
+import urllib.request
+
+api_url, token, node_id = sys.argv[1:4]
+count = 0
+page_token = ""
+
+while True:
+    query = {"limit": "5000"}
+    if page_token:
+        query["page_token"] = page_token
+    url = api_url.rstrip("/") + "/v1/cluster/sandbox-index?" + urllib.parse.urlencode(query)
+    req = urllib.request.Request(url, headers={"Authorization": "Bearer " + token})
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        body = json.load(resp)
+    for placement in body.get("placements", []):
+        if placement.get("owner_node_id") == node_id:
+            count += 1
+    page_token = body.get("next_page_token") or ""
+    if not page_token:
+        break
+
+print(count)
+PY
+}
+
+wait_for_empty() {
+	local start now count
+	start="$(date +%s)"
+	while true; do
+		count="$(owned_count)"
+		if [[ "$count" == "0" ]]; then
+			echo "node ${node_id} owns zero placements"
+			return 0
+		fi
+		now="$(date +%s)"
+		if (( timeout_s == 0 || now - start >= timeout_s )); then
+			echo "node ${node_id} still owns ${count} placement(s) after drain" >&2
+			return 1
+		fi
+		echo "waiting for node ${node_id} to empty; ${count} placement(s) remain"
+		sleep 10
+	done
+}
+
+encoded_node="$(urlencode "$node_id")"
+
+case "$cmd" in
+	drain|pre-role-change)
+		request POST "/v1/cluster/nodes/${encoded_node}/drain"
+		echo "drained node ${node_id}"
+		if [[ "$wait_empty" == "true" ]]; then
+			wait_for_empty
+		fi
+		;;
+	uncordon)
+		request POST "/v1/cluster/nodes/${encoded_node}/uncordon"
+		echo "uncordoned node ${node_id}"
+		;;
+	remove-member)
+		path="/v1/cluster/members/${encoded_node}"
+		if [[ "$force" == "true" ]]; then
+			path="${path}?force=true"
+		fi
+		request DELETE "$path"
+		echo "removed raft member ${node_id}"
+		;;
+esac

--- a/scripts/sandboxd-restore.sh
+++ b/scripts/sandboxd-restore.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: sandboxd-restore.sh --input /path/sandboxd-backup.tar.gz --target-root / [--force]
+
+Restores the archive produced by sandboxd-backup.sh. Stop sandboxd first.
+
+Options:
+  --input PATH        Backup archive. Required.
+  --target-root PATH  Restore root. Default: /
+  --force            Required acknowledgement for writes.
+  -h, --help         Show this help.
+USAGE
+}
+
+input=""
+target_root="/"
+force="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --input) input="${2:?missing --input value}"; shift 2 ;;
+    --target-root) target_root="${2:?missing --target-root value}"; shift 2 ;;
+    --force) force="true"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$input" ]]; then
+  echo "--input is required" >&2
+  usage >&2
+  exit 2
+fi
+if [[ "$force" != "true" ]]; then
+  echo "refusing to restore without --force; stop sandboxd and confirm this is the intended target" >&2
+  exit 2
+fi
+if [[ ! -f "$input" ]]; then
+  echo "backup archive not found: $input" >&2
+  exit 1
+fi
+
+mkdir -p "$target_root"
+tar -C "$target_root" -xzf "$input"
+echo "restored $input into $target_root"
+echo "verify ownership/modes, then start sandboxd"

--- a/sdk/go/pkg/types/types.go
+++ b/sdk/go/pkg/types/types.go
@@ -5,6 +5,7 @@ import "github.com/aerol-ai/microvm/pkg/models"
 type CreateSandboxOptions = models.CreateSandboxRequest
 type ResizeSandboxOptions = models.ResizeSandboxRequest
 type Lifecycle = models.Lifecycle
+type Failover = models.Failover
 type UpdateLifecycleOptions = models.UpdateLifecycleRequest
 type ExecRequest = models.ExecRequest
 type ExecResult = models.ExecResult
@@ -18,6 +19,11 @@ type SandboxSnapshot = models.SandboxSnapshot
 
 // ExposeProtocol selects the wire surface an exposure publishes through.
 type ExposeProtocol string
+
+const (
+	FailoverPolicyNone     = models.FailoverPolicyNone
+	FailoverPolicyRecreate = models.FailoverPolicyRecreate
+)
 
 const (
 	// ExposeProtocolHTTP is the default — Caddy HTTP reverse proxy at

--- a/sdk/java/README.md
+++ b/sdk/java/README.md
@@ -38,6 +38,7 @@ import ai.aerol.microvm.MicroVMClient;
 import ai.aerol.microvm.MicroVMConfig;
 import ai.aerol.microvm.Sandbox;
 import ai.aerol.microvm.model.CreateOptions;
+import ai.aerol.microvm.model.Failover;
 import ai.aerol.microvm.model.Lifecycle;
 import ai.aerol.microvm.model.MountSpec;
 
@@ -53,6 +54,7 @@ Sandbox sandbox = client.create(
         .setLifecycle(new Lifecycle()
             .setStopIfIdleFor(3_600_000_000_000L)
             .setDestroyAtAge(86_400_000_000_000L))
+        .setFailover(new Failover().setPolicy("recreate"))
         .setMounts(java.util.List.of(
             new MountSpec()
                 .setType("s3")

--- a/sdk/java/src/main/java/ai/aerol/microvm/MicroVMClient.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/MicroVMClient.java
@@ -630,6 +630,7 @@ public class MicroVMClient {
         copy.containerCommand = source.containerCommand;
         copy.mounts = source.mounts;
         copy.lifecycle = source.lifecycle;
+        copy.failover = source.failover;
         copy.runtime = source.runtime;
         copy.gpus = source.gpus;
         return copy;

--- a/sdk/java/src/main/java/ai/aerol/microvm/model/CreateOptions.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/model/CreateOptions.java
@@ -25,6 +25,7 @@ public class CreateOptions {
     public List<String> containerCommand;
     public List<MountSpec> mounts;
     public Lifecycle lifecycle;
+    public Failover failover;
     public String runtime;
     /** Attach GPU resources to the sandbox. Null means no GPU (CPU-only). */
     public GpuOptions gpus;
@@ -91,6 +92,11 @@ public class CreateOptions {
 
     public CreateOptions setLifecycle(Lifecycle lifecycle) {
         this.lifecycle = lifecycle;
+        return this;
+    }
+
+    public CreateOptions setFailover(Failover failover) {
+        this.failover = failover;
         return this;
     }
 

--- a/sdk/java/src/main/java/ai/aerol/microvm/model/Failover.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/model/Failover.java
@@ -1,0 +1,14 @@
+package ai.aerol.microvm.model;
+
+public class Failover {
+    public String policy;
+
+    public Failover setPolicy(String policy) {
+        this.policy = policy;
+        return this;
+    }
+
+    public Failover copy() {
+        return new Failover().setPolicy(policy);
+    }
+}

--- a/sdk/java/src/main/java/ai/aerol/microvm/model/SandboxData.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/model/SandboxData.java
@@ -36,6 +36,7 @@ public class SandboxData {
     public String lastError;
     public List<String> containerCommand;
     public Lifecycle lifecycle = new Lifecycle();
+    public Failover failover;
     public String runtime = "";
     /** GPU configuration this sandbox was created with. Null means no GPU. */
     public GpuOptions gpus;
@@ -72,6 +73,7 @@ public class SandboxData {
         lastError = other.lastError;
         containerCommand = other.containerCommand == null ? null : new ArrayList<>(other.containerCommand);
         lifecycle = other.lifecycle == null ? new Lifecycle() : other.lifecycle.copy();
+        failover = other.failover == null ? null : other.failover.copy();
         runtime = other.runtime == null ? "" : other.runtime;
         gpus = other.gpus == null ? null : other.gpus.copy();
     }

--- a/sdk/java/src/test/java/ai/aerol/microvm/MicroVMClientTest.java
+++ b/sdk/java/src/test/java/ai/aerol/microvm/MicroVMClientTest.java
@@ -33,6 +33,7 @@ import ai.aerol.microvm.model.ExecExitInfo;
 import ai.aerol.microvm.model.ExecRequest;
 import ai.aerol.microvm.model.ExecResult;
 import ai.aerol.microvm.model.ExecStreamOptions;
+import ai.aerol.microvm.model.Failover;
 import ai.aerol.microvm.model.Lifecycle;
 import ai.aerol.microvm.model.MountSpec;
 import ai.aerol.microvm.model.MountSpecRedacted;
@@ -259,7 +260,8 @@ class MicroVMClientTest {
                 "lifecycle", mapOf(
                     "stop_if_idle_for", 3_600_000_000_000L,
                     "destroy_at_age", 86_400_000_000_000L
-                )
+                ),
+                "failover", mapOf("policy", "recreate")
             ));
         });
 
@@ -279,6 +281,7 @@ class MicroVMClientTest {
                     .setLifecycle(new Lifecycle()
                         .setStopIfIdleFor(3_600_000_000_000L)
                         .setDestroyAtAge(86_400_000_000_000L))
+                    .setFailover(new Failover().setPolicy("recreate"))
             );
 
             assertEquals("sb-create", sandbox.id);
@@ -287,6 +290,8 @@ class MicroVMClientTest {
             assertEquals(2048, sandbox.memoryMb);
             assertEquals(3_600_000_000_000L, sandbox.lifecycle.stopIfIdleFor);
             assertEquals(86_400_000_000_000L, sandbox.lifecycle.destroyAtAge);
+            assertNotNull(sandbox.failover);
+            assertEquals("recreate", sandbox.failover.policy);
 
             Map<String, Object> payload = requestBody.get();
             assertEquals("ubuntu:22.04", payload.get("image"));
@@ -295,6 +300,8 @@ class MicroVMClientTest {
             Map<String, Object> lifecycle = castMap(payload.get("lifecycle"));
             assertEquals(3_600_000_000_000L, ((Number) lifecycle.get("stop_if_idle_for")).longValue());
             assertEquals(86_400_000_000_000L, ((Number) lifecycle.get("destroy_at_age")).longValue());
+            Map<String, Object> failover = castMap(payload.get("failover"));
+            assertEquals("recreate", failover.get("policy"));
         } finally {
             server.stop(0);
         }

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -32,6 +32,7 @@ sandbox = client.create(
 			"stopIfIdleFor": 3_600_000_000_000,
 			"destroyAtAge": 86_400_000_000_000,
 		},
+		"failover": {"policy": "recreate"},
 		"mounts": [
 			{
 				"type": "s3",

--- a/sdk/python/microvm/__init__.py
+++ b/sdk/python/microvm/__init__.py
@@ -5,6 +5,8 @@ from .types import (
     BuildImageResult,
     ExposeProtocol,
     ExposeResult,
+    Failover,
+    FailoverPolicy,
     SandboxSnapshot,
 )
 
@@ -15,5 +17,7 @@ __all__ = [
     "MicroVM",
     "ExposeProtocol",
     "ExposeResult",
+    "Failover",
+    "FailoverPolicy",
     "SandboxSnapshot",
 ]

--- a/sdk/python/microvm/client.py
+++ b/sdk/python/microvm/client.py
@@ -25,6 +25,7 @@ from .types import (
     ExecStreamOptions,
     ExposeProtocol,
     ExposeResult,
+    Failover,
     HealthStatus,
     Lifecycle,
     MountSpec,
@@ -795,6 +796,7 @@ def _build_tag_query(tags: Optional[Dict[str, str]]) -> str:
 
 def _to_api_create_options(options: CreateOptions) -> Dict[str, Any]:
     lifecycle = _first_of(options, "lifecycle")
+    failover = _first_of(options, "failover")
     return _compact(
         {
             "image": _first_of(options, "image"),
@@ -810,6 +812,7 @@ def _to_api_create_options(options: CreateOptions) -> Dict[str, Any]:
             "container_command": _first_of(options, "containerCommand", "container_command"),
             "mounts": [_to_api_mount_spec(item) for item in (_first_of(options, "mounts") or [])],
             "lifecycle": _to_api_lifecycle(lifecycle) if isinstance(lifecycle, dict) else None,
+            "failover": _to_api_failover(failover) if isinstance(failover, dict) else None,
         }
     )
 
@@ -889,6 +892,10 @@ def _to_api_lifecycle(lifecycle: Lifecycle) -> Dict[str, Any]:
             "destroy_at_age": _first_of(lifecycle, "destroyAtAge", "destroy_at_age"),
         }
     )
+
+
+def _to_api_failover(failover: Failover) -> Dict[str, Any]:
+    return _compact({"policy": _first_of(failover, "policy")})
 
 
 def _from_api_exec_result(result: Dict[str, Any]) -> ExecResult:
@@ -1043,6 +1050,7 @@ def _from_api_session(session: Dict[str, Any]) -> Session:
 def _from_api_sandbox(sandbox: Dict[str, Any]) -> SandboxData:
     exposed_ports = _first_of(sandbox, "exposed_ports", "exposedPorts") or []
     lifecycle = _first_of(sandbox, "lifecycle")
+    failover = _first_of(sandbox, "failover")
     result: SandboxData = {
         "id": str(_first_of(sandbox, "id") or ""),
         "image": str(_first_of(sandbox, "image") or ""),
@@ -1060,6 +1068,10 @@ def _from_api_sandbox(sandbox: Dict[str, Any]) -> SandboxData:
         "lastActiveAt": str(_first_of(sandbox, "last_active_at", "lastActiveAt") or ""),
         "lifecycle": _from_api_lifecycle(lifecycle) if isinstance(lifecycle, dict) else {},
     }
+    if isinstance(failover, dict):
+        mapped_failover = _from_api_failover(failover)
+        if mapped_failover:
+            result["failover"] = mapped_failover
 
     container_id = _first_of(sandbox, "container_id", "containerID")
     if container_id not in (None, ""):
@@ -1105,6 +1117,13 @@ def _from_api_lifecycle(lifecycle: Dict[str, Any]) -> Lifecycle:
         result["destroyAtAge"] = int(destroy_at_age)
 
     return result
+
+
+def _from_api_failover(failover: Dict[str, Any]) -> Failover:
+    policy = _first_of(failover, "policy")
+    if policy not in ("none", "recreate"):
+        return {}
+    return {"policy": policy}
 
 
 def _from_api_health_status(status: Dict[str, Any]) -> HealthStatus:

--- a/sdk/python/microvm/types.py
+++ b/sdk/python/microvm/types.py
@@ -78,6 +78,15 @@ class Lifecycle(TypedDict, total=False):
 UpdateLifecycleOptions = Lifecycle
 
 
+FailoverPolicy = Literal["none", "recreate"]
+
+
+class Failover(TypedDict, total=False):
+    # "none" (default) returns 410 Gone after owner-node death. "recreate"
+    # opts into best-effort cluster recreation from the replicated create spec.
+    policy: FailoverPolicy
+
+
 GPUVendor = Literal["nvidia", "amd", "apple"]
 
 
@@ -122,6 +131,7 @@ class CreateOptions(TypedDict, total=False):
     containerCommand: List[str]
     mounts: List[MountSpec]
     lifecycle: Lifecycle
+    failover: Failover
     # Container runtime to use for this sandbox. Omit to inherit the host
     # default (SB_CONTAINER_RUNTIME). Use "gvisor" for runsc-backed isolation
     # when running untrusted workloads. "kata" is reserved and rejected by the
@@ -281,6 +291,7 @@ class SandboxData(TypedDict, total=False):
     lastError: str
     containerCommand: List[str]
     lifecycle: Lifecycle
+    failover: Failover
     # Container runtime this sandbox is running under. Empty string indicates
     # a pre-migration row that resolves to the host default at start time.
     runtime: Literal["", "docker", "gvisor", "kata"]

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -35,6 +35,7 @@ class RecordingMicroVM(MicroVM):
                 "updated_at": "2026-05-07T10:00:00Z",
                 "last_active_at": "2026-05-07T10:00:00Z",
                 "lifecycle": payload.get("lifecycle", {}),
+                "failover": payload.get("failover"),
             }
         if method == "PUT" and path == "/v1/sandboxes/sb-1/lifecycle":
             return {
@@ -348,6 +349,7 @@ class ClientTests(unittest.TestCase):
                     "stopIfIdleFor": 3_600_000_000_000,
                     "destroyAtAge": 86_400_000_000_000,
                 },
+                "failover": {"policy": "recreate"},
             }
         )
 
@@ -376,6 +378,7 @@ class ClientTests(unittest.TestCase):
                         "stop_if_idle_for": 3_600_000_000_000,
                         "destroy_at_age": 86_400_000_000_000,
                     },
+                    "failover": {"policy": "recreate"},
                 },
             ),
         )
@@ -391,6 +394,7 @@ class ClientTests(unittest.TestCase):
                 "destroyAtAge": 86_400_000_000_000,
             },
         )
+        self.assertEqual(sandbox.failover, {"policy": "recreate"})
 
     def test_update_lifecycle_maps_request_and_updates_sandbox_state(self):
         client = RecordingMicroVM()

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -11,7 +11,7 @@ cargo add aerolvm-sdk
 ## Usage
 
 ```rust
-use aerolvm_sdk::{Client, CreateOptions, Lifecycle};
+use aerolvm_sdk::{Client, CreateOptions, Failover, Lifecycle};
 
 let client = Client::new(Some("http://127.0.0.1:21212"), Some("your-pat-token"))?;
 let health = client.health()?;
@@ -33,6 +33,7 @@ let sandbox = client.create(CreateOptions {
 		destroy_at_age: 86_400_000_000_000,
 		..Default::default()
 	}),
+	failover: Some(Failover { policy: "recreate".to_string() }),
 	runtime: None,
 	gpus: None,
 })?;
@@ -71,6 +72,7 @@ let sandbox = client.create(CreateOptions {
 	container_command: None,
 	mounts: None,
 	lifecycle: None,
+	failover: None,
 	runtime: None,
 	gpus: None,
 })?;

--- a/sdk/rust/examples/create_sandbox.rs
+++ b/sdk/rust/examples/create_sandbox.rs
@@ -2,7 +2,9 @@ use aerolvm_sdk::{Client, CreateOptions};
 use std::env;
 
 fn main() {
-    let api_url = env::args().nth(1).unwrap_or_else(|| "http://127.0.0.1:21212".to_owned());
+    let api_url = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "http://127.0.0.1:21212".to_owned());
     let pat_token = env::args().nth(2).expect("PAT token is required");
     let image = env::args().nth(3).expect("Image is required");
 
@@ -25,6 +27,7 @@ fn main() {
             container_command: None,
             mounts: None,
             lifecycle: None,
+            failover: None,
             runtime: None,
             gpus: None,
         })

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -27,10 +27,10 @@ use types::ExposePortResponseWire;
 pub use types::{
     BuildImageOptions, BuildImagePushOptions, BuildImageResult, CreateOptions,
     CreateSessionOptions, ExecExitInfo, ExecRequest, ExecResult, ExposeOptions, ExposeProtocol,
-    ExposeResult, ExposedPort, HealthStatus, Lifecycle, MountSpec, MountSpecRedacted, MountType,
-    NetworkUsage, RegisterSnapshotOptions, RegistryAuth, ResizeOptions, Sandbox as SandboxData,
-    SandboxSnapshot, Session, SessionList, SessionStatus, SetNetworkLimitsOptions,
-    UpdateLifecycleOptions,
+    ExposeResult, ExposedPort, Failover, HealthStatus, Lifecycle, MountSpec, MountSpecRedacted,
+    MountType, NetworkUsage, RegisterSnapshotOptions, RegistryAuth, ResizeOptions,
+    Sandbox as SandboxData, SandboxSnapshot, Session, SessionList, SessionStatus,
+    SetNetworkLimitsOptions, UpdateLifecycleOptions,
 };
 
 const DEFAULT_API_URL: &str = "http://127.0.0.1:21212";
@@ -606,8 +606,7 @@ impl Client {
     ) -> Result<Vec<Sandbox>, Error> {
         let mut path = format!("{}/sandboxes", self.version_prefix());
         path.push_str(&build_tag_query(tags));
-        let raw =
-            self.do_json::<(), Vec<SandboxData>>(Method::GET, &path, None)?;
+        let raw = self.do_json::<(), Vec<SandboxData>>(Method::GET, &path, None)?;
         Ok(raw
             .into_iter()
             .map(|item| Sandbox::new(self.clone(), item))
@@ -654,7 +653,10 @@ impl Client {
         )
     }
 
-    pub fn register_snapshot(&self, opts: RegisterSnapshotOptions) -> Result<SandboxSnapshot, Error> {
+    pub fn register_snapshot(
+        &self,
+        opts: RegisterSnapshotOptions,
+    ) -> Result<SandboxSnapshot, Error> {
         #[derive(Serialize)]
         struct RegisterSnapshotRequest<'a> {
             name: &'a str,
@@ -1650,6 +1652,7 @@ mod tests {
             container_command: None,
             mounts: None,
             lifecycle: None,
+            failover: None,
             runtime: None,
             gpus: None,
         }
@@ -1943,7 +1946,8 @@ mod tests {
             "lifecycle": {
                 "stop_if_idle_for": 3600000000000u64,
                 "destroy_at_age": 86400000000000u64
-            }
+            },
+            "failover": { "policy": "recreate" }
         })
         .to_string();
         let (url, request_rx) = spawn_json_server(body);
@@ -1955,6 +1959,9 @@ mod tests {
                     stop_if_idle_for: 3600000000000,
                     destroy_at_age: 86400000000000,
                     ..Default::default()
+                }),
+                failover: Some(Failover {
+                    policy: "recreate".to_string(),
                 }),
                 ..minimal_create_options()
             })
@@ -1969,7 +1976,8 @@ mod tests {
                 "lifecycle": {
                     "stop_if_idle_for": 3600000000000u64,
                     "destroy_at_age": 86400000000000u64
-                }
+                },
+                "failover": { "policy": "recreate" }
             })
         );
         assert_eq!(
@@ -1980,6 +1988,12 @@ mod tests {
                 stop_at_age: 0,
                 destroy_at_age: 86400000000000,
             }
+        );
+        assert_eq!(
+            sandbox.data.failover,
+            Some(Failover {
+                policy: "recreate".to_string()
+            })
         );
     }
 
@@ -2152,7 +2166,11 @@ mod tests {
                 "built",
                 &Image::base("debian:bookworm-slim").run_command("apt-get update"),
                 RegisterSnapshotOptions {
-                    entrypoint: vec!["/bin/sh".to_string(), "-c".to_string(), "echo hi".to_string()],
+                    entrypoint: vec![
+                        "/bin/sh".to_string(),
+                        "-c".to_string(),
+                        "echo hi".to_string(),
+                    ],
                     ..Default::default()
                 },
             )
@@ -2199,11 +2217,9 @@ mod tests {
                 ..Default::default()
             })
             .expect_err("missing image/dockerfile should fail");
-        assert!(
-            missing_payload
-                .to_string()
-                .contains("image or dockerfile_content is required")
-        );
+        assert!(missing_payload
+            .to_string()
+            .contains("image or dockerfile_content is required"));
 
         let both_set = client
             .register_snapshot(RegisterSnapshotOptions {

--- a/sdk/rust/src/types.rs
+++ b/sdk/rust/src/types.rs
@@ -128,7 +128,7 @@ pub struct GPUOptions {
     pub device_ids: Option<Vec<String>>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct CreateOptions {
     pub image: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -146,13 +146,19 @@ pub struct CreateOptions {
     /// Cap on bytes the sandbox may receive before its ingress is dropped via
     /// per-IP iptables rule. `0` (or omit) means unlimited. Limits can be
     /// raised or lifted at runtime via [`Client::set_network_limits`].
-    #[serde(rename = "network_bytes_in_limit", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "network_bytes_in_limit",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub network_bytes_in_limit: Option<i64>,
     /// Cap on bytes the sandbox may send before its egress is dropped. `0`
     /// (or omit) means unlimited. The block reuses the same iptables row as
     /// `network_block_all`; clearing the quota does not lift an operator-set
     /// blanket egress block.
-    #[serde(rename = "network_bytes_out_limit", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "network_bytes_out_limit",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub network_bytes_out_limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub registry: Option<RegistryAuth>,
@@ -162,6 +168,11 @@ pub struct CreateOptions {
     pub mounts: Option<Vec<MountSpec>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lifecycle: Option<Lifecycle>,
+    /// Owner-node death policy. Omit for non-HA sandboxes; set
+    /// `Failover { policy: "recreate".into() }` to opt into best-effort
+    /// cluster recreation from the replicated create spec.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failover: Option<Failover>,
     /// Container runtime for this sandbox. Omit to inherit the host default
     /// (SB_CONTAINER_RUNTIME). Use `"gvisor"` for runsc-backed isolation when
     /// running untrusted workloads. `"kata"` is reserved and rejected by the
@@ -176,17 +187,35 @@ pub struct CreateOptions {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
 pub struct Lifecycle {
-    #[serde(rename = "stop_if_idle_for", default, skip_serializing_if = "is_zero_u64")]
+    #[serde(
+        rename = "stop_if_idle_for",
+        default,
+        skip_serializing_if = "is_zero_u64"
+    )]
     pub stop_if_idle_for: u64,
-    #[serde(rename = "destroy_if_idle_for", default, skip_serializing_if = "is_zero_u64")]
+    #[serde(
+        rename = "destroy_if_idle_for",
+        default,
+        skip_serializing_if = "is_zero_u64"
+    )]
     pub destroy_if_idle_for: u64,
     #[serde(rename = "stop_at_age", default, skip_serializing_if = "is_zero_u64")]
     pub stop_at_age: u64,
-    #[serde(rename = "destroy_at_age", default, skip_serializing_if = "is_zero_u64")]
+    #[serde(
+        rename = "destroy_at_age",
+        default,
+        skip_serializing_if = "is_zero_u64"
+    )]
     pub destroy_at_age: u64,
 }
 
 pub type UpdateLifecycleOptions = Lifecycle;
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+pub struct Failover {
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub policy: String,
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ResizeOptions {
@@ -323,6 +352,10 @@ pub struct Sandbox {
     pub container_command: Option<Vec<String>>,
     #[serde(default)]
     pub lifecycle: Lifecycle,
+    /// Owner-node death policy this sandbox was created with. `None` means
+    /// the default non-HA behavior.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failover: Option<Failover>,
     /// Container runtime this sandbox is running under. Empty string indicates
     /// a pre-migration row that resolves to the host default at start time.
     #[serde(default)]
@@ -487,7 +520,11 @@ pub struct NetworkUsage {
     /// Absent (`None`) until the netstats poller has produced at least one
     /// sample. `default` lets us deserialize a server response that omits the
     /// field entirely (pre-first-tick) rather than failing.
-    #[serde(rename = "last_sampled_at", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "last_sampled_at",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub last_sampled_at: Option<String>,
 }
 
@@ -496,8 +533,14 @@ pub struct NetworkUsage {
 /// `Some(0)` means unlimited.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct SetNetworkLimitsOptions {
-    #[serde(rename = "network_bytes_in_limit", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "network_bytes_in_limit",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub network_bytes_in_limit: Option<i64>,
-    #[serde(rename = "network_bytes_out_limit", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "network_bytes_out_limit",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub network_bytes_out_limit: Option<i64>,
 }

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -16,6 +16,8 @@ export type {
   ExposePortOptions,
   ExposeProtocol,
   ExposeResult,
+  Failover,
+  FailoverPolicy,
   HealthStatus,
   Lifecycle,
   MountSpec,

--- a/sdk/typescript/src/internal/client.test.ts
+++ b/sdk/typescript/src/internal/client.test.ts
@@ -34,6 +34,7 @@ test("internal client create maps request and response", async () => {
           stop_if_idle_for: 3_600_000_000_000,
           destroy_at_age: 86_400_000_000_000,
         },
+        failover: { policy: "recreate" },
       }));
     },
   });
@@ -46,6 +47,7 @@ test("internal client create maps request and response", async () => {
       stopIfIdleFor: 3_600_000_000_000,
       destroyAtAge: 86_400_000_000_000,
     },
+    failover: { policy: "recreate" },
   });
   assert.equal(sandbox.id, "sb-create");
   assert.ok(seenRequest);
@@ -58,11 +60,13 @@ test("internal client create maps request and response", async () => {
       stop_if_idle_for: 3_600_000_000_000,
       destroy_at_age: 86_400_000_000_000,
     },
+    failover: { policy: "recreate" },
   });
   assert.deepEqual(sandbox.lifecycle, {
     stopIfIdleFor: 3_600_000_000_000,
     destroyAtAge: 86_400_000_000_000,
   });
+  assert.deepEqual(sandbox.failover, { policy: "recreate" });
 });
 
 test("internal client createSnapshot maps request and response", async () => {

--- a/sdk/typescript/src/internal/client.ts
+++ b/sdk/typescript/src/internal/client.ts
@@ -17,6 +17,7 @@ import type {
   ExposePortOptions,
   ExposeProtocol,
   ExposeResult,
+  Failover,
   HealthStatus,
   Lifecycle,
   ListOptions,
@@ -90,6 +91,10 @@ interface ApiLifecycle {
   destroy_at_age?: number;
 }
 
+interface ApiFailover {
+  policy?: string;
+}
+
 interface ApiSandbox {
   id: string;
   image: string;
@@ -112,6 +117,7 @@ interface ApiSandbox {
   last_error?: string;
   container_command?: string[];
   lifecycle?: ApiLifecycle;
+  failover?: ApiFailover;
   runtime?: string;
 }
 
@@ -575,6 +581,7 @@ export class SandboxResource implements Sandbox {
   declare lastError?: string;
   declare containerCommand?: string[];
   declare lifecycle: Lifecycle;
+  declare failover?: Failover;
   declare runtime: Sandbox["runtime"];
 
   protected readonly client: APIClient;
@@ -714,6 +721,7 @@ function toApiCreateOptions(options: CreateOptions): Record<string, unknown> {
     container_command: options.containerCommand,
     mounts: options.mounts?.map(toApiMountSpec),
     lifecycle: options.lifecycle ? toApiLifecycle(options.lifecycle) : undefined,
+    failover: options.failover ? toApiFailover(options.failover) : undefined,
     runtime: options.runtime,
   };
 }
@@ -772,6 +780,12 @@ function toApiLifecycle(lifecycle: Lifecycle): ApiLifecycle {
   };
 }
 
+function toApiFailover(failover: Failover): ApiFailover {
+  return {
+    policy: failover.policy,
+  };
+}
+
 function fromApiSandbox(sandbox: ApiSandbox): Sandbox {
   return {
     id: sandbox.id,
@@ -795,6 +809,7 @@ function fromApiSandbox(sandbox: ApiSandbox): Sandbox {
     lastError: sandbox.last_error,
     containerCommand: sandbox.container_command,
     lifecycle: fromApiLifecycle(sandbox.lifecycle),
+    failover: fromApiFailover(sandbox.failover),
     runtime: normalizeRuntime(sandbox.runtime),
   };
 }
@@ -955,6 +970,14 @@ function fromApiLifecycle(lifecycle?: ApiLifecycle): Lifecycle {
   return result;
 }
 
+function fromApiFailover(failover?: ApiFailover): Failover | undefined {
+  const policy = failover?.policy;
+  if (policy !== "recreate" && policy !== "none") {
+    return undefined;
+  }
+  return { policy };
+}
+
 // buildTagQuery renders ListOptions.tags as the server's wire format. The
 // `tag.` prefix is literal — the server's parseTagFilter does a prefix check
 // on the *decoded* query key, so only the user-supplied key and value get
@@ -978,6 +1001,7 @@ function cloneSandbox(sandbox: Sandbox): Sandbox {
     exposedPorts: sandbox.exposedPorts?.map((port) => ({ ...port })),
     containerCommand: sandbox.containerCommand ? [...sandbox.containerCommand] : undefined,
     lifecycle: { ...sandbox.lifecycle },
+    failover: sandbox.failover ? { ...sandbox.failover } : undefined,
   };
 }
 

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -86,6 +86,16 @@ export interface Lifecycle {
 
 export type UpdateLifecycleOptions = Lifecycle;
 
+export type FailoverPolicy = "none" | "recreate";
+
+export interface Failover {
+  /**
+   * "none" (default) returns 410 Gone after owner-node death. "recreate"
+   * opts into best-effort cluster recreation from the replicated create spec.
+   */
+  policy: FailoverPolicy;
+}
+
 export type GPUVendor = "nvidia" | "amd" | "apple";
 
 export interface GPUOptions {
@@ -152,6 +162,7 @@ export interface CreateOptions {
   containerCommand?: string[];
   mounts?: MountSpec[];
   lifecycle?: Lifecycle;
+  failover?: Failover;
   /**
    * Container runtime to use for this sandbox. Omit to inherit the host
    * default (`SB_CONTAINER_RUNTIME`). Use `"gvisor"` for runsc-backed
@@ -285,6 +296,7 @@ export interface Sandbox {
   lastError?: string;
   containerCommand?: string[];
   lifecycle: Lifecycle;
+  failover?: Failover;
   /**
    * Container runtime this sandbox is running under. Empty string indicates
    * a pre-migration row that resolves to the host default at start time.

--- a/setup/alertmanager/sandboxd-alertmanager-example.yml
+++ b/setup/alertmanager/sandboxd-alertmanager-example.yml
@@ -1,0 +1,33 @@
+route:
+  receiver: sandboxd-platform
+  group_by:
+    - alertname
+    - cluster
+    - component
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  routes:
+    - matchers:
+        - severity="critical"
+      receiver: sandboxd-platform-critical
+      repeat_interval: 30m
+
+receivers:
+  - name: sandboxd-platform
+    webhook_configs:
+      - url: http://alert-webhook.example.internal/sandboxd
+        send_resolved: true
+
+  - name: sandboxd-platform-critical
+    webhook_configs:
+      - url: http://alert-webhook.example.internal/sandboxd-critical
+        send_resolved: true
+
+inhibit_rules:
+  - source_matchers:
+      - alertname="SandboxdWorkerLeaseStale"
+    target_matchers:
+      - alertname="SandboxdCreateQueueBacklog"
+    equal:
+      - cluster

--- a/setup/cluster.md
+++ b/setup/cluster.md
@@ -1280,6 +1280,13 @@ errors, image-pull storms, and secret decrypt failures. An Alertmanager
 route/receiver example is available at
 `setup/alertmanager/sandboxd-alertmanager-example.yml`.
 
+Full incident runbooks are available under `setup/runbooks/`:
+
+- `backup-restore.md`
+- `lost-quorum-recovery.md`
+- `image-pull-storm.md`
+- `slo-breach.md`
+
 ---
 
 ## Troubleshooting

--- a/setup/cluster.md
+++ b/setup/cluster.md
@@ -1226,6 +1226,17 @@ A healthy cluster reports:
 Set up monitoring on `GET /v1/cluster/leader` returning empty for more than
 30 seconds — that's the earliest signal of a brewing quorum problem.
 
+For metric scraping, use the PAT-gated Prometheus endpoint on every node:
+
+```bash
+curl -H "Authorization: Bearer $SB_PAT_TOKEN" http://<node>:8080/v1/metrics
+```
+
+Scrape servers, workers, and ingress nodes separately. The endpoint exports
+only `aerolvm_*` metrics and includes the operational signals needed for the
+large-cluster SLOs: Raft apply/snapshot health, route lag, create queue depth,
+worker lease freshness, host pressure, and Caddy/admin errors.
+
 ---
 
 ## Troubleshooting

--- a/setup/cluster.md
+++ b/setup/cluster.md
@@ -1032,18 +1032,39 @@ it is added as a non-voter.
 
 ### Removing a node
 
-Stop the daemon on the node. After `SB_DEAD_OWNER_GRACE` (default 30s) the
-leader's dead-owner reconciler orphans every placement that node owned
-(`OwnerNodeID = ""` in the FSM — subsequent API calls for those sandboxes
-return `410 Gone`) and `RemoveServer`s the node from the raft configuration.
-Any sandboxes that were on it are gone for good under the current non-HA
-policy; clients should create fresh sandboxes.
+For worker or ingress-only nodes, drain admission first, wait until the node
+owns no placements, then replace or terminate the instance:
 
-There is no public API endpoint for explicit raft membership removal yet —
-`DELETE /v1/cluster/members/<node-id>` is **not implemented** in this release.
-Treat permanent node removal as an operator action and validate against the
-current raft membership before the node's data directory is reused or
-discarded.
+```bash
+export SB_PAT_TOKEN=<redacted>
+curl -fsS -X POST -H "Authorization: Bearer $SB_PAT_TOKEN" \
+  http://<any-node>:21212/v1/cluster/nodes/<node-id>/drain
+curl -fsS -H "Authorization: Bearer $SB_PAT_TOKEN" \
+  'http://<any-node>:21212/v1/cluster/sandbox-index?limit=5000'
+```
+
+The packaged helper does the same check and fails if long-lived placements are
+still present:
+
+```bash
+sudo /usr/local/sbin/sandboxd-node-lifecycle.sh pre-role-change <node-id>
+```
+
+For server-role raft members, stop the daemon or terminate the instance, then
+remove the stale raft member explicitly from any surviving node:
+
+```bash
+curl -fsS -X DELETE -H "Authorization: Bearer $SB_PAT_TOKEN" \
+  http://<any-survivor>:21212/v1/cluster/members/<node-id>
+```
+
+`DELETE /v1/cluster/members/<node-id>` persists a drain mark, orphans any
+placements owned by that node (`OwnerNodeID = ""`; subsequent API calls return
+`410 Gone` under the current non-HA policy), and calls raft `RemoveServer`.
+It refuses to remove a member that is still gossiped alive unless
+`?force=true` is supplied, and it refuses to remove the last raft voter.
+Any sandboxes that were on the removed node are gone for good under the current
+non-HA policy; clients should create fresh sandboxes.
 
 ### Rolling restart
 

--- a/setup/cluster.md
+++ b/setup/cluster.md
@@ -142,23 +142,24 @@ gossip on surviving nodes marks B "suspect" then "dead"
         │
         ▼
 leader runs the dead-owner reconciler:
-  - for each placement owned by B: set owner = "" (orphan)
+  - for each default placement owned by B: set owner = "" (orphan)
+  - for each placement with failover.policy="recreate": reassign to a live worker
   - RemoveServer B from the raft configuration
         │
         ▼
-subsequent API calls for any of B's sandboxes return 410 Gone
+default sandboxes return 410 Gone; opted-in sandboxes are recreated
         │
         ▼
 clients (or operators) issue a fresh create — placement picks
 a new owner from the live, healthy nodes
 ```
 
-**Sandboxes do not auto-recreate.** Spec, sealed credentials, and exposed-port
-metadata replicated via raft are *retained in the FSM* (and a future opt-in
-lifecycle policy may rematerialize them), but the current product policy is
-"a killed sandbox stays gone." The reassign + recreate code paths exist in
-`internal/cluster/{dead_owner,owner_watcher}.go` and `service.RecreateSandbox`
-but are gated off behind `clusterRecreateOnFailoverEnabled = false`.
+**Sandbox auto-recreate is opt-in.** Spec, sealed credentials, and exposed-port
+metadata replicated via raft are retained in the FSM for every sandbox, but
+the default product policy is "a killed sandbox stays gone." A create request
+with `failover.policy="recreate"` tells the dead-owner reconciler to reassign
+that placement to a live worker and let the owner watcher call
+`service.RecreateSandbox`.
 
 ### 4. A node joins for the first time
 
@@ -187,14 +188,16 @@ sandboxes and can accept new placements based on its capacity
 
 ## Failover semantics
 
-**The product policy is non-HA sandboxes.** When an owner node dies, every
-sandbox on it is gone. The cluster keeps running; the sandboxes do not.
+**The default product policy is non-HA sandboxes.** When an owner node dies,
+default sandboxes on it are gone. Sandboxes created with
+`failover.policy="recreate"` are best-effort recreated on another worker from
+their replicated spec. The cluster keeps running either way.
 
 | State | Survives node failure | Why |
 |---|---|---|
-| Sandbox spec, sealed creds, port intents | **Retained in the FSM, not auto-recreated** | Replicated by raft so a future opt-in failover policy could rematerialize the sandbox. The current default does not. |
+| Sandbox spec, sealed creds, port intents | **Retained in the FSM** | Replicated by raft for orphan inspection, manual recovery, and opt-in failover recreation. |
 | Sandbox runtime (container, filesystem, sessions, host ports, SSH) | **No** | Lives only on the dead host. There is no automatic replacement. |
-| Sandbox URL (`<id>.<domain>`) | **No** | The ID is gone from the live cluster — API returns 410 Gone. Clients should create a fresh sandbox and get a fresh ID. |
+| Sandbox URL (`<id>.<domain>`) | Default: **No**. Opt-in recreate: **Best effort** | Default placement is orphaned and API returns 410 Gone. Opted-in sandboxes keep the ID while ingress repoints to the new owner. |
 | Sessions / recordings on disk | **No (without external storage)** | Live in the dead host's `/var/lib/`. Use external mounts if you need to retrieve them later. |
 | Cluster control plane (raft, placement of *other* sandboxes) | **Yes** | Quorum stays available as long as you keep `(N-1)/2` voters alive. Other sandboxes on healthy nodes continue to run. |
 | New placements after the failure | **Yes** | Capacity from the dead node leaves the gossip pool; new creates pick from the remaining healthy candidates. |
@@ -210,10 +213,9 @@ inside one sandbox:
 3. Do not assume the sandbox URL, container ID, or host ports persist across
    the owner's death.
 
-The reassign + recreate code paths exist behind a gate
-(`clusterRecreateOnFailoverEnabled` in `internal/cluster/dead_owner.go`). They
-are preserved for a future opt-in lifecycle policy and are not active in this
-release.
+If a workload can tolerate writable-layer loss but should keep its sandbox ID,
+create it with `failover.policy="recreate"`. Local-only images are rejected
+for this policy because another worker cannot pull them.
 
 See [Durability and Failover](https://docs.aerol.ai/durability) for the
 production runbook.
@@ -985,13 +987,11 @@ on each node's `/debug/vars` are the operator signals.
 
 #### Preferred host-port replay during failover-recreate
 
-When a placement re-lands on a new owner via the failover-recreate path (gated
-off by default — sandboxes are not HA under current product policy), the FSM
-carries the original TCP `host_port` so the new owner can re-bind it and
-preserve the public endpoint. If that host port is already reserved on the
-new owner (taken by an unrelated TCP exposure, or in use locally), the
-replay **parks** the exposure rather than silently allocating a different
-host port:
+When a placement re-lands on a new owner via the opt-in failover-recreate path,
+the FSM carries the original TCP `host_port` so the new owner can re-bind it
+and preserve the public endpoint. If that host port is already reserved on the
+new owner (taken by an unrelated TCP exposure, or in use locally), the replay
+**parks** the exposure rather than silently allocating a different host port:
 
 - The FSM record (with the original `host_port`) stays intact.
 - The local re-bind fails with `ErrPreferredHostPortUnavailable`; the

--- a/setup/cluster.md
+++ b/setup/cluster.md
@@ -1105,6 +1105,11 @@ file themselves can set them directly in `/etc/sandboxd/cluster.env`.
 | `SB_CLUSTER_BOOTSTRAP` | yes | `true` only on the seed; `false` on joiners. |
 | `SB_CLUSTER_MAX_AUTO_VOTERS` | no | Max gossip-discovered nodes auto-promoted as raft voters. Default `5`; additional nodes become non-voters. Set `0` for unlimited. |
 | `SB_DEAD_OWNER_GRACE` | no | Wait before reassigning a dead node's placements. Default `30s`. |
+| `SB_OTEL_METRICS_ENDPOINT` | no | OTLP/HTTP metrics endpoint, for example `http://otel-collector:4318/v1/metrics`. Setting it enables OTEL metrics. |
+| `SB_OTEL_METRICS_ENABLED` | no | Enables OTEL metrics without an explicit endpoint; the OTEL exporter env defaults apply. |
+| `SB_OTEL_METRICS_INTERVAL` | no | OTEL export interval. Default `30s`. |
+| `SB_IMAGE_PULL_MAX_CONCURRENT` | no | Per-worker cap on concurrent Docker image pulls. Default `4`; set `0` to disable the cap. |
+| `SB_IMAGE_PULL_FAILURE_BACKOFF` | no | Per-image/auth retry suppression after a failed pull. Default `30s`; set `0s` to disable. |
 
 The daemon **refuses to boot** in cluster mode if either gossip or
 credential keys are missing (and the matching `INSECURE_*` flag isn't set).
@@ -1151,6 +1156,21 @@ For a full cluster recovery from total destruction, you also need the
 cluster TLS bundle (CA + CA key) and the gossip key. Store these in your
 secrets manager.
 
+The repo includes a backup helper that packages the local SQLite DB, Raft
+state, and `/etc/sandboxd` config tree into one restricted archive:
+
+```bash
+sudo scripts/sandboxd-backup.sh --output /secure/backups/sandboxd-$(hostname)-$(date +%F).tar.gz
+```
+
+To restore onto a stopped replacement node:
+
+```bash
+sudo systemctl stop sandboxd
+sudo scripts/sandboxd-restore.sh --input /secure/backups/sandboxd-node-a-2026-05-20.tar.gz --target-root / --force
+sudo systemctl start sandboxd
+```
+
 ---
 
 ## Lost-quorum recovery
@@ -1180,17 +1200,19 @@ If the lost voters are gone for good (disk loss, hardware destroyed):
 
 1. Stop `sandboxd` on every survivor.
 2. On the node with the highest raft `LastIndex` (check `journalctl`),
-   create `/var/lib/sandboxd/raft/peers.json`:
+   create `/var/lib/sandboxd/raft/peers.json` directly or with the helper:
 
-   ```json
-   [
-     { "id": "this-node-id", "address": "10.0.0.5:7000", "non_voter": false, "suffrage": "Voter" }
-   ]
+   ```bash
+   sudo scripts/raft-lost-quorum-recover.sh \
+     --raft-dir /var/lib/sandboxd/raft \
+     --node-id this-node-id \
+     --raft-address 10.0.0.5:7000
    ```
 
-3. Start `sandboxd` on that node only. It detects `peers.json` and rewrites
-   the raft configuration to itself — bootstraps a fresh single-node cluster
-   from its existing log.
+3. Start `sandboxd` on that node only. It detects `peers.json`, runs
+   HashiCorp Raft's recovery path, rewrites the raft configuration to the
+   supplied peers, and renames the file to `peers.json.applied.<unix>` after
+   success.
 4. Once it elects itself leader, re-add the other survivors:
 
    ```bash
@@ -1235,7 +1257,21 @@ curl -H "Authorization: Bearer $SB_PAT_TOKEN" http://<node>:8080/v1/metrics
 Scrape servers, workers, and ingress nodes separately. The endpoint exports
 only `aerolvm_*` metrics and includes the operational signals needed for the
 large-cluster SLOs: Raft apply/snapshot health, route lag, create queue depth,
-worker lease freshness, host pressure, and Caddy/admin errors.
+worker lease freshness, host pressure, image-pull pressure, and Caddy/admin
+errors.
+
+For OTEL, set:
+
+```bash
+SB_OTEL_METRICS_ENDPOINT=http://otel-collector:4318/v1/metrics
+SB_OTEL_METRICS_INTERVAL=30s
+OTEL_SERVICE_NAME=sandboxd
+```
+
+The OTEL bridge exports the same `aerolvm_*` expvars under
+`aerolvm.expvar.int64` and `aerolvm.expvar.float64`, with the original expvar
+name in the `metric` attribute. A starter Grafana dashboard is available at
+`setup/grafana/sandboxd-slo-dashboard.json`.
 
 ---
 

--- a/setup/cluster.md
+++ b/setup/cluster.md
@@ -1273,6 +1273,13 @@ The OTEL bridge exports the same `aerolvm_*` expvars under
 name in the `metric` attribute. A starter Grafana dashboard is available at
 `setup/grafana/sandboxd-slo-dashboard.json`.
 
+Prometheus alert rules are available at `setup/prometheus/sandboxd-alerts.yml`.
+They cover Raft apply/snapshot health, worker lease freshness, create backlog,
+capacity pressure, ingress route lag, Caddy/admin failures, owner-forward
+errors, image-pull storms, and secret decrypt failures. An Alertmanager
+route/receiver example is available at
+`setup/alertmanager/sandboxd-alertmanager-example.yml`.
+
 ---
 
 ## Troubleshooting

--- a/setup/cluster.md
+++ b/setup/cluster.md
@@ -1129,6 +1129,9 @@ file themselves can set them directly in `/etc/sandboxd/cluster.env`.
 | `SB_OTEL_METRICS_ENDPOINT` | no | OTLP/HTTP metrics endpoint, for example `http://otel-collector:4318/v1/metrics`. Setting it enables OTEL metrics. |
 | `SB_OTEL_METRICS_ENABLED` | no | Enables OTEL metrics without an explicit endpoint; the OTEL exporter env defaults apply. |
 | `SB_OTEL_METRICS_INTERVAL` | no | OTEL export interval. Default `30s`. |
+| `SB_OTEL_TRACES_ENDPOINT` | no | OTLP/HTTP traces endpoint, for example `http://otel-collector:4318/v1/traces`. Setting it enables OTEL traces. |
+| `SB_OTEL_TRACES_ENABLED` | no | Enables OTEL traces without an explicit endpoint; the OTEL exporter env defaults apply. |
+| `SB_OTEL_TRACES_SAMPLE_RATIO` | no | Parent-based trace sample ratio. Default `0.05`; use `1` for all root traces or `0` to disable local root sampling. |
 | `SB_IMAGE_PULL_MAX_CONCURRENT` | no | Per-worker cap on concurrent Docker image pulls. Default `4`; set `0` to disable the cap. |
 | `SB_IMAGE_PULL_FAILURE_BACKOFF` | no | Per-image/auth retry suppression after a failed pull. Default `30s`; set `0s` to disable. |
 
@@ -1286,12 +1289,17 @@ For OTEL, set:
 ```bash
 SB_OTEL_METRICS_ENDPOINT=http://otel-collector:4318/v1/metrics
 SB_OTEL_METRICS_INTERVAL=30s
+SB_OTEL_TRACES_ENDPOINT=http://otel-collector:4318/v1/traces
+SB_OTEL_TRACES_SAMPLE_RATIO=0.05
 OTEL_SERVICE_NAME=sandboxd
 ```
 
 The OTEL bridge exports the same `aerolvm_*` expvars under
 `aerolvm.expvar.int64` and `aerolvm.expvar.float64`, with the original expvar
-name in the `metric` attribute. A starter Grafana dashboard is available at
+name in the `metric` attribute. The trace exporter emits server spans for API
+requests, preserves incoming W3C trace context, and attaches the matched
+`http.route`, response status, node ID, node role, service name, and version.
+A starter Grafana dashboard is available at
 `setup/grafana/sandboxd-slo-dashboard.json`.
 
 Prometheus alert rules are available at `setup/prometheus/sandboxd-alerts.yml`.

--- a/setup/deployment/role-changes.md
+++ b/setup/deployment/role-changes.md
@@ -84,10 +84,23 @@ Total time: 5–10 minutes per node.
 
 | Concern | Mitigation |
 |---|---|
-| Workloads on a worker node are lost when it's recreated | Drain sandboxes before the apply (manual today; there's no `aerolvm drain` yet). For production, schedule role changes in maintenance windows. |
+| Workloads on a worker node are lost when it's recreated | Run `ansible-playbook Ansible/playbooks/prepare-role-change.yml --limit <node>` before the Terraform apply. It marks the node drained and waits until the cluster placement index shows zero owned placements. |
 | Brief capacity dip while the new instance comes up | Use `create_before_destroy = true` in the lifecycle block, especially for ingress nodes. New node + DNS record exist before old one disappears → zero public-traffic downtime. |
-| Losing a Raft voter momentarily | The cluster tolerates `(N-1)/2` voter losses. Change one server-role node at a time and you stay in quorum. With three voters, you can recreate one with no impact. |
+| Losing a Raft voter momentarily | The cluster tolerates `(N-1)/2` voter losses. Change one server-role node at a time and you stay in quorum. After terminating a stale server-role node, call `DELETE /v1/cluster/members/<node-id>` from a survivor to remove it from raft explicitly. |
 | "But 5–10 minutes is slow for me!" | If role changes are frequent enough that this hurts, the right fix is the long-term option below, not a faster patch. Role changes in real deployments are rare. |
+
+Pre-drain command:
+
+```bash
+cd Ansible
+ansible-playbook playbooks/prepare-role-change.yml --limit <inventory-host>
+```
+
+The playbook deploys `sandboxd-node-lifecycle.sh`, calls the node-local API to
+drain its own `SB_NODE_ID`, and waits up to
+`sandboxd_role_change_drain_timeout_s` seconds. A timeout is a hard stop: the
+Terraform apply should wait or the operator should intentionally destroy the
+remaining sandboxes first.
 
 ## What Ansible *does* own
 
@@ -97,6 +110,7 @@ still owns everything that isn't declared state:
 | Operation | Tool |
 |---|---|
 | Add / remove / resize / change role | Terraform |
+| Pre-drain before role change | Ansible (`playbooks/prepare-role-change.yml`) |
 | Push a new `sandboxd` binary | Ansible (`playbooks/update-sandboxd.yml`) |
 | Restart services, rotate PATs, tail logs | Ansible |
 | Run one-off shell commands across many nodes | Ansible |

--- a/setup/grafana/sandboxd-slo-dashboard.json
+++ b/setup/grafana/sandboxd-slo-dashboard.json
@@ -1,0 +1,145 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        { "expr": "sum(aerolvm_create_queue_depth)", "legendFormat": "queued creates", "refId": "A" }
+      ],
+      "title": "Create Queue Depth",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 0 },
+      "id": 2,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single", "sort": "none" } },
+      "targets": [
+        { "expr": "sum(rate(aerolvm_create_requests_total[5m]))", "legendFormat": "creates/s", "refId": "A" },
+        { "expr": "sum(rate(aerolvm_create_errors_total[5m]))", "legendFormat": "errors/s", "refId": "B" }
+      ],
+      "title": "Create Throughput And Errors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "percentunit" }, "overrides": [] },
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 0 },
+      "id": 3,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single", "sort": "none" } },
+      "targets": [
+        { "expr": "sum(aerolvm_host_pressure_reserved_cpu_millicores) / clamp_min(sum(aerolvm_host_pressure_cpu_budget_millicores), 1)", "legendFormat": "cpu", "refId": "A" },
+        { "expr": "sum(aerolvm_host_pressure_reserved_memory_mb) / clamp_min(sum(aerolvm_host_pressure_memory_budget_mb), 1)", "legendFormat": "memory", "refId": "B" },
+        { "expr": "sum(aerolvm_host_pressure_reserved_disk_gb) / clamp_min(sum(aerolvm_host_pressure_disk_budget_gb), 1)", "legendFormat": "disk", "refId": "C" }
+      ],
+      "title": "Worker Pressure",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 0 },
+      "id": 4,
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "targets": [
+        { "expr": "max(aerolvm_worker_lease_max_age_nanos) / 1e9", "legendFormat": "max lease age", "refId": "A" }
+      ],
+      "title": "Worker Lease Age",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 6 },
+      "id": 5,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single", "sort": "none" } },
+      "targets": [
+        { "expr": "max(aerolvm_ingress_route_desired_revision - aerolvm_ingress_route_applied_revision)", "legendFormat": "route lag", "refId": "A" },
+        { "expr": "sum(aerolvm_ingress_caddy_ops_pending)", "legendFormat": "caddy pending", "refId": "B" },
+        { "expr": "sum(aerolvm_ingress_caddy_ops_inflight)", "legendFormat": "caddy inflight", "refId": "C" }
+      ],
+      "title": "Ingress Route Lag",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 6 },
+      "id": 6,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single", "sort": "none" } },
+      "targets": [
+        { "expr": "sum(rate(aerolvm_raft_apply_errors_total[5m])) by (key)", "legendFormat": "{{key}}", "refId": "A" },
+        { "expr": "sum(rate(aerolvm_raft_snapshot_errors_total[5m])) by (key)", "legendFormat": "snapshot {{key}}", "refId": "B" }
+      ],
+      "title": "Raft Errors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 6 },
+      "id": 7,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single", "sort": "none" } },
+      "targets": [
+        { "expr": "sum(aerolvm_image_pull_inflight)", "legendFormat": "inflight", "refId": "A" },
+        { "expr": "sum(aerolvm_image_pull_queued)", "legendFormat": "queued", "refId": "B" },
+        { "expr": "sum(rate(aerolvm_image_pull_errors_total[5m])) by (key)", "legendFormat": "errors {{key}}", "refId": "C" },
+        { "expr": "sum(rate(aerolvm_image_pull_backoff_rejects_total[5m]))", "legendFormat": "backoff rejects/s", "refId": "D" }
+      ],
+      "title": "Image Pull Storms",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 14 },
+      "id": 8,
+      "options": { "legend": { "displayMode": "table", "placement": "right" }, "tooltip": { "mode": "single", "sort": "none" } },
+      "targets": [
+        { "expr": "sum(aerolvm_ingress_routes_by_shard) by (key)", "legendFormat": "shard {{key}}", "refId": "A" }
+      ],
+      "title": "Shard Health",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 14 },
+      "id": 9,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single", "sort": "none" } },
+      "targets": [
+        { "expr": "sum(rate(aerolvm_caddy_admin_errors_total[5m])) by (key)", "legendFormat": "{{key}}", "refId": "A" },
+        { "expr": "sum(rate(aerolvm_owner_forward_errors_total[5m])) by (key)", "legendFormat": "forward {{key}}", "refId": "B" }
+      ],
+      "title": "Data Plane Errors",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": ["sandboxd", "aerolvm", "slo"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "sandboxd SLOs",
+  "uid": "sandboxd-slos",
+  "version": 1,
+  "weekStart": ""
+}

--- a/setup/grafana/sandboxd-slo-dashboard.json
+++ b/setup/grafana/sandboxd-slo-dashboard.json
@@ -125,6 +125,91 @@
       ],
       "title": "Data Plane Errors",
       "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 21 },
+      "id": 10,
+      "options": { "legend": { "displayMode": "table", "placement": "right" }, "tooltip": { "mode": "single", "sort": "none" } },
+      "targets": [
+        { "expr": "sum(rate(aerolvm_create_latency_seconds_bucket[5m])) by (key)", "legendFormat": "{{key}}", "refId": "A" }
+      ],
+      "title": "Create Latency Buckets",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 21 },
+      "id": 11,
+      "options": { "legend": { "displayMode": "table", "placement": "right" }, "tooltip": { "mode": "single", "sort": "none" } },
+      "targets": [
+        { "expr": "sum(rate(aerolvm_create_admission_rejects_total[5m])) by (key)", "legendFormat": "admission {{key}}", "refId": "A" },
+        { "expr": "sum(rate(aerolvm_scheduler_decisions_total[5m])) by (key)", "legendFormat": "decision {{key}}", "refId": "B" },
+        { "expr": "sum(rate(aerolvm_scheduler_candidate_rejects_total[5m])) by (key)", "legendFormat": "candidate reject {{key}}", "refId": "C" }
+      ],
+      "title": "Admission And Scheduler Decisions",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 28 },
+      "id": 12,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single", "sort": "none" } },
+      "targets": [
+        { "expr": "sum(aerolvm_worker_leases_alive)", "legendFormat": "fresh worker leases", "refId": "A" },
+        { "expr": "sum(aerolvm_worker_leases_total)", "legendFormat": "known worker leases", "refId": "B" },
+        { "expr": "sum(aerolvm_gossip_members_alive)", "legendFormat": "alive gossip members", "refId": "C" },
+        { "expr": "sum(aerolvm_gossip_members_total)", "legendFormat": "known gossip members", "refId": "D" }
+      ],
+      "title": "Worker Lease Coverage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 28 },
+      "id": 13,
+      "options": { "legend": { "displayMode": "table", "placement": "right" }, "tooltip": { "mode": "single", "sort": "none" } },
+      "targets": [
+        { "expr": "sum(aerolvm_raft_apply_inflight)", "legendFormat": "apply inflight", "refId": "A" },
+        { "expr": "sum(rate(aerolvm_raft_apply_latency_seconds_bucket[5m])) by (key)", "legendFormat": "apply latency {{key}}", "refId": "B" },
+        { "expr": "max(aerolvm_raft_snapshot_last_bytes)", "legendFormat": "snapshot bytes", "refId": "C" },
+        { "expr": "max(aerolvm_raft_snapshot_placements_last)", "legendFormat": "snapshot placements", "refId": "D" }
+      ],
+      "title": "Raft Apply And Snapshot Cost",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 35 },
+      "id": 14,
+      "options": { "legend": { "displayMode": "table", "placement": "right" }, "tooltip": { "mode": "single", "sort": "none" } },
+      "targets": [
+        { "expr": "sum(rate(aerolvm_ingress_reconcile_errors_total[5m]))", "legendFormat": "reconcile errors/s", "refId": "A" },
+        { "expr": "sum(rate(aerolvm_ingress_route_misses_total[5m]))", "legendFormat": "route misses/s", "refId": "B" },
+        { "expr": "sum(rate(aerolvm_caddy_admin_latency_seconds_bucket[5m])) by (key)", "legendFormat": "caddy latency {{key}}", "refId": "C" }
+      ],
+      "title": "Ingress Reconcile And Caddy Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 35 },
+      "id": 15,
+      "options": { "legend": { "displayMode": "table", "placement": "right" }, "tooltip": { "mode": "single", "sort": "none" } },
+      "targets": [
+        { "expr": "sum(rate(aerolvm_secret_decrypt_errors_total[5m])) by (key)", "legendFormat": "decrypt error {{key}}", "refId": "A" },
+        { "expr": "sum(rate(aerolvm_secret_key_version_mismatches_total[5m]))", "legendFormat": "key version mismatch/s", "refId": "B" },
+        { "expr": "sum(rate(aerolvm_secret_recipient_denied_total[5m]))", "legendFormat": "recipient denied/s", "refId": "C" },
+        { "expr": "sum(rate(aerolvm_secret_decrypt_latency_seconds_bucket[5m])) by (key)", "legendFormat": "decrypt latency {{key}}", "refId": "D" }
+      ],
+      "title": "Secret Recovery Health",
+      "type": "timeseries"
     }
   ],
   "refresh": "10s",

--- a/setup/prometheus/sandboxd-alerts.yml
+++ b/setup/prometheus/sandboxd-alerts.yml
@@ -11,7 +11,7 @@ groups:
         annotations:
           summary: "sandboxd Raft apply errors are occurring"
           description: "Raft apply errors have been non-zero for 5 minutes. Writes may be failing or retrying."
-          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#verifying-cluster-health"
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/runbooks/slo-breach.md"
 
       - alert: SandboxdRaftApplyStuck
         expr: sum(aerolvm_raft_apply_inflight) > 0
@@ -22,7 +22,7 @@ groups:
         annotations:
           summary: "sandboxd Raft apply appears stuck"
           description: "At least one Raft apply has remained in-flight for more than 2 minutes."
-          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#verifying-cluster-health"
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/runbooks/slo-breach.md"
 
       - alert: SandboxdRaftSnapshotErrors
         expr: sum(rate(aerolvm_raft_snapshot_errors_total[10m])) > 0
@@ -33,7 +33,7 @@ groups:
         annotations:
           summary: "sandboxd Raft snapshot errors are occurring"
           description: "Snapshot persistence has reported errors. Follower recovery and restart time may degrade."
-          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#backups-in-cluster-mode"
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/runbooks/backup-restore.md"
 
       - alert: SandboxdWorkerLeaseStale
         expr: max(aerolvm_worker_lease_max_age_nanos) / 1e9 > 30
@@ -44,7 +44,7 @@ groups:
         annotations:
           summary: "sandboxd worker capacity leases are stale"
           description: "The freshest scheduler-visible worker capacity lease is older than 30 seconds. Placement may reject or misroute creates."
-          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#verifying-cluster-health"
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/runbooks/slo-breach.md"
 
       - alert: SandboxdWorkerLeaseLoss
         expr: sum(rate(aerolvm_worker_lease_lost_total[5m])) > 0
@@ -55,7 +55,7 @@ groups:
         annotations:
           summary: "sandboxd worker capacity leases are being lost"
           description: "Workers are dropping out of the scheduler's fresh-capacity set."
-          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/runbooks/slo-breach.md"
 
   - name: sandboxd.create-and-capacity
     interval: 30s
@@ -69,7 +69,7 @@ groups:
         annotations:
           summary: "sandboxd create queue backlog is high"
           description: "Create queue depth has been above 100 for 5 minutes. Clients may see 429/503 Retry-After responses."
-          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/runbooks/slo-breach.md"
 
       - alert: SandboxdCreateErrors
         expr: sum(rate(aerolvm_create_errors_total[5m])) > 0.1
@@ -80,7 +80,7 @@ groups:
         annotations:
           summary: "sandboxd create errors are elevated"
           description: "Sandbox create errors are above 0.1/s for 10 minutes."
-          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/runbooks/slo-breach.md"
 
       - alert: SandboxdNoAdmitWorkers
         expr: sum(aerolvm_host_pressure_can_admit) == 0
@@ -91,7 +91,7 @@ groups:
         annotations:
           summary: "no sandboxd worker can admit new sandboxes"
           description: "All scraped workers report can_admit=0. New sandbox creates will fail until capacity recovers."
-          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#verifying-cluster-health"
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/runbooks/slo-breach.md"
 
       - alert: SandboxdHighCPUReservation
         expr: sum(aerolvm_host_pressure_reserved_cpu_millicores) / clamp_min(sum(aerolvm_host_pressure_cpu_budget_millicores), 1) > 0.9
@@ -102,7 +102,7 @@ groups:
         annotations:
           summary: "sandboxd CPU reservation pressure is high"
           description: "Cluster-wide reserved CPU is above 90% of the configured admission budget."
-          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/runbooks/slo-breach.md"
 
       - alert: SandboxdHighMemoryReservation
         expr: sum(aerolvm_host_pressure_reserved_memory_mb) / clamp_min(sum(aerolvm_host_pressure_memory_budget_mb), 1) > 0.9
@@ -113,7 +113,7 @@ groups:
         annotations:
           summary: "sandboxd memory reservation pressure is high"
           description: "Cluster-wide reserved memory is above 90% of the configured admission budget."
-          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/runbooks/slo-breach.md"
 
       - alert: SandboxdHighDiskReservation
         expr: sum(aerolvm_host_pressure_disk_budget_gb) > 0 and sum(aerolvm_host_pressure_reserved_disk_gb) / clamp_min(sum(aerolvm_host_pressure_disk_budget_gb), 1) > 0.9
@@ -124,7 +124,7 @@ groups:
         annotations:
           summary: "sandboxd disk reservation pressure is high"
           description: "Cluster-wide reserved disk is above 90% of the configured admission budget."
-          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/runbooks/slo-breach.md"
 
   - name: sandboxd.ingress-and-data-plane
     interval: 30s
@@ -138,7 +138,7 @@ groups:
         annotations:
           summary: "sandboxd ingress route lag is high"
           description: "Ingress route reconciliation is more than 100 placement revisions behind."
-          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/runbooks/slo-breach.md"
 
       - alert: SandboxdIngressRouteReconcileErrors
         expr: sum(rate(aerolvm_ingress_reconcile_errors_total[5m])) > 0
@@ -149,7 +149,7 @@ groups:
         annotations:
           summary: "sandboxd ingress reconcile errors are occurring"
           description: "The ingress reconciler is failing to converge routes."
-          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/runbooks/slo-breach.md"
 
       - alert: SandboxdCaddyAdminErrors
         expr: sum(rate(aerolvm_caddy_admin_errors_total[5m])) > 0
@@ -160,7 +160,7 @@ groups:
         annotations:
           summary: "sandboxd Caddy admin errors are occurring"
           description: "Caddy admin calls are failing. Public route convergence may be delayed."
-          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/runbooks/slo-breach.md"
 
       - alert: SandboxdIngressRouteMisses
         expr: sum(rate(aerolvm_ingress_route_misses_total[5m])) > 0
@@ -171,7 +171,7 @@ groups:
         annotations:
           summary: "sandboxd owner route misses are occurring"
           description: "Requests are reaching nodes that cannot resolve a usable owner URL. Check gossip convergence and advertise URLs."
-          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/runbooks/slo-breach.md"
 
       - alert: SandboxdOwnerForwardErrors
         expr: sum(rate(aerolvm_owner_forward_errors_total[5m])) > 0
@@ -182,7 +182,7 @@ groups:
         annotations:
           summary: "sandboxd owner-forward errors are occurring"
           description: "Cross-node owner API forwards are failing."
-          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/runbooks/slo-breach.md"
 
   - name: sandboxd.image-pulls-and-secrets
     interval: 30s
@@ -196,7 +196,7 @@ groups:
         annotations:
           summary: "sandboxd image pulls are queued"
           description: "Image pulls have been waiting behind the per-worker concurrency cap for 10 minutes."
-          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/runbooks/image-pull-storm.md"
 
       - alert: SandboxdImagePullBackoffRejects
         expr: sum(rate(aerolvm_image_pull_backoff_rejects_total[5m])) > 0
@@ -207,7 +207,7 @@ groups:
         annotations:
           summary: "sandboxd image pulls are suppressed by failure backoff"
           description: "Repeated pulls for failing image/auth keys are being rejected by backoff. Check tags, registry auth, and registry rate limits."
-          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/runbooks/image-pull-storm.md"
 
       - alert: SandboxdImagePullErrors
         expr: sum(rate(aerolvm_image_pull_errors_total[5m])) > 0.05
@@ -218,7 +218,7 @@ groups:
         annotations:
           summary: "sandboxd image pull errors are elevated"
           description: "Image pull errors are above 0.05/s for 10 minutes."
-          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/runbooks/image-pull-storm.md"
 
       - alert: SandboxdSecretDecryptErrors
         expr: sum(rate(aerolvm_secret_decrypt_errors_total[5m])) > 0
@@ -229,4 +229,4 @@ groups:
         annotations:
           summary: "sandboxd secret decrypt errors are occurring"
           description: "Cluster recovery secret decrypts are failing. Verify credential encryption keys are identical on every node."
-          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/runbooks/slo-breach.md"

--- a/setup/prometheus/sandboxd-alerts.yml
+++ b/setup/prometheus/sandboxd-alerts.yml
@@ -1,0 +1,232 @@
+groups:
+  - name: sandboxd.control-plane
+    interval: 30s
+    rules:
+      - alert: SandboxdRaftApplyErrors
+        expr: sum(rate(aerolvm_raft_apply_errors_total[5m])) > 0
+        for: 5m
+        labels:
+          severity: critical
+          component: raft
+        annotations:
+          summary: "sandboxd Raft apply errors are occurring"
+          description: "Raft apply errors have been non-zero for 5 minutes. Writes may be failing or retrying."
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#verifying-cluster-health"
+
+      - alert: SandboxdRaftApplyStuck
+        expr: sum(aerolvm_raft_apply_inflight) > 0
+        for: 2m
+        labels:
+          severity: critical
+          component: raft
+        annotations:
+          summary: "sandboxd Raft apply appears stuck"
+          description: "At least one Raft apply has remained in-flight for more than 2 minutes."
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#verifying-cluster-health"
+
+      - alert: SandboxdRaftSnapshotErrors
+        expr: sum(rate(aerolvm_raft_snapshot_errors_total[10m])) > 0
+        for: 10m
+        labels:
+          severity: warning
+          component: raft
+        annotations:
+          summary: "sandboxd Raft snapshot errors are occurring"
+          description: "Snapshot persistence has reported errors. Follower recovery and restart time may degrade."
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#backups-in-cluster-mode"
+
+      - alert: SandboxdWorkerLeaseStale
+        expr: max(aerolvm_worker_lease_max_age_nanos) / 1e9 > 30
+        for: 2m
+        labels:
+          severity: critical
+          component: scheduler
+        annotations:
+          summary: "sandboxd worker capacity leases are stale"
+          description: "The freshest scheduler-visible worker capacity lease is older than 30 seconds. Placement may reject or misroute creates."
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#verifying-cluster-health"
+
+      - alert: SandboxdWorkerLeaseLoss
+        expr: sum(rate(aerolvm_worker_lease_lost_total[5m])) > 0
+        for: 5m
+        labels:
+          severity: warning
+          component: scheduler
+        annotations:
+          summary: "sandboxd worker capacity leases are being lost"
+          description: "Workers are dropping out of the scheduler's fresh-capacity set."
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+
+  - name: sandboxd.create-and-capacity
+    interval: 30s
+    rules:
+      - alert: SandboxdCreateQueueBacklog
+        expr: sum(aerolvm_create_queue_depth) > 100
+        for: 5m
+        labels:
+          severity: warning
+          component: create
+        annotations:
+          summary: "sandboxd create queue backlog is high"
+          description: "Create queue depth has been above 100 for 5 minutes. Clients may see 429/503 Retry-After responses."
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+
+      - alert: SandboxdCreateErrors
+        expr: sum(rate(aerolvm_create_errors_total[5m])) > 0.1
+        for: 10m
+        labels:
+          severity: warning
+          component: create
+        annotations:
+          summary: "sandboxd create errors are elevated"
+          description: "Sandbox create errors are above 0.1/s for 10 minutes."
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+
+      - alert: SandboxdNoAdmitWorkers
+        expr: sum(aerolvm_host_pressure_can_admit) == 0
+        for: 5m
+        labels:
+          severity: critical
+          component: capacity
+        annotations:
+          summary: "no sandboxd worker can admit new sandboxes"
+          description: "All scraped workers report can_admit=0. New sandbox creates will fail until capacity recovers."
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#verifying-cluster-health"
+
+      - alert: SandboxdHighCPUReservation
+        expr: sum(aerolvm_host_pressure_reserved_cpu_millicores) / clamp_min(sum(aerolvm_host_pressure_cpu_budget_millicores), 1) > 0.9
+        for: 10m
+        labels:
+          severity: warning
+          component: capacity
+        annotations:
+          summary: "sandboxd CPU reservation pressure is high"
+          description: "Cluster-wide reserved CPU is above 90% of the configured admission budget."
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+
+      - alert: SandboxdHighMemoryReservation
+        expr: sum(aerolvm_host_pressure_reserved_memory_mb) / clamp_min(sum(aerolvm_host_pressure_memory_budget_mb), 1) > 0.9
+        for: 10m
+        labels:
+          severity: warning
+          component: capacity
+        annotations:
+          summary: "sandboxd memory reservation pressure is high"
+          description: "Cluster-wide reserved memory is above 90% of the configured admission budget."
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+
+      - alert: SandboxdHighDiskReservation
+        expr: sum(aerolvm_host_pressure_disk_budget_gb) > 0 and sum(aerolvm_host_pressure_reserved_disk_gb) / clamp_min(sum(aerolvm_host_pressure_disk_budget_gb), 1) > 0.9
+        for: 10m
+        labels:
+          severity: warning
+          component: capacity
+        annotations:
+          summary: "sandboxd disk reservation pressure is high"
+          description: "Cluster-wide reserved disk is above 90% of the configured admission budget."
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+
+  - name: sandboxd.ingress-and-data-plane
+    interval: 30s
+    rules:
+      - alert: SandboxdIngressRouteLag
+        expr: max(aerolvm_ingress_route_lag_versions) > 100
+        for: 5m
+        labels:
+          severity: warning
+          component: ingress
+        annotations:
+          summary: "sandboxd ingress route lag is high"
+          description: "Ingress route reconciliation is more than 100 placement revisions behind."
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+
+      - alert: SandboxdIngressRouteReconcileErrors
+        expr: sum(rate(aerolvm_ingress_reconcile_errors_total[5m])) > 0
+        for: 5m
+        labels:
+          severity: warning
+          component: ingress
+        annotations:
+          summary: "sandboxd ingress reconcile errors are occurring"
+          description: "The ingress reconciler is failing to converge routes."
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+
+      - alert: SandboxdCaddyAdminErrors
+        expr: sum(rate(aerolvm_caddy_admin_errors_total[5m])) > 0
+        for: 5m
+        labels:
+          severity: warning
+          component: ingress
+        annotations:
+          summary: "sandboxd Caddy admin errors are occurring"
+          description: "Caddy admin calls are failing. Public route convergence may be delayed."
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+
+      - alert: SandboxdIngressRouteMisses
+        expr: sum(rate(aerolvm_ingress_route_misses_total[5m])) > 0
+        for: 10m
+        labels:
+          severity: warning
+          component: ingress
+        annotations:
+          summary: "sandboxd owner route misses are occurring"
+          description: "Requests are reaching nodes that cannot resolve a usable owner URL. Check gossip convergence and advertise URLs."
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+
+      - alert: SandboxdOwnerForwardErrors
+        expr: sum(rate(aerolvm_owner_forward_errors_total[5m])) > 0
+        for: 5m
+        labels:
+          severity: warning
+          component: data-plane
+        annotations:
+          summary: "sandboxd owner-forward errors are occurring"
+          description: "Cross-node owner API forwards are failing."
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+
+  - name: sandboxd.image-pulls-and-secrets
+    interval: 30s
+    rules:
+      - alert: SandboxdImagePullQueueBacklog
+        expr: sum(aerolvm_image_pull_queued) > 0
+        for: 10m
+        labels:
+          severity: warning
+          component: image-pull
+        annotations:
+          summary: "sandboxd image pulls are queued"
+          description: "Image pulls have been waiting behind the per-worker concurrency cap for 10 minutes."
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+
+      - alert: SandboxdImagePullBackoffRejects
+        expr: sum(rate(aerolvm_image_pull_backoff_rejects_total[5m])) > 0
+        for: 5m
+        labels:
+          severity: warning
+          component: image-pull
+        annotations:
+          summary: "sandboxd image pulls are suppressed by failure backoff"
+          description: "Repeated pulls for failing image/auth keys are being rejected by backoff. Check tags, registry auth, and registry rate limits."
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+
+      - alert: SandboxdImagePullErrors
+        expr: sum(rate(aerolvm_image_pull_errors_total[5m])) > 0.05
+        for: 10m
+        labels:
+          severity: warning
+          component: image-pull
+        annotations:
+          summary: "sandboxd image pull errors are elevated"
+          description: "Image pull errors are above 0.05/s for 10 minutes."
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"
+
+      - alert: SandboxdSecretDecryptErrors
+        expr: sum(rate(aerolvm_secret_decrypt_errors_total[5m])) > 0
+        for: 5m
+        labels:
+          severity: critical
+          component: secrets
+        annotations:
+          summary: "sandboxd secret decrypt errors are occurring"
+          description: "Cluster recovery secret decrypts are failing. Verify credential encryption keys are identical on every node."
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/cluster.md#troubleshooting"

--- a/setup/runbooks/README.md
+++ b/setup/runbooks/README.md
@@ -1,0 +1,62 @@
+# sandboxd Operational Runbooks
+
+These runbooks are the operator procedures for production clusters. They are
+intended to be copied into the same place as the Grafana dashboard and
+Prometheus alert rules by `Ansible/playbooks/configure-ops.yml`.
+
+Use them during incidents and during scheduled drills:
+
+| Runbook | Use when |
+|---|---|
+| [backup-restore.md](backup-restore.md) | You need to restore a node or prove backups are usable. |
+| [lost-quorum-recovery.md](lost-quorum-recovery.md) | Raft has no leader because too many voter nodes are gone. |
+| [image-pull-storm.md](image-pull-storm.md) | Image pulls are queued, failing, rate-limited, or suppressed by backoff. |
+| [slo-breach.md](slo-breach.md) | Any sandboxd SLO alert fires and the first response is not obvious. |
+
+## Incident Roles
+
+- **Incident commander:** owns decisions, declares severity, and timestamps
+  actions.
+- **Operator:** runs commands and changes cluster state.
+- **Comms:** updates users and stakeholders.
+- **Observer:** records metrics before, during, and after mitigation.
+
+For small teams, one person may hold multiple roles, but the incident log still
+needs a single commander and one timestamped command trail.
+
+## Standard First Five Minutes
+
+1. Identify the firing alert and affected cluster.
+2. Open the Grafana dashboard and the current Prometheus alert page.
+3. Capture `GET /v1/cluster/leader`, `GET /v1/cluster/members`, and
+   `GET /v1/metrics` from one server, one worker, and one ingress node.
+4. Stop deploys and topology changes until the incident commander clears them.
+5. Pick the narrow runbook below and follow its verification steps before
+   changing state.
+
+## Standard Evidence Commands
+
+```bash
+export SB_PAT_TOKEN=<redacted>
+curl -fsS -H "Authorization: Bearer $SB_PAT_TOKEN" \
+  http://127.0.0.1:21212/v1/cluster/leader | jq .
+curl -fsS -H "Authorization: Bearer $SB_PAT_TOKEN" \
+  http://127.0.0.1:21212/v1/cluster/members | jq .
+curl -fsS -H "Authorization: Bearer $SB_PAT_TOKEN" \
+  http://127.0.0.1:21212/v1/metrics | tee /tmp/sandboxd.metrics
+sudo journalctl -u sandboxd --since "30 minutes ago" --no-pager \
+  | grep -iE 'error|warn|raft|leader|capacity|image|pull|caddy|reconcile'
+```
+
+## Drill Cadence
+
+Run these drills on a staging cluster at least monthly:
+
+- Backup restore drill: restore the latest archive into a replacement node.
+- Lost quorum tabletop: walk the decision tree without creating `peers.json`.
+- Image pull storm drill: point one test workload at a deliberately missing
+  image tag and verify backoff alerts.
+- SLO breach drill: force a create backlog with a bounded load test and verify
+  alert, dashboard, and mitigation steps.
+
+Record the result in the drill template included in each runbook.

--- a/setup/runbooks/backup-restore.md
+++ b/setup/runbooks/backup-restore.md
@@ -1,0 +1,159 @@
+# Runbook: Backup and Restore
+
+Use this when you need to prove backups are usable, restore a failed node, or
+recover from accidental local state loss. This runbook covers the local
+sandboxd backup archive produced by `sandboxd-backup.sh`.
+
+## Severity
+
+| Severity | Criteria |
+|---|---|
+| SEV-1 | Multiple worker/server nodes lost data, or restore is required to regain quorum. |
+| SEV-2 | One production node lost local state but quorum and ingress still work. |
+| SEV-3 | Scheduled restore drill or non-production restore. |
+
+## Safety Rules
+
+- Do not restore over a running `sandboxd`.
+- Do not restore a backup from a different cluster unless you intentionally
+  want that cluster identity, PAT, TLS, Raft state, and credential key.
+- Do not reuse a Raft data directory with a different `SB_NODE_ID`.
+- Keep the original failed disk attached or snapshotted until verification is
+  complete.
+
+## What the Backup Contains
+
+The helper includes:
+
+- `/var/lib/sandboxd/state.db`
+- `/var/lib/sandboxd/raft/`
+- `/etc/sandboxd/`
+- a manifest with host, source path, and creation time
+
+The archive does **not** contain Docker image layers, running containers, or
+external mounted storage. Recovered sandboxes must still be recreated from
+pullable images and valid credentials.
+
+## Pre-Restore Checklist
+
+1. Confirm the target cluster and node identity.
+2. Find the newest backup archive for the node.
+3. Confirm the archive is readable:
+
+   ```bash
+   tar -tzf /secure/backups/sandboxd-node-a-YYYY-MM-DD.tar.gz | head
+   tar -xOzf /secure/backups/sandboxd-node-a-YYYY-MM-DD.tar.gz ./MANIFEST.txt
+   ```
+
+4. Confirm the replacement node is not running sandboxd:
+
+   ```bash
+   sudo systemctl is-active sandboxd || true
+   sudo systemctl stop sandboxd
+   ```
+
+5. Snapshot or copy any existing data on the replacement node:
+
+   ```bash
+   sudo tar -C / -czf /root/pre-restore-sandboxd-$(date +%F-%H%M%S).tar.gz \
+     etc/sandboxd var/lib/sandboxd || true
+   ```
+
+## Restore Procedure
+
+1. Copy the backup archive to the replacement node.
+
+2. Stop sandboxd:
+
+   ```bash
+   sudo systemctl stop sandboxd
+   ```
+
+3. Restore the archive:
+
+   ```bash
+   sudo /usr/local/sbin/sandboxd-restore.sh \
+     --input /secure/backups/sandboxd-node-a-YYYY-MM-DD.tar.gz \
+     --target-root / \
+     --force
+   ```
+
+4. Verify expected files:
+
+   ```bash
+   sudo test -f /etc/sandboxd/sandboxd.env
+   sudo test -f /var/lib/sandboxd/state.db
+   sudo test -d /var/lib/sandboxd/raft
+   sudo grep -E 'SB_NODE_ID|SB_NODE_ROLE|SB_ENABLE_CLUSTER' /etc/sandboxd/cluster.env
+   ```
+
+5. Start sandboxd:
+
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl start sandboxd
+   ```
+
+## Verification
+
+Run from the restored node:
+
+```bash
+export SB_PAT_TOKEN=<redacted>
+curl -fsS -H "Authorization: Bearer $SB_PAT_TOKEN" \
+  http://127.0.0.1:21212/health | jq .
+curl -fsS -H "Authorization: Bearer $SB_PAT_TOKEN" \
+  http://127.0.0.1:21212/v1/cluster/leader | jq .
+curl -fsS -H "Authorization: Bearer $SB_PAT_TOKEN" \
+  http://127.0.0.1:21212/v1/cluster/members | jq .
+curl -fsS -H "Authorization: Bearer $SB_PAT_TOKEN" \
+  http://127.0.0.1:21212/v1/metrics \
+  | grep -E 'aerolvm_raft|aerolvm_worker|aerolvm_create' | head
+```
+
+Expected:
+
+- `/health` is 200.
+- A leader exists unless this was a lost-quorum restore.
+- The restored node appears with the expected `node_id` and role.
+- `aerolvm_secret_decrypt_errors_total` is not increasing.
+- `aerolvm_worker_lease_max_age_nanos` returns to a fresh value on workers.
+
+## If This Restore Is Also a Lost-Quorum Recovery
+
+Do not start every survivor. Follow
+[lost-quorum-recovery.md](lost-quorum-recovery.md) after restoring the chosen
+survivor or replacement node.
+
+## Rollback
+
+If verification fails:
+
+1. Stop sandboxd.
+2. Preserve logs and current restored data:
+
+   ```bash
+   sudo journalctl -u sandboxd --since "1 hour ago" --no-pager > /root/sandboxd-restore-failed.log
+   sudo tar -C / -czf /root/failed-restore-state-$(date +%F-%H%M%S).tar.gz \
+     etc/sandboxd var/lib/sandboxd || true
+   ```
+
+3. Restore the pre-restore archive made in the checklist.
+4. Escalate before attempting a different backup.
+
+## Restore Drill
+
+Use a staging node or disposable replacement instance.
+
+| Field | Value |
+|---|---|
+| Date | |
+| Operator | |
+| Source backup | |
+| Target node | |
+| Restore start/end | |
+| Health passed | yes/no |
+| Leader visible | yes/no |
+| Members correct | yes/no |
+| Secret decrypt errors stable | yes/no |
+| Follow-up fixes | |

--- a/setup/runbooks/image-pull-storm.md
+++ b/setup/runbooks/image-pull-storm.md
@@ -1,0 +1,170 @@
+# Runbook: Image-Pull Storm
+
+Use this when image pulls are queued, failing, rate-limited, or repeatedly
+suppressed by the per-image failure backoff.
+
+## Alerts
+
+- `SandboxdImagePullQueueBacklog`
+- `SandboxdImagePullBackoffRejects`
+- `SandboxdImagePullErrors`
+- create queue alerts that coincide with image-pull metrics
+
+## Severity
+
+| Severity | Criteria |
+|---|---|
+| SEV-1 | Most creates fail or the registry is unavailable for production workloads. |
+| SEV-2 | A subset of images or tenants is failing, but other creates succeed. |
+| SEV-3 | Backoff is working and impact is limited to a test or bad image tag. |
+
+## First Checks
+
+Run on affected workers:
+
+```bash
+export SB_PAT_TOKEN=<redacted>
+curl -fsS -H "Authorization: Bearer $SB_PAT_TOKEN" \
+  http://127.0.0.1:21212/v1/metrics \
+  | grep -E 'aerolvm_image_pull|aerolvm_create_queue|aerolvm_create_errors'
+sudo journalctl -u sandboxd --since "30 minutes ago" --no-pager \
+  | grep -iE 'pull image|images/create|manifest|unauthorized|too many requests|rate'
+```
+
+Classify the failure:
+
+| Signal | Likely cause |
+|---|---|
+| `aerolvm_image_pull_queued > 0` | many distinct cold images or slow registry |
+| backoff rejects increasing | same image/auth key keeps failing |
+| error reason `not_found` | bad tag, deleted image, local-only image on wrong node |
+| error reason `auth` | registry credentials invalid or secret decrypt failure |
+| error reason `rate_limited` | registry throttling |
+| create queue rising too | user-visible create latency/failure |
+
+## Containment
+
+Pick the smallest action that stops amplification:
+
+1. Pause or rate-limit the caller issuing bad creates.
+2. If a tag is bad, reject that request path in the caller or control plane.
+3. If registry rate-limited, reduce create fan-in and pre-pull hot images.
+4. If credentials are failing, stop private-image creates until the credential
+   key or registry secret is fixed.
+5. If only one worker is overloaded, drain it from new placement:
+
+   ```bash
+   curl -fsS -X POST -H "Authorization: Bearer $SB_PAT_TOKEN" \
+     http://127.0.0.1:21212/v1/cluster/nodes/<node-id>/drain
+   ```
+
+Do not raise `SB_IMAGE_PULL_MAX_CONCURRENT` during registry rate limiting.
+That increases pressure. Raise it only when the registry is healthy and the
+worker has idle network/disk capacity.
+
+## Mitigation by Cause
+
+### Bad or Missing Image Tag
+
+1. Confirm the image reference from logs.
+2. Ask the caller to fix the tag or roll back the release.
+3. Wait for `SB_IMAGE_PULL_FAILURE_BACKOFF` to expire or restart sandboxd only
+   if the incident commander accepts the retry surge risk.
+
+### Registry Authentication Failure
+
+1. Check secret decrypt metrics:
+
+   ```bash
+   curl -fsS -H "Authorization: Bearer $SB_PAT_TOKEN" \
+     http://127.0.0.1:21212/v1/metrics \
+     | grep -E 'aerolvm_secret_decrypt_errors_total|aerolvm_secret_key_version_mismatches_total'
+   ```
+
+2. Verify `/var/lib/sandboxd/credential_encryption.key` matches across nodes.
+3. Rotate or re-store registry credentials.
+4. Retry one sandbox create before unpausing the caller.
+
+### Registry Rate Limit or Outage
+
+1. Reduce create concurrency at the caller.
+2. Pre-pull the affected image on workers if registry policy permits:
+
+   ```bash
+   sudo docker pull <image>
+   ```
+
+3. Consider temporarily lowering:
+
+   ```bash
+   SB_IMAGE_PULL_MAX_CONCURRENT=1
+   SB_IMAGE_PULL_FAILURE_BACKOFF=2m
+   ```
+
+   Apply through Ansible:
+
+   ```bash
+   ansible-playbook Ansible/playbooks/configure-ops.yml \
+     -e sandboxd_image_pull_max_concurrent=1 \
+     -e sandboxd_image_pull_failure_backoff=2m
+   ```
+
+4. Restore defaults after error rate is stable for 30 minutes.
+
+### Worker Disk or Network Saturation
+
+1. Check host pressure and Docker disk:
+
+   ```bash
+   df -h
+   sudo docker system df
+   curl -fsS -H "Authorization: Bearer $SB_PAT_TOKEN" \
+     http://127.0.0.1:21212/v1/metrics \
+     | grep -E 'aerolvm_host_pressure|aerolvm_image_pull'
+   ```
+
+2. Drain the worker if it cannot recover quickly.
+3. Run image GC only if the incident commander accepts cache misses after GC.
+
+## Recovery Verification
+
+The incident is mitigated when all are true for at least 15 minutes:
+
+- `sum(aerolvm_image_pull_queued) == 0`
+- `rate(aerolvm_image_pull_errors_total[5m])` is near zero
+- `rate(aerolvm_image_pull_backoff_rejects_total[5m])` is zero
+- create queue depth returns to normal
+- a known-good create succeeds
+
+## Rollback
+
+If you changed pull knobs through Ansible, restore defaults:
+
+```bash
+ansible-playbook Ansible/playbooks/configure-ops.yml \
+  -e sandboxd_image_pull_max_concurrent=4 \
+  -e sandboxd_image_pull_failure_backoff=30s
+```
+
+If you drained workers, uncordon one at a time:
+
+```bash
+curl -fsS -X POST -H "Authorization: Bearer $SB_PAT_TOKEN" \
+  http://127.0.0.1:21212/v1/cluster/nodes/<node-id>/uncordon
+```
+
+## Image-Pull Storm Drill
+
+Use a staging cluster.
+
+| Field | Value |
+|---|---|
+| Date | |
+| Operator | |
+| Test image | |
+| Expected failure reason | |
+| Alert fired | yes/no |
+| Backoff observed | yes/no |
+| Queue returned to zero | yes/no |
+| Create path recovered | yes/no |
+| Follow-up fixes | |

--- a/setup/runbooks/lost-quorum-recovery.md
+++ b/setup/runbooks/lost-quorum-recovery.md
@@ -1,0 +1,168 @@
+# Runbook: Lost-Quorum Recovery
+
+Use this only when Raft has no leader because too many voter nodes are gone and
+you cannot bring a majority back. This is a last-resort procedure.
+
+## Severity
+
+Lost quorum in production is **SEV-1**. New sandbox creates, placement writes,
+exposure changes, and recovery writes cannot commit until quorum returns.
+
+## Safety Rules
+
+- Try to bring the original voter nodes back first.
+- Stop sandboxd on every surviving server-role node before writing
+  `peers.json`.
+- Pick exactly one survivor as the recovery source.
+- Prefer the survivor with the highest Raft log index.
+- Do not delete old Raft data from other survivors until the recovered leader
+  is healthy and backed up.
+
+This recovery may implicitly commit entries that were present on the chosen
+survivor but not previously committed by a quorum. That is safer than inventing
+new log state, but it is still a durability compromise.
+
+## Confirm Lost Quorum
+
+Run on at least two surviving nodes:
+
+```bash
+export SB_PAT_TOKEN=<redacted>
+curl -s -H "Authorization: Bearer $SB_PAT_TOKEN" \
+  http://127.0.0.1:21212/v1/cluster/leader | jq .
+sudo journalctl -u sandboxd --since "15 minutes ago" --no-pager \
+  | grep -iE 'leader|election|failed to make requestVote|heartbeat timeout'
+```
+
+Lost quorum signature:
+
+- `Leader` is empty or unstable for more than 30 seconds.
+- Repeated election or heartbeat timeout logs.
+- A majority of configured voters is unavailable.
+
+If a majority can be restarted with intact disks, do that instead and stop this
+runbook.
+
+## Pick the Recovery Node
+
+On each surviving server node:
+
+```bash
+sudo journalctl -u sandboxd --since "24 hours ago" --no-pager \
+  | grep -iE 'last.index|last-index|raft.*index|snapshot' | tail -50
+sudo ls -lah /var/lib/sandboxd/raft
+sudo find /var/lib/sandboxd/raft -maxdepth 2 -type f -printf '%TY-%Tm-%Td %TH:%TM %s %p\n' \
+  | sort | tail -20
+```
+
+Choose the node with the most recent Raft state. Record why it was chosen in
+the incident log.
+
+## Recovery Procedure
+
+1. Stop sandboxd on every surviving server node:
+
+   ```bash
+   sudo systemctl stop sandboxd
+   ```
+
+2. Back up the chosen survivor before mutation:
+
+   ```bash
+   sudo /usr/local/sbin/sandboxd-backup.sh \
+     --output /root/pre-quorum-recovery-$(hostname)-$(date +%F-%H%M%S).tar.gz
+   ```
+
+3. On the chosen node, write `peers.json`:
+
+   ```bash
+   sudo /usr/local/sbin/raft-lost-quorum-recover.sh \
+     --raft-dir /var/lib/sandboxd/raft \
+     --node-id <chosen-node-id> \
+     --raft-address <chosen-private-ip>:7000
+   ```
+
+4. Start sandboxd on the chosen node only:
+
+   ```bash
+   sudo systemctl start sandboxd
+   sudo journalctl -u sandboxd -f
+   ```
+
+5. Wait for recovery to apply. The recovery file should be renamed:
+
+   ```bash
+   sudo ls -l /var/lib/sandboxd/raft/peers.json*
+   ```
+
+Expected: `peers.json.applied.<unix>` exists and plain `peers.json` is gone.
+
+## Verification Before Rejoining Nodes
+
+```bash
+export SB_PAT_TOKEN=<redacted>
+curl -fsS -H "Authorization: Bearer $SB_PAT_TOKEN" \
+  http://127.0.0.1:21212/v1/cluster/leader | jq .
+curl -fsS -H "Authorization: Bearer $SB_PAT_TOKEN" \
+  http://127.0.0.1:21212/v1/cluster/members | jq .
+curl -fsS -H "Authorization: Bearer $SB_PAT_TOKEN" \
+  http://127.0.0.1:21212/v1/metrics \
+  | grep -E 'aerolvm_raft_apply_errors_total|aerolvm_raft_apply_inflight'
+```
+
+Expected:
+
+- The chosen node is leader.
+- Raft apply errors are not increasing.
+- `aerolvm_raft_apply_inflight` is 0.
+- The cluster accepts a harmless read and can list members.
+
+## Rejoin Other Nodes
+
+For every other surviving server node, do not reuse stale Raft state:
+
+```bash
+sudo systemctl stop sandboxd
+sudo mv /var/lib/sandboxd/raft /var/lib/sandboxd/raft.pre-rejoin.$(date +%s)
+sudo /usr/local/sbin/cluster-join.sh \
+  --gossip-key '<key>' \
+  --peers <recovered-node-private-ip>:7001 \
+  --tls-bundle /path/to/aerolvm-tls-bundle.tar.gz \
+  --force
+```
+
+Rejoin one server at a time. Wait for membership and health before the next.
+
+## Post-Recovery Cleanup
+
+1. Take a fresh backup from the new leader.
+2. Confirm expected voter count.
+3. Confirm no worker lease or create backlog alerts are firing.
+4. Inspect orphaned placements and decide whether to reclaim or force-delete.
+5. Open a postmortem with:
+   - failed voter list
+   - chosen survivor and why
+   - data-loss risk assessment
+   - exact recovery timestamps
+
+## Rollback
+
+There is no clean in-place rollback once `RecoverCluster` has rewritten Raft
+state. Rollback means stopping the recovered cluster and restoring the
+pre-recovery archive from the chosen node. Escalate before doing this in
+production.
+
+## Lost-Quorum Drill
+
+Perform as a tabletop unless you are in a disposable staging cluster.
+
+| Field | Value |
+|---|---|
+| Date | |
+| Commander | |
+| Simulated failed voters | |
+| Recovery node selected | |
+| Evidence used for selection | |
+| `peers.json` command reviewed | yes/no |
+| Rejoin order reviewed | yes/no |
+| Gaps found | |

--- a/setup/runbooks/slo-breach.md
+++ b/setup/runbooks/slo-breach.md
@@ -1,0 +1,185 @@
+# Runbook: SLO Breach
+
+Use this for any sandboxd SLO alert that does not have a more specific active
+incident runbook. Start here, then branch to backup/restore, lost quorum, or
+image-pull storm if the signals point there.
+
+## SLO Surfaces
+
+| Area | Primary signals |
+|---|---|
+| Control plane | Raft apply errors, in-flight applies, leader visibility |
+| Scheduler | worker lease age/loss, no-admit workers, capacity pressure |
+| Create path | queue depth, create errors, create latency buckets |
+| Ingress | route lag, reconcile errors, Caddy admin errors |
+| Data plane | owner-forward errors, route misses |
+| Image pulls | queued pulls, pull errors, backoff rejects |
+| Secrets | decrypt errors, key version mismatches |
+
+## First Five Minutes
+
+1. Freeze deploys and topology changes.
+2. Identify alert group and affected cluster.
+3. Open Grafana dashboard `sandboxd SLOs`.
+4. Capture evidence:
+
+   ```bash
+   export SB_PAT_TOKEN=<redacted>
+   curl -fsS -H "Authorization: Bearer $SB_PAT_TOKEN" \
+     http://127.0.0.1:21212/v1/cluster/leader | jq .
+   curl -fsS -H "Authorization: Bearer $SB_PAT_TOKEN" \
+     http://127.0.0.1:21212/v1/cluster/members | jq .
+   curl -fsS -H "Authorization: Bearer $SB_PAT_TOKEN" \
+     http://127.0.0.1:21212/v1/metrics > /tmp/sandboxd.metrics
+   ```
+
+5. Decide the branch:
+   - no leader: [lost-quorum-recovery.md](lost-quorum-recovery.md)
+   - image pull metrics high: [image-pull-storm.md](image-pull-storm.md)
+   - restore needed: [backup-restore.md](backup-restore.md)
+   - otherwise continue below.
+
+## Triage Matrix
+
+| Alert | First action | Escalate when |
+|---|---|---|
+| `SandboxdRaftApplyErrors` | Inspect leader logs and recent deploys. | any create/expose writes fail. |
+| `SandboxdRaftApplyStuck` | Stop new deploys; inspect leader CPU/disk/network. | in-flight apply remains > 5 minutes. |
+| `SandboxdWorkerLeaseStale` | Check worker health and mTLS/gossip connectivity. | stale age keeps rising or all workers stale. |
+| `SandboxdNoAdmitWorkers` | Check capacity, disk, and drains. | all creates fail or no workers can uncordon. |
+| `SandboxdCreateQueueBacklog` | Determine if backlog is image, capacity, or Raft bound. | queue grows for > 10 minutes. |
+| `SandboxdIngressRouteLag` | Check Caddy admin errors and ingress CPU. | route lag increases while creates continue. |
+| `SandboxdCaddyAdminErrors` | Check Caddy service and admin endpoint. | public URLs fail or route lag grows. |
+| `SandboxdOwnerForwardErrors` | Check owner node health and advertise URLs. | many sandboxes fail cross-node operations. |
+| `SandboxdSecretDecryptErrors` | Check credential encryption key consistency. | failover/recreate workloads cannot start. |
+
+## Control Plane Checks
+
+```bash
+curl -fsS -H "Authorization: Bearer $SB_PAT_TOKEN" \
+  http://127.0.0.1:21212/v1/cluster/leader | jq .
+curl -fsS -H "Authorization: Bearer $SB_PAT_TOKEN" \
+  http://127.0.0.1:21212/v1/metrics \
+  | grep -E 'aerolvm_raft_apply|aerolvm_raft_snapshot|aerolvm_gossip'
+sudo journalctl -u sandboxd --since "30 minutes ago" --no-pager \
+  | grep -iE 'raft|leader|apply|snapshot|election|error'
+```
+
+Mitigation:
+
+- If leader exists and apply errors correlate with one bad request type, stop
+  that caller.
+- If no leader exists, move to lost-quorum recovery.
+- If snapshot errors correlate with disk full, free disk or move the node out
+  of service.
+
+## Scheduler and Capacity Checks
+
+```bash
+curl -fsS -H "Authorization: Bearer $SB_PAT_TOKEN" \
+  http://127.0.0.1:21212/v1/cluster/members | jq .
+curl -fsS -H "Authorization: Bearer $SB_PAT_TOKEN" \
+  http://127.0.0.1:21212/v1/metrics \
+  | grep -E 'aerolvm_worker_lease|aerolvm_host_pressure|aerolvm_scheduler'
+```
+
+Mitigation:
+
+- Uncordon accidentally drained workers.
+- Add workers if capacity pressure is real and sustained.
+- Drain workers with stale leases only if they are flapping and causing
+  placement retries.
+- Do not manually create sandboxes on server/ingress-only nodes.
+
+## Create Path Checks
+
+```bash
+curl -fsS -H "Authorization: Bearer $SB_PAT_TOKEN" \
+  http://127.0.0.1:21212/v1/metrics \
+  | grep -E 'aerolvm_create_|aerolvm_image_pull_|aerolvm_host_pressure'
+```
+
+Mitigation:
+
+- If image-pull signals are high, use image-pull storm runbook.
+- If capacity reject reasons dominate, scale workers or reduce requested
+  resources.
+- If reservation conflicts dominate, check for duplicate idempotency keys or
+  client retry behavior.
+
+## Ingress and Data Plane Checks
+
+```bash
+curl -fsS -H "Authorization: Bearer $SB_PAT_TOKEN" \
+  http://127.0.0.1:21212/v1/metrics \
+  | grep -E 'aerolvm_ingress|aerolvm_caddy|aerolvm_owner_forward'
+sudo systemctl status caddy --no-pager || true
+sudo journalctl -u caddy --since "30 minutes ago" --no-pager || true
+```
+
+Mitigation:
+
+- Restart Caddy only if admin calls fail and the route table is not actively
+  converging.
+- Reduce create/expose churn if route lag grows faster than it drains.
+- Check `SB_DATA_PLANE_ADVERTISE_HOST` and `SB_CLUSTER_INTERNAL_ADVERTISE`
+  when owner-forward errors or route misses appear after topology changes.
+
+## Secret Failure Checks
+
+```bash
+curl -fsS -H "Authorization: Bearer $SB_PAT_TOKEN" \
+  http://127.0.0.1:21212/v1/metrics \
+  | grep -E 'aerolvm_secret_decrypt|aerolvm_secret_key_version'
+sudo sha256sum /var/lib/sandboxd/credential_encryption.key
+```
+
+Mitigation:
+
+- If key hashes differ across nodes, stop failover/recreate work and restore
+  the intended cluster-wide key.
+- Re-run `configure-ops.yml` only after key consistency is fixed; it does not
+  rotate credential keys.
+
+## Recovery Criteria
+
+Declare the SLO breach recovered only after all relevant conditions are true:
+
+- all critical alerts resolved for 15 minutes
+- create queue depth back to normal
+- worker lease age fresh
+- route lag drains to normal
+- no new Raft apply errors
+- one known-good create/expose/delete smoke test succeeds
+
+Smoke test:
+
+```bash
+# Replace with your normal SDK or API smoke create.
+curl -fsS -H "Authorization: Bearer $SB_PAT_TOKEN" \
+  http://127.0.0.1:21212/health | jq .
+```
+
+## Post-Incident
+
+Within 24 hours:
+
+1. Attach `/tmp/sandboxd.metrics` samples and relevant journal excerpts.
+2. Record the first alert, first user impact, mitigation time, and recovery
+   time.
+3. Tune alert thresholds if they were noisy or late.
+4. Add a staging drill if the response required improvisation.
+
+## SLO Drill
+
+| Field | Value |
+|---|---|
+| Date | |
+| Alert tested | |
+| Trigger method | |
+| Alert fired within expected time | yes/no |
+| Dashboard showed signal | yes/no |
+| Runbook branch was clear | yes/no |
+| Smoke test passed after mitigation | yes/no |
+| Alert resolved automatically | yes/no |
+| Follow-up fixes | |


### PR DESCRIPTION
## Summary

- Restructures the cluster control plane to clear the **Stage-4 product bar** (500 nodes, 100K sandboxes, HA control plane and create-path, no public API/SDK regression). See `plans/cluster-criticial-thinking-stage-4/02-positive-outcomes.md` for the line-by-line bar check.
- Lands the operational hardening the prior PR stack left out: capacity heartbeats, batch reservations + backpressure, file-based recovery store, failover policy, drain / remove-member node lifecycle, dedicated-role enforcement above 10 nodes, network-isolation reconcile.
- Adds the production observability + ops surface: Prometheus `/v1/metrics`, OTEL metrics + traces, Grafana SLO dashboard, alert rules, Alertmanager config, runbooks (backup/restore, lost-quorum recovery, image-pull storm, SLO breach), backup/restore scripts, and Terraform/Ansible wiring for all of it.
- Pushes the FSM spec write-through into `Service.ResizeSandbox` / `Service.UpdateLifecycle` so Daytona and E2B inherit the same cluster contract as v1 (closes stage-4 issue I2). Regression test: `internal/service/cluster_spec_replicate_test.go`.

Explicitly NOT in scope: the harsher Stage-3 redesign for 10K nodes / 1M sandboxes (true server/worker Raft split, sharded FSM, incremental snapshots, multi-process 500-node integration test). Limitations are enumerated in `plans/cluster-criticial-thinking-stage-4/03-limitations.md`.

## Sandbox boot impact

The boot path gains **two best-effort additions** that fire at daemon start, not per-create:

1. **OTEL exporter init** (`cmd/sandboxd/main.go`): conditional on `SB_OTEL_EXPORTER_OTLP_ENDPOINT`. ~tens of ms once at startup, bounded by a 5s timeout. Failure is logged and skipped — does not block boot.
2. **Capacity lease loop** (`internal/cluster/capacity_lease.go`): a 5s-interval polled fetch from leader to peers' `/v1/capacity`. Concurrent fan-out capped at 32, per-request timeout 2s. Runs on server-role nodes only. **Not on the `CreateSandbox` path** — `SelectPlacement` reads cached snapshots, never blocks on a fetch.

`CreateSandbox` itself: no new synchronous work. The reservation-first flow established by PR #79 is unchanged. Batch reservations (`internal/cluster/fsm.go:opReserveBatch`) reduce Raft log entries under burst but do not add per-create work — a 1-sandbox create still commits one opReserve.

Recovery-store write happens in the FSM apply path on placement commit, not on the request goroutine, so client-visible boot latency is unchanged.

## Idempotency

| Surface | Behavior |
|---|---|
| `POST /v1/sandboxes` (and Daytona / E2B equivalents) | Unchanged from PR #79. Reservation-first flow via `pkg/api/clustercreate` — duplicate (name, idempotency-key) on any node replays the existing placement. |
| `POST /v1/cluster/nodes/{id}/drain` and `/uncordon` | Idempotent — re-draining a drained node returns 204; uncordoning an already-uncordoned node returns 204. State diffs gate the Raft commit. |
| `DELETE /v1/cluster/members/{id}` (force=true/false) | Idempotent on absent members (404 → no-op via `RemoveMember` checking config). Re-removal returns success. |
| `POST /v1/cluster/orphans/{id}/reclaim-local` | Idempotent — FSM rejects with `ErrOrphanClaimConflict` if the orphan was already reclaimed by someone else; safe to retry. |
| `Service.ResizeSandbox` / `Service.UpdateLifecycle` | Local mutation unchanged. The new FSM write-through (`replicateSpecPatch`) is best-effort: failure is logged warn, next mutation refreshes. Concurrent resizes for the same sandbox serialize at the docker layer; the FSM can momentarily see a stale spec but the next mutation reconciles. |
| `failover.policy` on `CreateSandbox` | New field, normalized via `models.NormalizeFailoverPolicy` to `none` (default) or `recreate`. Re-creating the same sandbox with a different policy is rejected on the idempotency-replay path. |

**Retry-5-times check**: every new HTTP surface returns deterministic state after 5x retries with identical inputs. Concurrent duplicate drains/uncordons race-collapse at the FSM (one apply wins, the others observe steady state).

## Failure-path consistency

This PR does not introduce new multi-step caddy+store writes. The two paths that touch both are unchanged from PR #79:

- `clustercreate.CreateOnSelectedNode` rollback rules documented in `pkg/api/clustercreate/clustercreate.go` (unchanged).
- `Service.exposePort` / `allocateHostPort` rollback rule (the `reused` flag + park-don't-reallocate policy) unchanged. Regression tests in `internal/service/cluster_exposure_test.go`.

New best-effort write-throughs:

- `Service.replicateSpecPatch`: log warn on FSM failure, local mutation is authoritative, next mutation refreshes.
- `cluster.RecoveryStore.Put`: failure prevents the placement opPlace from committing (FSM rejects with the error). On the read side, missing recovery blob falls back to the legacy in-FSM secrets — no orphan placement is created.

Drain / uncordon / remove-member: single Raft command each; partial failure leaves the cluster in the pre-call state because each is one `Apply`.

## L4 / host-port-pool changes

**N/A — neither touched.** `TryReserveHostPort`, the `host_port` partial unique index, `allocateHostPort`, `EnsureLayer4`, `EnsureLayer4Ready`, and the `l4Ready` latch are all byte-identical to PR #79. Existing regression coverage in `internal/store/store_test.go` and `internal/service/layer4_bootstrap_test.go` continues to apply.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./internal/... ./pkg/...` clean (one transient flake on `TestLoggingMiddlewareCreatesHTTPServerSpan` did not reproduce on 20x `-race` reruns of `./pkg/api`).
- [x] New regression tests for stage-4 I2: `internal/service/cluster_spec_replicate_test.go` (3 tests covering Resize, UpdateLifecycle, and the pre-cluster no-op case).
- [x] Existing scale gates pass: `internal/cluster/scale_harness_test.go`, `internal/cluster/recovery_replication_test.go`, `internal/cluster/raft_recovery_test.go`, `internal/cluster/topology_test.go`, `internal/cluster/capacity_lease_test.go`.
- [x] SDK tests pass: typescript, python, go, rust, java (failover field round-trip).
- [ ] **Not run / not in scope**: multi-process 500-node integration test (stage-4 L1 — the biggest "we don't know" risk; tracked as a follow-up).
- [ ] **Not run**: full Caddy admin under 100K routes (stage-4 L8 — acceptable at the 100K-sandbox steady-state ceiling; tracked as a follow-up).