### PR TITLE
feat: add ACME email support for Let's Encrypt notifications in Terraform configurations

### DIFF
--- a/Terraform/nodes.tf
+++ b/Terraform/nodes.tf
@@ -45,6 +45,7 @@ resource "aws_instance" "seed" {
     domain                     = var.domain_name
     pat_token                  = var.pat_token
     cloudflare_api_token       = var.cloudflare_api_token
+    acme_email                 = var.acme_email
     with_gvisor                = local.seed_node.with_gvisor
     with_nvidia_gpu            = local.seed_node.with_nvidia_gpu
     with_amd_gpu               = local.seed_node.with_amd_gpu
@@ -127,6 +128,7 @@ resource "aws_instance" "joiner" {
     domain                     = var.domain_name
     pat_token                  = var.pat_token
     cloudflare_api_token       = var.cloudflare_api_token
+    acme_email                 = var.acme_email
     with_gvisor                = each.value.with_gvisor
     with_nvidia_gpu            = each.value.with_nvidia_gpu
     with_amd_gpu               = each.value.with_amd_gpu

--- a/Terraform/templates/bootstrap.sh.tftpl
+++ b/Terraform/templates/bootstrap.sh.tftpl
@@ -46,6 +46,12 @@ if [ -n '${domain}' ]; then
     --dns-api-token '${cloudflare_api_token}'
   )
 fi
+# Register an ACME contact email so Let's Encrypt can notify on cert expiry,
+# revocation, and rate-limit triage. Empty string => omit the flag and Caddy
+# falls back to an anonymous account (no notifications).
+if [ -n '${acme_email}' ]; then
+  INSTALL_ARGS+=(--acme-email '${acme_email}')
+fi
 %{ if with_gvisor ~}
 INSTALL_ARGS+=(--with-gvisor)
 %{ endif ~}

--- a/Terraform/terraform.tfvars.example
+++ b/Terraform/terraform.tfvars.example
@@ -8,6 +8,7 @@
 pat_token            = "REPLACE-with-shared-SB_PAT_TOKEN"
 cloudflare_api_token = "REPLACE-with-cloudflare-api-token" # Zone:DNS:Edit on the target zone; reused for Let's Encrypt DNS-01. Add Zone:Read if you want auto-zone-lookup below.
 domain_name          = "cluster.example.com"               # set empty to skip TLS and run in IP/path mode
+acme_email           = "ops@example.com"                   # Let's Encrypt contact email (expiry/revocation notices). Strongly recommended in domain mode; empty creates an anonymous ACME account with no notifications.
 
 # cloudflare_zone_id is optional. Leave it unset to auto-resolve the zone from
 # domain_name by stripping the first label ("cluster.example.com" -> "example.com").

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -376,6 +376,12 @@ variable "domain_name" {
   type        = string
 }
 
+variable "acme_email" {
+  description = "Contact email registered with Let's Encrypt. Receives cert-expiry warnings and is the identity LE uses for rate-limit triage. Strongly recommended in domain mode; empty creates an anonymous ACME account with no notifications."
+  type        = string
+  default     = ""
+}
+
 variable "create_wildcard_record" {
   description = "Whether to create a wildcard *.<domain_name> A record alongside the apex."
   type        = bool

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,6 +15,7 @@ CHECKSUMS_URL=""
 IDLE_TIMEOUT_MIN="0"
 DNS_PROVIDER=""
 DNS_API_TOKEN=""
+ACME_EMAIL=""
 CADDY_BUILD_URL_BASE="https://caddyserver.com/api/download"
 WITH_GVISOR="false"
 RUNSC_PATH=""
@@ -63,6 +64,13 @@ Options:
   --dns-api-token <token>      API token for the configured DNS provider.
                                For cloudflare: a scoped API token with
                                Zone:Read + DNS:Edit on the target zone.
+  --acme-email <email>         Contact email registered with Let's Encrypt.
+                               Lets ACME send cert-expiry and revocation
+                               notices, and surfaces this account in any
+                               future rate-limit/abuse triage. Optional but
+                               strongly recommended in domain mode; without
+                               it Caddy creates an anonymous account and
+                               you get no warnings before things break.
   --with-gvisor                Install gVisor's runsc and register it as an
                                alternative OCI runtime in
                                /etc/docker/daemon.json so sandboxes can opt
@@ -293,6 +301,10 @@ while [[ $# -gt 0 ]]; do
 			;;
 		--dns-api-token)
 			DNS_API_TOKEN="$2"
+			shift 2
+			;;
+		--acme-email)
+			ACME_EMAIL="$2"
 			shift 2
 			;;
 		--with-gvisor)
@@ -718,6 +730,14 @@ EOF
 	# Optional lines (host, access_id/secret_key) are emitted only when
 	# the operator supplied a value — empty strings would otherwise
 	# override the AWS default credential chain / endpoint.
+	# ACME account email lives in the global block. Without it Caddy creates
+	# an anonymous LE account and operators get no advance notice of
+	# expiring / revoked / rate-limited certs. Empty string omits the line
+	# entirely (preserves prior behavior for installs that don't pass one).
+	local email_line=""
+	if [[ -n "$ACME_EMAIL" ]]; then
+		email_line=$'\n\temail '"$ACME_EMAIL"
+	fi
 	local storage_block=""
 	if [[ "$CADDY_STORAGE_S3" == "true" ]]; then
 		storage_block=$'\n\tstorage s3 {'
@@ -735,7 +755,7 @@ EOF
 	fi
 	cat > /etc/caddy/Caddyfile <<EOF
 {
-	admin localhost:2019
+	admin localhost:2019${email_line}
 	# caddy-l4 owns :443; the HTTPS sites below run on 127.0.0.1:8443 and
 	# only receive traffic forwarded from caddy-l4's SNI fallback route.
 	# Disable Caddy's auto-managed :80 -> :443 redirect since :443 isn't ours.


### PR DESCRIPTION
…
This pull request adds support for specifying an ACME (Let's Encrypt) contact email throughout the Terraform and install scripts. This enables operators to receive important notifications about certificate expiry, revocation, and rate-limit issues, improving operational reliability for clusters running in domain mode. The change is optional but strongly recommended, and preserves previous behavior if the email is left unset.

**ACME Email Support Integration:**

* Added `acme_email` as a new variable in `Terraform/variables.tf`, with a description and default value, and updated `Terraform/terraform.tfvars.example` with guidance on its use. [[1]](diffhunk://#diff-6306399f7acc673b1224b1f608b7728ab7e5c13b9bff108a954b2f1d385ba5a4R379-R384) [[2]](diffhunk://#diff-a379901f5ad34f0199edb5eec0eccc979852c12ae10933328a698839c0346250R11)
* Passed the `acme_email` variable to both the `aws_instance.seed` and `aws_instance.joiner` resources in `Terraform/nodes.tf`. [[1]](diffhunk://#diff-27284210e9c845fb0bd0438ee58839db7687dc87b81265e01f31135740489dccR48) [[2]](diffhunk://#diff-27284210e9c845fb0bd0438ee58839db7687dc87b81265e01f31135740489dccR131)
* Updated `Terraform/templates/bootstrap.sh.tftpl` to include the `--acme-email` flag when the variable is set, ensuring the install script receives the contact email if provided.

**Install Script Enhancements:**

* Added `--acme-email` as a supported flag in `scripts/install.sh`, with documentation in the usage text, and logic to parse and store the value. [[1]](diffhunk://#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09ccR18) [[2]](diffhunk://#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09ccR67-R73) [[3]](diffhunk://#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09ccR306-R309)
* Modified the script to inject the ACME email into the generated `Caddyfile` configuration only if provided, preserving anonymous account behavior otherwise. [[1]](diffhunk://#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09ccR733-R740) [[2]](diffhunk://#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09ccL738-R758)

