### PR TITLE
feat: add support for managed Caddy cert bucket deletion and update documentation

### DIFF
--- a/Terraform/README.md
+++ b/Terraform/README.md
@@ -126,6 +126,13 @@ The S3 bucket is private, SSE-encrypted, and `force_destroy = true` by
 default so `terraform destroy` doesn't fail on leftover objects. Flip
 `bundle_bucket_force_destroy = false` if you want belt-and-braces.
 
+If you enable managed shared cert storage (`caddy_shared_cert_storage = {
+enabled = true }` with the default `mode = "managed"`), Terraform creates a
+second versioned S3 bucket for Caddy certs. That bucket stays conservative by
+default: `caddy_certs_bucket_force_destroy = false`. Set it to `true` before
+`terraform destroy` if you want Terraform to purge stored cert object versions
+and remove the bucket automatically.
+
 ## Observability and pull-storm controls
 
 Prometheus scraping is always available at `GET /v1/metrics` on each node's
@@ -191,4 +198,6 @@ terraform destroy
 ```
 
 This deletes the VPC, instances, security group, IAM profiles, S3 bundle
-bucket (force-destroyed), and the Cloudflare records.
+bucket (force-destroyed), and the Cloudflare records. If managed shared cert
+storage is enabled, the cert bucket is only auto-deleted when
+`caddy_certs_bucket_force_destroy = true`; otherwise empty it manually first.

--- a/Terraform/iam.tf
+++ b/Terraform/iam.tf
@@ -125,15 +125,16 @@ resource "aws_iam_instance_profile" "joiner" {
 # keys via var.caddy_shared_cert_storage and we skip the IAM attachment.
 #
 # Versioning is ON so an accidental delete of a renewed cert is recoverable.
-# force_destroy is OFF — `terraform destroy` should not silently wipe long-
-# lived TLS material the way the one-shot bundle bucket can be.
+# force_destroy defaults OFF — `terraform destroy` should not silently wipe
+# long-lived TLS material the way the one-shot bundle bucket can be unless the
+# operator explicitly opts in for full teardown.
 ###############################################################################
 
 resource "aws_s3_bucket" "caddy_certs" {
   count = local.caddy_storage_s3_managed ? 1 : 0
 
   bucket        = local.caddy_certs_bucket_name
-  force_destroy = false
+  force_destroy = var.caddy_certs_bucket_force_destroy
 }
 
 resource "aws_s3_bucket_public_access_block" "caddy_certs" {

--- a/Terraform/terraform.tfvars.example
+++ b/Terraform/terraform.tfvars.example
@@ -137,6 +137,10 @@ nodes = {
 #   enabled = true
 # }
 #
+# If you want `terraform destroy` to also purge the managed cert bucket's
+# object versions, set:
+# caddy_certs_bucket_force_destroy = true
+#
 # BYO mode — point at an existing S3-compatible bucket (R2, MinIO, ...):
 # caddy_shared_cert_storage = {
 #   enabled        = true

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -428,6 +428,12 @@ variable "bundle_bucket_force_destroy" {
   default     = true
 }
 
+variable "caddy_certs_bucket_force_destroy" {
+  description = "Whether `terraform destroy` may delete the managed Caddy cert S3 bucket even if it still has object versions."
+  type        = bool
+  default     = false
+}
+
 variable "seed_wait_max_seconds" {
   description = "How long a joiner will poll S3 for the seed's gossip key + TLS bundle before giving up."
   type        = number


### PR DESCRIPTION
This pull request introduces an option to control whether the managed Caddy certificate S3 bucket is force-destroyed during `terraform destroy`. By default, the bucket is protected from accidental deletion, but operators can now explicitly opt in to purge all stored certificate object versions and remove the bucket automatically. The documentation and example configuration files have been updated to reflect this new behavior.

**Managed Caddy certificate S3 bucket destruction controls:**

- Added a new Terraform variable `caddy_certs_bucket_force_destroy` (default: `false`) to control whether the managed Caddy cert S3 bucket is force-destroyed during `terraform destroy`. This prevents accidental deletion of long-lived TLS material unless the operator opts in. [[1]](diffhunk://#diff-6306399f7acc673b1224b1f608b7728ab7e5c13b9bff108a954b2f1d385ba5a4R431-R436) [[2]](diffhunk://#diff-c3170a0bb156927602431c3b9cf6d6287d2a2d60cde1920fb2524ab007eec512L128-R137)
- Updated the S3 bucket resource `aws_s3_bucket.caddy_certs` to use the new variable for its `force_destroy` property.

**Documentation updates:**

- Expanded the `Terraform/README.md` to document the new behavior for managed shared cert storage, including how to enable force-destroy for the cert bucket and the implications for `terraform destroy`. [[1]](diffhunk://#diff-e236e2d863f30a3543aa94a911c05a4b0ac38c2d4cd81d8b12f9b195693fbf23R129-R135) [[2]](diffhunk://#diff-e236e2d863f30a3543aa94a911c05a4b0ac38c2d4cd81d8b12f9b195693fbf23L194-R203)
- Updated `Terraform/terraform.tfvars.example` to show how to set `caddy_certs_bucket_force_destroy = true` if full teardown of the cert bucket is desired.