### PR TITLE
fix: add fallback to AWS default credential chain for Caddy S3 storage

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -749,6 +749,12 @@ EOF
 		if [[ -n "$CADDY_STORAGE_S3_ACCESS_KEY" ]]; then
 			storage_block+=$'\n\t\taccess_id {env.SB_CADDY_S3_ACCESS_KEY}'
 			storage_block+=$'\n\t\tsecret_key {env.SB_CADDY_S3_SECRET_KEY}'
+		else
+			# No static creds → fall back to the AWS default credential
+			# chain (EC2 instance role, IRSA, env vars, ~/.aws/credentials).
+			# Without this line certmagic-s3 refuses to start with
+			# "access_id is empty and use_iam_provider is false".
+			storage_block+=$'\n\t\tuse_iam_provider true'
 		fi
 		storage_block+=$'\n\t\tencryption_key {env.SB_CADDY_S3_ENCRYPTION_KEY}'
 		storage_block+=$'\n\t}'


### PR DESCRIPTION
- Implement a fallback mechanism to use the AWS default credential chain when static credentials are not provided for Caddy S3 storage.
- This change prevents errors related to empty access IDs by enabling the use of IAM provider automatically.

## Summary

- Added a fallback to the AWS default credential chain for Caddy S3 storage to handle cases where static credentials are not set.

## Sandbox boot impact

N/A — no work added to sandbox boot path.

## Idempotency

N/A — no API surface changed.

## Failure-path consistency

N/A — no multi-step write path changed.

## L4 / host-port-pool changes

N/A — neither touched.

## Test plan

- Verified that Caddy S3 storage starts correctly with the fallback mechanism when no static credentials are provided.
- Tested various scenarios to ensure proper handling of credentials.

