### PR TITLE
feat: implement input handling for Daytona session commands and add corresponding tests

### DIFF
--- a/cmd/toolboxd/daytona_process.go
+++ b/cmd/toolboxd/daytona_process.go
@@ -76,6 +76,10 @@ type daytonaSessionLogsResponse struct {
 	Stdout string `json:"stdout"`
 }
 
+type daytonaSessionInputRequest struct {
+	Data string `json:"data"`
+}
+
 func newDaytonaCompat() *daytonaCompat {
 	return &daytonaCompat{sessions: map[string]*daytonaSessionState{}}
 }
@@ -259,10 +263,47 @@ func (s *server) handleDaytonaSessionCommandRoute(w http.ResponseWriter, r *http
 		}
 		s.handleDaytonaSessionCommandLogs(w, r, sessionID, commandID)
 	case "input":
-		writeError(w, http.StatusNotImplemented, "interactive command input is not implemented")
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		s.handleDaytonaSessionCommandInput(w, r, sessionID, commandID)
 	default:
 		writeError(w, http.StatusNotFound, "not found")
 	}
+}
+
+// handleDaytonaSessionCommandInput forwards bytes from a Daytona-style
+// {"data": "..."} payload to the session's stdin. The shell that backs the
+// session reads stdin one byte at a time when stdin is a pipe (a documented
+// bash behavior for non-interactive scripts), so a `read` builtin inside the
+// running command picks up the input directly — no shared-buffer races with
+// the wrapper's end marker. Data is written verbatim; callers that need a
+// trailing newline must include it.
+func (s *server) handleDaytonaSessionCommandInput(w http.ResponseWriter, r *http.Request, sessionID, commandID string) {
+	sess, state, ok := s.lookupDaytonaSession(sessionID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	if _, ok := state.command(commandID); !ok {
+		writeError(w, http.StatusNotFound, "command not found")
+		return
+	}
+	if !state.acceptsInput(commandID) {
+		writeError(w, http.StatusConflict, "command is not currently accepting input")
+		return
+	}
+	var req daytonaSessionInputRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if _, err := sess.Write([]byte(req.Data)); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusOK)
 }
 
 func (s *server) handleDaytonaSessionCreate(w http.ResponseWriter, r *http.Request) {
@@ -433,7 +474,14 @@ func (s *server) runDaytonaSessionCommand(sess *sessions.Session, state *daytona
 	defer cancel()
 	state.setActive(command.id)
 
-	payload := "printf '%s\\n' " + shellSingleQuote(startMarker) + "\n" + command.command + "\n__sb_daytona_status=$?\nprintf '%s:%s\\n' " + shellSingleQuote(endMarker) + " \"$__sb_daytona_status\"\n"
+	// Wrap the user command in a `{ ... }` brace group joined by semicolons so
+	// the wrapper is a single compound statement. Bash buffers its stdin and
+	// parses the entire compound before executing — without the group, a
+	// `read` inside the user command would consume the wrapper's own follow-up
+	// lines (status capture, end marker) from bash's parse buffer instead of
+	// waiting for input. The trailing newline before `}` lets the user's last
+	// command terminate normally.
+	payload := "printf '%s\\n' " + shellSingleQuote(startMarker) + "; { " + command.command + "\n}; __sb_daytona_status=$?; printf '%s:%s\\n' " + shellSingleQuote(endMarker) + " \"$__sb_daytona_status\"\n"
 	if _, err := sess.Write([]byte(payload)); err != nil {
 		state.finishCommand(command.id, "", err.Error(), 1)
 		return nil, err

--- a/cmd/toolboxd/daytona_process_test.go
+++ b/cmd/toolboxd/daytona_process_test.go
@@ -8,7 +8,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/aerol-ai/microvm/cmd/toolboxd/sessions"
 )
@@ -107,4 +109,120 @@ func TestHandleDaytonaProcessRouteSessionLifecycle(t *testing.T) {
 	if deleteRec.Code != http.StatusNoContent {
 		t.Fatalf("delete status = %d", deleteRec.Code)
 	}
+}
+
+func TestHandleDaytonaSessionCommandInputDeliversStdin(t *testing.T) {
+	srv := newDaytonaTestServer(t)
+
+	createReq := httptest.NewRequest(http.MethodPost, "/process/session",
+		bytes.NewBufferString(`{"sessionId":"input-session"}`))
+	createRec := httptest.NewRecorder()
+	if !srv.handleDaytonaProcessRoute(createRec, createReq) {
+		t.Fatal("expected create route to be handled")
+	}
+
+	// Run an async interactive command that blocks on `read` until we send input.
+	execBody := `{"command":"read name && printf 'Hello, %s' \"$name\"","runAsync":true}`
+	execReq := httptest.NewRequest(http.MethodPost, "/process/session/input-session/exec",
+		bytes.NewBufferString(execBody))
+	execRec := httptest.NewRecorder()
+	if !srv.handleDaytonaProcessRoute(execRec, execReq) {
+		t.Fatal("expected exec route to be handled")
+	}
+	if execRec.Code != http.StatusOK {
+		t.Fatalf("async exec status = %d body=%s", execRec.Code, execRec.Body.String())
+	}
+	var execResp daytonaSessionExecuteResponse
+	if err := json.Unmarshal(execRec.Body.Bytes(), &execResp); err != nil {
+		t.Fatalf("decode exec response: %v", err)
+	}
+	if execResp.CmdID == "" {
+		t.Fatal("expected cmdId in async exec response")
+	}
+
+	// Wait for the goroutine to mark the command active before sending input.
+	if !waitForActiveCommand(t, srv, "input-session", execResp.CmdID, 2*time.Second) {
+		t.Fatal("command never reached the active state")
+	}
+
+	inputReq := httptest.NewRequest(http.MethodPost,
+		"/process/session/input-session/command/"+execResp.CmdID+"/input",
+		bytes.NewBufferString(`{"data":"Alice\n"}`))
+	inputRec := httptest.NewRecorder()
+	if !srv.handleDaytonaProcessRoute(inputRec, inputReq) {
+		t.Fatal("expected input route to be handled")
+	}
+	if inputRec.Code != http.StatusOK {
+		t.Fatalf("input status = %d body=%s", inputRec.Code, inputRec.Body.String())
+	}
+
+	// Once the command receives the line, the wrapper script prints the end
+	// marker and finishCommand records stdout. Poll until that happens.
+	if !waitForCommandStdoutContains(t, srv, "input-session", execResp.CmdID, "Hello, Alice", 3*time.Second) {
+		t.Fatal("never saw expected stdout from interactive command")
+	}
+}
+
+func TestHandleDaytonaSessionCommandInputRejectsInactive(t *testing.T) {
+	srv := newDaytonaTestServer(t)
+
+	createReq := httptest.NewRequest(http.MethodPost, "/process/session",
+		bytes.NewBufferString(`{"sessionId":"input-session-2"}`))
+	createRec := httptest.NewRecorder()
+	if !srv.handleDaytonaProcessRoute(createRec, createReq) {
+		t.Fatal("expected create route to be handled")
+	}
+
+	// Sync exec — the command is finished before the response returns.
+	execReq := httptest.NewRequest(http.MethodPost, "/process/session/input-session-2/exec",
+		bytes.NewBufferString(`{"command":"printf done"}`))
+	execRec := httptest.NewRecorder()
+	if !srv.handleDaytonaProcessRoute(execRec, execReq) {
+		t.Fatal("expected exec route to be handled")
+	}
+	if execRec.Code != http.StatusOK {
+		t.Fatalf("sync exec status = %d", execRec.Code)
+	}
+	var execResp daytonaSessionExecuteResponse
+	if err := json.Unmarshal(execRec.Body.Bytes(), &execResp); err != nil {
+		t.Fatalf("decode exec response: %v", err)
+	}
+
+	inputReq := httptest.NewRequest(http.MethodPost,
+		"/process/session/input-session-2/command/"+execResp.CmdID+"/input",
+		bytes.NewBufferString(`{"data":"hi\n"}`))
+	inputRec := httptest.NewRecorder()
+	if !srv.handleDaytonaProcessRoute(inputRec, inputReq) {
+		t.Fatal("expected input route to be handled")
+	}
+	if inputRec.Code != http.StatusConflict {
+		t.Fatalf("input status = %d, want %d, body=%s",
+			inputRec.Code, http.StatusConflict, inputRec.Body.String())
+	}
+}
+
+func waitForActiveCommand(t *testing.T, srv *server, sessionID, commandID string, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, state, ok := srv.lookupDaytonaSession(sessionID); ok && state.acceptsInput(commandID) {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+func waitForCommandStdoutContains(t *testing.T, srv *server, sessionID, commandID, want string, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, state, ok := srv.lookupDaytonaSession(sessionID); ok {
+			if cmd, found := state.command(commandID); found && strings.Contains(cmd.stdout, want) {
+				return true
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
 }


### PR DESCRIPTION
This pull request adds support for interactive command input in Daytona sessions, allowing clients to send data to a running command's standard input (stdin). It introduces a new API endpoint to deliver input, updates the session command wrapper to handle interactive commands correctly, and provides comprehensive tests for these new behaviors.

**Interactive command input support:**

* Added a new `daytonaSessionInputRequest` struct and implemented the `/input` route to accept POST requests with a `{"data": ...}` payload, forwarding the data to the session's stdin. This enables interactive commands to receive input during execution. [[1]](diffhunk://#diff-5d39854fec42de3efffa8d035f66ed704fa86f6eb595600a3b89741dc74fea72R79-R82) [[2]](diffhunk://#diff-5d39854fec42de3efffa8d035f66ed704fa86f6eb595600a3b89741dc74fea72L262-R308)

* Improved the shell command wrapper in `runDaytonaSessionCommand` to use a brace group, preventing bash from pre-consuming input meant for the user command. This change ensures that interactive commands like `read` work as expected.

**Testing enhancements:**

* Added tests to verify that input is delivered to interactive commands and that input is rejected when the command is not active, ensuring robust handling of both success and error cases. Helper functions were introduced for polling command state and output.

* Updated imports in the test file to support new test logic.