### PR TITLE
bug: implement Daytona code execution endpoint and add corresponding tests

### DIFF
--- a/cmd/toolboxd/daytona_code_run.go
+++ b/cmd/toolboxd/daytona_code_run.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// daytonaCodeRunRequest mirrors the @daytona/sdk Process.codeRun payload
+// (node_modules/@daytona/sdk/esm/Process.js:147-153). The Daytona SDK calls
+// POST /process/code-run on the toolbox proxy expecting a temp-file + interpreter
+// execution against the language label set at sandbox creation.
+type daytonaCodeRunRequest struct {
+	Code     string            `json:"code"`
+	Language string            `json:"language"`
+	Argv     []string          `json:"argv,omitempty"`
+	Envs     map[string]string `json:"envs,omitempty"`
+	Timeout  int               `json:"timeout,omitempty"`
+}
+
+// daytonaCodeRunResponse matches the fields Process.codeRun consumes
+// (Process.js:155-164): exitCode + result (stdout). Charts are an
+// E2B/Jupyter-only feature; we omit the artifacts envelope and let the SDK
+// default it to an empty array client-side.
+type daytonaCodeRunResponse struct {
+	ExitCode int    `json:"exitCode"`
+	Result   string `json:"result"`
+}
+
+// codeRunSpec describes how to materialize and execute a code snippet for a
+// given language. Cmd is looked up via exec.LookPath at request time so we
+// can give a useful error if the interpreter is missing from the image.
+type codeRunSpec struct {
+	// suffix is the temp-file extension. Some interpreters (notably ts-node)
+	// dispatch on file extension, so .ts must be .ts — not .txt.
+	suffix string
+	// cmd is the interpreter binary name as it appears on PATH.
+	cmd string
+	// args are flags prepended before the script path. Keep these minimal —
+	// users can set their own flags via shebang/env if they need more.
+	args []string
+}
+
+var codeRunSpecs = map[string]codeRunSpec{
+	"python":     {suffix: ".py", cmd: "python3"},
+	"python3":    {suffix: ".py", cmd: "python3"},
+	"javascript": {suffix: ".js", cmd: "node"},
+	"js":         {suffix: ".js", cmd: "node"},
+	"node":       {suffix: ".js", cmd: "node"},
+	"typescript": {suffix: ".ts", cmd: "ts-node"},
+	"ts":         {suffix: ".ts", cmd: "ts-node"},
+	"bash":       {suffix: ".sh", cmd: "bash"},
+	"sh":         {suffix: ".sh", cmd: "sh"},
+	"shell":      {suffix: ".sh", cmd: "sh"},
+}
+
+func (s *server) handleDaytonaCodeRun(w http.ResponseWriter, r *http.Request) {
+	var req daytonaCodeRunRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if req.Code == "" {
+		writeError(w, http.StatusBadRequest, "code is required")
+		return
+	}
+	spec, ok := codeRunSpecs[strings.ToLower(strings.TrimSpace(req.Language))]
+	if !ok {
+		writeError(w, http.StatusBadRequest, "language not supported: "+req.Language)
+		return
+	}
+
+	// Interpreter must actually be on PATH. ts-node / node / python3 are
+	// image-dependent — we surface a 400 instead of letting exec fail
+	// opaquely with "no such file or directory".
+	interp, err := exec.LookPath(spec.cmd)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "interpreter not installed in sandbox: "+spec.cmd)
+		return
+	}
+
+	scriptPath, cleanup, err := writeCodeRunScript(req.Code, spec.suffix)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	defer cleanup()
+
+	timeout := time.Duration(req.Timeout) * time.Second
+	if timeout <= 0 {
+		timeout = 5 * time.Minute
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), timeout)
+	defer cancel()
+
+	args := append([]string{}, spec.args...)
+	args = append(args, scriptPath)
+	args = append(args, req.Argv...)
+	cmd := exec.CommandContext(ctx, interp, args...)
+	cmd.Env = append(os.Environ(), envMapToSlice(req.Envs)...)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if err := cmd.Start(); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	var stdoutBytes, stderrBytes []byte
+	var readWG sync.WaitGroup
+	readWG.Add(2)
+	go func() {
+		defer readWG.Done()
+		stdoutBytes, _ = io.ReadAll(stdout)
+	}()
+	go func() {
+		defer readWG.Done()
+		stderrBytes, _ = io.ReadAll(stderr)
+	}()
+	readWG.Wait()
+	waitErr := cmd.Wait()
+
+	exitCode, _ := interpretWaitResult(waitErr)
+	// The SDK exposes only `result` (stdout) and `exitCode`. Merge stderr in
+	// when stdout is empty so users on a non-zero exit aren't staring at a
+	// blank string; otherwise mirror handleExec and discard it. This also
+	// preserves the spawn-failure message we appended below.
+	stdoutStr := string(stdoutBytes)
+	stderrStr := string(stderrBytes)
+	if waitErr != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(waitErr, &exitErr) && !errors.Is(waitErr, syscall.ECHILD) {
+			stderrStr = strings.TrimSpace(stderrStr + "\n" + waitErr.Error())
+		}
+	}
+	result := stdoutStr
+	if result == "" {
+		result = stderrStr
+	}
+	writeJSON(w, http.StatusOK, daytonaCodeRunResponse{ExitCode: exitCode, Result: result})
+}
+
+// writeCodeRunScript drops the snippet into an isolated temp dir so cleanup
+// removes both the script and any sibling files the interpreter may write
+// (ts-node's .tsbuildinfo, __pycache__, etc.) without us having to enumerate
+// them.
+func writeCodeRunScript(code, suffix string) (string, func(), error) {
+	dir, err := os.MkdirTemp("", "sb-coderun-*")
+	if err != nil {
+		return "", nil, err
+	}
+	scriptPath := filepath.Join(dir, "script"+suffix)
+	if err := os.WriteFile(scriptPath, []byte(code), 0o600); err != nil {
+		_ = os.RemoveAll(dir)
+		return "", nil, err
+	}
+	return scriptPath, func() { _ = os.RemoveAll(dir) }, nil
+}

--- a/cmd/toolboxd/daytona_code_run_test.go
+++ b/cmd/toolboxd/daytona_code_run_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestHandleDaytonaCodeRunShell(t *testing.T) {
+	srv := newDaytonaTestServer(t)
+
+	body := bytes.NewBufferString(`{"code":"printf hello-daytona-code-run","language":"sh"}`)
+	req := httptest.NewRequest(http.MethodPost, "/process/code-run", body)
+	rec := httptest.NewRecorder()
+	srv.handleDaytonaCodeRun(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp daytonaCodeRunResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ExitCode != 0 {
+		t.Fatalf("exitCode = %d want 0; result=%q", resp.ExitCode, resp.Result)
+	}
+	if resp.Result != "hello-daytona-code-run" {
+		t.Fatalf("result = %q want %q", resp.Result, "hello-daytona-code-run")
+	}
+}
+
+func TestHandleDaytonaCodeRunPropagatesNonZeroExit(t *testing.T) {
+	srv := newDaytonaTestServer(t)
+
+	// `exit 7` returns 7. stdout is empty, so handleDaytonaCodeRun's fallback
+	// path picks up stderr (also empty here) — what matters is exitCode is
+	// surfaced so the SDK's `codeResult.exitCode !== 0` branch works.
+	body := bytes.NewBufferString(`{"code":"exit 7","language":"sh"}`)
+	req := httptest.NewRequest(http.MethodPost, "/process/code-run", body)
+	rec := httptest.NewRecorder()
+	srv.handleDaytonaCodeRun(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp daytonaCodeRunResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ExitCode != 7 {
+		t.Fatalf("exitCode = %d want 7", resp.ExitCode)
+	}
+}
+
+func TestHandleDaytonaCodeRunRejectsUnknownLanguage(t *testing.T) {
+	srv := newDaytonaTestServer(t)
+
+	body := bytes.NewBufferString(`{"code":"print(1)","language":"cobol"}`)
+	req := httptest.NewRequest(http.MethodPost, "/process/code-run", body)
+	rec := httptest.NewRecorder()
+	srv.handleDaytonaCodeRun(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "not supported") {
+		t.Fatalf("body = %s, want 'not supported'", rec.Body.String())
+	}
+}
+
+func TestHandleDaytonaCodeRunMissingInterpreterReturns400(t *testing.T) {
+	// We can only assert the missing-interpreter path when the interpreter
+	// genuinely is missing on the test host. Skip when it happens to be
+	// installed (CI doesn't ship ts-node by default).
+	if _, err := exec.LookPath("ts-node"); err == nil {
+		t.Skip("ts-node is on PATH on this host; skipping")
+	}
+	srv := newDaytonaTestServer(t)
+
+	body := bytes.NewBufferString(`{"code":"console.log('hi')","language":"typescript"}`)
+	req := httptest.NewRequest(http.MethodPost, "/process/code-run", body)
+	rec := httptest.NewRecorder()
+	srv.handleDaytonaCodeRun(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "interpreter not installed") {
+		t.Fatalf("body = %s, want 'interpreter not installed'", rec.Body.String())
+	}
+}

--- a/cmd/toolboxd/main.go
+++ b/cmd/toolboxd/main.go
@@ -206,6 +206,21 @@ func (s *server) routes() http.Handler {
 				return
 			}
 			s.handleExec(w, r)
+		case r.Method == http.MethodPost && r.URL.Path == "/process/code-run":
+			if !s.requireAuth(w, r) {
+				return
+			}
+			s.handleDaytonaCodeRun(w, r)
+		case strings.HasPrefix(r.URL.Path, "/process/interpreter/"):
+			// codeInterpreter.runCode() is Daytona's stateful Jupyter-kernel API.
+			// We don't host a kernel in the default toolbox image; without an
+			// explicit 501 here a WS upgrade GET would 404 with the default
+			// branch's "not found" body, which the SDK can't disambiguate from
+			// other "thing missing" failures. Hand back a clear 501.
+			if !s.requireAuth(w, r) {
+				return
+			}
+			writeError(w, http.StatusNotImplemented, "codeInterpreter is not implemented; use process.codeRun or process.executeCommand instead")
 		case strings.HasPrefix(r.URL.Path, "/process/session"):
 			if !s.requireAuth(w, r) {
 				return

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -2407,7 +2407,7 @@ func (s *Service) applyInFluxRoute(ctx context.Context, p cluster.Placement) err
 			continue
 		}
 		if s.cfg.Domain == "" {
-			if err := s.caddy.DeletePortRoute(ctx, p.SandboxID, port); err != nil && firstErr == nil {
+			if err := s.caddy.DeleteRouteByID(ctx, caddy.PortRouteID(p.SandboxID, port)); err != nil && firstErr == nil {
 				firstErr = err
 			}
 		} else {

--- a/pkg/api/daytona/toolbox.go
+++ b/pkg/api/daytona/toolbox.go
@@ -69,7 +69,10 @@ func (h *handlers) toolbox(w http.ResponseWriter, r *http.Request) {
 		h.proxyToolbox(w, r, sandboxID, "/"+path)
 	case strings.HasPrefix(path, "process/interpreter/"):
 		// /process/interpreter/execute is a WebSocket stream; the context
-		// endpoints are plain HTTP. ReverseProxy handles both.
+		// endpoints are plain HTTP. ReverseProxy handles both. The shipped
+		// toolboxd returns 501 from this prefix (see daytona_code_run.go);
+		// custom toolbox builds can implement a Jupyter kernel and have
+		// requests reach them transparently.
 		h.proxyToolbox(w, r, sandboxID, "/"+path)
 	case path == "process/pty" || strings.HasPrefix(path, "process/pty/"):
 		// /process/pty (bare) covers list/create; /process/pty/{id}/connect

--- a/pkg/caddy/client.go
+++ b/pkg/caddy/client.go
@@ -467,6 +467,8 @@ func inFluxPortRouteID(id string, port int) string {
 }
 
 // IDs exposed for the zombie GC to add to its keep-set.
+func SandboxRouteID(id string) string              { return sandboxRouteID(id) }
+func PortRouteID(id string, port int) string       { return portRouteID(id, port) }
 func InFluxSandboxRouteID(id string) string        { return inFluxSandboxRouteID(id) }
 func InFluxPortRouteID(id string, port int) string { return inFluxPortRouteID(id, port) }
 


### PR DESCRIPTION
- Introduced a new endpoint for executing code snippets in various languages via the Daytona API.
- Added corresponding tests to ensure functionality and error handling for the new endpoint.
- Enhanced error responses for unsupported languages and missing interpreters.

