### PR TITLE
feat: Enhance documentation and implement shared S3-backed Caddy cert storage

### DIFF
--- a/.claude/skills/touch-create-sandbox/SKILL.md
+++ b/.claude/skills/touch-create-sandbox/SKILL.md
@@ -5,32 +5,80 @@ description: Safely modify Service.CreateSandbox or anything it transitively cal
 
 # Touch `CreateSandbox` / the sandbox boot path
 
-`Service.CreateSandbox` (`internal/service/service.go:80`) latency is a load-bearing UX metric. Treat the boot path as protected.
+`Service.CreateSandbox` latency is a load-bearing UX metric. Treat the boot path as protected.
 
-## The boot path, in order
+## Entry points
 
-1. `normalizeCreateRequest(req)` + image / runtime / mount / lifecycle / GPU validation
-2. `s.sealMounts(req.Mounts)` (AEAD via `pkg/secrets`)
-3. Generate `toolboxToken`, sandbox SSH keypair, sandbox ID
-4. `s.admitter.Admit(...)` — capacity reservation
-5. `s.mounts.MountAll(...)` — external storage mount
-6. `s.docker.Create(...)` — container creation
-7. Store row insert (`Store.Create`) + caddy route install
+There are three public ways a sandbox is born — all funnel into the same private
+`createSandbox` worker in `internal/service/service.go`:
+
+- `Service.CreateSandbox(ctx, req)` — fresh user-driven create; generates a new sandbox ID.
+- `Service.CreateSandboxWithID(ctx, req, id)` — failover-recreate entry point. Reuses an
+  existing sandbox ID and short-circuits to the existing local record if there is one
+  (idempotent at the cluster boundary).
+- `Service.RecreateSandbox(ctx, id, spec, secrets, exposedPorts)` — implements
+  `cluster.SandboxRecreator`. Called by the cluster owner watcher when an FSM placement
+  points to self after another owner died. It re-merges encrypted cluster secrets
+  (`OpenClusterSecretsForNode`), calls `CreateSandboxWithID`, then replays the
+  replicated port intents. Only sandboxes with `failover.policy=recreate` reach this path.
+
+If you're editing the boot path, your change has to be safe on all three.
+
+## The boot path (in `createSandbox`)
+
+1. `ClusterTopologyError()` — cluster topology gate (errors fail fast before any work).
+2. Cluster-mode role check: if cluster is enabled and this node is not a worker,
+   reject with `cluster.ErrNoPlacementTarget` — non-worker nodes must forward
+   `CreateSandbox` to a placement target.
+3. `normalizeCreateRequest(req)` + `NormalizeCreateImageDistribution(ctx, &req)`
+   + `NormalizeCreateFailover(&req)`.
+4. Validation: image / runtime / mount count + per-mount / lifecycle / GPU /
+   network-byte limits.
+5. `s.sealMounts(req.Mounts)` — AEAD-seal mount specs via `pkg/secrets`.
+6. Generate `toolboxToken` and sandbox SSH keypair (Ed25519).
+7. Choose sandbox ID: `idOverride` if non-empty (recreate path), else generate
+   a fresh one. The ID is also the container name, so it must be stable before
+   `docker.Create`.
+8. `s.admitter.Admit(sandboxID, capacityRequestFromCreate(req))` — capacity
+   reservation. Every failure path below this point must `releaseAdmission()`.
+9. `s.mounts.MountAll(ctx, sandboxID, req.Mounts)` — external-storage mount.
+   Every failure path below this point must also `cleanupMounts()`.
+10. `s.docker.Create(ctx, req, sandboxID, toolboxToken, binds)` — container
+    creation.
+11. `s.sealRegistry(req.Registry)` — AEAD-seal registry creds before the row
+    is built, so a marshal/encrypt error rolls back through the same chain as
+    any later store error.
+12. `s.caddy.UpsertSandboxRoute(ctx, sandboxID, containerIP, toolboxPort)` —
+    install the L7 toolbox route.
+13. `s.store.Create(ctx, sandbox)` — persist the row.
+14. `s.store.PutMounts(ctx, sandbox.ID, sealedMounts)` if there were any
+    mounts.
 
 ## Failure-cleanup rules
 
-Every failure path **below** admission must call `releaseAdmission()`. Every failure path **below** `mounts.MountAll` must call `cleanupMounts()`. These are local closures in `CreateSandbox` — use them, don't reinvent.
+The rollback chain after each successful step is cumulative. Every failure path
+**below** admission must call `releaseAdmission()`. Every failure path **below**
+`mounts.MountAll` must also call `cleanupMounts()`. Every failure path **below**
+`docker.Create` must additionally call `s.docker.Destroy(ctx, sandbox)`. Every
+failure path **below** `caddy.UpsertSandboxRoute` must additionally call
+`s.caddy.DeleteSandboxRoute(ctx, sandbox.ID)`. Every failure path **below**
+`store.Create` must additionally call `s.store.Delete(ctx, sandbox.ID)`.
 
-If you add a new step between two existing steps, ALSO add a defer/cleanup for it and call out the rollback rule in the PR description's "Failure-path consistency" section.
+These rollback helpers are local closures + inline calls inside `createSandbox`.
+**Use them, don't reinvent.** If you add a new step between two existing steps,
+ALSO add the matching rollback into the chain and call out the rollback rule in
+the PR description's "Failure-path consistency" section.
 
 ## What you must document in the PR
 
 Fill in **"Sandbox boot impact"** in the PR template. Don't leave it blank.
 
 Answer:
-- What was added (DB query, HTTP round-trip, file I/O, lock acquisition)?
+- What was added (DB query, HTTP round-trip, file I/O, lock acquisition, FSM
+  propose, gossip publish)?
 - Expected added latency in the success case
-- When it fires (every create? first create? on a flag? on a feature gate?)
+- When it fires (every create? first create? on a flag? on a feature gate? only
+  on the cluster recreate path?)
 - Whether it's bounded
 
 > "It's only on the first call" is **still impact** and must be called out.
@@ -58,7 +106,20 @@ func (s *Service) EnsureXReady(ctx context.Context) error {
 }
 ```
 
-Mirror `EnsureLayer4Ready` — don't reinvent. **Anti-patterns:** retrying bootstrap on every request; failing the daemon outright on a transient bootstrap error; logging-and-forgetting so the first user request gets a confusing "X not found".
+Mirror `EnsureLayer4Ready` (and the parallel `clusterReady` latch) — don't reinvent. **Anti-patterns:** retrying bootstrap on every request; failing the daemon outright on a transient bootstrap error; logging-and-forgetting so the first user request gets a confusing "X not found".
+
+## Cluster-mode notes
+
+- The cluster placement decision happens **above** `Service.CreateSandbox` — at
+  the API layer, a non-worker node forwards the request to a chosen worker.
+  Don't add placement logic inside `createSandbox`.
+- `idOverride` is non-empty **only** on the cluster owner watcher's recreate
+  path. Any new work you add to `createSandbox` runs on the recreate path too —
+  make sure it's idempotent (the sandbox may have been partially created on
+  the previous owner before it died).
+- If you touch anything that mutates cluster state (FSM, gossip, capacity
+  heartbeats, recovery store), the change is now **dual-fragile**: boot-path
+  latency + cluster correctness. Get a second opinion before merging.
 
 ## Idempotency
 

--- a/.claude/skills/touch-tcp-pool/SKILL.md
+++ b/.claude/skills/touch-tcp-pool/SKILL.md
@@ -16,7 +16,7 @@ Any change to:
 - `Service.allocateHostPort` allocator loop (`internal/service/`)
 - `Service.EnsureLayer4` / `Service.EnsureLayer4Ready` (`internal/service/service.go`)
 - The `l4Ready` `atomic.Bool` latch or the `l4Mu` mutex
-- `allocatorRandomAttempts` constant (`internal/service/service.go:37`)
+- `allocatorRandomAttempts` constant (`internal/service/service.go`)
 - `pkg/caddy/client.go` L4 route installation
 
 ## What you MUST do

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,9 +21,10 @@ Read [`pr-review.md`](./pr-review.md) before opening any PR that touches the ser
 
 ### API & server changes
 
-Before touching `internal/service`, `internal/store`, `pkg/caddy`, `pkg/api`, or
-the SDKs, read [`pr-review.md`](./pr-review.md). Non-negotiables (silence in the
-PR description is **not** acceptable on these axes):
+Before touching `internal/service`, `internal/store`, `internal/cluster`,
+`pkg/caddy`, `pkg/api`, or the SDKs, read [`pr-review.md`](./pr-review.md).
+Non-negotiables (silence in the PR description is **not** acceptable on
+these axes):
 
 1. **Idempotency.** Every sandbox API must be safe under retry + concurrent
    duplicate calls. `expose_port` returns the existing URL; never walks the
@@ -42,6 +43,15 @@ PR description is **not** acceptable on these axes):
    `EnsureLayer4`, `EnsureLayer4Ready`, or the `l4Ready` latch needs a
    regression test (see `store_test.go` / `layer4_bootstrap_test.go`) AND a PR
    call-out.
+6. **Cluster mode is fragile.** `internal/cluster/` runs Raft (FSM placement
+   state), SWIM gossip (membership + capacity heartbeats), and cross-node
+   forwarding. Any change to the FSM, placement selection, recovery
+   replication, owner watcher, or capacity-lease/heartbeat path needs a
+   regression test next to the file it changes (cluster_test.go, fsm_*_test.go,
+   placement_test.go, etc.) AND a PR call-out describing the cluster-correctness
+   impact (split brain risk, replay safety, leader-change behavior, single-node
+   regression). Cluster-mode code must remain a no-op when `cfg.EnableCluster`
+   is false — `Noop` exists for that.
 
 ## Repository map
 
@@ -51,12 +61,23 @@ cmd/
                  caddy → service → api server).
   toolboxd/      In-container agent (file/exec/sessions proxy target).
 internal/
+  cluster/       Cluster mode (Phase 1): SWIM gossip + Raft FSM placement +
+                 owner-sharded execution. cluster.go is the package overview.
+                 fsm.go owns the placement state machine; placement.go does
+                 power-of-two-choices selection; recovery_replication.go and
+                 recovery_store.go handle failover replicas; forward.go is
+                 the cross-node HTTP reverse proxy. High-risk area — touching
+                 anything in here needs the same care as the TCP pool.
   config/        Env-driven config loader.
+  observability/ OTEL traces + expvar metrics exporter for sandboxd.
   runtime/       Runtime.Runtime interface (Docker today, gVisor/Kata later).
+  scaleobs/      Scale-out observability metrics (admission / placement).
   service/       Business logic. Version-agnostic. Owns Service struct,
-                 CreateSandbox path, lifecycle, snapshots, l4 latch, mounts.
-                 Daytona/E2B helpers live here as named files (daytona.go,
-                 e2b.go), NOT version-aware branching.
+                 CreateSandbox / CreateSandboxWithID / RecreateSandbox entry
+                 points, lifecycle, snapshots, l4 latch, mounts, cluster
+                 secrets, image distribution. Daytona/E2B helpers live here
+                 as named files (daytona.go, e2b.go), NOT version-aware
+                 branching.
   store/         SQLite store. Single-writer (MaxOpenConns=1, WAL).
                  store.go has all schema + CRUD; store_test.go is the
                  regression-test target for host-port pool changes.
@@ -97,6 +118,18 @@ plans/
 .github/
   pull_request_template.md   Auto-fills PR descriptions; sections are required.
   workflows/                 test.yml (path-filtered), release.yml, publish-sdks.yml.
+Ansible/         Cluster deployment + role-change playbooks (sandboxd install,
+                 inventory, drain/remove-member, recovery runbooks).
+Terraform/       AWS provisioning for AerolVM clusters (network, nodes, IAM,
+                 DNS via Cloudflare, S3 backend for state).
+agentic_docs/    Reference docs for AI agents working in this repo
+                 (E2B SDK method map, request flow, idempotency timeline).
+packaging/       Systemd unit + Caddyfile template for sandboxd deployment.
+scripts/         Operational scripts (install/uninstall, cluster init/join,
+                 backup/restore, lost-quorum recovery, node-lifecycle, load).
+setup/           Operator-facing setup assets (Prometheus alerts, Alertmanager
+                 config, Grafana dashboards, deployment topology docs,
+                 runbooks).
 pr-review.md     The canonical PR review rules. Read before reviewing.
 .claude/skills/  Project-local Claude Code skills — invocable via /<name>.
                  See "Project skills" below.
@@ -152,11 +185,17 @@ For changes that don't match a skill, the file-level "where to look" map is:
 | Task | Start here |
 |---|---|
 | Add server business logic | `internal/service/service.go` (or new file in same package) |
+| Cluster placement / Raft FSM / gossip / failover | `internal/cluster/` — see `cluster.go` for the package overview, `fsm.go` + `placement.go` for owner assignment, `recovery_*.go` for failover replicas |
+| OTEL traces / expvar metrics exporter | `internal/observability/` |
 | Caddy route / TLS / L4 wiring | `pkg/caddy/client.go` |
 | Capacity / admission rules | `pkg/capacity/` |
 | Docker events / image GC | `pkg/docker/events.go`, `pkg/docker/image_gc_test.go` |
 | SSH gateway behavior | `pkg/sshgateway/gateway.go` |
 | In-sandbox toolbox agent | `cmd/toolboxd/` |
+| Cluster ops playbooks / inventory | `Ansible/playbooks/`, `Ansible/inventory/` |
+| Cluster infra (AWS) | `Terraform/` |
+| Operator alerts / dashboards / runbooks | `setup/prometheus/`, `setup/alertmanager/`, `setup/grafana/`, `setup/runbooks/` |
+| Operational scripts (backup, restore, cluster lifecycle) | `scripts/` |
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ curl -fsSL https://github.com/aerol-ai/microvm/releases/latest/download/install.
 
 > **`--domain` requires `--dns-provider`.** The installer hard-fails otherwise. Caddy issues exactly two certificates — `<domain>` and `*.<domain>` — once at startup via DNS-01, then renews them on a schedule. Use `--local` for the only no-DNS path (binds to `127.0.0.1`, no TLS).
 
+> **Running 10+ ingress nodes?** Opt into S3-backed shared Caddy cert storage so one node issues the wildcard and the rest read it from S3 — see [`setup/multi-node-cert-sharing.md`](./setup/multi-node-cert-sharing.md). Off by default.
+
 If you omit `--pat-token`, the installer generates a token and prints it once at the end.
 
 ## What AerolVM Does

--- a/Terraform/iam.tf
+++ b/Terraform/iam.tf
@@ -112,3 +112,108 @@ resource "aws_iam_instance_profile" "joiner" {
   name = "${var.cluster_name}-joiner"
   role = aws_iam_role.joiner.name
 }
+
+###############################################################################
+# Optional: shared Caddy cert storage bucket.
+#
+# Off by default. When enabled in managed mode, Terraform owns the bucket so
+# every ingress node has IAM-granted R/W and never needs static access keys.
+# In BYO mode (existing bucket, R2, MinIO) we just attach an IAM policy
+# against the supplied bucket ARN so the daemon's default credential chain
+# resolves automatically when the operator's bucket lives in this same AWS
+# account; for cross-account / non-AWS buckets the operator passes static
+# keys via var.caddy_shared_cert_storage and we skip the IAM attachment.
+#
+# Versioning is ON so an accidental delete of a renewed cert is recoverable.
+# force_destroy is OFF — `terraform destroy` should not silently wipe long-
+# lived TLS material the way the one-shot bundle bucket can be.
+###############################################################################
+
+resource "aws_s3_bucket" "caddy_certs" {
+  count = local.caddy_storage_s3_managed ? 1 : 0
+
+  bucket        = local.caddy_certs_bucket_name
+  force_destroy = false
+}
+
+resource "aws_s3_bucket_public_access_block" "caddy_certs" {
+  count = local.caddy_storage_s3_managed ? 1 : 0
+
+  bucket                  = aws_s3_bucket.caddy_certs[0].id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "caddy_certs" {
+  count = local.caddy_storage_s3_managed ? 1 : 0
+
+  bucket = aws_s3_bucket.caddy_certs[0].id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "caddy_certs" {
+  count = local.caddy_storage_s3_managed ? 1 : 0
+
+  bucket = aws_s3_bucket.caddy_certs[0].id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# IAM grants: every node may renew (certmagic picks one via the distributed
+# lock). Attach to both seed and joiner roles for managed mode AND for byo
+# mode when no static creds were supplied (which is the "bucket is in the
+# same AWS account" case — easiest setup, no key handling).
+locals {
+  caddy_certs_bucket_arn = (
+    local.caddy_storage_s3_managed
+    ? (length(aws_s3_bucket.caddy_certs) > 0 ? aws_s3_bucket.caddy_certs[0].arn : "")
+    : (var.caddy_shared_cert_storage.bucket != "" ? "arn:aws:s3:::${var.caddy_shared_cert_storage.bucket}" : "")
+  )
+
+  caddy_certs_attach_iam = (
+    var.caddy_shared_cert_storage.enabled
+    && var.caddy_shared_cert_storage.access_key == ""
+    && local.caddy_certs_bucket_arn != ""
+  )
+}
+
+data "aws_iam_policy_document" "caddy_certs_rw" {
+  count = local.caddy_certs_attach_iam ? 1 : 0
+
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:HeadObject",
+    ]
+    resources = ["${local.caddy_certs_bucket_arn}/${var.caddy_shared_cert_storage.prefix}/*"]
+  }
+  statement {
+    actions   = ["s3:ListBucket"]
+    resources = [local.caddy_certs_bucket_arn]
+  }
+}
+
+resource "aws_iam_role_policy" "caddy_certs_seed_rw" {
+  count = local.caddy_certs_attach_iam ? 1 : 0
+
+  name   = "${var.cluster_name}-caddy-certs-rw"
+  role   = aws_iam_role.seed.id
+  policy = data.aws_iam_policy_document.caddy_certs_rw[0].json
+}
+
+resource "aws_iam_role_policy" "caddy_certs_joiner_rw" {
+  count = local.caddy_certs_attach_iam ? 1 : 0
+
+  name   = "${var.cluster_name}-caddy-certs-rw"
+  role   = aws_iam_role.joiner.id
+  policy = data.aws_iam_policy_document.caddy_certs_rw[0].json
+}

--- a/Terraform/locals.tf
+++ b/Terraform/locals.tf
@@ -60,4 +60,51 @@ locals {
     substr(lower(replace(var.cluster_name, "/[^a-z0-9-]/", "-")), 0, 40),
     random_id.bundle_suffix.hex,
   )
+
+  # Caddy shared cert storage — resolved config that bootstrap.sh.tftpl
+  # consumes regardless of mode. In managed mode, fields point at TF-created
+  # resources; in byo mode, fields come straight from the user's tfvars. The
+  # template never needs to branch on mode this way.
+  caddy_storage_s3_enabled = var.caddy_shared_cert_storage.enabled
+  caddy_storage_s3_managed = (
+    var.caddy_shared_cert_storage.enabled
+    && var.caddy_shared_cert_storage.mode == "managed"
+  )
+  caddy_certs_bucket_name = format(
+    "%s-caddy-certs-%s",
+    substr(lower(replace(var.cluster_name, "/[^a-z0-9-]/", "-")), 0, 40),
+    random_id.bundle_suffix.hex,
+  )
+  caddy_storage_s3 = {
+    enabled  = var.caddy_shared_cert_storage.enabled
+    bucket   = local.caddy_storage_s3_managed ? local.caddy_certs_bucket_name : var.caddy_shared_cert_storage.bucket
+    region   = local.caddy_storage_s3_managed ? var.aws_region : var.caddy_shared_cert_storage.region
+    endpoint = var.caddy_shared_cert_storage.endpoint
+    prefix   = var.caddy_shared_cert_storage.prefix
+    # In managed mode the EC2 instance role grants the bucket, so we leave
+    # static creds empty (the AWS SDK default chain picks up the role).
+    # BYO mode passes whatever the operator supplied.
+    access_key = local.caddy_storage_s3_managed ? "" : var.caddy_shared_cert_storage.access_key
+    secret_key = local.caddy_storage_s3_managed ? "" : var.caddy_shared_cert_storage.secret_key
+    encryption_key = (
+      local.caddy_storage_s3_managed
+      ? (length(random_id.caddy_storage_s3_encryption_key) > 0 ? random_id.caddy_storage_s3_encryption_key[0].b64_std : "")
+      : var.caddy_shared_cert_storage.encryption_key
+    )
+  }
+}
+
+# certmagic-s3 encrypts cert+private-key bytes with this 32-byte key before
+# uploading. Every node MUST present the same value or readers can't decrypt
+# what the issuing node wrote. Managed mode auto-generates and threads it via
+# user_data; BYO mode uses var.caddy_shared_cert_storage.encryption_key
+# directly (and this resource is suppressed).
+#
+# random_id with byte_length = 32 gives us a true 32-byte secret; b64_std
+# emits the same base64 format an operator would produce by hand with
+# `openssl rand -base64 32`.
+resource "random_id" "caddy_storage_s3_encryption_key" {
+  count = local.caddy_storage_s3_managed && var.caddy_shared_cert_storage.encryption_key == "" ? 1 : 0
+
+  byte_length = 32
 }

--- a/Terraform/nodes.tf
+++ b/Terraform/nodes.tf
@@ -66,6 +66,15 @@ resource "aws_instance" "seed" {
     image_pull_max_concurrent  = var.image_pull_max_concurrent
     image_pull_failure_backoff = var.image_pull_failure_backoff
     extra_user_data            = local.seed_node.extra_user_data
+    # Shared S3-backed Caddy cert storage — see local.caddy_storage_s3.
+    caddy_storage_s3_enabled        = local.caddy_storage_s3.enabled
+    caddy_storage_s3_bucket         = local.caddy_storage_s3.bucket
+    caddy_storage_s3_region         = local.caddy_storage_s3.region
+    caddy_storage_s3_endpoint       = local.caddy_storage_s3.endpoint
+    caddy_storage_s3_prefix         = local.caddy_storage_s3.prefix
+    caddy_storage_s3_access_key     = local.caddy_storage_s3.access_key
+    caddy_storage_s3_secret_key     = local.caddy_storage_s3.secret_key
+    caddy_storage_s3_encryption_key = local.caddy_storage_s3.encryption_key
   })
 
   tags = merge(
@@ -139,6 +148,15 @@ resource "aws_instance" "joiner" {
     image_pull_max_concurrent  = var.image_pull_max_concurrent
     image_pull_failure_backoff = var.image_pull_failure_backoff
     extra_user_data            = each.value.extra_user_data
+    # Shared S3-backed Caddy cert storage — see local.caddy_storage_s3.
+    caddy_storage_s3_enabled        = local.caddy_storage_s3.enabled
+    caddy_storage_s3_bucket         = local.caddy_storage_s3.bucket
+    caddy_storage_s3_region         = local.caddy_storage_s3.region
+    caddy_storage_s3_endpoint       = local.caddy_storage_s3.endpoint
+    caddy_storage_s3_prefix         = local.caddy_storage_s3.prefix
+    caddy_storage_s3_access_key     = local.caddy_storage_s3.access_key
+    caddy_storage_s3_secret_key     = local.caddy_storage_s3.secret_key
+    caddy_storage_s3_encryption_key = local.caddy_storage_s3.encryption_key
   })
 
   depends_on = [aws_instance.seed]

--- a/Terraform/outputs.tf
+++ b/Terraform/outputs.tf
@@ -35,6 +35,17 @@ output "bundle_bucket" {
   value       = aws_s3_bucket.bundle.bucket
 }
 
+output "caddy_certs_bucket" {
+  description = "Shared Caddy cert storage bucket name. Empty when shared storage is disabled. In BYO mode this echoes the operator-supplied bucket."
+  value       = local.caddy_storage_s3.enabled ? local.caddy_storage_s3.bucket : ""
+}
+
+output "caddy_certs_encryption_key" {
+  description = "Encryption key used by certmagic-s3 to protect cert bytes at rest in S3. SAVE THIS — losing it means the bucket's stored certs become unreadable. Re-export with `terraform output -raw caddy_certs_encryption_key`."
+  value       = local.caddy_storage_s3.encryption_key
+  sensitive   = true
+}
+
 output "ssh_command_seed" {
   description = "Convenience SSH command to the seed (uses default Ubuntu user)."
   value       = "ssh ubuntu@${aws_instance.seed.public_ip}"

--- a/Terraform/templates/bootstrap.sh.tftpl
+++ b/Terraform/templates/bootstrap.sh.tftpl
@@ -58,6 +58,29 @@ INSTALL_ARGS+=(--with-amd-gpu)
 %{ if idle_timeout_min > 0 ~}
 INSTALL_ARGS+=(--idle-timeout-min '${idle_timeout_min}')
 %{ endif ~}
+%{ if caddy_storage_s3_enabled ~}
+# Shared S3-backed Caddy cert storage. Every node points at the same
+# bucket; certmagic-s3 holds a distributed lock during ACME so only the
+# leader issues / renews. encryption_key must match across every node
+# or readers can't decrypt what the leader wrote. See
+# setup/multi-node-cert-sharing.md for the operator-level explanation.
+INSTALL_ARGS+=(
+  --caddy-storage-s3
+  --caddy-storage-s3-bucket '${caddy_storage_s3_bucket}'
+  --caddy-storage-s3-region '${caddy_storage_s3_region}'
+  --caddy-storage-s3-prefix '${caddy_storage_s3_prefix}'
+  --caddy-storage-s3-encryption-key '${caddy_storage_s3_encryption_key}'
+)
+%{ if caddy_storage_s3_endpoint != "" ~}
+INSTALL_ARGS+=(--caddy-storage-s3-endpoint '${caddy_storage_s3_endpoint}')
+%{ endif ~}
+%{ if caddy_storage_s3_access_key != "" ~}
+INSTALL_ARGS+=(
+  --caddy-storage-s3-access-key '${caddy_storage_s3_access_key}'
+  --caddy-storage-s3-secret-key '${caddy_storage_s3_secret_key}'
+)
+%{ endif ~}
+%{ endif ~}
 
 sudo /tmp/install.sh "$${INSTALL_ARGS[@]}"
 

--- a/Terraform/terraform.tfvars.example
+++ b/Terraform/terraform.tfvars.example
@@ -126,6 +126,28 @@ nodes = {
 # How long joiners wait for the seed's S3 artifacts before failing cloud-init.
 # seed_wait_max_seconds = 1800
 
+# Shared Caddy cert storage. Off by default — each node issues its own
+# wildcard cert via DNS-01, which works at low ingress counts. Flip on
+# when running 10+ ingress nodes so a single node holds the ACME lock
+# and the rest read the cert from S3. See setup/multi-node-cert-sharing.md.
+#
+# Managed mode — Terraform owns the bucket + IAM + encryption key:
+# caddy_shared_cert_storage = {
+#   enabled = true
+# }
+#
+# BYO mode — point at an existing S3-compatible bucket (R2, MinIO, ...):
+# caddy_shared_cert_storage = {
+#   enabled        = true
+#   mode           = "byo"
+#   bucket         = "my-caddy-certs"
+#   region         = "auto"                                                    # "auto" for R2
+#   endpoint       = "https://<accountid>.r2.cloudflarestorage.com"
+#   access_key     = "REPLACE-with-r2-or-minio-key"
+#   secret_key     = "REPLACE-with-r2-or-minio-secret"
+#   encryption_key = "REPLACE-with-output-of-openssl-rand-base64-32"
+# }
+
 # Extra tags applied to every AWS resource.
 # extra_tags = {
 #   Env   = "prod"

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -427,3 +427,57 @@ variable "seed_wait_max_seconds" {
   type        = number
   default     = 1800
 }
+
+variable "caddy_shared_cert_storage" {
+  description = <<-EOT
+    Shared S3-backed Caddy cert storage. Lets every ingress node read the
+    wildcard cert issued by one node, sidestepping Let's Encrypt rate
+    limits when the cluster has 10+ ingress-bearing nodes. Disabled by
+    default; each node issues its own cert when off (the existing
+    behaviour, fine up to a handful of nodes).
+
+    mode = "managed": Terraform creates a dedicated S3 bucket + IAM
+                      grants, and generates the encryption_key
+                      automatically (stored in TF state).
+    mode = "byo":     Operator supplies bucket / region / encryption_key
+                      (and optional creds for non-EC2-instance-role auth).
+                      Useful when the bucket already exists, lives in
+                      another account, or is Cloudflare R2 / MinIO.
+
+    encryption_key must be a base64-encoded 32-byte secret and identical
+    on every node. Losing it makes existing stored certs unreadable.
+    See setup/multi-node-cert-sharing.md.
+  EOT
+  type = object({
+    enabled        = bool
+    mode           = optional(string, "managed")
+    bucket         = optional(string, "")
+    region         = optional(string, "")
+    endpoint       = optional(string, "")
+    prefix         = optional(string, "caddy")
+    access_key     = optional(string, "")
+    secret_key     = optional(string, "")
+    encryption_key = optional(string, "")
+  })
+  default = {
+    enabled = false
+  }
+
+  validation {
+    condition     = !var.caddy_shared_cert_storage.enabled || contains(["managed", "byo"], var.caddy_shared_cert_storage.mode)
+    error_message = "caddy_shared_cert_storage.mode must be either \"managed\" or \"byo\"."
+  }
+
+  validation {
+    condition = (
+      !var.caddy_shared_cert_storage.enabled
+      || var.caddy_shared_cert_storage.mode != "byo"
+      || (
+        var.caddy_shared_cert_storage.bucket != ""
+        && var.caddy_shared_cert_storage.region != ""
+        && var.caddy_shared_cert_storage.encryption_key != ""
+      )
+    )
+    error_message = "When caddy_shared_cert_storage.mode = \"byo\", bucket, region, and encryption_key are all required."
+  }
+}

--- a/packaging/Caddyfile.template
+++ b/packaging/Caddyfile.template
@@ -6,6 +6,13 @@
 # domain ceiling. HTTP-01 on-demand was removed because the per-subdomain ask
 # endpoint allowed arbitrary subdomain probes to burn the issuance quota.
 #
+# Optional shared cert storage (opt-in, see setup/multi-node-cert-sharing.md):
+# when scripts/install.sh is invoked with --caddy-storage-s3, an additional
+# `storage s3 { ... }` directive is injected into the global block below.
+# certmagic-s3 then holds a distributed lock during ACME, so exactly one node
+# issues / renews the wildcard while the rest read it from S3 — the path that
+# matters once a cluster has 10+ ingress nodes racing for the same wildcard.
+#
 # Substitution placeholders below:
 #   {{ROOT_SITE_ADDRESS}}     — the apex domain ($DOMAIN)
 #   {{WILDCARD_SITE_ADDRESS}} — *.$DOMAIN

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,6 +23,20 @@ WITH_AMD_GPU="false"
 LOCAL_MODE="false"
 NODE_NAME=""
 
+# Shared Caddy cert storage (S3). All default empty / off; the feature is
+# off unless --caddy-storage-s3 is passed. When enabled, every node points
+# at the same S3 bucket so exactly one node holds the ACME lock and the
+# rest read the cert from S3 — sidesteps Let's Encrypt rate limits at 10+
+# ingress nodes. See setup/multi-node-cert-sharing.md.
+CADDY_STORAGE_S3="false"
+CADDY_STORAGE_S3_BUCKET=""
+CADDY_STORAGE_S3_REGION=""
+CADDY_STORAGE_S3_ENDPOINT=""
+CADDY_STORAGE_S3_PREFIX="caddy"
+CADDY_STORAGE_S3_ACCESS_KEY=""
+CADDY_STORAGE_S3_SECRET_KEY=""
+CADDY_STORAGE_S3_ENCRYPTION_KEY=""
+
 usage() {
 	cat <<'EOF'
 Usage: install.sh [options]
@@ -80,6 +94,43 @@ Options:
                                sandboxd.env. Defaults to empty, in which
                                case the dashboard falls back to the
                                hostname-derived node_id.
+  --caddy-storage-s3           Enable S3-backed shared Caddy cert storage.
+                               One node issues + renews the wildcard cert
+                               via DNS-01; every node reads it from S3.
+                               Requires --domain and --dns-provider.
+                               Off by default; each node issues its own
+                               cert when off (fine up to a handful of
+                               ingress nodes, brittle at 10+ because of
+                               Let's Encrypt rate limits).
+  --caddy-storage-s3-bucket <name>
+                               S3 bucket holding the encrypted cert
+                               objects. Required when --caddy-storage-s3
+                               is set.
+  --caddy-storage-s3-region <region>
+                               AWS region of the bucket (or the region
+                               header for non-AWS endpoints). Required
+                               when --caddy-storage-s3 is set.
+  --caddy-storage-s3-endpoint <url>
+                               Optional S3-compatible endpoint URL for
+                               Cloudflare R2, MinIO, etc. Empty selects
+                               the default AWS S3 endpoint for the region.
+  --caddy-storage-s3-prefix <path>
+                               Key prefix inside the bucket. Default
+                               "caddy". All nodes must agree.
+  --caddy-storage-s3-access-key <key>
+                               Static access key. Optional — empty falls
+                               back to the AWS default credential chain
+                               (env vars, EC2 instance role, IRSA).
+  --caddy-storage-s3-secret-key <secret>
+                               Static secret key. Pair with access key.
+  --caddy-storage-s3-encryption-key <b64>
+                               Base64-encoded 32-byte key used to encrypt
+                               cert + private key bytes before upload.
+                               Generate once with
+                               'openssl rand -base64 32' and use the
+                               SAME value on every node. Required when
+                               --caddy-storage-s3 is set; losing it
+                               renders stored certs unrecoverable.
   --local                      Local development mode. The server binds to
                                127.0.0.1:21212 with no Caddy or TLS. Supported
                                on both macOS and Linux. Docker Desktop (macOS)
@@ -268,6 +319,38 @@ while [[ $# -gt 0 ]]; do
 			NODE_NAME="$2"
 			shift 2
 			;;
+		--caddy-storage-s3)
+			CADDY_STORAGE_S3="true"
+			shift
+			;;
+		--caddy-storage-s3-bucket)
+			CADDY_STORAGE_S3_BUCKET="$2"
+			shift 2
+			;;
+		--caddy-storage-s3-region)
+			CADDY_STORAGE_S3_REGION="$2"
+			shift 2
+			;;
+		--caddy-storage-s3-endpoint)
+			CADDY_STORAGE_S3_ENDPOINT="$2"
+			shift 2
+			;;
+		--caddy-storage-s3-prefix)
+			CADDY_STORAGE_S3_PREFIX="$2"
+			shift 2
+			;;
+		--caddy-storage-s3-access-key)
+			CADDY_STORAGE_S3_ACCESS_KEY="$2"
+			shift 2
+			;;
+		--caddy-storage-s3-secret-key)
+			CADDY_STORAGE_S3_SECRET_KEY="$2"
+			shift 2
+			;;
+		--caddy-storage-s3-encryption-key)
+			CADDY_STORAGE_S3_ENCRYPTION_KEY="$2"
+			shift 2
+			;;
 		--help)
 			usage
 			exit 0
@@ -335,6 +418,36 @@ if [[ -n "$DNS_PROVIDER" ]]; then
 	L4_TLS_LISTEN_DEFAULT=":443"
 else
 	L4_TLS_LISTEN_DEFAULT=""
+fi
+
+# Shared cert storage validation. The feature only makes sense alongside
+# DNS-01 wildcard issuance — sharing has no benefit in IP/local mode (no
+# TLS) and HTTP-01 isn't supported here anyway. Missing required values
+# should fail at install time with a paste-able remediation, never at
+# first cert-renewal hours/days later.
+if [[ "$CADDY_STORAGE_S3" == "true" ]]; then
+	if [[ -z "$DOMAIN" || -z "$DNS_PROVIDER" ]]; then
+		echo "--caddy-storage-s3 requires --domain and --dns-provider (DNS-01 wildcard TLS)." >&2
+		echo "Shared cert storage only matters when there is a wildcard cert to share." >&2
+		exit 1
+	fi
+	missing=()
+	[[ -z "$CADDY_STORAGE_S3_BUCKET" ]] && missing+=("--caddy-storage-s3-bucket")
+	[[ -z "$CADDY_STORAGE_S3_REGION" ]] && missing+=("--caddy-storage-s3-region")
+	[[ -z "$CADDY_STORAGE_S3_ENCRYPTION_KEY" ]] && missing+=("--caddy-storage-s3-encryption-key")
+	if [[ ${#missing[@]} -gt 0 ]]; then
+		echo "--caddy-storage-s3 requires: ${missing[*]}" >&2
+		echo "" >&2
+		echo "Generate the encryption key ONCE for the whole cluster and reuse it on every node:" >&2
+		echo "  openssl rand -base64 32" >&2
+		echo "Losing the key means stored certs cannot be decrypted — keep it in a secrets manager." >&2
+		exit 1
+	fi
+	if [[ -n "$CADDY_STORAGE_S3_ACCESS_KEY" && -z "$CADDY_STORAGE_S3_SECRET_KEY" ]] \
+	   || [[ -z "$CADDY_STORAGE_S3_ACCESS_KEY" && -n "$CADDY_STORAGE_S3_SECRET_KEY" ]]; then
+		echo "--caddy-storage-s3-access-key and --caddy-storage-s3-secret-key must be set together (or both omitted to use the default credential chain)." >&2
+		exit 1
+	fi
 fi
 
 if [[ "$BUILD_FROM_SOURCE" == "auto" ]]; then
@@ -437,6 +550,13 @@ install_custom_caddy() {
 	if [[ -n "$provider" ]]; then
 		download_url="${download_url}&p=github.com/caddy-dns/${provider}"
 	fi
+	# Shared cert storage adds the certmagic-s3 plugin so multiple ingress
+	# nodes can pool ACME issuance via a single S3 object set. The plugin
+	# handles distributed locking via S3 conditional writes — no
+	# orchestration code lives in install.sh.
+	if [[ "$CADDY_STORAGE_S3" == "true" ]]; then
+		download_url="${download_url}&p=github.com/ss098/certmagic-s3"
+	fi
 
 	local tmp_binary
 	tmp_binary="$(mktemp)"
@@ -470,6 +590,10 @@ install_custom_caddy() {
 	if [[ -n "$provider" ]]; then
 		required_modules+=("dns.providers.${provider}")
 	fi
+	if [[ "$CADDY_STORAGE_S3" == "true" ]]; then
+		# The ss098 module registers under caddy.storage.s3.
+		required_modules+=("caddy.storage.s3")
+	fi
 	local module
 	local present
 	present="$("$tmp_binary" list-modules 2>/dev/null || true)"
@@ -477,7 +601,7 @@ install_custom_caddy() {
 		if ! grep -q "^${module}\$" <<<"$present"; then
 			echo "Downloaded Caddy does not include required module: ${module}" >&2
 			echo "Modules present (filtered):" >&2
-			grep -E "^(layer4|dns\.providers)" <<<"$present" >&2 || true
+			grep -E "^(layer4|dns\.providers|caddy\.storage)" <<<"$present" >&2 || true
 			rm -f "$tmp_binary"
 			exit 1
 		fi
@@ -586,13 +710,36 @@ EOF
 	#     first L4 expose call.
 	#   - DNS-01 means we don't need :443 free for ACME (validation goes
 	#     through DNS), so handing :443 to caddy-l4 is safe.
+	#
+	# Shared cert storage: when --caddy-storage-s3 is set, we inject a
+	# `storage s3` directive so every node points at the same bucket.
+	# certmagic-s3 holds a distributed lock during ACME, so exactly one
+	# node issues / renews the wildcard while the others read from S3.
+	# Optional lines (host, access_id/secret_key) are emitted only when
+	# the operator supplied a value — empty strings would otherwise
+	# override the AWS default credential chain / endpoint.
+	local storage_block=""
+	if [[ "$CADDY_STORAGE_S3" == "true" ]]; then
+		storage_block=$'\n\tstorage s3 {'
+		if [[ -n "$CADDY_STORAGE_S3_ENDPOINT" ]]; then
+			storage_block+=$'\n\t\thost {env.SB_CADDY_S3_ENDPOINT}'
+		fi
+		storage_block+=$'\n\t\tbucket {env.SB_CADDY_S3_BUCKET}'
+		storage_block+=$'\n\t\tprefix {env.SB_CADDY_S3_PREFIX}'
+		if [[ -n "$CADDY_STORAGE_S3_ACCESS_KEY" ]]; then
+			storage_block+=$'\n\t\taccess_id {env.SB_CADDY_S3_ACCESS_KEY}'
+			storage_block+=$'\n\t\tsecret_key {env.SB_CADDY_S3_SECRET_KEY}'
+		fi
+		storage_block+=$'\n\t\tencryption_key {env.SB_CADDY_S3_ENCRYPTION_KEY}'
+		storage_block+=$'\n\t}'
+	fi
 	cat > /etc/caddy/Caddyfile <<EOF
 {
 	admin localhost:2019
 	# caddy-l4 owns :443; the HTTPS sites below run on 127.0.0.1:8443 and
 	# only receive traffic forwarded from caddy-l4's SNI fallback route.
 	# Disable Caddy's auto-managed :80 -> :443 redirect since :443 isn't ours.
-	auto_https disable_redirects
+	auto_https disable_redirects${storage_block}
 }
 
 https://$DOMAIN:8443 {
@@ -620,24 +767,49 @@ EOF
 }
 
 write_caddy_env() {
-	if [[ -z "$DNS_PROVIDER" ]]; then
+	if [[ -z "$DNS_PROVIDER" && "$CADDY_STORAGE_S3" != "true" ]]; then
 		return
 	fi
 	# The stock Caddy debian unit from Cloudsmith does NOT load
 	# /etc/default/caddy as an EnvironmentFile, so writing it alone is not
 	# enough. write_caddy_systemd_dropin() installs a drop-in that wires it
 	# in. 0600 root:root is fine — Caddy receives the value via process env.
-	cat > /etc/default/caddy <<EOF
-# Managed by AerolVM install.sh.
-# Read by Caddy via {env.SB_DNS_API_TOKEN} substitution in /etc/caddy/Caddyfile.
-SB_DNS_API_TOKEN=$DNS_API_TOKEN
-EOF
+	{
+		echo "# Managed by AerolVM install.sh."
+		echo "# Read by Caddy via {env.NAME} substitution in /etc/caddy/Caddyfile."
+		if [[ -n "$DNS_PROVIDER" ]]; then
+			echo "SB_DNS_API_TOKEN=$DNS_API_TOKEN"
+		fi
+		if [[ "$CADDY_STORAGE_S3" == "true" ]]; then
+			# certmagic-s3 reads these via the {env.NAME} substitutions
+			# emitted by write_caddyfile. Encryption key MUST match every
+			# other node — losing it means the bucket's cert objects are
+			# unreadable. See setup/multi-node-cert-sharing.md.
+			echo "SB_CADDY_S3_BUCKET=$CADDY_STORAGE_S3_BUCKET"
+			echo "SB_CADDY_S3_REGION=$CADDY_STORAGE_S3_REGION"
+			echo "SB_CADDY_S3_ENDPOINT=$CADDY_STORAGE_S3_ENDPOINT"
+			echo "SB_CADDY_S3_PREFIX=$CADDY_STORAGE_S3_PREFIX"
+			# AWS_REGION lets the SDK inside certmagic-s3 pick the right
+			# endpoint when SB_CADDY_S3_ENDPOINT is empty.
+			echo "AWS_REGION=$CADDY_STORAGE_S3_REGION"
+			if [[ -n "$CADDY_STORAGE_S3_ACCESS_KEY" ]]; then
+				echo "SB_CADDY_S3_ACCESS_KEY=$CADDY_STORAGE_S3_ACCESS_KEY"
+				echo "SB_CADDY_S3_SECRET_KEY=$CADDY_STORAGE_S3_SECRET_KEY"
+				# Also expose under the canonical AWS SDK names so the
+				# default credential chain inside certmagic-s3 picks them
+				# up even when the Caddyfile lines are omitted.
+				echo "AWS_ACCESS_KEY_ID=$CADDY_STORAGE_S3_ACCESS_KEY"
+				echo "AWS_SECRET_ACCESS_KEY=$CADDY_STORAGE_S3_SECRET_KEY"
+			fi
+			echo "SB_CADDY_S3_ENCRYPTION_KEY=$CADDY_STORAGE_S3_ENCRYPTION_KEY"
+		fi
+	} > /etc/default/caddy
 	chmod 0600 /etc/default/caddy
 	chown root:root /etc/default/caddy
 }
 
 write_caddy_systemd_dropin() {
-	if [[ -z "$DNS_PROVIDER" ]]; then
+	if [[ -z "$DNS_PROVIDER" && "$CADDY_STORAGE_S3" != "true" ]]; then
 		return
 	fi
 	mkdir -p /etc/systemd/system/caddy.service.d

--- a/setup/multi-node-cert-sharing.md
+++ b/setup/multi-node-cert-sharing.md
@@ -1,0 +1,270 @@
+# Multi-Node Cert Sharing (S3-backed Caddy storage)
+
+Opt-in feature for clusters with **10+ ingress-bearing nodes**. Lets one node
+issue and renew the wildcard cert via Let's Encrypt while every other node
+reads the same cert from S3 — sidestepping the rate limits that bite when
+many independent Caddys race for the same `*.<domain>` cert.
+
+When to pick this:
+
+- You run a cluster with 10 or more ingress nodes (`role` containing
+  `ingress`, `edge`, or `mixed`).
+- You've hit (or are close to hitting) Let's Encrypt's
+  5-duplicate-certificates-per-week or 50-certificates-per-week-per-
+  registered-domain limits.
+- You want one ACME issuance per cluster, not N.
+
+When **not** to pick this:
+
+- Single-node deployment ([`single-node.md`](./single-node.md)) — no
+  contention exists.
+- Small clusters (≤5 ingress nodes). The independent-issuance model in
+  [`cluster.md`](./cluster.md) is simpler and fits inside the rate limits.
+- Cluster does not use a wildcard cert. Shared storage only matters when
+  there is a wildcard to share.
+
+This feature does NOT change SDK behaviour, sandbox URL shape, or the wire
+protocol. End users see no difference.
+
+---
+
+## How it works
+
+```
++----------------+      DNS-01 once per renewal   +----------------+
+| 1 winning node | -----------------------------> | Let's Encrypt  |
++----------------+ <----------------------------- +----------------+
+        |          cert + private key
+        |
+        | PUT (AES-256-encrypted)
+        v
++-----------------------------+
+| S3 bucket (TF-mgmt or BYO)  | <-- distributed lock during ACME
++-----------------------------+
+        ^
+        | GET (every Caddy reads at boot + on cache miss)
+        |
++----------------+ +----------------+ +----------------+
+| ingress node 1 | | ingress node 2 | | ingress node N |
++----------------+ +----------------+ +----------------+
+```
+
+Locking and leader election are handled by `certmagic-s3` using S3
+conditional writes — there is no orchestration code on the AerolVM side.
+
+The bucket holds two cert objects (`<domain>` and `*.<domain>`) plus
+account-key metadata. Cert files are tiny (~5 KB each); S3 storage and
+request costs are negligible.
+
+---
+
+## Two modes
+
+### Managed mode (Terraform creates the bucket)
+
+The default when you flip `enabled = true`. Terraform owns the bucket, the
+IAM grants, and auto-generates the encryption key.
+
+In `terraform.tfvars`:
+
+```hcl
+caddy_shared_cert_storage = {
+  enabled = true
+}
+```
+
+Then `terraform apply`. Outputs you should grab and store securely:
+
+```bash
+terraform output caddy_certs_bucket
+terraform output -raw caddy_certs_encryption_key  # SAVE THIS
+```
+
+The encryption key lives in Terraform state. Copy it into your secrets
+manager (1Password, AWS Secrets Manager, Vault) — losing it makes existing
+stored certs unrecoverable.
+
+### BYO mode (you bring an existing bucket)
+
+Use when:
+
+- The bucket already exists.
+- You want it in a different AWS account.
+- You want to use a non-AWS S3-compatible store (Cloudflare R2, MinIO,
+  Backblaze B2).
+
+In `terraform.tfvars`:
+
+```hcl
+caddy_shared_cert_storage = {
+  enabled        = true
+  mode           = "byo"
+  bucket         = "my-caddy-certs"
+  region         = "us-east-1"
+  encryption_key = "<base64 of 32 random bytes>"   # generate once
+}
+```
+
+Generate the encryption key once for the whole cluster:
+
+```bash
+openssl rand -base64 32
+```
+
+If the bucket is **in the same AWS account** and your EC2 instance role
+can already reach it, leave `access_key` / `secret_key` empty —
+Terraform attaches an IAM policy granting the cluster's instance roles
+R/W on the prefix.
+
+If the bucket is **elsewhere** (cross-account, R2, MinIO), supply static
+keys:
+
+```hcl
+caddy_shared_cert_storage = {
+  enabled        = true
+  mode           = "byo"
+  bucket         = "my-caddy-certs"
+  region         = "auto"
+  endpoint       = "https://<account-id>.r2.cloudflarestorage.com"
+  access_key     = "<r2-access-key-id>"
+  secret_key     = "<r2-secret-access-key>"
+  encryption_key = "<base64 of 32 random bytes>"
+}
+```
+
+---
+
+## Required S3 bucket policy (BYO mode)
+
+When you supply your own bucket, grant the nodes' principals the following
+operations on the prefix you chose (default `caddy/`):
+
+| Action | Resource |
+|---|---|
+| `s3:GetObject` | `<bucket-arn>/<prefix>/*` |
+| `s3:PutObject` | `<bucket-arn>/<prefix>/*` |
+| `s3:DeleteObject` | `<bucket-arn>/<prefix>/*` |
+| `s3:HeadObject` | `<bucket-arn>/<prefix>/*` |
+| `s3:ListBucket` | `<bucket-arn>` |
+
+For an existing-bucket-in-same-account setup with TF doing the IAM, you
+don't need to write a bucket policy — Terraform attaches the policy to the
+cluster's instance roles.
+
+For R2 / MinIO, scope the credentials similarly via the provider's own
+ACL system.
+
+---
+
+## Without Terraform (bare metal install)
+
+`scripts/install.sh` also accepts the flags directly:
+
+```bash
+sudo ./install.sh \
+  --domain sandbox.example.com \
+  --dns-provider cloudflare \
+  --dns-api-token <token> \
+  --caddy-storage-s3 \
+  --caddy-storage-s3-bucket my-caddy-certs \
+  --caddy-storage-s3-region us-east-1 \
+  --caddy-storage-s3-encryption-key "$(cat /etc/caddy-shared.key)"
+```
+
+Pre-conditions:
+
+- `--domain` and `--dns-provider` are required. Shared storage only
+  matters in DNS-01 wildcard mode.
+- The encryption key MUST be identical on every node. Generate once,
+  distribute via your existing secret-distribution mechanism (e.g.
+  cluster bootstrap, configuration management, secrets manager).
+- For non-EC2 hosts or buckets that don't honour the AWS default
+  credential chain, also pass
+  `--caddy-storage-s3-access-key` / `--caddy-storage-s3-secret-key`.
+- For non-AWS endpoints, pass `--caddy-storage-s3-endpoint`.
+
+`install.sh --help` lists the full flag set.
+
+---
+
+## Verification
+
+After applying, check from any node:
+
+```bash
+sudo journalctl -u caddy --since '5 minutes ago' | grep -E 'storage|certificate'
+```
+
+Look for `loaded certificate from storage` on every node except one, which
+should show ACME activity for the first issuance. List the bucket:
+
+```bash
+aws s3 ls s3://<bucket>/<prefix>/ --recursive
+```
+
+You should see exactly one set of cert files, not one per node.
+
+Then try the API endpoint from outside the cluster against each ingress
+node's public IP — every node should serve the same valid cert:
+
+```bash
+curl --resolve sandbox.example.com:443:<node-ip> https://sandbox.example.com/health
+```
+
+---
+
+## Operational notes
+
+### Encryption key loss
+
+The key is the only way to decrypt the cert + private key bytes in S3. If
+it's lost:
+
+1. Empty the bucket (or change the `prefix`).
+2. Generate a new key, distribute, redeploy.
+3. The first node up will re-issue against Let's Encrypt — this counts
+   against the weekly cert-issuance ceiling, so don't do it casually.
+
+**Mitigation:** copy `terraform output -raw caddy_certs_encryption_key`
+into your secrets manager immediately after the first apply, and treat
+it like any other root credential.
+
+### Key rotation
+
+`certmagic-s3` does not support in-place encryption-key rotation. Rotating
+means re-issuing certs: empty the prefix, set the new key on every node,
+restart Caddy in sequence. Plan around the Let's Encrypt rate limit.
+
+### Renewal storms
+
+With shared storage there is no renewal storm — only the lock holder
+performs ACME. Other nodes pick up the rotated cert from S3 on their next
+read (certmagic re-reads on cache expiry).
+
+### Toggling the feature on a live cluster
+
+Flipping `enabled = false → true` forces a `user_data_replace_on_change`
+recycle of every node. Plan this as a rolling change (or schedule it
+during a maintenance window) — Terraform will report the recreate in
+the plan.
+
+### Cost
+
+- S3 storage: ~10 KB per cert × 1 cert set per cluster — sub-cent.
+- S3 requests: a few PUT/GET operations per renewal cycle, plus one
+  GET per Caddy startup per node — also sub-cent at any realistic
+  cluster size.
+
+The economic cost of this feature is the operator's time to manage the
+encryption key, not the bucket itself.
+
+---
+
+## Reference
+
+- Plugin: [`github.com/ss098/certmagic-s3`](https://github.com/ss098/certmagic-s3)
+- install.sh flags: see `scripts/install.sh --help`
+- Terraform variable schema: see `Terraform/variables.tf` →
+  `caddy_shared_cert_storage`
+- Cluster topology / when this becomes necessary:
+  [`plans/cluster-criticial-thinking/02-assumptions-challenged.md`](../plans/cluster-criticial-thinking/02-assumptions-challenged.md) §A10


### PR DESCRIPTION
- Update SKILL.md to provide clearer guidance on sandbox creation and TCP pool changes.
- Introduce shared S3-backed Caddy certificate storage to improve certificate management in multi-node clusters, allowing one node to issue certificates while others read from S3. This change optimizes operations when running multiple ingress nodes.

