### PR TITLE
Add unit tests for network statistics and service runtime functionality

### DIFF
--- a/Ansible/inventory/group_vars/all.yml
+++ b/Ansible/inventory/group_vars/all.yml
@@ -3,6 +3,9 @@
 
 sandboxd_binary_path:   /usr/local/bin/sandboxd
 sandboxd_service_name:  sandboxd
+# Toolboxd is the in-container agent; it's bind-mounted into every sandbox
+# from this host path (see pkg/docker/client.go and packaging/.env.template).
+toolboxd_binary_path:   /usr/local/bin/toolboxd
 sandboxd_env_file:      /etc/sandboxd/sandboxd.env
 sandboxd_cluster_env_file: /etc/sandboxd/cluster.env
 sandboxd_health_url:    "http://127.0.0.1:21212/health"

--- a/Ansible/playbooks/update-toolboxd.yml
+++ b/Ansible/playbooks/update-toolboxd.yml
@@ -1,0 +1,127 @@
+---
+# Roll a new toolboxd binary across the cluster.
+#
+# Toolboxd is the in-container agent. Sandboxd bind-mounts it read-only into
+# every new sandbox at container-create time (pkg/docker/client.go:318), so:
+#   - There is no systemd service to restart on the host.
+#   - The host's /health endpoint reflects sandboxd, not toolboxd, so we
+#     can't verify the new binary works without creating a sandbox.
+#   - Existing sandboxes keep running the OLD toolboxd loaded into RAM at
+#     their create time. They MUST be recreated to pick up the new binary.
+#
+# Usage:
+#   # Push a locally-built binary (the common case while developing):
+#   ansible-playbook playbooks/update-toolboxd.yml \
+#     -e toolboxd_local_binary=../bin/toolboxd
+#
+#   # Or fetch from a GitHub release URL on each node:
+#   ansible-playbook playbooks/update-toolboxd.yml \
+#     -e toolboxd_remote_url=https://github.com/aerol-ai/microvm/releases/latest/download/toolboxd_linux_amd64
+#
+#   # Limit to a single host while testing:
+#   ansible-playbook playbooks/update-toolboxd.yml -e ... --limit aerolvm-srv1
+#
+# Safety:
+#   - serial: 1 → one node at a time. Not strictly required (no host process
+#     restart), but matches update-sandboxd.yml so concurrent sandbox creates
+#     never race the file-swap.
+#   - The atomic mv guarantees a sandbox starting during the rollout sees
+#     either the old or the new inode, never a half-written file.
+#   - become: true → /usr/local/bin writes require root.
+
+- name: Update toolboxd across the AerolVM cluster
+  hosts: all
+  become: true
+  serial: 1
+  any_errors_fatal: true
+  gather_facts: false
+
+  pre_tasks:
+    - name: Validate that exactly one source was provided
+      delegate_to: localhost
+      become: false
+      run_once: true
+      ansible.builtin.assert:
+        that:
+          - (toolboxd_local_binary is defined) != (toolboxd_remote_url is defined)
+        fail_msg: >-
+          Set exactly one of -e toolboxd_local_binary=<path> or
+          -e toolboxd_remote_url=<url>.
+
+    # Ansible doesn't run tasks in the directory you invoked ansible-playbook
+    # from — it switches into its own temp dir, so a user-supplied relative
+    # path like `../bin/toolboxd` would silently miss. Anchor relative paths
+    # to playbook_dir so the same -e value works regardless of CWD. The
+    # passed path is assumed to be relative to the Ansible/ directory (one
+    # level above playbooks/), matching how operators run this from there.
+    - name: Resolve toolboxd_local_binary to an absolute path
+      when: toolboxd_local_binary is defined
+      delegate_to: localhost
+      become: false
+      run_once: true
+      ansible.builtin.set_fact:
+        toolboxd_local_binary_abs: >-
+          {{ toolboxd_local_binary if toolboxd_local_binary.startswith('/')
+             else (playbook_dir + '/../' + toolboxd_local_binary) }}
+
+    - name: Confirm local binary exists
+      delegate_to: localhost
+      become: false
+      run_once: true
+      when: toolboxd_local_binary is defined
+      ansible.builtin.stat:
+        path: "{{ toolboxd_local_binary_abs }}"
+      register: local_bin_stat
+      failed_when: not local_bin_stat.stat.exists
+
+  tasks:
+    - name: "[{{ inventory_hostname }}] Stage new binary at /tmp/toolboxd.new (local upload)"
+      when: toolboxd_local_binary is defined
+      ansible.builtin.copy:
+        src: "{{ toolboxd_local_binary_abs }}"
+        dest: /tmp/toolboxd.new
+        mode: "0755"
+        owner: root
+        group: root
+
+    - name: "[{{ inventory_hostname }}] Stage new binary at /tmp/toolboxd.new (remote fetch)"
+      when: toolboxd_remote_url is defined
+      ansible.builtin.get_url:
+        url: "{{ toolboxd_remote_url }}"
+        dest: /tmp/toolboxd.new
+        mode: "0755"
+        owner: root
+        group: root
+        force: true
+
+    - name: "[{{ inventory_hostname }}] Atomic swap into {{ toolboxd_binary_path }}"
+      # mv is atomic within a filesystem. A sandbox bind-mount captured before
+      # the swap keeps its old inode; one captured after sees the new file.
+      ansible.builtin.command:
+        cmd: mv -f /tmp/toolboxd.new {{ toolboxd_binary_path }}
+      changed_when: true
+
+  post_tasks:
+    - name: "[{{ inventory_hostname }}] Report installed toolboxd version"
+      # Wrap in `timeout 5s`: toolboxd builds older than the --version flag
+      # (added 2026-05-23) interpret any argv as a user entrypoint and then
+      # block on ListenAndServe, hanging the playbook. The timeout bounds
+      # that worst case — newer binaries return in milliseconds.
+      ansible.builtin.command:
+        cmd: timeout 5s {{ toolboxd_binary_path }} --version
+      register: ver
+      changed_when: false
+      failed_when: false
+
+    - name: "[{{ inventory_hostname }}] toolboxd version"
+      ansible.builtin.debug:
+        msg: "{{ ver.stdout | default(ver.stderr) | default('(--version unsupported)') }}"
+
+    - name: "[{{ inventory_hostname }}] Reminder"
+      run_once: true
+      delegate_to: localhost
+      become: false
+      ansible.builtin.debug:
+        msg: >-
+          toolboxd binary replaced on host(s). EXISTING sandboxes still run the
+          old in-RAM binary — destroy and recreate them to pick up the new code.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # AerolVM
 
+[![Tests](https://github.com/aerol-ai/microvm/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/aerol-ai/microvm/actions/workflows/test.yml)
+[![Release](https://github.com/aerol-ai/microvm/actions/workflows/release.yml/badge.svg)](https://github.com/aerol-ai/microvm/actions/workflows/release.yml)
+[![Publish SDKs](https://github.com/aerol-ai/microvm/actions/workflows/publish-sdks.yml/badge.svg)](https://github.com/aerol-ai/microvm/actions/workflows/publish-sdks.yml)
+
 AerolVM is a self-hosted platform for creating isolated Docker-backed sandboxes on a single Linux host. This repository contains the server, installer, SDKs, and documentation you use to provision a host, create containers, expose preview URLs, and manage sandboxes over an API.
 
 ## Start Here

--- a/cmd/toolboxd/main.go
+++ b/cmd/toolboxd/main.go
@@ -62,6 +62,21 @@ func (s *server) portAllowed(port int) bool {
 }
 
 func main() {
+	// --version / -v must be handled before any server setup so deploy
+	// tooling (Ansible's update-toolboxd.yml) can probe an installed binary
+	// without accidentally launching it as a daemon. Note: when toolboxd
+	// runs inside a sandbox container, os.Args[1:] is the user's entry-point
+	// command — there's no ambiguity here because a user command starting
+	// with "--version" isn't a sensible sandbox entrypoint, and treating it
+	// as a flag means we exit before binding the listener.
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "--version", "-v", "version":
+			fmt.Println(version.Version)
+			return
+		}
+	}
+
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{}))
 
 	srv := &server{

--- a/internal/cluster/agent_wrapper_additional_test.go
+++ b/internal/cluster/agent_wrapper_additional_test.go
@@ -1,0 +1,430 @@
+package cluster
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/pkg/capacity"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+type agentControlPlaneCapture struct {
+	mu                sync.Mutex
+	commands          []command
+	recoveryBlobs     []RecoveryBlob
+	selectRequests    []SelectPlacementRequest
+	shardFilters      []PlacementShardFilter
+	pageRequests      []PlacementPageRequest
+	removeMemberPaths []string
+}
+
+func (c *agentControlPlaneCapture) handler(t *testing.T, extra func(http.ResponseWriter, *http.Request) bool) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == PublicInternalApplyPath:
+			payload, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read apply payload: %v", err)
+			}
+			cmd, err := decodeCommand(payload)
+			if err != nil {
+				t.Fatalf("decode apply payload: %v", err)
+			}
+			c.mu.Lock()
+			c.commands = append(c.commands, cmd)
+			c.mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, PublicInternalRecoveryPath):
+			var blob RecoveryBlob
+			if err := json.NewDecoder(r.Body).Decode(&blob); err != nil {
+				t.Fatalf("decode recovery blob: %v", err)
+			}
+			c.mu.Lock()
+			c.recoveryBlobs = append(c.recoveryBlobs, blob)
+			c.mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		case extra != nil && extra(w, r):
+			return
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.RequestURI())
+		}
+	})
+}
+
+func (c *agentControlPlaneCapture) appendSelectRequest(req SelectPlacementRequest) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.selectRequests = append(c.selectRequests, req)
+}
+
+func (c *agentControlPlaneCapture) appendShardFilter(filter PlacementShardFilter) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.shardFilters = append(c.shardFilters, filter)
+}
+
+func (c *agentControlPlaneCapture) appendPageRequest(req PlacementPageRequest) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.pageRequests = append(c.pageRequests, req)
+}
+
+func (c *agentControlPlaneCapture) appendRemoveMemberPath(path string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.removeMemberPaths = append(c.removeMemberPaths, path)
+}
+
+func (c *agentControlPlaneCapture) commandsSnapshot() []command {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]command(nil), c.commands...)
+}
+
+func (c *agentControlPlaneCapture) recoveryBlobsSnapshot() []RecoveryBlob {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]RecoveryBlob(nil), c.recoveryBlobs...)
+}
+
+func (c *agentControlPlaneCapture) selectRequestsSnapshot() []SelectPlacementRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]SelectPlacementRequest(nil), c.selectRequests...)
+}
+
+func (c *agentControlPlaneCapture) shardFiltersSnapshot() []PlacementShardFilter {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]PlacementShardFilter(nil), c.shardFilters...)
+}
+
+func (c *agentControlPlaneCapture) pageRequestsSnapshot() []PlacementPageRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]PlacementPageRequest(nil), c.pageRequests...)
+}
+
+func (c *agentControlPlaneCapture) removeMemberPathsSnapshot() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.removeMemberPaths...)
+}
+
+func TestAgentOwnerOfNameAndSelectPlacement(t *testing.T) {
+	capture := &agentControlPlaneCapture{}
+	demoPath := PublicInternalPlacementByNamePath + base64.RawURLEncoding.EncodeToString([]byte("demo name"))
+	missingPath := PublicInternalPlacementByNamePath + base64.RawURLEncoding.EncodeToString([]byte("missing"))
+	orphanPath := PublicInternalPlacementByNamePath + base64.RawURLEncoding.EncodeToString([]byte("orphan"))
+	agent := newAgentControlPlaneHarness(t, capture.handler(t, func(w http.ResponseWriter, r *http.Request) bool {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == demoPath:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(PlacementLookupResponse{
+				SandboxID: "sb-demo",
+				Owner:     OwnerInfo{NodeID: "worker-self", APIURL: "http://ignored"},
+			})
+			return true
+		case r.Method == http.MethodGet && r.URL.Path == missingPath:
+			http.Error(w, "not found", http.StatusNotFound)
+			return true
+		case r.Method == http.MethodGet && r.URL.Path == orphanPath:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(PlacementLookupResponse{SandboxID: "sb-orphan", Orphaned: true})
+			return true
+		case r.Method == http.MethodPost && r.URL.Path == PublicInternalSelectPlacementPath:
+			var req SelectPlacementRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode select placement request: %v", err)
+			}
+			capture.appendSelectRequest(req)
+			w.Header().Set("Content-Type", "application/json")
+			if req.Request.CPU == 99 {
+				_ = json.NewEncoder(w).Encode(SelectPlacementResponse{Error: ErrNoPlacementTarget.Error()})
+				return true
+			}
+			_ = json.NewEncoder(w).Encode(SelectPlacementResponse{Target: PlacementTarget{NodeID: "worker-self", APIURL: "http://server", DataPlaneHost: "ignored", InternalURL: "https://ignored"}})
+			return true
+		default:
+			return false
+		}
+	}), Member{NodeID: "worker-self", Alive: true, Role: config.NodeRoleWorker})
+	agent.apiURL = "http://self"
+	agent.dataPlaneHost = "self-dp"
+	agent.internalURL = "https://self-internal"
+
+	if got := agent.SelfNodeID(); got != "worker-self" {
+		t.Fatalf("SelfNodeID() = %q, want worker-self", got)
+	}
+	if got := agent.SelfAPIURL(); got != "http://self" {
+		t.Fatalf("SelfAPIURL() = %q, want http://self", got)
+	}
+
+	id, owner, err := agent.OwnerOfName("  demo name ")
+	if err != nil {
+		t.Fatalf("OwnerOfName() error = %v", err)
+	}
+	if id != "sb-demo" {
+		t.Fatalf("OwnerOfName() sandbox id = %q, want sb-demo", id)
+	}
+	if owner.NodeID != "worker-self" || !owner.IsSelf {
+		t.Fatalf("OwnerOfName() owner = %+v, want self owner", owner)
+	}
+	if _, _, err := agent.OwnerOfName("missing"); !errors.Is(err, ErrUnknownSandbox) {
+		t.Fatalf("OwnerOfName(missing) error = %v, want ErrUnknownSandbox", err)
+	}
+	id, _, err = agent.OwnerOfName("orphan")
+	if !errors.Is(err, ErrOrphaned) || id != "sb-orphan" {
+		t.Fatalf("OwnerOfName(orphan) = (%q, %v), want (sb-orphan, ErrOrphaned)", id, err)
+	}
+
+	target, err := agent.SelectPlacement(capacity.Request{CPU: 2, MemoryMB: 1024})
+	if err != nil {
+		t.Fatalf("SelectPlacement() error = %v", err)
+	}
+	if target.NodeID != "worker-self" || target.APIURL != "http://self" || target.DataPlaneHost != "self-dp" || target.InternalURL != "https://self-internal" || !target.IsSelf {
+		t.Fatalf("SelectPlacement() target = %+v, want self target metadata rewritten", target)
+	}
+	if _, err := agent.SelectPlacement(capacity.Request{CPU: 99}); !errors.Is(err, ErrNoPlacementTarget) {
+		t.Fatalf("SelectPlacement(no target) error = %v, want ErrNoPlacementTarget", err)
+	}
+	requests := capture.selectRequestsSnapshot()
+	if len(requests) != 2 || requests[0].Request.CPU != 2 || requests[0].Request.MemoryMB != 1024 {
+		t.Fatalf("select placement requests = %+v, want first request footprint preserved", requests)
+	}
+}
+
+func TestAgentLookupDerivedReadsAndMutationWrappers(t *testing.T) {
+	capture := &agentControlPlaneCapture{}
+	agent := newAgentControlPlaneHarness(t, capture.handler(t, func(w http.ResponseWriter, r *http.Request) bool {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == PublicInternalPlacementPath+"sb-state":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(PlacementLookupResponse{
+				SandboxID: "sb-state",
+				Placement: Placement{
+					SandboxID:         "sb-state",
+					Version:           12,
+					SecretRef:         "cluster-secret://sandbox/sb-state/v1",
+					SecretVersion:     3,
+					SealedSecrets:     []byte("sealed"),
+					ExposedPortRoutes: map[int]ExposedPortRoute{5432: {Protocol: "tcp", HostPort: 22432, PublicURL: "tcp://sandbox.example.com:22432"}},
+				},
+				Owner: OwnerInfo{NodeID: "server-1", APIURL: "http://server-1"},
+			})
+			return true
+		case r.Method == http.MethodGet && r.URL.Path == PublicInternalPlacementPath+"missing":
+			http.Error(w, "not found", http.StatusNotFound)
+			return true
+		case r.Method == http.MethodGet && r.URL.Path == PublicInternalDrainStatePath+"node-a":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(DrainStateResponse{Drained: true})
+			return true
+		case r.Method == http.MethodGet && r.URL.Path == PublicInternalDrainStatePath+"node-b":
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return true
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/v1/cluster/members/"):
+			capture.appendRemoveMemberPath(r.URL.RequestURI())
+			if strings.HasSuffix(r.URL.Path, "/missing") {
+				http.Error(w, ErrUnknownMember.Error(), http.StatusNotFound)
+				return true
+			}
+			w.WriteHeader(http.StatusNoContent)
+			return true
+		default:
+			return false
+		}
+	}), Member{NodeID: "worker-self", Alive: true, Role: config.NodeRoleWorker})
+
+	placement, ok := agent.PlacementOf("sb-state")
+	if !ok || placement.SandboxID != "sb-state" || placement.Version != 12 {
+		t.Fatalf("PlacementOf() = (%+v, %v), want sb-state placement and true", placement, ok)
+	}
+	if got := agent.PlacementVersion(); got != 12 {
+		t.Fatalf("PlacementVersion() = %d, want 12", got)
+	}
+	secrets := agent.SecretsOf("sb-state")
+	if secrets.Ref != "cluster-secret://sandbox/sb-state/v1" || secrets.Version != 3 || string(secrets.LegacySealed) != "sealed" {
+		t.Fatalf("SecretsOf() = %+v, want replicated secret handle", secrets)
+	}
+	if got := agent.SealedSecretsOf("sb-state"); string(got) != "sealed" {
+		t.Fatalf("SealedSecretsOf() = %q, want sealed", string(got))
+	}
+	routes := agent.ExposedPortsOf("sb-state")
+	if routes[5432].HostPort != 22432 || routes[5432].Protocol != "tcp" {
+		t.Fatalf("ExposedPortsOf() = %+v, want tcp route metadata", routes)
+	}
+	if placement, ok := agent.PlacementOf("missing"); ok || placement.SandboxID != "" {
+		t.Fatalf("PlacementOf(missing) = (%+v, %v), want zero placement and false", placement, ok)
+	}
+	if !agent.IsNodeDrained("node-a") {
+		t.Fatal("IsNodeDrained(node-a) = false, want true")
+	}
+	if agent.IsNodeDrained("node-b") {
+		t.Fatal("IsNodeDrained(node-b) = true, want false on control-plane error")
+	}
+
+	ctx := context.Background()
+	if err := agent.RecordPlacement(ctx, "sb-record", nil, PlacementSecrets{}); err != nil {
+		t.Fatalf("RecordPlacement() error = %v", err)
+	}
+	if err := agent.ClaimOrphan(ctx, "sb-claim", nil, PlacementSecrets{}); err != nil {
+		t.Fatalf("ClaimOrphan() error = %v", err)
+	}
+	if err := agent.UpsertSpec(ctx, "sb-upsert", &models.CreateSandboxRequest{Image: "alpine:3.20", Name: "named"}, PlacementSecrets{}); err != nil {
+		t.Fatalf("UpsertSpec() error = %v", err)
+	}
+	if err := agent.AddExposedPort(ctx, "sb-port", 8080, ExposedPortRoute{Protocol: "http", PublicURL: "https://sandbox.example.com"}); err != nil {
+		t.Fatalf("AddExposedPort() error = %v", err)
+	}
+	if err := agent.RemoveExposedPort(ctx, "sb-port", 8080); err != nil {
+		t.Fatalf("RemoveExposedPort() error = %v", err)
+	}
+	if err := agent.DeletePlacement(ctx, "sb-delete"); err != nil {
+		t.Fatalf("DeletePlacement() error = %v", err)
+	}
+	if err := agent.ReserveOnTarget(ctx, "sb-reserve", PlacementTarget{NodeID: "node-a", APIURL: "http://node-a", DataPlaneHost: "dp-a"}, nil, PlacementSecrets{}, time.Minute); err != nil {
+		t.Fatalf("ReserveOnTarget() error = %v", err)
+	}
+	if err := agent.CancelReservation(ctx, "sb-reserve"); err != nil {
+		t.Fatalf("CancelReservation() error = %v", err)
+	}
+	if err := agent.SetNodeDrainState(ctx, "node-a", true); err != nil {
+		t.Fatalf("SetNodeDrainState() error = %v", err)
+	}
+	if err := agent.SetNodeDrainState(ctx, "", true); err == nil {
+		t.Fatal("SetNodeDrainState() accepted empty node id")
+	}
+	if err := agent.RemoveMember(ctx, "node-a", true); err != nil {
+		t.Fatalf("RemoveMember() error = %v", err)
+	}
+	if err := agent.RemoveMember(ctx, "missing", false); !errors.Is(err, ErrUnknownMember) {
+		t.Fatalf("RemoveMember(missing) error = %v, want ErrUnknownMember", err)
+	}
+	encoded, err := encodeCommand(command{Op: opDelete, SandboxID: "sb-encoded"})
+	if err != nil {
+		t.Fatalf("encodeCommand: %v", err)
+	}
+	if err := agent.ApplyEncoded(ctx, encoded); err != nil {
+		t.Fatalf("ApplyEncoded() error = %v", err)
+	}
+	if err := agent.ApplyEncoded(ctx, []byte("not-json")); err == nil {
+		t.Fatal("ApplyEncoded() accepted invalid payload")
+	}
+
+	blobs := capture.recoveryBlobsSnapshot()
+	if len(blobs) != 1 || blobs[0].SandboxID != "sb-upsert" || blobs[0].Spec == nil || blobs[0].Spec.Image != "alpine:3.20" {
+		t.Fatalf("recovery blobs = %+v, want one upsert-spec blob", blobs)
+	}
+	cmds := capture.commandsSnapshot()
+	if len(cmds) != 10 {
+		t.Fatalf("captured commands = %d, want 10", len(cmds))
+	}
+	var upsert command
+	seen := make(map[opCode]int)
+	for _, cmd := range cmds {
+		seen[cmd.Op]++
+		if cmd.Op == opUpsertSpec {
+			upsert = cmd
+		}
+	}
+	for _, op := range []opCode{opPlace, opClaimOrphan, opUpsertSpec, opAddExposedPort, opRemoveExposedPort, opDelete, opReserve, opCancelReserve, opSetNodeDrainState} {
+		if seen[op] == 0 {
+			t.Fatalf("captured commands missing op %d: %+v", op, cmds)
+		}
+	}
+	if upsert.RecoveryRef == "" || upsert.Spec != nil {
+		t.Fatalf("upsert command = %+v, want recovery ref externalized and nil spec", upsert)
+	}
+	paths := capture.removeMemberPathsSnapshot()
+	if len(paths) != 2 || paths[0] != "/v1/cluster/members/node-a?force=true" || paths[1] != "/v1/cluster/members/missing" {
+		t.Fatalf("remove member paths = %v, want force path then missing path", paths)
+	}
+}
+
+func TestAgentPlacementCollectionsUseControlPlaneAndFallbackCache(t *testing.T) {
+	capture := &agentControlPlaneCapture{}
+	allPlacements := []Placement{{SandboxID: "sb-a", Version: 21}, {SandboxID: "sb-b", Version: 18}}
+	shardPlacements := []Placement{{SandboxID: "sb-shard", Version: 22}}
+	pagePlacements := []Placement{{SandboxID: "sb-page", Version: 23}}
+	failAllReads := false
+	failShardQuery := false
+	agent := newAgentControlPlaneHarness(t, capture.handler(t, func(w http.ResponseWriter, r *http.Request) bool {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == PublicInternalPlacementsPath:
+			if failAllReads {
+				http.Error(w, "boom", http.StatusInternalServerError)
+				return true
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(allPlacements)
+			return true
+		case r.Method == http.MethodPost && r.URL.Path == PublicInternalPlacementsQueryPath:
+			var filter PlacementShardFilter
+			if err := json.NewDecoder(r.Body).Decode(&filter); err != nil {
+				t.Fatalf("decode shard filter: %v", err)
+			}
+			capture.appendShardFilter(filter)
+			if failShardQuery {
+				http.Error(w, "boom", http.StatusInternalServerError)
+				return true
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(shardPlacements)
+			return true
+		case r.Method == http.MethodPost && r.URL.Path == PublicInternalPlacementsPagePath:
+			var req PlacementPageRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode placement page request: %v", err)
+			}
+			capture.appendPageRequest(req)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(PlacementPageResponse{Placements: pagePlacements, NextPageToken: "next-page"})
+			return true
+		default:
+			return false
+		}
+	}), Member{NodeID: "worker-self", Alive: true, Role: config.NodeRoleWorker})
+
+	if got := agent.Placements(); len(got) != 2 || got[0].SandboxID != "sb-a" {
+		t.Fatalf("Placements() = %+v, want control-plane placements", got)
+	}
+	if got := agent.PlacementVersion(); got != 21 {
+		t.Fatalf("PlacementVersion() = %d, want 21 after full placements read", got)
+	}
+
+	filter := PlacementShardFilter{ShardCount: 32, Shards: []int{7, 2, 7}}
+	if got := agent.PlacementsForShards(filter); len(got) != 1 || got[0].SandboxID != "sb-shard" {
+		t.Fatalf("PlacementsForShards() = %+v, want shard placement", got)
+	}
+	failShardQuery = true
+	if got := agent.PlacementsForShards(filter); len(got) != 1 || got[0].SandboxID != "sb-shard" {
+		t.Fatalf("PlacementsForShards() fallback = %+v, want cached shard placement", got)
+	}
+	failAllReads = true
+	if got := agent.Placements(); len(got) != 2 || got[0].SandboxID != "sb-a" {
+		t.Fatalf("Placements() fallback = %+v, want cached full placement view", got)
+	}
+	page := agent.PlacementPage(PlacementPageRequest{})
+	if len(page.Placements) != 1 || page.Placements[0].SandboxID != "sb-page" || page.NextPageToken != "next-page" {
+		t.Fatalf("PlacementPage() = %+v, want paged response", page)
+	}
+	filters := capture.shardFiltersSnapshot()
+	if len(filters) != 2 || filters[0].ShardCount != 32 || len(filters[0].Shards) != 2 {
+		t.Fatalf("shard filters = %+v, want normalized deduplicated filter", filters)
+	}
+	pages := capture.pageRequestsSnapshot()
+	if len(pages) != 1 || pages[0].Limit != DefaultPlacementPageLimit {
+		t.Fatalf("page requests = %+v, want normalized default limit", pages)
+	}
+}

--- a/internal/cluster/agent_wrapper_additional_test.go
+++ b/internal/cluster/agent_wrapper_additional_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
@@ -426,5 +427,47 @@ func TestAgentPlacementCollectionsUseControlPlaneAndFallbackCache(t *testing.T) 
 	pages := capture.pageRequestsSnapshot()
 	if len(pages) != 1 || pages[0].Limit != DefaultPlacementPageLimit {
 		t.Fatalf("page requests = %+v, want normalized default limit", pages)
+	}
+}
+
+func TestAgentMiscWrappers(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Cluster-Forwarded") != "1" {
+			t.Fatalf("forwarded request missing loop-detection header")
+		}
+		_, _ = w.Write([]byte("forwarded"))
+	}))
+	defer target.Close()
+
+	agent := &Agent{
+		publicProxies:  newProxyCache(defaultPublicTransport),
+		internalServer: &internalServer{},
+		placementCache: []Placement{{SandboxID: "sb-cache"}},
+		shardCache: map[string][]Placement{
+			placementShardFilterCacheKey(PlacementShardFilter{}): {{SandboxID: "sb-cache"}},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/sandboxes/sb-cache", nil)
+	rr := httptest.NewRecorder()
+	agent.ForwardHTTP(Endpoint{APIURL: target.URL}, rr, req)
+	if rr.Code != http.StatusOK || rr.Body.String() != "forwarded" {
+		t.Fatalf("ForwardHTTP() = (%d, %q), want (200, forwarded)", rr.Code, rr.Body.String())
+	}
+
+	agent.AttachInternalHandler(http.NotFoundHandler())
+	if agent.internalServer.extra.Load() == nil {
+		t.Fatal("AttachInternalHandler() did not install the extra handler")
+	}
+	if got := agent.SubscribePlacement(context.Background()); got != nil {
+		t.Fatalf("SubscribePlacement() = %v, want nil", got)
+	}
+	cached := agent.cachedPlacements()
+	if len(cached) != 1 || cached[0].SandboxID != "sb-cache" {
+		t.Fatalf("cachedPlacements() = %+v, want cached placement copy", cached)
+	}
+	cached[0].SandboxID = "mutated"
+	if agent.placementCache[0].SandboxID != "sb-cache" {
+		t.Fatalf("cachedPlacements() did not deep-clone: %+v", agent.placementCache)
 	}
 }

--- a/internal/cluster/client_wrapper_additional_test.go
+++ b/internal/cluster/client_wrapper_additional_test.go
@@ -1,0 +1,281 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/capacity"
+	"github.com/aerol-ai/microvm/pkg/models"
+	"github.com/hashicorp/raft"
+)
+
+func TestClusterLocalClientReadWrappers(t *testing.T) {
+	c := &Cluster{
+		nodeID:         "self-node",
+		apiURL:         "http://self-node",
+		fsm:            newPlacementFSM(),
+		gossip:         &gossipNode{memberIndex: newGossipMemberIndex()},
+		internalServer: &internalServer{},
+		logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	c.gossip.memberIndex.replace([]Member{
+		{NodeID: "self-node", APIURL: "http://self-node", Alive: true},
+		{NodeID: "owner-node", APIURL: "http://owner-node", InternalURL: "https://owner-node.internal", Alive: true},
+	})
+
+	applyOp(t, c.fsm, command{
+		Op:            opPlace,
+		SandboxID:     "sb-demo",
+		OwnerNodeID:   "owner-node",
+		Spec:          &models.CreateSandboxRequest{Name: "demo", Image: "alpine:3.20"},
+		SecretRef:     "cluster-secret://sandbox/sb-demo/v1",
+		SecretVersion: 1,
+		SealedSecrets: []byte("legacy-sealed"),
+	})
+	applyOp(t, c.fsm, command{Op: opAddExposedPort, SandboxID: "sb-demo", Port: 8080, Protocol: "http"})
+	applyOp(t, c.fsm, command{Op: opSetNodeDrainState, NodeID: "drained-node", Drained: true})
+	applyOp(t, c.fsm, command{
+		Op:            opPlace,
+		SandboxID:     "sb-legacy",
+		OwnerNodeID:   "self-node",
+		Spec:          &models.CreateSandboxRequest{Name: "legacy", Image: "busybox"},
+		SealedSecrets: []byte("legacy-sealed"),
+	})
+
+	if got := c.SelfNodeID(); got != "self-node" {
+		t.Fatalf("SelfNodeID() = %q, want self-node", got)
+	}
+	if got := c.SelfAPIURL(); got != "http://self-node" {
+		t.Fatalf("SelfAPIURL() = %q, want http://self-node", got)
+	}
+	c.AttachInternalHandler(http.NotFoundHandler())
+	if c.internalServer.extra.Load() == nil {
+		t.Fatal("AttachInternalHandler() did not install the extra handler")
+	}
+
+	sandboxID, owner, err := c.OwnerOfName("demo")
+	if err != nil {
+		t.Fatalf("OwnerOfName() error = %v", err)
+	}
+	if sandboxID != "sb-demo" {
+		t.Fatalf("OwnerOfName() sandbox id = %q, want sb-demo", sandboxID)
+	}
+	if owner.NodeID != "owner-node" || owner.APIURL != "http://owner-node" || owner.InternalURL != "https://owner-node.internal" || owner.IsSelf {
+		t.Fatalf("OwnerOfName() owner = %+v, want gossip-enriched remote owner", owner)
+	}
+	if _, _, err := c.OwnerOfName("missing"); !errors.Is(err, ErrUnknownSandbox) {
+		t.Fatalf("OwnerOfName(missing) error = %v, want ErrUnknownSandbox", err)
+	}
+
+	secrets := c.SecretsOf("sb-demo")
+	if secrets.Ref != "cluster-secret://sandbox/sb-demo/v1" || secrets.Version != 1 || len(secrets.LegacySealed) != 0 {
+		t.Fatalf("SecretsOf() = %+v, want stored secret handle", secrets)
+	}
+	if got := string(c.SealedSecretsOf("sb-legacy")); got != "legacy-sealed" {
+		t.Fatalf("SealedSecretsOf() = %q, want legacy-sealed", got)
+	}
+	routes := c.ExposedPortsOf("sb-demo")
+	if routes[8080].Protocol != "http" {
+		t.Fatalf("ExposedPortsOf() = %+v, want http route", routes)
+	}
+	if !c.IsNodeDrained("drained-node") {
+		t.Fatal("IsNodeDrained() = false, want true")
+	}
+	if got := c.Placements(); len(got) != 2 {
+		t.Fatalf("Placements() = %+v, want two placements", got)
+	}
+	filter := PlacementShardFilter{ShardCount: DefaultPlacementShardCount, Shards: []int{PlacementShardForSandbox("sb-demo", DefaultPlacementShardCount)}}
+	if got := c.PlacementsForShards(filter); len(got) != 1 || got[0].SandboxID != "sb-demo" {
+		t.Fatalf("PlacementsForShards() = %+v, want shard-filtered placement", got)
+	}
+	page := c.PlacementPage(PlacementPageRequest{Limit: 1})
+	if len(page.Placements) != 1 || page.Placements[0].SandboxID != "sb-demo" || page.NextPageToken != "sb-demo" {
+		t.Fatalf("PlacementPage() = %+v, want single row page with next token", page)
+	}
+	if placement, ok := c.PlacementOf("sb-demo"); !ok || placement.SandboxID != "sb-demo" {
+		t.Fatalf("PlacementOf() = (%+v, %v), want sb-demo placement and true", placement, ok)
+	}
+	if got := c.PlacementVersion(); got != 0 {
+		t.Fatalf("PlacementVersion() = %d, want 0 for zero-index local FSM applies", got)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	wake := c.SubscribePlacement(ctx)
+	if wake == nil {
+		t.Fatal("SubscribePlacement() returned nil")
+	}
+	applyOp(t, c.fsm, command{Op: opPlace, SandboxID: "sb-second", OwnerNodeID: "self-node"})
+	select {
+	case <-wake:
+	case <-time.After(2 * time.Second):
+		t.Fatal("SubscribePlacement() did not receive a wake signal")
+	}
+}
+
+func TestClusterClientReservationAndMutationWrappers(t *testing.T) {
+	c, cleanup := newTestCluster(t, "client-wrap-leader", true, nil)
+	defer cleanup()
+	waitForLeader(t, c, 5*time.Second)
+
+	c.gossip.delegate.mu.Lock()
+	admitter := capacity.New(
+		capacity.HostInfo{CPUCores: 8, MemoryTotalMB: 8192, DiskTotalGB: 100, DiskFreeGB: 100},
+		capacity.Limits{CPUReservationRatio: 1, MemoryReservationRatio: 1, DiskReservationRatio: 1},
+		nil,
+	)
+	c.gossip.delegate.admitter = admitter
+	c.gossip.delegate.mu.Unlock()
+	c.gossip.refreshMemberIndex()
+	c.capacityLeases.admitter = admitter
+	c.capacityLeases.set(c.nodeID, admitter.Snapshot(), time.Now())
+
+	ctx := context.Background()
+	if err := c.RecordPlacement(ctx, "sb-expose", nil, PlacementSecrets{}); err != nil {
+		t.Fatalf("RecordPlacement() error = %v", err)
+	}
+	if err := c.AddExposedPort(ctx, "sb-expose", 8080, ExposedPortRoute{Protocol: "http"}); err != nil {
+		t.Fatalf("AddExposedPort() error = %v", err)
+	}
+	if err := c.RemoveExposedPort(ctx, "sb-expose", 8080); err != nil {
+		t.Fatalf("RemoveExposedPort() error = %v", err)
+	}
+	if routes := c.ExposedPortsOf("sb-expose"); len(routes) != 0 {
+		t.Fatalf("ExposedPortsOf() after remove = %+v, want empty map", routes)
+	}
+
+	target := PlacementTarget{NodeID: c.nodeID, APIURL: c.apiURL, DataPlaneHost: c.dataPlaneHost}
+	if err := c.ReserveOnTarget(ctx, "sb-reserve", target, nil, PlacementSecrets{}, time.Minute); err != nil {
+		t.Fatalf("ReserveOnTarget() error = %v", err)
+	}
+	if placement, ok := c.PlacementOf("sb-reserve"); !ok || placement.State != PlacementStateReserved {
+		t.Fatalf("reserved placement = (%+v, %v), want reserved row", placement, ok)
+	}
+	if err := c.CancelReservation(ctx, "sb-reserve"); err != nil {
+		t.Fatalf("CancelReservation() error = %v", err)
+	}
+	if _, ok := c.PlacementOf("sb-reserve"); ok {
+		t.Fatal("CancelReservation() left the reserved placement behind")
+	}
+
+	batch := []PlacementReservation{
+		{SandboxID: "sb-batch-a", Target: target, TTL: time.Minute},
+		{SandboxID: "sb-batch-b", Target: target, TTL: time.Minute},
+	}
+	if err := c.ReserveBatchOnTargets(ctx, batch); err != nil {
+		t.Fatalf("ReserveBatchOnTargets() error = %v", err)
+	}
+	for _, id := range []string{"sb-batch-a", "sb-batch-b"} {
+		if placement, ok := c.PlacementOf(id); !ok || placement.State != PlacementStateReserved {
+			t.Fatalf("batch reservation %q = (%+v, %v), want reserved row", id, placement, ok)
+		}
+	}
+
+	if err := c.SetNodeDrainState(ctx, "node-drain", true); err != nil {
+		t.Fatalf("SetNodeDrainState() error = %v", err)
+	}
+	if !c.IsNodeDrained("node-drain") {
+		t.Fatal("SetNodeDrainState() did not mark node as drained")
+	}
+	if err := c.SetNodeDrainState(ctx, "", true); err == nil {
+		t.Fatal("SetNodeDrainState() accepted an empty node id")
+	}
+	if err := c.ReserveOnTarget(ctx, "sb-bad-ttl", target, nil, PlacementSecrets{}, 0); err == nil {
+		t.Fatal("ReserveOnTarget() accepted ttl <= 0")
+	}
+	if err := c.ReserveBatchOnTargets(ctx, []PlacementReservation{{SandboxID: "sb-bad-batch", Target: target, TTL: 0}}); err == nil {
+		t.Fatal("ReserveBatchOnTargets() accepted ttl <= 0")
+	}
+}
+
+func TestClusterRemoveMemberLocalForcePath(t *testing.T) {
+	leader, cleanupLeader := newTestCluster(t, "leader-remove", true, nil)
+	defer cleanupLeader()
+	follower, cleanupFollower := newTestCluster(t, "follower-remove", false, []string{leader.gossip.ml.LocalNode().Address()})
+	defer cleanupFollower()
+
+	waitForLeader(t, leader, 5*time.Second)
+	waitForVoter(t, leader, follower.nodeID, 20*time.Second)
+
+	ctx := context.Background()
+	if err := leader.RemoveMember(ctx, "", false); err == nil {
+		t.Fatal("RemoveMember() accepted an empty node id")
+	}
+	if err := leader.RemoveMember(ctx, follower.nodeID, false); !errors.Is(err, ErrMemberStillAlive) {
+		t.Fatalf("RemoveMember(alive follower) error = %v, want ErrMemberStillAlive", err)
+	}
+	if err := leader.RemoveMember(ctx, follower.nodeID, true); err != nil {
+		t.Fatalf("RemoveMember(force) error = %v", err)
+	}
+	cfgFuture := leader.raft.raft.GetConfiguration()
+	if err := cfgFuture.Error(); err != nil {
+		t.Fatalf("GetConfiguration() error = %v", err)
+	}
+	for _, srv := range cfgFuture.Configuration().Servers {
+		if srv.ID == raft.ServerID(follower.nodeID) {
+			t.Fatalf("removed follower still present in raft config: %+v", cfgFuture.Configuration().Servers)
+		}
+	}
+}
+
+func TestClusterDoLeaderLifecycleMapsResponses(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name    string
+		status  int
+		body    string
+		wantErr error
+	}{
+		{name: "success", status: http.StatusNoContent},
+		{name: "not leader", status: http.StatusServiceUnavailable, body: ErrNotLeader.Error(), wantErr: ErrNotLeader},
+		{name: "unknown member", status: http.StatusNotFound, body: ErrUnknownMember.Error(), wantErr: ErrUnknownMember},
+		{name: "member alive", status: http.StatusConflict, body: ErrMemberStillAlive.Error(), wantErr: ErrMemberStillAlive},
+		{name: "last voter", status: http.StatusConflict, body: ErrLastVoter.Error(), wantErr: ErrLastVoter},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sawAuth := false
+			sawContentType := false
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				sawAuth = r.Header.Get("Authorization") == "Bearer cluster-pat"
+				sawContentType = r.Header.Get("Content-Type") == "application/json"
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			c := &Cluster{httpClient: server.Client(), patToken: "cluster-pat"}
+			err := c.doLeaderLifecycle(ctx, server.Client(), server.URL+"/v1/cluster/members/node-a", http.MethodDelete, []byte(`{"force":true}`))
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Fatalf("doLeaderLifecycle() error = %v, want nil", err)
+				}
+			} else if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("doLeaderLifecycle() error = %v, want %v", err, tt.wantErr)
+			}
+			if !sawAuth {
+				t.Fatal("doLeaderLifecycle() did not send PAT auth header")
+			}
+			if !sawContentType {
+				t.Fatal("doLeaderLifecycle() did not mark JSON request bodies")
+			}
+		})
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	c := &Cluster{httpClient: server.Client()}
+	if err := c.doLeaderLifecycle(ctx, server.Client(), server.URL+"/v1/cluster/members/node-a", http.MethodDelete, nil); err == nil || !strings.Contains(err.Error(), "status 500") {
+		t.Fatalf("doLeaderLifecycle(500) error = %v, want status 500 message", err)
+	}
+}

--- a/internal/cluster/helper_additional_test.go
+++ b/internal/cluster/helper_additional_test.go
@@ -1,0 +1,180 @@
+package cluster
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/pkg/models"
+	"github.com/hashicorp/raft"
+)
+
+func newAgentControlPlaneHarness(t *testing.T, handler http.Handler, gossipMembers ...Member) *Agent {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	index := newGossipMemberIndex()
+	index.upsert(Member{NodeID: "server-1", APIURL: server.URL, Alive: true, Role: config.NodeRoleServer})
+	for _, member := range gossipMembers {
+		index.upsert(member)
+	}
+
+	return &Agent{
+		logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		nodeID:     "worker-self",
+		httpClient: server.Client(),
+		gossip:     &gossipNode{memberIndex: index},
+	}
+}
+
+func memberIDs(members []Member) []string {
+	ids := make([]string, 0, len(members))
+	for _, member := range members {
+		ids = append(ids, member.NodeID)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func TestAgentSpecOfUsesControlPlaneAndReturnsDeepCopy(t *testing.T) {
+	redacted := &models.CreateSandboxRequest{
+		Image:            "alpine:3.20",
+		Env:              map[string]string{"A": "1"},
+		Mounts:           []models.MountSpec{{Source: "tmpfs", Target: "/workspace"}},
+		ContainerCommand: []string{"sh", "-c", "echo hi"},
+	}
+	agent := newAgentControlPlaneHarness(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != PublicInternalPlacementPath+"sb-agent-spec" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(PlacementLookupResponse{
+			SandboxID: "sb-agent-spec",
+			Placement: Placement{SandboxID: "sb-agent-spec", Version: 7, Spec: redacted},
+			Owner:     OwnerInfo{NodeID: "worker-self", IsSelf: true},
+		})
+	}), Member{NodeID: "worker-self", Alive: true, Role: config.NodeRoleWorker})
+
+	got := agent.SpecOf("sb-agent-spec")
+	if got == nil {
+		t.Fatal("SpecOf() returned nil, want cloned spec")
+	}
+	got.Env["A"] = "mutated"
+	got.Mounts[0].Target = "/mutated"
+	got.ContainerCommand[0] = "bash"
+
+	again := agent.SpecOf("sb-agent-spec")
+	if again == nil {
+		t.Fatal("SpecOf() returned nil on second read")
+	}
+	if again.Env["A"] != "1" {
+		t.Fatalf("SpecOf() env mutation leaked: %q", again.Env["A"])
+	}
+	if again.Mounts[0].Target != "/workspace" {
+		t.Fatalf("SpecOf() mount mutation leaked: %q", again.Mounts[0].Target)
+	}
+	if again.ContainerCommand[0] != "sh" {
+		t.Fatalf("SpecOf() command mutation leaked: %q", again.ContainerCommand[0])
+	}
+	if gotVersion := agent.PlacementVersion(); gotVersion != 7 {
+		t.Fatalf("PlacementVersion() = %d, want 7", gotVersion)
+	}
+}
+
+func TestAgentMembersUsesControlPlaneResponse(t *testing.T) {
+	controlPlaneMembers := []Member{{NodeID: "server-control", Alive: true, Role: config.NodeRoleServer}}
+	agent := newAgentControlPlaneHarness(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/cluster/members" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"members": controlPlaneMembers})
+	}), Member{NodeID: "worker-self", Alive: true, Role: config.NodeRoleWorker})
+
+	got := agent.Members()
+	if ids := memberIDs(got); len(ids) != 1 || ids[0] != "server-control" {
+		t.Fatalf("Members() ids = %v, want [server-control]", ids)
+	}
+}
+
+func TestAgentMembersFallsBackToGossipOnControlPlaneError(t *testing.T) {
+	agent := newAgentControlPlaneHarness(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}),
+		Member{NodeID: "worker-self", Alive: true, Role: config.NodeRoleWorker},
+		Member{NodeID: "worker-2", Alive: true, Role: config.NodeRoleWorker},
+	)
+
+	got := agent.Members()
+	if ids := memberIDs(got); len(ids) != 3 || ids[0] != "server-1" || ids[1] != "worker-2" || ids[2] != "worker-self" {
+		t.Fatalf("Members() fallback ids = %v, want [server-1 worker-2 worker-self]", ids)
+	}
+}
+
+func TestAgentLeaderReadsControlPlane(t *testing.T) {
+	agent := newAgentControlPlaneHarness(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != PublicInternalClusterLeaderPath {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"leader": "server-1"})
+	}), Member{NodeID: "worker-self", Alive: true, Role: config.NodeRoleWorker})
+
+	if got := agent.Leader(); got != "server-1" {
+		t.Fatalf("Leader() = %q, want server-1", got)
+	}
+}
+
+func TestClusterSpecOfReturnsDeepCopy(t *testing.T) {
+	fsm := newPlacementFSM()
+	payload, err := encodeCommand(command{
+		Op:          opPlace,
+		SandboxID:   "sb-cluster-spec",
+		OwnerNodeID: "node-a",
+		OwnerAPIURL: "http://node-a",
+		Spec: &models.CreateSandboxRequest{
+			Image:            "alpine:3.20",
+			Env:              map[string]string{"A": "1"},
+			Mounts:           []models.MountSpec{{Source: "tmpfs", Target: "/workspace"}},
+			ContainerCommand: []string{"sh", "-c", "echo hi"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("encodeCommand: %v", err)
+	}
+	if got := fsm.Apply(&raft.Log{Data: payload}); got != nil {
+		t.Fatalf("fsm.Apply() = %v, want nil", got)
+	}
+
+	cluster := &Cluster{fsm: fsm}
+	got := cluster.SpecOf("sb-cluster-spec")
+	if got == nil {
+		t.Fatal("SpecOf() returned nil, want cloned spec")
+	}
+	got.Env["A"] = "mutated"
+	got.Mounts[0].Target = "/mutated"
+	got.ContainerCommand[0] = "bash"
+
+	again := cluster.SpecOf("sb-cluster-spec")
+	if again == nil {
+		t.Fatal("SpecOf() returned nil on second read")
+	}
+	if again.Env["A"] != "1" {
+		t.Fatalf("SpecOf() env mutation leaked: %q", again.Env["A"])
+	}
+	if again.Mounts[0].Target != "/workspace" {
+		t.Fatalf("SpecOf() mount mutation leaked: %q", again.Mounts[0].Target)
+	}
+	if again.ContainerCommand[0] != "sh" {
+		t.Fatalf("SpecOf() command mutation leaked: %q", again.ContainerCommand[0])
+	}
+}

--- a/internal/cluster/helper_additional_test.go
+++ b/internal/cluster/helper_additional_test.go
@@ -151,6 +151,25 @@ func TestAgentMembersFallsBackToGossipOnControlPlaneError(t *testing.T) {
 	}
 }
 
+func TestAgentMembersFallsBackToGossipWhenControlPlanePayloadHasNoMembers(t *testing.T) {
+	agent := newAgentControlPlaneHarness(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/cluster/members" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	}),
+		Member{NodeID: "worker-self", Alive: true, Role: config.NodeRoleWorker},
+		Member{NodeID: "worker-2", Alive: true, Role: config.NodeRoleWorker},
+	)
+
+	got := agent.Members()
+	if ids := memberIDs(got); len(ids) != 3 || ids[0] != "server-1" || ids[1] != "worker-2" || ids[2] != "worker-self" {
+		t.Fatalf("Members() fallback ids = %v, want [server-1 worker-2 worker-self]", ids)
+	}
+}
+
 func TestAgentLeaderReadsControlPlane(t *testing.T) {
 	agent := newAgentControlPlaneHarness(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != PublicInternalClusterLeaderPath {
@@ -163,6 +182,16 @@ func TestAgentLeaderReadsControlPlane(t *testing.T) {
 
 	if got := agent.Leader(); got != "server-1" {
 		t.Fatalf("Leader() = %q, want server-1", got)
+	}
+}
+
+func TestAgentLeaderReturnsEmptyOnControlPlaneError(t *testing.T) {
+	agent := newAgentControlPlaneHarness(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}), Member{NodeID: "worker-self", Alive: true, Role: config.NodeRoleWorker})
+
+	if got := agent.Leader(); got != "" {
+		t.Fatalf("Leader() = %q, want empty string on control-plane error", got)
 	}
 }
 

--- a/internal/cluster/helper_additional_test.go
+++ b/internal/cluster/helper_additional_test.go
@@ -88,6 +88,38 @@ func TestAgentSpecOfUsesControlPlaneAndReturnsDeepCopy(t *testing.T) {
 	}
 }
 
+func TestAgentSpecOfReturnsNilOnControlPlaneError(t *testing.T) {
+	agent := newAgentControlPlaneHarness(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}), Member{NodeID: "worker-self", Alive: true, Role: config.NodeRoleWorker})
+
+	if got := agent.SpecOf("sb-agent-error"); got != nil {
+		t.Fatalf("SpecOf() = %+v, want nil on control-plane error", got)
+	}
+}
+
+func TestAgentSpecOfReturnsNilWhenPlacementHasNoSpec(t *testing.T) {
+	agent := newAgentControlPlaneHarness(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != PublicInternalPlacementPath+"sb-agent-no-spec" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(PlacementLookupResponse{
+			SandboxID: "sb-agent-no-spec",
+			Placement: Placement{SandboxID: "sb-agent-no-spec", Version: 9},
+			Owner:     OwnerInfo{NodeID: "worker-self", IsSelf: true},
+		})
+	}), Member{NodeID: "worker-self", Alive: true, Role: config.NodeRoleWorker})
+
+	if got := agent.SpecOf("sb-agent-no-spec"); got != nil {
+		t.Fatalf("SpecOf() = %+v, want nil when placement spec is absent", got)
+	}
+	if gotVersion := agent.PlacementVersion(); gotVersion != 9 {
+		t.Fatalf("PlacementVersion() = %d, want 9 after nil-spec lookup", gotVersion)
+	}
+}
+
 func TestAgentMembersUsesControlPlaneResponse(t *testing.T) {
 	controlPlaneMembers := []Member{{NodeID: "server-control", Alive: true, Role: config.NodeRoleServer}}
 	agent := newAgentControlPlaneHarness(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cluster/recovery_store_test.go
+++ b/internal/cluster/recovery_store_test.go
@@ -1,0 +1,60 @@
+package cluster
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func TestPlacementRecoveryFileStoreDeleteRemovesBlobAndIgnoresMissing(t *testing.T) {
+	store, err := newPlacementRecoveryFileStore(filepath.Join(t.TempDir(), "recovery"))
+	if err != nil {
+		t.Fatalf("newPlacementRecoveryFileStore() error = %v", err)
+	}
+
+	ref, err := store.Put("sb-delete", placementRecovery{Spec: &models.CreateSandboxRequest{Image: "alpine:3.20"}})
+	if err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	if err := store.Delete(ref); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if _, ok, err := store.GetRecord(ref); err != nil || ok {
+		t.Fatalf("GetRecord() after delete = ok:%v err:%v, want ok:false err:nil", ok, err)
+	}
+	if err := store.Delete(ref); err != nil {
+		t.Fatalf("Delete() missing ref error = %v, want nil", err)
+	}
+}
+
+func TestPlacementRecoveryFileStoreDeleteRejectsInvalidRef(t *testing.T) {
+	store, err := newPlacementRecoveryFileStore(filepath.Join(t.TempDir(), "recovery"))
+	if err != nil {
+		t.Fatalf("newPlacementRecoveryFileStore() error = %v", err)
+	}
+
+	err = store.Delete("bad-ref")
+	if err == nil || !strings.Contains(err.Error(), "invalid ref") {
+		t.Fatalf("Delete() error = %v, want invalid ref", err)
+	}
+}
+
+func TestPlacementRecoveryMemoryStoreDeleteRemovesBlob(t *testing.T) {
+	store := newPlacementRecoveryMemoryStore()
+	ref, err := store.Put("sb-memory-delete", placementRecovery{Spec: &models.CreateSandboxRequest{Image: "alpine:3.20"}})
+	if err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	if err := store.Delete(ref); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if _, ok, err := store.Get(ref); err != nil || ok {
+		t.Fatalf("Get() after delete = ok:%v err:%v, want ok:false err:nil", ok, err)
+	}
+	if err := store.Delete(""); err != nil && !errors.Is(err, nil) {
+		t.Fatalf("Delete() empty ref error = %v, want nil", err)
+	}
+}

--- a/internal/cluster/recovery_store_test.go
+++ b/internal/cluster/recovery_store_test.go
@@ -60,6 +60,56 @@ func TestPlacementRecoveryMemoryStoreDeleteRemovesBlob(t *testing.T) {
 	}
 }
 
+func TestPlacementRecoveryFileStorePutAndGetRecordRoundTrip(t *testing.T) {
+	store, err := newPlacementRecoveryFileStore(filepath.Join(t.TempDir(), "recovery"))
+	if err != nil {
+		t.Fatalf("newPlacementRecoveryFileStore() error = %v", err)
+	}
+
+	ref, err := store.Put("sb-roundtrip", placementRecovery{
+		Spec:          &models.CreateSandboxRequest{Image: "alpine:3.20"},
+		SecretRef:     "cluster-secret:demo",
+		SecretVersion: 7,
+		SealedSecrets: []byte("sealed"),
+	})
+	if err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	if !strings.HasPrefix(ref, placementRecoveryRefPrefix) {
+		t.Fatalf("Put() ref = %q, want %q prefix", ref, placementRecoveryRefPrefix)
+	}
+
+	record, ok, err := store.GetRecord(ref)
+	if err != nil || !ok {
+		t.Fatalf("GetRecord() = ok:%v err:%v, want ok:true err:nil", ok, err)
+	}
+	if record.SandboxID != "sb-roundtrip" {
+		t.Fatalf("GetRecord() sandbox id = %q, want sb-roundtrip", record.SandboxID)
+	}
+	if record.Recovery.Spec == nil || record.Recovery.Spec.Image != "alpine:3.20" {
+		t.Fatalf("GetRecord() spec = %+v, want alpine spec", record.Recovery.Spec)
+	}
+	if record.Recovery.SecretRef != "cluster-secret:demo" || record.Recovery.SecretVersion != 7 {
+		t.Fatalf("GetRecord() secrets = %+v, want ref/version preserved", record.Recovery)
+	}
+	if string(record.Recovery.SealedSecrets) != "sealed" {
+		t.Fatalf("GetRecord() sealed secrets = %q, want sealed", string(record.Recovery.SealedSecrets))
+	}
+
+	record.Recovery.Spec.Image = "mutated"
+	record.Recovery.SealedSecrets[0] = 'X'
+	again, ok, err := store.GetRecord(ref)
+	if err != nil || !ok {
+		t.Fatalf("GetRecord() second read = ok:%v err:%v, want ok:true err:nil", ok, err)
+	}
+	if again.Recovery.Spec == nil || again.Recovery.Spec.Image != "alpine:3.20" {
+		t.Fatalf("GetRecord() second read spec = %+v, want original alpine spec", again.Recovery.Spec)
+	}
+	if string(again.Recovery.SealedSecrets) != "sealed" {
+		t.Fatalf("GetRecord() second read sealed secrets = %q, want sealed", string(again.Recovery.SealedSecrets))
+	}
+}
+
 func TestPlacementRecoveryFileStoreGetRecordRejectsCorruptBlob(t *testing.T) {
 	store, err := newPlacementRecoveryFileStore(filepath.Join(t.TempDir(), "recovery"))
 	if err != nil {
@@ -132,5 +182,45 @@ func TestPlacementRecoveryFileStoreRetainSnapshotRefsRejectsCorruptManifest(t *t
 	err = store.RetainSnapshotRefs([]string{placementRecoveryRefPrefix + strings.Repeat("0", 64)})
 	if err == nil || !strings.Contains(err.Error(), "decode gc manifest") {
 		t.Fatalf("RetainSnapshotRefs() error = %v, want decode gc manifest", err)
+	}
+}
+
+func TestPlacementRecoveryFileStoreRetainSnapshotRefsKeepsLastThreeWindows(t *testing.T) {
+	store, err := newPlacementRecoveryFileStore(filepath.Join(t.TempDir(), "recovery"))
+	if err != nil {
+		t.Fatalf("newPlacementRecoveryFileStore() error = %v", err)
+	}
+
+	refs := make([]string, 0, 4)
+	for i := 0; i < 4; i++ {
+		ref, err := store.Put("sb-window-"+string(rune('a'+i)), placementRecovery{Spec: &models.CreateSandboxRequest{Image: "image:" + string(rune('a'+i))}})
+		if err != nil {
+			t.Fatalf("Put(%d) error = %v", i, err)
+		}
+		refs = append(refs, ref)
+		if err := store.RetainSnapshotRefs([]string{ref}); err != nil {
+			t.Fatalf("RetainSnapshotRefs(%q) error = %v", ref, err)
+		}
+	}
+
+	manifest, err := store.readGCManifest()
+	if err != nil {
+		t.Fatalf("readGCManifest() error = %v", err)
+	}
+	if len(manifest.Snapshots) != placementRecoverySnapshotRefSets {
+		t.Fatalf("len(manifest.Snapshots) = %d, want %d", len(manifest.Snapshots), placementRecoverySnapshotRefSets)
+	}
+	for i, want := range refs[1:] {
+		if got := manifest.Snapshots[i].Refs; len(got) != 1 || got[0] != want {
+			t.Fatalf("manifest window %d refs = %v, want [%s]", i, got, want)
+		}
+	}
+	if _, ok, err := store.GetRecord(refs[0]); err != nil || ok {
+		t.Fatalf("GetRecord(oldest) = ok:%v err:%v, want ok:false err:nil", ok, err)
+	}
+	for _, ref := range refs[1:] {
+		if _, ok, err := store.GetRecord(ref); err != nil || !ok {
+			t.Fatalf("GetRecord(%q) = ok:%v err:%v, want ok:true err:nil", ref, ok, err)
+		}
 	}
 }

--- a/internal/cluster/recovery_store_test.go
+++ b/internal/cluster/recovery_store_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -56,5 +57,80 @@ func TestPlacementRecoveryMemoryStoreDeleteRemovesBlob(t *testing.T) {
 	}
 	if err := store.Delete(""); err != nil && !errors.Is(err, nil) {
 		t.Fatalf("Delete() empty ref error = %v, want nil", err)
+	}
+}
+
+func TestPlacementRecoveryFileStoreGetRecordRejectsCorruptBlob(t *testing.T) {
+	store, err := newPlacementRecoveryFileStore(filepath.Join(t.TempDir(), "recovery"))
+	if err != nil {
+		t.Fatalf("newPlacementRecoveryFileStore() error = %v", err)
+	}
+
+	ref := placementRecoveryRefPrefix + strings.Repeat("0", 64)
+	path, err := store.pathForRef(ref)
+	if err != nil {
+		t.Fatalf("pathForRef() error = %v", err)
+	}
+	if err := os.WriteFile(path, []byte("{not-json"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	_, ok, err := store.GetRecord(ref)
+	if err == nil || !strings.Contains(err.Error(), "decode") {
+		t.Fatalf("GetRecord() error = %v, want decode error", err)
+	}
+	if ok {
+		t.Fatal("GetRecord() ok = true, want false for corrupt blob")
+	}
+}
+
+func TestPlacementRecoveryFileStoreRetainSnapshotRefsGCsUnreferencedBlobs(t *testing.T) {
+	store, err := newPlacementRecoveryFileStore(filepath.Join(t.TempDir(), "recovery"))
+	if err != nil {
+		t.Fatalf("newPlacementRecoveryFileStore() error = %v", err)
+	}
+
+	keepRef, err := store.Put("sb-keep", placementRecovery{Spec: &models.CreateSandboxRequest{Image: "alpine:3.20"}})
+	if err != nil {
+		t.Fatalf("Put(keep) error = %v", err)
+	}
+	dropRef, err := store.Put("sb-drop", placementRecovery{Spec: &models.CreateSandboxRequest{Image: "busybox:latest"}})
+	if err != nil {
+		t.Fatalf("Put(drop) error = %v", err)
+	}
+
+	if err := store.RetainSnapshotRefs([]string{"", keepRef, keepRef}); err != nil {
+		t.Fatalf("RetainSnapshotRefs() error = %v", err)
+	}
+	if _, ok, err := store.GetRecord(keepRef); err != nil || !ok {
+		t.Fatalf("GetRecord(keep) = ok:%v err:%v, want ok:true err:nil", ok, err)
+	}
+	if _, ok, err := store.GetRecord(dropRef); err != nil || ok {
+		t.Fatalf("GetRecord(drop) = ok:%v err:%v, want ok:false err:nil", ok, err)
+	}
+	manifest, err := store.readGCManifest()
+	if err != nil {
+		t.Fatalf("readGCManifest() error = %v", err)
+	}
+	if len(manifest.Snapshots) != 1 {
+		t.Fatalf("len(manifest.Snapshots) = %d, want 1", len(manifest.Snapshots))
+	}
+	if refs := manifest.Snapshots[0].Refs; len(refs) != 1 || refs[0] != keepRef {
+		t.Fatalf("manifest refs = %v, want [%s]", refs, keepRef)
+	}
+}
+
+func TestPlacementRecoveryFileStoreRetainSnapshotRefsRejectsCorruptManifest(t *testing.T) {
+	store, err := newPlacementRecoveryFileStore(filepath.Join(t.TempDir(), "recovery"))
+	if err != nil {
+		t.Fatalf("newPlacementRecoveryFileStore() error = %v", err)
+	}
+	if err := os.WriteFile(store.gcManifestPath(), []byte("{not-json"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	err = store.RetainSnapshotRefs([]string{placementRecoveryRefPrefix + strings.Repeat("0", 64)})
+	if err == nil || !strings.Contains(err.Error(), "decode gc manifest") {
+		t.Fatalf("RetainSnapshotRefs() error = %v, want decode gc manifest", err)
 	}
 }

--- a/internal/cluster/topology_test.go
+++ b/internal/cluster/topology_test.go
@@ -30,6 +30,20 @@ func TestIsMixedArchitectureRole(t *testing.T) {
 	}
 }
 
+func TestLiveMemberCountSkipsDeadAndBlankNodes(t *testing.T) {
+	members := []Member{
+		{NodeID: "node-1", Alive: true},
+		{NodeID: "node-2", Alive: false},
+		{NodeID: "", Alive: true},
+		{NodeID: "   ", Alive: true},
+		{NodeID: "node-3", Alive: true},
+	}
+
+	if got := LiveMemberCount(members); got != 2 {
+		t.Fatalf("LiveMemberCount() = %d, want 2", got)
+	}
+}
+
 func TestLargeClusterTopologyAllowsSmallMixedCluster(t *testing.T) {
 	members := makeTopologyMembers(
 		config.NodeRoleMixed,

--- a/internal/cluster/utility_additional_test.go
+++ b/internal/cluster/utility_additional_test.go
@@ -1,0 +1,277 @@
+package cluster
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/capacity"
+	"github.com/hashicorp/raft"
+)
+
+func TestNoopAdditionalMethods(t *testing.T) {
+	n := NewNoop("", "http://localhost:21212")
+	if n.SelfNodeID() != "standalone" {
+		t.Fatalf("SelfNodeID() = %q, want standalone", n.SelfNodeID())
+	}
+	if n.SelfAPIURL() != "http://localhost:21212" {
+		t.Fatalf("SelfAPIURL() = %q", n.SelfAPIURL())
+	}
+	if _, _, err := n.OwnerOfName("demo"); !errors.Is(err, ErrUnknownSandbox) {
+		t.Fatalf("OwnerOfName() error = %v, want ErrUnknownSandbox", err)
+	}
+	if n.SpecOf("demo") != nil {
+		t.Fatal("SpecOf() should be nil in single-node mode")
+	}
+	if got := n.SecretsOf("demo"); got.Ref != "" || got.Version != 0 || len(got.LegacySealed) != 0 {
+		t.Fatalf("SecretsOf() = %+v, want zero value", got)
+	}
+	if got := n.SealedSecretsOf("demo"); got != nil {
+		t.Fatalf("SealedSecretsOf() = %v, want nil", got)
+	}
+	if err := n.AddExposedPort(context.Background(), "demo", 8080, ExposedPortRoute{Protocol: "http"}); err != nil {
+		t.Fatalf("AddExposedPort() error = %v", err)
+	}
+	if err := n.RemoveExposedPort(context.Background(), "demo", 8080); err != nil {
+		t.Fatalf("RemoveExposedPort() error = %v", err)
+	}
+	if got := n.ExposedPortsOf("demo"); got != nil {
+		t.Fatalf("ExposedPortsOf() = %v, want nil", got)
+	}
+	if err := n.ReserveOnTarget(context.Background(), "demo", PlacementTarget{}, nil, PlacementSecrets{}, time.Second); err != nil {
+		t.Fatalf("ReserveOnTarget() error = %v", err)
+	}
+	if err := n.CancelReservation(context.Background(), "demo"); err != nil {
+		t.Fatalf("CancelReservation() error = %v", err)
+	}
+	if err := n.SetNodeDrainState(context.Background(), "node-a", true); err != nil {
+		t.Fatalf("SetNodeDrainState() error = %v", err)
+	}
+	if err := n.RemoveMember(context.Background(), "missing", false); !errors.Is(err, ErrUnknownMember) {
+		t.Fatalf("RemoveMember() error = %v, want ErrUnknownMember", err)
+	}
+	if n.IsNodeDrained("node-a") {
+		t.Fatal("IsNodeDrained() should be false in single-node mode")
+	}
+	if err := n.ApplyEncoded(context.Background(), []byte("payload")); err != nil {
+		t.Fatalf("ApplyEncoded() error = %v", err)
+	}
+	n.AttachInternalHandler(http.NotFoundHandler())
+	if got := n.Placements(); got != nil {
+		t.Fatalf("Placements() = %v, want nil", got)
+	}
+	if got := n.PlacementsForShards(PlacementShardFilter{}); got != nil {
+		t.Fatalf("PlacementsForShards() = %v, want nil", got)
+	}
+	if got := n.PlacementPage(PlacementPageRequest{}); len(got.Placements) != 0 || got.NextPageToken != "" {
+		t.Fatalf("PlacementPage() = %+v, want zero value fields", got)
+	}
+	if placement, ok := n.PlacementOf("demo"); ok || placement.SandboxID != "" || placement.OwnerNodeID != "" || placement.Version != 0 {
+		t.Fatalf("PlacementOf() = (%+v, %v), want zero placement and false", placement, ok)
+	}
+	if got := n.PlacementVersion(); got != 0 {
+		t.Fatalf("PlacementVersion() = %d, want 0", got)
+	}
+	if got := n.SubscribePlacement(context.Background()); got != nil {
+		t.Fatalf("SubscribePlacement() = %v, want nil", got)
+	}
+	if got, err := n.SelectPlacement(capacity.Request{CPU: 1}); err != nil || got.NodeID == "" {
+		t.Fatal("SelectPlacement() should still return self target metadata")
+	}
+}
+
+func TestDecodeGossipSecretKeyAndAdvertiseHelpers(t *testing.T) {
+	if key, err := decodeGossipSecretKey(""); err != nil || key != nil {
+		t.Fatalf("decode empty key = (%v, %v), want (nil, nil)", key, err)
+	}
+	if _, err := decodeGossipSecretKey("not-base64"); err == nil {
+		t.Fatal("decodeGossipSecretKey() accepted invalid base64")
+	}
+	encoded := base64.StdEncoding.EncodeToString([]byte("0123456789abcdef"))
+	if key, err := decodeGossipSecretKey(encoded); err != nil || len(key) != 16 {
+		t.Fatalf("decodeGossipSecretKey() = (%d bytes, %v), want 16-byte key", len(key), err)
+	}
+
+	if got := deriveInternalAdvertiseURL("https://node.example/internal/", ":9443", "0.0.0.0:9443"); got != "https://node.example/internal" {
+		t.Fatalf("operator advertise URL = %q, want operator override without trailing slash", got)
+	}
+	if got := deriveInternalAdvertiseURL("", "192.0.2.4:9443", "0.0.0.0:9443"); got != "https://192.0.2.4:9443" {
+		t.Fatalf("derived advertise URL = %q, want listen host fallback", got)
+	}
+	if got := deriveInternalAdvertiseURL("", ":9443", "[::]:9443"); got != "https://127.0.0.1:9443" {
+		t.Fatalf("derived wildcard advertise URL = %q, want loopback fallback", got)
+	}
+
+	if host, port := splitHostForAdvertise("127.0.0.1:9443"); host != "127.0.0.1" || port != "9443" {
+		t.Fatalf("splitHostForAdvertise() = (%q,%q), want (127.0.0.1,9443)", host, port)
+	}
+	if host, port := splitHostForAdvertise("example.internal"); host != "example.internal" || port != "" {
+		t.Fatalf("splitHostForAdvertise() = (%q,%q), want (example.internal,'')", host, port)
+	}
+	if !isUnspecifiedHost("0.0.0.0") || !isUnspecifiedHost("[::]") || isUnspecifiedHost("192.0.2.4") {
+		t.Fatal("isUnspecifiedHost() did not classify hosts correctly")
+	}
+	if (&Cluster{}).HealthyForReads() {
+		t.Fatal("zero-value Cluster should not report HealthyForReads")
+	}
+}
+
+func TestExposedPortRoutesForPlacementCoversBothShapes(t *testing.T) {
+	routes := ExposedPortRoutesForPlacement(Placement{
+		ExposedPortRoutes: map[int]ExposedPortRoute{5432: {Protocol: "tcp", HostPort: 22432, PublicURL: "tcp://sandbox.example.com:22432"}},
+	})
+	if routes[5432].HostPort != 22432 {
+		t.Fatalf("route metadata = %+v, want host port preserved", routes[5432])
+	}
+	routes[5432] = ExposedPortRoute{Protocol: "http"}
+	legacy := ExposedPortRoutesForPlacement(Placement{ExposedPorts: map[int]string{8080: "http"}})
+	if legacy[8080].Protocol != "http" || legacy[8080].HostPort != 0 {
+		t.Fatalf("legacy route = %+v, want protocol-only route", legacy[8080])
+	}
+	if got := ExposedPortRoutesForPlacement(Placement{}); got != nil {
+		t.Fatalf("empty placement routes = %v, want nil", got)
+	}
+}
+
+func TestClusterMetricHelpersAdditional(t *testing.T) {
+	forwardBefore := raftLeaderForward.Value()
+	forwardErrBefore := expvarMapValue(raftLeaderForwardErrs, "reservation_conflict")
+	snapshotBefore := raftSnapshotTotal.Value()
+	snapshotErrBefore := expvarMapValue(raftSnapshotErrors, "timeout")
+	restoreBefore := raftSnapshotRestore.Value()
+	restoreErrBefore := expvarMapValue(raftSnapshotRestoreErrs, "decode")
+	targetMissBefore := expvarMapValue(ownerForwardTargetMisses, "target_unknown")
+	expiredBefore := clusterReservationsExpired.Value()
+
+	done := beginLeaderForwardApply()
+	done(ErrReservationConflict)
+	recordSnapshotPersist(5*time.Millisecond, 1234, 5, context.DeadlineExceeded)
+	recordSnapshotRestore(3*time.Millisecond, errors.New("decode failure"))
+	recordOwnerForwardTargetMiss("target_unknown")
+	recordExpiredReservation()
+
+	if got := raftLeaderForward.Value() - forwardBefore; got != 1 {
+		t.Fatalf("leader forward delta = %d, want 1", got)
+	}
+	if got := expvarMapValue(raftLeaderForwardErrs, "reservation_conflict") - forwardErrBefore; got != 1 {
+		t.Fatalf("leader forward error delta = %d, want 1", got)
+	}
+	if got := raftSnapshotTotal.Value() - snapshotBefore; got != 1 {
+		t.Fatalf("snapshot persist delta = %d, want 1", got)
+	}
+	if got := expvarMapValue(raftSnapshotErrors, "timeout") - snapshotErrBefore; got != 1 {
+		t.Fatalf("snapshot timeout delta = %d, want 1", got)
+	}
+	if got := raftSnapshotRestore.Value() - restoreBefore; got != 1 {
+		t.Fatalf("snapshot restore delta = %d, want 1", got)
+	}
+	if got := expvarMapValue(raftSnapshotRestoreErrs, "decode") - restoreErrBefore; got != 1 {
+		t.Fatalf("snapshot restore decode delta = %d, want 1", got)
+	}
+	if got := expvarMapValue(ownerForwardTargetMisses, "target_unknown") - targetMissBefore; got != 1 {
+		t.Fatalf("owner forward target miss delta = %d, want 1", got)
+	}
+	if got := clusterReservationsExpired.Value() - expiredBefore; got != 1 {
+		t.Fatalf("expired reservation delta = %d, want 1", got)
+	}
+	if got := classifyClusterMetricError(errors.New("forwarding loop detected")); got != "stale_owner" {
+		t.Fatalf("stale owner classification = %q, want stale_owner", got)
+	}
+	if got := classifyClusterMetricError(errors.New("peer API URL unknown")); got != "target_unknown" {
+		t.Fatalf("target unknown classification = %q, want target_unknown", got)
+	}
+}
+
+func TestTLSStreamLayerDialAcceptAndClose(t *testing.T) {
+	cert := mustSelfSignedCert(t)
+	serverCfg := &tls.Config{Certificates: []tls.Certificate{cert}}
+	clientCfg := &tls.Config{InsecureSkipVerify: true}
+	advertise := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 9443}
+
+	layer, err := newTLSStreamLayer("127.0.0.1:0", advertise, serverCfg, clientCfg)
+	if err != nil {
+		t.Fatalf("newTLSStreamLayer() error = %v", err)
+	}
+	defer layer.Close()
+
+	acceptErr := make(chan error, 1)
+	go func() {
+		conn, err := layer.Accept()
+		if err != nil {
+			acceptErr <- err
+			return
+		}
+		defer conn.Close()
+		if tlsConn, ok := conn.(*tls.Conn); ok {
+			acceptErr <- tlsConn.Handshake()
+			return
+		}
+		acceptErr <- nil
+	}()
+
+	conn, err := layer.Dial(raft.ServerAddress(layer.listener.Addr().String()), time.Second)
+	if err != nil {
+		t.Fatalf("Dial() error = %v", err)
+	}
+	conn.Close()
+	if err := <-acceptErr; err != nil {
+		t.Fatalf("Accept()/Handshake error = %v", err)
+	}
+	if layer.Addr().String() != advertise.String() {
+		t.Fatalf("Addr() = %q, want %q", layer.Addr(), advertise)
+	}
+	if err := layer.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+}
+
+func TestNewTLSStreamLayerRequiresConfigs(t *testing.T) {
+	if _, err := newTLSStreamLayer("127.0.0.1:0", &net.TCPAddr{}, nil, &tls.Config{}); err == nil {
+		t.Fatal("newTLSStreamLayer() accepted nil server config")
+	}
+	if _, err := newTLSStreamLayer("127.0.0.1:0", &net.TCPAddr{}, &tls.Config{}, nil); err == nil {
+		t.Fatal("newTLSStreamLayer() accepted nil client config")
+	}
+}
+
+func mustSelfSignedCert(t *testing.T) tls.Certificate {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal private key: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("X509KeyPair: %v", err)
+	}
+	return cert
+}

--- a/internal/service/cluster_exposure_test.go
+++ b/internal/service/cluster_exposure_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/aerol-ai/microvm/internal/cluster"
+	"github.com/aerol-ai/microvm/internal/config"
+	storepkg "github.com/aerol-ai/microvm/internal/store"
 	"github.com/aerol-ai/microvm/pkg/models"
 )
 
@@ -110,6 +112,78 @@ func TestRecreateSandboxReplaysPortsForExistingSandbox(t *testing.T) {
 	exposure := findExposure(got, 3000)
 	if exposure == nil || exposure.Protocol != models.ExposedPortProtocolHTTP {
 		t.Fatalf("expected replayed http exposure, got %+v", exposure)
+	}
+}
+
+func TestRecreateSandboxRejectsMissingImageSpec(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+
+	err := svc.RecreateSandbox(ctx, "sb-recreate-missing-image", models.CreateSandboxRequest{}, cluster.PlacementSecrets{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "image is required") {
+		t.Fatalf("RecreateSandbox() error = %v, want missing image", err)
+	}
+	if rt.createCalls != 0 {
+		t.Fatalf("runtime Create calls = %d, want 0", rt.createCalls)
+	}
+	if _, err := st.Get(ctx, "sb-recreate-missing-image"); !errors.Is(err, storepkg.ErrNotFound) {
+		t.Fatalf("sandbox row after rejected recreate = %v, want ErrNotFound", err)
+	}
+}
+
+func TestRecreateSandboxFailsWhenClusterSecretRefMissing(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+
+	err := svc.RecreateSandbox(ctx, "sb-recreate-missing-secret", models.CreateSandboxRequest{Image: "alpine:3.20"}, cluster.PlacementSecrets{
+		Ref:     "cluster-secret:missing",
+		Version: 1,
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("RecreateSandbox() error = %v, want missing secret ref", err)
+	}
+	if rt.createCalls != 0 {
+		t.Fatalf("runtime Create calls = %d, want 0", rt.createCalls)
+	}
+	if _, err := st.Get(ctx, "sb-recreate-missing-secret"); !errors.Is(err, storepkg.ErrNotFound) {
+		t.Fatalf("sandbox row after secret-open failure = %v, want ErrNotFound", err)
+	}
+}
+
+func TestRecreateSandboxKeepsCreatedSandboxWhenReplayFails(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+	svc.cfg.EnableCluster = true
+	svc.cfg.NodeRole = config.NodeRoleWorker
+	svc.cfg.L4PortRangeStart = 30500
+	svc.cfg.L4PortRangeEnd = 30510
+	reserver := &hostPortReserveCluster{
+		Noop:     cluster.NewNoop("self", "http://self"),
+		reserved: map[int]bool{30505: true},
+	}
+	svc.AttachCluster(reserver)
+
+	err := svc.RecreateSandbox(ctx, "sb-recreate-replay-failure", models.CreateSandboxRequest{Image: "alpine:3.20"}, cluster.PlacementSecrets{}, map[int]cluster.ExposedPortRoute{
+		5432: {Protocol: models.ExposedPortProtocolTCP, HostPort: 30505},
+	})
+	if err == nil || !errors.Is(err, ErrPreferredHostPortUnavailable) {
+		t.Fatalf("RecreateSandbox() error = %v, want ErrPreferredHostPortUnavailable", err)
+	}
+	if rt.createCalls != 1 {
+		t.Fatalf("runtime Create calls = %d, want 1", rt.createCalls)
+	}
+	got, err := st.Get(ctx, "sb-recreate-replay-failure")
+	if err != nil {
+		t.Fatalf("store.Get() error = %v", err)
+	}
+	if got.Status != models.SandboxStatusStarted {
+		t.Fatalf("sandbox status = %q, want started", got.Status)
+	}
+	if exposure := findExposure(got, 5432); exposure != nil {
+		t.Fatalf("failing replay unexpectedly persisted exposure: %+v", exposure)
 	}
 }
 

--- a/internal/service/cluster_secrets_test.go
+++ b/internal/service/cluster_secrets_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"path/filepath"
 	"testing"
 
+	"github.com/aerol-ai/microvm/internal/cluster"
 	storepkg "github.com/aerol-ai/microvm/internal/store"
 	"github.com/aerol-ai/microvm/pkg/models"
 	"github.com/aerol-ai/microvm/pkg/secrets"
@@ -223,5 +225,71 @@ func TestUnsealClusterSecretsEmpty(t *testing.T) {
 	}
 	if out.Image != "alpine" {
 		t.Fatalf("passthrough lost spec: %+v", out)
+	}
+}
+
+func TestOpenClusterSecretsLegacyEnvelopeWrapper(t *testing.T) {
+	s := &Service{cipher: newTestCipher(t)}
+	req := models.CreateSandboxRequest{
+		Image:    "private.example.com/app:latest",
+		Registry: &models.RegistryAuth{Server: "private.example.com", Username: "alice", Password: "super-secret-password"},
+	}
+	redacted := RedactClusterSecrets(req)
+	plain, err := json.Marshal(clusterSealedSecrets{
+		Registry: &models.RegistryAuth{Server: "private.example.com", Username: "alice", Password: "super-secret-password"},
+	})
+	if err != nil {
+		t.Fatalf("marshal cluster secret bag: %v", err)
+	}
+	sealedPayload, err := s.cipher.EncryptWithAAD(plain, clusterSecretAAD([]string{"*"}))
+	if err != nil {
+		t.Fatalf("EncryptWithAAD: %v", err)
+	}
+	envelope, err := json.Marshal(clusterSealedSecretsEnvelope{
+		Version:    2,
+		Recipients: []string{"*"},
+		Payload:    sealedPayload,
+	})
+	if err != nil {
+		t.Fatalf("marshal legacy envelope: %v", err)
+	}
+	merged, err := s.OpenClusterSecrets(context.Background(), redacted, cluster.PlacementSecrets{LegacySealed: envelope})
+	if err != nil {
+		t.Fatalf("OpenClusterSecrets: %v", err)
+	}
+	if merged.Registry == nil || merged.Registry.Password != "super-secret-password" {
+		t.Fatalf("legacy envelope merge lost registry password: %+v", merged.Registry)
+	}
+}
+
+func TestDeleteClusterSecretsRemovesProviderRecord(t *testing.T) {
+	ctx := context.Background()
+	st, err := storepkg.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("Open store: %v", err)
+	}
+	defer st.Close()
+
+	s := &Service{cipher: newTestCipher(t), store: st}
+	handle, err := s.PutClusterSecretsForRecipient(ctx, "sb-delete-secrets", models.CreateSandboxRequest{
+		Image:    "private.example.com/app:latest",
+		Registry: &models.RegistryAuth{Server: "private.example.com", Username: "alice", Password: "super-secret-password"},
+	}, "node-a")
+	if err != nil {
+		t.Fatalf("PutClusterSecretsForRecipient: %v", err)
+	}
+	if err := s.DeleteClusterSecrets(ctx, "sb-delete-secrets"); err != nil {
+		t.Fatalf("DeleteClusterSecrets: %v", err)
+	}
+	if _, err := st.GetClusterSecret(ctx, handle.Ref); !errors.Is(err, storepkg.ErrNotFound) {
+		t.Fatalf("GetClusterSecret() error = %v, want ErrNotFound after delete", err)
+	}
+
+	var nilService *Service
+	if err := nilService.DeleteClusterSecrets(ctx, "ignored"); err != nil {
+		t.Fatalf("nil service DeleteClusterSecrets() error = %v", err)
+	}
+	if err := (&Service{}).DeleteClusterSecrets(ctx, "ignored"); err != nil {
+		t.Fatalf("storeless DeleteClusterSecrets() error = %v", err)
 	}
 }

--- a/internal/service/events_additional_test.go
+++ b/internal/service/events_additional_test.go
@@ -2,13 +2,50 @@ package service
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/aerol-ai/microvm/internal/config"
 	"github.com/aerol-ai/microvm/pkg/capacity"
 	"github.com/aerol-ai/microvm/pkg/docker"
 	"github.com/aerol-ai/microvm/pkg/models"
 )
+
+func newEventMonitorDockerClient(t *testing.T, handler http.Handler) *docker.Client {
+	t.Helper()
+	socketPath := fmt.Sprintf("/tmp/aerolvm-events-%d.sock", time.Now().UnixNano())
+	_ = os.Remove(socketPath)
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	server := &http.Server{Handler: handler}
+	go func() {
+		_ = server.Serve(listener)
+	}()
+	t.Cleanup(func() {
+		_ = server.Close()
+		_ = listener.Close()
+		_ = os.Remove(socketPath)
+	})
+	t.Setenv("DOCKER_HOST", "unix://"+socketPath)
+
+	client, err := docker.New(slog.New(slog.NewTextHandler(io.Discard, nil)), config.Config{
+		ToolboxBinaryPath: "toolboxd",
+		HTTPClientTimeout: time.Second,
+	}, nil)
+	if err != nil {
+		t.Fatalf("docker.New: %v", err)
+	}
+	return client
+}
 
 func TestConsumeEventsProcessesStopEvent(t *testing.T) {
 	ctx := context.Background()
@@ -61,4 +98,92 @@ func TestConsumeEventsReturnsWhenContextCanceled(t *testing.T) {
 	if snap := admitter.Snapshot(); snap.SandboxesActive != 1 {
 		t.Fatalf("admitter snapshot = %+v, want reservation unchanged", snap)
 	}
+}
+
+func TestStartEventMonitorDisabledSkipsDockerStream(t *testing.T) {
+	var requests atomic.Int32
+	client := newEventMonitorDockerClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	svc, _, _ := newCapacityHarness(t, nil, nil)
+	svc.events = client
+	svc.cfg.EnableEventMonitor = false
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	svc.StartEventMonitor(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	if got := requests.Load(); got != 0 {
+		t.Fatalf("docker event requests = %d, want 0 when monitor disabled", got)
+	}
+}
+
+func TestStartEventMonitorReconnectsAfterStreamError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	svc, admitter, st := newCapacityHarness(t, nil, nil)
+	const sandboxID = "sb-event-reconnect"
+	seedSandbox(t, st, sandboxID, models.SandboxStatusStarted, 2, 2048)
+	admitter.Reserve(sandboxID, capacity.Request{CPU: 2, MemoryMB: 2048})
+
+	firstRequest := make(chan struct{}, 1)
+	secondRequest := make(chan struct{}, 1)
+	var requests atomic.Int32
+	client := newEventMonitorDockerClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/events" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		switch requests.Add(1) {
+		case 1:
+			firstRequest <- struct{}{}
+			http.Error(w, "boom", http.StatusInternalServerError)
+		case 2:
+			secondRequest <- struct{}{}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"stop","id":"ctr-event-reconnect","time":1716336000,"Actor":{"Attributes":{"name":"/sb-event-reconnect"}}}` + "\n"))
+		default:
+			http.Error(w, "unexpected extra request", http.StatusInternalServerError)
+		}
+	}))
+	svc.events = client
+	svc.cfg.EnableEventMonitor = true
+
+	svc.StartEventMonitor(ctx)
+
+	select {
+	case <-firstRequest:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first docker /events request did not arrive")
+	}
+	select {
+	case <-secondRequest:
+	case <-time.After(2500 * time.Millisecond):
+		t.Fatal("second docker /events request did not arrive after reconnect backoff")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		got, err := st.Get(ctx, sandboxID)
+		if err != nil {
+			t.Fatalf("store.Get: %v", err)
+		}
+		if got.Status == models.SandboxStatusStopped {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("sandbox status = %q, want stopped after streamed event", got.Status)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if snap := admitter.Snapshot(); snap.SandboxesActive != 0 {
+		t.Fatalf("admitter snapshot = %+v, want released capacity after streamed stop event", snap)
+	}
+	if got := requests.Load(); got < 2 {
+		t.Fatalf("docker event requests = %d, want at least 2", got)
+	}
+	cancel()
 }

--- a/internal/service/events_additional_test.go
+++ b/internal/service/events_additional_test.go
@@ -1,0 +1,64 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/capacity"
+	"github.com/aerol-ai/microvm/pkg/docker"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func TestConsumeEventsProcessesStopEvent(t *testing.T) {
+	ctx := context.Background()
+	svc, admitter, st := newCapacityHarness(t, nil, nil)
+
+	const sandboxID = "sb-consume-stop"
+	seedSandbox(t, st, sandboxID, models.SandboxStatusStarted, 2, 2048)
+	admitter.Reserve(sandboxID, capacity.Request{CPU: 2, MemoryMB: 2048})
+
+	events := make(chan docker.DockerEvent, 1)
+	events <- docker.DockerEvent{SandboxID: sandboxID, Action: "stop", Time: time.Now().UTC()}
+	close(events)
+
+	svc.consumeEvents(ctx, events)
+
+	got, err := st.Get(ctx, sandboxID)
+	if err != nil {
+		t.Fatalf("store.Get() error = %v", err)
+	}
+	if got.Status != models.SandboxStatusStopped {
+		t.Fatalf("sandbox status = %q, want stopped", got.Status)
+	}
+	if snap := admitter.Snapshot(); snap.SandboxesActive != 0 {
+		t.Fatalf("admitter snapshot = %+v, want released capacity", snap)
+	}
+}
+
+func TestConsumeEventsReturnsWhenContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	svc, admitter, st := newCapacityHarness(t, nil, nil)
+
+	const sandboxID = "sb-consume-canceled"
+	seedSandbox(t, st, sandboxID, models.SandboxStatusStarted, 1, 1024)
+	admitter.Reserve(sandboxID, capacity.Request{CPU: 1, MemoryMB: 1024})
+
+	events := make(chan docker.DockerEvent, 1)
+	events <- docker.DockerEvent{SandboxID: sandboxID, Action: "stop", Time: time.Now().UTC()}
+	close(events)
+	cancel()
+
+	svc.consumeEvents(ctx, events)
+
+	got, err := st.Get(context.Background(), sandboxID)
+	if err != nil {
+		t.Fatalf("store.Get() error = %v", err)
+	}
+	if got.Status != models.SandboxStatusStarted {
+		t.Fatalf("sandbox status = %q, want unchanged started", got.Status)
+	}
+	if snap := admitter.Snapshot(); snap.SandboxesActive != 1 {
+		t.Fatalf("admitter snapshot = %+v, want reservation unchanged", snap)
+	}
+}

--- a/internal/service/facade_state_test.go
+++ b/internal/service/facade_state_test.go
@@ -1,0 +1,279 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"expvar"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	storepkg "github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func TestFacadeStateCompatAndTagHelpers(t *testing.T) {
+	ctx := context.Background()
+	svc, st := newFacadeStateTestService(t)
+
+	sandbox := &models.Sandbox{
+		ID:             "sb-facade",
+		Image:          "alpine:3.20",
+		Status:         models.SandboxStatusStarted,
+		PublicURL:      "https://sb-facade.example.test",
+		ContainerID:    "ctr-facade",
+		ContainerIP:    "10.0.0.10",
+		CPU:            1,
+		MemoryMB:       512,
+		DiskGB:         10,
+		OSUser:         "root",
+		ToolboxEnabled: true,
+		Name:           "facade-name",
+		CreatedAt:      time.Now().UTC(),
+		UpdatedAt:      time.Now().UTC(),
+		LastActiveAt:   time.Now().UTC(),
+	}
+	if err := st.Create(ctx, sandbox); err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	if err := svc.UpsertCompatState(ctx, sandbox.ID, models.FacadeDaytona, `{"target":"ws-1"}`); err != nil {
+		t.Fatalf("upsert compat state: %v", err)
+	}
+	if err := svc.UpsertCompatState(ctx, sandbox.ID, models.FacadeDaytona, `{"target":"ws-2"}`); err != nil {
+		t.Fatalf("update compat state: %v", err)
+	}
+
+	state, err := svc.GetCompatState(ctx, sandbox.ID, models.FacadeDaytona)
+	if err != nil {
+		t.Fatalf("get compat state: %v", err)
+	}
+	if state.StateJSON != `{"target":"ws-2"}` {
+		t.Fatalf("state json = %q, want updated value", state.StateJSON)
+	}
+
+	states, err := svc.ListCompatState(ctx, models.FacadeDaytona)
+	if err != nil {
+		t.Fatalf("list compat state: %v", err)
+	}
+	if got := len(states); got != 1 {
+		t.Fatalf("compat state count = %d, want 1", got)
+	}
+	if got := states[sandbox.ID].StateJSON; got != state.StateJSON {
+		t.Fatalf("listed state json = %q, want %q", got, state.StateJSON)
+	}
+
+	resolvedID, err := svc.ResolveSandboxIDByName(ctx, sandbox.Name)
+	if err != nil {
+		t.Fatalf("resolve sandbox id by name: %v", err)
+	}
+	if resolvedID != sandbox.ID {
+		t.Fatalf("resolved id = %q, want %q", resolvedID, sandbox.ID)
+	}
+
+	tags := map[string]string{"team": "platform", "env": "test"}
+	if err := svc.UpdateTags(ctx, sandbox.ID, tags); err != nil {
+		t.Fatalf("update tags: %v", err)
+	}
+	stored, err := st.Get(ctx, sandbox.ID)
+	if err != nil {
+		t.Fatalf("get sandbox after tag update: %v", err)
+	}
+	if got := stored.Tags["team"]; got != "platform" {
+		t.Fatalf("team tag = %q, want platform", got)
+	}
+	if got := stored.Tags["env"]; got != "test" {
+		t.Fatalf("env tag = %q, want test", got)
+	}
+}
+
+func TestFacadeStateSnapshotAliasHelpers(t *testing.T) {
+	ctx := context.Background()
+	svc, st := newFacadeStateTestService(t)
+
+	snapshot := &models.SandboxSnapshot{
+		Name:            "snap-facade",
+		Image:           "registry.example.test/facade:snap",
+		SourceSandboxID: "sb-source",
+		CreatedAt:       time.Now().UTC(),
+	}
+	if err := st.CreateSnapshot(ctx, snapshot); err != nil {
+		t.Fatalf("create snapshot: %v", err)
+	}
+
+	alias := models.SnapshotAlias{
+		Alias:        "alias-facade",
+		SnapshotName: snapshot.Name,
+		Facade:       models.FacadeE2B,
+		ExtraNames:   []string{"snapshot-alpha", "snapshot-beta"},
+	}
+	if err := svc.UpsertSnapshotAlias(ctx, alias); err != nil {
+		t.Fatalf("upsert snapshot alias: %v", err)
+	}
+
+	alias.ExtraNames = []string{"snapshot-gamma"}
+	if err := svc.UpsertSnapshotAlias(ctx, alias); err != nil {
+		t.Fatalf("update snapshot alias: %v", err)
+	}
+
+	got, err := svc.GetSnapshotAlias(ctx, alias.Alias)
+	if err != nil {
+		t.Fatalf("get snapshot alias: %v", err)
+	}
+	if got.SnapshotName != snapshot.Name {
+		t.Fatalf("snapshot name = %q, want %q", got.SnapshotName, snapshot.Name)
+	}
+	if len(got.ExtraNames) != 1 || got.ExtraNames[0] != "snapshot-gamma" {
+		t.Fatalf("extra names = %v, want [snapshot-gamma]", got.ExtraNames)
+	}
+
+	aliases, err := svc.ListSnapshotAliases(ctx, models.FacadeE2B)
+	if err != nil {
+		t.Fatalf("list snapshot aliases: %v", err)
+	}
+	if got := len(aliases); got != 1 {
+		t.Fatalf("snapshot alias count = %d, want 1", got)
+	}
+	if aliases[alias.Alias].SnapshotName != snapshot.Name {
+		t.Fatalf("listed snapshot name = %q, want %q", aliases[alias.Alias].SnapshotName, snapshot.Name)
+	}
+
+	if err := svc.DeleteSnapshotAlias(ctx, alias.Alias); err != nil {
+		t.Fatalf("delete snapshot alias: %v", err)
+	}
+	_, err = svc.GetSnapshotAlias(ctx, alias.Alias)
+	if !errors.Is(err, storepkg.ErrNotFound) {
+		t.Fatalf("get deleted snapshot alias error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestFacadeStateIdempotentRequestHelpers(t *testing.T) {
+	ctx := context.Background()
+	svc, _ := newFacadeStateTestService(t)
+	const (
+		scope       = "e2b.create"
+		fingerprint = "fp-123"
+	)
+	now := time.Now().UTC()
+
+	claimsBefore := expvarMapValue(facadeIdempotencyClaims, scope+".pending")
+	readyClaimsBefore := expvarMapValue(facadeIdempotencyClaims, scope+".ready")
+	acquiredBefore := expvarMapValue(facadeIdempotencyAcquired, scope)
+	conflictsBefore := expvarMapValue(facadeIdempotencyConflicts, scope)
+	completeBefore := expvarMapValue(facadeIdempotencyComplete, scope)
+	deletesBefore := expvarMapValue(facadeIdempotencyDeletes, scope)
+
+	if _, _, err := svc.ClaimIdempotentRequest(ctx, "", fingerprint, now, 30*time.Second); err == nil {
+		t.Fatal("blank scope claim unexpectedly succeeded")
+	}
+
+	record, acquired, err := svc.ClaimIdempotentRequest(ctx, scope, fingerprint, now, 30*time.Second)
+	if err != nil {
+		t.Fatalf("initial claim: %v", err)
+	}
+	if !acquired {
+		t.Fatal("initial claim not acquired")
+	}
+	if record.State != models.RequestStatePending {
+		t.Fatalf("initial claim state = %q, want pending", record.State)
+	}
+
+	pendingRecord, acquired, err := svc.ClaimIdempotentRequest(ctx, scope, fingerprint, now.Add(5*time.Second), 30*time.Second)
+	if err != nil {
+		t.Fatalf("second claim while pending: %v", err)
+	}
+	if acquired {
+		t.Fatal("second claim unexpectedly acquired")
+	}
+	if pendingRecord.State != models.RequestStatePending {
+		t.Fatalf("pending claim state = %q, want pending", pendingRecord.State)
+	}
+
+	if err := svc.CompleteIdempotentRequest(ctx, scope, "missing", "sb-missing", now, time.Minute); err == nil {
+		t.Fatal("complete missing request unexpectedly succeeded")
+	}
+	if err := svc.CompleteIdempotentRequest(ctx, scope, fingerprint, "sb-claimed", now.Add(10*time.Second), time.Minute); err != nil {
+		t.Fatalf("complete claim: %v", err)
+	}
+
+	readyRecord, err := svc.GetIdempotentRequest(ctx, scope, fingerprint)
+	if err != nil {
+		t.Fatalf("get ready request: %v", err)
+	}
+	if readyRecord.State != models.RequestStateReady {
+		t.Fatalf("ready record state = %q, want ready", readyRecord.State)
+	}
+	if readyRecord.TargetID != "sb-claimed" {
+		t.Fatalf("ready record target = %q, want sb-claimed", readyRecord.TargetID)
+	}
+
+	replayedRecord, acquired, err := svc.ClaimIdempotentRequest(ctx, scope, fingerprint, now.Add(20*time.Second), 30*time.Second)
+	if err != nil {
+		t.Fatalf("claim ready request: %v", err)
+	}
+	if acquired {
+		t.Fatal("ready request unexpectedly acquired")
+	}
+	if replayedRecord.State != models.RequestStateReady {
+		t.Fatalf("replayed record state = %q, want ready", replayedRecord.State)
+	}
+
+	if err := svc.DeleteIdempotentRequest(ctx, scope, "missing"); err == nil {
+		t.Fatal("delete missing request unexpectedly succeeded")
+	}
+	if err := svc.DeleteIdempotentRequest(ctx, scope, fingerprint); err != nil {
+		t.Fatalf("delete request: %v", err)
+	}
+	if _, err := svc.GetIdempotentRequest(ctx, scope, fingerprint); !errors.Is(err, storepkg.ErrNotFound) {
+		t.Fatalf("get deleted request error = %v, want ErrNotFound", err)
+	}
+
+	if got := expvarMapValue(facadeIdempotencyClaims, scope+".pending") - claimsBefore; got != 2 {
+		t.Fatalf("pending claim metric delta = %d, want 2", got)
+	}
+	if got := expvarMapValue(facadeIdempotencyClaims, scope+".ready") - readyClaimsBefore; got != 1 {
+		t.Fatalf("ready claim metric delta = %d, want 1", got)
+	}
+	if got := expvarMapValue(facadeIdempotencyAcquired, scope) - acquiredBefore; got != 1 {
+		t.Fatalf("acquired metric delta = %d, want 1", got)
+	}
+	if got := expvarMapValue(facadeIdempotencyConflicts, scope) - conflictsBefore; got != 1 {
+		t.Fatalf("conflicts metric delta = %d, want 1", got)
+	}
+	if got := expvarMapValue(facadeIdempotencyComplete, scope) - completeBefore; got != 1 {
+		t.Fatalf("complete metric delta = %d, want 1", got)
+	}
+	if got := expvarMapValue(facadeIdempotencyDeletes, scope) - deletesBefore; got != 1 {
+		t.Fatalf("delete metric delta = %d, want 1", got)
+	}
+}
+
+func newFacadeStateTestService(t *testing.T) (*Service, *storepkg.Store) {
+	t.Helper()
+	st, err := storepkg.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := st.Close(); err != nil {
+			t.Fatalf("close store: %v", err)
+		}
+	})
+	return &Service{store: st}, st
+}
+
+func expvarMapValue(metric *expvar.Map, key string) int64 {
+	if metric == nil {
+		return 0
+	}
+	value := metric.Get(key)
+	if value == nil {
+		return 0
+	}
+	parsed, err := strconv.ParseInt(value.String(), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return parsed
+}

--- a/internal/service/ingress_additional_test.go
+++ b/internal/service/ingress_additional_test.go
@@ -1,0 +1,286 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/cluster"
+	"github.com/aerol-ai/microvm/internal/config"
+	storepkg "github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/caddy"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+type applyInFluxCaddyFake struct {
+	mu     sync.Mutex
+	routes map[string]map[string]any
+}
+
+func newApplyInFluxCaddyFake(routeIDs ...string) *applyInFluxCaddyFake {
+	routes := make(map[string]map[string]any, len(routeIDs))
+	for _, routeID := range routeIDs {
+		routes[routeID] = map[string]any{"@id": routeID}
+	}
+	return &applyInFluxCaddyFake{routes: routes}
+}
+
+func (f *applyInFluxCaddyFake) handler(t *testing.T) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/id/"):
+			routeID := strings.TrimPrefix(r.URL.Path, "/id/")
+			switch r.Method {
+			case http.MethodDelete:
+				f.mu.Lock()
+				defer f.mu.Unlock()
+				if _, ok := f.routes[routeID]; !ok {
+					http.Error(w, "not found", http.StatusNotFound)
+					return
+				}
+				delete(f.routes, routeID)
+				w.WriteHeader(http.StatusOK)
+			case http.MethodPatch:
+				var route map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&route); err != nil {
+					t.Fatalf("decode patched route: %v", err)
+				}
+				f.mu.Lock()
+				defer f.mu.Unlock()
+				if _, ok := f.routes[routeID]; !ok {
+					http.Error(w, "not found", http.StatusNotFound)
+					return
+				}
+				f.routes[routeID] = route
+				w.WriteHeader(http.StatusOK)
+			default:
+				t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+		case r.Method == http.MethodPut && r.URL.Path == "/config/apps/http/servers/srv0/routes/0":
+			var route map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&route); err != nil {
+				t.Fatalf("decode inserted route: %v", err)
+			}
+			routeID, _ := route["@id"].(string)
+			if routeID == "" {
+				t.Fatal("inserted route missing @id")
+			}
+			f.mu.Lock()
+			f.routes[routeID] = route
+			f.mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+}
+
+func (f *applyInFluxCaddyFake) hasRoute(routeID string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.routes[routeID]
+	return ok
+}
+
+func TestApplyInFluxRouteIPModeDeletesLiveRoutesAndSkipsTCP(t *testing.T) {
+	fake := newApplyInFluxCaddyFake(
+		"sandbox-flux-ip",
+		"sandbox-flux-ip-port-3000",
+		"sandbox-flux-ip-port-5432",
+		"sandbox-flux-ip-port-8443",
+	)
+	server := httptest.NewServer(fake.handler(t))
+	t.Cleanup(server.Close)
+
+	svc := &Service{
+		cfg:    config.Config{CaddyAdminURL: server.URL, CaddyServerID: "srv0", EnableCaddy: true, HTTPClientTimeout: time.Second},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		caddy:  caddy.New(config.Config{CaddyAdminURL: server.URL, CaddyServerID: "srv0", EnableCaddy: true, HTTPClientTimeout: time.Second}),
+	}
+
+	placement := cluster.Placement{
+		SandboxID: "flux-ip",
+		ExposedPortRoutes: map[int]cluster.ExposedPortRoute{
+			3000: {Protocol: models.ExposedPortProtocolHTTP},
+			5432: {Protocol: models.ExposedPortProtocolTCP},
+			8443: {Protocol: models.ExposedPortProtocolTLS},
+		},
+	}
+
+	if err := svc.applyInFluxRoute(context.Background(), placement); err != nil {
+		t.Fatalf("applyInFluxRoute() error = %v", err)
+	}
+
+	for _, routeID := range []string{
+		"sandbox-flux-ip",
+		"sandbox-flux-ip-port-3000",
+		"sandbox-flux-ip-port-8443",
+	} {
+		if fake.hasRoute(routeID) {
+			t.Fatalf("live route %q still present after in-flux apply", routeID)
+		}
+	}
+	if !fake.hasRoute("sandbox-flux-ip-port-5432") {
+		t.Fatal("tcp live route should be untouched by applyInFluxRoute")
+	}
+	for _, routeID := range []string{
+		caddy.InFluxSandboxRouteID("flux-ip"),
+		caddy.InFluxPortRouteID("flux-ip", 3000),
+		caddy.InFluxPortRouteID("flux-ip", 8443),
+	} {
+		if !fake.hasRoute(routeID) {
+			t.Fatalf("expected in-flux route %q to be installed", routeID)
+		}
+	}
+	if fake.hasRoute(caddy.InFluxPortRouteID("flux-ip", 5432)) {
+		t.Fatal("tcp in-flux route should not be installed")
+	}
+}
+
+func TestApplyInFluxRouteDomainModeUsesIngressRouteIDs(t *testing.T) {
+	fake := newApplyInFluxCaddyFake(
+		"sandbox-flux-domain",
+		"sandbox-flux-domain-port-3000",
+		caddy.IngressSandboxSNIRouteID("flux-domain"),
+		caddy.IngressPortSNIRouteID("flux-domain", 3000),
+		caddy.IngressPortSNIRouteID("flux-domain", 8443),
+	)
+	server := httptest.NewServer(fake.handler(t))
+	t.Cleanup(server.Close)
+
+	svc := &Service{
+		cfg:    config.Config{Domain: "example.test", CaddyAdminURL: server.URL, CaddyServerID: "srv0", EnableCaddy: true, HTTPClientTimeout: time.Second},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		caddy:  caddy.New(config.Config{Domain: "example.test", CaddyAdminURL: server.URL, CaddyServerID: "srv0", EnableCaddy: true, HTTPClientTimeout: time.Second}),
+	}
+
+	placement := cluster.Placement{
+		SandboxID: "flux-domain",
+		ExposedPortRoutes: map[int]cluster.ExposedPortRoute{
+			3000: {Protocol: models.ExposedPortProtocolHTTP},
+			5432: {Protocol: models.ExposedPortProtocolTCP},
+			8443: {Protocol: models.ExposedPortProtocolTLS},
+		},
+	}
+
+	if err := svc.applyInFluxRoute(context.Background(), placement); err != nil {
+		t.Fatalf("applyInFluxRoute() error = %v", err)
+	}
+
+	for _, routeID := range []string{
+		caddy.IngressSandboxSNIRouteID("flux-domain"),
+		caddy.IngressPortSNIRouteID("flux-domain", 3000),
+		caddy.IngressPortSNIRouteID("flux-domain", 8443),
+	} {
+		if fake.hasRoute(routeID) {
+			t.Fatalf("domain ingress route %q still present after in-flux apply", routeID)
+		}
+	}
+	for _, routeID := range []string{
+		"sandbox-flux-domain",
+		"sandbox-flux-domain-port-3000",
+	} {
+		if !fake.hasRoute(routeID) {
+			t.Fatalf("path-mode route %q should be untouched in domain mode", routeID)
+		}
+	}
+	for _, routeID := range []string{
+		caddy.InFluxSandboxRouteID("flux-domain"),
+		caddy.InFluxPortRouteID("flux-domain", 3000),
+		caddy.InFluxPortRouteID("flux-domain", 8443),
+	} {
+		if !fake.hasRoute(routeID) {
+			t.Fatalf("expected in-flux route %q to be installed", routeID)
+		}
+	}
+	if fake.hasRoute(caddy.InFluxPortRouteID("flux-domain", 5432)) {
+		t.Fatal("tcp in-flux route should not be installed in domain mode")
+	}
+}
+
+func TestGCClusterIngressRoutesUsesStoreRows(t *testing.T) {
+	ctx := context.Background()
+	st, err := storepkg.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := st.Close(); closeErr != nil {
+			t.Fatalf("store.Close() error = %v", closeErr)
+		}
+	})
+
+	if err := st.Create(ctx, &models.Sandbox{
+		ID:        "live",
+		Image:     "alpine:3.20",
+		Status:    models.SandboxStatusStarted,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("store.Create() error = %v", err)
+	}
+
+	fake := newGCCaddyFake()
+	fake.httpRouteIDs["sandbox-live"] = struct{}{}
+	fake.httpRouteIDs["sandbox-zombie"] = struct{}{}
+	server := httptest.NewServer(fake.handler(t))
+	t.Cleanup(server.Close)
+
+	svc := &Service{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		store:  st,
+		caddy: caddy.New(config.Config{
+			CaddyAdminURL:     server.URL,
+			CaddyServerID:     "srv0",
+			EnableCaddy:       true,
+			HTTPClientTimeout: time.Second,
+		}),
+	}
+
+	if err := svc.gcClusterIngressRoutes(ctx); err != nil {
+		t.Fatalf("gcClusterIngressRoutes() error = %v", err)
+	}
+
+	if got := fake.keys(fake.httpRouteIDs); !equalSorted(got, []string{"sandbox-live"}) {
+		t.Fatalf("cluster ingress gc http routes = %v, want [sandbox-live]", got)
+	}
+}
+
+func TestStartReconcileLoopRunsPeriodicReconcile(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	svc, st, _ := newServiceRuntimeHarness(t, &recordingRuntime{})
+	svc.cfg.ReconcileInterval = 10 * time.Millisecond
+
+	if _, err := svc.CreateSandboxWithID(ctx, models.CreateSandboxRequest{Image: "alpine:3.20"}, "sb-reconcile-loop"); err != nil {
+		t.Fatalf("CreateSandboxWithID() error = %v", err)
+	}
+
+	svc.StartReconcileLoop(ctx)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		_, err := st.Get(ctx, "sb-reconcile-loop")
+		if errors.Is(err, storepkg.ErrNotFound) {
+			return
+		}
+		if err != nil {
+			t.Fatalf("store.Get() error = %v", err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("periodic reconcile did not delete sandbox missing from runtime")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/internal/service/metrics_test.go
+++ b/internal/service/metrics_test.go
@@ -1,0 +1,126 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aerol-ai/microvm/pkg/capacity"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func TestBeginSandboxCreateMetricTracksSuccessAndTimeouts(t *testing.T) {
+	totalBefore := createRequestsTotal.Value()
+	timeoutErrorsBefore := expvarMapValue(createErrors, "timeout")
+	timeoutsBefore := expvarMapValue(createTimeouts, "timeout")
+
+	success := beginSandboxCreateMetric()
+	if got := createQueueDepth.Value(); got < 1 {
+		t.Fatalf("queue depth during in-flight create = %d, want >= 1", got)
+	}
+	success(nil)
+	if got := createRequestsTotal.Value() - totalBefore; got != 1 {
+		t.Fatalf("successful create request delta = %d, want 1", got)
+	}
+	if got := createQueueDepth.Value(); got != 0 {
+		t.Fatalf("queue depth after successful create = %d, want 0", got)
+	}
+
+	failure := beginSandboxCreateMetric()
+	failure(context.DeadlineExceeded)
+	if got := createRequestsTotal.Value() - totalBefore; got != 2 {
+		t.Fatalf("total create request delta = %d, want 2", got)
+	}
+	if got := expvarMapValue(createErrors, "timeout") - timeoutErrorsBefore; got != 1 {
+		t.Fatalf("timeout error delta = %d, want 1", got)
+	}
+	if got := expvarMapValue(createTimeouts, "timeout") - timeoutsBefore; got != 1 {
+		t.Fatalf("timeout counter delta = %d, want 1", got)
+	}
+}
+
+func TestMetricHelpersIncrementExpectedCounters(t *testing.T) {
+	reservationBefore := expvarMapValue(createReservationStates, "ready")
+	expiredBefore := createReservationExpired.Value()
+	replaysBefore := expvarMapValue(facadeIdempotencyReplays, "e2b_create")
+	conflictsBefore := expvarMapValue(facadeIdempotencyConflicts, "e2b_create")
+	decryptBefore := clusterSecretOpenTotal.Value()
+	secretDeniedBefore := expvarMapValue(clusterSecretOpenErrors, "recipient_denied")
+	secretRecipientDeniesBefore := clusterSecretRecipientDenies.Value()
+	keyMismatchBefore := clusterSecretKeyMismatches.Value()
+
+	RecordCreateReservationState("ready")
+	RecordExpiredReservations(3)
+	RecordExpiredReservations(0)
+	RecordFacadeIdempotencyReplay("e2b.create")
+	RecordFacadeIdempotencyConflict("e2b.create")
+	secretDone := beginClusterSecretOpen()
+	secretDone(errors.New("recipient not allowed to open this payload"))
+	recordClusterSecretKeyMismatch()
+
+	if got := expvarMapValue(createReservationStates, "ready") - reservationBefore; got != 1 {
+		t.Fatalf("reservation state delta = %d, want 1", got)
+	}
+	if got := createReservationExpired.Value() - expiredBefore; got != 3 {
+		t.Fatalf("expired reservation delta = %d, want 3", got)
+	}
+	if got := expvarMapValue(facadeIdempotencyReplays, "e2b_create") - replaysBefore; got != 1 {
+		t.Fatalf("replay metric delta = %d, want 1", got)
+	}
+	if got := expvarMapValue(facadeIdempotencyConflicts, "e2b_create") - conflictsBefore; got != 1 {
+		t.Fatalf("conflict metric delta = %d, want 1", got)
+	}
+	if got := clusterSecretOpenTotal.Value() - decryptBefore; got != 1 {
+		t.Fatalf("secret open total delta = %d, want 1", got)
+	}
+	if got := expvarMapValue(clusterSecretOpenErrors, "recipient_denied") - secretDeniedBefore; got != 1 {
+		t.Fatalf("recipient denied metric delta = %d, want 1", got)
+	}
+	if got := clusterSecretRecipientDenies.Value() - secretRecipientDeniesBefore; got != 1 {
+		t.Fatalf("recipient denied total delta = %d, want 1", got)
+	}
+	if got := clusterSecretKeyMismatches.Value() - keyMismatchBefore; got != 1 {
+		t.Fatalf("key mismatch delta = %d, want 1", got)
+	}
+}
+
+func TestClassifyMetricErrorsAndHelpers(t *testing.T) {
+	if got := classifyServiceMetricError(capacity.ErrCapacityExceeded); got != "capacity" {
+		t.Fatalf("capacity error classification = %q, want capacity", got)
+	}
+	if got := classifyServiceMetricError(errors.New("runtime kata not implemented")); got != "runtime_not_implemented" {
+		t.Fatalf("runtime error classification = %q, want runtime_not_implemented", got)
+	}
+	if got := classifyServiceMetricError(errors.New("name already in use")); got != "name_conflict" {
+		t.Fatalf("name conflict classification = %q, want name_conflict", got)
+	}
+	if got := classifyServiceMetricError(errors.New("reservation conflict while allocating")); got != "reservation_conflict" {
+		t.Fatalf("reservation conflict classification = %q, want reservation_conflict", got)
+	}
+	if got := classifyServiceMetricError(errors.New("must be greater than zero")); got != "validation" {
+		t.Fatalf("validation classification = %q, want validation", got)
+	}
+
+	if got := classifySecretMetricError(errors.New("version mismatch for cluster secret ref")); got != "key_version_mismatch" {
+		t.Fatalf("secret key mismatch classification = %q, want key_version_mismatch", got)
+	}
+	if got := classifySecretMetricError(errors.New("decrypt failed")); got != "decrypt_failed" {
+		t.Fatalf("secret decrypt classification = %q, want decrypt_failed", got)
+	}
+	if got := classifySecretMetricError(errors.New("unmarshal payload")); got != "decode_failed" {
+		t.Fatalf("secret decode classification = %q, want decode_failed", got)
+	}
+
+	if got := idempotencyScope("   "); got != "unknown" {
+		t.Fatalf("blank idempotency scope = %q, want unknown", got)
+	}
+	if got := idempotencyState(nil); got != "unknown" {
+		t.Fatalf("nil idempotency record state = %q, want unknown", got)
+	}
+	if got := idempotencyState(&models.IdempotentRequestRecord{State: models.RequestStateReady}); got != "ready" {
+		t.Fatalf("ready idempotency state = %q, want ready", got)
+	}
+	if got := idempotencyState(&models.IdempotentRequestRecord{State: models.RequestStatePending}); got != "pending" {
+		t.Fatalf("pending idempotency state = %q, want pending", got)
+	}
+}

--- a/internal/service/netstats_test.go
+++ b/internal/service/netstats_test.go
@@ -1,0 +1,218 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	storepkg "github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/docker"
+	"github.com/aerol-ai/microvm/pkg/docker/netstats"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func TestEnsureNetstatsReadyLatches(t *testing.T) {
+	rt := &recordingRuntime{}
+	svc, _, _ := newServiceRuntimeHarness(t, rt)
+	svc.cfg.NetstatsPollInterval = time.Hour
+	svc.events = &docker.Client{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := svc.EnsureNetstatsReady(ctx); err != nil {
+		t.Fatalf("EnsureNetstatsReady() error = %v", err)
+	}
+	if !svc.netstatsReady.Load() {
+		t.Fatal("netstats ready latch should be true after successful bootstrap")
+	}
+	poller := svc.netstatsPoller
+	if poller == nil {
+		t.Fatal("expected netstats poller to be stored")
+	}
+	if err := svc.EnsureNetstatsReady(ctx); err != nil {
+		t.Fatalf("EnsureNetstatsReady() second call error = %v", err)
+	}
+	if svc.netstatsPoller != poller {
+		t.Fatal("netstats poller should be reused after the latch flips")
+	}
+}
+
+func TestGetNetworkUsageReturnsStoredCountersWhenBootstrapFails(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+	svc.cfg = config.Config{}
+
+	quotaAt := time.Now().UTC().Add(-time.Minute)
+	sampleAt := time.Now().UTC()
+	svc.netstatsLastTick.Store(sampleAt.UnixNano())
+	seedNetstatsSandbox(t, st, &models.Sandbox{
+		ID:                     "sb-usage",
+		Image:                  "alpine:3.20",
+		Status:                 models.SandboxStatusStarted,
+		ContainerID:            "ctr-usage",
+		ContainerIP:            "10.0.0.10",
+		CPU:                    1,
+		MemoryMB:               256,
+		DiskGB:                 5,
+		OSUser:                 "root",
+		NetworkBytesIn:         123,
+		NetworkBytesOut:        456,
+		NetworkBytesInLimit:    1000,
+		NetworkBytesOutLimit:   2000,
+		NetworkQuotaExceeded:   true,
+		NetworkQuotaExceededAt: &quotaAt,
+	})
+
+	usage, err := svc.GetNetworkUsage(ctx, "sb-usage")
+	if err != nil {
+		t.Fatalf("GetNetworkUsage() error = %v", err)
+	}
+	if usage.BytesIn != 123 || usage.BytesOut != 456 {
+		t.Fatalf("usage counters = %+v, want 123/456", usage)
+	}
+	if usage.BytesInLimit != 1000 || usage.BytesOutLimit != 2000 {
+		t.Fatalf("usage limits = %+v, want 1000/2000", usage)
+	}
+	if usage.LastSampledAt == nil || !usage.LastSampledAt.Equal(sampleAt) {
+		t.Fatalf("last sampled at = %v, want %v", usage.LastSampledAt, sampleAt)
+	}
+	if svc.netstatsReady.Load() {
+		t.Fatal("bootstrap failure should not flip the netstats ready latch")
+	}
+}
+
+func TestSetNetworkLimitsAppliesAndClearsQuotaState(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+	seedNetstatsSandbox(t, st, &models.Sandbox{
+		ID:              "sb-limits",
+		Image:           "alpine:3.20",
+		Status:          models.SandboxStatusStarted,
+		ContainerID:     "ctr-limits",
+		ContainerIP:     "10.0.0.11",
+		CPU:             1,
+		MemoryMB:        256,
+		DiskGB:          5,
+		OSUser:          "root",
+		NetworkBytesIn:  120,
+		NetworkBytesOut: 220,
+	})
+
+	usage, err := svc.SetNetworkLimits(ctx, "sb-limits", 100, 200)
+	if err != nil {
+		t.Fatalf("SetNetworkLimits() apply error = %v", err)
+	}
+	if !usage.QuotaExceeded {
+		t.Fatal("quota should be marked exceeded once counters are over the limits")
+	}
+	if got := len(rt.applyNetworkBlockAllCalls); got != 1 {
+		t.Fatalf("egress block calls = %d, want 1", got)
+	}
+	if got := len(rt.applyNetworkBlockIngresses); got != 1 {
+		t.Fatalf("ingress block calls = %d, want 1", got)
+	}
+
+	clearedUsage, err := svc.SetNetworkLimits(ctx, "sb-limits", 500, 500)
+	if err != nil {
+		t.Fatalf("SetNetworkLimits() clear error = %v", err)
+	}
+	if clearedUsage.QuotaExceeded {
+		t.Fatal("quota should clear after the limits move above current usage")
+	}
+	if got := len(rt.clearNetworkBlockEgresses); got != 1 {
+		t.Fatalf("egress clear calls = %d, want 1", got)
+	}
+	if got := len(rt.clearNetworkBlockIngresses); got != 1 {
+		t.Fatalf("ingress clear calls = %d, want 1", got)
+	}
+	stored, err := st.Get(ctx, "sb-limits")
+	if err != nil {
+		t.Fatalf("store.Get() after limit clear error = %v", err)
+	}
+	if stored.NetworkQuotaExceeded {
+		t.Fatal("store row still marked over quota after limits were raised")
+	}
+}
+
+func TestNetstatsTargetsAndHandleSamples(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+	seedNetstatsSandbox(t, st, &models.Sandbox{
+		ID:                   "sb-sample",
+		Image:                "alpine:3.20",
+		Status:               models.SandboxStatusStarted,
+		ContainerID:          "",
+		ContainerIP:          "10.0.0.12",
+		CPU:                  1,
+		MemoryMB:             256,
+		DiskGB:               5,
+		OSUser:               "root",
+		NetworkBytesInLimit:  50,
+		NetworkBytesOutLimit: 70,
+	})
+	seedNetstatsSandbox(t, st, &models.Sandbox{
+		ID:          "sb-stopped",
+		Image:       "alpine:3.20",
+		Status:      models.SandboxStatusStopped,
+		ContainerID: "ctr-stopped",
+		ContainerIP: "10.0.0.13",
+		CPU:         1,
+		MemoryMB:    256,
+		DiskGB:      5,
+		OSUser:      "root",
+	})
+
+	targets := netstatsServiceLister{svc: svc}.NetstatsTargets(ctx)
+	if len(targets) != 1 {
+		t.Fatalf("netstats targets = %v, want one started sandbox", targets)
+	}
+	if targets[0].SandboxID != "sb-sample" || targets[0].ContainerRef != "sb-sample" {
+		t.Fatalf("netstats target = %+v, want sandbox id fallback container ref", targets[0])
+	}
+
+	sampledAt := time.Now().UTC()
+	netstatsServiceSink{svc: svc}.HandleSamples(ctx, []netstats.Sample{
+		{SandboxID: "sb-sample", BytesIn: 60, BytesOut: 80, SampledAt: sampledAt},
+		{SandboxID: "sb-sample", BytesIn: 0, BytesOut: 0, SampledAt: sampledAt},
+		{SandboxID: "sb-missing", BytesIn: 1, BytesOut: 1, SampledAt: sampledAt},
+	})
+
+	stored, err := st.Get(ctx, "sb-sample")
+	if err != nil {
+		t.Fatalf("store.Get() after samples error = %v", err)
+	}
+	if stored.NetworkBytesIn != 60 || stored.NetworkBytesOut != 80 {
+		t.Fatalf("stored counters = in:%d out:%d, want 60/80", stored.NetworkBytesIn, stored.NetworkBytesOut)
+	}
+	if !stored.NetworkQuotaExceeded {
+		t.Fatal("quota should be marked exceeded after over-limit sample")
+	}
+	if len(rt.applyNetworkBlockAllCalls) == 0 || len(rt.applyNetworkBlockIngresses) == 0 {
+		t.Fatalf("quota block calls missing: all=%v ingress=%v", rt.applyNetworkBlockAllCalls, rt.applyNetworkBlockIngresses)
+	}
+	if got := svc.netstatsLastTick.Load(); got != sampledAt.UnixNano() {
+		t.Fatalf("netstats last tick = %d, want %d", got, sampledAt.UnixNano())
+	}
+}
+
+func seedNetstatsSandbox(t *testing.T, st *storepkg.Store, sandbox *models.Sandbox) {
+	t.Helper()
+	now := time.Now().UTC()
+	if sandbox.CreatedAt.IsZero() {
+		sandbox.CreatedAt = now
+	}
+	if sandbox.UpdatedAt.IsZero() {
+		sandbox.UpdatedAt = now
+	}
+	if sandbox.LastActiveAt.IsZero() {
+		sandbox.LastActiveAt = now
+	}
+	if err := st.Create(context.Background(), sandbox); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+}

--- a/internal/service/port_start_additional_test.go
+++ b/internal/service/port_start_additional_test.go
@@ -1,0 +1,566 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/cluster"
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/internal/runtime"
+	storepkg "github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/caddy"
+	"github.com/aerol-ai/microvm/pkg/capacity"
+	"github.com/aerol-ai/microvm/pkg/models"
+	"github.com/aerol-ai/microvm/pkg/mounts"
+)
+
+type pushErrorRuntime struct {
+	*recordingRuntime
+	pushErr error
+}
+
+func (r *pushErrorRuntime) PushAllowedPorts(_ context.Context, containerIP, toolboxToken string, ports []int) error {
+	copyPorts := append([]int(nil), ports...)
+	r.pushes = append(r.pushes, allowedPortsPush{containerIP: containerIP, token: toolboxToken, ports: copyPorts})
+	return r.pushErr
+}
+
+type routeAdminCaddyFake struct {
+	mu             sync.Mutex
+	httpRouteIDs   map[string]struct{}
+	l4TCPServerIDs map[string]struct{}
+	l4TLSRouteIDs  map[string]struct{}
+	afterMutation  func(method, path, id string)
+}
+
+func newRouteAdminCaddyFake() *routeAdminCaddyFake {
+	return &routeAdminCaddyFake{
+		httpRouteIDs:   map[string]struct{}{},
+		l4TCPServerIDs: map[string]struct{}{},
+		l4TLSRouteIDs:  map[string]struct{}{},
+	}
+}
+
+func (f *routeAdminCaddyFake) handler(t *testing.T) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/id/"):
+			id := strings.TrimPrefix(r.URL.Path, "/id/")
+			switch r.Method {
+			case http.MethodPatch:
+				f.mu.Lock()
+				_, httpOK := f.httpRouteIDs[id]
+				_, tlsOK := f.l4TLSRouteIDs[id]
+				f.mu.Unlock()
+				if !httpOK && !tlsOK {
+					http.Error(w, "not found", http.StatusNotFound)
+					return
+				}
+				if f.afterMutation != nil {
+					f.afterMutation(r.Method, r.URL.Path, id)
+				}
+				w.WriteHeader(http.StatusOK)
+			case http.MethodDelete:
+				f.mu.Lock()
+				if _, ok := f.httpRouteIDs[id]; ok {
+					delete(f.httpRouteIDs, id)
+					f.mu.Unlock()
+					if f.afterMutation != nil {
+						f.afterMutation(r.Method, r.URL.Path, id)
+					}
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				if _, ok := f.l4TLSRouteIDs[id]; ok {
+					delete(f.l4TLSRouteIDs, id)
+					f.mu.Unlock()
+					if f.afterMutation != nil {
+						f.afterMutation(r.Method, r.URL.Path, id)
+					}
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				f.mu.Unlock()
+				http.Error(w, "not found", http.StatusNotFound)
+			default:
+				t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+
+		case r.Method == http.MethodPut && r.URL.Path == "/config/apps/http/servers/srv0/routes/0":
+			var route map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&route); err != nil {
+				t.Fatalf("decode http route: %v", err)
+			}
+			id, _ := route["@id"].(string)
+			if id == "" {
+				t.Fatal("inserted http route missing @id")
+			}
+			f.mu.Lock()
+			f.httpRouteIDs[id] = struct{}{}
+			f.mu.Unlock()
+			if f.afterMutation != nil {
+				f.afterMutation(r.Method, r.URL.Path, id)
+			}
+			w.WriteHeader(http.StatusOK)
+
+		case r.Method == http.MethodPut && r.URL.Path == "/config/apps/layer4/servers/tls-mux/routes/0":
+			var route map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&route); err != nil {
+				t.Fatalf("decode tls route: %v", err)
+			}
+			id, _ := route["@id"].(string)
+			if id == "" {
+				t.Fatal("inserted tls route missing @id")
+			}
+			f.mu.Lock()
+			f.l4TLSRouteIDs[id] = struct{}{}
+			f.mu.Unlock()
+			if f.afterMutation != nil {
+				f.afterMutation(r.Method, r.URL.Path, id)
+			}
+			w.WriteHeader(http.StatusOK)
+
+		case strings.HasPrefix(r.URL.Path, "/config/apps/layer4/servers/"):
+			serverID := strings.TrimPrefix(r.URL.Path, "/config/apps/layer4/servers/")
+			switch r.Method {
+			case http.MethodPut:
+				f.mu.Lock()
+				f.l4TCPServerIDs[serverID] = struct{}{}
+				f.mu.Unlock()
+				if f.afterMutation != nil {
+					f.afterMutation(r.Method, r.URL.Path, serverID)
+				}
+				w.WriteHeader(http.StatusOK)
+			case http.MethodDelete:
+				f.mu.Lock()
+				if _, ok := f.l4TCPServerIDs[serverID]; !ok {
+					f.mu.Unlock()
+					http.Error(w, "not found", http.StatusNotFound)
+					return
+				}
+				delete(f.l4TCPServerIDs, serverID)
+				f.mu.Unlock()
+				if f.afterMutation != nil {
+					f.afterMutation(r.Method, r.URL.Path, serverID)
+				}
+				w.WriteHeader(http.StatusOK)
+			default:
+				t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+}
+
+func (f *routeAdminCaddyFake) hasHTTPRoute(id string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.httpRouteIDs[id]
+	return ok
+}
+
+func (f *routeAdminCaddyFake) hasTCPServer(id string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.l4TCPServerIDs[id]
+	return ok
+}
+
+func (f *routeAdminCaddyFake) hasTLSRoute(id string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.l4TLSRouteIDs[id]
+	return ok
+}
+
+func sqliteDSNForTest(path string) string {
+	options := url.Values{}
+	options.Set("_busy_timeout", "5000")
+	options.Set("_foreign_keys", "on")
+	options.Set("_journal_mode", "WAL")
+	return path + "?" + options.Encode()
+}
+
+func newServiceRuntimeHarnessAtPath(t *testing.T, dbPath string, driver runtime.Runtime) (*Service, *storepkg.Store, *capacity.Admitter) {
+	t.Helper()
+	st, err := storepkg.Open(dbPath)
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = st.Close()
+	})
+
+	mgr, err := mounts.New(slog.New(slog.NewTextHandler(io.Discard, nil)), mounts.Config{
+		RootDir:     filepath.Join(t.TempDir(), "mounts"),
+		CredDir:     filepath.Join(t.TempDir(), "cred"),
+		WaitTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("mounts.New: %v", err)
+	}
+	t.Cleanup(mgr.Close)
+
+	admitter := capacity.New(
+		capacity.HostInfo{CPUCores: 8, MemoryTotalMB: 16384},
+		capacity.Limits{CPUReservationRatio: 1, MemoryReservationRatio: 1},
+		nil,
+	)
+
+	svc := &Service{
+		cfg: config.Config{
+			Runtime:           models.RuntimeDocker,
+			ToolboxPort:       4321,
+			EnableCaddy:       false,
+			HTTPClientTimeout: time.Second,
+		},
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		store:    st,
+		docker:   driver,
+		caddy:    caddy.New(config.Config{EnableCaddy: false, HTTPClientTimeout: time.Second}),
+		mounts:   mgr,
+		admitter: admitter,
+		images:   newDefaultImageDistributionProvider(""),
+	}
+	return svc, st, admitter
+}
+
+func TestExposePortHTTPReplacementKeepsExistingExposureOnClusterFailure(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+	fake := newRouteAdminCaddyFake()
+	server := httptest.NewServer(fake.handler(t))
+	t.Cleanup(server.Close)
+
+	svc.cfg = config.Config{EnableCaddy: true, CaddyAdminURL: server.URL, CaddyServerID: "srv0", Domain: "sandbox.example.com", HTTPClientTimeout: time.Second}
+	svc.caddy = caddy.New(svc.cfg)
+	svc.AttachCluster(&failingExposeCluster{Noop: cluster.NewNoop("node-1", "http://node-1"), addErr: errors.New("cluster write failed")})
+
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{ID: "sb-http-replace", Image: "alpine:3.20", Status: models.SandboxStatusStarted, ContainerID: "ctr-http-replace", ContainerIP: "10.0.0.70", Runtime: models.RuntimeDocker, CPU: 1, MemoryMB: 256, DiskGB: 5, CreatedAt: now, UpdatedAt: now, LastActiveAt: now}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+	if err := st.UpsertPort(ctx, models.ExposedPort{SandboxID: "sb-http-replace", Port: 8080, Protocol: models.ExposedPortProtocolHTTP, PublicURL: "https://sb-http-replace-8080.sandbox.example.com", CreatedAt: now}); err != nil {
+		t.Fatalf("UpsertPort() error = %v", err)
+	}
+
+	_, err := svc.ExposePort(ctx, "sb-http-replace", 8080, models.ExposedPortProtocolHTTP)
+	if err == nil || !strings.Contains(err.Error(), "cluster: record exposed port") {
+		t.Fatalf("ExposePort() error = %v, want cluster record failure", err)
+	}
+	got, err := st.Get(ctx, "sb-http-replace")
+	if err != nil {
+		t.Fatalf("store.Get() error = %v", err)
+	}
+	exposure := findExposure(got, 8080)
+	if exposure == nil || exposure.Protocol != models.ExposedPortProtocolHTTP {
+		t.Fatalf("http exposure after failed replace = %+v, want existing http row", exposure)
+	}
+	if !fake.hasHTTPRoute(caddy.PortRouteID("sb-http-replace", 8080)) {
+		t.Fatal("HTTP route should remain installed on replacement failure")
+	}
+	if len(rt.pushes) != 0 {
+		t.Fatalf("allowlist pushes = %d, want 0 on failed replacement", len(rt.pushes))
+	}
+}
+
+func TestExposePortTCPReusedReservationKeepsRouteOnClusterFailure(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+	fake := newRouteAdminCaddyFake()
+	server := httptest.NewServer(fake.handler(t))
+	t.Cleanup(server.Close)
+
+	svc.cfg = config.Config{EnableCaddy: true, CaddyAdminURL: server.URL, CaddyServerID: "srv0", Domain: "sandbox.example.com", HTTPClientTimeout: time.Second}
+	svc.caddy = caddy.New(svc.cfg)
+	svc.l4Ready.Store(true)
+	svc.AttachCluster(&failingExposeCluster{Noop: cluster.NewNoop("node-1", "http://node-1"), addErr: errors.New("cluster write failed")})
+
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{ID: "sb-tcp-replace", Image: "postgres:16", Status: models.SandboxStatusStarted, ContainerID: "ctr-tcp-replace", ContainerIP: "10.0.0.71", Runtime: models.RuntimeDocker, CPU: 1, MemoryMB: 256, DiskGB: 5, CreatedAt: now, UpdatedAt: now, LastActiveAt: now}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+	if err := st.UpsertPort(ctx, models.ExposedPort{SandboxID: "sb-tcp-replace", Port: 5432, Protocol: models.ExposedPortProtocolTCP, HostPort: 32123, PublicURL: "tcp://sandbox.example.com:32123", CreatedAt: now}); err != nil {
+		t.Fatalf("UpsertPort() error = %v", err)
+	}
+
+	_, err := svc.ExposePort(ctx, "sb-tcp-replace", 5432, models.ExposedPortProtocolTCP)
+	if err == nil || !strings.Contains(err.Error(), "cluster: record exposed port") {
+		t.Fatalf("ExposePort() error = %v, want cluster record failure", err)
+	}
+	got, err := st.Get(ctx, "sb-tcp-replace")
+	if err != nil {
+		t.Fatalf("store.Get() error = %v", err)
+	}
+	exposure := findExposure(got, 5432)
+	if exposure == nil || exposure.Protocol != models.ExposedPortProtocolTCP || exposure.HostPort != 32123 {
+		t.Fatalf("tcp exposure after failed replace = %+v, want existing tcp row", exposure)
+	}
+	if !fake.hasTCPServer(testTCPServerID(32123)) {
+		t.Fatal("TCP server should remain installed on reused reservation failure")
+	}
+	if len(rt.pushes) != 0 {
+		t.Fatalf("allowlist pushes = %d, want 0 on failed replacement", len(rt.pushes))
+	}
+}
+
+func TestExposePortTCPRollsBackReservedRowOnCaddyFailure(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/config/apps/layer4/servers/tcp-port-") {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+	}))
+	t.Cleanup(server.Close)
+
+	svc.cfg = config.Config{EnableCaddy: true, CaddyAdminURL: server.URL, CaddyServerID: "srv0", Domain: "sandbox.example.com", L4PortRangeStart: 32000, L4PortRangeEnd: 32002, HTTPClientTimeout: time.Second}
+	svc.caddy = caddy.New(svc.cfg)
+	svc.l4Ready.Store(true)
+
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{ID: "sb-tcp-rollback", Image: "postgres:16", Status: models.SandboxStatusStarted, ContainerID: "ctr-tcp-rollback", ContainerIP: "10.0.0.72", Runtime: models.RuntimeDocker, CPU: 1, MemoryMB: 256, DiskGB: 5, CreatedAt: now, UpdatedAt: now, LastActiveAt: now}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+
+	_, err := svc.ExposePort(ctx, "sb-tcp-rollback", 5432, models.ExposedPortProtocolTCP)
+	if err == nil || !strings.Contains(err.Error(), "upsert tcp server failed: 500") {
+		t.Fatalf("ExposePort() error = %v, want caddy tcp failure", err)
+	}
+	got, err := st.Get(ctx, "sb-tcp-rollback")
+	if err != nil {
+		t.Fatalf("store.Get() error = %v", err)
+	}
+	if exposure := findExposure(got, 5432); exposure != nil {
+		t.Fatalf("tcp exposure after rollback = %+v, want none", exposure)
+	}
+}
+
+func TestExposePortTLSRollsBackRouteOnStoreFailure(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "state.db")
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarnessAtPath(t, dbPath, rt)
+	fake := newRouteAdminCaddyFake()
+	fake.afterMutation = func(method, path, id string) {
+		if method == http.MethodPut && path == "/config/apps/layer4/servers/tls-mux/routes/0" {
+			_ = st.Close()
+		}
+	}
+	server := httptest.NewServer(fake.handler(t))
+	t.Cleanup(server.Close)
+
+	svc.cfg = config.Config{EnableCaddy: true, CaddyAdminURL: server.URL, CaddyServerID: "srv0", Domain: "sandbox.example.com", L4TLSListen: ":443", HTTPClientTimeout: time.Second}
+	svc.caddy = caddy.New(svc.cfg)
+	svc.l4Ready.Store(true)
+
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{ID: "sb-tls-rollback", Image: "redis:7", Status: models.SandboxStatusStarted, ContainerID: "ctr-tls-rollback", ContainerIP: "10.0.0.73", Runtime: models.RuntimeDocker, CPU: 1, MemoryMB: 256, DiskGB: 5, CreatedAt: now, UpdatedAt: now, LastActiveAt: now}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+
+	_, err := svc.ExposePort(ctx, "sb-tls-rollback", 8443, models.ExposedPortProtocolTLS)
+	if err == nil || !strings.Contains(err.Error(), "database is closed") {
+		t.Fatalf("ExposePort() error = %v, want store failure after tls route upsert", err)
+	}
+	if fake.hasTLSRoute(testTLSRouteID("sb-tls-rollback", 8443)) {
+		t.Fatal("TLS route should have been deleted during rollback")
+	}
+	reopened, err := storepkg.Open(dbPath)
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	defer reopened.Close()
+	got, err := reopened.Get(ctx, "sb-tls-rollback")
+	if err != nil {
+		t.Fatalf("reopened store.Get() error = %v", err)
+	}
+	if exposure := findExposure(got, 8443); exposure != nil {
+		t.Fatalf("tls exposure after rollback = %+v, want none", exposure)
+	}
+}
+
+func TestUnexposePortReturnsDeleteRouteErrorAndKeepsExposure(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete && r.URL.Path == "/id/"+caddy.PortRouteID("sb-unexpose-route-fail", 8080) {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+	}))
+	t.Cleanup(server.Close)
+
+	svc.cfg = config.Config{EnableCaddy: true, CaddyAdminURL: server.URL, CaddyServerID: "srv0", Domain: "sandbox.example.com", HTTPClientTimeout: time.Second}
+	svc.caddy = caddy.New(svc.cfg)
+
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{ID: "sb-unexpose-route-fail", Image: "alpine:3.20", Status: models.SandboxStatusStarted, ContainerID: "ctr-unexpose-route-fail", ContainerIP: "10.0.0.74", Runtime: models.RuntimeDocker, CPU: 1, MemoryMB: 256, DiskGB: 5, CreatedAt: now, UpdatedAt: now, LastActiveAt: now}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+	if err := st.UpsertPort(ctx, models.ExposedPort{SandboxID: "sb-unexpose-route-fail", Port: 8080, Protocol: models.ExposedPortProtocolHTTP, PublicURL: "https://sb-unexpose-route-fail-8080.sandbox.example.com", CreatedAt: now}); err != nil {
+		t.Fatalf("UpsertPort() error = %v", err)
+	}
+
+	err := svc.UnexposePort(ctx, "sb-unexpose-route-fail", 8080)
+	if err == nil || !strings.Contains(err.Error(), "delete caddy route failed: 500") {
+		t.Fatalf("UnexposePort() error = %v, want route delete failure", err)
+	}
+	got, err := st.Get(ctx, "sb-unexpose-route-fail")
+	if err != nil {
+		t.Fatalf("store.Get() error = %v", err)
+	}
+	if exposure := findExposure(got, 8080); exposure == nil || exposure.Protocol != models.ExposedPortProtocolHTTP {
+		t.Fatalf("http exposure after failed unexpose = %+v, want preserved row", exposure)
+	}
+}
+
+func TestStartSandboxReturnsErrorWhenSandboxRouteUpsertFails(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{startState: &models.SandboxRuntimeState{SandboxID: "sb-start-sandbox-route-fail", ContainerID: "ctr-start-sandbox-route-new", ContainerIP: "10.0.0.75", Status: models.SandboxStatusStarted}}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch && r.URL.Path == "/id/"+caddy.SandboxRouteID("sb-start-sandbox-route-fail") {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+	}))
+	t.Cleanup(server.Close)
+
+	svc.cfg = config.Config{Runtime: models.RuntimeDocker, ToolboxPort: 4321, EnableCaddy: true, CaddyAdminURL: server.URL, CaddyServerID: "srv0", Domain: "sandbox.example.com", HTTPClientTimeout: time.Second}
+	svc.caddy = caddy.New(svc.cfg)
+
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{ID: "sb-start-sandbox-route-fail", Image: "alpine:3.20", Status: models.SandboxStatusStopped, ContainerID: "ctr-start-sandbox-route-old", ContainerIP: "10.0.0.44", Runtime: models.RuntimeDocker, CPU: 1, MemoryMB: 256, DiskGB: 5, CreatedAt: now, UpdatedAt: now, LastActiveAt: now}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+
+	_, err := svc.StartSandbox(ctx, "sb-start-sandbox-route-fail")
+	if err == nil || !strings.Contains(err.Error(), "patch caddy route failed: 500") {
+		t.Fatalf("StartSandbox() error = %v, want sandbox-route caddy failure", err)
+	}
+	if len(rt.startRefs) != 1 || rt.startRefs[0] != "ctr-start-sandbox-route-old" {
+		t.Fatalf("runtime Start refs = %v, want [ctr-start-sandbox-route-old]", rt.startRefs)
+	}
+	if len(rt.pushes) != 0 {
+		t.Fatalf("allowlist pushes = %d, want none on failed restart", len(rt.pushes))
+	}
+	if cap := svc.Capacity(); cap.SandboxesActive != 1 || cap.ReservedCPU != 1 || cap.ReservedMemoryMB != 256 {
+		t.Fatalf("capacity snapshot after sandbox-route failure = %+v, want running reservation kept", cap)
+	}
+	got, err := st.Get(ctx, "sb-start-sandbox-route-fail")
+	if err != nil {
+		t.Fatalf("store.Get() error = %v", err)
+	}
+	if got.Status != models.SandboxStatusStopped || got.ContainerID != "ctr-start-sandbox-route-old" || got.ContainerIP != "10.0.0.44" {
+		t.Fatalf("stored sandbox after failed restart = %+v, want original stopped row", got)
+	}
+}
+
+func TestStartSandboxReturnsErrorWhenRefreshGetMissesAfterUpsert(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "state.db")
+	rt := &recordingRuntime{startState: &models.SandboxRuntimeState{SandboxID: "sb-start-refresh-miss", ContainerID: "ctr-start-refresh-new", ContainerIP: "10.0.0.76", Status: models.SandboxStatusStarted}}
+	svc, st, _ := newServiceRuntimeHarnessAtPath(t, dbPath, rt)
+	fake := newRouteAdminCaddyFake()
+	server := httptest.NewServer(fake.handler(t))
+	t.Cleanup(server.Close)
+
+	svc.cfg = config.Config{Runtime: models.RuntimeDocker, ToolboxPort: 4321, EnableCaddy: true, CaddyAdminURL: server.URL, CaddyServerID: "srv0", Domain: "sandbox.example.com", HTTPClientTimeout: time.Second}
+	svc.caddy = caddy.New(svc.cfg)
+
+	rawDB, err := sql.Open("sqlite3", sqliteDSNForTest(dbPath))
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer rawDB.Close()
+	if _, err := rawDB.Exec(`
+		CREATE TRIGGER delete_started_after_restart
+		AFTER UPDATE ON sandboxes
+		WHEN NEW.id = 'sb-start-refresh-miss' AND NEW.status = 'started'
+		BEGIN
+			DELETE FROM sandboxes WHERE id = NEW.id;
+		END;
+	`); err != nil {
+		t.Fatalf("create trigger: %v", err)
+	}
+
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{ID: "sb-start-refresh-miss", Image: "alpine:3.20", Status: models.SandboxStatusStopped, ContainerID: "ctr-start-refresh-old", ContainerIP: "10.0.0.45", Runtime: models.RuntimeDocker, CPU: 1, MemoryMB: 256, DiskGB: 5, CreatedAt: now, UpdatedAt: now, LastActiveAt: now}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+
+	_, err = svc.StartSandbox(ctx, "sb-start-refresh-miss")
+	if !errors.Is(err, storepkg.ErrNotFound) {
+		t.Fatalf("StartSandbox() error = %v, want ErrNotFound after refresh get misses", err)
+	}
+	if len(rt.pushes) != 0 {
+		t.Fatalf("allowlist pushes = %d, want none when refresh get fails", len(rt.pushes))
+	}
+	if !fake.hasHTTPRoute(caddy.SandboxRouteID("sb-start-refresh-miss")) {
+		t.Fatal("sandbox route should remain installed before refresh get failure")
+	}
+}
+
+func TestStartSandboxSucceedsWhenAllowedPortsSyncFails(t *testing.T) {
+	ctx := context.Background()
+	base := &recordingRuntime{startState: &models.SandboxRuntimeState{SandboxID: "sb-start-allowlist", ContainerID: "ctr-start-allowlist-new", ContainerIP: "10.0.0.77", Status: models.SandboxStatusStarted}}
+	rt := &pushErrorRuntime{recordingRuntime: base, pushErr: errors.New("toolbox down")}
+	svc, st, _ := newServiceRuntimeHarness(t, base)
+	fake := newRouteAdminCaddyFake()
+	server := httptest.NewServer(fake.handler(t))
+	t.Cleanup(server.Close)
+
+	svc.docker = rt
+	svc.cfg = config.Config{Runtime: models.RuntimeDocker, ToolboxPort: 4321, EnableCaddy: true, CaddyAdminURL: server.URL, CaddyServerID: "srv0", Domain: "sandbox.example.com", HTTPClientTimeout: time.Second}
+	svc.caddy = caddy.New(svc.cfg)
+
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{ID: "sb-start-allowlist", Image: "alpine:3.20", Status: models.SandboxStatusStopped, ContainerID: "ctr-start-allowlist-old", ContainerIP: "10.0.0.46", Runtime: models.RuntimeDocker, CPU: 1, MemoryMB: 256, DiskGB: 5, ToolboxToken: "toolbox-token", CreatedAt: now, UpdatedAt: now, LastActiveAt: now}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+
+	started, err := svc.StartSandbox(ctx, "sb-start-allowlist")
+	if err != nil {
+		t.Fatalf("StartSandbox() error = %v", err)
+	}
+	if started.Status != models.SandboxStatusStarted || started.ContainerID != "ctr-start-allowlist-new" || started.ContainerIP != "10.0.0.77" {
+		t.Fatalf("returned sandbox = %+v, want refreshed started sandbox", started)
+	}
+	if len(rt.pushes) != 1 {
+		t.Fatalf("push attempts = %d, want 1", len(rt.pushes))
+	}
+	if rt.pushes[0].containerIP != "10.0.0.77" || rt.pushes[0].token != "toolbox-token" {
+		t.Fatalf("allowlist push = %+v, want refreshed container IP and token", rt.pushes[0])
+	}
+	got, err := st.Get(ctx, "sb-start-allowlist")
+	if err != nil {
+		t.Fatalf("store.Get() error = %v", err)
+	}
+	if got.Status != models.SandboxStatusStarted || got.ContainerID != "ctr-start-allowlist-new" || got.ContainerIP != "10.0.0.77" {
+		t.Fatalf("stored sandbox = %+v, want persisted started row", got)
+	}
+}

--- a/internal/service/service_error_paths_test.go
+++ b/internal/service/service_error_paths_test.go
@@ -1,0 +1,312 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/cluster"
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/pkg/caddy"
+	"github.com/aerol-ai/microvm/pkg/capacity"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+type failingExposeCluster struct {
+	*cluster.Noop
+	addErr error
+}
+
+func (c *failingExposeCluster) AddExposedPort(ctx context.Context, sandboxID string, port int, route cluster.ExposedPortRoute) error {
+	return c.addErr
+}
+
+type networkBlockFailRuntime struct {
+	*recordingRuntime
+	applyErr error
+}
+
+func (r *networkBlockFailRuntime) ApplyNetworkBlockAll(containerIP string) error {
+	r.applyNetworkBlockAllCalls = append(r.applyNetworkBlockAllCalls, containerIP)
+	return r.applyErr
+}
+
+func TestStartSandboxRuntimeFailureMarksSandboxErrorAndReleasesAdmission(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{startErr: errors.New("start failed")}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{
+		ID:           "sb-start-runtime-fail",
+		Image:        "alpine:3.20",
+		Status:       models.SandboxStatusStopped,
+		ContainerID:  "ctr-start-runtime-fail",
+		ContainerIP:  "10.0.0.21",
+		Runtime:      models.RuntimeDocker,
+		CPU:          2,
+		MemoryMB:     1024,
+		DiskGB:       10,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		LastActiveAt: now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+
+	_, err := svc.StartSandbox(ctx, "sb-start-runtime-fail")
+	if err == nil || !strings.Contains(err.Error(), "start failed") {
+		t.Fatalf("StartSandbox() error = %v, want runtime start failure", err)
+	}
+	if len(rt.startRefs) != 1 || rt.startRefs[0] != "ctr-start-runtime-fail" {
+		t.Fatalf("runtime Start refs = %v, want [ctr-start-runtime-fail]", rt.startRefs)
+	}
+	if len(rt.stopRefs) != 0 {
+		t.Fatalf("runtime Stop refs = %v, want none on direct start failure", rt.stopRefs)
+	}
+	if cap := svc.Capacity(); cap.SandboxesActive != 0 || cap.ReservedCPU != 0 || cap.ReservedMemoryMB != 0 {
+		t.Fatalf("capacity snapshot after failed start = %+v, want released admission", cap)
+	}
+	got, err := st.Get(ctx, "sb-start-runtime-fail")
+	if err != nil {
+		t.Fatalf("store.Get() error = %v", err)
+	}
+	if got.Status != models.SandboxStatusError {
+		t.Fatalf("sandbox status = %q, want error after failed start", got.Status)
+	}
+}
+
+func TestStartSandboxNetworkBlockFailureStopsContainerAndReleasesAdmission(t *testing.T) {
+	ctx := context.Background()
+	baseRuntime := &recordingRuntime{
+		startState: &models.SandboxRuntimeState{
+			SandboxID:   "sb-start-netblock-fail",
+			ContainerID: "ctr-start-netblock-new",
+			ContainerIP: "10.0.0.44",
+			Status:      models.SandboxStatusStarted,
+		},
+	}
+	svc, st, _ := newServiceRuntimeHarness(t, baseRuntime)
+	svc.docker = &networkBlockFailRuntime{recordingRuntime: baseRuntime, applyErr: errors.New("iptables failed")}
+
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{
+		ID:              "sb-start-netblock-fail",
+		Image:           "alpine:3.20",
+		Status:          models.SandboxStatusStopped,
+		ContainerID:     "ctr-start-netblock-old",
+		ContainerIP:     "10.0.0.22",
+		Runtime:         models.RuntimeDocker,
+		CPU:             2,
+		MemoryMB:        1024,
+		DiskGB:          10,
+		NetworkBlockAll: true,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		LastActiveAt:    now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+
+	_, err := svc.StartSandbox(ctx, "sb-start-netblock-fail")
+	if err == nil || !strings.Contains(err.Error(), "apply network block on start") {
+		t.Fatalf("StartSandbox() error = %v, want network-block failure", err)
+	}
+	if len(baseRuntime.applyNetworkBlockAllCalls) != 1 || baseRuntime.applyNetworkBlockAllCalls[0] != "10.0.0.44" {
+		t.Fatalf("ApplyNetworkBlockAll calls = %v, want [10.0.0.44]", baseRuntime.applyNetworkBlockAllCalls)
+	}
+	if len(baseRuntime.stopRefs) != 1 || baseRuntime.stopRefs[0] != "ctr-start-netblock-new" {
+		t.Fatalf("runtime Stop refs = %v, want [ctr-start-netblock-new]", baseRuntime.stopRefs)
+	}
+	if cap := svc.Capacity(); cap.SandboxesActive != 0 || cap.ReservedCPU != 0 || cap.ReservedMemoryMB != 0 {
+		t.Fatalf("capacity snapshot after failed start = %+v, want released admission", cap)
+	}
+	got, err := st.Get(ctx, "sb-start-netblock-fail")
+	if err != nil {
+		t.Fatalf("store.Get() error = %v", err)
+	}
+	if got.Status != models.SandboxStatusError {
+		t.Fatalf("sandbox status = %q, want error after network-block failure", got.Status)
+	}
+}
+
+func TestExposePortHTTPRollsBackOnClusterRecordFailure(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+	fake := newApplyInFluxCaddyFake()
+	server := httptest.NewServer(fake.handler(t))
+	t.Cleanup(server.Close)
+
+	svc.cfg = config.Config{
+		EnableCaddy:       true,
+		CaddyAdminURL:     server.URL,
+		CaddyServerID:     "srv0",
+		Domain:            "sandbox.example.com",
+		HTTPClientTimeout: time.Second,
+	}
+	svc.caddy = caddy.New(svc.cfg)
+	svc.AttachCluster(&failingExposeCluster{
+		Noop:   cluster.NewNoop("node-1", "http://node-1"),
+		addErr: errors.New("cluster write failed"),
+	})
+
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{
+		ID:           "sb-http-rollback",
+		Image:        "alpine:3.20",
+		Status:       models.SandboxStatusStarted,
+		ContainerID:  "ctr-http-rollback",
+		ContainerIP:  "10.0.0.30",
+		Runtime:      models.RuntimeDocker,
+		CPU:          1,
+		MemoryMB:     256,
+		DiskGB:       5,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		LastActiveAt: now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+
+	_, err := svc.ExposePort(ctx, "sb-http-rollback", 8080, models.ExposedPortProtocolHTTP)
+	if err == nil || !strings.Contains(err.Error(), "cluster: record exposed port") {
+		t.Fatalf("ExposePort() error = %v, want cluster record failure", err)
+	}
+	got, err := st.Get(ctx, "sb-http-rollback")
+	if err != nil {
+		t.Fatalf("store.Get() error = %v", err)
+	}
+	if len(got.ExposedPorts) != 0 {
+		t.Fatalf("exposed ports after rollback = %+v, want none", got.ExposedPorts)
+	}
+	if fake.hasRoute(caddy.PortRouteID("sb-http-rollback", 8080)) {
+		t.Fatal("HTTP route should have been deleted during rollback")
+	}
+	if len(rt.pushes) != 0 {
+		t.Fatalf("allowlist pushes = %d, want 0 on failed expose", len(rt.pushes))
+	}
+}
+
+func TestStopSandboxIgnoresCaddyCleanupFailures(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, admitter := newServiceRuntimeHarness(t, rt)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/id/") {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+	}))
+	t.Cleanup(server.Close)
+
+	svc.cfg = config.Config{
+		EnableCaddy:       true,
+		CaddyAdminURL:     server.URL,
+		CaddyServerID:     "srv0",
+		Domain:            "sandbox.example.com",
+		HTTPClientTimeout: time.Second,
+	}
+	svc.caddy = caddy.New(svc.cfg)
+
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{
+		ID:          "sb-stop-cleanup",
+		Image:       "alpine:3.20",
+		Status:      models.SandboxStatusStarted,
+		ContainerID: "ctr-stop-cleanup",
+		ContainerIP: "10.0.0.31",
+		Runtime:     models.RuntimeDocker,
+		CPU:         1,
+		MemoryMB:    256,
+		DiskGB:      5,
+		ExposedPorts: []models.ExposedPort{{
+			SandboxID: "sb-stop-cleanup",
+			Port:      8080,
+			Protocol:  models.ExposedPortProtocolHTTP,
+			PublicURL: "https://sb-stop-cleanup-8080.sandbox.example.com",
+		}},
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		LastActiveAt: now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+	admitter.Reserve("sb-stop-cleanup", capacity.Request{CPU: 1, MemoryMB: 256})
+
+	stopped, err := svc.StopSandbox(ctx, "sb-stop-cleanup")
+	if err != nil {
+		t.Fatalf("StopSandbox() error = %v", err)
+	}
+	if stopped.Status != models.SandboxStatusStopped {
+		t.Fatalf("returned sandbox status = %q, want stopped", stopped.Status)
+	}
+	if len(rt.stopRefs) != 1 || rt.stopRefs[0] != "ctr-stop-cleanup" {
+		t.Fatalf("runtime Stop refs = %v, want [ctr-stop-cleanup]", rt.stopRefs)
+	}
+	if cap := svc.Capacity(); cap.SandboxesActive != 0 || cap.ReservedCPU != 0 || cap.ReservedMemoryMB != 0 {
+		t.Fatalf("capacity snapshot after stop = %+v, want released admission", cap)
+	}
+	got, err := st.Get(ctx, "sb-stop-cleanup")
+	if err != nil {
+		t.Fatalf("store.Get() error = %v", err)
+	}
+	if got.Status != models.SandboxStatusStopped {
+		t.Fatalf("stored sandbox status = %q, want stopped", got.Status)
+	}
+}
+
+func TestUnexposePortDeletesLegacyHTTPRouteWhenRowMissing(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+	fake := newApplyInFluxCaddyFake(caddy.PortRouteID("sb-legacy-unexpose", 8080))
+	server := httptest.NewServer(fake.handler(t))
+	t.Cleanup(server.Close)
+
+	svc.cfg = config.Config{
+		EnableCaddy:       true,
+		CaddyAdminURL:     server.URL,
+		CaddyServerID:     "srv0",
+		Domain:            "sandbox.example.com",
+		HTTPClientTimeout: time.Second,
+	}
+	svc.caddy = caddy.New(svc.cfg)
+
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{
+		ID:           "sb-legacy-unexpose",
+		Image:        "alpine:3.20",
+		Status:       models.SandboxStatusStarted,
+		ContainerID:  "ctr-legacy-unexpose",
+		ContainerIP:  "10.0.0.32",
+		Runtime:      models.RuntimeDocker,
+		CPU:          1,
+		MemoryMB:     256,
+		DiskGB:       5,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		LastActiveAt: now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+
+	if err := svc.UnexposePort(ctx, "sb-legacy-unexpose", 8080); err != nil {
+		t.Fatalf("UnexposePort() error = %v", err)
+	}
+	if fake.hasRoute(caddy.PortRouteID("sb-legacy-unexpose", 8080)) {
+		t.Fatal("legacy HTTP route should have been deleted")
+	}
+	got, err := st.Get(ctx, "sb-legacy-unexpose")
+	if err != nil {
+		t.Fatalf("store.Get() error = %v", err)
+	}
+	if len(got.ExposedPorts) != 0 {
+		t.Fatalf("exposed ports after legacy unexpose = %+v, want none", got.ExposedPorts)
+	}
+}

--- a/internal/service/service_error_paths_test.go
+++ b/internal/service/service_error_paths_test.go
@@ -3,17 +3,23 @@ package service
 import (
 	"context"
 	"errors"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/aerol-ai/microvm/internal/cluster"
 	"github.com/aerol-ai/microvm/internal/config"
+	storepkg "github.com/aerol-ai/microvm/internal/store"
 	"github.com/aerol-ai/microvm/pkg/caddy"
 	"github.com/aerol-ai/microvm/pkg/capacity"
 	"github.com/aerol-ai/microvm/pkg/models"
+	"github.com/aerol-ai/microvm/pkg/mounts"
 )
 
 type failingExposeCluster struct {
@@ -30,9 +36,74 @@ type networkBlockFailRuntime struct {
 	applyErr error
 }
 
+type startHookRuntime struct {
+	*recordingRuntime
+	afterStart func()
+}
+
 func (r *networkBlockFailRuntime) ApplyNetworkBlockAll(containerIP string) error {
 	r.applyNetworkBlockAllCalls = append(r.applyNetworkBlockAllCalls, containerIP)
 	return r.applyErr
+}
+
+func (r *startHookRuntime) Start(ctx context.Context, containerRef string) (*models.SandboxRuntimeState, error) {
+	state, err := r.recordingRuntime.Start(ctx, containerRef)
+	if err == nil && r.afterStart != nil {
+		r.afterStart()
+	}
+	return state, err
+}
+
+func testTCPServerID(hostPort int) string {
+	return "tcp-port-" + strconv.Itoa(hostPort)
+}
+
+func testTLSRouteID(id string, port int) string {
+	return "sandbox-" + id + "-port-" + strconv.Itoa(port) + "-tls"
+}
+
+func newServiceRuntimeHarnessAllowStoreClose(t *testing.T, rt *recordingRuntime) (*Service, *storepkg.Store, *capacity.Admitter) {
+	t.Helper()
+	st, err := storepkg.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = st.Close()
+	})
+
+	mgr, err := mounts.New(slog.New(slog.NewTextHandler(io.Discard, nil)), mounts.Config{
+		RootDir:     filepath.Join(t.TempDir(), "mounts"),
+		CredDir:     filepath.Join(t.TempDir(), "cred"),
+		WaitTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("mounts.New: %v", err)
+	}
+	t.Cleanup(mgr.Close)
+
+	admitter := capacity.New(
+		capacity.HostInfo{CPUCores: 8, MemoryTotalMB: 16384},
+		capacity.Limits{CPUReservationRatio: 1, MemoryReservationRatio: 1},
+		nil,
+	)
+
+	svc := &Service{
+		cfg: config.Config{
+			Runtime:           models.RuntimeDocker,
+			ToolboxPort:       4321,
+			EnableCaddy:       false,
+			HTTPClientTimeout: time.Second,
+		},
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		store:    st,
+		docker:   rt,
+		caddy:    caddy.New(config.Config{EnableCaddy: false, HTTPClientTimeout: time.Second}),
+		mounts:   mgr,
+		admitter: admitter,
+		images:   newDefaultImageDistributionProvider(""),
+	}
+	return svc, st, admitter
 }
 
 func TestStartSandboxRuntimeFailureMarksSandboxErrorAndReleasesAdmission(t *testing.T) {
@@ -131,6 +202,136 @@ func TestStartSandboxNetworkBlockFailureStopsContainerAndReleasesAdmission(t *te
 	}
 	if got.Status != models.SandboxStatusError {
 		t.Fatalf("sandbox status = %q, want error after network-block failure", got.Status)
+	}
+}
+
+func TestStartSandboxReturnsErrorWhenExposedPortRouteReupsertFails(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{startState: &models.SandboxRuntimeState{
+		SandboxID:   "sb-start-route-fail",
+		ContainerID: "ctr-start-route-new",
+		ContainerIP: "10.0.0.55",
+		Status:      models.SandboxStatusStarted,
+	}}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPatch && r.URL.Path == "/id/"+caddy.SandboxRouteID("sb-start-route-fail"):
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPatch && r.URL.Path == "/id/"+caddy.PortRouteID("sb-start-route-fail", 8080):
+			http.Error(w, "boom", http.StatusInternalServerError)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	svc.cfg = config.Config{
+		Runtime:           models.RuntimeDocker,
+		ToolboxPort:       4321,
+		EnableCaddy:       true,
+		CaddyAdminURL:     server.URL,
+		CaddyServerID:     "srv0",
+		Domain:            "sandbox.example.com",
+		HTTPClientTimeout: time.Second,
+	}
+	svc.caddy = caddy.New(svc.cfg)
+
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{
+		ID:           "sb-start-route-fail",
+		Image:        "alpine:3.20",
+		Status:       models.SandboxStatusStopped,
+		ContainerID:  "ctr-start-route-old",
+		ContainerIP:  "10.0.0.40",
+		Runtime:      models.RuntimeDocker,
+		CPU:          1,
+		MemoryMB:     256,
+		DiskGB:       5,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		LastActiveAt: now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+	if err := st.UpsertPort(ctx, models.ExposedPort{
+		SandboxID: "sb-start-route-fail",
+		Port:      8080,
+		Protocol:  models.ExposedPortProtocolHTTP,
+		PublicURL: "https://sb-start-route-fail-8080.sandbox.example.com",
+		CreatedAt: now,
+	}); err != nil {
+		t.Fatalf("UpsertPort() error = %v", err)
+	}
+
+	_, err := svc.StartSandbox(ctx, "sb-start-route-fail")
+	if err == nil || !strings.Contains(err.Error(), "patch caddy route failed: 500") {
+		t.Fatalf("StartSandbox() error = %v, want exposed-port caddy failure", err)
+	}
+	if len(rt.startRefs) != 1 || rt.startRefs[0] != "ctr-start-route-old" {
+		t.Fatalf("runtime Start refs = %v, want [ctr-start-route-old]", rt.startRefs)
+	}
+	if len(rt.pushes) != 0 {
+		t.Fatalf("allowlist pushes = %d, want none on failed restart", len(rt.pushes))
+	}
+	if cap := svc.Capacity(); cap.SandboxesActive != 1 || cap.ReservedCPU != 1 || cap.ReservedMemoryMB != 256 {
+		t.Fatalf("capacity snapshot after caddy failure = %+v, want running reservation kept", cap)
+	}
+	got, err := st.Get(ctx, "sb-start-route-fail")
+	if err != nil {
+		t.Fatalf("store.Get() error = %v", err)
+	}
+	if got.Status != models.SandboxStatusStopped || got.ContainerID != "ctr-start-route-old" || got.ContainerIP != "10.0.0.40" {
+		t.Fatalf("stored sandbox after failed restart = %+v, want original stopped row", got)
+	}
+}
+
+func TestStartSandboxReturnsErrorWhenStoreUpsertFails(t *testing.T) {
+	ctx := context.Background()
+	baseRuntime := &recordingRuntime{startState: &models.SandboxRuntimeState{
+		SandboxID:   "sb-start-store-fail",
+		ContainerID: "ctr-start-store-new",
+		ContainerIP: "10.0.0.56",
+		Status:      models.SandboxStatusStarted,
+	}}
+	svc, st, _ := newServiceRuntimeHarnessAllowStoreClose(t, baseRuntime)
+	svc.docker = &startHookRuntime{
+		recordingRuntime: baseRuntime,
+		afterStart: func() {
+			_ = st.Close()
+		},
+	}
+
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{
+		ID:           "sb-start-store-fail",
+		Image:        "alpine:3.20",
+		Status:       models.SandboxStatusStopped,
+		ContainerID:  "ctr-start-store-old",
+		ContainerIP:  "10.0.0.41",
+		Runtime:      models.RuntimeDocker,
+		CPU:          1,
+		MemoryMB:     256,
+		DiskGB:       5,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		LastActiveAt: now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+
+	_, err := svc.StartSandbox(ctx, "sb-start-store-fail")
+	if err == nil || !strings.Contains(err.Error(), "database is closed") {
+		t.Fatalf("StartSandbox() error = %v, want store upsert failure", err)
+	}
+	if len(baseRuntime.startRefs) != 1 || baseRuntime.startRefs[0] != "ctr-start-store-old" {
+		t.Fatalf("runtime Start refs = %v, want [ctr-start-store-old]", baseRuntime.startRefs)
+	}
+	if len(baseRuntime.pushes) != 0 {
+		t.Fatalf("allowlist pushes = %d, want none on failed restart", len(baseRuntime.pushes))
+	}
+	if cap := svc.Capacity(); cap.SandboxesActive != 1 || cap.ReservedCPU != 1 || cap.ReservedMemoryMB != 256 {
+		t.Fatalf("capacity snapshot after store failure = %+v, want running reservation kept", cap)
 	}
 }
 
@@ -253,6 +454,131 @@ func TestStopSandboxIgnoresCaddyCleanupFailures(t *testing.T) {
 		t.Fatalf("capacity snapshot after stop = %+v, want released admission", cap)
 	}
 	got, err := st.Get(ctx, "sb-stop-cleanup")
+	if err != nil {
+		t.Fatalf("store.Get() error = %v", err)
+	}
+	if got.Status != models.SandboxStatusStopped {
+		t.Fatalf("stored sandbox status = %q, want stopped", got.Status)
+	}
+}
+
+func TestStopSandboxReturnsRuntimeStopFailureWithoutMutatingState(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{stopErr: errors.New("stop failed")}
+	svc, st, admitter := newServiceRuntimeHarness(t, rt)
+
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{
+		ID:           "sb-stop-runtime-fail",
+		Image:        "alpine:3.20",
+		Status:       models.SandboxStatusStarted,
+		ContainerID:  "ctr-stop-runtime-fail",
+		ContainerIP:  "10.0.0.42",
+		Runtime:      models.RuntimeDocker,
+		CPU:          2,
+		MemoryMB:     1024,
+		DiskGB:       10,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		LastActiveAt: now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+	admitter.Reserve("sb-stop-runtime-fail", capacity.Request{CPU: 2, MemoryMB: 1024})
+
+	_, err := svc.StopSandbox(ctx, "sb-stop-runtime-fail")
+	if err == nil || !strings.Contains(err.Error(), "stop failed") {
+		t.Fatalf("StopSandbox() error = %v, want runtime stop failure", err)
+	}
+	if len(rt.stopRefs) != 1 || rt.stopRefs[0] != "ctr-stop-runtime-fail" {
+		t.Fatalf("runtime Stop refs = %v, want [ctr-stop-runtime-fail]", rt.stopRefs)
+	}
+	if cap := svc.Capacity(); cap.SandboxesActive != 1 || cap.ReservedCPU != 2 || cap.ReservedMemoryMB != 1024 {
+		t.Fatalf("capacity snapshot after failed stop = %+v, want reservation preserved", cap)
+	}
+	got, err := st.Get(ctx, "sb-stop-runtime-fail")
+	if err != nil {
+		t.Fatalf("store.Get() error = %v", err)
+	}
+	if got.Status != models.SandboxStatusStarted {
+		t.Fatalf("stored sandbox status = %q, want started after failed stop", got.Status)
+	}
+}
+
+func TestStopSandboxCleansUpMixedProtocolRoutes(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, admitter := newServiceRuntimeHarness(t, rt)
+	fake := newGCCaddyFake()
+	fake.httpRouteIDs[caddy.SandboxRouteID("sb-stop-mixed")] = struct{}{}
+	fake.httpRouteIDs[caddy.PortRouteID("sb-stop-mixed", 8080)] = struct{}{}
+	fake.l4TCPServerIDs[testTCPServerID(37412)] = struct{}{}
+	fake.l4TLSRouteIDs[testTLSRouteID("sb-stop-mixed", 8443)] = struct{}{}
+	server := httptest.NewServer(fake.handler(t))
+	t.Cleanup(server.Close)
+
+	svc.cfg = config.Config{
+		Runtime:           models.RuntimeDocker,
+		ToolboxPort:       4321,
+		EnableCaddy:       true,
+		CaddyAdminURL:     server.URL,
+		CaddyServerID:     "srv0",
+		Domain:            "sandbox.example.com",
+		HTTPClientTimeout: time.Second,
+	}
+	svc.caddy = caddy.New(svc.cfg)
+
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{
+		ID:           "sb-stop-mixed",
+		Image:        "alpine:3.20",
+		Status:       models.SandboxStatusStarted,
+		ContainerID:  "ctr-stop-mixed",
+		ContainerIP:  "10.0.0.43",
+		Runtime:      models.RuntimeDocker,
+		CPU:          1,
+		MemoryMB:     256,
+		DiskGB:       5,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		LastActiveAt: now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+	for _, exposure := range []models.ExposedPort{
+		{SandboxID: "sb-stop-mixed", Port: 8080, Protocol: models.ExposedPortProtocolHTTP, PublicURL: "https://sb-stop-mixed-8080.sandbox.example.com", CreatedAt: now},
+		{SandboxID: "sb-stop-mixed", Port: 5432, Protocol: models.ExposedPortProtocolTCP, HostPort: 37412, PublicURL: "tcp://sandbox.example.com:37412", CreatedAt: now},
+		{SandboxID: "sb-stop-mixed", Port: 8443, Protocol: models.ExposedPortProtocolTLS, PublicURL: "tls://sb-stop-mixed-8443.sandbox.example.com:443", CreatedAt: now},
+	} {
+		if err := st.UpsertPort(ctx, exposure); err != nil {
+			t.Fatalf("UpsertPort(%d) error = %v", exposure.Port, err)
+		}
+	}
+	admitter.Reserve("sb-stop-mixed", capacity.Request{CPU: 1, MemoryMB: 256})
+
+	stopped, err := svc.StopSandbox(ctx, "sb-stop-mixed")
+	if err != nil {
+		t.Fatalf("StopSandbox() error = %v", err)
+	}
+	if stopped.Status != models.SandboxStatusStopped {
+		t.Fatalf("returned sandbox status = %q, want stopped", stopped.Status)
+	}
+	if len(rt.stopRefs) != 1 || rt.stopRefs[0] != "ctr-stop-mixed" {
+		t.Fatalf("runtime Stop refs = %v, want [ctr-stop-mixed]", rt.stopRefs)
+	}
+	if got := fake.keys(fake.httpRouteIDs); len(got) != 0 {
+		t.Fatalf("http routes after stop = %v, want none", got)
+	}
+	if got := fake.keys(fake.l4TCPServerIDs); len(got) != 0 {
+		t.Fatalf("tcp servers after stop = %v, want none", got)
+	}
+	if got := fake.keys(fake.l4TLSRouteIDs); len(got) != 0 {
+		t.Fatalf("tls routes after stop = %v, want none", got)
+	}
+	if cap := svc.Capacity(); cap.SandboxesActive != 0 || cap.ReservedCPU != 0 || cap.ReservedMemoryMB != 0 {
+		t.Fatalf("capacity snapshot after stop = %+v, want released admission", cap)
+	}
+	got, err := st.Get(ctx, "sb-stop-mixed")
 	if err != nil {
 		t.Fatalf("store.Get() error = %v", err)
 	}

--- a/internal/service/service_runtime_flow_test.go
+++ b/internal/service/service_runtime_flow_test.go
@@ -348,6 +348,64 @@ func TestServiceLifecycleStopStartDestroyAndHealth(t *testing.T) {
 	}
 }
 
+func TestStartSandboxReleasesAdmissionWhenMountLoadFails(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+
+	sealCipher := newTestCipher(t)
+	svc.cipher = sealCipher
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{
+		ID:           "sb-start-mount-error",
+		Image:        "alpine:3.20",
+		Status:       models.SandboxStatusStopped,
+		ContainerID:  "ctr-start-mount-error",
+		ContainerIP:  "10.0.0.20",
+		Runtime:      models.RuntimeDocker,
+		CPU:          2,
+		MemoryMB:     1024,
+		DiskGB:       10,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		LastActiveAt: now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+	sealed, err := svc.sealMounts([]models.MountSpec{{
+		Type:        models.MountTypeS3,
+		Target:      "/data",
+		Source:      "bucket",
+		Credentials: map[string]string{"access_key": "key", "secret_key": "secret"},
+	}})
+	if err != nil {
+		t.Fatalf("sealMounts() error = %v", err)
+	}
+	if err := st.PutMounts(ctx, "sb-start-mount-error", sealed); err != nil {
+		t.Fatalf("PutMounts() error = %v", err)
+	}
+	// Swap to a different key so loadMounts fails before docker.Start runs.
+	svc.cipher = newTestCipher(t)
+
+	_, err = svc.StartSandbox(ctx, "sb-start-mount-error")
+	if err == nil || !strings.Contains(err.Error(), "decrypt mounts") {
+		t.Fatalf("StartSandbox() error = %v, want mount decrypt failure", err)
+	}
+	if len(rt.startRefs) != 0 {
+		t.Fatalf("runtime Start refs = %v, want none when mount load fails first", rt.startRefs)
+	}
+	if cap := svc.Capacity(); cap.SandboxesActive != 0 || cap.ReservedCPU != 0 || cap.ReservedMemoryMB != 0 {
+		t.Fatalf("capacity snapshot after failed start = %+v, want released admission", cap)
+	}
+	got, err := st.Get(ctx, "sb-start-mount-error")
+	if err != nil {
+		t.Fatalf("store.Get() error = %v", err)
+	}
+	if got.Status != models.SandboxStatusStopped {
+		t.Fatalf("sandbox status = %q, want stopped after failed start", got.Status)
+	}
+}
+
 func TestToolboxTargetRequiresContainerIP(t *testing.T) {
 	ctx := context.Background()
 	rt := &recordingRuntime{}

--- a/internal/service/service_runtime_flow_test.go
+++ b/internal/service/service_runtime_flow_test.go
@@ -1,0 +1,769 @@
+package service
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/cluster"
+	"github.com/aerol-ai/microvm/internal/config"
+	storepkg "github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/caddy"
+	"github.com/aerol-ai/microvm/pkg/capacity"
+	"github.com/aerol-ai/microvm/pkg/models"
+	"github.com/aerol-ai/microvm/pkg/mounts"
+	"golang.org/x/crypto/ssh"
+)
+
+type allowedPortsPush struct {
+	containerIP string
+	token       string
+	ports       []int
+}
+
+type recordingRuntime struct {
+	createCalls      int
+	createState      *models.SandboxRuntimeState
+	createErr        error
+	lastCreateReq    models.CreateSandboxRequest
+	lastCreateID     string
+	lastToolboxToken string
+
+	startState *models.SandboxRuntimeState
+	startErr   error
+	startRefs  []string
+
+	stopErr  error
+	stopRefs []string
+
+	destroyErr error
+	destroyIDs []string
+
+	pingErr error
+
+	pushes []allowedPortsPush
+
+	applyNetworkBlockAllCalls  []string
+	applyNetworkBlockIngresses []string
+	clearNetworkBlockIngresses []string
+	clearNetworkBlockEgresses  []string
+	removeImages               []string
+
+	inspect map[string]*models.SandboxRuntimeState
+	managed map[string]*models.SandboxRuntimeState
+}
+
+type leaderCluster struct {
+	*cluster.Noop
+	leader string
+}
+
+func (c *leaderCluster) Leader() string { return c.leader }
+
+func (r *recordingRuntime) Create(_ context.Context, req models.CreateSandboxRequest, sandboxID, toolboxToken string, _ []mounts.ContainerBind) (*models.SandboxRuntimeState, error) {
+	r.createCalls++
+	r.lastCreateReq = req
+	r.lastCreateID = sandboxID
+	r.lastToolboxToken = toolboxToken
+	if r.createErr != nil {
+		return nil, r.createErr
+	}
+	if r.createState != nil {
+		state := *r.createState
+		return &state, nil
+	}
+	return &models.SandboxRuntimeState{
+		SandboxID:   sandboxID,
+		ContainerID: "ctr-" + sandboxID,
+		ContainerIP: "10.0.0.2",
+		Status:      models.SandboxStatusStarted,
+	}, nil
+}
+
+func (r *recordingRuntime) Start(_ context.Context, containerRef string) (*models.SandboxRuntimeState, error) {
+	r.startRefs = append(r.startRefs, containerRef)
+	if r.startErr != nil {
+		return nil, r.startErr
+	}
+	if r.startState != nil {
+		state := *r.startState
+		return &state, nil
+	}
+	return &models.SandboxRuntimeState{ContainerID: containerRef, ContainerIP: "10.0.0.3", Status: models.SandboxStatusStarted}, nil
+}
+
+func (r *recordingRuntime) Stop(_ context.Context, containerRef string) error {
+	r.stopRefs = append(r.stopRefs, containerRef)
+	return r.stopErr
+}
+
+func (r *recordingRuntime) Destroy(_ context.Context, sandbox *models.Sandbox) error {
+	if sandbox != nil {
+		r.destroyIDs = append(r.destroyIDs, sandbox.ID)
+	}
+	return r.destroyErr
+}
+
+func (r *recordingRuntime) CreateSnapshot(context.Context, string, string) (string, error) {
+	panic("unexpected CreateSnapshot")
+}
+
+func (r *recordingRuntime) Resize(context.Context, string, models.ResizeSandboxRequest) error {
+	panic("unexpected Resize")
+}
+
+func (r *recordingRuntime) Inspect(_ context.Context, ref string) (*models.SandboxRuntimeState, error) {
+	if r.inspect != nil {
+		if state, ok := r.inspect[ref]; ok {
+			copy := *state
+			return &copy, nil
+		}
+	}
+	return &models.SandboxRuntimeState{}, nil
+}
+
+func (r *recordingRuntime) ListManaged(_ context.Context) (map[string]*models.SandboxRuntimeState, error) {
+	out := make(map[string]*models.SandboxRuntimeState, len(r.managed))
+	for id, state := range r.managed {
+		copy := *state
+		out[id] = &copy
+	}
+	return out, nil
+}
+
+func (r *recordingRuntime) Ping(context.Context) error { return r.pingErr }
+
+func (r *recordingRuntime) RemoveImage(_ context.Context, imageRef string) error {
+	r.removeImages = append(r.removeImages, imageRef)
+	return nil
+}
+
+func (r *recordingRuntime) PushAllowedPorts(_ context.Context, containerIP, toolboxToken string, ports []int) error {
+	copyPorts := append([]int(nil), ports...)
+	r.pushes = append(r.pushes, allowedPortsPush{containerIP: containerIP, token: toolboxToken, ports: copyPorts})
+	return nil
+}
+
+func (r *recordingRuntime) ClearNetworkRules(string) error { return nil }
+
+func (r *recordingRuntime) ApplyNetworkBlockAll(containerIP string) error {
+	r.applyNetworkBlockAllCalls = append(r.applyNetworkBlockAllCalls, containerIP)
+	return nil
+}
+
+func (r *recordingRuntime) ApplyNetworkBlockIngress(containerIP string) error {
+	r.applyNetworkBlockIngresses = append(r.applyNetworkBlockIngresses, containerIP)
+	return nil
+}
+
+func (r *recordingRuntime) ClearNetworkBlockIngress(containerIP string) error {
+	r.clearNetworkBlockIngresses = append(r.clearNetworkBlockIngresses, containerIP)
+	return nil
+}
+
+func (r *recordingRuntime) ClearNetworkBlockEgress(containerIP string) error {
+	r.clearNetworkBlockEgresses = append(r.clearNetworkBlockEgresses, containerIP)
+	return nil
+}
+
+func TestServiceCreateWithIDAndAccessors(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+
+	resp, err := svc.CreateSandboxWithID(ctx, models.CreateSandboxRequest{
+		Image: "alpine:3.20",
+		Name:  "alpha",
+		Tags:  map[string]string{"team": "platform", "env": "test"},
+	}, "sb-fixed")
+	if err != nil {
+		t.Fatalf("CreateSandboxWithID() error = %v", err)
+	}
+	if rt.createCalls != 1 {
+		t.Fatalf("runtime Create calls = %d, want 1", rt.createCalls)
+	}
+	if rt.lastCreateID != "sb-fixed" {
+		t.Fatalf("runtime create id = %q, want sb-fixed", rt.lastCreateID)
+	}
+	if rt.lastCreateReq.Runtime != models.RuntimeDocker {
+		t.Fatalf("runtime create request runtime = %q, want %q", rt.lastCreateReq.Runtime, models.RuntimeDocker)
+	}
+	if len(rt.lastToolboxToken) != 64 {
+		t.Fatalf("toolbox token length = %d, want 64 hex chars", len(rt.lastToolboxToken))
+	}
+	if _, err := hex.DecodeString(rt.lastToolboxToken); err != nil {
+		t.Fatalf("toolbox token is not hex: %v", err)
+	}
+	if resp.ID != "sb-fixed" {
+		t.Fatalf("response sandbox id = %q, want sb-fixed", resp.ID)
+	}
+	if resp.Runtime != models.RuntimeDocker {
+		t.Fatalf("response runtime = %q, want %q", resp.Runtime, models.RuntimeDocker)
+	}
+	if resp.CPU != models.DefaultCPU || resp.MemoryMB != models.DefaultMemoryMB || resp.DiskGB != models.DefaultDiskGB {
+		t.Fatalf("normalized defaults = cpu:%v mem:%d disk:%d, want %v/%d/%d", resp.CPU, resp.MemoryMB, resp.DiskGB, models.DefaultCPU, models.DefaultMemoryMB, models.DefaultDiskGB)
+	}
+	if resp.OSUser != "root" {
+		t.Fatalf("os user = %q, want root", resp.OSUser)
+	}
+	if !strings.Contains(resp.SSHPrivateKey, "PRIVATE KEY") {
+		t.Fatalf("ssh private key missing PEM block: %q", resp.SSHPrivateKey)
+	}
+
+	got, err := svc.GetSandbox(ctx, resp.ID)
+	if err != nil {
+		t.Fatalf("GetSandbox() error = %v", err)
+	}
+	if got.ToolboxToken != rt.lastToolboxToken {
+		t.Fatalf("stored toolbox token = %q, want runtime token", got.ToolboxToken)
+	}
+
+	filtered, err := svc.ListSandboxes(ctx, map[string]string{"team": "platform"})
+	if err != nil {
+		t.Fatalf("ListSandboxes() error = %v", err)
+	}
+	if len(filtered) != 1 || filtered[0].ID != resp.ID {
+		t.Fatalf("filtered sandboxes = %+v, want only %q", filtered, resp.ID)
+	}
+
+	now := got.LastActiveAt
+	time.Sleep(10 * time.Millisecond)
+	if err := svc.TouchSandbox(ctx, resp.ID); err != nil {
+		t.Fatalf("TouchSandbox() error = %v", err)
+	}
+	touched, err := st.Get(ctx, resp.ID)
+	if err != nil {
+		t.Fatalf("store.Get() after touch error = %v", err)
+	}
+	if !touched.LastActiveAt.After(now) {
+		t.Fatalf("last active time did not advance: before=%v after=%v", now, touched.LastActiveAt)
+	}
+
+	endpoint, err := svc.ToolboxTarget(ctx, resp.ID)
+	if err != nil {
+		t.Fatalf("ToolboxTarget() error = %v", err)
+	}
+	if endpoint.URL != "http://10.0.0.2:4321" {
+		t.Fatalf("toolbox url = %q, want http://10.0.0.2:4321", endpoint.URL)
+	}
+	if endpoint.Token != rt.lastToolboxToken {
+		t.Fatalf("toolbox token = %q, want %q", endpoint.Token, rt.lastToolboxToken)
+	}
+
+	cap := svc.Capacity()
+	if cap.SandboxesActive != 1 || cap.ReservedCPU != models.DefaultCPU {
+		t.Fatalf("capacity snapshot = %+v, want one active sandbox reserving default CPU", cap)
+	}
+
+	again, err := svc.CreateSandboxWithID(ctx, models.CreateSandboxRequest{Image: "busybox:latest"}, resp.ID)
+	if err != nil {
+		t.Fatalf("CreateSandboxWithID() on existing sandbox error = %v", err)
+	}
+	if rt.createCalls != 1 {
+		t.Fatalf("runtime Create calls after no-op recreate = %d, want 1", rt.createCalls)
+	}
+	if again.Image != resp.Image {
+		t.Fatalf("existing sandbox image = %q, want original %q", again.Image, resp.Image)
+	}
+}
+
+func TestServiceLifecycleStopStartDestroyAndHealth(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+
+	resp, err := svc.CreateSandboxWithID(ctx, models.CreateSandboxRequest{Image: "ubuntu:22.04"}, "sb-life")
+	if err != nil {
+		t.Fatalf("CreateSandboxWithID() error = %v", err)
+	}
+
+	health, err := svc.Health(ctx)
+	if err != nil {
+		t.Fatalf("Health() error = %v", err)
+	}
+	if health.Status != "ok" || health.Sandboxes != 1 || health.Docker != "ok" || health.Caddy != "ok" {
+		t.Fatalf("initial health = %+v, want ok with one live sandbox", health)
+	}
+
+	stopped, err := svc.StopSandbox(ctx, resp.ID)
+	if err != nil {
+		t.Fatalf("StopSandbox() error = %v", err)
+	}
+	if len(rt.stopRefs) != 1 || rt.stopRefs[0] != resp.ContainerID {
+		t.Fatalf("runtime stop refs = %v, want [%s]", rt.stopRefs, resp.ContainerID)
+	}
+	if stopped.Status != models.SandboxStatusStopped {
+		t.Fatalf("stopped sandbox status = %q, want stopped", stopped.Status)
+	}
+	if got := svc.Capacity().SandboxesActive; got != 0 {
+		t.Fatalf("active sandboxes after stop = %d, want 0", got)
+	}
+
+	rt.startState = &models.SandboxRuntimeState{
+		SandboxID:   resp.ID,
+		ContainerID: "ctr-restart",
+		ContainerIP: "10.0.0.9",
+		Status:      models.SandboxStatusStarted,
+	}
+	restarted, err := svc.StartSandbox(ctx, resp.ID)
+	if err != nil {
+		t.Fatalf("StartSandbox() error = %v", err)
+	}
+	if restarted.ContainerID != "ctr-restart" || restarted.ContainerIP != "10.0.0.9" {
+		t.Fatalf("restarted sandbox runtime identity = %q/%q, want ctr-restart/10.0.0.9", restarted.ContainerID, restarted.ContainerIP)
+	}
+	if len(rt.pushes) == 0 {
+		t.Fatal("expected StartSandbox to sync allowed ports")
+	}
+	if last := rt.pushes[len(rt.pushes)-1]; last.containerIP != "10.0.0.9" || last.token == "" || len(last.ports) != 0 {
+		t.Fatalf("allowed ports push = %+v, want restart ip with empty port list", last)
+	}
+
+	rt.pingErr = errors.New("docker down")
+	degraded, err := svc.Health(ctx)
+	if err != nil {
+		t.Fatalf("Health() with docker failure error = %v", err)
+	}
+	if degraded.Status != "degraded" || degraded.Docker != "docker down" {
+		t.Fatalf("degraded health = %+v, want docker-down degraded state", degraded)
+	}
+
+	if err := svc.DestroySandbox(ctx, resp.ID); err != nil {
+		t.Fatalf("DestroySandbox() error = %v", err)
+	}
+	if len(rt.destroyIDs) != 1 || rt.destroyIDs[0] != resp.ID {
+		t.Fatalf("runtime destroy ids = %v, want [%s]", rt.destroyIDs, resp.ID)
+	}
+	if len(rt.removeImages) != 1 || rt.removeImages[0] != resp.Image {
+		t.Fatalf("removed images = %v, want [%s]", rt.removeImages, resp.Image)
+	}
+	if _, err := st.Get(ctx, resp.ID); !errors.Is(err, storepkg.ErrNotFound) {
+		t.Fatalf("sandbox still present after destroy: %v", err)
+	}
+}
+
+func TestToolboxTargetRequiresContainerIP(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{
+		ID:             "sb-no-ip",
+		Image:          "alpine:3.20",
+		Status:         models.SandboxStatusStarted,
+		ContainerID:    "ctr-no-ip",
+		ContainerIP:    "",
+		CPU:            1,
+		MemoryMB:       256,
+		DiskGB:         5,
+		OSUser:         "root",
+		ToolboxEnabled: true,
+		ToolboxToken:   "toolbox-token",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		LastActiveAt:   now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+
+	_, err := svc.ToolboxTarget(ctx, "sb-no-ip")
+	if err == nil || !strings.Contains(err.Error(), "container IP is not available") {
+		t.Fatalf("ToolboxTarget() error = %v, want missing container IP", err)
+	}
+}
+
+func TestServiceHelperUtilities(t *testing.T) {
+	authorizedKey, privateKey, err := generateSandboxSSHKeys()
+	if err != nil {
+		t.Fatalf("generateSandboxSSHKeys() error = %v", err)
+	}
+	if _, _, _, _, err := ssh.ParseAuthorizedKey([]byte(authorizedKey)); err != nil {
+		t.Fatalf("authorized key is not parseable: %v", err)
+	}
+	if !strings.Contains(privateKey, "PRIVATE KEY") {
+		t.Fatalf("private key missing PEM block: %q", privateKey)
+	}
+
+	token, err := generateToolboxToken()
+	if err != nil {
+		t.Fatalf("generateToolboxToken() error = %v", err)
+	}
+	if len(token) != 64 {
+		t.Fatalf("toolbox token length = %d, want 64", len(token))
+	}
+	if _, err := hex.DecodeString(token); err != nil {
+		t.Fatalf("toolbox token is not hex: %v", err)
+	}
+
+	id, err := GenerateSandboxID()
+	if err != nil {
+		t.Fatalf("GenerateSandboxID() error = %v", err)
+	}
+	if !strings.HasPrefix(id, "sb-") || len(id) != 19 {
+		t.Fatalf("sandbox id = %q, want sb- prefix plus 16 hex chars", id)
+	}
+
+	if got := (&Service{}).Capacity(); !got.CanAdmit {
+		t.Fatalf("zero-value capacity snapshot = %+v, want CanAdmit=true", got)
+	}
+
+	hostCases := map[string]string{
+		"https://sandbox.example.com/path": "sandbox.example.com",
+		"127.0.0.1:8443":                   "127.0.0.1",
+		"[2001:db8::1]:443":                "2001:db8::1",
+		"plain-host":                       "plain-host",
+	}
+	for input, want := range hostCases {
+		if got := hostFromURL(input); got != want {
+			t.Fatalf("hostFromURL(%q) = %q, want %q", input, got, want)
+		}
+	}
+
+	portCases := map[string]int{
+		":443":           443,
+		"8443":           8443,
+		"127.0.0.1:9443": 9443,
+		"not-a-port":     0,
+		"":               0,
+	}
+	for input, want := range portCases {
+		if got := l4ListenPort(input); got != want {
+			t.Fatalf("l4ListenPort(%q) = %d, want %d", input, got, want)
+		}
+	}
+}
+
+func TestHealthReportsClusterTopologyDegraded(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, _, _ := newServiceRuntimeHarness(t, rt)
+	svc.cfg.EnableCluster = true
+	svc.AttachCluster(&topologyCluster{
+		Noop: cluster.NewNoop("node-01", "http://node-01"),
+		members: []cluster.Member{
+			{NodeID: "server-1", Role: config.NodeRoleServer, Alive: true},
+			{NodeID: "server-2", Role: config.NodeRoleServer, Alive: true},
+			{NodeID: "server-3", Role: config.NodeRoleServer, Alive: true},
+			{NodeID: "worker-1", Role: config.NodeRoleWorker, Alive: true},
+			{NodeID: "worker-2", Role: config.NodeRoleWorker, Alive: true},
+			{NodeID: "worker-3", Role: config.NodeRoleWorker, Alive: true},
+			{NodeID: "worker-4", Role: config.NodeRoleWorker, Alive: true},
+			{NodeID: "worker-5", Role: config.NodeRoleWorker, Alive: true},
+			{NodeID: "worker-6", Role: config.NodeRoleWorker, Alive: true},
+			{NodeID: "ingress-1", Role: config.NodeRoleIngress, Alive: true},
+			{NodeID: "edge-1", Role: "worker,ingress", Alive: true},
+		},
+	})
+
+	health, err := svc.Health(ctx)
+	if err != nil {
+		t.Fatalf("Health() error = %v", err)
+	}
+	if health.Status != "degraded" {
+		t.Fatalf("health status = %q, want degraded", health.Status)
+	}
+	if health.ClusterTopology == "" {
+		t.Fatal("cluster topology error should be populated")
+	}
+	if health.ClusterNodes != 11 {
+		t.Fatalf("cluster nodes = %d, want 11 live members", health.ClusterNodes)
+	}
+}
+
+func TestEnsureClusterReadyCoversInitAndLeaderPaths(t *testing.T) {
+	t.Run("missing cluster", func(t *testing.T) {
+		svc := &Service{}
+		if err := svc.EnsureClusterReady(context.Background()); err == nil || !strings.Contains(err.Error(), "not initialized") {
+			t.Fatalf("EnsureClusterReady() error = %v, want not initialized", err)
+		}
+	})
+
+	t.Run("context canceled before leader election", func(t *testing.T) {
+		svc := &Service{}
+		svc.AttachCluster(&leaderCluster{Noop: cluster.NewNoop("self", "http://self"), leader: ""})
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := svc.EnsureClusterReady(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("EnsureClusterReady() error = %v, want context.Canceled", err)
+		}
+	})
+
+	t.Run("leader available latches readiness", func(t *testing.T) {
+		svc := &Service{}
+		svc.AttachCluster(&leaderCluster{Noop: cluster.NewNoop("self", "http://self"), leader: "leader-1"})
+		if err := svc.EnsureClusterReady(context.Background()); err != nil {
+			t.Fatalf("EnsureClusterReady() error = %v", err)
+		}
+		if !svc.clusterReady.Load() {
+			t.Fatal("cluster ready latch should be set after a successful readiness check")
+		}
+	})
+}
+
+func TestListMountsReturnsRedactedSpecs(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+	svc.cipher = newTestCipher(t)
+
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{
+		ID:             "sb-mounts",
+		Image:          "alpine:3.20",
+		Status:         models.SandboxStatusStarted,
+		ContainerID:    "ctr-mounts",
+		ContainerIP:    "10.0.0.14",
+		CPU:            1,
+		MemoryMB:       256,
+		DiskGB:         5,
+		OSUser:         "root",
+		ToolboxEnabled: true,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		LastActiveAt:   now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+
+	sealed, err := svc.sealMounts([]models.MountSpec{{
+		Type:        models.MountTypeS3,
+		Target:      "/data",
+		Source:      "my-bucket",
+		Options:     map[string]string{"region": "us-east-1"},
+		Credentials: map[string]string{"access_key": "key", "secret_key": "secret"},
+		ReadOnly:    true,
+	}})
+	if err != nil {
+		t.Fatalf("sealMounts() error = %v", err)
+	}
+	if err := st.PutMounts(ctx, "sb-mounts", sealed); err != nil {
+		t.Fatalf("PutMounts() error = %v", err)
+	}
+
+	mounts, err := svc.ListMounts(ctx, "sb-mounts")
+	if err != nil {
+		t.Fatalf("ListMounts() error = %v", err)
+	}
+	if len(mounts) != 1 {
+		t.Fatalf("mount count = %d, want 1", len(mounts))
+	}
+	if mounts[0].Target != "/data" || mounts[0].Source != "my-bucket" || !mounts[0].HasCredentials || !mounts[0].ReadOnly {
+		t.Fatalf("redacted mount = %+v, want redacted data mount with credentials flag", mounts[0])
+	}
+}
+
+func TestCreateSandboxValidationAndRollbackPaths(t *testing.T) {
+	t.Run("validation failures", func(t *testing.T) {
+		cases := []struct {
+			name string
+			req  models.CreateSandboxRequest
+			want string
+		}{
+			{name: "missing image", req: models.CreateSandboxRequest{}, want: "image is required"},
+			{name: "runtime not implemented", req: models.CreateSandboxRequest{Image: "alpine:3.20", Runtime: models.RuntimeKata}, want: models.ErrRuntimeNotImplemented.Error()},
+			{name: "too many mounts", req: models.CreateSandboxRequest{Image: "alpine:3.20", Mounts: make([]models.MountSpec, models.MaxMountsPerSandbox+1)}, want: "too many mounts"},
+			{name: "invalid lifecycle", req: models.CreateSandboxRequest{Image: "alpine:3.20", Lifecycle: &models.Lifecycle{StopIfIdleFor: -time.Second}}, want: "invalid lifecycle"},
+			{name: "invalid gpu", req: models.CreateSandboxRequest{Image: "alpine:3.20", GPUs: &models.GPURequest{Vendor: "bogus"}}, want: "invalid gpu request"},
+			{name: "negative network limit", req: models.CreateSandboxRequest{Image: "alpine:3.20", NetworkBytesInLimit: -1}, want: "network byte limits must be >= 0"},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				rt := &recordingRuntime{}
+				svc, _, _ := newServiceRuntimeHarness(t, rt)
+				_, err := svc.CreateSandbox(context.Background(), tc.req)
+				if err == nil || !strings.Contains(err.Error(), tc.want) {
+					t.Fatalf("CreateSandbox() error = %v, want substring %q", err, tc.want)
+				}
+				if rt.createCalls != 0 {
+					t.Fatalf("runtime Create calls = %d, want 0 on validation failure", rt.createCalls)
+				}
+			})
+		}
+	})
+
+	t.Run("runtime create failure releases admission", func(t *testing.T) {
+		rt := &recordingRuntime{createErr: errors.New("create failed")}
+		svc, _, _ := newServiceRuntimeHarness(t, rt)
+		_, err := svc.CreateSandboxWithID(context.Background(), models.CreateSandboxRequest{Image: "alpine:3.20"}, "sb-runtime-fail")
+		if err == nil || !strings.Contains(err.Error(), "create failed") {
+			t.Fatalf("CreateSandboxWithID() error = %v, want runtime create failure", err)
+		}
+		if got := svc.Capacity().SandboxesActive; got != 0 {
+			t.Fatalf("active sandboxes after runtime failure = %d, want 0", got)
+		}
+	})
+
+	t.Run("name conflict destroys created runtime artifact", func(t *testing.T) {
+		ctx := context.Background()
+		rt := &recordingRuntime{createState: &models.SandboxRuntimeState{SandboxID: "sb-conflict", ContainerID: "ctr-conflict", ContainerIP: "10.0.0.30", Status: models.SandboxStatusStarted}}
+		svc, st, _ := newServiceRuntimeHarness(t, rt)
+		now := time.Now().UTC()
+		if err := st.Create(ctx, &models.Sandbox{
+			ID:             "sb-existing",
+			Image:          "alpine:3.20",
+			Status:         models.SandboxStatusStarted,
+			ContainerID:    "ctr-existing",
+			ContainerIP:    "10.0.0.31",
+			CPU:            1,
+			MemoryMB:       256,
+			DiskGB:         5,
+			OSUser:         "root",
+			ToolboxEnabled: true,
+			Name:           "dup-name",
+			CreatedAt:      now,
+			UpdatedAt:      now,
+			LastActiveAt:   now,
+		}); err != nil {
+			t.Fatalf("seed existing sandbox: %v", err)
+		}
+
+		_, err := svc.CreateSandboxWithID(ctx, models.CreateSandboxRequest{Image: "alpine:3.20", Name: "dup-name"}, "sb-conflict")
+		if !errors.Is(err, storepkg.ErrSandboxNameConflict) {
+			t.Fatalf("CreateSandboxWithID() error = %v, want ErrSandboxNameConflict", err)
+		}
+		if len(rt.destroyIDs) != 1 || rt.destroyIDs[0] != "sb-conflict" {
+			t.Fatalf("runtime destroy ids after conflict = %v, want [sb-conflict]", rt.destroyIDs)
+		}
+		if _, err := st.Get(ctx, "sb-conflict"); !errors.Is(err, storepkg.ErrNotFound) {
+			t.Fatalf("conflicting sandbox leaked into store: %v", err)
+		}
+	})
+}
+
+func TestExposeAndUnexposePortProtocols(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+	svc.cfg = config.Config{
+		Runtime:           models.RuntimeDocker,
+		ToolboxPort:       4321,
+		EnableCaddy:       false,
+		PublicHost:        "203.0.113.10",
+		Domain:            "sandbox.example.com",
+		L4TLSListen:       ":443",
+		L4PortRangeStart:  32000,
+		L4PortRangeEnd:    32010,
+		HTTPClientTimeout: time.Second,
+	}
+	svc.caddy = caddy.New(svc.cfg)
+
+	resp, err := svc.CreateSandboxWithID(ctx, models.CreateSandboxRequest{Image: "alpine:3.20"}, "sb-ports")
+	if err != nil {
+		t.Fatalf("CreateSandboxWithID() error = %v", err)
+	}
+
+	httpExposure, err := svc.ExposePort(ctx, resp.ID, 8080, models.ExposedPortProtocolHTTP)
+	if err != nil {
+		t.Fatalf("ExposePort(http) error = %v", err)
+	}
+	if httpExposure.PublicURL != "https://sb-ports-8080.sandbox.example.com" {
+		t.Fatalf("http exposure URL = %q, want domain-mode HTTP URL", httpExposure.PublicURL)
+	}
+
+	tcpExposure, err := svc.ExposePort(ctx, resp.ID, 5432, models.ExposedPortProtocolTCP)
+	if err != nil {
+		t.Fatalf("ExposePort(tcp) error = %v", err)
+	}
+	if tcpExposure.HostPort < 32000 || tcpExposure.HostPort > 32010 {
+		t.Fatalf("tcp host port = %d, want configured range [32000,32010]", tcpExposure.HostPort)
+	}
+	if !strings.HasPrefix(tcpExposure.PublicURL, "tcp://sandbox.example.com:") {
+		t.Fatalf("tcp exposure URL = %q, want tcp://sandbox.example.com:<port>", tcpExposure.PublicURL)
+	}
+
+	tcpExposureAgain, err := svc.ExposePort(ctx, resp.ID, 5432, models.ExposedPortProtocolTCP)
+	if err != nil {
+		t.Fatalf("ExposePort(tcp replay) error = %v", err)
+	}
+	if tcpExposureAgain.HostPort != tcpExposure.HostPort {
+		t.Fatalf("tcp replay host port = %d, want original %d", tcpExposureAgain.HostPort, tcpExposure.HostPort)
+	}
+
+	tlsExposure, err := svc.ExposePort(ctx, resp.ID, 8443, models.ExposedPortProtocolTLS)
+	if err != nil {
+		t.Fatalf("ExposePort(tls) error = %v", err)
+	}
+	if tlsExposure.PublicURL != "tls://sb-ports-8443.sandbox.example.com:443" {
+		t.Fatalf("tls exposure URL = %q, want TLS-SNI endpoint", tlsExposure.PublicURL)
+	}
+
+	stored, err := st.Get(ctx, resp.ID)
+	if err != nil {
+		t.Fatalf("store.Get() after expose error = %v", err)
+	}
+	if len(stored.ExposedPorts) != 3 {
+		t.Fatalf("exposed port count = %d, want 3", len(stored.ExposedPorts))
+	}
+
+	for _, port := range []int{8080, 5432, 8443} {
+		if err := svc.UnexposePort(ctx, resp.ID, port); err != nil {
+			t.Fatalf("UnexposePort(%d) error = %v", port, err)
+		}
+	}
+	updated, err := st.Get(ctx, resp.ID)
+	if err != nil {
+		t.Fatalf("store.Get() after unexpose error = %v", err)
+	}
+	if len(updated.ExposedPorts) != 0 {
+		t.Fatalf("remaining exposed ports = %+v, want none", updated.ExposedPorts)
+	}
+	if len(rt.pushes) < 4 {
+		t.Fatalf("expected allowlist pushes during expose/unexpose, got %d", len(rt.pushes))
+	}
+	if !svc.l4Ready.Load() {
+		t.Fatal("L4 readiness latch should flip after TCP/TLS exposure")
+	}
+}
+
+func newServiceRuntimeHarness(t *testing.T, rt *recordingRuntime) (*Service, *storepkg.Store, *capacity.Admitter) {
+	t.Helper()
+	st, err := storepkg.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := st.Close(); err != nil {
+			t.Fatalf("store.Close: %v", err)
+		}
+	})
+
+	mgr, err := mounts.New(slog.New(slog.NewTextHandler(io.Discard, nil)), mounts.Config{
+		RootDir:     filepath.Join(t.TempDir(), "mounts"),
+		CredDir:     filepath.Join(t.TempDir(), "cred"),
+		WaitTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("mounts.New: %v", err)
+	}
+	t.Cleanup(mgr.Close)
+
+	admitter := capacity.New(
+		capacity.HostInfo{CPUCores: 8, MemoryTotalMB: 16384},
+		capacity.Limits{CPUReservationRatio: 1, MemoryReservationRatio: 1},
+		nil,
+	)
+
+	svc := &Service{
+		cfg: config.Config{
+			Runtime:           models.RuntimeDocker,
+			ToolboxPort:       4321,
+			EnableCaddy:       false,
+			HTTPClientTimeout: time.Second,
+		},
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		store:    st,
+		docker:   rt,
+		caddy:    caddy.New(config.Config{EnableCaddy: false, HTTPClientTimeout: time.Second}),
+		mounts:   mgr,
+		admitter: admitter,
+		images:   newDefaultImageDistributionProvider(""),
+	}
+	return svc, st, admitter
+}

--- a/internal/service/snapshot_test.go
+++ b/internal/service/snapshot_test.go
@@ -202,3 +202,80 @@ func TestDeleteSnapshotRemovesImageAndStoreEntry(t *testing.T) {
 		t.Fatalf("expected ErrNotFound after delete, got %v", err)
 	}
 }
+
+func TestGetSnapshotFindsByImageID(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "state.db")
+	st, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	defer st.Close()
+
+	snapshot := &models.SandboxSnapshot{
+		Name:            "demo-snapshot-by-id",
+		Image:           "snapshots/demo:by-id",
+		ImageID:         "sha256:demo-by-id",
+		SourceSandboxID: "sb-source",
+		CreatedAt:       time.Now().UTC().Round(0),
+	}
+	if err := st.CreateSnapshot(ctx, snapshot); err != nil {
+		t.Fatalf("CreateSnapshot() error = %v", err)
+	}
+
+	svc := &Service{store: st, docker: &fakeSnapshotRuntime{}, logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	got, err := svc.GetSnapshot(ctx, snapshot.ImageID)
+	if err != nil {
+		t.Fatalf("GetSnapshot() by image id error = %v", err)
+	}
+	if got.Name != snapshot.Name {
+		t.Fatalf("GetSnapshot() name = %q, want %q", got.Name, snapshot.Name)
+	}
+	if got.ImageID != snapshot.ImageID {
+		t.Fatalf("GetSnapshot() image id = %q, want %q", got.ImageID, snapshot.ImageID)
+	}
+}
+
+func TestListSnapshotsReturnsNewestFirst(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "state.db")
+	st, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	defer st.Close()
+
+	older := &models.SandboxSnapshot{
+		Name:            "demo-snapshot-older",
+		Image:           "snapshots/demo:older",
+		ImageID:         "sha256:older",
+		SourceSandboxID: "sb-source",
+		CreatedAt:       time.Now().UTC().Add(-time.Minute).Round(0),
+	}
+	newer := &models.SandboxSnapshot{
+		Name:            "demo-snapshot-newer",
+		Image:           "snapshots/demo:newer",
+		ImageID:         "sha256:newer",
+		SourceSandboxID: "sb-source",
+		CreatedAt:       time.Now().UTC().Round(0),
+	}
+	for _, snapshot := range []*models.SandboxSnapshot{older, newer} {
+		if err := st.CreateSnapshot(ctx, snapshot); err != nil {
+			t.Fatalf("CreateSnapshot(%q) error = %v", snapshot.Name, err)
+		}
+	}
+
+	svc := &Service{store: st, docker: &fakeSnapshotRuntime{}, logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	items, err := svc.ListSnapshots(ctx)
+	if err != nil {
+		t.Fatalf("ListSnapshots() error = %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("len(ListSnapshots()) = %d, want 2", len(items))
+	}
+	if items[0].Name != newer.Name || items[1].Name != older.Name {
+		t.Fatalf("ListSnapshots() order = [%s %s], want [%s %s]", items[0].Name, items[1].Name, newer.Name, older.Name)
+	}
+}


### PR DESCRIPTION
This pull request introduces several improvements and new features, focusing on enhanced testing for cluster components, improved deployment and versioning for the `toolboxd` binary, and better project documentation. The most significant changes are the addition of comprehensive tests for cluster logic, a new Ansible playbook for updating the `toolboxd` agent, and improved usability for version reporting and documentation.

**Testing and reliability improvements:**

* Added extensive new tests for cluster agent and cluster recovery logic, including deep copy validation, error handling, member lookup fallbacks, and recovery store garbage collection. New test files: `internal/cluster/helper_additional_test.go` and `internal/cluster/recovery_store_test.go`. [[1]](diffhunk://#diff-e854a3becc26d8b4d98846494b5f2aac8f606bd4ee9df04b4ce9460c6c932a6eR1-R241) [[2]](diffhunk://#diff-b92146d1d9af11424415a2071a654f48e3db1406d1f48c91540e524ce21abf3eR1-R226)
* Added a test for `LiveMemberCount` to ensure it correctly skips dead and blank nodes in `internal/cluster/topology_test.go`.

**Deployment and operational enhancements:**

* Introduced a new Ansible playbook, `update-toolboxd.yml`, for rolling out the `toolboxd` binary across the cluster. The playbook supports both local and remote binary sources, performs atomic swaps, and provides clear instructions and safety checks.
* Updated `group_vars/all.yml` to include the `toolboxd_binary_path` variable and documentation for the in-container agent.

**Usability and documentation:**

* Added a `--version` flag to the `toolboxd` binary (in `cmd/toolboxd/main.go`), allowing deployment tooling and operators to easily check the installed version without launching the daemon.
* Enhanced the `README.md` with CI/CD status badges for tests, releases, and SDK publishing, improving project visibility and status tracking.
---
<!--
GitHub auto-fills new PR descriptions with this template. Fill in EVERY
section below. "N/A — <one-line reason>" is a valid answer; an empty answer
is not. See pr-review.md at the repo root for what each section is asking.
-->

## Summary

- Introduced unit tests for network statistics and service runtime functionalities to ensure reliability and correctness.
- Enhanced existing tests for snapshot retrieval and listing to improve coverage.

## Sandbox boot impact

N/A — no work added to sandbox boot path.

## Idempotency

N/A — no API surface changed.

## Failure-path consistency

N/A — no multi-step write path changed.

## L4 / host-port-pool changes

N/A — neither touched.

## Test plan

- Verified functionality by running all new and existing tests.
- Ensured all tests pass without errors.

