### PR TITLE
fix: improve end marker handling in Daytona session command logs to prevent stalling on short outputs

### DIFF
--- a/cmd/toolboxd/daytona_process.go
+++ b/cmd/toolboxd/daytona_process.go
@@ -760,11 +760,13 @@ func (s *server) runDaytonaSessionCommand(sess *sessions.Session, state *daytona
 				Stdout:   stringOrNil(stdoutText),
 			}, nil
 		}
-		// No end marker yet: broadcast everything except a trailing
-		// window that could still resolve into the marker. Holding back
-		// len(pattern)-1 bytes is the minimum safe — a full marker is
-		// only possible once we have len(pattern) bytes of buffer.
-		hold := len(pattern) - 1
+		// No end marker yet. Only hold back the trailing window that is
+		// actually a partial prefix of the end marker — anything else
+		// can be broadcast immediately. A naive `hold := len(pattern)-1`
+		// would stall short outputs ("Enter name: \n" = 18 bytes,
+		// pattern = ~34 bytes) until enough later text accumulates,
+		// which never happens for interactive commands blocked on stdin.
+		hold := longestEndMarkerPrefixSuffix(captured, pattern)
 		if safeLen := len(captured) - hold; safeLen > stdoutBroadcasted {
 			command.stream.broadcast(sessions.StreamStdout, []byte(captured[stdoutBroadcasted:safeLen]))
 			stdoutBroadcasted = safeLen
@@ -803,6 +805,24 @@ func newDaytonaCommandID() (string, error) {
 
 func shellSingleQuote(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}
+
+// longestEndMarkerPrefixSuffix returns the length of the longest trailing
+// substring of `captured` that is also a prefix of `pattern`. Used by the
+// streaming runner to decide how many bytes at the end of the stdout
+// buffer MUST stay un-broadcast in case they turn out to be the start of
+// the end marker. Any shorter suffix is safe to flush immediately, which
+// is what makes short interactive output (e.g. "Enter name: \n") visible
+// to /logs?follow=true subscribers without waiting for the command to
+// finish.
+func longestEndMarkerPrefixSuffix(captured, pattern string) int {
+	maxLen := min(len(pattern)-1, len(captured))
+	for k := maxLen; k > 0; k-- {
+		if strings.HasPrefix(pattern, captured[len(captured)-k:]) {
+			return k
+		}
+	}
+	return 0
 }
 
 func int32Ptr(value int32) *int32 {

--- a/cmd/toolboxd/daytona_process_test.go
+++ b/cmd/toolboxd/daytona_process_test.go
@@ -229,6 +229,101 @@ func waitForCommandStdoutContains(t *testing.T, srv *server, sessionID, commandI
 	return false
 }
 
+// TestLongestEndMarkerPrefixSuffix pins the rolling-match behavior that
+// decides how many trailing bytes the streaming runner must withhold
+// from /logs?follow=true subscribers. Getting this wrong stalls
+// interactive commands (short output, blocked on stdin) because the
+// fixed hold-back kept everything inside the buffer.
+func TestLongestEndMarkerPrefixSuffix(t *testing.T) {
+	pattern := "__SB_DAYTONA_END_abcd__:"
+	tests := []struct {
+		name     string
+		captured string
+		want     int
+	}{
+		{"no overlap — flush all", "Enter your name: \n", 0},
+		{"trailing newline — flush all", "Hello, Alice\n", 0},
+		{"buffer ends with marker prefix", "some output __SB_", 5},
+		{"buffer ends with longer prefix", "x__SB_DAYTONA", 12},
+		{"trailing single underscore — partial start", "blah_", 1},
+		{"empty buffer", "", 0},
+		{"buffer shorter than any prefix", "ab", 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := longestEndMarkerPrefixSuffix(tc.captured, pattern)
+			if got != tc.want {
+				t.Fatalf("longestEndMarkerPrefixSuffix(%q, ...) = %d, want %d",
+					tc.captured, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHandleDaytonaSessionCommandLogsFollowStreamsShortOutput pins the
+// regression case behind the hold-back fix: a command that prints a
+// short prompt and then blocks on stdin must still surface that prompt
+// over the WebSocket promptly, well before the command itself finishes.
+func TestHandleDaytonaSessionCommandLogsFollowStreamsShortOutput(t *testing.T) {
+	srv := newDaytonaTestServer(t)
+
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !srv.handleDaytonaProcessRoute(w, r) {
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(httpSrv.Close)
+
+	createResp, err := http.Post(httpSrv.URL+"/process/session", "application/json",
+		bytes.NewBufferString(`{"sessionId":"short-output-session"}`))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	_ = createResp.Body.Close()
+
+	// printf then read — read blocks forever (no input sent), so the
+	// command never reaches its end marker. The prompt MUST still
+	// appear on the WS before we time out the test.
+	execBody := `{"command":"printf 'Enter your name: ' ; read name","runAsync":true}`
+	execResp, err := http.Post(httpSrv.URL+"/process/session/short-output-session/exec",
+		"application/json", bytes.NewBufferString(execBody))
+	if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	defer execResp.Body.Close()
+	var execPayload daytonaSessionExecuteResponse
+	if err := json.NewDecoder(execResp.Body).Decode(&execPayload); err != nil {
+		t.Fatalf("decode exec: %v", err)
+	}
+
+	wsURL := strings.Replace(httpSrv.URL, "http://", "ws://", 1) +
+		"/process/session/short-output-session/command/" + execPayload.CmdID + "/logs?follow=true"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("WS dial: %v", err)
+	}
+	defer conn.Close()
+
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var collected []byte
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		_, payload, err := conn.ReadMessage()
+		if err != nil {
+			break
+		}
+		collected = append(collected, payload...)
+		demuxed := bytes.ReplaceAll(collected, daytonaStdoutPrefix, nil)
+		demuxed = bytes.ReplaceAll(demuxed, daytonaStderrPrefix, nil)
+		if bytes.Contains(demuxed, []byte("Enter your name:")) {
+			return
+		}
+	}
+	demuxed := bytes.ReplaceAll(collected, daytonaStdoutPrefix, nil)
+	demuxed = bytes.ReplaceAll(demuxed, daytonaStderrPrefix, nil)
+	t.Fatalf("never saw the prompt on the WS within 2s; got %q", demuxed)
+}
+
 // TestHandleDaytonaSessionCommandLogsFollowStreamsWebSocket pins the
 // /process/session/{sid}/command/{cid}/logs?follow=true contract: the
 // handler must accept a WebSocket upgrade and emit stdout/stderr chunks


### PR DESCRIPTION
This pull request improves the streaming of command output for interactive Daytona sessions by making the output more responsive, especially for commands that prompt for input and then block. The main change is a smarter algorithm that determines how much of the output buffer to withhold to avoid accidentally sending part of the end marker, which previously caused short outputs to be delayed. The update is well-covered with new unit and regression tests.

**Streaming logic improvements:**

* Replaced the fixed hold-back logic with a new `longestEndMarkerPrefixSuffix` function that calculates the minimal safe trailing window to withhold, ensuring that short interactive outputs (like prompts) are sent to clients immediately without waiting for the command to finish.
* Added the `longestEndMarkerPrefixSuffix` function to implement the above logic, with comments explaining its purpose and use.

**Testing improvements:**

* Added a unit test `TestLongestEndMarkerPrefixSuffix` to pin the behavior of the new buffer-hold logic and verify correctness in edge cases.
* Added a regression test `TestHandleDaytonaSessionCommandLogsFollowStreamsShortOutput` to ensure that short prompts from interactive commands are surfaced promptly over WebSocket, fixing the previous stall issue.
<!--
GitHub auto-fills new PR descriptions with this template. Fill in EVERY
section below. "N/A — <one-line reason>" is a valid answer; an empty answer
is not. See pr-review.md at the repo root for what each section is asking.
-->