### PR TITLE
Fix session command input handling to append trailing newline

### DIFF
--- a/cmd/toolboxd/daytona_process.go
+++ b/cmd/toolboxd/daytona_process.go
@@ -417,8 +417,16 @@ func (s *server) handleDaytonaSessionCommandRoute(w http.ResponseWriter, r *http
 // session reads stdin one byte at a time when stdin is a pipe (a documented
 // bash behavior for non-interactive scripts), so a `read` builtin inside the
 // running command picks up the input directly — no shared-buffer races with
-// the wrapper's end marker. Data is written verbatim; callers that need a
-// trailing newline must include it.
+// the wrapper's end marker.
+//
+// We append a trailing newline if the payload doesn't already end in one
+// (\n or \r). Daytona's own SDK helper `sendSessionCommandInput(sid, cid,
+// 'Alice')` ships line-oriented examples that omit the terminator, and
+// bash's `read` builtin blocks forever without it, so verbatim forwarding
+// silently hangs interactive commands. Auto-terminating preserves the
+// obvious semantics ("send a line of input"), matches what the Daytona
+// platform appears to do, and still lets explicit-newline callers send
+// multi-line input by including their own \n bytes.
 func (s *server) handleDaytonaSessionCommandInput(w http.ResponseWriter, r *http.Request, sessionID, commandID string) {
 	sess, state, ok := s.lookupDaytonaSession(sessionID)
 	if !ok {
@@ -438,7 +446,11 @@ func (s *server) handleDaytonaSessionCommandInput(w http.ResponseWriter, r *http
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-	if _, err := sess.Write([]byte(req.Data)); err != nil {
+	data := req.Data
+	if !strings.HasSuffix(data, "\n") && !strings.HasSuffix(data, "\r") {
+		data += "\n"
+	}
+	if _, err := sess.Write([]byte(data)); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/cmd/toolboxd/daytona_process_test.go
+++ b/cmd/toolboxd/daytona_process_test.go
@@ -165,6 +165,57 @@ func TestHandleDaytonaSessionCommandInputDeliversStdin(t *testing.T) {
 	}
 }
 
+// TestHandleDaytonaSessionCommandInputAutoTerminates pins the auto-newline
+// accommodation: bash's `read` blocks until EOL, and the Daytona SDK's
+// sendSessionCommandInput helper ships examples that omit the trailing \n.
+// The server appends one when missing so the "send a line of input" intent
+// works without forcing callers to know the bash detail.
+func TestHandleDaytonaSessionCommandInputAutoTerminates(t *testing.T) {
+	srv := newDaytonaTestServer(t)
+
+	createReq := httptest.NewRequest(http.MethodPost, "/process/session",
+		bytes.NewBufferString(`{"sessionId":"auto-newline-session"}`))
+	createRec := httptest.NewRecorder()
+	if !srv.handleDaytonaProcessRoute(createRec, createReq) {
+		t.Fatal("expected create route to be handled")
+	}
+
+	execBody := `{"command":"read name && printf 'Hello, %s' \"$name\"","runAsync":true}`
+	execReq := httptest.NewRequest(http.MethodPost, "/process/session/auto-newline-session/exec",
+		bytes.NewBufferString(execBody))
+	execRec := httptest.NewRecorder()
+	if !srv.handleDaytonaProcessRoute(execRec, execReq) {
+		t.Fatal("expected exec route to be handled")
+	}
+	var execResp daytonaSessionExecuteResponse
+	if err := json.Unmarshal(execRec.Body.Bytes(), &execResp); err != nil {
+		t.Fatalf("decode exec response: %v", err)
+	}
+
+	if !waitForActiveCommand(t, srv, "auto-newline-session", execResp.CmdID, 2*time.Second) {
+		t.Fatal("command never reached the active state")
+	}
+
+	// Send the input without a trailing newline, matching what the
+	// Daytona SDK does for `sendSessionCommandInput(sid, cid, 'Alice')`.
+	inputReq := httptest.NewRequest(http.MethodPost,
+		"/process/session/auto-newline-session/command/"+execResp.CmdID+"/input",
+		bytes.NewBufferString(`{"data":"Alice"}`))
+	inputRec := httptest.NewRecorder()
+	if !srv.handleDaytonaProcessRoute(inputRec, inputReq) {
+		t.Fatal("expected input route to be handled")
+	}
+	if inputRec.Code != http.StatusOK {
+		t.Fatalf("input status = %d body=%s", inputRec.Code, inputRec.Body.String())
+	}
+
+	// The command should still complete, proving that the server
+	// supplied the missing newline for `read`.
+	if !waitForCommandStdoutContains(t, srv, "auto-newline-session", execResp.CmdID, "Hello, Alice", 3*time.Second) {
+		t.Fatal("command never received the input (no auto-newline?)")
+	}
+}
+
 func TestHandleDaytonaSessionCommandInputRejectsInactive(t *testing.T) {
 	srv := newDaytonaTestServer(t)
 

--- a/pkg/api/daytona/toolbox_proxy_test.go
+++ b/pkg/api/daytona/toolbox_proxy_test.go
@@ -137,7 +137,14 @@ func newToolboxProxyTestEnv(t *testing.T) *toolboxProxyTestEnv {
 		_, _, _ = conn.ReadMessage()
 	}
 	mux.HandleFunc("/process/interpreter/execute", wsHandler)
-	mux.HandleFunc("/process/session/", wsHandler)
+	mux.HandleFunc("/process/session", echoOK)
+	mux.HandleFunc("/process/session/", func(w http.ResponseWriter, r *http.Request) {
+		if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+			wsHandler(w, r)
+			return
+		}
+		echoOK(w, r)
+	})
 
 	toolboxServer := httptest.NewServer(mux)
 	wsClose = toolboxServer.Close
@@ -419,6 +426,10 @@ func TestToolboxProxyForwardedRoutes(t *testing.T) {
 		// pty (bare path covers list + create)
 		{"createPty", "pty", http.MethodPost, "/process/pty", "/process/pty"},
 		{"listPty", "pty", http.MethodGet, "/process/pty", "/process/pty"},
+		// exec-command session lifecycle + stdin
+		{"createSession", "exec-command", http.MethodPost, "/process/session", "/process/session"},
+		{"sessionExec", "exec-command", http.MethodPost, "/process/session/s1/exec", "/process/session/s1/exec"},
+		{"sessionInput", "exec-command", http.MethodPost, "/process/session/s1/command/c1/input", "/process/session/s1/command/c1/input"},
 	}
 
 	env := newToolboxProxyTestEnv(t)


### PR DESCRIPTION
<!--
GitHub auto-fills new PR descriptions with this template. Fill in EVERY
section below. "N/A — <one-line reason>" is a valid answer; an empty answer
is not. See pr-review.md at the repo root for what each section is asking.
-->

## Summary

- Append a trailing newline to session command input to prevent blocking in bash.
- Ensure compatibility with Daytona SDK examples that omit the newline.

## Sandbox boot impact

N/A — no work added to sandbox boot path.

## Idempotency

N/A — no API surface changed.

## Failure-path consistency

N/A — no multi-step write path changed.

## L4 / host-port-pool changes

N/A — neither touched.

## Test plan

- Added unit tests to verify that the server appends a newline when missing.
- Confirmed that commands complete successfully with and without the newline.

