### PR TITLE
feat: add support for replicated owners in ingress route handling and implement tests for small and large ingress tiers

### DIFF
--- a/internal/cluster/shards.go
+++ b/internal/cluster/shards.go
@@ -14,6 +14,11 @@ const DefaultPlacementShardCount = 16384
 const (
 	DefaultPlacementPageLimit = 1000
 	MaxPlacementPageLimit     = 5000
+	// MaxReplicatedIngressRouteNodes is the largest ingress tier where every
+	// ingress-capable node keeps the full public route table. Ordinary DNS
+	// round-robin / TCP load balancers can only work if any advertised ingress
+	// node can answer for any sandbox.
+	MaxReplicatedIngressRouteNodes = 10
 )
 
 // PlacementShardFilter asks the control plane for only a subset of placement
@@ -104,10 +109,11 @@ func PlacementShardForSandbox(sandboxID string, count int) int {
 	return int(h.Sum32() % uint32(count))
 }
 
-// IngressShardFilterForNode returns the stable placement shard subset a single
-// ingress-capable node should reconcile. The nodeID is included even if gossip
-// has not reported the local member yet, which keeps a freshly booted ingress
-// process from temporarily reconciling the full placement table.
+// IngressShardFilterForNode returns the placement shard subset a single
+// ingress-capable node should reconcile. Small ingress tiers replicate the full
+// public route table to each ingress node so ordinary DNS round-robin / TCP
+// load balancers work for every sandbox. Very large ingress tiers shard the
+// table and require a shard-aware upstream router.
 func IngressShardFilterForNode(members []Member, nodeID string) PlacementShardFilter {
 	if nodeID == "" {
 		return PlacementShardFilter{}
@@ -134,6 +140,9 @@ func IngressShardFilterForNode(members []Member, nodeID string) PlacementShardFi
 	if selfIndex < 0 || len(ids) == 0 {
 		return PlacementShardFilter{}
 	}
+	if len(ids) <= MaxReplicatedIngressRouteNodes {
+		return PlacementShardFilter{}
+	}
 
 	shards := make([]int, 0, DefaultPlacementShardCount/len(ids)+1)
 	for shard := 0; shard < DefaultPlacementShardCount; shard++ {
@@ -148,9 +157,8 @@ func IngressShardFilterForNode(members []Member, nodeID string) PlacementShardFi
 }
 
 // IngressRouteForSandbox returns the ingress owner set an upstream router
-// should target for sandboxID. Today the owner set has one member; the slice is
-// intentional so replicated shard owners can be added without changing the
-// response shape.
+// should target for sandboxID. Small ingress tiers all own every sandbox route;
+// very large ingress tiers return the stable shard owner.
 func IngressRouteForSandbox(members []Member, sandboxID string) IngressShardRoute {
 	shardCount := DefaultPlacementShardCount
 	shard := PlacementShardForSandbox(sandboxID, shardCount)
@@ -162,6 +170,10 @@ func IngressRouteForSandbox(members []Member, sandboxID string) IngressShardRout
 		Owners:     []IngressRouteOwner{},
 	}
 	if len(owners) == 0 {
+		return route
+	}
+	if len(owners) <= MaxReplicatedIngressRouteNodes {
+		route.Owners = owners
 		return route
 	}
 	route.Owners = append(route.Owners, owners[shard%len(owners)])

--- a/internal/cluster/shards_test.go
+++ b/internal/cluster/shards_test.go
@@ -1,0 +1,80 @@
+package cluster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aerol-ai/microvm/internal/config"
+)
+
+func TestIngressShardFilterReplicatesSmallIngressTier(t *testing.T) {
+	members := []Member{
+		{NodeID: "worker-a", Role: config.NodeRoleWorker, Alive: true},
+		{NodeID: "ing-a", Role: config.NodeRoleIngress, Alive: true},
+		{NodeID: "ing-b", Role: config.NodeRoleIngress, Alive: true},
+		{NodeID: "ing-c", Role: config.NodeRoleIngress, Alive: true},
+	}
+
+	filter := IngressShardFilterForNode(members, "ing-b")
+	if filter.ShardCount != 0 || len(filter.Shards) != 0 {
+		t.Fatalf("filter = %+v, want empty all-shards filter for small ingress tier", filter)
+	}
+}
+
+func TestIngressShardFilterShardsLargeIngressTier(t *testing.T) {
+	members := make([]Member, 0, MaxReplicatedIngressRouteNodes+1)
+	for i := 0; i < MaxReplicatedIngressRouteNodes+1; i++ {
+		members = append(members, Member{
+			NodeID: fmt.Sprintf("ing-%02d", i),
+			Role:   config.NodeRoleIngress,
+			Alive:  true,
+		})
+	}
+
+	filter := IngressShardFilterForNode(members, "ing-05")
+	if filter.ShardCount != DefaultPlacementShardCount {
+		t.Fatalf("shard count = %d, want %d", filter.ShardCount, DefaultPlacementShardCount)
+	}
+	if len(filter.Shards) == 0 {
+		t.Fatal("large ingress tier returned all-shards filter, want stable subset")
+	}
+	if len(filter.Shards) >= DefaultPlacementShardCount {
+		t.Fatalf("large ingress tier returned %d shards, want subset", len(filter.Shards))
+	}
+}
+
+func TestIngressRouteForSandboxReturnsAllOwnersForSmallIngressTier(t *testing.T) {
+	members := []Member{
+		{NodeID: "ing-b", APIURL: "http://ing-b:21212", DataPlaneHost: "ing-b.internal", Alive: true, Role: config.NodeRoleIngress},
+		{NodeID: "worker-a", APIURL: "http://worker-a:21212", Alive: true, Role: config.NodeRoleWorker},
+		{NodeID: "ing-a", APIURL: "http://ing-a:21212", DataPlaneHost: "ing-a.internal", Alive: true, Role: config.NodeRoleIngress},
+	}
+
+	route := IngressRouteForSandbox(members, "sb-route")
+	if len(route.Owners) != 2 {
+		t.Fatalf("owners = %+v, want both ingress owners", route.Owners)
+	}
+	if route.Owners[0].NodeID != "ing-a" || route.Owners[1].NodeID != "ing-b" {
+		t.Fatalf("owners = %+v, want sorted ingress owners ing-a, ing-b", route.Owners)
+	}
+}
+
+func TestIngressRouteForSandboxReturnsShardOwnerForLargeIngressTier(t *testing.T) {
+	members := make([]Member, 0, MaxReplicatedIngressRouteNodes+1)
+	for i := 0; i < MaxReplicatedIngressRouteNodes+1; i++ {
+		members = append(members, Member{
+			NodeID:        fmt.Sprintf("ing-%02d", i),
+			APIURL:        fmt.Sprintf("http://ing-%02d:21212", i),
+			DataPlaneHost: fmt.Sprintf("ing-%02d.internal", i),
+			Alive:         true,
+			Role:          config.NodeRoleIngress,
+		})
+	}
+
+	route := IngressRouteForSandbox(members, "sb-route")
+	wantShard := PlacementShardForSandbox("sb-route", DefaultPlacementShardCount)
+	wantOwner := fmt.Sprintf("ing-%02d", wantShard%len(members))
+	if len(route.Owners) != 1 || route.Owners[0].NodeID != wantOwner {
+		t.Fatalf("owners = %+v, want single shard owner %q", route.Owners, wantOwner)
+	}
+}

--- a/pkg/api/v1/cluster_handler_test.go
+++ b/pkg/api/v1/cluster_handler_test.go
@@ -408,7 +408,7 @@ func TestClusterListWrapRejectsOversizedFanoutWithoutChangingResponseShape(t *te
 	}
 }
 
-func TestClusterIngressRouteReturnsDeterministicShardOwner(t *testing.T) {
+func TestClusterIngressRouteReturnsReplicatedOwnersForSmallIngressTier(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	svc := service.New(config.Config{}, logger, nil, nil, nil, nil, nil, nil, nil)
 	members := []cluster.Member{
@@ -439,9 +439,8 @@ func TestClusterIngressRouteReturnsDeterministicShardOwner(t *testing.T) {
 	if got.SandboxID != "sb-route" || got.Shard != wantShard || got.ShardCount != cluster.DefaultPlacementShardCount {
 		t.Fatalf("route = %+v, want sandbox_id=sb-route shard=%d shard_count=%d", got, wantShard, cluster.DefaultPlacementShardCount)
 	}
-	wantOwner := []string{"ing-a", "ing-b"}[wantShard%2]
-	if len(got.Owners) != 1 || got.Owners[0].NodeID != wantOwner {
-		t.Fatalf("owners = %+v, want single owner %q", got.Owners, wantOwner)
+	if len(got.Owners) != 2 || got.Owners[0].NodeID != "ing-a" || got.Owners[1].NodeID != "ing-b" {
+		t.Fatalf("owners = %+v, want replicated owners ing-a and ing-b", got.Owners)
 	}
 	if got.Owners[0].DataPlaneHost == "" || got.Owners[0].APIURL == "" || got.Owners[0].InternalURL == "" {
 		t.Fatalf("owner = %+v, want route targets populated for upstream routers", got.Owners[0])


### PR DESCRIPTION
This pull request updates the ingress routing logic to better support both small and large ingress tiers by distinguishing between fully replicated and sharded routing strategies. It introduces a threshold for when to replicate the full route table to all ingress nodes and adds comprehensive tests to ensure correct behavior across different cluster sizes.

**Ingress routing logic improvements:**

* Introduced `MaxReplicatedIngressRouteNodes` constant to define the largest ingress tier where every ingress-capable node replicates the full public route table, ensuring compatibility with DNS round-robin and TCP load balancers.
* Updated `IngressShardFilterForNode` to return all shards (replication) for small ingress tiers and a sharded subset for larger tiers, based on the new threshold. [[1]](diffhunk://#diff-96bde22f3cc4afdaa4b4e95b2093410d2bc5b98decb72a525f32eb03617513faL107-R116) [[2]](diffhunk://#diff-96bde22f3cc4afdaa4b4e95b2093410d2bc5b98decb72a525f32eb03617513faR143-R145)
* Modified `IngressRouteForSandbox` to return all ingress owners for small tiers and a single shard owner for large tiers. [[1]](diffhunk://#diff-96bde22f3cc4afdaa4b4e95b2093410d2bc5b98decb72a525f32eb03617513faL151-R161) [[2]](diffhunk://#diff-96bde22f3cc4afdaa4b4e95b2093410d2bc5b98decb72a525f32eb03617513faR175-R178)

**Testing enhancements:**

* Added new tests in `shards_test.go` to verify that small ingress tiers replicate routes to all nodes, while large tiers use sharding, and to check correct owner selection for both cases.
* Updated API handler tests to expect replicated owners for small ingress tiers, reflecting the new routing logic. [[1]](diffhunk://#diff-7574f4e9026964d70439b9c1186b9464e8e722be7765f4eca9f27ccda4916d72L411-R411) [[2]](diffhunk://#diff-7574f4e9026964d70439b9c1186b9464e8e722be7765f4eca9f27ccda4916d72L442-R443)