### PR TITLE
Implement AOCR integration, serverless sandboxes, and auto-import reconciler

### DIFF
--- a/AUTHENTICATED_MIRROR.md
+++ b/AUTHENTICATED_MIRROR.md
@@ -1,0 +1,143 @@
+# Authenticated Mirror & Auto-Import
+
+This document is the operator reference for the AerolVM-side knobs that
+route sandbox image pulls through the AOCR authenticated mirror and
+optionally auto-import private upstream images into the cluster namespace
+after first pull.
+
+> Companion reading: `aocr.sh/MIRROR.md` (mirror server architecture),
+> `aocr.sh/plans/cluster-mirror-and-snapshot-distribution.md` (full spec,
+> phases F17-F21), and `pkg/docker/pull_mirror.go` (rewrite implementation).
+
+## What this gives you
+
+When `SB_MIRROR_HOST` is configured, sandboxd rewrites every public-registry
+pull (`ghcr.io`, `gcr.io`, `quay.io`, `registry.k8s.io` by default) onto the
+AOCR mirror vhost. Two things follow:
+
+1. **Bytes are cached cluster-side.** Repeated pulls of the same image
+   across the cluster hit the mirror's S3 backend, not the upstream — no
+   rate limiting, no upstream outage exposure.
+2. **Per-pull credentials never leave the node.** With `SB_UPSTREAM_WRAP_KEY_PATH`
+   configured, sandboxd wraps the upstream PAT/password into an opaque
+   `identitytoken` that only AOCR's mirror auth can unwrap. Docker daemons
+   see the wrapped form on the wire; the mirror unwraps it server-side and
+   uses the underlying credential to authenticate to the upstream.
+
+When `SB_AUTO_IMPORT_ENABLED=true` is added on top, sandboxd asks AOCR to
+re-mount the just-cached bytes under the cluster's own namespace
+(`cluster/<id>/_imported/<host>/<repo>`) after each successful private
+pull. Subsequent failovers pull from the cluster namespace with a cluster
+PAT — fully decoupled from the original upstream credential, surviving
+upstream password rotations that would otherwise break F17 wrap-creds.
+
+Docker Hub (`docker.io`) is intentionally **not** rewritten — operators
+should configure that on the daemon's `registry-mirrors` setting instead.
+
+## Required vs optional
+
+| Goal                                        | Required env vars                                                                                                  |
+|---------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| Mirror-cached public pulls                  | `SB_MIRROR_HOST`                                                                                                   |
+| Mirror-cached **private** pulls (no leak)   | `SB_MIRROR_HOST` + `SB_UPSTREAM_WRAP_KEY_PATH`                                                                     |
+| + Post-pull auto-import into cluster ns     | All of the above + `SB_AUTO_IMPORT_ENABLED=true` + `SB_AUTO_IMPORT_HOOKS_URL` + `SB_AUTO_IMPORT_CLUSTER_ID` + `SB_AUTO_IMPORT_CLUSTER_PAT_PATH` |
+
+`SB_MIRROR_HOST` is the only piece that has to be in place for any of this
+to function — everything else is additive.
+
+## Environment variables
+
+### Mirror rewrite
+
+| Variable                     | Default                                                            | Purpose                                                                                                                                                |
+|------------------------------|--------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `SB_MIRROR_HOST`             | *(empty — disables rewrite)*                                       | Mirror vhost for cached pulls, e.g. `mirror.aocr.aerol.ai`. When empty, all upstream refs are passed through unchanged.                               |
+| `SB_MIRROR_PUSH_HOST`        | *(empty)*                                                          | Push vhost for the same AOCR cluster (e.g. `aocr.aerol.ai`). Refs already pointing here are left alone so they are not double-rewritten.              |
+| `SB_MIRROR_UPSTREAMS`        | `ghcr.io=ghcr,gcr.io=gcr,quay.io=quay,registry.k8s.io=k8s`         | Comma-separated `host=shortname` map controlling which upstreams get rewritten and the short name used in the rewritten ref (`mirror/_/<short>/...`). |
+| `SB_UPSTREAM_WRAP_KEY_PATH`  | *(empty — soft-fail to raw creds)*                                 | Path to the base64-encoded 32-byte upstream wrap key. When unset, pulls are still rewritten but creds go to the mirror unwrapped (public images only). |
+
+`SB_UPSTREAM_WRAP_KEY_PATH` is intentionally **soft-fail**: a missing key
+logs a warning and rewriting continues. Anonymous pulls (public images)
+still work; private upstreams will 401 at the mirror. This matches the
+production rollout where the wrap key is templated in by Kubernetes after
+the first deploy.
+
+### Auto-import (F21)
+
+| Variable                              | Default        | Purpose                                                                                                                                          |
+|---------------------------------------|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| `SB_AUTO_IMPORT_ENABLED`              | `false`        | Master switch. When false, the post-pull hook never fires and the reconciler never starts.                                                       |
+| `SB_AUTO_IMPORT_HOOKS_URL`            | *(required)*   | AOCR hooks service root, no trailing slash, e.g. `https://aocr.aerol.ai`. The importer appends `/v1/internal/imports`.                          |
+| `SB_AUTO_IMPORT_CLUSTER_ID`           | *(required)*   | Identifies this sandboxd cluster on the AOCR side. Goes into the import payload and scopes the cluster PAT.                                      |
+| `SB_AUTO_IMPORT_CLUSTER_PAT_PATH`     | *(required)*   | Path to a file containing the cluster PAT bearer token. Sourced from file (not env) so it can be a Kubernetes Secret without escaping the value. |
+| `SB_AUTO_IMPORT_RETENTION_SUFFIX`     | `--idle-90d`   | Suffix appended to the imported tag in the cluster namespace. Must start with `--`. Drives the reaper's idle-eviction window (see `RETENTION.md`). |
+| `SB_AUTO_IMPORT_REQUEST_TIMEOUT`      | `15s`          | Per-call timeout for the ImportAPI POST. The mount-from-repo flow is normally sub-second; the timeout guards against an upstream layer-list hang.|
+| `SB_AUTO_IMPORT_RECONCILE_INTERVAL`   | `5m`           | Ticker period for the local `auto_import_pending` reconciler. Must be > 0. Lower values increase Docker daemon load on recovery.                 |
+| `SB_AUTO_IMPORT_MAX_IN_FLIGHT`        | `4`            | Bounded fan-out cap for one sweep. Keeps a recovery storm from saturating the local Docker daemon or AOCR.                                       |
+
+If `SB_AUTO_IMPORT_ENABLED=true` is set without one of the three
+required pieces (`HOOKS_URL`, `CLUSTER_ID`, `CLUSTER_PAT_PATH`),
+sandboxd refuses to start with a config-validation error rather than
+silently degrading.
+
+## Operational notes
+
+- **PAT file format.** `SB_AUTO_IMPORT_CLUSTER_PAT_PATH` is read once at
+  startup. A trailing newline is tolerated (common when generating with
+  `echo ... > pat`). Rotate by replacing the file and restarting sandboxd.
+- **Wrap key format.** `SB_UPSTREAM_WRAP_KEY_PATH` must contain a
+  base64-encoded 32-byte key. Rotate by deploying the new key alongside
+  the old in the key ring (see `pkg/secrets/upstream_wrap.go`); sandboxd
+  reads on startup so a rolling restart picks up new keys.
+- **Reconciler is per-node, no leader election.** Each worker runs its
+  own ticker against its local `auto_import_pending` rows. The reconciler
+  is idempotent: a second successful import for an already-imported tag
+  is a no-op (`AlreadyPresent=true`).
+- **Spec write-back is best-effort.** A successful import flips the
+  replicated `CreateSandboxRequest.ImageDistributionMode` to
+  `aocr_imported` and rewrites `ImageRegistryRef` to point at the
+  cluster-side ref. The write goes through the Raft leader; non-leader
+  forwarding failures are logged and absorbed because the imported
+  bytes are already in AOCR and future pulls of the original ref still
+  resolve cleanly through the mirror.
+- **Standalone (single-node) mode.** With no cluster, `cluster.Client.SpecOf`
+  returns nil. The reconciler treats that as "drop the flag, nothing to
+  retry" — recreate is already impossible without a replicated spec.
+
+## Kubernetes example
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata: { name: sandboxd-mirror }
+data:
+  SB_MIRROR_HOST: "mirror.aocr.aerol.ai"
+  SB_MIRROR_PUSH_HOST: "aocr.aerol.ai"
+  SB_AUTO_IMPORT_ENABLED: "true"
+  SB_AUTO_IMPORT_HOOKS_URL: "https://aocr.aerol.ai"
+  SB_AUTO_IMPORT_CLUSTER_ID: "prod-us-east-1"
+  SB_AUTO_IMPORT_CLUSTER_PAT_PATH: "/etc/aocr/cluster-pat"
+  SB_UPSTREAM_WRAP_KEY_PATH: "/etc/aocr/upstream-wrap-key"
+---
+apiVersion: v1
+kind: Secret
+metadata: { name: sandboxd-aocr-secrets }
+stringData:
+  cluster-pat: "aocr_cluster_xxxxxxxxxxxxxxxxxxxxxxxx"
+  upstream-wrap-key: "base64-32-bytes-here=="
+```
+
+Mount both files into the sandboxd Pod at the paths above and reference
+the ConfigMap with `envFrom`. The Secret is the authoritative storage for
+both tokens; the env vars are just file paths so rotation does not
+restart-thrash the ConfigMap.
+
+## Troubleshooting
+
+| Symptom                                                      | Likely cause                                                                                                                     |
+|--------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| All pulls work, mirror cache stays empty.                    | `SB_MIRROR_HOST` empty, or upstream not in `SB_MIRROR_UPSTREAMS`. Check sandboxd logs for `mirror not configured`.              |
+| Private upstream pulls 401 at the mirror.                    | `SB_UPSTREAM_WRAP_KEY_PATH` missing or wrong format. Sandboxd logs a warning at startup; mirror logs the unwrap failure.        |
+| `auto-import reconcile sweep failed: ...`                    | `auto_import_pending` rows piling up. Check `SB_AUTO_IMPORT_HOOKS_URL` reachability + cluster PAT validity at AOCR `/v1/internal/imports`. |
+| Reconciler logs `drop pending flag: no spec`.                | The sandbox row was flagged but no replicated spec exists (standalone mode, or pre-cluster sandbox). Expected; not an error.    |
+| Spec still shows `external_registry` after import succeeded. | Spec write-back hit a non-leader/Raft error. Bytes are imported and pullable; the spec refreshes on the next mutation.          |

--- a/Ansible/README.md
+++ b/Ansible/README.md
@@ -168,6 +168,201 @@ playbooks/
   tail-logs.yml        # journalctl across the fleet
 ```
 
+## Connect this cluster to AOCR (mirror + auto-import)
+
+If you operate an [AOCR](https://github.com/aerolai/aocr) deployment alongside
+this cluster, you can route every public-registry pull through AOCR's
+authenticated mirror — and optionally auto-import each first pull into a
+cluster-owned namespace so future failovers are decoupled from the original
+upstream credential. The defaults in `inventory/group_vars/all.yml` and the
+secret-copy + env-template tasks in `playbooks/configure-ops.yml` are
+already in place. Enabling it requires zero code edits — only values and
+two secret files on the control node.
+
+Use this path if you bootstrapped nodes with Ansible only, or if you want to
+flip the AOCR wiring on existing nodes without recycling EC2 instances
+(Terraform's path replaces them).
+
+For the threat model and per-node env-var contract, read
+[`../AUTHENTICATED_MIRROR.md`](../AUTHENTICATED_MIRROR.md). For AOCR-side
+architecture, read
+[`aocr.sh/MIRROR.md`](https://github.com/aerolai/aocr/blob/main/MIRROR.md).
+For the full end-to-end deploy + stitch story, read
+[`aocr.sh/aocr_aerol_stitch.md`](https://github.com/aerolai/aocr/blob/main/aocr_aerol_stitch.md).
+
+### Step 1 — Pull values from your AOCR side
+
+The AOCR Ansible playbook auto-generates every secret on first deploy. After
+you've run it once, the values you need are in `aocr.sh/secrets/` and
+`aocr.sh/ansible/inventory/group_vars/all/vars.yml`:
+
+```bash
+cd /path/to/aocr.sh
+
+# 1. Mirror host — derived from your aocr_global_domain
+#    Default is "mirror." + aocr_global_domain (e.g. mirror.aocr.aerol.ai).
+grep aocr_global_domain ansible/inventory/group_vars/all/vars.yml
+
+# 2. Upstream wrap key (base64, 32 bytes) — required for private upstream pulls
+cat secrets/upstream_wrap_key
+
+# 3. Internal API token (64-char bearer) — only for auto-import
+cat secrets/internal_api_token
+
+# 4. Hooks URL — the AOCR root, no trailing slash (e.g. https://aocr.aerol.ai)
+```
+
+> **Where does the value actually live?** Each AOCR secret is *either* a
+> generated file under `aocr.sh/secrets/` (default on first deploy) *or* an
+> inline override in `aocr.sh/ansible/inventory/group_vars/all/secrets.yml`
+> (the deploy playbook skips file generation when the override is set). If
+> `cat secrets/upstream_wrap_key` errors with "No such file or directory",
+> grep `secrets.yml` for the matching `aocr_*` key instead:
+>
+> ```bash
+> cd /path/to/aocr.sh
+> # Falls back from inline override → generated file
+> aocr_secret() {
+>   local s="ansible/inventory/group_vars/all/secrets.yml" v
+>   v=$(awk -F'"' -v k="^$1:" '$0 ~ k {print $2; exit}' "$s" 2>/dev/null)
+>   if [ -n "$v" ]; then echo "$v"; else cat "secrets/$2"; fi
+> }
+> aocr_secret aocr_auth_upstream_wrap_key upstream_wrap_key
+> aocr_secret aocr_internal_api_token     internal_api_token
+> ```
+>
+> See `aocr.sh/aocr_aerol_stitch.md` § *Resolving AOCR secret values* for
+> the full table.
+
+You also pick a **cluster ID** yourself — any string matching
+`^[A-Za-z0-9_-]{1,64}$`, e.g. `prod-aerolvm-us-east-1`. AOCR has no
+pre-registered list of clusters; this is a label you choose so AOCR can
+group your imported tags under `cluster/<your-id>/_imported/...`. Pick once
+per cluster and never change it (changing it later orphans previously
+imported tags under the old namespace).
+
+### Step 2 — Stage the two secret files on the control node
+
+Ansible's secret-copy tasks take a path on the **control node** (your laptop
+or whatever box runs `ansible-playbook`) and copy each file to
+`/etc/sandboxd/secrets/` on every managed host at `0600`.
+
+```bash
+mkdir -p ~/aerol-secrets
+chmod 0700 ~/aerol-secrets
+
+# If AOCR generated the secret files, copy them directly:
+cp /path/to/aocr.sh/secrets/upstream_wrap_key  ~/aerol-secrets/upstream_wrap_key
+cp /path/to/aocr.sh/secrets/internal_api_token ~/aerol-secrets/cluster_pat
+
+# If the values are inline overrides in aocr.sh/ansible/.../secrets.yml,
+# use the `aocr_secret` helper from Step 1's note to write the files:
+#   aocr_secret aocr_auth_upstream_wrap_key upstream_wrap_key > ~/aerol-secrets/upstream_wrap_key
+#   aocr_secret aocr_internal_api_token     internal_api_token > ~/aerol-secrets/cluster_pat
+
+chmod 0600 ~/aerol-secrets/*
+```
+
+If your fleet renders these via Vault or another mechanism, leave the
+corresponding `*_src` var empty and the play skips the copy.
+
+### Step 3 — Fill in the vars
+
+Either edit `inventory/group_vars/all.yml` for the whole fleet, or create a
+group/host-specific file (e.g. `inventory/group_vars/aerolvm_role_worker.yml`)
+to scope the change. Either way, set:
+
+```yaml
+# Mirror rewrite — required
+sandboxd_mirror_host:                  "mirror.aocr.aerol.ai"
+sandboxd_upstream_wrap_key_src:        "/home/you/aerol-secrets/upstream_wrap_key"
+
+# Auto-import (F21) — optional; drop these four for cache-only mode
+sandboxd_auto_import_enabled:          true
+sandboxd_auto_import_hooks_url:        "https://aocr.aerol.ai"
+sandboxd_auto_import_cluster_id:       "prod-aerolvm-us-east-1"   # pick once, never change
+sandboxd_auto_import_cluster_pat_src:  "/home/you/aerol-secrets/cluster_pat"
+# sandboxd_auto_import_retention_suffix: "--idle-90d"   # default
+```
+
+### Step 4 — Run configure-ops
+
+```bash
+ansible-playbook playbooks/configure-ops.yml
+```
+
+For each host the play:
+
+1. Creates `/etc/sandboxd/secrets/` at `0700`.
+2. Copies `upstream_wrap_key` → `/etc/sandboxd/secrets/upstream-wrap.key` (`0600`).
+3. Copies `cluster_pat` → `/etc/sandboxd/secrets/cluster-pat` (`0600`).
+4. Re-renders `/etc/sandboxd/cluster.env` with the `SB_MIRROR_*` / `SB_AUTO_IMPORT_*` lines.
+5. Restarts `sandboxd` (gated by `sandboxd_restart_after_ops_config`, default true).
+
+The cluster PAT is **file-sourced** — never an env var, never visible in
+`systemctl show sandboxd` or process listings.
+
+### Step 5 — Verify
+
+SSH into any node:
+
+```bash
+sudo grep -E '^SB_(MIRROR|AUTO_IMPORT)_' /etc/sandboxd/cluster.env
+sudo ls -l /etc/sandboxd/secrets/        # both files 0600 root:root
+systemctl is-active sandboxd
+```
+
+Then trigger a private pull (via any sandbox) and check AOCR:
+
+```bash
+# Mirror cache populated?
+curl -sf -H "Authorization: Bearer $(cat aocr.sh/secrets/auth_pat_token)" \
+  "https://aocr.aerol.ai/v1/images?limit=20" | jq -r '.images[].repository' | sort -u
+
+# Auto-import landed under your cluster namespace?
+curl -sf -H "Authorization: Bearer $(cat aocr.sh/secrets/auth_pat_token)" \
+  "https://aocr.aerol.ai/v1/images?limit=200" | jq -r '.images[].repository' \
+  | grep "cluster/prod-aerolvm-us-east-1/_imported/"
+```
+
+### What each `sandboxd_*` var means
+
+| Var | Purpose | Where the value comes from |
+|---|---|---|
+| `sandboxd_mirror_host` | Vhost sandboxd rewrites `ghcr.io` / `gcr.io` / `quay.io` / `registry.k8s.io` pulls onto. Empty disables rewrite entirely. Docker Hub is intentionally not rewritten. | AOCR side — derived from `aocr_global_domain` |
+| `sandboxd_mirror_push_host` | Optional. Push vhost (e.g. `aocr.aerol.ai`) so already-pushed refs aren't double-rewritten. Leave empty unless sandboxes also push. | AOCR side |
+| `sandboxd_mirror_upstreams` | Default `ghcr.io=ghcr,gcr.io=gcr,quay.io=quay,registry.k8s.io=k8s`. Override only if your AOCR exposes different upstream shortnames. | AOCR operator |
+| `sandboxd_upstream_wrap_key_src` | Path on the **control node** to the base64 32-byte AES-GCM key. The play copies it to `/etc/sandboxd/secrets/upstream-wrap.key`. Sandboxd wraps per-pull upstream creds with this; only AOCR's mirror can unwrap. Without it, private upstream pulls 401 at the mirror. | AOCR side — `secrets/upstream_wrap_key` (auto-generated on first AOCR deploy) |
+| `sandboxd_auto_import_enabled` | Master switch for F21. When true, every successful private pull triggers a re-mount under `cluster/<id>/_imported/...`. | You |
+| `sandboxd_auto_import_hooks_url` | AOCR hooks service root, e.g. `https://aocr.aerol.ai`. Sandboxd appends `/v1/internal/imports`. | AOCR side — same as `aocr_global_domain` |
+| `sandboxd_auto_import_cluster_id` | **A label you choose**, not internal AOCR config. AOCR validates only the format (`^[A-Za-z0-9_-]{1,64}$`) and uses it as a namespace prefix for imported tags. Pick a meaningful per-cluster name like `prod-us-east-1`, `staging`, `dev-suman`. | You |
+| `sandboxd_auto_import_cluster_pat_src` | Path on the **control node** to a file containing the bearer token sandboxd presents on `POST /v1/internal/imports`. Despite the name, this is AOCR's `internal_api_token`, not the UUID-keyed cluster PAT used by `auth/src/clusterPat.ts` (different concept; see `aocr_aerol_stitch.md`). | AOCR side — `secrets/internal_api_token` |
+| `sandboxd_auto_import_retention_suffix` | Suffix appended to imported tags. Drives the reaper's idle-eviction window (see [`aocr.sh/RETENTION.md`](https://github.com/aerolai/aocr/blob/main/RETENTION.md)). | Operator policy |
+
+Everything else (`request_timeout`, `reconcile_interval`, `max_in_flight`)
+has a sensible default in `inventory/group_vars/all.yml` — only tune if
+recovery storms or remote latency warrant it.
+
+### Rotating secrets
+
+- **Wrap key.** Add the new key alongside the old one in AOCR's
+  `UPSTREAM_AUTH_WRAP_KEYS` (comma-separated), then overwrite the file at
+  `sandboxd_upstream_wrap_key_src` and rerun `configure-ops.yml`. After
+  every node has rotated, drop the old key from AOCR.
+- **Internal API token / cluster PAT.** Rotate AOCR's `INTERNAL_API_TOKEN`,
+  overwrite `sandboxd_auto_import_cluster_pat_src`, and rerun
+  `configure-ops.yml`. Auto-imports queued under the old token will fail
+  and the local reconciler will retry under the new one.
+
+### TL;DR
+
+1. AOCR was deployed once; its secrets sit in `aocr.sh/secrets/`.
+2. Stage `upstream_wrap_key` + `internal_api_token` on the control node.
+3. Set the `sandboxd_mirror_*` / `sandboxd_auto_import_*` vars in
+   `inventory/group_vars/all.yml` (or a tighter scope).
+4. `ansible-playbook playbooks/configure-ops.yml`.
+5. Verify with `grep` / `ls` on a node and `curl /v1/images` on AOCR.
+
 ## When to use this vs. Terraform
 
 | You want to...                                  | Use         |

--- a/Ansible/inventory/group_vars/all.yml
+++ b/Ansible/inventory/group_vars/all.yml
@@ -38,3 +38,35 @@ sandboxd_backup_retention_days: 7
 
 # Node lifecycle defaults used by playbooks/prepare-role-change.yml.
 sandboxd_role_change_drain_timeout_s: 3600
+
+# --- Phase 4: Authenticated Mirror + Auto-Import (SB_MIRROR_*, SB_AUTO_IMPORT_*)
+# See sandbox-library/AUTHENTICATED_MIRROR.md for the full operator reference.
+# Defaults below leave the feature disabled (empty SB_MIRROR_HOST). Set
+# sandboxd_mirror_host on a host/group to opt in; the playbook then templates
+# wrap-key and cluster-PAT files into /etc/sandboxd/secrets/ from the control
+# node and wires the matching SB_* env vars into the sandboxd env file.
+
+sandboxd_secrets_dir: /etc/sandboxd/secrets
+sandboxd_upstream_wrap_key_path: "{{ sandboxd_secrets_dir }}/upstream-wrap.key"
+sandboxd_auto_import_cluster_pat_path: "{{ sandboxd_secrets_dir }}/cluster-pat"
+
+# Source files on the Ansible control node. Empty values skip the copy (use
+# this if your fleet renders these files via another mechanism, e.g. Vault).
+sandboxd_upstream_wrap_key_src: ""
+sandboxd_auto_import_cluster_pat_src: ""
+
+# Mirror rewrite (empty SB_MIRROR_HOST disables all of this).
+sandboxd_mirror_host: ""
+sandboxd_mirror_push_host: ""
+sandboxd_mirror_upstreams: "ghcr.io=ghcr,gcr.io=gcr,quay.io=quay,registry.k8s.io=k8s"
+
+# Auto-import (F21). Master switch + the three required pieces. Validation
+# at sandboxd startup will refuse to boot if SB_AUTO_IMPORT_ENABLED=true is
+# set without HOOKS_URL, CLUSTER_ID, and CLUSTER_PAT_PATH all present.
+sandboxd_auto_import_enabled: false
+sandboxd_auto_import_hooks_url: ""
+sandboxd_auto_import_cluster_id: ""
+sandboxd_auto_import_retention_suffix: "--idle-90d"
+sandboxd_auto_import_request_timeout: "15s"
+sandboxd_auto_import_reconcile_interval: "5m"
+sandboxd_auto_import_max_in_flight: 4

--- a/Ansible/playbooks/configure-ops.yml
+++ b/Ansible/playbooks/configure-ops.yml
@@ -25,6 +25,18 @@
       OTEL_SERVICE_NAME: "{{ sandboxd_otel_service_name }}"
       SB_IMAGE_PULL_MAX_CONCURRENT: "{{ sandboxd_image_pull_max_concurrent }}"
       SB_IMAGE_PULL_FAILURE_BACKOFF: "{{ sandboxd_image_pull_failure_backoff }}"
+      SB_MIRROR_HOST: "{{ sandboxd_mirror_host }}"
+      SB_MIRROR_PUSH_HOST: "{{ sandboxd_mirror_push_host }}"
+      SB_MIRROR_UPSTREAMS: "{{ sandboxd_mirror_upstreams }}"
+      SB_UPSTREAM_WRAP_KEY_PATH: "{{ sandboxd_upstream_wrap_key_path if (sandboxd_upstream_wrap_key_src | length > 0) else '' }}"
+      SB_AUTO_IMPORT_ENABLED: "{{ sandboxd_auto_import_enabled | bool | string | lower }}"
+      SB_AUTO_IMPORT_HOOKS_URL: "{{ sandboxd_auto_import_hooks_url }}"
+      SB_AUTO_IMPORT_CLUSTER_ID: "{{ sandboxd_auto_import_cluster_id }}"
+      SB_AUTO_IMPORT_CLUSTER_PAT_PATH: "{{ sandboxd_auto_import_cluster_pat_path if (sandboxd_auto_import_cluster_pat_src | length > 0) else '' }}"
+      SB_AUTO_IMPORT_RETENTION_SUFFIX: "{{ sandboxd_auto_import_retention_suffix }}"
+      SB_AUTO_IMPORT_REQUEST_TIMEOUT: "{{ sandboxd_auto_import_request_timeout }}"
+      SB_AUTO_IMPORT_RECONCILE_INTERVAL: "{{ sandboxd_auto_import_reconcile_interval }}"
+      SB_AUTO_IMPORT_MAX_IN_FLIGHT: "{{ sandboxd_auto_import_max_in_flight }}"
 
   pre_tasks:
     - name: Check base sandboxd env file
@@ -130,6 +142,35 @@
         - "../../setup/runbooks/lost-quorum-recovery.md"
         - "../../setup/runbooks/image-pull-storm.md"
         - "../../setup/runbooks/slo-breach.md"
+
+    - name: Ensure sandboxd secrets directory exists
+      when: (sandboxd_upstream_wrap_key_src | length > 0) or (sandboxd_auto_import_cluster_pat_src | length > 0)
+      ansible.builtin.file:
+        path: "{{ sandboxd_secrets_dir }}"
+        state: directory
+        mode: "0700"
+        owner: root
+        group: root
+
+    - name: Install upstream wrap key (Phase 4 F17)
+      when: sandboxd_upstream_wrap_key_src | length > 0
+      ansible.builtin.copy:
+        src: "{{ sandboxd_upstream_wrap_key_src }}"
+        dest: "{{ sandboxd_upstream_wrap_key_path }}"
+        mode: "0600"
+        owner: root
+        group: root
+      notify: Apply sandboxd ops config
+
+    - name: Install cluster PAT for auto-import (Phase 4 F21)
+      when: sandboxd_auto_import_cluster_pat_src | length > 0
+      ansible.builtin.copy:
+        src: "{{ sandboxd_auto_import_cluster_pat_src }}"
+        dest: "{{ sandboxd_auto_import_cluster_pat_path }}"
+        mode: "0600"
+        owner: root
+        group: root
+      notify: Apply sandboxd ops config
 
     - name: Write sandboxd operational env vars
       ansible.builtin.lineinfile:

--- a/Terraform/README.md
+++ b/Terraform/README.md
@@ -191,6 +191,163 @@ proxies HTTP(S); leave it `false` for raw TCP ingress.
 | `templates/bootstrap.sh.tftpl` | Single user_data template (seed/joiner) |
 | `terraform.tfvars.example`  | Drop-in starter config                    |
 
+## Connect this cluster to AOCR (mirror + auto-import)
+
+If you operate an [AOCR](https://github.com/aerolai/aocr) deployment alongside
+this cluster, you can route every public-registry pull through AOCR's
+authenticated mirror — and optionally auto-import each first pull into a
+cluster-owned namespace so future failovers are decoupled from the original
+upstream credential. The Terraform variable `aocr` (defined in
+`variables.tf`) is already plumbed through `locals.tf` → `nodes.tf` → the
+node user_data template. Enabling it requires zero code edits — only values.
+
+For the threat model and per-node env-var contract, read
+[`../AUTHENTICATED_MIRROR.md`](../AUTHENTICATED_MIRROR.md). For AOCR-side
+architecture, read
+[`aocr.sh/MIRROR.md`](https://github.com/aerolai/aocr/blob/main/MIRROR.md).
+For the full end-to-end deploy + stitch story, read
+[`aocr.sh/aocr_aerol_stitch.md`](https://github.com/aerolai/aocr/blob/main/aocr_aerol_stitch.md).
+
+### Step 1 — Pull 4 values from your AOCR side
+
+The AOCR Ansible playbook auto-generates every secret on first deploy. After
+you've run it once, the values you need are sitting in `aocr.sh/secrets/`
+and `aocr.sh/ansible/inventory/group_vars/all/vars.yml`:
+
+```bash
+cd /path/to/aocr.sh
+
+# 1. Mirror host — derived from your aocr_global_domain
+#    Default is "mirror." + aocr_global_domain (e.g. mirror.aocr.aerol.ai).
+grep aocr_global_domain ansible/inventory/group_vars/all/vars.yml
+
+# 2. Upstream wrap key (base64, 32 bytes) — required for private upstream pulls
+cat secrets/upstream_wrap_key
+
+# 3. Internal API token (64-char bearer) — only needed if auto_import_enabled=true
+cat secrets/internal_api_token
+
+# 4. Hooks URL — the AOCR root, no trailing slash (e.g. https://aocr.aerol.ai)
+```
+
+> **Where does the value actually live?** Each AOCR secret is *either* a
+> generated file under `aocr.sh/secrets/` (default on first deploy) *or* an
+> inline override in `aocr.sh/ansible/inventory/group_vars/all/secrets.yml`
+> (the deploy playbook skips file generation when the override is set). If
+> `cat secrets/upstream_wrap_key` errors with "No such file or directory",
+> grep `secrets.yml` for the matching `aocr_*` key instead:
+>
+> ```bash
+> cd /path/to/aocr.sh
+> # Falls back from inline override → generated file
+> aocr_secret() {
+>   local s="ansible/inventory/group_vars/all/secrets.yml" v
+>   v=$(awk -F'"' -v k="^$1:" '$0 ~ k {print $2; exit}' "$s" 2>/dev/null)
+>   if [ -n "$v" ]; then echo "$v"; else cat "secrets/$2"; fi
+> }
+> aocr_secret aocr_auth_upstream_wrap_key upstream_wrap_key
+> aocr_secret aocr_internal_api_token     internal_api_token
+> ```
+>
+> See `aocr.sh/aocr_aerol_stitch.md` § *Resolving AOCR secret values* for
+> the full table.
+
+You also pick a **cluster ID** yourself — any string matching
+`^[A-Za-z0-9_-]{1,64}$`, e.g. `prod-aerolvm-us-east-1`. AOCR has no
+pre-registered list of clusters; this is a label you choose so AOCR can
+group your imported tags under `cluster/<your-id>/_imported/...`. Pick once
+per cluster and never change it (changing it later orphans previously
+imported tags under the old namespace).
+
+### Step 2 — Add the `aocr` block to `terraform.tfvars`
+
+```hcl
+aocr = {
+  enabled             = true
+  mirror_host         = "mirror.aocr.aerol.ai"
+  upstream_wrap_key   = "<paste contents of aocr.sh/secrets/upstream_wrap_key>"
+
+  # Auto-import (F21) — drop these four if you only want the cached mirror.
+  auto_import_enabled = true
+  hooks_url           = "https://aocr.aerol.ai"
+  cluster_id          = "prod-aerolvm-us-east-1"   # pick once, never change
+  cluster_pat         = "<paste contents of aocr.sh/secrets/internal_api_token>"
+  # retention_suffix  = "--idle-90d"   # default; cluster-imported tags live 90 days idle
+}
+```
+
+The whole variable is `sensitive = true`, so `terraform plan/apply` won't
+print the wrap key or PAT.
+
+### Step 3 — Apply
+
+```bash
+terraform plan       # expect existing nodes to recycle; user_data changed
+terraform apply
+```
+
+`nodes.tf` sets `user_data_replace_on_change = true`, so existing EC2
+instances **are replaced** when this block changes. New nodes come up with:
+
+1. `/etc/sandboxd/secrets/upstream-wrap.key` written at `0600`.
+2. `/etc/sandboxd/secrets/cluster-pat` written at `0600` (when auto-import on).
+3. `SB_MIRROR_*` and `SB_AUTO_IMPORT_*` appended to `/etc/sandboxd/cluster.env`.
+4. `systemctl restart sandboxd`.
+
+The cluster PAT is **file-sourced** — never an env var, never visible in
+`systemctl show sandboxd` or process listings.
+
+### Step 4 — Verify
+
+SSH into any node:
+
+```bash
+sudo grep -E '^SB_(MIRROR|AUTO_IMPORT)_' /etc/sandboxd/cluster.env
+sudo ls -l /etc/sandboxd/secrets/        # both files 0600 root:root
+systemctl is-active sandboxd
+```
+
+Then trigger a private pull (via any sandbox) and check AOCR:
+
+```bash
+# Mirror cache populated?
+curl -sf -H "Authorization: Bearer $(cat aocr.sh/secrets/auth_pat_token)" \
+  "https://aocr.aerol.ai/v1/images?limit=20" | jq -r '.images[].repository' | sort -u
+
+# Auto-import landed under your cluster namespace?
+curl -sf -H "Authorization: Bearer $(cat aocr.sh/secrets/auth_pat_token)" \
+  "https://aocr.aerol.ai/v1/images?limit=200" | jq -r '.images[].repository' \
+  | grep "cluster/prod-aerolvm-us-east-1/_imported/"
+```
+
+### What each `aocr.*` field means
+
+| Field | Purpose | Where the value comes from |
+|---|---|---|
+| `enabled` | Master switch. When false, nothing else templates. | You |
+| `mirror_host` | Vhost sandboxd rewrites `ghcr.io` / `gcr.io` / `quay.io` / `registry.k8s.io` pulls onto. Docker Hub is intentionally not rewritten. | AOCR side — derived from `aocr_global_domain` |
+| `upstream_wrap_key` | Base64 32-byte AES-GCM key. Sandboxd wraps per-pull upstream creds with this; only AOCR's mirror can unwrap. Without it, private upstream pulls 401 at the mirror. | AOCR side — `secrets/upstream_wrap_key` (auto-generated on first AOCR deploy) |
+| `mirror_push_host` | Optional. Push vhost (e.g. `aocr.aerol.ai`) so already-pushed refs aren't double-rewritten. Leave empty unless you also push from sandboxes. | AOCR side |
+| `mirror_upstreams` | Default `ghcr.io=ghcr,gcr.io=gcr,quay.io=quay,registry.k8s.io=k8s`. Override only if your AOCR exposes different upstream shortnames. | AOCR operator |
+| `auto_import_enabled` | Master switch for F21. When true, every successful private pull triggers a re-mount under `cluster/<id>/_imported/...`. | You |
+| `hooks_url` | AOCR hooks service root, e.g. `https://aocr.aerol.ai`. Sandboxd appends `/v1/internal/imports`. | AOCR side — same as `aocr_global_domain` |
+| `cluster_id` | **A label you choose**, not internal AOCR config. AOCR validates only the format (`^[A-Za-z0-9_-]{1,64}$`) and uses it as a namespace prefix for imported tags. Pick a meaningful per-cluster name like `prod-us-east-1`, `staging`, `dev-suman`. | You |
+| `cluster_pat` | Bearer token sandboxd presents on `POST /v1/internal/imports`. Despite the name, this is AOCR's `internal_api_token`, not the UUID-keyed cluster PAT used by `auth/src/clusterPat.ts` (different concept; see `aocr_aerol_stitch.md`). | AOCR side — `secrets/internal_api_token` |
+| `retention_suffix` | Suffix appended to imported tags. Drives the reaper's idle-eviction window (see [`aocr.sh/RETENTION.md`](https://github.com/aerolai/aocr/blob/main/RETENTION.md)). | Operator policy |
+
+Everything else (`request_timeout`, `reconcile_interval`, `max_in_flight`)
+has a sensible default — only tune if recovery storms or remote latency
+warrant it. The full default set lives in `variables.tf`.
+
+### TL;DR
+
+1. AOCR was deployed once; its secrets sit in `aocr.sh/secrets/`.
+2. Add the `aocr = { … }` block to `terraform.tfvars` with values copied
+   from those files plus a `cluster_id` you pick.
+3. `terraform apply` — nodes recycle, secrets land at `/etc/sandboxd/secrets/`,
+   sandboxd restarts wired to the mirror.
+4. Verify with `grep` / `ls` on a node and `curl /v1/images` on AOCR.
+
 ## Tear-down
 
 ```bash

--- a/Terraform/locals.tf
+++ b/Terraform/locals.tf
@@ -92,6 +92,27 @@ locals {
       : var.caddy_shared_cert_storage.encryption_key
     )
   }
+
+  # AOCR (Phase 4 F17-F21) — resolved view for bootstrap.sh.tftpl. Same
+  # pattern as caddy_storage_s3: when enabled is false, every field
+  # collapses to its empty/default value so the template can splat the
+  # whole shape unconditionally and the `if aocr_enabled` block stays
+  # the only branch the renderer evaluates.
+  aocr = {
+    enabled             = var.aocr.enabled
+    mirror_host         = var.aocr.enabled ? var.aocr.mirror_host : ""
+    mirror_push_host    = var.aocr.enabled ? var.aocr.mirror_push_host : ""
+    mirror_upstreams    = var.aocr.enabled ? var.aocr.mirror_upstreams : ""
+    upstream_wrap_key   = var.aocr.enabled ? var.aocr.upstream_wrap_key : ""
+    auto_import_enabled = var.aocr.enabled && var.aocr.auto_import_enabled
+    hooks_url           = var.aocr.enabled ? var.aocr.hooks_url : ""
+    cluster_id          = var.aocr.enabled ? var.aocr.cluster_id : ""
+    cluster_pat         = var.aocr.enabled ? var.aocr.cluster_pat : ""
+    retention_suffix    = var.aocr.enabled ? var.aocr.retention_suffix : "--idle-90d"
+    request_timeout     = var.aocr.enabled ? var.aocr.request_timeout : "15s"
+    reconcile_interval  = var.aocr.enabled ? var.aocr.reconcile_interval : "5m"
+    max_in_flight       = var.aocr.enabled ? var.aocr.max_in_flight : 4
+  }
 }
 
 # certmagic-s3 encrypts cert+private-key bytes with this 32-byte key before

--- a/Terraform/nodes.tf
+++ b/Terraform/nodes.tf
@@ -76,6 +76,20 @@ resource "aws_instance" "seed" {
     caddy_storage_s3_access_key     = local.caddy_storage_s3.access_key
     caddy_storage_s3_secret_key     = local.caddy_storage_s3.secret_key
     caddy_storage_s3_encryption_key = local.caddy_storage_s3.encryption_key
+    # AOCR mirror + auto-import (Phase 4 F17-F21) — see local.aocr.
+    aocr_enabled             = local.aocr.enabled
+    aocr_mirror_host         = local.aocr.mirror_host
+    aocr_mirror_push_host    = local.aocr.mirror_push_host
+    aocr_mirror_upstreams    = local.aocr.mirror_upstreams
+    aocr_upstream_wrap_key   = local.aocr.upstream_wrap_key
+    aocr_auto_import_enabled = local.aocr.auto_import_enabled
+    aocr_hooks_url           = local.aocr.hooks_url
+    aocr_cluster_id          = local.aocr.cluster_id
+    aocr_cluster_pat         = local.aocr.cluster_pat
+    aocr_retention_suffix    = local.aocr.retention_suffix
+    aocr_request_timeout     = local.aocr.request_timeout
+    aocr_reconcile_interval  = local.aocr.reconcile_interval
+    aocr_max_in_flight       = local.aocr.max_in_flight
   })
 
   tags = merge(
@@ -159,6 +173,20 @@ resource "aws_instance" "joiner" {
     caddy_storage_s3_access_key     = local.caddy_storage_s3.access_key
     caddy_storage_s3_secret_key     = local.caddy_storage_s3.secret_key
     caddy_storage_s3_encryption_key = local.caddy_storage_s3.encryption_key
+    # AOCR mirror + auto-import (Phase 4 F17-F21) — see local.aocr.
+    aocr_enabled             = local.aocr.enabled
+    aocr_mirror_host         = local.aocr.mirror_host
+    aocr_mirror_push_host    = local.aocr.mirror_push_host
+    aocr_mirror_upstreams    = local.aocr.mirror_upstreams
+    aocr_upstream_wrap_key   = local.aocr.upstream_wrap_key
+    aocr_auto_import_enabled = local.aocr.auto_import_enabled
+    aocr_hooks_url           = local.aocr.hooks_url
+    aocr_cluster_id          = local.aocr.cluster_id
+    aocr_cluster_pat         = local.aocr.cluster_pat
+    aocr_retention_suffix    = local.aocr.retention_suffix
+    aocr_request_timeout     = local.aocr.request_timeout
+    aocr_reconcile_interval  = local.aocr.reconcile_interval
+    aocr_max_in_flight       = local.aocr.max_in_flight
   })
 
   depends_on = [aws_instance.seed]

--- a/Terraform/templates/bootstrap.sh.tftpl
+++ b/Terraform/templates/bootstrap.sh.tftpl
@@ -179,6 +179,60 @@ OTEL_SERVICE_NAME=${otel_service_name}
 SB_IMAGE_PULL_MAX_CONCURRENT=${image_pull_max_concurrent}
 SB_IMAGE_PULL_FAILURE_BACKOFF=${image_pull_failure_backoff}
 EOF
+
+%{ if aocr_enabled ~}
+###############################################################################
+# 3b. AOCR (Phase 4 F17-F21) — authenticated mirror + auto-import.
+#
+# Wrap key and cluster PAT are file-sourced so they never appear in
+# `systemctl show sandboxd` env dumps or process listings. Install both at
+# 0600 under /etc/sandboxd/secrets/ (matches the paths the sandboxd
+# config defaults expect and that the Ansible configure-ops playbook uses).
+###############################################################################
+sudo install -d -m 0700 -o root -g root /etc/sandboxd/secrets
+
+%{ if aocr_upstream_wrap_key != "" ~}
+# Base64 AES-GCM wrap key. Must match an entry in AOCR's
+# UPSTREAM_AUTH_WRAP_KEYS env var or wrapping will silently fail and
+# private upstream pulls will 401.
+umask 077
+cat > /etc/sandboxd/secrets/upstream-wrap.key <<'EOF'
+${aocr_upstream_wrap_key}
+EOF
+sudo chown root:root /etc/sandboxd/secrets/upstream-wrap.key
+sudo chmod 0600 /etc/sandboxd/secrets/upstream-wrap.key
+%{ endif ~}
+
+%{ if aocr_cluster_pat != "" ~}
+# Cluster PAT used as Bearer token on POST /v1/internal/imports. Sandboxd
+# reads it via SB_AUTO_IMPORT_CLUSTER_PAT_PATH at request time; never put it
+# in an env var (it would land in logs and `ps`/`systemctl show` output).
+umask 077
+cat > /etc/sandboxd/secrets/cluster-pat <<'EOF'
+${aocr_cluster_pat}
+EOF
+sudo chown root:root /etc/sandboxd/secrets/cluster-pat
+sudo chmod 0600 /etc/sandboxd/secrets/cluster-pat
+%{ endif ~}
+
+cat >> /tmp/aerolvm-ops.env <<'EOF'
+
+# Managed by Terraform bootstrap: AOCR mirror + auto-import (Phase 4).
+SB_MIRROR_HOST=${aocr_mirror_host}
+SB_MIRROR_PUSH_HOST=${aocr_mirror_push_host}
+SB_MIRROR_UPSTREAMS=${aocr_mirror_upstreams}
+SB_UPSTREAM_WRAP_KEY_PATH=%{ if aocr_upstream_wrap_key != "" ~}/etc/sandboxd/secrets/upstream-wrap.key%{ endif ~}
+SB_AUTO_IMPORT_ENABLED=${aocr_auto_import_enabled}
+SB_AUTO_IMPORT_HOOKS_URL=${aocr_hooks_url}
+SB_AUTO_IMPORT_CLUSTER_ID=${aocr_cluster_id}
+SB_AUTO_IMPORT_CLUSTER_PAT_PATH=%{ if aocr_cluster_pat != "" ~}/etc/sandboxd/secrets/cluster-pat%{ endif ~}
+SB_AUTO_IMPORT_RETENTION_SUFFIX=${aocr_retention_suffix}
+SB_AUTO_IMPORT_REQUEST_TIMEOUT=${aocr_request_timeout}
+SB_AUTO_IMPORT_RECONCILE_INTERVAL=${aocr_reconcile_interval}
+SB_AUTO_IMPORT_MAX_IN_FLIGHT=${aocr_max_in_flight}
+EOF
+%{ endif ~}
+
 sudo tee -a /etc/sandboxd/cluster.env < /tmp/aerolvm-ops.env >/dev/null
 sudo systemctl restart sandboxd
 

--- a/Terraform/terraform.tfvars.example
+++ b/Terraform/terraform.tfvars.example
@@ -158,3 +158,36 @@ nodes = {
 #   Env   = "prod"
 #   Owner = "platform-team"
 # }
+
+# --- AOCR (authenticated mirror + auto-import) ------------------------------
+#
+# Day-0 wiring against an already-deployed AOCR (Phase 4 F17-F21). Off by
+# default; flip enabled = true to template SB_MIRROR_* / SB_AUTO_IMPORT_*
+# into cluster.env and install wrap-key + cluster-PAT secrets under
+# /etc/sandboxd/secrets/ on every node. See sandbox-library/AUTHENTICATED_MIRROR.md.
+#
+# Mirror-only mode (cache + credential wrapping, no Raft-coordinated
+# imports). Pulls flowing through SB_MIRROR_HOST get private upstream
+# credentials wrapped with upstream_wrap_key before they leave the node.
+# aocr = {
+#   enabled            = true
+#   mirror_host        = "mirror.aocr.aerol.ai"
+#   mirror_push_host   = "aocr.aerol.ai"
+#   upstream_wrap_key  = "REPLACE-with-base64-32-byte-key-from-aocr-secrets/upstream_wrap_key"
+# }
+#
+# Mirror + auto-import (full F21). hooks_url / cluster_id / cluster_pat are
+# required when auto_import_enabled = true (plan-time validation matches
+# sandboxd's startup guard). cluster_pat must equal the AOCR side's
+# INTERNAL_API_TOKEN (file aocr/secrets/internal_api_token).
+# aocr = {
+#   enabled             = true
+#   mirror_host         = "mirror.aocr.aerol.ai"
+#   mirror_push_host    = "aocr.aerol.ai"
+#   upstream_wrap_key   = "REPLACE-with-base64-32-byte-key"
+#   auto_import_enabled = true
+#   hooks_url           = "https://aocr.aerol.ai"
+#   cluster_id          = "prod-aerolvm-us-east-1"
+#   cluster_pat         = "REPLACE-with-internal-api-token"
+#   retention_suffix    = "--idle-90d"
+# }

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -493,3 +493,122 @@ variable "caddy_shared_cert_storage" {
     error_message = "When caddy_shared_cert_storage.mode = \"byo\", bucket, region, and encryption_key are all required."
   }
 }
+
+###############################################################################
+# AOCR (Aerol OCI Registry) — Authenticated mirror + auto-import (Phase 4 F17-F21)
+#
+# Day-0 wiring against an already-deployed AOCR. When enabled = false (the
+# default), nothing AOCR-related is templated and the bootstrap is identical
+# to the pre-Phase-4 path. See sandbox-library/AUTHENTICATED_MIRROR.md for
+# the full operator reference.
+#
+# upstream_wrap_key and cluster_pat are real secrets and end up both in
+# Terraform state and in the EC2 instance user_data — same handling as
+# pat_token and cloudflare_api_token. Marking the whole object sensitive
+# keeps them out of plan/apply output.
+###############################################################################
+
+variable "aocr" {
+  description = <<-EOT
+    Connect this cluster to an already-deployed AOCR.
+
+    enabled              Master switch. When false, no AOCR env or secret
+                         files are templated.
+    mirror_host          Mirror vhost for cached pulls (e.g.
+                         "mirror.aocr.aerol.ai"). Empty disables rewrite
+                         even when enabled = true (auto-import can still
+                         run on its own).
+    mirror_push_host     Push vhost for the same AOCR cluster (e.g.
+                         "aocr.aerol.ai"). Refs already pointing here are
+                         left alone so they are not double-rewritten.
+    mirror_upstreams     Comma-separated host=short map of upstreams the
+                         mirror handles. Default covers ghcr/gcr/quay/k8s.
+    upstream_wrap_key    Base64-encoded 32-byte AES-GCM key. Must equal
+                         the active key in AOCR's UPSTREAM_AUTH_WRAP_KEYS
+                         (use the value from secrets/upstream_wrap_key
+                         emitted by the AOCR Ansible playbook). Empty
+                         disables credential wrapping; private pulls 401.
+    auto_import_enabled  Turn on post-pull auto-import (F21). When true,
+                         hooks_url + cluster_id + cluster_pat are required
+                         (plan-time validation mirrors sandboxd's startup
+                         guard).
+    hooks_url            AOCR hooks service root, no trailing slash, e.g.
+                         "https://aocr.aerol.ai".
+    cluster_id           This cluster's ID on the AOCR side.
+    cluster_pat          Bearer token AOCR validates against its
+                         INTERNAL_API_TOKEN. Same value as
+                         aocr_internal_api_token on the AOCR side
+                         (secrets/internal_api_token).
+    retention_suffix     Tag suffix imported tags get in the cluster
+                         namespace (e.g. "--idle-90d"); drives reaper
+                         eviction window.
+    request_timeout      Per-call timeout for the ImportAPI POST.
+    reconcile_interval   Ticker period for the local auto_import_pending
+                         reconciler.
+    max_in_flight        Fan-out cap for one reconciler sweep.
+  EOT
+  type = object({
+    enabled             = bool
+    mirror_host         = optional(string, "")
+    mirror_push_host    = optional(string, "")
+    mirror_upstreams    = optional(string, "ghcr.io=ghcr,gcr.io=gcr,quay.io=quay,registry.k8s.io=k8s")
+    upstream_wrap_key   = optional(string, "")
+    auto_import_enabled = optional(bool, false)
+    hooks_url           = optional(string, "")
+    cluster_id          = optional(string, "")
+    cluster_pat         = optional(string, "")
+    retention_suffix    = optional(string, "--idle-90d")
+    request_timeout     = optional(string, "15s")
+    reconcile_interval  = optional(string, "5m")
+    max_in_flight       = optional(number, 4)
+  })
+  sensitive = true
+  default = {
+    enabled = false
+  }
+
+  validation {
+    condition = (
+      !var.aocr.enabled
+      || !var.aocr.auto_import_enabled
+      || (
+        var.aocr.hooks_url != ""
+        && var.aocr.cluster_id != ""
+        && var.aocr.cluster_pat != ""
+      )
+    )
+    error_message = "When aocr.auto_import_enabled = true, aocr.hooks_url, aocr.cluster_id, and aocr.cluster_pat are all required."
+  }
+
+  validation {
+    condition = (
+      !var.aocr.enabled
+      || var.aocr.cluster_id == ""
+      || can(regex("^[A-Za-z0-9_-]{1,64}$", var.aocr.cluster_id))
+    )
+    error_message = "aocr.cluster_id must match ^[A-Za-z0-9_-]{1,64}$ (matches AOCR ImportAPI validation)."
+  }
+
+  validation {
+    condition = (
+      var.aocr.retention_suffix == ""
+      || can(regex("^--[a-z0-9]+(-[a-z0-9]+)*$", var.aocr.retention_suffix))
+    )
+    error_message = "aocr.retention_suffix must start with '--' followed by lowercase alphanumerics, e.g. '--idle-90d'."
+  }
+
+  validation {
+    condition     = can(regex("^[0-9]+(ns|us|ms|s|m|h)$", var.aocr.request_timeout))
+    error_message = "aocr.request_timeout must be a Go duration such as 15s or 1m."
+  }
+
+  validation {
+    condition     = can(regex("^[0-9]+(ns|us|ms|s|m|h)$", var.aocr.reconcile_interval))
+    error_message = "aocr.reconcile_interval must be a Go duration such as 5m or 30s."
+  }
+
+  validation {
+    condition     = var.aocr.max_in_flight >= 1
+    error_message = "aocr.max_in_flight must be >= 1."
+  }
+}

--- a/cmd/sandboxd/main.go
+++ b/cmd/sandboxd/main.go
@@ -531,6 +531,12 @@ func startAutoImportReconciler(ctx context.Context, logger *slog.Logger, cfg con
 		// start a goroutine that has nothing to do.
 		return
 	}
+	// Wire the spec write-back so successful imports flip the replicated
+	// CreateSandboxRequest to ImageDistributionAOCRImported and point
+	// ImageRegistryRef at the new cluster-side ref. Subsequent failovers
+	// then pull through the cluster PAT, fully decoupled from the original
+	// upstream credential.
+	r.SetSpecMutator(svc)
 	logger.Info("auto-import reconciler started",
 		"hooks_url", importer.Endpoint(),
 		"interval", cfg.AutoImportReconcileInterval,

--- a/cmd/sandboxd/main.go
+++ b/cmd/sandboxd/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -97,6 +98,7 @@ func main() {
 		logger.Error("failed to create docker client", "error", err)
 		os.Exit(1)
 	}
+	configureMirror(logger, cfg, dockerClient)
 
 	caddyClient := caddy.New(cfg)
 
@@ -278,6 +280,25 @@ func main() {
 		svc.StartEventMonitor(ctx)
 		svc.StartBuiltImageGC(ctx)
 		startAutoImportReconciler(ctx, logger, cfg, db, svc)
+		if cfg.AutoImportEnabled {
+			// Wire the post-pull trigger: when the docker client finishes a
+			// successful pull that BOTH used the mirror AND carried private
+			// creds, the observer flips the sandbox row's auto_import_pending
+			// flag. The reconciler then picks it up on its next sweep, calls
+			// AOCR ImportAPI, and clears the flag on success. Worker-only:
+			// non-worker nodes never pull sandbox images.
+			dockerClient.SetPullObserver(func(obsCtx context.Context, sandboxID string) {
+				// Use a fresh short-deadline context: the pull's ctx may be
+				// cancelled before this fires (Docker ack races container
+				// start), and a SQLite UPDATE is local and quick.
+				flagCtx, flagCancel := context.WithTimeout(context.Background(), 2*time.Second)
+				defer flagCancel()
+				if err := db.SetAutoImportPending(flagCtx, sandboxID, true); err != nil {
+					logger.Warn("auto-import: flag pending failed; reconciler will not retry",
+						"sandbox_id", sandboxID, "error", err)
+				}
+			})
+		}
 	}
 
 	if cfg.EnableSSHGateway && cfg.IsWorker() {
@@ -422,6 +443,53 @@ func specFromSandbox(svc *service.Service, sb *models.Sandbox, logger *slog.Logg
 		spec.Registry = auth
 	}
 	return spec
+}
+
+// configureMirror loads the upstream wrap-key ring (if a path is set) and
+// hands a built MirrorConfig to the docker client. Disabled-by-default:
+// MirrorHost empty or upstream list empty means rewriting stays off and the
+// docker client pulls from upstream registries directly.
+//
+// Wrap-key absence is a soft failure: we log a clear warning and configure
+// the mirror without a ring. Public images still mirror cleanly (anonymous
+// auth); private images will 401 against the mirror until the operator
+// installs the key. This keeps the node bootable on a misconfigured wrap
+// path rather than gating all pulls behind one secret.
+func configureMirror(logger *slog.Logger, cfg config.Config, c *docker.Client) {
+	if strings.TrimSpace(cfg.MirrorHost) == "" || len(cfg.MirrorUpstreams) == 0 {
+		return
+	}
+	upstreams := make([]docker.MirrorUpstream, 0, len(cfg.MirrorUpstreams))
+	for _, m := range cfg.MirrorUpstreams {
+		upstreams = append(upstreams, docker.MirrorUpstream{Host: m.Host, Shortname: m.Shortname})
+	}
+	mcfg := docker.MirrorConfig{
+		Host:      cfg.MirrorHost,
+		PushHost:  cfg.MirrorPushHost,
+		Upstreams: upstreams,
+	}
+
+	var ring *secrets.UpstreamWrapKeyRing
+	if cfg.UpstreamWrapKeyPath != "" {
+		r, err := secrets.LoadUpstreamWrapKeyRing(cfg.UpstreamWrapKeyPath)
+		if err != nil {
+			logger.Warn("mirror: upstream wrap key unavailable; private images via the mirror will 401 until the key is installed",
+				"path", cfg.UpstreamWrapKeyPath, "error", err)
+		} else {
+			ring = r
+		}
+	} else {
+		logger.Info("mirror: no upstream wrap key path configured; private-image pulls via the mirror are not supported on this node",
+			"hint", "set SB_UPSTREAM_WRAP_KEY_PATH to enable wrapped-credential auth")
+	}
+
+	c.ConfigureMirror(mcfg, ring)
+	logger.Info("mirror configured",
+		"host", mcfg.Host,
+		"push_host", mcfg.PushHost,
+		"upstreams", len(mcfg.Upstreams),
+		"wrap_key_loaded", ring != nil,
+	)
 }
 
 // startAutoImportReconciler builds the F21 auto-import importer + reconciler

--- a/cmd/sandboxd/main.go
+++ b/cmd/sandboxd/main.go
@@ -277,6 +277,7 @@ func main() {
 		svc.StartLifecycleSweep(ctx)
 		svc.StartEventMonitor(ctx)
 		svc.StartBuiltImageGC(ctx)
+		startAutoImportReconciler(ctx, logger, cfg, db, svc)
 	}
 
 	if cfg.EnableSSHGateway && cfg.IsWorker() {
@@ -421,6 +422,114 @@ func specFromSandbox(svc *service.Service, sb *models.Sandbox, logger *slog.Logg
 		spec.Registry = auth
 	}
 	return spec
+}
+
+// startAutoImportReconciler builds the F21 auto-import importer + reconciler
+// and starts a ticker goroutine if the feature is enabled. When disabled (or
+// when the importer fails to build) we log and return without scheduling
+// anything — the rest of the daemon runs unchanged. The reconciler depends on
+// the cluster client for replicated CreateSandboxRequest lookup; in
+// standalone mode the noop cluster returns nil for every spec and the
+// reconciler's `retryOne` will clear the flag with reason `no spec`. That's
+// the right behavior: without a replicated spec there's no recreate path that
+// could benefit from the import anyway.
+func startAutoImportReconciler(ctx context.Context, logger *slog.Logger, cfg config.Config, db *store.Store, svc *service.Service) {
+	if !cfg.AutoImportEnabled {
+		return
+	}
+	pat, err := os.ReadFile(cfg.AutoImportClusterPATPath)
+	if err != nil {
+		logger.Warn("auto-import: PAT file unreadable; feature stays off until next restart",
+			"path", cfg.AutoImportClusterPATPath, "error", err)
+		return
+	}
+	importer, err := service.NewAutoImporter(service.AutoImportConfig{
+		Enabled:         true,
+		HooksBaseURL:    cfg.AutoImportHooksBaseURL,
+		ClusterID:       cfg.AutoImportClusterID,
+		ClusterPAT:      string(bytesTrimSpace(pat)),
+		RetentionSuffix: cfg.AutoImportRetentionSuffix,
+		RequestTimeout:  cfg.AutoImportRequestTimeout,
+	})
+	if err != nil {
+		logger.Warn("auto-import: importer build failed; feature stays off",
+			"error", err)
+		return
+	}
+	resolver := autoImportSpecResolver{svc: svc}
+	r := service.NewAutoImportReconciler(importer, db, resolver, logger, cfg.AutoImportMaxInFlight)
+	if r == nil {
+		// Should not happen when importer is non-nil, but defensive: don't
+		// start a goroutine that has nothing to do.
+		return
+	}
+	logger.Info("auto-import reconciler started",
+		"hooks_url", importer.Endpoint(),
+		"interval", cfg.AutoImportReconcileInterval,
+		"max_in_flight", cfg.AutoImportMaxInFlight,
+	)
+	go func() {
+		t := time.NewTicker(cfg.AutoImportReconcileInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				stats, err := r.RunOnce(ctx)
+				if err != nil {
+					logger.Warn("auto-import reconcile sweep failed", "error", err)
+					continue
+				}
+				if stats.Scanned == 0 {
+					continue
+				}
+				logger.Info("auto-import reconcile sweep",
+					"scanned", stats.Scanned,
+					"succeeded", stats.Succeeded,
+					"failed", stats.Failed,
+					"skipped", stats.Skipped,
+				)
+			}
+		}
+	}()
+}
+
+// autoImportSpecResolver adapts the service+cluster surface to the
+// AutoImportSpecResolver interface. The replicated CreateSandboxRequest lives
+// in the cluster FSM (via cluster.SpecOf); we go through svc.Cluster() so the
+// adapter works under both Noop (standalone) and Cluster/Agent modes.
+type autoImportSpecResolver struct {
+	svc *service.Service
+}
+
+func (r autoImportSpecResolver) GetSandboxSpec(sandboxID string) (*models.CreateSandboxRequest, bool) {
+	c := r.svc.Cluster()
+	if c == nil {
+		return nil, false
+	}
+	spec := c.SpecOf(sandboxID)
+	if spec == nil {
+		return nil, false
+	}
+	return spec, true
+}
+
+// bytesTrimSpace is a tiny helper so we don't pull `strings` for one call —
+// PAT files commonly include a trailing newline.
+func bytesTrimSpace(b []byte) []byte {
+	start, end := 0, len(b)
+	for start < end && isSpace(b[start]) {
+		start++
+	}
+	for end > start && isSpace(b[end-1]) {
+		end--
+	}
+	return b[start:end]
+}
+
+func isSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
 }
 
 // portsFromSandbox extracts the routing intents the sandbox currently has

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -386,6 +386,50 @@ type Config struct {
 	// image/auth key after Docker or the registry returns an error. This keeps a
 	// bad tag or rate-limit response from turning into a per-create retry storm.
 	ImagePullFailureBackoff time.Duration
+
+	// AutoImportEnabled gates the F21 post-pull auto-import path: after a
+	// successful pull of a private upstream image, sandboxd asks AOCR to
+	// re-mount the bytes under `cluster/<id>/_imported/...` so future
+	// recreates on other nodes pull with the cluster PAT and survive an
+	// upstream credential rotation. Off by default; flipping it on requires
+	// AutoImportHooksBaseURL, AutoImportClusterID, and a non-empty PAT file.
+	// SB_AUTO_IMPORT_ENABLED.
+	AutoImportEnabled bool
+	// AutoImportHooksBaseURL is the AOCR hooks service root (no trailing
+	// slash). The importer appends `/v1/internal/imports`.
+	// SB_AUTO_IMPORT_HOOKS_URL.
+	AutoImportHooksBaseURL string
+	// AutoImportClusterID identifies this sandboxd cluster to AOCR. Goes
+	// into the import request body and constrains the cluster PAT's scope
+	// on the AOCR side. SB_AUTO_IMPORT_CLUSTER_ID.
+	AutoImportClusterID string
+	// AutoImportClusterPATPath is the file path to the bearer token
+	// presented to the AOCR ImportAPI. File-sourced (not env) so the secret
+	// is rotatable without restarting and never appears in process listings.
+	// SB_AUTO_IMPORT_CLUSTER_PAT_PATH.
+	AutoImportClusterPATPath string
+	// AutoImportRetentionSuffix is appended to the imported tag in the
+	// cluster namespace (e.g. `--idle-90d`). Must begin with `--` to match
+	// AOCR's retention parser; empty falls back to the server-side default.
+	// SB_AUTO_IMPORT_RETENTION_SUFFIX.
+	AutoImportRetentionSuffix string
+	// AutoImportRequestTimeout caps a single ImportAPI call. The mount-from-
+	// repo flow is normally sub-second; the timeout guards against an
+	// upstream that hangs on layer enumeration.
+	// SB_AUTO_IMPORT_REQUEST_TIMEOUT.
+	AutoImportRequestTimeout time.Duration
+	// AutoImportReconcileInterval is the period between retry sweeps for
+	// rows the post-pull path left flagged `auto_import_pending`. Too short
+	// and a flapping AOCR causes a fan-out storm; too long and a transient
+	// outage leaves the failover path on the F17 wrap-creds fallback for
+	// longer than necessary. Default 5m.
+	// SB_AUTO_IMPORT_RECONCILE_INTERVAL.
+	AutoImportReconcileInterval time.Duration
+	// AutoImportMaxInFlight bounds per-tick fan-out so a recovery storm
+	// (everything pending at once after a long outage) cannot saturate
+	// AOCR or the local Docker socket. Default 4.
+	// SB_AUTO_IMPORT_MAX_IN_FLIGHT.
+	AutoImportMaxInFlight int
 }
 
 func Load() (Config, error) {
@@ -488,6 +532,14 @@ func Load() (Config, error) {
 		ImageDistributionAOCRHost:        strings.TrimSpace(getEnv("SB_IMAGE_DISTRIBUTION_AOCR_HOST", "aocr.aerol.ai")),
 		ImagePullMaxConcurrent:           getEnvInt("SB_IMAGE_PULL_MAX_CONCURRENT", 4),
 		ImagePullFailureBackoff:          getEnvDuration("SB_IMAGE_PULL_FAILURE_BACKOFF", 30*time.Second),
+		AutoImportEnabled:                getEnvBool("SB_AUTO_IMPORT_ENABLED", false),
+		AutoImportHooksBaseURL:           strings.TrimSpace(os.Getenv("SB_AUTO_IMPORT_HOOKS_URL")),
+		AutoImportClusterID:              strings.TrimSpace(os.Getenv("SB_AUTO_IMPORT_CLUSTER_ID")),
+		AutoImportClusterPATPath:         strings.TrimSpace(os.Getenv("SB_AUTO_IMPORT_CLUSTER_PAT_PATH")),
+		AutoImportRetentionSuffix:        strings.TrimSpace(getEnv("SB_AUTO_IMPORT_RETENTION_SUFFIX", "--idle-90d")),
+		AutoImportRequestTimeout:         getEnvDuration("SB_AUTO_IMPORT_REQUEST_TIMEOUT", 15*time.Second),
+		AutoImportReconcileInterval:      getEnvDuration("SB_AUTO_IMPORT_RECONCILE_INTERVAL", 5*time.Minute),
+		AutoImportMaxInFlight:            getEnvInt("SB_AUTO_IMPORT_MAX_IN_FLIGHT", 4),
 	}
 	if cfg.OTELMetricsEndpoint != "" || strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")) != "" {
 		cfg.OTELMetricsEnabled = true
@@ -514,6 +566,23 @@ func Load() (Config, error) {
 	}
 	if cfg.ImagePullFailureBackoff < 0 {
 		return Config{}, errors.New("SB_IMAGE_PULL_FAILURE_BACKOFF must be >= 0")
+	}
+	if cfg.AutoImportEnabled {
+		if cfg.AutoImportHooksBaseURL == "" {
+			return Config{}, errors.New("SB_AUTO_IMPORT_HOOKS_URL is required when SB_AUTO_IMPORT_ENABLED=true")
+		}
+		if cfg.AutoImportClusterID == "" {
+			return Config{}, errors.New("SB_AUTO_IMPORT_CLUSTER_ID is required when SB_AUTO_IMPORT_ENABLED=true")
+		}
+		if cfg.AutoImportClusterPATPath == "" {
+			return Config{}, errors.New("SB_AUTO_IMPORT_CLUSTER_PAT_PATH is required when SB_AUTO_IMPORT_ENABLED=true")
+		}
+		if cfg.AutoImportReconcileInterval <= 0 {
+			return Config{}, errors.New("SB_AUTO_IMPORT_RECONCILE_INTERVAL must be > 0 when auto-import is enabled")
+		}
+		if cfg.AutoImportRetentionSuffix != "" && !strings.HasPrefix(cfg.AutoImportRetentionSuffix, "--") {
+			return Config{}, fmt.Errorf("SB_AUTO_IMPORT_RETENTION_SUFFIX must start with `--`, got %q", cfg.AutoImportRetentionSuffix)
+		}
 	}
 
 	if cfg.ToolboxMountPath == "" || !strings.HasPrefix(cfg.ToolboxMountPath, "/") {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -430,6 +430,41 @@ type Config struct {
 	// AOCR or the local Docker socket. Default 4.
 	// SB_AUTO_IMPORT_MAX_IN_FLIGHT.
 	AutoImportMaxInFlight int
+
+	// MirrorHost is the AOCR pull-through mirror vhost
+	// (e.g. `mirror.aocr.aerol.ai`). When non-empty AND at least one
+	// upstream is configured, the docker client rewrites matching image
+	// refs through this host before pulling. Empty disables rewriting and
+	// pulls hit the upstream registry directly — the safety hatch for
+	// nodes not running with AOCR mirror enabled. SB_MIRROR_HOST.
+	MirrorHost string
+	// MirrorPushHost is the AOCR push vhost (e.g. `aocr.aerol.ai`). Used
+	// only for idempotency: a ref that already points at the push vhost
+	// (e.g. a cluster snapshot or a previously-imported image) is not
+	// re-rewritten. Optional. SB_MIRROR_PUSH_HOST.
+	MirrorPushHost string
+	// MirrorUpstreams is the comma-separated host=shortname mapping
+	// (`ghcr.io=ghcr,gcr.io=gcr,quay.io=quay,registry.k8s.io=k8s`). Docker
+	// Hub is intentionally absent — it's mirrored via the Docker daemon's
+	// `registry-mirrors` daemon.json setting, not client-side rewriting.
+	// SB_MIRROR_UPSTREAMS.
+	MirrorUpstreams []MirrorUpstreamMapping
+	// UpstreamWrapKeyPath is the file path to the per-cluster AES-GCM wrap
+	// key used to seal docker `RegistryAuth` payloads before they reach
+	// the mirror, so the mirror vhost never sees raw upstream PATs.
+	// File-sourced (not env) with required mode 0400. When empty or
+	// unreadable, the mirror falls back to anonymous pulls — fine for
+	// public images, but private images will 401. SB_UPSTREAM_WRAP_KEY_PATH.
+	UpstreamWrapKeyPath string
+}
+
+// MirrorUpstreamMapping is a single host=shortname pair parsed from
+// SB_MIRROR_UPSTREAMS. Kept here (not in pkg/docker) so the config layer
+// has no dependency on the docker package — main.go translates to
+// docker.MirrorUpstream at wiring time.
+type MirrorUpstreamMapping struct {
+	Host      string
+	Shortname string
 }
 
 func Load() (Config, error) {
@@ -540,6 +575,10 @@ func Load() (Config, error) {
 		AutoImportRequestTimeout:         getEnvDuration("SB_AUTO_IMPORT_REQUEST_TIMEOUT", 15*time.Second),
 		AutoImportReconcileInterval:      getEnvDuration("SB_AUTO_IMPORT_RECONCILE_INTERVAL", 5*time.Minute),
 		AutoImportMaxInFlight:            getEnvInt("SB_AUTO_IMPORT_MAX_IN_FLIGHT", 4),
+		MirrorHost:                       strings.TrimSpace(os.Getenv("SB_MIRROR_HOST")),
+		MirrorPushHost:                   strings.TrimSpace(os.Getenv("SB_MIRROR_PUSH_HOST")),
+		MirrorUpstreams:                  parseMirrorUpstreams(getEnv("SB_MIRROR_UPSTREAMS", "ghcr.io=ghcr,gcr.io=gcr,quay.io=quay,registry.k8s.io=k8s")),
+		UpstreamWrapKeyPath:              strings.TrimSpace(os.Getenv("SB_UPSTREAM_WRAP_KEY_PATH")),
 	}
 	if cfg.OTELMetricsEndpoint != "" || strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")) != "" {
 		cfg.OTELMetricsEnabled = true
@@ -866,6 +905,30 @@ func getEnvDuration(key string, fallback time.Duration) time.Duration {
 
 func normalizeHost(value string) string {
 	return strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(value, "https://"), "http://"))
+}
+
+// parseMirrorUpstreams parses the comma-separated host=shortname list for
+// SB_MIRROR_UPSTREAMS. Tolerates surrounding whitespace and skips malformed
+// entries silently — a typo in one entry shouldn't prevent the others from
+// taking effect, and `MirrorConfig.Enabled()` already requires at least one
+// valid entry. Empty input returns an empty (non-nil) slice so callers can
+// range over it unconditionally.
+func parseMirrorUpstreams(raw string) []MirrorUpstreamMapping {
+	out := []MirrorUpstreamMapping{}
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		host, short, ok := strings.Cut(part, "=")
+		host = strings.TrimSpace(host)
+		short = strings.TrimSpace(short)
+		if !ok || host == "" || short == "" {
+			continue
+		}
+		out = append(out, MirrorUpstreamMapping{Host: host, Shortname: short})
+	}
+	return out
 }
 
 func normalizeAdvertiseHost(value string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -823,3 +823,36 @@ func TestDurationAndNormalizeCases(t *testing.T) {
 		t.Run(tc.name, tc.run)
 	}
 }
+
+func TestParseMirrorUpstreams(t *testing.T) {
+	cases := []struct {
+		name, raw string
+		want      []MirrorUpstreamMapping
+	}{
+		{"empty input returns empty slice", "", []MirrorUpstreamMapping{}},
+		{"single pair", "ghcr.io=ghcr", []MirrorUpstreamMapping{{"ghcr.io", "ghcr"}}},
+		{
+			"default day-1 four upstreams",
+			"ghcr.io=ghcr,gcr.io=gcr,quay.io=quay,registry.k8s.io=k8s",
+			[]MirrorUpstreamMapping{
+				{"ghcr.io", "ghcr"}, {"gcr.io", "gcr"}, {"quay.io", "quay"}, {"registry.k8s.io", "k8s"},
+			},
+		},
+		{"whitespace tolerated", "  ghcr.io = ghcr , gcr.io = gcr  ", []MirrorUpstreamMapping{{"ghcr.io", "ghcr"}, {"gcr.io", "gcr"}}},
+		{"malformed entries skipped silently", "ghcr.io=ghcr,bogus,quay.io=quay,=,no_value=,=no_host", []MirrorUpstreamMapping{{"ghcr.io", "ghcr"}, {"quay.io", "quay"}}},
+		{"only commas and spaces returns empty", " , , , ", []MirrorUpstreamMapping{}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := parseMirrorUpstreams(c.raw)
+			if len(got) != len(c.want) {
+				t.Fatalf("len = %d, want %d (%+v)", len(got), len(c.want), got)
+			}
+			for i := range got {
+				if got[i] != c.want[i] {
+					t.Fatalf("entry %d = %+v, want %+v", i, got[i], c.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/service/auto_import.go
+++ b/internal/service/auto_import.go
@@ -1,0 +1,219 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// AutoImportConfig wires the post-pull auto-import path to a specific AOCR
+// hooks deployment. A zero value disables auto-import; the rest of the
+// service runs exactly as before. main() is expected to validate that the
+// PAT + cluster ID are set when Enabled=true.
+//
+// See `plans/cluster-mirror-and-snapshot-distribution.md` F21 for the full
+// motivation. Short version: the first time a private upstream image is
+// pulled on a sandbox with `failover.policy: recreate`, sandboxd asks AOCR
+// to re-mount the just-cached bytes under
+// `cluster/<id>/_imported/<host>/<repo>`. Future recreates pull from the
+// cluster namespace with a cluster PAT — surviving an upstream credential
+// rotation that would otherwise break the F17 wrap-creds path.
+type AutoImportConfig struct {
+	// Enabled gates the whole feature. When false the post-pull path
+	// short-circuits and the auto-importer is never built.
+	Enabled bool
+	// HooksBaseURL is the root URL of the AOCR hooks service (no trailing
+	// slash, e.g. `https://aocr.aerol.ai`). The importer appends
+	// `/v1/internal/imports`.
+	HooksBaseURL string
+	// ClusterID identifies this sandboxd cluster to AOCR. Goes into the
+	// import request body and constrains the cluster PAT's scope.
+	ClusterID string
+	// ClusterPAT is the bearer token presented to the ImportAPI. Treat as
+	// secret; do not log. Sourced from a file path at startup, not env.
+	ClusterPAT string
+	// RetentionSuffix is appended to the target tag in the cluster
+	// namespace (e.g. `--idle-90d`). Empty means use the ImportAPI's
+	// server-side default (`--idle-90d`).
+	RetentionSuffix string
+	// RequestTimeout caps a single ImportAPI call. The mount-from-repo
+	// flow is normally sub-second (no byte transfer) but the timeout
+	// guards against an upstream that hangs on layer enumeration.
+	RequestTimeout time.Duration
+}
+
+// Validate enforces the consistency rules the rest of the service relies on.
+// Returns nil for a disabled config so callers can validate unconditionally.
+func (c AutoImportConfig) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	if strings.TrimSpace(c.HooksBaseURL) == "" {
+		return errors.New("AutoImportConfig: HooksBaseURL required when Enabled")
+	}
+	if _, err := url.Parse(c.HooksBaseURL); err != nil {
+		return fmt.Errorf("AutoImportConfig: HooksBaseURL invalid: %w", err)
+	}
+	if strings.TrimSpace(c.ClusterID) == "" {
+		return errors.New("AutoImportConfig: ClusterID required when Enabled")
+	}
+	if strings.TrimSpace(c.ClusterPAT) == "" {
+		return errors.New("AutoImportConfig: ClusterPAT required when Enabled")
+	}
+	if c.RetentionSuffix != "" && !strings.HasPrefix(c.RetentionSuffix, "--") {
+		return fmt.Errorf("AutoImportConfig: RetentionSuffix must start with `--`, got %q", c.RetentionSuffix)
+	}
+	return nil
+}
+
+// AutoImportRequest is the per-sandbox import payload. Fields mirror what
+// AOCR `ImportAPI` (hooks/src/controllers/ImportAPI.ts) expects on the
+// wire; the JSON marshaller below pins the contract.
+type AutoImportRequest struct {
+	UpstreamHost   string
+	UpstreamRepo   string
+	UpstreamTag    string
+	UpstreamDigest string
+}
+
+// AutoImportResult is what comes back. RegistryRef is the *cluster-side*
+// pull reference the caller should write onto the sandbox spec (replacing
+// the user's upstream ref for future recreates). AlreadyPresent=true
+// means the destination tag already existed at the right digest — the
+// importer treats that as success but the caller may want to suppress
+// the spec mutation to avoid an unnecessary Raft write.
+type AutoImportResult struct {
+	RegistryRef    string
+	AlreadyPresent bool
+}
+
+// AutoImporter is the leaf dependency that actually talks to AOCR. It
+// holds no per-sandbox state; instantiate once at boot and reuse. Safe
+// for concurrent use (it's just an http.Client wrapper).
+type AutoImporter struct {
+	cfg    AutoImportConfig
+	client *http.Client
+	// endpoint is the cached full URL so we don't re-parse on every call.
+	endpoint string
+}
+
+// NewAutoImporter builds an importer. Returns nil if cfg.Enabled is false
+// so callers can do `if importer == nil { return }` on the post-pull path
+// without an extra config check.
+func NewAutoImporter(cfg AutoImportConfig) (*AutoImporter, error) {
+	if !cfg.Enabled {
+		return nil, nil
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	timeout := cfg.RequestTimeout
+	if timeout <= 0 {
+		timeout = 15 * time.Second
+	}
+	return &AutoImporter{
+		cfg:      cfg,
+		client:   &http.Client{Timeout: timeout},
+		endpoint: strings.TrimRight(cfg.HooksBaseURL, "/") + "/v1/internal/imports",
+	}, nil
+}
+
+// importBody is the on-the-wire payload. Field tags must exactly match
+// the keys ImportAPI.ts validates against, otherwise the AOCR side returns
+// 400 `invalid_request` — there is a regression test on both sides that
+// pins these names.
+type importBody struct {
+	UpstreamHost     string `json:"upstream_host"`
+	UpstreamRepo     string `json:"upstream_repo"`
+	UpstreamTag      string `json:"upstream_tag,omitempty"`
+	UpstreamDigest   string `json:"upstream_digest"`
+	ClusterID        string `json:"cluster_id"`
+	TargetTagSuffix  string `json:"target_tag_suffix,omitempty"`
+}
+
+// importResponse is the success shape. status is one of "imported" /
+// "already_present" per ImportAPI.ts.
+type importResponse struct {
+	Status      string `json:"status"`
+	RegistryRef string `json:"registry_ref"`
+}
+
+// Import calls the AOCR ImportAPI once. Idempotent on (upstream_digest,
+// cluster_id, target_tag): re-posting an already-imported sandbox returns
+// AlreadyPresent=true without an error. Network/HTTP failures return a
+// wrapped error so the caller can decide whether to log+flag or surface.
+func (a *AutoImporter) Import(ctx context.Context, req AutoImportRequest) (AutoImportResult, error) {
+	if a == nil {
+		return AutoImportResult{}, errors.New("auto-import disabled (importer is nil)")
+	}
+	if strings.TrimSpace(req.UpstreamHost) == "" || strings.TrimSpace(req.UpstreamRepo) == "" {
+		return AutoImportResult{}, errors.New("auto-import: upstream host and repo required")
+	}
+	if strings.TrimSpace(req.UpstreamDigest) == "" {
+		return AutoImportResult{}, errors.New("auto-import: upstream digest required (mount-from-repo is digest-keyed)")
+	}
+
+	body := importBody{
+		UpstreamHost:    strings.TrimSpace(req.UpstreamHost),
+		UpstreamRepo:    strings.TrimSpace(req.UpstreamRepo),
+		UpstreamTag:     strings.TrimSpace(req.UpstreamTag),
+		UpstreamDigest:  strings.TrimSpace(req.UpstreamDigest),
+		ClusterID:       strings.TrimSpace(a.cfg.ClusterID),
+		TargetTagSuffix: strings.TrimSpace(a.cfg.RetentionSuffix),
+	}
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		return AutoImportResult{}, fmt.Errorf("auto-import: marshal body: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, a.endpoint, bytes.NewReader(encoded))
+	if err != nil {
+		return AutoImportResult{}, fmt.Errorf("auto-import: build request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+a.cfg.ClusterPAT)
+
+	resp, err := a.client.Do(httpReq)
+	if err != nil {
+		return AutoImportResult{}, fmt.Errorf("auto-import: POST %s: %w", a.endpoint, err)
+	}
+	defer resp.Body.Close()
+
+	// 401/403 means the cluster PAT is wrong or revoked — caller can use
+	// this to surface a clear operator-visible alert rather than silently
+	// retrying forever. We don't special-case it here; the wrapped error
+	// message includes the status code.
+	if resp.StatusCode >= 400 {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return AutoImportResult{}, fmt.Errorf("auto-import: AOCR returned HTTP %d: %s",
+			resp.StatusCode, strings.TrimSpace(string(snippet)))
+	}
+
+	var parsed importResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return AutoImportResult{}, fmt.Errorf("auto-import: decode response: %w", err)
+	}
+	if strings.TrimSpace(parsed.RegistryRef) == "" {
+		return AutoImportResult{}, errors.New("auto-import: AOCR returned empty registry_ref")
+	}
+	return AutoImportResult{
+		RegistryRef:    parsed.RegistryRef,
+		AlreadyPresent: parsed.Status == "already_present",
+	}, nil
+}
+
+// Endpoint is exposed for log/debug use. Returns "" for a nil importer so
+// callers can log it unconditionally.
+func (a *AutoImporter) Endpoint() string {
+	if a == nil {
+		return ""
+	}
+	return a.endpoint
+}

--- a/internal/service/auto_import_retry.go
+++ b/internal/service/auto_import_retry.go
@@ -1,0 +1,317 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// AutoImportPendingStore is the narrow store surface the reconciler needs.
+// Pulled out as an interface so the reconciler can be tested without
+// instantiating a full SQLite store — and so future store backends can
+// satisfy it without growing the reconciler's dependency surface.
+type AutoImportPendingStore interface {
+	ListAutoImportPendingIDs(ctx context.Context) ([]string, error)
+	Get(ctx context.Context, id string) (*models.Sandbox, error)
+	SetAutoImportPending(ctx context.Context, id string, pending bool) error
+}
+
+// AutoImportSpecResolver lets the reconciler look up the replicated
+// CreateSandboxRequest that owns a given sandbox. The reconciler needs
+// this because the spec carries the original upstream ref + the failover
+// policy (the gate for whether import should happen at all), but the
+// sandbox row only carries the runtime view. In standalone mode this is
+// backed by an in-memory map; in cluster mode by the Raft FSM.
+//
+// Returns nil, false when no replicated spec exists — the reconciler
+// treats that as "drop the flag, nothing to retry" rather than as an
+// error, since a sandbox without a spec cannot meaningfully be recreated
+// elsewhere anyway.
+type AutoImportSpecResolver interface {
+	GetSandboxSpec(sandboxID string) (*models.CreateSandboxRequest, bool)
+}
+
+// AutoImportReconciler walks the rows the post-pull path flagged
+// `auto_import_pending = true` and re-tries them. One ticker per node;
+// fan-out inside a single tick is capped to keep a recovery storm from
+// saturating the local Docker daemon or AOCR.
+//
+// The reconciler does not own a goroutine — `RunOnce` is the unit of
+// work, and a thin wrapper in main.go schedules it on a ticker. That
+// keeps the type fully testable (table-driven, no time.Tick) and lets
+// the operator trigger an immediate retry from a debug endpoint if
+// they want.
+type AutoImportReconciler struct {
+	importer   *AutoImporter
+	store      AutoImportPendingStore
+	specs      AutoImportSpecResolver
+	logger     *slog.Logger
+	maxInFlight int
+}
+
+// NewAutoImportReconciler builds the reconciler. Returns nil if the
+// importer is nil (auto-import disabled) so callers can `if r == nil
+// { return }` cheaply. maxInFlight clamps fan-out per tick; pass 0 for
+// the safe default (4).
+func NewAutoImportReconciler(importer *AutoImporter, store AutoImportPendingStore, specs AutoImportSpecResolver, logger *slog.Logger, maxInFlight int) *AutoImportReconciler {
+	if importer == nil || store == nil || specs == nil {
+		return nil
+	}
+	if maxInFlight <= 0 {
+		maxInFlight = 4
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &AutoImportReconciler{
+		importer:    importer,
+		store:       store,
+		specs:       specs,
+		logger:      logger,
+		maxInFlight: maxInFlight,
+	}
+}
+
+// AutoImportReconcileStats is what RunOnce reports back. Used by tests
+// and by the metrics-collection wrapper in main.go.
+type AutoImportReconcileStats struct {
+	Scanned   int
+	Succeeded int
+	Failed    int
+	Skipped   int
+}
+
+// RunOnce processes one sweep of the auto-import pending queue. Blocks
+// until all per-sandbox attempts have returned (success, failure, or
+// context cancel). The bounded semaphore caps in-flight HTTP calls;
+// the AOCR side is happy with the load but the local Docker network
+// stack is not infinitely parallel.
+func (r *AutoImportReconciler) RunOnce(ctx context.Context) (AutoImportReconcileStats, error) {
+	if r == nil {
+		return AutoImportReconcileStats{}, nil
+	}
+	ids, err := r.store.ListAutoImportPendingIDs(ctx)
+	if err != nil {
+		return AutoImportReconcileStats{}, err
+	}
+	stats := AutoImportReconcileStats{Scanned: len(ids)}
+	if len(ids) == 0 {
+		return stats, nil
+	}
+
+	sem := make(chan struct{}, r.maxInFlight)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+
+	for _, id := range ids {
+		if err := ctx.Err(); err != nil {
+			return stats, err
+		}
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(id string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			outcome := r.retryOne(ctx, id)
+			mu.Lock()
+			switch outcome {
+			case retrySucceeded:
+				stats.Succeeded++
+			case retryFailed:
+				stats.Failed++
+			case retrySkipped:
+				stats.Skipped++
+			}
+			mu.Unlock()
+		}(id)
+	}
+	wg.Wait()
+	return stats, nil
+}
+
+type retryOutcome int
+
+const (
+	retrySucceeded retryOutcome = iota
+	retryFailed
+	retrySkipped
+)
+
+// retryOne re-imports a single sandbox. Errors are logged and turned into
+// `retryFailed` (the row stays pending for the next tick); they are not
+// propagated up because one bad sandbox should not abort the whole sweep.
+// The retry is best-effort by design — the cluster failover path will
+// fall back to F17 wrap-creds if the import never succeeds.
+func (r *AutoImportReconciler) retryOne(ctx context.Context, sandboxID string) retryOutcome {
+	sandbox, err := r.store.Get(ctx, sandboxID)
+	if err != nil {
+		// Sandbox was deleted between the scan and the retry — drop the
+		// flag is not possible (the row is gone), so treat as skip.
+		r.logger.Debug("auto-import retry: sandbox vanished",
+			"sandbox_id", sandboxID, "error", err)
+		return retrySkipped
+	}
+	if !sandbox.AutoImportPending {
+		// Concurrent reconcile (or operator-cleared) won the race. Nothing
+		// to do — the index scan saw it but it's no longer pending.
+		return retrySkipped
+	}
+
+	spec, ok := r.specs.GetSandboxSpec(sandboxID)
+	if !ok || spec == nil {
+		// No replicated spec → no useful import. Clear the flag so we
+		// don't keep scanning this row forever; recreate is already
+		// impossible without a spec.
+		if err := r.store.SetAutoImportPending(ctx, sandboxID, false); err != nil {
+			r.logger.Warn("auto-import retry: drop pending flag failed",
+				"sandbox_id", sandboxID, "error", err)
+		}
+		return retrySkipped
+	}
+
+	req, ok := autoImportRequestFromSpec(spec)
+	if !ok {
+		// Spec no longer eligible (e.g. failover policy was patched to
+		// "none" after the import was scheduled). Drop the flag.
+		if err := r.store.SetAutoImportPending(ctx, sandboxID, false); err != nil {
+			r.logger.Warn("auto-import retry: drop pending flag failed",
+				"sandbox_id", sandboxID, "error", err)
+		}
+		return retrySkipped
+	}
+
+	result, err := r.importer.Import(ctx, req)
+	if err != nil {
+		r.logger.Warn("auto-import retry: import call failed",
+			"sandbox_id", sandboxID, "upstream", req.UpstreamHost+"/"+req.UpstreamRepo, "error", err)
+		return retryFailed
+	}
+
+	// Import succeeded — clear the flag. The spec's RegistryRef rewrite
+	// is intentionally NOT done here: it requires a Raft write and the
+	// reconciler runs on every node, including non-leader nodes. The
+	// service layer (callsite of the reconciler) is responsible for
+	// proposing the spec mutation through the cluster.Client path. For
+	// now we just clear the local flag and log the new ref so an operator
+	// can observe progress.
+	if err := r.store.SetAutoImportPending(ctx, sandboxID, false); err != nil {
+		r.logger.Warn("auto-import retry: succeeded but flag clear failed",
+			"sandbox_id", sandboxID, "ref", result.RegistryRef, "error", err)
+		return retryFailed
+	}
+	r.logger.Info("auto-import retry: succeeded",
+		"sandbox_id", sandboxID, "registry_ref", result.RegistryRef,
+		"already_present", result.AlreadyPresent)
+	return retrySucceeded
+}
+
+// autoImportRequestFromSpec extracts the upstream coordinates from a
+// replicated create-spec. Returns ok=false when the spec is no longer
+// eligible (no failover, no upstream digest, mode is already
+// `aocr_imported`, etc.) so the reconciler can clear the flag without
+// firing a doomed retry.
+func autoImportRequestFromSpec(spec *models.CreateSandboxRequest) (AutoImportRequest, bool) {
+	if spec == nil {
+		return AutoImportRequest{}, false
+	}
+	if spec.Failover == nil || !spec.Failover.ShouldRecreate() {
+		return AutoImportRequest{}, false
+	}
+	if spec.ImageDistributionMode == models.ImageDistributionAOCRImported {
+		// Already imported — nothing to do.
+		return AutoImportRequest{}, false
+	}
+	// We need the digest to do a deterministic mount-from-repo. Without
+	// it the import is non-idempotent and a tag race could overwrite the
+	// wrong manifest.
+	if spec.ImageDigest == "" {
+		return AutoImportRequest{}, false
+	}
+	host, repo, tag := parseUpstreamFromRegistryRef(spec.ImageRegistryRef, spec.Image)
+	if host == "" || repo == "" {
+		return AutoImportRequest{}, false
+	}
+	return AutoImportRequest{
+		UpstreamHost:   host,
+		UpstreamRepo:   repo,
+		UpstreamTag:    tag,
+		UpstreamDigest: spec.ImageDigest,
+	}, true
+}
+
+// parseUpstreamFromRegistryRef splits a `host/repo[:tag]` reference into
+// its components. Prefers the explicit ImageRegistryRef (set during pull
+// classification) and falls back to the user-supplied Image string. Tag
+// is optional — the digest is what makes the import authoritative.
+//
+// This deliberately does NOT understand AOCR mirror-prefix rewriting
+// (`mirror.aocr.aerol.ai/_/ghcr/...`): the AutoImport path runs against
+// the *original* upstream ref, not the mirror-rewritten one. The mirror
+// rewrite is a pull-time concern only.
+func parseUpstreamFromRegistryRef(registryRef, image string) (host, repo, tag string) {
+	pick := registryRef
+	if pick == "" {
+		pick = image
+	}
+	first, rest, ok := splitOnce(pick, "/")
+	if !ok {
+		return "", "", ""
+	}
+	// Same host detection as docker.splitHostRepo — must contain `.`/`:`
+	// or be `localhost`. Bare names like `library/redis` are docker.io
+	// and have no upstream host.
+	if first != "localhost" && !containsAny(first, ".:") {
+		return "", "", ""
+	}
+	host = first
+	repo = rest
+	if at := lastIndexByte(repo, ':'); at >= 0 {
+		// Only treat as tag if the colon is after the last slash —
+		// otherwise it's part of a port we already split.
+		if lastIndexByte(repo, '/') < at {
+			tag = repo[at+1:]
+			repo = repo[:at]
+		}
+	}
+	return host, repo, tag
+}
+
+// Trivial string helpers kept local to avoid pulling pkg/docker into the
+// service package just for substring math.
+func splitOnce(s, sep string) (a, b string, ok bool) {
+	for i := 0; i+len(sep) <= len(s); i++ {
+		if s[i:i+len(sep)] == sep {
+			return s[:i], s[i+len(sep):], true
+		}
+	}
+	return s, "", false
+}
+
+func containsAny(s, chars string) bool {
+	for i := 0; i < len(s); i++ {
+		for j := 0; j < len(chars); j++ {
+			if s[i] == chars[j] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func lastIndexByte(s string, c byte) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}
+
+// AutoImportDisabledError is returned by callsites that want to distinguish
+// "feature off" from "feature on, but failed". main() can switch on it to
+// suppress alerts.
+var AutoImportDisabledError = errors.New("auto-import disabled")

--- a/internal/service/auto_import_retry.go
+++ b/internal/service/auto_import_retry.go
@@ -34,6 +34,25 @@ type AutoImportSpecResolver interface {
 	GetSandboxSpec(sandboxID string) (*models.CreateSandboxRequest, bool)
 }
 
+// AutoImportSpecMutator is the optional write-back hook. After a successful
+// import, the reconciler calls MarkImported so the replicated spec carries
+// the new cluster registry ref and `aocr_imported` distribution mode. Future
+// failovers then pull from the cluster namespace with the cluster PAT, fully
+// decoupled from the original upstream credential.
+//
+// Implementations must be safe to call on a non-leader node: the leader-
+// forwarding lives below this surface (cluster.UpsertSpec proposes through
+// the Raft FSM regardless of caller node). Errors are absorbed inside the
+// implementation — the reconciler always treats import success as a clean
+// retryOutcome even if the mutator can't reach the leader, because the
+// imported bytes are already in AOCR.
+//
+// A nil mutator disables write-through cleanly; the reconciler logs the new
+// ref and moves on. This is the standalone-mode default.
+type AutoImportSpecMutator interface {
+	MarkImported(ctx context.Context, sandboxID string, registryRef string)
+}
+
 // AutoImportReconciler walks the rows the post-pull path flagged
 // `auto_import_pending = true` and re-tries them. One ticker per node;
 // fan-out inside a single tick is capped to keep a recovery storm from
@@ -45,11 +64,23 @@ type AutoImportSpecResolver interface {
 // the operator trigger an immediate retry from a debug endpoint if
 // they want.
 type AutoImportReconciler struct {
-	importer   *AutoImporter
-	store      AutoImportPendingStore
-	specs      AutoImportSpecResolver
-	logger     *slog.Logger
+	importer    *AutoImporter
+	store       AutoImportPendingStore
+	specs       AutoImportSpecResolver
+	mutator     AutoImportSpecMutator
+	logger      *slog.Logger
 	maxInFlight int
+}
+
+// SetSpecMutator installs the optional write-back hook. Calling again
+// replaces the previous one; pass nil to disable. Separated from the
+// constructor so existing call sites (and tests) keep working unchanged —
+// the mutator is a strict upgrade, not a required dependency.
+func (r *AutoImportReconciler) SetSpecMutator(m AutoImportSpecMutator) {
+	if r == nil {
+		return
+	}
+	r.mutator = m
 }
 
 // NewAutoImportReconciler builds the reconciler. Returns nil if the
@@ -191,17 +222,18 @@ func (r *AutoImportReconciler) retryOne(ctx context.Context, sandboxID string) r
 		return retryFailed
 	}
 
-	// Import succeeded — clear the flag. The spec's RegistryRef rewrite
-	// is intentionally NOT done here: it requires a Raft write and the
-	// reconciler runs on every node, including non-leader nodes. The
-	// service layer (callsite of the reconciler) is responsible for
-	// proposing the spec mutation through the cluster.Client path. For
-	// now we just clear the local flag and log the new ref so an operator
-	// can observe progress.
+	// Import succeeded — clear the flag, then (best-effort) propose the
+	// spec mutation through the cluster. The spec write-through goes via
+	// the leader regardless of which node we're on; failures are absorbed
+	// by the mutator since the bytes are already in AOCR and future
+	// pulls of the original ref still resolve cleanly through the mirror.
 	if err := r.store.SetAutoImportPending(ctx, sandboxID, false); err != nil {
 		r.logger.Warn("auto-import retry: succeeded but flag clear failed",
 			"sandbox_id", sandboxID, "ref", result.RegistryRef, "error", err)
 		return retryFailed
+	}
+	if r.mutator != nil {
+		r.mutator.MarkImported(ctx, sandboxID, result.RegistryRef)
 	}
 	r.logger.Info("auto-import retry: succeeded",
 		"sandbox_id", sandboxID, "registry_ref", result.RegistryRef,

--- a/internal/service/auto_import_retry_test.go
+++ b/internal/service/auto_import_retry_test.go
@@ -1,0 +1,314 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// fakePendingStore is a hand-rolled in-memory store covering only the
+// surface AutoImportReconciler depends on. Concurrent-safe so the
+// reconciler's bounded fan-out doesn't race the test.
+type fakePendingStore struct {
+	mu       sync.Mutex
+	sandbox  map[string]*models.Sandbox
+	pending  map[string]bool
+	getErr   map[string]error
+	setCalls atomic.Int64
+}
+
+func newFakeStore() *fakePendingStore {
+	return &fakePendingStore{
+		sandbox: map[string]*models.Sandbox{},
+		pending: map[string]bool{},
+		getErr:  map[string]error{},
+	}
+}
+
+func (f *fakePendingStore) seed(id string, pending bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sandbox[id] = &models.Sandbox{ID: id, AutoImportPending: pending}
+	f.pending[id] = pending
+}
+
+func (f *fakePendingStore) seedDeleted(id string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.pending[id] = true
+	f.getErr[id] = errors.New("sandbox vanished")
+}
+
+func (f *fakePendingStore) ListAutoImportPendingIDs(ctx context.Context) ([]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, 0, len(f.pending))
+	for id, on := range f.pending {
+		if on {
+			out = append(out, id)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakePendingStore) Get(ctx context.Context, id string) (*models.Sandbox, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.getErr[id]; err != nil {
+		return nil, err
+	}
+	s, ok := f.sandbox[id]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	copy := *s
+	copy.AutoImportPending = f.pending[id]
+	return &copy, nil
+}
+
+func (f *fakePendingStore) SetAutoImportPending(ctx context.Context, id string, pending bool) error {
+	f.setCalls.Add(1)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.pending[id] = pending
+	if s, ok := f.sandbox[id]; ok {
+		s.AutoImportPending = pending
+	}
+	return nil
+}
+
+type fakeSpecResolver struct {
+	specs map[string]*models.CreateSandboxRequest
+}
+
+func (r *fakeSpecResolver) GetSandboxSpec(id string) (*models.CreateSandboxRequest, bool) {
+	s, ok := r.specs[id]
+	return s, ok
+}
+
+func eligibleSpec() *models.CreateSandboxRequest {
+	return &models.CreateSandboxRequest{
+		Image:                 "ghcr.io/aerol-ai/sandbox:v1",
+		ImageDigest:           "sha256:aabbccdd",
+		ImageRegistryRef:      "ghcr.io/aerol-ai/sandbox:v1",
+		ImageDistributionMode: models.ImageDistributionExternalRegistry,
+		Failover:              &models.Failover{Policy: models.FailoverPolicyRecreate},
+	}
+}
+
+func runReconciler(t *testing.T, store *fakePendingStore, specs map[string]*models.CreateSandboxRequest, srv *httptest.Server) AutoImportReconcileStats {
+	t.Helper()
+	imp, err := NewAutoImporter(validImportCfg(srv.URL))
+	if err != nil {
+		t.Fatalf("importer: %v", err)
+	}
+	r := NewAutoImportReconciler(imp, store, &fakeSpecResolver{specs: specs}, slog.Default(), 2)
+	stats, err := r.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	return stats
+}
+
+func TestReconciler_SuccessClearsPending(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(importResponse{
+			Status: "imported", RegistryRef: "aocr.aerol.ai/cluster/cl/_imported/ghcr.io/aerol-ai/sandbox:v1--idle-90d",
+		})
+	}))
+	defer srv.Close()
+
+	store := newFakeStore()
+	store.seed("sb-1", true)
+	stats := runReconciler(t, store, map[string]*models.CreateSandboxRequest{"sb-1": eligibleSpec()}, srv)
+	if stats.Succeeded != 1 || stats.Failed != 0 || stats.Skipped != 0 {
+		t.Fatalf("stats = %+v, want 1/0/0", stats)
+	}
+	if store.pending["sb-1"] {
+		t.Fatalf("pending flag not cleared after success")
+	}
+}
+
+func TestReconciler_FailureLeavesPending(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad gateway", http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	store := newFakeStore()
+	store.seed("sb-1", true)
+	stats := runReconciler(t, store, map[string]*models.CreateSandboxRequest{"sb-1": eligibleSpec()}, srv)
+	if stats.Failed != 1 {
+		t.Fatalf("expected Failed=1, got %+v", stats)
+	}
+	if !store.pending["sb-1"] {
+		t.Fatalf("pending flag must remain set on failure for next sweep")
+	}
+}
+
+func TestReconciler_NoSpecSkipsAndClears(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("import endpoint hit despite missing spec")
+	}))
+	defer srv.Close()
+
+	store := newFakeStore()
+	store.seed("sb-orphan", true)
+	stats := runReconciler(t, store, map[string]*models.CreateSandboxRequest{}, srv) // no spec for sb-orphan
+	if stats.Skipped != 1 {
+		t.Fatalf("expected Skipped=1, got %+v", stats)
+	}
+	if store.pending["sb-orphan"] {
+		t.Fatalf("missing-spec rows must have their flag cleared to avoid infinite scan")
+	}
+}
+
+func TestReconciler_FailoverNoneSkipsAndClears(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("import endpoint hit despite failover=none")
+	}))
+	defer srv.Close()
+
+	spec := eligibleSpec()
+	spec.Failover = &models.Failover{Policy: models.FailoverPolicyNone}
+	store := newFakeStore()
+	store.seed("sb-1", true)
+	stats := runReconciler(t, store, map[string]*models.CreateSandboxRequest{"sb-1": spec}, srv)
+	if stats.Skipped != 1 {
+		t.Fatalf("expected Skipped=1, got %+v", stats)
+	}
+	if store.pending["sb-1"] {
+		t.Fatalf("non-recreate spec must clear the flag")
+	}
+}
+
+func TestReconciler_AlreadyImportedSpecSkips(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("import endpoint hit despite mode=aocr_imported")
+	}))
+	defer srv.Close()
+
+	spec := eligibleSpec()
+	spec.ImageDistributionMode = models.ImageDistributionAOCRImported
+	store := newFakeStore()
+	store.seed("sb-1", true)
+	stats := runReconciler(t, store, map[string]*models.CreateSandboxRequest{"sb-1": spec}, srv)
+	if stats.Skipped != 1 {
+		t.Fatalf("expected Skipped=1, got %+v", stats)
+	}
+}
+
+func TestReconciler_MissingDigestSkips(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("import endpoint hit despite missing digest")
+	}))
+	defer srv.Close()
+
+	spec := eligibleSpec()
+	spec.ImageDigest = ""
+	store := newFakeStore()
+	store.seed("sb-1", true)
+	stats := runReconciler(t, store, map[string]*models.CreateSandboxRequest{"sb-1": spec}, srv)
+	if stats.Skipped != 1 {
+		t.Fatalf("expected Skipped=1, got %+v", stats)
+	}
+}
+
+func TestReconciler_DeletedSandboxSkipped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("import endpoint hit despite sandbox vanished")
+	}))
+	defer srv.Close()
+
+	store := newFakeStore()
+	store.seedDeleted("sb-gone")
+	stats := runReconciler(t, store, map[string]*models.CreateSandboxRequest{"sb-gone": eligibleSpec()}, srv)
+	if stats.Skipped != 1 {
+		t.Fatalf("expected Skipped=1, got %+v", stats)
+	}
+}
+
+func TestReconciler_BoundedConcurrency(t *testing.T) {
+	var inFlight atomic.Int64
+	var peak atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cur := inFlight.Add(1)
+		for {
+			p := peak.Load()
+			if cur <= p || peak.CompareAndSwap(p, cur) {
+				break
+			}
+		}
+		time.Sleep(40 * time.Millisecond)
+		inFlight.Add(-1)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(importResponse{Status: "imported", RegistryRef: "x"})
+	}))
+	defer srv.Close()
+
+	store := newFakeStore()
+	specs := map[string]*models.CreateSandboxRequest{}
+	for i := 0; i < 6; i++ {
+		id := "sb-" + string(rune('a'+i))
+		store.seed(id, true)
+		specs[id] = eligibleSpec()
+	}
+	stats := runReconciler(t, store, specs, srv) // maxInFlight=2 in helper
+	if stats.Succeeded != 6 {
+		t.Fatalf("expected 6 succeeded, got %+v", stats)
+	}
+	if peak.Load() > 2 {
+		t.Fatalf("peak concurrency %d > cap 2", peak.Load())
+	}
+}
+
+func TestReconciler_EmptyListNoOp(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("server should not be hit when no rows pending")
+	}))
+	defer srv.Close()
+
+	store := newFakeStore()
+	stats := runReconciler(t, store, map[string]*models.CreateSandboxRequest{}, srv)
+	if stats.Scanned != 0 {
+		t.Fatalf("scanned %d > 0 on empty store", stats.Scanned)
+	}
+}
+
+func TestReconciler_NilImporterYieldsNoReconciler(t *testing.T) {
+	r := NewAutoImportReconciler(nil, newFakeStore(), &fakeSpecResolver{}, slog.Default(), 0)
+	if r != nil {
+		t.Fatalf("expected nil reconciler when importer is nil, got %v", r)
+	}
+}
+
+func TestParseUpstreamFromRegistryRef(t *testing.T) {
+	cases := []struct {
+		name, ref, image, host, repo, tag string
+	}{
+		{"prefers ref", "ghcr.io/foo/bar:v1", "", "ghcr.io", "foo/bar", "v1"},
+		{"falls back to image", "", "ghcr.io/foo/bar:v1", "ghcr.io", "foo/bar", "v1"},
+		{"no tag", "ghcr.io/foo/bar", "", "ghcr.io", "foo/bar", ""},
+		{"dockerhub bare returns empty", "", "redis:7", "", "", ""},
+		{"dockerhub library returns empty", "", "library/redis", "", "", ""},
+		{"localhost host", "localhost:5000/foo:bar", "", "localhost:5000", "foo", "bar"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h, r, tg := parseUpstreamFromRegistryRef(c.ref, c.image)
+			if h != c.host || r != c.repo || tg != c.tag {
+				t.Fatalf("got (%q,%q,%q) want (%q,%q,%q)", h, r, tg, c.host, c.repo, c.tag)
+			}
+		})
+	}
+}

--- a/internal/service/auto_import_test.go
+++ b/internal/service/auto_import_test.go
@@ -1,0 +1,183 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func validImportCfg(baseURL string) AutoImportConfig {
+	return AutoImportConfig{
+		Enabled:         true,
+		HooksBaseURL:    baseURL,
+		ClusterID:       "cl-prod-us-east",
+		ClusterPAT:      "pat_xxxxxxxxxxxxxxxx",
+		RetentionSuffix: "--idle-90d",
+		RequestTimeout:  500 * time.Millisecond,
+	}
+}
+
+func TestAutoImportConfig_ValidateDisabledAlwaysOK(t *testing.T) {
+	if err := (AutoImportConfig{}).Validate(); err != nil {
+		t.Fatalf("disabled config must validate clean: %v", err)
+	}
+}
+
+func TestAutoImportConfig_ValidateRequiresFields(t *testing.T) {
+	cases := map[string]AutoImportConfig{
+		"no host":   {Enabled: true, ClusterID: "x", ClusterPAT: "y"},
+		"no id":     {Enabled: true, HooksBaseURL: "https://x", ClusterPAT: "y"},
+		"no pat":    {Enabled: true, HooksBaseURL: "https://x", ClusterID: "y"},
+		"bad suffix":{Enabled: true, HooksBaseURL: "https://x", ClusterID: "y", ClusterPAT: "z", RetentionSuffix: "idle-90d"},
+	}
+	for name, cfg := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := cfg.Validate(); err == nil {
+				t.Fatalf("expected validation error for %s", name)
+			}
+		})
+	}
+}
+
+func TestNewAutoImporter_DisabledReturnsNilNil(t *testing.T) {
+	imp, err := NewAutoImporter(AutoImportConfig{})
+	if err != nil || imp != nil {
+		t.Fatalf("disabled config must yield (nil, nil), got (%v, %v)", imp, err)
+	}
+}
+
+func TestAutoImporter_ImportSuccess(t *testing.T) {
+	var calls atomic.Int64
+	var capturedBody importBody
+	var capturedAuth string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		capturedAuth = r.Header.Get("Authorization")
+		if r.URL.Path != "/v1/internal/imports" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &capturedBody); err != nil {
+			t.Errorf("invalid JSON body: %v", err)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(importResponse{
+			Status:      "imported",
+			RegistryRef: "aocr.aerol.ai/cluster/cl-prod-us-east/_imported/ghcr.io/aerol-ai/sandbox:v1--idle-90d",
+		})
+	}))
+	defer srv.Close()
+
+	imp, err := NewAutoImporter(validImportCfg(srv.URL))
+	if err != nil {
+		t.Fatalf("NewAutoImporter: %v", err)
+	}
+	res, err := imp.Import(context.Background(), AutoImportRequest{
+		UpstreamHost:   "ghcr.io",
+		UpstreamRepo:   "aerol-ai/sandbox",
+		UpstreamTag:    "v1",
+		UpstreamDigest: "sha256:aabbccdd",
+	})
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if res.AlreadyPresent {
+		t.Fatalf("expected fresh import, got AlreadyPresent=true")
+	}
+	if !strings.HasSuffix(res.RegistryRef, "--idle-90d") {
+		t.Fatalf("registry_ref missing retention suffix: %s", res.RegistryRef)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("calls = %d, want 1", got)
+	}
+	if capturedAuth != "Bearer pat_xxxxxxxxxxxxxxxx" {
+		t.Fatalf("Authorization header: %q", capturedAuth)
+	}
+	if capturedBody.UpstreamHost != "ghcr.io" || capturedBody.UpstreamRepo != "aerol-ai/sandbox" ||
+		capturedBody.UpstreamDigest != "sha256:aabbccdd" || capturedBody.ClusterID != "cl-prod-us-east" ||
+		capturedBody.TargetTagSuffix != "--idle-90d" {
+		t.Fatalf("request body mismatch: %+v", capturedBody)
+	}
+}
+
+func TestAutoImporter_ImportAlreadyPresent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(importResponse{
+			Status:      "already_present",
+			RegistryRef: "aocr.aerol.ai/cluster/X/_imported/ghcr.io/foo/bar:v1--idle-90d",
+		})
+	}))
+	defer srv.Close()
+
+	imp, _ := NewAutoImporter(validImportCfg(srv.URL))
+	res, err := imp.Import(context.Background(), AutoImportRequest{
+		UpstreamHost: "ghcr.io", UpstreamRepo: "foo/bar", UpstreamDigest: "sha256:xx",
+	})
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if !res.AlreadyPresent {
+		t.Fatalf("expected AlreadyPresent=true for already_present status")
+	}
+}
+
+func TestAutoImporter_RejectsMissingFields(t *testing.T) {
+	imp, _ := NewAutoImporter(validImportCfg("http://unused"))
+	cases := map[string]AutoImportRequest{
+		"no host":   {UpstreamRepo: "foo/bar", UpstreamDigest: "sha256:x"},
+		"no repo":   {UpstreamHost: "ghcr.io", UpstreamDigest: "sha256:x"},
+		"no digest": {UpstreamHost: "ghcr.io", UpstreamRepo: "foo/bar"},
+	}
+	for name, req := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := imp.Import(context.Background(), req); err == nil {
+				t.Fatalf("expected validation error")
+			}
+		})
+	}
+}
+
+func TestAutoImporter_PropagatesHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"forbidden"}`, http.StatusForbidden)
+	}))
+	defer srv.Close()
+	imp, _ := NewAutoImporter(validImportCfg(srv.URL))
+	_, err := imp.Import(context.Background(), AutoImportRequest{
+		UpstreamHost: "ghcr.io", UpstreamRepo: "foo/bar", UpstreamDigest: "sha256:x",
+	})
+	if err == nil || !strings.Contains(err.Error(), "403") {
+		t.Fatalf("expected 403 wrapped error, got %v", err)
+	}
+}
+
+func TestAutoImporter_RejectsEmptyRegistryRef(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(importResponse{Status: "imported", RegistryRef: ""})
+	}))
+	defer srv.Close()
+	imp, _ := NewAutoImporter(validImportCfg(srv.URL))
+	if _, err := imp.Import(context.Background(), AutoImportRequest{
+		UpstreamHost: "ghcr.io", UpstreamRepo: "foo/bar", UpstreamDigest: "sha256:x",
+	}); err == nil {
+		t.Fatalf("expected error on empty registry_ref")
+	}
+}
+
+func TestAutoImporter_NilImporterReturnsError(t *testing.T) {
+	var imp *AutoImporter
+	if _, err := imp.Import(context.Background(), AutoImportRequest{
+		UpstreamHost: "ghcr.io", UpstreamRepo: "foo/bar", UpstreamDigest: "sha256:x",
+	}); err == nil {
+		t.Fatalf("expected error from nil importer")
+	}
+}

--- a/internal/service/auto_import_writeback.go
+++ b/internal/service/auto_import_writeback.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+	"context"
+	"strings"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// MarkImported is the spec write-back invoked by the AutoImportReconciler
+// after a successful import. It flips the replicated spec's distribution
+// mode to `aocr_imported` and points ImageRegistryRef at the new cluster-
+// side ref so any future failover/recreate pulls from the cluster
+// namespace (cluster PAT) instead of the original upstream.
+//
+// Best-effort by contract: a missing spec, a non-leader UpsertSpec
+// rejection, or a Raft commit error all log+return without surfacing the
+// failure. The bytes are already in AOCR; the original ref still resolves
+// through the mirror; the next mutation will refresh the FSM. This is the
+// AutoImportSpecMutator implementation referenced by the reconciler.
+func (s *Service) MarkImported(ctx context.Context, sandboxID string, registryRef string) {
+	if s == nil {
+		return
+	}
+	registryRef = strings.TrimSpace(registryRef)
+	if registryRef == "" {
+		return
+	}
+	s.replicateSpecPatch(ctx, sandboxID, func(spec *models.CreateSandboxRequest) {
+		spec.ImageDistributionMode = models.ImageDistributionAOCRImported
+		spec.ImageRegistryRef = registryRef
+	})
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -88,6 +88,7 @@ func Open(path string) (*Store, error) {
 			net_bytes_out_limit INTEGER NOT NULL DEFAULT 0,
 			net_quota_exceeded INTEGER NOT NULL DEFAULT 0,
 			net_quota_exceeded_at DATETIME,
+			auto_import_pending INTEGER NOT NULL DEFAULT 0,
 			created_at DATETIME NOT NULL,
 			updated_at DATETIME NOT NULL,
 			last_active_at DATETIME NOT NULL
@@ -269,6 +270,12 @@ func Open(path string) (*Store, error) {
 		`ALTER TABLE sandbox_snapshots ADD COLUMN image_digest TEXT NOT NULL DEFAULT '';`,
 		`ALTER TABLE sandbox_snapshots ADD COLUMN image_registry_ref TEXT NOT NULL DEFAULT '';`,
 		`ALTER TABLE sandbox_snapshots ADD COLUMN image_verified_at DATETIME;`,
+		// auto_import_pending is set when the post-pull AOCR auto-import
+		// (F21) failed and a background reconciler should retry. It is
+		// local-node bookkeeping only — never replicated, never user-visible.
+		// The partial index below makes the reconciler scan cheap even when
+		// the steady-state count of pending rows is zero.
+		`ALTER TABLE sandboxes ADD COLUMN auto_import_pending INTEGER NOT NULL DEFAULT 0;`,
 	}
 	for _, stmt := range migrations {
 		if _, err := db.Exec(stmt); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
@@ -284,6 +291,14 @@ func Open(path string) (*Store, error) {
 	if _, err := db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_exposed_ports_host_port ON exposed_ports(host_port) WHERE host_port > 0;`); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("create exposed_ports host_port index: %w", err)
+	}
+
+	// Partial index keeps the auto-import reconciler scan O(pending), not
+	// O(sandboxes). Steady-state count is zero so the index footprint is
+	// negligible; spikes happen when AOCR is briefly unreachable.
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_sandboxes_auto_import_pending ON sandboxes(id) WHERE auto_import_pending = 1;`); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("create sandboxes auto_import_pending index: %w", err)
 	}
 
 	// SQLite materialized the DB file (and the WAL/SHM sidecars on the
@@ -353,8 +368,9 @@ func (s *Store) Create(ctx context.Context, sandbox *models.Sandbox) error {
 			runtime, gpus_json,
 			net_bytes_in, net_bytes_out, net_bytes_in_limit, net_bytes_out_limit,
 			net_quota_exceeded, net_quota_exceeded_at,
-			registry_auth_sealed
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			registry_auth_sealed,
+			auto_import_pending
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		sandbox.ID,
 		sandbox.Image,
@@ -392,6 +408,7 @@ func (s *Store) Create(ctx context.Context, sandbox *models.Sandbox) error {
 		boolToInt(sandbox.NetworkQuotaExceeded),
 		nullableTime(sandbox.NetworkQuotaExceededAt),
 		nullableBlob(sandbox.RegistryAuthSealed),
+		boolToInt(sandbox.AutoImportPending),
 	)
 	if err != nil {
 		if isSandboxNameConflict(err, sandbox.Name) {
@@ -453,8 +470,9 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 			runtime, gpus_json,
 			net_bytes_in, net_bytes_out, net_bytes_in_limit, net_bytes_out_limit,
 			net_quota_exceeded, net_quota_exceeded_at,
-			registry_auth_sealed
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			registry_auth_sealed,
+			auto_import_pending
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			image = excluded.image,
 			status = excluded.status,
@@ -485,7 +503,8 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 			gpus_json = excluded.gpus_json,
 			net_bytes_in_limit = excluded.net_bytes_in_limit,
 			net_bytes_out_limit = excluded.net_bytes_out_limit,
-			registry_auth_sealed = excluded.registry_auth_sealed
+			registry_auth_sealed = excluded.registry_auth_sealed,
+			auto_import_pending = excluded.auto_import_pending
 	`,
 		sandbox.ID,
 		sandbox.Image,
@@ -523,6 +542,7 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 		boolToInt(sandbox.NetworkQuotaExceeded),
 		nullableTime(sandbox.NetworkQuotaExceededAt),
 		nullableBlob(sandbox.RegistryAuthSealed),
+		boolToInt(sandbox.AutoImportPending),
 	)
 	if err != nil {
 		if isSandboxNameConflict(err, sandbox.Name) {
@@ -543,7 +563,8 @@ func (s *Store) Get(ctx context.Context, id string) (*models.Sandbox, error) {
 			runtime, gpus_json,
 			net_bytes_in, net_bytes_out, net_bytes_in_limit, net_bytes_out_limit,
 			net_quota_exceeded, net_quota_exceeded_at,
-			registry_auth_sealed
+			registry_auth_sealed,
+			auto_import_pending
 		FROM sandboxes
 		WHERE id = ?
 	`, id)
@@ -575,7 +596,8 @@ func (s *Store) List(ctx context.Context) ([]*models.Sandbox, error) {
 			runtime, gpus_json,
 			net_bytes_in, net_bytes_out, net_bytes_in_limit, net_bytes_out_limit,
 			net_quota_exceeded, net_quota_exceeded_at,
-			registry_auth_sealed
+			registry_auth_sealed,
+			auto_import_pending
 		FROM sandboxes
 		ORDER BY created_at DESC
 	`)
@@ -821,6 +843,53 @@ func (s *Store) ClearNetworkQuotaExceeded(ctx context.Context, id string) error 
 		return ErrNotFound
 	}
 	return nil
+}
+
+// SetAutoImportPending toggles the AOCR auto-import retry flag. The post-pull
+// auto-import path sets it to true on failure; the reconciler clears it after
+// a successful import. The reconciler must call this rather than Upsert to
+// avoid racing the runtime-state machine on the rest of the sandbox row.
+func (s *Store) SetAutoImportPending(ctx context.Context, id string, pending bool) error {
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE sandboxes
+		SET auto_import_pending = ?,
+		    updated_at = ?
+		WHERE id = ?
+	`, boolToInt(pending), time.Now().UTC(), id)
+	if err != nil {
+		return fmt.Errorf("set auto_import_pending: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err == nil && affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ListAutoImportPendingIDs returns the IDs of sandboxes whose post-pull
+// auto-import has not yet succeeded. Returns IDs only (not full Sandbox
+// rows) so the reconciler can fetch+retry one at a time and skip rows that
+// have meanwhile been deleted without holding a large in-memory snapshot.
+// Hits the partial index on (auto_import_pending = 1).
+func (s *Store) ListAutoImportPendingIDs(ctx context.Context) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id FROM sandboxes
+		WHERE auto_import_pending = 1
+		ORDER BY updated_at ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list auto_import_pending sandboxes: %w", err)
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan auto_import_pending id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
 }
 
 func (s *Store) Delete(ctx context.Context, id string) error {
@@ -1543,6 +1612,7 @@ func scanSandbox(scanner interface {
 	var netQuotaExceeded int
 	var netQuotaExceededAt sql.NullTime
 	var registryAuthSealed []byte
+	var autoImportPending int
 
 	err := scanner.Scan(
 		&sandbox.ID,
@@ -1581,6 +1651,7 @@ func scanSandbox(scanner interface {
 		&netQuotaExceeded,
 		&netQuotaExceededAt,
 		&registryAuthSealed,
+		&autoImportPending,
 	)
 	if err != nil {
 		return nil, err
@@ -1591,6 +1662,7 @@ func scanSandbox(scanner interface {
 		sandbox.NetworkQuotaExceededAt = &t
 	}
 	sandbox.RegistryAuthSealed = nullableBlob(registryAuthSealed)
+	sandbox.AutoImportPending = autoImportPending == 1
 
 	if envJSON != "" {
 		if err := json.Unmarshal([]byte(envJSON), &sandbox.Env); err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1232,6 +1232,7 @@ func TestStoreHelperCases(t *testing.T) {
 			0,              // net_quota_exceeded
 			sql.NullTime{}, // net_quota_exceeded_at
 			[]byte(nil),    // registry_auth_sealed
+			0,              // auto_import_pending
 		}}
 		_, err := scanSandbox(row)
 		if err == nil {

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aerol-ai/microvm/pkg/docker/netrules"
 	"github.com/aerol-ai/microvm/pkg/models"
 	"github.com/aerol-ai/microvm/pkg/mounts"
+	"github.com/aerol-ai/microvm/pkg/secrets"
 )
 
 // managedLabelKey is the Docker label every sandbox container we create
@@ -64,6 +65,12 @@ type Client struct {
 	pullSlots          chan struct{}
 	pullBackoff        time.Duration
 	pullFailures       map[string]imagePullFailure
+	// Mirror configuration: zero value disables rewriting and the pull
+	// path behaves exactly as it did before AOCR mirror support landed.
+	// Set via ConfigureMirror after construction; main() is responsible
+	// for loading the key ring once and handing it in.
+	mirrorCfg     MirrorConfig
+	wrapKeyRing   *secrets.UpstreamWrapKeyRing
 }
 
 type imagePull struct {
@@ -118,6 +125,16 @@ func New(logger *slog.Logger, cfg config.Config, rules *netrules.Manager) (*Clie
 		pullBackoff:        cfg.ImagePullFailureBackoff,
 		pullFailures:       make(map[string]imagePullFailure),
 	}, nil
+}
+
+// ConfigureMirror installs the AOCR mirror policy onto an existing Client.
+// Both arguments are optional: a zero MirrorConfig disables rewriting, and
+// a nil key ring disables identity-token wrapping (the pull falls back to
+// raw username/password in X-Registry-Auth). main() is expected to load the
+// wrap key ring exactly once at startup and hand it in here.
+func (c *Client) ConfigureMirror(cfg MirrorConfig, ring *secrets.UpstreamWrapKeyRing) {
+	c.mirrorCfg = cfg
+	c.wrapKeyRing = ring
 }
 
 // ClearNetworkRules releases any per-IP network rules previously attached to a
@@ -617,20 +634,52 @@ func (c *Client) ensureToolboxBinary() error {
 }
 
 func (c *Client) pullImage(ctx context.Context, imageRef string, auth *models.RegistryAuth) error {
+	// Apply mirror rewrite first so the auth payload we build below can be
+	// keyed off the *upstream* host (the AOCR auth service wants the
+	// upstream's username/password wrapped inside an identity token, not the
+	// mirror vhost as the serveraddress).
+	rewrite := RewriteImageRefForMirror(imageRef, c.mirrorCfg)
+	pullRef := rewrite.RewrittenRef
+
 	headers := map[string]string{}
 	if auth != nil && auth.Username != "" {
-		encoded, err := json.Marshal(map[string]string{
+		authPayload := map[string]string{
 			"username":      auth.Username,
 			"password":      auth.Password,
 			"serveraddress": auth.Server,
-		})
+		}
+		// When the ref was rewritten and we have a wrap key ring, hand
+		// the upstream credentials to AOCR as a wrapped identity token.
+		// Docker's auth handling treats `identitytoken` as authoritative
+		// and ignores username/password when it's present, which is what
+		// we want — the mirror sees only the opaque blob.
+		if rewrite.Rewritten && c.wrapKeyRing != nil {
+			creds := secrets.UpstreamCredentials{
+				UpstreamHost: rewrite.UpstreamHost,
+				Username:     auth.Username,
+				Password:     auth.Password,
+				Scope:        "repository:" + rewrite.UpstreamRepo + ":pull",
+			}
+			token, err := secrets.WrapUpstreamCreds(c.wrapKeyRing, creds)
+			if err != nil {
+				return fmt.Errorf("wrap upstream credentials: %w", err)
+			}
+			// Identity token is authoritative: blank username/password so
+			// the mirror never sees the upstream PAT in cleartext, even
+			// in error paths.
+			authPayload = map[string]string{
+				"identitytoken": token,
+				"serveraddress": c.mirrorCfg.Host,
+			}
+		}
+		encoded, err := json.Marshal(authPayload)
 		if err != nil {
 			return fmt.Errorf("marshal registry auth: %w", err)
 		}
 		headers["X-Registry-Auth"] = base64.StdEncoding.EncodeToString(encoded)
 	}
 
-	query := queryValues(map[string]string{"fromImage": imageRef})
+	query := queryValues(map[string]string{"fromImage": pullRef})
 	target := "http://docker/images/create?" + query.Encode()
 	request, err := http.NewRequestWithContext(ctx, http.MethodPost, target, nil)
 	if err != nil {

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -69,8 +69,9 @@ type Client struct {
 	// path behaves exactly as it did before AOCR mirror support landed.
 	// Set via ConfigureMirror after construction; main() is responsible
 	// for loading the key ring once and handing it in.
-	mirrorCfg     MirrorConfig
-	wrapKeyRing   *secrets.UpstreamWrapKeyRing
+	mirrorCfg    MirrorConfig
+	wrapKeyRing  *secrets.UpstreamWrapKeyRing
+	pullObserver PullObserver
 }
 
 type imagePull struct {
@@ -135,6 +136,48 @@ func New(logger *slog.Logger, cfg config.Config, rules *netrules.Manager) (*Clie
 func (c *Client) ConfigureMirror(cfg MirrorConfig, ring *secrets.UpstreamWrapKeyRing) {
 	c.mirrorCfg = cfg
 	c.wrapKeyRing = ring
+}
+
+// PullObserver is invoked exactly once per successful pull that BOTH went
+// through a mirror rewrite AND used non-anonymous upstream credentials —
+// the precondition for the F21 auto-import flow. The sandboxID is whatever
+// the caller stashed on the context with WithSandboxID; empty IDs skip the
+// observer call (no row to flag).
+//
+// Errors inside the observer are the caller's problem: pullImage does not
+// surface them, so the observer must not panic and should handle its own
+// retry/logging. The observer runs synchronously on the pull goroutine; keep
+// it fast.
+type PullObserver func(ctx context.Context, sandboxID string)
+
+// SetPullObserver installs a single observer. Calling again replaces the
+// previous one. Pass nil to disable. main() is expected to set this once at
+// startup to wire the post-pull AutoImportPending flag.
+func (c *Client) SetPullObserver(obs PullObserver) {
+	c.pullObserver = obs
+}
+
+// sandboxIDCtxKey is the unexported type used to stash the sandbox ID on the
+// pull context so pullImage can pass it to the PullObserver without us
+// having to grow signatures across the (already wide) pull stack.
+type sandboxIDCtxKey struct{}
+
+// WithSandboxID returns a context derived from parent that carries the
+// sandbox identifier the pull is being executed on behalf of. Used by the
+// Create path so the PullObserver fired after a successful private mirror
+// pull can flag the correct row. Empty IDs are ignored.
+func WithSandboxID(parent context.Context, sandboxID string) context.Context {
+	if strings.TrimSpace(sandboxID) == "" {
+		return parent
+	}
+	return context.WithValue(parent, sandboxIDCtxKey{}, sandboxID)
+}
+
+// sandboxIDFromContext is the readback half of WithSandboxID. Returns "" if
+// no ID was stashed — callers must treat empty as "no observer call".
+func sandboxIDFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(sandboxIDCtxKey{}).(string)
+	return v
 }
 
 // ClearNetworkRules releases any per-IP network rules previously attached to a
@@ -289,7 +332,11 @@ func (c *Client) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 		if IsLocalOnlyImageRef(req.Image) || req.ImageDistributionMode == models.ImageDistributionLocalOnly {
 			return nil, fmt.Errorf("image %q is local-only and is not present on this node; push/register it to a registry or pre-distribute it before failover recreate", req.Image)
 		}
-		if pullErr := c.pullImageDedup(ctx, req.Image, req.Registry); pullErr != nil {
+		// Stash the sandbox ID on the pull context so the PullObserver can
+		// route the post-pull AutoImportPending flag to the right row when
+		// the pull qualifies (mirror rewrite + private creds).
+		pullCtx := WithSandboxID(ctx, sandboxID)
+		if pullErr := c.pullImageDedup(pullCtx, req.Image, req.Registry); pullErr != nil {
 			return nil, pullErr
 		}
 		imageInspect, err = c.inspectImage(ctx, req.Image)
@@ -714,6 +761,7 @@ func (c *Client) pullImage(ctx context.Context, imageRef string, auth *models.Re
 		}
 		if err := decoder.Decode(&msg); err != nil {
 			if errors.Is(err, io.EOF) {
+				c.firePullObserver(ctx, rewrite, auth)
 				return nil
 			}
 			return fmt.Errorf("decode pull stream: %w", err)
@@ -725,6 +773,24 @@ func (c *Client) pullImage(ctx context.Context, imageRef string, auth *models.Re
 			return fmt.Errorf("pull image %s: %s", imageRef, msg.Error)
 		}
 	}
+}
+
+// firePullObserver invokes the registered observer iff the pull was a
+// private-image pull that went through the mirror — the F21 precondition.
+// Anonymous pulls (no auth), pass-through pulls (no rewrite), missing sandbox
+// ID, and an unset observer all short-circuit cheaply.
+func (c *Client) firePullObserver(ctx context.Context, rewrite MirrorRewrite, auth *models.RegistryAuth) {
+	if c.pullObserver == nil || !rewrite.Rewritten {
+		return
+	}
+	if auth == nil || strings.TrimSpace(auth.Username) == "" {
+		return
+	}
+	sandboxID := sandboxIDFromContext(ctx)
+	if sandboxID == "" {
+		return
+	}
+	c.pullObserver(ctx, sandboxID)
 }
 
 func (c *Client) pullImageDedup(ctx context.Context, imageRef string, auth *models.RegistryAuth) error {

--- a/pkg/docker/mirror_rewrite.go
+++ b/pkg/docker/mirror_rewrite.go
@@ -1,0 +1,186 @@
+package docker
+
+import (
+	"strings"
+)
+
+// MirrorUpstream maps an upstream registry host to the short prefix the
+// AOCR mirror uses to disambiguate it in its URL path.
+//
+// Example: `{Host: "ghcr.io", Shortname: "ghcr"}` causes
+// `ghcr.io/aerol-ai/sandbox:v1` to be rewritten to
+// `mirror.aocr.aerol.ai/_/ghcr/aerol-ai/sandbox:v1`. The `_/` prefix is the
+// Distribution-v2 reserved-namespace convention; AOCR's auth route helper
+// (`auth/src/upstreamAuth/route.ts`) strips `_/<short>/` back off when
+// routing scope strings to the upstream probe.
+//
+// Docker Hub is intentionally absent from this list: it's handled by the
+// Docker daemon's `registry-mirrors` daemon.json setting (which only
+// supports DockerHub), not by client-side rewriting. Refs that resolve to
+// `docker.io` pass through unchanged here.
+type MirrorUpstream struct {
+	Host      string
+	Shortname string
+}
+
+// MirrorConfig is the per-node mirror policy. A zero value disables all
+// rewriting — pullImage behaves exactly as it did before. This is the
+// safety hatch for any node that isn't running with AOCR mirror enabled.
+//
+// `Host` is the mirror vhost (e.g. `mirror.aocr.aerol.ai`). `PushHost`
+// is the AOCR push vhost (e.g. `aocr.aerol.ai`); we recognize both so
+// already-rewritten refs and cluster-snapshot refs pass through
+// unchanged — important on the failover path where a sandbox's stored
+// `RegistryRef` may already point at the AOCR side.
+type MirrorConfig struct {
+	Host      string
+	PushHost  string
+	Upstreams []MirrorUpstream
+}
+
+// Enabled reports whether mirror rewriting is active. Returns false for
+// any zero/empty config so callers can short-circuit without parsing.
+func (c MirrorConfig) Enabled() bool {
+	return strings.TrimSpace(c.Host) != "" && len(c.Upstreams) > 0
+}
+
+// MirrorRewrite is the structured result of `RewriteImageRefForMirror`.
+// All fields are populated even when no rewrite happened so the caller
+// has a single value to plumb through (no nil checks).
+type MirrorRewrite struct {
+	// RewrittenRef is what should actually be pulled. When Rewritten=false
+	// this equals the original input.
+	RewrittenRef string
+	// OriginalRef is the user-visible ref (what to store on the sandbox
+	// row for trace/display). Always equals the input.
+	OriginalRef string
+	// Rewritten=true means the ref was redirected to the mirror.
+	Rewritten bool
+	// UpstreamHost / UpstreamRepo / UpstreamTag are the components AOCR's
+	// auth service needs to validate a wrapped credential and probe the
+	// upstream. They are populated only when Rewritten=true.
+	UpstreamHost string
+	// UpstreamRepo is the *mirror-side* repo path, e.g.
+	// `_/ghcr/aerol-ai/sandbox` — this matches the Distribution scope
+	// string AOCR's `route.ts` parses. For Docker Hub passthrough or
+	// non-rewritten refs this is empty.
+	UpstreamRepo string
+	UpstreamTag  string
+}
+
+// RewriteImageRefForMirror is a pure function: no I/O, no globals. It
+// inspects an image reference and decides whether to redirect it through
+// the AOCR mirror vhost.
+//
+// Rules (in order):
+//  1. Empty / unparseable refs are passed through.
+//  2. Refs that already point at the mirror or push vhost are passed
+//     through (idempotency — re-running a rewrite is a no-op).
+//  3. Refs whose host matches a configured `MirrorUpstream.Host` are
+//     rewritten to `<mirrorHost>/_/<short>/<repo>:<tag>`.
+//  4. Docker Hub refs (host=docker.io, or no host prefix at all) pass
+//     through — the Docker daemon handles them via `registry-mirrors`.
+//  5. Refs with an unknown host pass through, so private registries the
+//     operator didn't configure as mirror upstreams keep working.
+func RewriteImageRefForMirror(ref string, cfg MirrorConfig) MirrorRewrite {
+	original := strings.TrimSpace(ref)
+	pass := MirrorRewrite{RewrittenRef: original, OriginalRef: original}
+
+	if original == "" || !cfg.Enabled() {
+		return pass
+	}
+
+	host, rest := splitHostRepo(original)
+
+	// Already pointing at our own mirror or push vhost — leave it alone.
+	mirrorHost := strings.ToLower(strings.TrimSpace(cfg.Host))
+	pushHost := strings.ToLower(strings.TrimSpace(cfg.PushHost))
+	if host != "" {
+		hostLower := strings.ToLower(host)
+		if hostLower == mirrorHost || (pushHost != "" && hostLower == pushHost) {
+			return pass
+		}
+	}
+
+	// Find an upstream match. Comparison is host-only, lowercase; AOCR's
+	// route table is likewise case-insensitive.
+	short := ""
+	upstreamHost := ""
+	if host != "" {
+		for _, u := range cfg.Upstreams {
+			if strings.EqualFold(strings.TrimSpace(u.Host), host) {
+				short = strings.TrimSpace(u.Shortname)
+				upstreamHost = strings.ToLower(strings.TrimSpace(u.Host))
+				break
+			}
+		}
+	}
+	if short == "" {
+		// Unknown / not-configured host (includes docker.io which intentionally
+		// isn't in the upstreams list — handled by daemon.json registry-mirrors).
+		return pass
+	}
+
+	repoOnly, tag, digest := splitRepoRefTag(rest)
+	if repoOnly == "" {
+		return pass
+	}
+
+	mirrorRepo := "_/" + short + "/" + repoOnly
+	rewrittenRef := mirrorHost + "/" + mirrorRepo
+	if tag != "" {
+		rewrittenRef += ":" + tag
+	} else if digest != "" {
+		rewrittenRef += "@" + digest
+	}
+
+	return MirrorRewrite{
+		RewrittenRef: rewrittenRef,
+		OriginalRef:  original,
+		Rewritten:    true,
+		UpstreamHost: upstreamHost,
+		UpstreamRepo: mirrorRepo,
+		UpstreamTag:  tag,
+	}
+}
+
+// splitHostRepo splits `host/repo...` from a Docker image reference.
+// Returns `("", ref)` when there is no host prefix (Docker Hub
+// shortcut form like `library/redis` or `redis:tag`).
+//
+// The host-detection heuristic matches what Docker itself uses: the
+// first slash-delimited segment is a host if it contains `:` (port) or
+// `.` (FQDN), or is literally `localhost`. Anything else is treated as
+// a Docker Hub namespace, not a host.
+func splitHostRepo(ref string) (host, repo string) {
+	first, rest, ok := strings.Cut(ref, "/")
+	if !ok {
+		// No slash → bare image name → no host.
+		return "", ref
+	}
+	if first == "localhost" || strings.Contains(first, ".") || strings.Contains(first, ":") {
+		return first, rest
+	}
+	return "", ref
+}
+
+// splitRepoRefTag splits a `repo[:tag][@digest]` string. The digest takes
+// precedence over the tag per OCI conventions (`repo:tag@digest` keeps the
+// digest authoritative). Tag colons inside a host:port were already
+// peeled off by splitHostRepo.
+func splitRepoRefTag(s string) (repo, tag, digest string) {
+	// Digest first — `@sha256:...` is unambiguous.
+	if at := strings.IndexByte(s, '@'); at >= 0 {
+		digest = s[at+1:]
+		s = s[:at]
+	}
+	// Tag is the last `:` IF it appears after the last `/` (otherwise it
+	// could be a port we somehow didn't strip — defense in depth).
+	if colon := strings.LastIndexByte(s, ':'); colon >= 0 {
+		if slash := strings.LastIndexByte(s, '/'); colon > slash {
+			tag = s[colon+1:]
+			s = s[:colon]
+		}
+	}
+	return s, tag, digest
+}

--- a/pkg/docker/mirror_rewrite_test.go
+++ b/pkg/docker/mirror_rewrite_test.go
@@ -1,0 +1,211 @@
+package docker
+
+import (
+	"testing"
+)
+
+func defaultMirrorCfg() MirrorConfig {
+	return MirrorConfig{
+		Host:     "mirror.aocr.aerol.ai",
+		PushHost: "aocr.aerol.ai",
+		Upstreams: []MirrorUpstream{
+			{Host: "ghcr.io", Shortname: "ghcr"},
+			{Host: "gcr.io", Shortname: "gcr"},
+			{Host: "quay.io", Shortname: "quay"},
+			{Host: "registry.k8s.io", Shortname: "k8s"},
+		},
+	}
+}
+
+func TestRewriteImageRefForMirror_DisabledConfig(t *testing.T) {
+	for name, cfg := range map[string]MirrorConfig{
+		"zero":       {},
+		"no-host":    {Upstreams: []MirrorUpstream{{Host: "ghcr.io", Shortname: "ghcr"}}},
+		"no-upstreams": {Host: "mirror.aocr.aerol.ai"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			r := RewriteImageRefForMirror("ghcr.io/aerol-ai/sandbox:v1", cfg)
+			if r.Rewritten {
+				t.Fatalf("disabled cfg should never rewrite (case %s): got %+v", name, r)
+			}
+			if r.RewrittenRef != "ghcr.io/aerol-ai/sandbox:v1" {
+				t.Fatalf("ref must pass through unchanged: %s", r.RewrittenRef)
+			}
+		})
+	}
+}
+
+func TestRewriteImageRefForMirror_EmptyAndWhitespace(t *testing.T) {
+	cfg := defaultMirrorCfg()
+	for _, ref := range []string{"", "   ", "\n"} {
+		r := RewriteImageRefForMirror(ref, cfg)
+		if r.Rewritten {
+			t.Fatalf("empty input must not rewrite, got %+v", r)
+		}
+	}
+}
+
+func TestRewriteImageRefForMirror_GHCRWithTag(t *testing.T) {
+	r := RewriteImageRefForMirror("ghcr.io/aerol-ai/sandbox:v1.2.3", defaultMirrorCfg())
+	if !r.Rewritten {
+		t.Fatalf("expected rewrite, got %+v", r)
+	}
+	if r.RewrittenRef != "mirror.aocr.aerol.ai/_/ghcr/aerol-ai/sandbox:v1.2.3" {
+		t.Fatalf("unexpected rewritten ref: %s", r.RewrittenRef)
+	}
+	if r.OriginalRef != "ghcr.io/aerol-ai/sandbox:v1.2.3" {
+		t.Fatalf("original ref lost: %s", r.OriginalRef)
+	}
+	if r.UpstreamHost != "ghcr.io" {
+		t.Fatalf("UpstreamHost: %s", r.UpstreamHost)
+	}
+	if r.UpstreamRepo != "_/ghcr/aerol-ai/sandbox" {
+		t.Fatalf("UpstreamRepo: %s", r.UpstreamRepo)
+	}
+	if r.UpstreamTag != "v1.2.3" {
+		t.Fatalf("UpstreamTag: %s", r.UpstreamTag)
+	}
+}
+
+func TestRewriteImageRefForMirror_DigestRef(t *testing.T) {
+	digest := "sha256:aabbccdd"
+	r := RewriteImageRefForMirror("gcr.io/distroless/base@"+digest, defaultMirrorCfg())
+	if !r.Rewritten {
+		t.Fatalf("expected rewrite, got %+v", r)
+	}
+	want := "mirror.aocr.aerol.ai/_/gcr/distroless/base@" + digest
+	if r.RewrittenRef != want {
+		t.Fatalf("rewritten ref: got %s want %s", r.RewrittenRef, want)
+	}
+	if r.UpstreamTag != "" {
+		t.Fatalf("digest pull should have no tag, got %q", r.UpstreamTag)
+	}
+}
+
+func TestRewriteImageRefForMirror_NoTag(t *testing.T) {
+	r := RewriteImageRefForMirror("quay.io/prometheus/node-exporter", defaultMirrorCfg())
+	if !r.Rewritten {
+		t.Fatalf("expected rewrite, got %+v", r)
+	}
+	if r.RewrittenRef != "mirror.aocr.aerol.ai/_/quay/prometheus/node-exporter" {
+		t.Fatalf("rewritten ref: %s", r.RewrittenRef)
+	}
+	if r.UpstreamTag != "" {
+		t.Fatalf("UpstreamTag should be empty, got %q", r.UpstreamTag)
+	}
+}
+
+func TestRewriteImageRefForMirror_K8sSingleSegment(t *testing.T) {
+	// registry.k8s.io/pause:3.9 — one path segment after the host. Common
+	// shape and a regression target since some splitters assume org/repo.
+	r := RewriteImageRefForMirror("registry.k8s.io/pause:3.9", defaultMirrorCfg())
+	if !r.Rewritten {
+		t.Fatalf("expected rewrite, got %+v", r)
+	}
+	if r.RewrittenRef != "mirror.aocr.aerol.ai/_/k8s/pause:3.9" {
+		t.Fatalf("rewritten ref: %s", r.RewrittenRef)
+	}
+	if r.UpstreamRepo != "_/k8s/pause" {
+		t.Fatalf("UpstreamRepo: %s", r.UpstreamRepo)
+	}
+}
+
+func TestRewriteImageRefForMirror_DockerHubPassThrough(t *testing.T) {
+	cfg := defaultMirrorCfg()
+	for _, ref := range []string{
+		"redis",
+		"redis:7.2",
+		"library/redis",
+		"library/redis:7.2",
+		"grafana/grafana:11",
+		"docker.io/library/redis:7.2", // explicit docker.io still passes through
+	} {
+		r := RewriteImageRefForMirror(ref, cfg)
+		if r.Rewritten {
+			t.Fatalf("docker.io ref %q must not be rewritten (daemon.json mirror handles it), got %+v", ref, r)
+		}
+		if r.RewrittenRef != ref {
+			t.Fatalf("ref %q changed to %q", ref, r.RewrittenRef)
+		}
+	}
+}
+
+func TestRewriteImageRefForMirror_UnknownHostPassesThrough(t *testing.T) {
+	cfg := defaultMirrorCfg()
+	for _, ref := range []string{
+		"my-private-registry.corp.example.com/team/app:v1",
+		"123.dkr.ecr.us-east-1.amazonaws.com/team/app:v1",
+		"localhost:5000/dev/app:latest",
+	} {
+		r := RewriteImageRefForMirror(ref, cfg)
+		if r.Rewritten {
+			t.Fatalf("unknown host %q must pass through, got %+v", ref, r)
+		}
+	}
+}
+
+func TestRewriteImageRefForMirror_IdempotentOnAlreadyRewritten(t *testing.T) {
+	cfg := defaultMirrorCfg()
+	ref := "mirror.aocr.aerol.ai/_/ghcr/aerol-ai/sandbox:v1"
+	r := RewriteImageRefForMirror(ref, cfg)
+	if r.Rewritten {
+		t.Fatalf("already-rewritten ref must pass through, got %+v", r)
+	}
+	if r.RewrittenRef != ref {
+		t.Fatalf("ref mutated: %s", r.RewrittenRef)
+	}
+}
+
+func TestRewriteImageRefForMirror_PushVhostPassesThrough(t *testing.T) {
+	cfg := defaultMirrorCfg()
+	// Cluster-snapshot refs live under the push vhost — never rewrite them.
+	ref := "aocr.aerol.ai/cluster/abc/snap:foo"
+	r := RewriteImageRefForMirror(ref, cfg)
+	if r.Rewritten {
+		t.Fatalf("push-vhost ref must pass through, got %+v", r)
+	}
+}
+
+func TestRewriteImageRefForMirror_HostCaseInsensitive(t *testing.T) {
+	r := RewriteImageRefForMirror("GHCR.IO/Aerol-AI/Sandbox:V1", defaultMirrorCfg())
+	if !r.Rewritten {
+		t.Fatalf("uppercase host should still match, got %+v", r)
+	}
+	// Host gets lowercased but repo + tag are preserved verbatim.
+	if r.RewrittenRef != "mirror.aocr.aerol.ai/_/ghcr/Aerol-AI/Sandbox:V1" {
+		t.Fatalf("rewritten ref: %s", r.RewrittenRef)
+	}
+}
+
+func TestSplitHostRepo(t *testing.T) {
+	cases := []struct{ in, host, repo string }{
+		{"redis", "", "redis"},
+		{"library/redis", "", "library/redis"},
+		{"ghcr.io/foo/bar", "ghcr.io", "foo/bar"},
+		{"localhost:5000/foo", "localhost:5000", "foo"},
+		{"localhost/foo", "localhost", "foo"},
+		{"registry.k8s.io/pause", "registry.k8s.io", "pause"},
+	}
+	for _, c := range cases {
+		h, r := splitHostRepo(c.in)
+		if h != c.host || r != c.repo {
+			t.Fatalf("splitHostRepo(%q) = (%q,%q) want (%q,%q)", c.in, h, r, c.host, c.repo)
+		}
+	}
+}
+
+func TestSplitRepoRefTag(t *testing.T) {
+	cases := []struct{ in, repo, tag, digest string }{
+		{"foo/bar", "foo/bar", "", ""},
+		{"foo/bar:1.2", "foo/bar", "1.2", ""},
+		{"foo/bar@sha256:abc", "foo/bar", "", "sha256:abc"},
+		{"foo/bar:1.2@sha256:abc", "foo/bar", "1.2", "sha256:abc"},
+		{"pause:3.9", "pause", "3.9", ""},
+	}
+	for _, c := range cases {
+		r, tg, d := splitRepoRefTag(c.in)
+		if r != c.repo || tg != c.tag || d != c.digest {
+			t.Fatalf("splitRepoRefTag(%q) = (%q,%q,%q) want (%q,%q,%q)", c.in, r, tg, d, c.repo, c.tag, c.digest)
+		}
+	}
+}

--- a/pkg/docker/pull_mirror_test.go
+++ b/pkg/docker/pull_mirror_test.go
@@ -164,6 +164,81 @@ func TestPullImage_DockerHub_PassesThrough_EvenWithMirror(t *testing.T) {
 	}
 }
 
+// observerFires tests the PullObserver firing predicate. Hand-rolled against
+// the actual pullImage path (no daemon, just our roundtrip stub) so the
+// truth table is observable: only (mirror-rewrite AND non-anonymous auth AND
+// sandbox ID on ctx AND observer set) fires the callback.
+func TestPullObserver_FirePredicate(t *testing.T) {
+	ring := secrets.ParseUpstreamWrapKeyRing(b64DockerTest(key32DockerTest(0x42)))
+	cases := []struct {
+		name      string
+		image     string
+		auth      *models.RegistryAuth
+		ctxSbxID  string
+		setObs    bool
+		wantFires bool
+	}{
+		{"private mirror pull + sandbox id fires once", "ghcr.io/aerol-ai/sandbox:v1", &models.RegistryAuth{Username: "u", Password: "p", Server: "ghcr.io"}, "sb-1", true, true},
+		{"anonymous mirror pull does not fire", "ghcr.io/aerol-ai/sandbox:v1", nil, "sb-1", true, false},
+		{"empty username treated as anonymous", "ghcr.io/aerol-ai/sandbox:v1", &models.RegistryAuth{Username: "", Password: ""}, "sb-1", true, false},
+		{"docker.io passthrough does not fire", "redis:7", &models.RegistryAuth{Username: "u", Password: "p", Server: "https://index.docker.io/v1/"}, "sb-1", true, false},
+		{"missing sandbox id does not fire", "ghcr.io/aerol-ai/sandbox:v1", &models.RegistryAuth{Username: "u", Password: "p", Server: "ghcr.io"}, "", true, false},
+		{"no observer installed is a no-op", "ghcr.io/aerol-ai/sandbox:v1", &models.RegistryAuth{Username: "u", Password: "p", Server: "ghcr.io"}, "sb-1", false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cap := newCaptureClient(defaultMirrorCfg(), ring)
+			var fired atomic.Int64
+			var gotID atomic.Value
+			gotID.Store("")
+			if c.setObs {
+				cap.client.SetPullObserver(func(_ context.Context, id string) {
+					fired.Add(1)
+					gotID.Store(id)
+				})
+			}
+			ctx := context.Background()
+			if c.ctxSbxID != "" {
+				ctx = WithSandboxID(ctx, c.ctxSbxID)
+			}
+			if err := cap.client.pullImage(ctx, c.image, c.auth); err != nil {
+				t.Fatalf("pullImage: %v", err)
+			}
+			got := fired.Load()
+			if c.wantFires {
+				if got != 1 {
+					t.Fatalf("observer fired %d times, want 1", got)
+				}
+				if id := gotID.Load().(string); id != c.ctxSbxID {
+					t.Fatalf("observer got sandbox id %q, want %q", id, c.ctxSbxID)
+				}
+			} else if got != 0 {
+				t.Fatalf("observer fired %d times, want 0", got)
+			}
+		})
+	}
+}
+
+// TestWithSandboxID_RoundTripAndEmptyHandling asserts the ctx helper drops
+// empty IDs (a guardrail so a missing sandboxID doesn't accidentally overwrite
+// a real one set further up the stack).
+func TestWithSandboxID_RoundTripAndEmptyHandling(t *testing.T) {
+	base := context.Background()
+	if got := sandboxIDFromContext(base); got != "" {
+		t.Fatalf("empty base ctx returned %q, want empty", got)
+	}
+	ctx := WithSandboxID(base, "sb-42")
+	if got := sandboxIDFromContext(ctx); got != "sb-42" {
+		t.Fatalf("round-trip returned %q, want sb-42", got)
+	}
+	// Whitespace-only IDs are treated as empty so they don't shadow the
+	// parent's real value.
+	ctx2 := WithSandboxID(ctx, "   ")
+	if got := sandboxIDFromContext(ctx2); got != "sb-42" {
+		t.Fatalf("whitespace ID shadowed parent: got %q", got)
+	}
+}
+
 // Local helpers (duplicated rather than imported across packages — these
 // mirror the secrets/test helpers so we don't widen the secrets package's
 // export surface just for tests).

--- a/pkg/docker/pull_mirror_test.go
+++ b/pkg/docker/pull_mirror_test.go
@@ -1,0 +1,177 @@
+package docker
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+	"github.com/aerol-ai/microvm/pkg/secrets"
+)
+
+// captureClient builds a Client that records the X-Registry-Auth header and
+// the fromImage query value of the last /images/create call.
+type captureClient struct {
+	client      *Client
+	calls       atomic.Int64
+	lastFrom    atomic.Value // string
+	lastAuthB64 atomic.Value // string
+}
+
+func newCaptureClient(cfg MirrorConfig, ring *secrets.UpstreamWrapKeyRing) *captureClient {
+	cap := &captureClient{}
+	cap.lastFrom.Store("")
+	cap.lastAuthB64.Store("")
+	cap.client = &Client{
+		logger: slog.Default(),
+		streamClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			cap.calls.Add(1)
+			q, _ := url.ParseQuery(r.URL.RawQuery)
+			cap.lastFrom.Store(q.Get("fromImage"))
+			cap.lastAuthB64.Store(r.Header.Get("X-Registry-Auth"))
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"status":"done"}`)),
+				Header:     make(http.Header),
+			}, nil
+		})},
+	}
+	cap.client.ConfigureMirror(cfg, ring)
+	return cap
+}
+
+func (c *captureClient) from() string { return c.lastFrom.Load().(string) }
+func (c *captureClient) auth() map[string]string {
+	raw := c.lastAuthB64.Load().(string)
+	if raw == "" {
+		return nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(raw)
+	if err != nil {
+		return nil
+	}
+	var m map[string]string
+	if err := json.Unmarshal(decoded, &m); err != nil {
+		return nil
+	}
+	return m
+}
+
+func TestPullImage_NoMirrorConfig_PassesThrough(t *testing.T) {
+	cap := newCaptureClient(MirrorConfig{}, nil)
+	auth := &models.RegistryAuth{Server: "ghcr.io", Username: "u", Password: "p"}
+	if err := cap.client.pullImage(context.Background(), "ghcr.io/aerol-ai/sandbox:v1", auth); err != nil {
+		t.Fatalf("pullImage: %v", err)
+	}
+	if cap.from() != "ghcr.io/aerol-ai/sandbox:v1" {
+		t.Fatalf("fromImage rewritten despite disabled mirror: %q", cap.from())
+	}
+	a := cap.auth()
+	if a["username"] != "u" || a["password"] != "p" {
+		t.Fatalf("auth dropped raw creds: %+v", a)
+	}
+	if _, hasToken := a["identitytoken"]; hasToken {
+		t.Fatalf("unexpected identitytoken without mirror config: %+v", a)
+	}
+}
+
+func TestPullImage_MirrorEnabled_RewritesURL(t *testing.T) {
+	ring := secrets.ParseUpstreamWrapKeyRing(b64DockerTest(key32DockerTest(0xa7)))
+	cap := newCaptureClient(defaultMirrorCfg(), ring)
+	auth := &models.RegistryAuth{Server: "ghcr.io", Username: "octocat", Password: "ghp_xxx"}
+	if err := cap.client.pullImage(context.Background(), "ghcr.io/aerol-ai/sandbox:v1", auth); err != nil {
+		t.Fatalf("pullImage: %v", err)
+	}
+	if want := "mirror.aocr.aerol.ai/_/ghcr/aerol-ai/sandbox:v1"; cap.from() != want {
+		t.Fatalf("fromImage: got %q want %q", cap.from(), want)
+	}
+	a := cap.auth()
+	tok := a["identitytoken"]
+	if !strings.HasPrefix(tok, secrets.IdentityTokenPrefix) {
+		t.Fatalf("identitytoken missing or wrong prefix: %q", tok)
+	}
+	if a["username"] != "" || a["password"] != "" {
+		t.Fatalf("identitytoken path must blank username/password (leaks otherwise): %+v", a)
+	}
+	if a["serveraddress"] != "mirror.aocr.aerol.ai" {
+		t.Fatalf("serveraddress: %q", a["serveraddress"])
+	}
+}
+
+func TestPullImage_MirrorEnabled_NoWrapKeyRing_FallsBackToRawAuth(t *testing.T) {
+	// Rewriting still happens (so the daemon hits the mirror vhost), but
+	// without a key ring we can't wrap creds — Docker sends raw u/p. This
+	// is the documented degraded mode; the mirror will then 401 on private
+	// upstreams, but public pulls (no auth) still work.
+	cap := newCaptureClient(defaultMirrorCfg(), nil)
+	auth := &models.RegistryAuth{Server: "ghcr.io", Username: "octocat", Password: "ghp_xxx"}
+	if err := cap.client.pullImage(context.Background(), "ghcr.io/aerol-ai/sandbox:v1", auth); err != nil {
+		t.Fatalf("pullImage: %v", err)
+	}
+	if cap.from() != "mirror.aocr.aerol.ai/_/ghcr/aerol-ai/sandbox:v1" {
+		t.Fatalf("fromImage: %q", cap.from())
+	}
+	a := cap.auth()
+	if _, hasToken := a["identitytoken"]; hasToken {
+		t.Fatalf("identitytoken set despite nil key ring: %+v", a)
+	}
+	if a["username"] != "octocat" {
+		t.Fatalf("raw username dropped: %+v", a)
+	}
+}
+
+func TestPullImage_MirrorEnabled_NoAuth_NoIdentityToken(t *testing.T) {
+	// Anonymous pulls of public images: still rewritten, but no auth
+	// header at all (preserves existing behaviour for unauth pulls).
+	ring := secrets.ParseUpstreamWrapKeyRing(b64DockerTest(key32DockerTest(0xa8)))
+	cap := newCaptureClient(defaultMirrorCfg(), ring)
+	if err := cap.client.pullImage(context.Background(), "ghcr.io/aerol-ai/sandbox:v1", nil); err != nil {
+		t.Fatalf("pullImage: %v", err)
+	}
+	if cap.from() != "mirror.aocr.aerol.ai/_/ghcr/aerol-ai/sandbox:v1" {
+		t.Fatalf("fromImage: %q", cap.from())
+	}
+	if cap.lastAuthB64.Load().(string) != "" {
+		t.Fatalf("expected no X-Registry-Auth for anonymous pull, got %q", cap.lastAuthB64.Load())
+	}
+}
+
+func TestPullImage_DockerHub_PassesThrough_EvenWithMirror(t *testing.T) {
+	// Docker Hub is handled by the daemon's registry-mirrors setting, not
+	// by us. We must not rewrite docker.io refs even when mirror is on.
+	ring := secrets.ParseUpstreamWrapKeyRing(b64DockerTest(key32DockerTest(0xa9)))
+	cap := newCaptureClient(defaultMirrorCfg(), ring)
+	auth := &models.RegistryAuth{Server: "docker.io", Username: "u", Password: "p"}
+	if err := cap.client.pullImage(context.Background(), "redis:7.2", auth); err != nil {
+		t.Fatalf("pullImage: %v", err)
+	}
+	if cap.from() != "redis:7.2" {
+		t.Fatalf("docker hub ref rewritten: %q", cap.from())
+	}
+	a := cap.auth()
+	if _, hasToken := a["identitytoken"]; hasToken {
+		t.Fatalf("identitytoken set for docker.io passthrough: %+v", a)
+	}
+	if a["username"] != "u" {
+		t.Fatalf("raw username dropped on passthrough: %+v", a)
+	}
+}
+
+// Local helpers (duplicated rather than imported across packages — these
+// mirror the secrets/test helpers so we don't widen the secrets package's
+// export surface just for tests).
+func key32DockerTest(b byte) []byte {
+	out := make([]byte, 32)
+	for i := range out {
+		out[i] = b
+	}
+	return out
+}
+func b64DockerTest(k []byte) string { return base64.StdEncoding.EncodeToString(k) }

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -236,6 +236,15 @@ const (
 	ImageDistributionExternalRegistry = "external_registry"
 	ImageDistributionAOCR             = "aocr"
 	ImageDistributionLocalOnly        = "local_only"
+	// ImageDistributionAOCRImported is the post-auto-import distribution mode:
+	// the bytes have been re-mounted under the cluster's own AOCR namespace
+	// (`cluster/<id>/_imported/...`) and subsequent pulls use the cluster PAT,
+	// not the user's upstream credentials. The user-visible Image field is
+	// preserved; only the RegistryRef and mode flip. See F21 of the
+	// cluster-mirror-and-snapshot-distribution plan for the full rationale —
+	// the short version is that this is what makes `failover.policy: recreate`
+	// survive upstream credential rotation.
+	ImageDistributionAOCRImported = "aocr_imported"
 )
 
 const (
@@ -293,7 +302,7 @@ func NormalizeImageDistributionMode(mode string) (string, error) {
 	switch normalized := strings.ToLower(strings.TrimSpace(mode)); normalized {
 	case "":
 		return "", nil
-	case ImageDistributionExternalRegistry, ImageDistributionAOCR, ImageDistributionLocalOnly:
+	case ImageDistributionExternalRegistry, ImageDistributionAOCR, ImageDistributionAOCRImported, ImageDistributionLocalOnly:
 		return normalized, nil
 	default:
 		return "", fmt.Errorf("invalid image distribution mode %q", mode)
@@ -455,6 +464,14 @@ type Sandbox struct {
 	// NetworkQuotaExceededAt is the wall-clock time the limit was first
 	// observed crossed. Nil while under quota.
 	NetworkQuotaExceededAt *time.Time `json:"network_quota_exceeded_at,omitempty"`
+	// AutoImportPending is set by the post-pull auto-import path when the
+	// AOCR ImportAPI call failed. A background reconciler walks rows with
+	// this flag and re-tries the import; once the import succeeds the flag
+	// is cleared and the create spec's ImageDistributionMode flips to
+	// `aocr_imported`. The flag is local-node bookkeeping — it is not
+	// replicated via Raft, since each owner gets one opportunistic shot
+	// at the import per pull.
+	AutoImportPending bool `json:"-"`
 }
 
 // NetworkUsage is the response shape for GET /v1/sandboxes/{id}/network/usage.

--- a/pkg/secrets/upstream_wrap.go
+++ b/pkg/secrets/upstream_wrap.go
@@ -1,0 +1,97 @@
+package secrets
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+)
+
+// UpstreamCredentials is the plaintext shape AOCR's auth service expects
+// inside a wrapped blob. Field names are JSON-serialized as-is; they must
+// match `auth/src/upstreamAuth/wrap.ts` exactly or the round-trip breaks.
+//
+// `Scope` pins the wrap to a specific Distribution token-server scope
+// string (e.g. `repository:_/ghcr/org/repo:pull`). AOCR cross-checks the
+// scope inside the blob against the scope on the `/v2/token` request, so
+// a leaked blob cannot be reused for a different repo.
+type UpstreamCredentials struct {
+	UpstreamHost string `json:"upstreamHost"`
+	Username     string `json:"username"`
+	Password     string `json:"password"`
+	Scope        string `json:"scope"`
+}
+
+// IdentityTokenPrefix is the sentinel AOCR's auth service uses to route
+// `aocrwrap:<blob>` strings through the wrap-validation path rather than
+// the static-PAT or cluster-PAT paths. Anything starting with this prefix
+// is treated as a wrapped upstream credential.
+const IdentityTokenPrefix = "aocrwrap:"
+
+// envelopeVersion matches `ENVELOPE_VERSION` in the AOCR-side wrap.ts.
+// Bump only with a coordinated rollout that teaches both sides about the
+// new version.
+const envelopeVersion = 1
+
+type wrapEnvelope struct {
+	V     int                 `json:"v"`
+	Ts    int64               `json:"ts"` // unix milliseconds, matching JS Date.getTime()
+	Creds UpstreamCredentials `json:"creds"`
+}
+
+// WrapUpstreamCreds seals `creds` with the current key in `ring` and
+// returns a Docker `identitytoken` value of the form `aocrwrap:<base64url>`.
+// AOCR's auth service unwraps and probes the upstream registry with the
+// embedded credentials.
+//
+// The blob layout is AES-256-GCM `nonce(12) || ciphertext || tag(16)`,
+// then base64url. AOCR's `unwrap` reads exactly this format.
+func WrapUpstreamCreds(ring *UpstreamWrapKeyRing, creds UpstreamCredentials) (string, error) {
+	return wrapWithClock(ring, creds, time.Now)
+}
+
+func wrapWithClock(ring *UpstreamWrapKeyRing, creds UpstreamCredentials, now func() time.Time) (string, error) {
+	current, ok := ring.Current()
+	if !ok {
+		return "", errors.New("upstream wrap key ring is empty")
+	}
+	if creds.UpstreamHost == "" {
+		return "", errors.New("upstream host is required")
+	}
+
+	envelope := wrapEnvelope{
+		V:     envelopeVersion,
+		Ts:    now().UnixMilli(),
+		Creds: creds,
+	}
+	plaintext, err := json.Marshal(envelope)
+	if err != nil {
+		return "", fmt.Errorf("marshal wrap envelope: %w", err)
+	}
+
+	block, err := aes.NewCipher(current.Bytes)
+	if err != nil {
+		return "", fmt.Errorf("aes cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("gcm wrap: %w", err)
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", fmt.Errorf("nonce: %w", err)
+	}
+	// gcm.Seal returns ciphertext || tag — exactly the layout AOCR's
+	// `crypto.createDecipheriv('aes-256-gcm', ...).setAuthTag(tag)` expects
+	// when given the same nonce. No AAD: matches the JS side, which also
+	// passes no AAD to `setAuthTag`.
+	sealed := gcm.Seal(nil, nonce, plaintext, nil)
+	blob := append(append([]byte{}, nonce...), sealed...)
+
+	return IdentityTokenPrefix + base64.RawURLEncoding.EncodeToString(blob), nil
+}

--- a/pkg/secrets/upstream_wrap_test.go
+++ b/pkg/secrets/upstream_wrap_test.go
@@ -1,0 +1,172 @@
+package secrets
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func sampleCreds() UpstreamCredentials {
+	return UpstreamCredentials{
+		UpstreamHost: "ghcr.io",
+		Username:     "octocat",
+		Password:     "ghp_xxxxxxxxxxxx",
+		Scope:        "repository:_/ghcr/aerol-ai/sandbox:pull",
+	}
+}
+
+// unwrapForTest is the AOCR-side `unwrap` reimplemented in Go against the
+// wire format. If WrapUpstreamCreds ever drifts from what AOCR's auth
+// service expects, this round-trip will break and so will production.
+func unwrapForTest(t *testing.T, token string, key []byte) wrapEnvelope {
+	t.Helper()
+	if !strings.HasPrefix(token, IdentityTokenPrefix) {
+		t.Fatalf("token missing %q prefix", IdentityTokenPrefix)
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(token, IdentityTokenPrefix))
+	if err != nil {
+		t.Fatalf("base64url decode: %v", err)
+	}
+	const tagLen = 16
+	const nonceLen = 12
+	if len(raw) < nonceLen+tagLen+1 {
+		t.Fatalf("blob too short: %d", len(raw))
+	}
+	nonce := raw[:nonceLen]
+	body := raw[nonceLen:]
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatalf("cipher: %v", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatalf("gcm: %v", err)
+	}
+	plain, err := gcm.Open(nil, nonce, body, nil)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	var env wrapEnvelope
+	if err := json.Unmarshal(plain, &env); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	return env
+}
+
+func TestWrapUpstreamCreds_RoundTrip(t *testing.T) {
+	ring := ParseUpstreamWrapKeyRing(b64(key32(0xaa)))
+	creds := sampleCreds()
+	token, err := WrapUpstreamCreds(ring, creds)
+	if err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+	env := unwrapForTest(t, token, key32(0xaa))
+	if env.V != 1 {
+		t.Fatalf("envelope version: got %d", env.V)
+	}
+	if env.Creds != creds {
+		t.Fatalf("creds round-trip mismatch: got %+v want %+v", env.Creds, creds)
+	}
+	// Timestamp should be within a few seconds of now.
+	age := time.Since(time.UnixMilli(env.Ts))
+	if age < 0 || age > 5*time.Second {
+		t.Fatalf("envelope timestamp implausible: ts=%d age=%v", env.Ts, age)
+	}
+}
+
+func TestWrapUpstreamCreds_UsesCurrentKey(t *testing.T) {
+	raw := "new:" + b64(key32(0x11)) + "," + "old:" + b64(key32(0x22))
+	ring := ParseUpstreamWrapKeyRing(raw)
+	token, err := WrapUpstreamCreds(ring, sampleCreds())
+	if err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+	// The current key must decrypt successfully (the negative case — old
+	// key cannot — is covered by TestWrapUpstreamCreds_OldKeyCannotDecryptNewBlob).
+	_ = unwrapForTest(t, token, key32(0x11))
+}
+
+func TestWrapUpstreamCreds_OldKeyCannotDecryptNewBlob(t *testing.T) {
+	raw := "new:" + b64(key32(0x11)) + "," + "old:" + b64(key32(0x22))
+	ring := ParseUpstreamWrapKeyRing(raw)
+	token, err := WrapUpstreamCreds(ring, sampleCreds())
+	if err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+	// Manual decrypt with the OLD key — must fail.
+	body, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(token, IdentityTokenPrefix))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	block, _ := aes.NewCipher(key32(0x22))
+	gcm, _ := cipher.NewGCM(block)
+	if _, err := gcm.Open(nil, body[:12], body[12:], nil); err == nil {
+		t.Fatalf("old key unexpectedly decrypted new blob")
+	}
+}
+
+func TestWrapUpstreamCreds_EmptyRing(t *testing.T) {
+	ring := &UpstreamWrapKeyRing{}
+	if _, err := WrapUpstreamCreds(ring, sampleCreds()); err == nil {
+		t.Fatalf("expected error for empty ring")
+	}
+}
+
+func TestWrapUpstreamCreds_RequiresHost(t *testing.T) {
+	ring := ParseUpstreamWrapKeyRing(b64(key32(0xaa)))
+	creds := sampleCreds()
+	creds.UpstreamHost = ""
+	if _, err := WrapUpstreamCreds(ring, creds); err == nil {
+		t.Fatalf("expected error for empty upstream host")
+	}
+}
+
+func TestWrapUpstreamCreds_TamperedBlobFailsToOpen(t *testing.T) {
+	ring := ParseUpstreamWrapKeyRing(b64(key32(0xaa)))
+	token, err := WrapUpstreamCreds(ring, sampleCreds())
+	if err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+	body, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(token, IdentityTokenPrefix))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Flip a byte in the ciphertext region (after nonce, before tag).
+	body[15] ^= 0xff
+	block, _ := aes.NewCipher(key32(0xaa))
+	gcm, _ := cipher.NewGCM(block)
+	if _, err := gcm.Open(nil, body[:12], body[12:], nil); err == nil {
+		t.Fatalf("tampered blob unexpectedly verified")
+	}
+}
+
+func TestWrapUpstreamCreds_DeterministicEnvelopeVersion(t *testing.T) {
+	// The AOCR side hard-rejects anything that isn't envelope v=1. This
+	// catches silent drift if the constant is ever bumped without
+	// coordination.
+	ring := ParseUpstreamWrapKeyRing(b64(key32(0xee)))
+	token, err := wrapWithClock(ring, sampleCreds(), func() time.Time { return time.UnixMilli(1700000000000) })
+	if err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+	env := unwrapForTest(t, token, key32(0xee))
+	if env.V != 1 {
+		t.Fatalf("envelope v must be 1, got %d", env.V)
+	}
+	if env.Ts != 1700000000000 {
+		t.Fatalf("clock not respected, got ts=%d", env.Ts)
+	}
+}
+
+func TestIdentityTokenPrefixIsStable(t *testing.T) {
+	// Constant value lock-in. Changing this requires a coordinated
+	// rollout with AOCR (`WRAPPED_UPSTREAM_TOKEN_PREFIX` in
+	// auth/src/upstreamAuth/strategy.ts).
+	if IdentityTokenPrefix != "aocrwrap:" {
+		t.Fatalf("prefix drifted from contract: %q", IdentityTokenPrefix)
+	}
+}

--- a/pkg/secrets/wrap_key_loader.go
+++ b/pkg/secrets/wrap_key_loader.go
@@ -1,0 +1,121 @@
+package secrets
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// UpstreamWrapKey is one key in the rotation ring. `ID` is a short, human-
+// readable identifier surfaced in metrics and logs; the cryptographic
+// material is `Bytes`. The wire format on AOCR's side and ours must agree
+// exactly: 32-byte AES-256 keys, base64 (standard alphabet), optionally
+// prefixed with `<id>:`.
+type UpstreamWrapKey struct {
+	ID    string
+	Bytes []byte
+}
+
+// UpstreamWrapKeyRing holds the ordered list of wrap keys. The first entry
+// is the *current* key used for wrapping new tokens; all entries are kept
+// available for unwrap (here only as a future-proofing detail — sandboxd
+// only wraps, never unwraps — but matching AOCR's structure keeps the two
+// sides interchangeable).
+//
+// Rotation policy: prepend a new key (`new:<b64>,old:<b64>`) on every node,
+// wait one full token lifetime so any in-flight wrapped credentials have
+// expired on the AOCR side, then drop the old entry. See the
+// `rotate-upstream-wrap-key.yml` playbook for the operator flow.
+type UpstreamWrapKeyRing struct {
+	Keys []UpstreamWrapKey
+}
+
+// Current returns the active wrap key. Callers should not cache the
+// returned key across reloads.
+func (r *UpstreamWrapKeyRing) Current() (UpstreamWrapKey, bool) {
+	if r == nil || len(r.Keys) == 0 {
+		return UpstreamWrapKey{}, false
+	}
+	return r.Keys[0], true
+}
+
+// LoadUpstreamWrapKeyRing reads the wrap key file at `path` and parses it
+// into a key ring. The file must be mode 0400 (owner-readable only); any
+// looser mode is refused at load time to prevent operator-mistake leaks via
+// world-readable home directories or `cp -p` from a wide-mode source.
+//
+// The file body is a comma-separated list of `<b64>` or `<id>:<b64>`
+// entries — same format as the AOCR side's `UPSTREAM_AUTH_WRAP_KEYS`
+// env var. Whitespace around commas is tolerated. Malformed entries are
+// silently dropped (matching AOCR behavior) so a partial-bad rotation
+// does not break the node entirely, but the final ring must have at least
+// one valid key or LoadUpstreamWrapKeyRing returns an error.
+//
+// If the file does not exist, LoadUpstreamWrapKeyRing returns
+// `os.ErrNotExist` wrapped so callers can fall through to "wrap keys not
+// configured" without treating it as fatal — the daemon may still run for
+// public images.
+func LoadUpstreamWrapKeyRing(path string) (*UpstreamWrapKeyRing, error) {
+	if path == "" {
+		return nil, errors.New("upstream wrap key path is empty")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	// The mode check is intentionally strict: any group/world read or any
+	// write bit at all is rejected. Owner-execute is allowed but irrelevant
+	// (regular files shouldn't have it; we don't enforce its absence).
+	mode := info.Mode().Perm()
+	if mode&0o077 != 0 {
+		return nil, fmt.Errorf("upstream wrap key file %s has insecure mode %#o; want 0400", path, mode)
+	}
+	if mode&0o200 != 0 {
+		return nil, fmt.Errorf("upstream wrap key file %s is writable (%#o); want 0400", path, mode)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read upstream wrap key %s: %w", path, err)
+	}
+	ring := ParseUpstreamWrapKeyRing(string(body))
+	if len(ring.Keys) == 0 {
+		return nil, fmt.Errorf("upstream wrap key file %s contained no usable keys", path)
+	}
+	return ring, nil
+}
+
+// ParseUpstreamWrapKeyRing parses the comma-separated wrap-key format.
+// Public so callers (tests, config validators) can validate a string
+// without writing it to disk.
+func ParseUpstreamWrapKeyRing(raw string) *UpstreamWrapKeyRing {
+	ring := &UpstreamWrapKeyRing{}
+	if strings.TrimSpace(raw) == "" {
+		return ring
+	}
+	for i, entry := range strings.Split(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		// Accept both `<b64>` and `<id>:<b64>`. `id` length cap matches
+		// AOCR's parser (<16 chars) so the wire-format check stays
+		// symmetric across implementations.
+		id := fmt.Sprintf("k%d", i)
+		b64 := entry
+		if colon := strings.IndexByte(entry, ':'); colon > 0 && colon < 16 {
+			id = entry[:colon]
+			b64 = entry[colon+1:]
+		}
+		decoded, err := base64.StdEncoding.DecodeString(b64)
+		if err != nil {
+			continue
+		}
+		if len(decoded) != 32 {
+			continue
+		}
+		ring.Keys = append(ring.Keys, UpstreamWrapKey{ID: id, Bytes: decoded})
+	}
+	return ring
+}

--- a/pkg/secrets/wrap_key_loader_test.go
+++ b/pkg/secrets/wrap_key_loader_test.go
@@ -1,0 +1,142 @@
+package secrets
+
+import (
+	"bytes"
+	"encoding/base64"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func key32(b byte) []byte { return bytes.Repeat([]byte{b}, 32) }
+
+func b64(k []byte) string { return base64.StdEncoding.EncodeToString(k) }
+
+func TestParseUpstreamWrapKeyRing_EmptyAndWhitespace(t *testing.T) {
+	for _, raw := range []string{"", "   ", "\n", ",,, , ,"} {
+		ring := ParseUpstreamWrapKeyRing(raw)
+		if len(ring.Keys) != 0 {
+			t.Fatalf("%q: expected empty ring, got %d keys", raw, len(ring.Keys))
+		}
+	}
+}
+
+func TestParseUpstreamWrapKeyRing_SingleKey(t *testing.T) {
+	ring := ParseUpstreamWrapKeyRing(b64(key32(0xaa)))
+	if len(ring.Keys) != 1 {
+		t.Fatalf("want 1 key, got %d", len(ring.Keys))
+	}
+	if !bytes.Equal(ring.Keys[0].Bytes, key32(0xaa)) {
+		t.Fatalf("key bytes mismatch")
+	}
+	// No explicit id → auto-assigned k0
+	if ring.Keys[0].ID != "k0" {
+		t.Fatalf("want id k0, got %q", ring.Keys[0].ID)
+	}
+}
+
+func TestParseUpstreamWrapKeyRing_NamedAndRotated(t *testing.T) {
+	raw := "new:" + b64(key32(0x11)) + ", old:" + b64(key32(0x22))
+	ring := ParseUpstreamWrapKeyRing(raw)
+	if len(ring.Keys) != 2 {
+		t.Fatalf("want 2 keys, got %d", len(ring.Keys))
+	}
+	if ring.Keys[0].ID != "new" || ring.Keys[1].ID != "old" {
+		t.Fatalf("ids: %q / %q", ring.Keys[0].ID, ring.Keys[1].ID)
+	}
+	// First entry is current.
+	cur, ok := ring.Current()
+	if !ok || cur.ID != "new" {
+		t.Fatalf("Current() returned %+v ok=%v", cur, ok)
+	}
+}
+
+func TestParseUpstreamWrapKeyRing_DropsBadEntries(t *testing.T) {
+	// One valid + one short (16-byte) + one not-base64.
+	short := base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0x33}, 16))
+	raw := b64(key32(0x55)) + ", " + short + ", !!! not base64 !!!"
+	ring := ParseUpstreamWrapKeyRing(raw)
+	if len(ring.Keys) != 1 {
+		t.Fatalf("want 1 key surviving, got %d", len(ring.Keys))
+	}
+	if !bytes.Equal(ring.Keys[0].Bytes, key32(0x55)) {
+		t.Fatalf("wrong key survived")
+	}
+}
+
+func TestLoadUpstreamWrapKeyRing_MissingFile(t *testing.T) {
+	_, err := LoadUpstreamWrapKeyRing(filepath.Join(t.TempDir(), "nope.key"))
+	if err == nil || !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("want os.ErrNotExist, got %v", err)
+	}
+}
+
+func TestLoadUpstreamWrapKeyRing_EmptyPath(t *testing.T) {
+	_, err := LoadUpstreamWrapKeyRing("")
+	if err == nil {
+		t.Fatalf("expected error for empty path")
+	}
+}
+
+func TestLoadUpstreamWrapKeyRing_RejectsLooseMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wrap.key")
+	body := b64(key32(0xab))
+	for _, mode := range []os.FileMode{0o600, 0o604, 0o640, 0o644, 0o444} {
+		if err := os.WriteFile(path, []byte(body), mode); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		// Some umasks may drop bits — re-chmod to be exact.
+		if err := os.Chmod(path, mode); err != nil {
+			t.Fatalf("chmod: %v", err)
+		}
+		_, err := LoadUpstreamWrapKeyRing(path)
+		if err == nil {
+			t.Fatalf("mode %#o: expected refusal", mode)
+		}
+	}
+}
+
+func TestLoadUpstreamWrapKeyRing_AcceptsTightMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wrap.key")
+	if err := os.WriteFile(path, []byte(b64(key32(0xcd))), 0o400); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.Chmod(path, 0o400); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	ring, err := LoadUpstreamWrapKeyRing(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(ring.Keys) != 1 {
+		t.Fatalf("want 1 key, got %d", len(ring.Keys))
+	}
+}
+
+func TestLoadUpstreamWrapKeyRing_NoUsableKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wrap.key")
+	// All entries malformed → empty ring → error.
+	if err := os.WriteFile(path, []byte("not-base64,also-bad"), 0o400); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.Chmod(path, 0o400); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	if _, err := LoadUpstreamWrapKeyRing(path); err == nil {
+		t.Fatalf("expected error for unparseable body")
+	}
+}
+
+func TestCurrentOnNilRingIsSafe(t *testing.T) {
+	var ring *UpstreamWrapKeyRing
+	if _, ok := ring.Current(); ok {
+		t.Fatalf("nil ring should not have a current key")
+	}
+	if _, ok := (&UpstreamWrapKeyRing{}).Current(); ok {
+		t.Fatalf("empty ring should not have a current key")
+	}
+}

--- a/plans/aocr-pull-through-cache.md
+++ b/plans/aocr-pull-through-cache.md
@@ -1,0 +1,521 @@
+# AOCR Integration: Snapshot Push + Cross-Node Image Pull
+
+> Supersedes the earlier draft of this file, which assumed AOCR had a
+> pull-through cache feature. After reading
+> `/Users/sumansaurabh/Documents/startup-3/aocr.sh/` (README, understanding.md,
+> RETENTION.md, registry/config.yml), the correct picture is:
+>
+> - AOCR is **Docker Distribution v2** + Postgres metadata + Node.js hooks +
+>   token auth (no proxy mode is configured today).
+> - Storage backend is **S3-compatible** (MinIO in dev).
+> - Retention is encoded **in the tag name** as `--ttl-7d`, `--idle-30d`, etc.
+>   Plain tags are kept-latest-only.
+> - Namespace shape is `<host>/<org>/<image>:<tag>` (e.g. `aocr.aerol.ai/aocr/my-image:main`).
+> - Auth is token-based via the auth service's `/v2/token` realm; the Docker
+>   login uses a PAT-style token as password.
+>
+> This plan integrates that AOCR into AerolVM. DockerHub pull-through caching
+> is intentionally **out of scope** here — Distribution proxy mode is push-
+> incompatible (a registry in proxy mode is read-only), so the two features
+> can't live in one AOCR instance. That work, if pursued, is a separate plan
+> involving either a second proxy-mode Distribution instance or an AOCR
+> feature addition.
+
+## Context
+
+Today in AerolVM:
+
+- `Service.CreateSnapshotWithOwnership` (`internal/service/service.go:969`)
+  calls `docker.CreateSnapshot` which does `POST /commit` → produces a local
+  image tag.
+- The snapshot row is forced to `ImageDistributionLocalOnly` via
+  `normalizeSnapshotImageDistribution(ctx, snapshot, true)`
+  (`service.go:1004`).
+- `ImageRequiresLocalPlacement` (`image_distribution.go:140`) then pins any
+  sandbox using that snapshot to the originating node.
+- `failover.policy="recreate"` is rejected for local-only images
+  (`service.go:2510`).
+- The cluster placement path (`cluster/owner_watcher.go:153`,
+  `cluster/dead_owner.go:284`) short-circuits cross-node recreation when the
+  image is local-only.
+
+Concretely: a snapshot taken on node-1 is invisible to node-2. The whole
+cluster's snapshot mobility story is currently "you can't."
+
+The fix is to push the snapshot to AOCR on commit, rewrite the stored image
+reference to the AOCR-qualified form, flip distribution mode from
+`local_only` to `aocr`, and let every other node pull it via the same
+`RegistryAuth`-bearing `pullImage` path that already exists.
+
+## Goal
+
+After this change, when a user does:
+
+```ts
+await client.createSnapshot(sandboxId, { name: 'redis-with-data' });
+// ... later, possibly on a different node ...
+await client.create({ image: 'redis-with-data', ... });
+```
+
+The sequence is:
+
+1. **First call** (on node-1):
+   - `docker commit` produces a local image (existing behavior).
+   - sandboxd tags it as `<aocr_host>/<cluster_org>/redis-with-data:<rev>--idle-30d`
+     and `docker push`es it to AOCR using cluster-wide AOCR credentials.
+   - Snapshot row stores `Image = <aocr_host>/<cluster_org>/redis-with-data:<rev>--idle-30d`
+     and `ImageDistributionMode = "aocr"`.
+2. **Second call** (placement lands on node-2):
+   - `NormalizeCreateImageDistribution` already resolves snapshot-name aliases
+     to the stored image ref (`image_distribution.go:65`). It now resolves
+     to the AOCR-qualified ref.
+   - `pullImage` on node-2 hits the AOCR endpoint with the cluster's
+     AOCR credentials → image streams from AOCR's S3 backend → sandbox starts.
+3. **Failover unlocked**: `failover.policy="recreate"` now works for
+   snapshots because `ImageRequiresLocalPlacement` returns false.
+4. **AOCR's reaper handles cleanup**: the `--idle-30d` suffix means snapshots
+   not pulled in 30 days are evicted automatically. No new sandboxd-side GC.
+
+## Non-goals (this plan)
+
+- **DockerHub / public-registry pull-through caching.** That problem is
+  real but architecturally separate. AOCR's Distribution backend cannot
+  simultaneously accept pushes and proxy upstreams. If we want it, options
+  are: (a) stand up a second Distribution instance in `proxy:` mode behind
+  `aocr-mirror.aerol.ai`, (b) put Spegel on each node, (c) extend AOCR with
+  a custom proxy handler. All belong in a follow-up plan.
+- **Per-tenant AOCR credentials.** v1 uses one cluster-wide AOCR identity
+  for snapshot push/pull. Per-user push-as-the-user is a real multi-tenant
+  story (matches the hosted aocr.aerol.ai model) but expands scope
+  significantly — defer.
+- **Snapshot-name → tag uniqueness across clusters.** Each cluster gets its
+  own AOCR namespace prefix (`<cluster_org>`) so two clusters can both have
+  a snapshot called `redis-with-data` without colliding.
+
+## Architecture
+
+```
+   ┌─────────────────────────────────────┐
+   │            AOCR (Distribution v2)   │
+   │   ┌──────────────────────────────┐  │
+   │   │  /v2/<org>/<image>/manifests │  │
+   │   │  /v2/<org>/<image>/blobs     │──┼──> S3 / MinIO
+   │   └──────────────────────────────┘  │
+   │   ┌──────────────────────────────┐  │
+   │   │ Postgres: users/repos/tags   │  │   (cluster identity = one
+   │   │ + retention metadata         │  │    AOCR user/PAT, scoped to
+   │   └──────────────────────────────┘  │    org=<cluster_org>)
+   │   ┌──────────────────────────────┐  │
+   │   │ Reaper                       │  │
+   │   │  - keep-latest plain tags    │  │
+   │   │  - --ttl-* age TTL           │  │
+   │   │  - --idle-* idle TTL  ◄──────┼──┼── snapshots use --idle-30d
+   │   └──────────────────────────────┘  │
+   └──────────────────┬──────────────────┘
+                      │ HTTPS push/pull
+                      │ X-Registry-Auth: <cluster PAT>
+                      │
+      ┌───────────────┼───────────────┐
+      ▼               ▼               ▼
+   ┌──────┐       ┌──────┐         ┌──────┐
+   │node-1│       │node-2│   ...   │node-N│
+   │      │       │      │         │      │
+   │CreateSnap   │ pull snap        │
+   │ → push to AOCR  │  on demand   │
+   └──────┘       └──────┘         └──────┘
+```
+
+## Tag scheme
+
+AOCR's namespace is `<host>/<org>/<image>:<tag>`. The proposed mapping:
+
+- **host**: configurable via `SB_IMAGE_DISTRIBUTION_AOCR_HOST`
+  (already exists, default `aocr.aerol.ai`).
+- **org**: configurable via new `SB_AOCR_ORG`. Defaults to the cluster name
+  if `SB_CLUSTER_NAME` is set, else `default`. Lets multiple clusters share
+  one AOCR without colliding.
+- **image**: the snapshot name, lowercased + slugified per Docker tag rules.
+- **tag**: `<short-snapshot-id>--idle-30d` for sandbox-committed snapshots,
+  or `<short-snapshot-id>--ttl-30d` (configurable) for paths that prefer
+  age-TTL over idle-TTL.
+
+Concrete: snapshot named `redis-with-data` taken in cluster `prod-us-east`
+becomes:
+
+```
+aocr.aerol.ai/prod-us-east/redis-with-data:abc12345--idle-30d
+```
+
+The short-id-in-tag makes pushes content-addressable per snapshot — two
+snapshots called `redis-with-data` get different tags and AOCR's
+keep-latest cleanup doesn't accidentally evict one because of the other.
+The `--idle-30d` suffix tells AOCR's reaper to evict if 30 days pass
+without a pull.
+
+**Why `--idle-30d` over `--ttl-30d`** for sandbox snapshots: sandboxes
+created from a snapshot pull it, which bumps `last_pulled_at` in AOCR's
+Postgres. Active snapshots stay forever; truly dormant ones expire. This
+matches user intent ("keep snapshots I'm using").
+
+## Configuration changes
+
+**File:** `internal/config/config.go` (additions near `ImageDistributionAOCRHost`)
+
+```go
+// AOCROrg is the AOCR org/namespace prefix this cluster pushes to.
+// Required when SB_ENABLE_AOCR_SNAPSHOT_PUSH=true. Falls back to
+// SB_CLUSTER_NAME, then "default".
+AOCROrg string
+
+// AOCRUsername is the login name presented during docker login to AOCR.
+// Matches the auth service's user `id`, `username`, or `email` per
+// aocr.sh/README.md.
+AOCRUsername string
+
+// AOCRTokenPath is a filesystem path to the AOCR PAT token (read at
+// startup; not held in env to keep it out of logs/proc). The path is
+// templated into the sealed-creds discovery, same pattern as
+// CredentialEncryptionKeyPath.
+AOCRTokenPath string
+
+// EnableAOCRSnapshotPush gates the push-on-commit behavior. When false
+// (default), snapshots remain local_only as today. Set true once AOCR
+// is reachable and the cluster identity is provisioned.
+EnableAOCRSnapshotPush bool
+
+// AOCRSnapshotRetentionSuffix is the tag suffix appended to snapshot
+// pushes. Default "--idle-30d". Validated against AOCR's supported
+// suffix list (see aocr.sh/RETENTION.md).
+AOCRSnapshotRetentionSuffix string
+```
+
+Env mapping:
+
+```
+SB_AOCR_ORG=prod-us-east
+SB_AOCR_USERNAME=cluster-prod-us-east
+SB_AOCR_TOKEN_PATH=/etc/sandboxd/aocr.token
+SB_ENABLE_AOCR_SNAPSHOT_PUSH=true
+SB_AOCR_SNAPSHOT_RETENTION_SUFFIX=--idle-30d
+```
+
+Startup validation:
+- If `EnableAOCRSnapshotPush=true` and any of (AOCROrg, AOCRUsername,
+  AOCRTokenPath) is missing → fail-fast.
+- If `AOCRSnapshotRetentionSuffix` doesn't match the allowlist
+  (`--idle-7d|30d|90d|180d` or `--ttl-1h|6h|24h|7d|30d|90d|180d|365d`) →
+  fail-fast.
+- Token file must be readable at startup; otherwise warn and disable
+  the feature (do **not** fail the daemon — operator may be mid-rollout).
+
+## Code changes
+
+### C1. Add `PushImage` to `pkg/docker/client.go`
+
+Mirrors `pullImage` (`client.go:619`): builds `X-Registry-Auth`, streams
+the NDJSON response, surfaces stream errors.
+
+```go
+func (c *Client) PushImage(ctx context.Context, imageRef string, auth *models.RegistryAuth) error {
+    // POST /images/<name>/push?tag=<tag>
+    // X-Registry-Auth: base64(json{username,password,serveraddress})
+    // Streamed NDJSON, errors land in body with HTTP 200, scan for errorDetail.
+}
+```
+
+Reuse the existing pull-slot semaphore? **No** — pulls and pushes have
+different bandwidth/CPU profiles and the pull cap exists to protect the
+local daemon during boot storms. A separate `pushSlots` (smaller, e.g. 2)
+prevents a snapshot-push burst from saturating sandboxd's connection to
+AOCR. New config knob: `SB_IMAGE_PUSH_MAX_CONCURRENT` (default 2).
+
+### C2. Add `TagImage` to `pkg/docker/client.go`
+
+`POST /images/<source>/tag?repo=<repo>&tag=<tag>` — needed to give the
+locally-committed image its AOCR-qualified second tag before push without
+having to re-commit.
+
+### C3. Snapshot push integration in `internal/service/service.go`
+
+In `CreateSnapshotWithOwnership` (`service.go:969`), after the existing
+`s.docker.CreateSnapshot(...)` returns `imageID`:
+
+```go
+imageID, err := s.docker.CreateSnapshot(ctx, sandboxContainerRef(sandbox), name)
+if err != nil {
+    return nil, false, err
+}
+
+aocrRef := ""
+if s.cfg.EnableAOCRSnapshotPush {
+    aocrRef = s.buildAOCRSnapshotRef(name, shortID(imageID))
+    if err := s.docker.TagImage(ctx, name, aocrRef); err != nil {
+        // Don't fail the snapshot — fall back to local_only with a warning.
+        s.logger.Warn("aocr tag failed, falling back to local-only snapshot",
+            "snapshot", name, "error", err)
+    } else if err := s.docker.PushImage(ctx, aocrRef, s.aocrAuth()); err != nil {
+        s.logger.Warn("aocr push failed, falling back to local-only snapshot",
+            "snapshot", name, "ref", aocrRef, "error", err)
+        aocrRef = ""
+    }
+}
+
+snapshot := &models.SandboxSnapshot{
+    Name:            name,
+    Image:           firstNonEmpty(aocrRef, name), // <-- key change
+    ImageID:         imageID,
+    SourceSandboxID: sandboxID,
+    CreatedAt:       time.Now().UTC(),
+}
+forceLocal := aocrRef == ""
+if err := s.normalizeSnapshotImageDistribution(ctx, snapshot, forceLocal); err != nil {
+    return nil, false, err
+}
+```
+
+**Failure-path consistency** (CLAUDE.md hard rule #4): the snapshot row
+should always be created successfully even if AOCR is unreachable. If push
+fails, we degrade to `local_only` with a warning — the same behavior as
+today. The snapshot is still usable on the originating node; it just can't
+move. The PR description must call this out.
+
+### C4. `buildAOCRSnapshotRef` helper
+
+In `internal/service/image_distribution.go`:
+
+```go
+func (s *Service) buildAOCRSnapshotRef(snapshotName, shortImageID string) string {
+    host := s.cfg.ImageDistributionAOCRHost
+    org := s.cfg.AOCROrg
+    suffix := s.cfg.AOCRSnapshotRetentionSuffix
+    repo := slugifyForDockerTag(snapshotName) // [a-z0-9_-]+ enforced
+    tag := shortImageID + suffix
+    return fmt.Sprintf("%s/%s/%s:%s", host, org, repo, tag)
+}
+```
+
+`slugifyForDockerTag` is needed because AOCR snapshot names accept things
+Docker's tag/repo grammar doesn't (uppercase, colons, etc.). Validate the
+output is a legal OCI ref or error out.
+
+### C5. AOCR credentials helper
+
+```go
+func (s *Service) aocrAuth() *models.RegistryAuth {
+    return &models.RegistryAuth{
+        Username: s.cfg.AOCRUsername,
+        Password: s.aocrToken, // loaded once at startup from AOCRTokenPath
+        Server:   s.cfg.ImageDistributionAOCRHost,
+    }
+}
+```
+
+Token rotation: re-read the file on SIGHUP or every N minutes
+(`SB_AOCR_TOKEN_REFRESH_INTERVAL`, default 5m). Memoized, atomic swap, no
+restart needed.
+
+### C6. Pull path on other nodes — wire AOCR auth into `Service.CreateSandbox`
+
+Today `pkg/docker/client.go:pullImage` accepts a `*models.RegistryAuth`
+already pulled from `CreateSandboxRequest.Registry` (the per-sandbox creds
+path). When the image ref points at the cluster's AOCR host, we need to
+inject the cluster's AOCR auth automatically rather than require the SDK
+to pass it.
+
+In `pkg/docker/client.go`, `pullImage` is the canonical entry point. Add
+auth resolution upstream of it: at the service layer, before calling pull,
+check if the image host matches `cfg.ImageDistributionAOCRHost` and the
+caller didn't supply explicit creds — if so, inject the cluster AOCR auth.
+
+```go
+// In Service, around the CreateSandbox path that calls into docker.PullImage:
+func (s *Service) resolvePullAuth(image string, supplied *models.RegistryAuth) *models.RegistryAuth {
+    if supplied != nil && supplied.Username != "" {
+        return supplied  // explicit creds win
+    }
+    if imageRegistryHost(image) == s.cfg.ImageDistributionAOCRHost && s.aocrToken != "" {
+        return s.aocrAuth()
+    }
+    return nil
+}
+```
+
+`imageRegistryHost` already exists in `image_distribution.go:144`.
+
+### C7. Distribution mode classifier respects the new ref shape
+
+`defaultImageDistributionProvider.ClassifyImage` already returns
+`ImageDistributionAOCR` when the host matches (`image_distribution.go:42`).
+No code change there — it just starts seeing more AOCR-qualified refs as
+inputs.
+
+### C8. Snapshot delete should also delete the AOCR tag (best-effort)
+
+In `Service.DeleteSnapshot` (find call site via `s.docker.RemoveImage` or
+similar):
+
+```go
+if snapshot.ImageDistributionMode == models.ImageDistributionAOCR && snapshot.Image != "" {
+    // Distribution v2 supports DELETE /v2/<name>/manifests/<reference>.
+    // AOCR's reaper will eventually GC unreferenced blobs.
+    // Best-effort — log on failure but don't fail the snapshot delete.
+    _ = s.docker.DeleteRemoteImage(ctx, snapshot.Image, s.aocrAuth())
+}
+```
+
+`DeleteRemoteImage` is new — uses the OCI Distribution `DELETE /v2/.../manifests/`
+endpoint directly via the registry HTTP API (not Docker daemon, which
+doesn't expose this). If AOCR's auth requires write scope for delete, the
+cluster PAT needs `delete` permission. Verify with AOCR maintainer.
+
+If delete is operationally fraught, an alternative is to do nothing here
+and rely entirely on AOCR's `--idle-30d` reaper. Simpler, slightly more
+S3 cost, but failure-safe. **Default to relying on the reaper**; add the
+explicit delete only if storage cost becomes measurable.
+
+### C9. Image-locality placement affinity (optional, deferred)
+
+Even with AOCR, a node that already has the image cached locally avoids
+the pull entirely. Implementation sketch:
+
+- Each node gossips its top-K cached images (LRU, K=64) on the existing
+  capacity heartbeat.
+- `headroomScore` in `internal/cluster/placement.go:195` gets a small
+  additive bonus (~+0.15) for a candidate that has the image.
+- Power-of-two-choices then tiebreaks toward cached nodes without giving
+  up load balance.
+
+**Defer** to a follow-up. Ship the AOCR push path first, measure pull
+volume to AOCR, only add affinity if AOCR pull pressure justifies it.
+
+## Failure modes & invariants
+
+| Failure | Behavior | Why |
+|---|---|---|
+| AOCR push fails on snapshot commit | Snapshot still created locally as `local_only`; warning logged. Sandbox using this snapshot pins to origin node. | Failure-path consistency rule. Don't lose user data because of an infra hiccup. |
+| AOCR pull fails on a recreate-failover | Recreate retries on next live target per existing failover logic. If AOCR is truly down, the sandbox stays orphaned (same as today's local-only behavior). | Don't pretend the cluster is healthy when it isn't. |
+| AOCR token rotation | Read from file every 5m; atomic swap. Active pulls/pushes use the auth they captured at request start. | Avoid race between rotation and in-flight HTTP. |
+| Snapshot name collision across clusters | Solved by the `<org>` prefix in the AOCR ref. Two clusters pushing `redis-with-data` go to different orgs. | Multi-tenant safety. |
+| Reaper evicts an active snapshot | Should never happen with `--idle-30d` if it's been pulled in last 30 days. If it does (e.g. operator pushed `--ttl-1h` by mistake), pull fails → sandbox create fails with a clear AOCR 404. | Surface as `models.ErrSnapshotImageGone`, distinct from `ErrSnapshotNotFound`. |
+| AOCR reachable from leader but not from a follower | The follower's `Service.CreateSandbox` pull fails. Existing pull-failure handling applies (admission error, sandbox stays in `error` state). | No new behavior; existing semantics. |
+
+## Tests
+
+### Server-side unit (`internal/service/`)
+
+- `snapshot_push_test.go` (new): given `EnableAOCRSnapshotPush=true` and a
+  fake docker client that records calls, assert:
+  - `CreateSnapshot` → `TagImage` is called with the expected AOCR ref.
+  - `PushImage` is called with the cluster AOCR auth.
+  - On `PushImage` failure, snapshot row's `Image` field falls back to
+    the local tag and `ImageDistributionMode == local_only`.
+  - On both success → snapshot row has AOCR-qualified `Image` and
+    `ImageDistributionMode == aocr`.
+- Extend `image_distribution_test.go`: cover `buildAOCRSnapshotRef`'s
+  slugification and the suffix-validation allowlist.
+
+### Cluster integration
+
+- Extend `internal/cluster/dead_owner_test.go` and
+  `owner_watcher_test.go`: a snapshot with `ImageDistributionMode=aocr`
+  is eligible for cross-node recreation; a `local_only` one is not.
+  (Regression-guard the existing branch as-is, add the new case.)
+
+### End-to-end (manual; documented in PR description)
+
+1. Bring up a 2-node cluster + a self-hosted AOCR (docker-compose from
+   aocr.sh).
+2. Create sandbox on node-1, run a workload, `createSnapshot`.
+3. Verify AOCR push by `curl https://aocr/v2/<org>/<repo>/tags/list` (or
+   `docker pull` from a third machine).
+4. Create a new sandbox from that snapshot; verify placement allows
+   node-2; verify node-2 pulls from AOCR (check `docker images` on node-2
+   shows the AOCR-qualified ref, AOCR's metrics show the pull).
+5. Set `failover.policy=recreate`, kill node-1, verify recreation on
+   node-2.
+
+### CLAUDE.md compliance checks
+
+- This change touches `internal/service/service.go` (CreateSnapshot path,
+  CLAUDE.md skill `/touch-create-sandbox` doesn't directly apply but the
+  same rigor does) — boot-path latency is **not** affected (push happens
+  on snapshot commit, not sandbox boot), but call this out in PR.
+- No change to the TCP host-port pool or L4 bootstrap → no regression
+  test there.
+- Cluster placement code unchanged in v1 (affinity deferred) → no
+  cluster-correctness call-out needed beyond noting that `aocr` mode now
+  appears legitimately in the placement-eligible branch.
+- SDK surface unchanged → no per-language SDK work.
+- Docs: add `docs/src/content/docs/operations/snapshot-distribution.mdx`
+  (new page) covering the operator setup. Register in
+  `docs/src/content.config.ts`. Five-tab examples for the SDK-visible
+  bits (essentially `createSnapshot` + create-from-snapshot showing
+  failover policy now works).
+
+## Rollout
+
+1. Land the code changes with `EnableAOCRSnapshotPush=false` default
+   (no behavior change).
+2. Deploy AOCR (Helm or compose) in a dev cluster.
+3. Provision an AOCR user/PAT for the cluster identity; install
+   `/etc/sandboxd/aocr.token` via Ansible.
+4. Flip `SB_ENABLE_AOCR_SNAPSHOT_PUSH=true` on one node in dev; create
+   a snapshot, verify AOCR push, then enable on the rest.
+5. Production rollout: same staged flip, behind a feature flag in the
+   Ansible inventory.
+
+## Open questions
+
+1. **Cluster identity provisioning.** Today AOCR users come from the
+   `app.aerol.ai` upstream validation service. Self-hosted deployments
+   point at their own validator. Need a story for "this cluster is a
+   first-class AOCR push identity" — probably a special account class on
+   the auth service that has push rights to one specific org, no expiry.
+   This is an AOCR-side decision; document the contract here, implement
+   over there.
+
+2. **Snapshot tag immutability.** Distribution v2 allows tag overwrites
+   by default. AOCR's keep-latest policy assumes pushes are immutable
+   within their tag (it's the *plain tag* that gets reaped to one).
+   By embedding `shortImageID` in the tag, we make our tags effectively
+   immutable. Validate that AOCR's reaper handles many `--idle-30d`
+   tags per repository (it should — Postgres index on `last_pulled_at`).
+
+3. **Cluster-name vs explicit org.** Defaulting `AOCROrg` to
+   `SB_CLUSTER_NAME` is convenient but ties two unrelated concerns. Maybe
+   require explicit `SB_AOCR_ORG` to force operator intent. Lean toward
+   explicit-required when `EnableAOCRSnapshotPush=true`.
+
+4. **Public vs private AOCR.** The hosted `aocr.aerol.ai` is multi-tenant
+   with each user pushing to their own org. A self-hosted single-tenant
+   AOCR is the obvious model for production AerolVM clusters. v1 assumes
+   self-hosted; the public path requires per-user auth which is the
+   "per-tenant credentials" non-goal.
+
+5. **Pull-through cache for DockerHub.** Punted to a follow-up plan. The
+   most plausible implementation is a separate Distribution instance in
+   `proxy:` mode at `aocr-mirror.aerol.ai`, with daemons configured via
+   `--registry-mirror`. AOCR-the-product stays focused on push.
+
+## Estimated scope
+
+- `internal/config/config.go`: ~60 LOC (config fields, env loading, validation).
+- `pkg/docker/client.go`: ~150 LOC (`PushImage`, `TagImage`, optional
+  `DeleteRemoteImage`).
+- `internal/service/service.go`: ~80 LOC (push-on-commit integration in
+  `CreateSnapshotWithOwnership`, pull-auth resolution).
+- `internal/service/image_distribution.go`: ~50 LOC (`buildAOCRSnapshotRef`,
+  slugification, suffix validation).
+- Tests: ~300 LOC.
+- Docs: one new `.mdx` page + sidebar entry.
+- Ansible: token file deployment task.
+
+Total: ~600 LOC of production code + tests + docs. Single PR, behind a
+feature flag that defaults off.
+
+## What this plan does NOT close
+
+- DockerHub / external-registry pull amplification (separate plan).
+- Per-tenant snapshot push (single cluster-wide identity in v1).
+- Image-locality placement affinity (deferred to follow-up).
+- AOCR HA topology (single AOCR instance assumed for v1; ops concern).

--- a/plans/serverless-sandbox-http-wake.md
+++ b/plans/serverless-sandbox-http-wake.md
@@ -1,0 +1,607 @@
+# Serverless Sandboxes: Auto-Stop + HTTP Wake
+
+## 20 use cases first
+
+The target shape is not "generic sleeping containers." It is a specific
+product behavior: an HTTP-addressable sandbox can stop after idle time,
+preserve its filesystem state, and wake when the next HTTP request arrives.
+
+### 1. Preview apps and product surfaces
+
+| # | Use case | Why HTTP wake matters | Main HTTP surface |
+|---:|---|---|---|
+| 1 | Pull-request preview app | A preview that costs money while idle is much less useful than one that wakes on demand. | `exposePort(3000)` |
+| 2 | Feature-branch admin panel | Engineers only open it occasionally; scale-to-zero keeps long-tail branches cheap. | `exposePort(3000)` |
+| 3 | Per-customer demo environment | Sales or success teams need it to feel instantly available without paying for 24/7 uptime. | `exposePort(8080)` |
+| 4 | White-label customer portal replica | Every tenant can have an isolated server without every tenant holding live CPU/RAM. | `exposePort(3000)` |
+| 5 | Support repro UI with seeded data | The environment can sit dormant until a support engineer opens the bug URL. | `exposePort(3000)` |
+
+### 2. Agent-facing HTTP tools and MCP-style servers
+
+| # | Use case | Why HTTP wake matters | Main HTTP surface |
+|---:|---|---|---|
+| 6 | MCP server for a coding agent | Agents call the tool sporadically; idle periods should not hold a whole sandbox open. | HTTP server inside sandbox |
+| 7 | Internal agent tool server | Tool sandboxes should wake per task instead of burning resources between jobs. | HTTP API |
+| 8 | Eval harness callback server | The harness only receives traffic during a run; outside the run it should sleep. | HTTP API |
+| 9 | RAG query API per workspace | Each workspace can keep its own isolated retrieval stack without permanent runtime cost. | HTTP API |
+| 10 | Workflow automation webhook target | An agent or SaaS product can hit a webhook URL that wakes the sandboxed worker. | HTTP webhook |
+
+### 3. Customer and internal APIs
+
+| # | Use case | Why HTTP wake matters | Main HTTP surface |
+|---:|---|---|---|
+| 11 | Per-customer REST backend | Tenant isolation becomes cheaper when idle tenants fall to zero. | HTTP API |
+| 12 | Internal admin API per environment | Rarely used operator surfaces should not stay hot all day. | HTTP API |
+| 13 | Secure contractor integration backend | External collaborators can have isolated APIs without persistent host cost. | HTTP API |
+| 14 | Third-party callback receiver | Many integrations are bursty; the receiver should wake only when callbacks arrive. | HTTP webhook |
+| 15 | Sales demo API with seeded records | Demo environments can look live while actually sleeping most of the day. | HTTP API |
+
+### 4. Data and processing services exposed over HTTP
+
+| # | Use case | Why HTTP wake matters | Main HTTP surface |
+|---:|---|---|---|
+| 16 | Document conversion or OCR API | CPU-heavy but bursty workloads are a natural fit for wake-on-request. | HTTP API |
+| 17 | Image resize or PDF render worker | Requests are sporadic; the worker should not stay running between conversions. | HTTP API |
+| 18 | Notebook or report publishing service | A user opens a report URL a few times a day; the service can sleep otherwise. | HTTP app |
+| 19 | Lightweight embedding or inference API | Small model-serving sandboxes can scale to zero when traffic disappears. | HTTP API |
+| 20 | Staging control-plane replica | A low-traffic internal service can preserve state while avoiding constant runtime cost. | HTTP API |
+
+## Context
+
+The current codebase is already close to a serverless-style stop/start model:
+
+- Per-sandbox lifecycle timers already exist in `pkg/models/types.go` and the
+  minute sweep in `internal/service/service.go` already auto-stops or
+  auto-destroys sandboxes.
+- `StartSandbox` and `StopSandbox` already preserve the container's writable
+  layer and reapply mounts, network rules, and Caddy routes on restart.
+- The Docker runtime already waits for the in-container `toolboxd` health
+  endpoint before reporting a sandbox as started.
+- The E2B facade already proves the basic pattern: `connect` explicitly starts
+  a stopped sandbox before handing back runtime access.
+
+What is missing is not lifecycle control. What is missing is wake-aware HTTP
+ ingress:
+
+- toolbox/session/runtime HTTP paths fail if `ToolboxTarget(...)` sees no
+  `ContainerIP`.
+- exposed HTTP ports are routed directly by Caddy to the container IP.
+- `StopSandbox` and docker stop events tear those routes down.
+- public HTTP traffic does not update `last_active_at`, so a busy preview app
+  can still look idle to the lifecycle sweep.
+
+## Goal
+
+Support a first-class "resource server" mode where a sandbox:
+
+1. can auto-stop after idle time,
+2. keeps its filesystem state,
+3. wakes when the next HTTP request arrives,
+4. preserves manual stop semantics, and
+5. works in both single-node and cluster mode.
+
+## Non-goals (this plan)
+
+- Memory snapshot, VM hibernation, or process-memory resume. This is Docker
+  stop/start, not Firecracker suspend.
+- Raw TCP or TLS-SNI wake in the first cut. `protocol: "tcp"` and
+  `protocol: "tls"` stay as live-only surfaces.
+- Multi-instance autoscaling or load balancing for one sandbox.
+- Billing, quotas, or tenancy policy beyond the wake mechanics.
+- Browser-desktop wake semantics separate from normal HTTP routing.
+
+## Product contract
+
+### What "serverless" means here
+
+In AerolVM, "serverless sandbox" means:
+
+- the sandbox container is stopped when idle,
+- no host CPU or memory reservation is held while stopped,
+- the writable filesystem and mounted state are restored on start,
+- the next HTTP request can trigger a start and then be proxied.
+
+It does **not** mean memory resume or zero-latency cold starts.
+
+### Manual stop vs sleeping stop
+
+The platform must distinguish between:
+
+- **manual stop**: operator/user explicitly stopped the sandbox; inbound HTTP
+  must not auto-wake it.
+- **sleeping stop**: lifecycle auto-stop armed wake-on-HTTP; inbound HTTP may
+  wake it.
+
+The current `stopped` status alone is not enough to represent both.
+
+### First-request behavior
+
+Recommended behavior:
+
+- sandboxd waits up to `SB_HTTP_WAKE_TIMEOUT` for the sandbox to start,
+  then proxies the same HTTP request through.
+- if the start does not complete in time, return `503 Service Unavailable`
+  with `Retry-After: 2`.
+
+This gives the cleanest UX for normal GET/POST requests while still bounding
+request hold time.
+
+## Proposed architecture
+
+### A1. Add a public wake policy and an internal armed-state bit
+
+Add two different concepts:
+
+1. **Public intent**: `Lifecycle.WakeOnHTTP bool`
+   - user-facing, persisted, SDK-visible
+   - means "this sandbox may wake from HTTP after an auto-stop"
+2. **Internal runtime state**: `wake_armed bool`
+   - store-only
+   - means "this specific stopped sandbox is currently asleep and should wake
+     on HTTP"
+
+Why both are needed:
+
+- `WakeOnHTTP` is durable policy.
+- `wake_armed` distinguishes lifecycle sleep from manual stop.
+
+Rules:
+
+- manual `StopSandbox` sets `wake_armed = false`
+- lifecycle auto-stop for a wake-enabled HTTP sandbox sets `wake_armed = true`
+- `StartSandbox` clears `wake_armed`
+- destroy clears everything
+
+### A2. Route wake-enabled HTTP traffic through sandboxd, not directly to the container
+
+This is the key architectural choice.
+
+For ordinary HTTP exposed ports today, Caddy routes directly to
+`containerIP:port`. That is incompatible with serverless behavior because:
+
+- Caddy cannot decide whether to start the sandbox,
+- public HTTP requests do not touch `last_active_at`,
+- stop currently tears the route down entirely.
+
+For wake-enabled HTTP exposures, Caddy should instead proxy to a new
+**loopback-only internal ingress handler in sandboxd**.
+
+That handler will:
+
+1. resolve the sandbox and port,
+2. forward to the owner in cluster mode if needed,
+3. `TouchSandbox(...)` for activity accounting,
+4. if stopped and `wake_armed == true`, single-flight `StartSandbox(...)`,
+5. proxy the same request to the sandbox's target port,
+6. return `503 + Retry-After` on wake timeout or capacity rejection.
+
+This is the only design in the current architecture that solves **both** wake
+and accurate HTTP idle accounting.
+
+### A3. Keep live-only routing for raw TCP and TLS
+
+`protocol: "tcp"` and `protocol: "tls"` stay on the current direct Caddy-l4
+paths in the first cut.
+
+Reason:
+
+- they do not have an HTTP request to intercept,
+- buffering and replay semantics are different,
+- the current host-port and SNI routing code is already a fragile area.
+
+### A4. Auto-wake toolbox/session/runtime HTTP paths inside sandboxd
+
+The control-plane HTTP proxies already pass through sandboxd, so they only
+need wake-aware resolution:
+
+- `pkg/api/v1/proxy.go`
+- `pkg/api/daytona/toolbox.go`
+- `pkg/api/e2b/runtime_proxy.go`
+
+Instead of calling `ToolboxTarget(...)` directly and failing on empty
+`ContainerIP`, these paths should call a new helper such as
+`EnsureSandboxAwakeForHTTP(...)` and then resolve the toolbox endpoint.
+
+### A5. Preserve the current Docker start contract
+
+Do not invent a new runtime contract. Reuse the existing one:
+
+- `StartSandbox(...)` re-admits capacity,
+- re-establishes mounts,
+- starts the container,
+- waits for `toolboxd` health,
+- reapplies network rules,
+- republishes routes.
+
+The wake path should be a thin wrapper around the existing start path, with a
+single-flight guard so concurrent HTTP requests do not race multiple starts.
+
+## State machine
+
+Recommended internal state model:
+
+```text
+started
+  -> manual stop            => stopped, wake_armed=false
+  -> lifecycle auto-stop    => stopped, wake_armed=true  (only if WakeOnHTTP && HTTP surfaces exist)
+  -> destroy                => destroyed
+
+stopped, wake_armed=true
+  -> HTTP request           => start -> started
+  -> manual start           => started
+  -> destroy                => destroyed
+
+stopped, wake_armed=false
+  -> manual start           => started
+  -> HTTP request           => no wake
+```
+
+The status enum can stay `started/stopped/error/destroyed`; the new behavior
+is carried by `wake_armed`.
+
+## Configuration changes
+
+Add three config knobs:
+
+1. `SB_ENABLE_HTTP_WAKE` (default `false`)
+   - global rollout gate
+   - sandbox-level `WakeOnHTTP` is ignored unless this is enabled
+
+2. `SB_INTERNAL_INGRESS_ADDR` (default `127.0.0.1:21213`)
+   - loopback-only listener Caddy uses for wake-aware HTTP port routes
+
+3. `SB_HTTP_WAKE_TIMEOUT` (default `30s`)
+   - max time the ingress proxy waits for a sleeping sandbox to start before
+     returning `503 + Retry-After`
+
+## Code changes
+
+### C1. Extend the lifecycle model and store schema
+
+**Files:**
+
+- `pkg/models/types.go`
+- `internal/store/store.go`
+- `internal/store/store_test.go`
+
+**Changes:**
+
+- add `WakeOnHTTP bool` to `models.Lifecycle`
+- add `wake_on_http` column to `sandboxes`
+- add `wake_armed` column to `sandboxes`
+- thread both fields through create, upsert, get, list, and `UpdateLifecycle`
+- keep zero/default behavior identical for old rows
+
+Why this is the root fix:
+
+- policy and runtime state become durable across daemon restart and reconcile
+
+### C2. Add a loopback-only internal ingress proxy package
+
+**Files:**
+
+- `pkg/api/ingressproxy/routes.go` (new)
+- `pkg/api/ingressproxy/handlers.go` (new)
+- `pkg/api/server.go`
+
+**Changes:**
+
+- add a new unversioned internal route family such as:
+  - `GET /__ingress/http/{id}/{port}`
+  - `GET /__ingress/http/{id}/{port}/{path...}`
+  - same for other HTTP verbs
+- these routes are mounted only on the internal loopback listener, not on the
+  public API listener
+- handler resolves owner, touches activity, optionally wakes, then reverse
+  proxies to the sandbox port
+
+Why a separate listener is recommended:
+
+- no new public unauthenticated wake endpoint
+- no Caddy-shared bearer token required
+- easy to reason about deployment: local Caddy talks to local sandboxd only
+
+### C3. Start a second HTTP server in sandboxd for the loopback ingress proxy
+
+**Files:**
+
+- `cmd/sandboxd/main.go`
+- `internal/config/config.go`
+- `internal/config/config_test.go`
+
+**Changes:**
+
+- load the new config knobs
+- start a second `http.Server` on `SB_INTERNAL_INGRESS_ADDR`
+- wire graceful shutdown for both servers
+- only enable the listener when Caddy is enabled and `SB_ENABLE_HTTP_WAKE`
+  is on
+
+### C4. Add wake-aware HTTP route builders in the Caddy client
+
+**Files:**
+
+- `pkg/caddy/client.go`
+- `pkg/caddy/client_test.go`
+
+**Changes:**
+
+- add helpers for wake-enabled HTTP routes, for example:
+  - `UpsertWakeHTTPPortRoute(...)`
+  - `DeleteWakeHTTPPortRoute(...)`
+- these routes match the existing public host/path but dial the internal
+  ingress listener instead of `containerIP:port`
+- preserve the existing direct route helpers for non-wake HTTP exposures
+- add route-ID helpers so reconcile keeps wake routes instead of garbage
+  collecting them as zombies
+
+### C5. Split stop behavior into manual stop vs lifecycle sleep
+
+**Files:**
+
+- `internal/service/service.go`
+- `internal/service/events.go`
+- `internal/service/lifecycle_test.go`
+- `internal/service/service_runtime_flow_test.go`
+
+**Changes:**
+
+- refactor stop flow into an internal helper that accepts a stop mode:
+  - manual stop
+  - lifecycle sleep
+- lifecycle sleep sets `wake_armed=true` before container stop
+- manual stop sets `wake_armed=false`
+- docker stop/die event handling must preserve wake-enabled HTTP routes when
+  `wake_armed=true`, and delete them otherwise
+- reconcile must rebuild wake routes for `stopped + wake_armed=true` rows
+
+Why this matters:
+
+- without event-path changes, the docker stop event will tear wake routes down
+  even if the lifecycle sweep intended to keep them active
+
+### C6. Add single-flight wake helpers in the service layer
+
+**Files:**
+
+- `internal/service/service.go`
+- `internal/service/metrics.go`
+
+**Changes:**
+
+- add a per-sandbox single-flight helper such as `EnsureSandboxAwakeForHTTP`
+- if sandbox is already running: no-op
+- if sandbox is stopped but `wake_armed=false`: do not start
+- if sandbox is stopped and `wake_armed=true`: call `StartSandbox`
+- record wake metrics:
+  - requests
+  - cold starts
+  - failures
+  - wake duration
+
+### C7. Make API toolbox/session/runtime proxies wake-aware
+
+**Files:**
+
+- `pkg/api/v1/proxy.go`
+- `pkg/api/daytona/toolbox.go`
+- `pkg/api/e2b/runtime_proxy.go`
+- `pkg/api/e2b/handlers.go`
+- `pkg/api/e2b/meta.go`
+
+**Changes:**
+
+- replace direct `ToolboxTarget(...)` resolution with wake-aware resolution
+- keep E2B `connect` behavior, but map E2B `autoResume` onto the new native
+  `WakeOnHTTP` lifecycle field
+- make Daytona and v1 toolbox proxies honor the same native wake policy
+
+### C8. Publish HTTP exposed ports differently when wake is enabled
+
+**Files:**
+
+- `internal/service/service.go`
+- `internal/service/port_start_additional_test.go`
+- `internal/service/cluster_exposure_test.go`
+
+**Changes:**
+
+- update `upsertExposedPortRoute(...)` so HTTP exposure chooses between:
+  - direct Caddy -> `containerIP:port` route when `WakeOnHTTP=false`
+  - wake-aware Caddy -> internal ingress proxy route when `WakeOnHTTP=true`
+- `deleteExposedPortRoute(...)` must delete the correct route family
+- do **not** change raw TCP or TLS route behavior in this plan
+
+### C9. Keep reconcile and zombie-GC aware of sleeping routes
+
+**Files:**
+
+- `internal/service/service.go`
+- `pkg/caddy/client.go`
+
+**Changes:**
+
+- `gcZombieCaddyEntries(...)` must treat wake HTTP route IDs as live when the
+  sandbox row is `stopped + wake_armed=true`
+- stopped sleeping sandboxes should not lose their wake routes on reconcile
+- started wake-enabled sandboxes should keep the same ingress-proxy route
+  shape so `last_active_at` keeps updating on every request
+
+### C10. Extend SDKs and docs after the server contract is stable
+
+**Files:**
+
+- `sdk/typescript/src/internal/client.ts`
+- `sdk/typescript/src/internal/client.test.ts`
+- `sdk/python/...`
+- `sdk/go/...`
+- `sdk/rust/...`
+- `sdk/java/...`
+- `docs/src/content/docs/...` (new top-level page)
+- `docs/src/content.config.ts`
+
+**Changes:**
+
+- expose `wakeOnHttp` in create/update lifecycle calls across all five SDKs
+- add a docs page specifically for serverless HTTP sandboxes and wake-on-
+  request behavior
+- document the cold-start contract and the fact that TCP/TLS are not included
+  in phase 1
+
+## Tests
+
+### Server-side unit
+
+- `internal/store/store_test.go`
+  - migration compatibility for `wake_on_http` and `wake_armed`
+  - full replace semantics for `UpdateLifecycle`
+- `internal/service/lifecycle_test.go`
+  - wake-enabled lifecycle sleep arms `wake_armed`
+  - manual stop does not arm it
+  - stopped/manual rows do not auto-wake
+- `internal/service/service_runtime_flow_test.go`
+  - sleeping sandbox wakes on HTTP helper
+  - concurrent wake requests single-flight to one start
+  - capacity failure returns error without mutating state
+- `pkg/caddy/client_test.go`
+  - wake HTTP route uses internal ingress listener target
+  - route IDs are stable in domain and path mode
+
+### API and ingress tests
+
+- `pkg/api/v1/..._test.go`
+  - toolbox proxy wakes sleeping sandbox
+  - toolbox proxy does not wake manually stopped sandbox
+- `pkg/api/e2b/handlers_test.go`
+  - `autoResume` maps to native wake policy
+- `pkg/api/e2b/runtime_proxy_test.go` (new if needed)
+  - runtime proxy wakes sleeping sandbox
+- `pkg/api/ingressproxy/..._test.go`
+  - GET/POST/PUT requests survive wake and proxy correctly
+  - wake timeout returns `503 + Retry-After`
+
+### Cluster tests
+
+- ingress request arriving on non-owner forwards to owner, then wakes there
+- orphaned owner still returns the current 410/503 semantics
+- sleeping wake routes survive cluster reconcile on ingress nodes
+
+### End-to-end manual run
+
+1. Create sandbox with `stop_if_idle_for` and `wake_on_http=true`.
+2. Start an HTTP app and `exposePort(3000)`.
+3. Hit the public URL successfully.
+4. Wait for lifecycle auto-stop.
+5. Hit the same URL again and verify wake + successful response.
+6. Manually stop the sandbox.
+7. Hit the same URL and verify it does **not** wake.
+8. Repeat in cluster mode through a non-owner ingress node.
+
+## Failure modes and invariants
+
+### Invariants
+
+1. Manual stop must never silently become wake-enabled.
+2. Destroyed sandboxes never wake.
+3. Wake requests must not bypass admission control.
+4. Only one cold start runs per sandbox at a time.
+5. Wake-enabled HTTP routes must survive reconcile while the sandbox sleeps.
+6. TCP host-port and TLS-SNI behavior stay byte-identical in this plan.
+
+### Expected failure behavior
+
+- If admission rejects the wake, return `503`.
+- If start times out, return `503` with `Retry-After`.
+- If the owner is orphaned in cluster mode, keep existing 410 behavior.
+- If the sandbox row exists but the container is gone and start fails, surface
+  the existing store/runtime error rather than inventing a new status.
+
+## Rollout
+
+### Phase 1
+
+- ship store fields, service wake helper, and toolbox/runtime auto-wake only
+- gate behind `SB_ENABLE_HTTP_WAKE=false` by default
+- no public HTTP port wake yet
+
+### Phase 2
+
+- ship internal ingress listener and wake-aware HTTP exposure routes
+- enable on a single-node staging environment first
+- verify idle accounting by hitting an exposed HTTP route repeatedly and
+  confirming the lifecycle sweep does not stop an active sandbox
+
+### Phase 3
+
+- enable in one cluster environment
+- verify non-owner ingress wake, reconcile stability, and route GC behavior
+- only then expose the SDK and docs surface publicly
+
+## Files that change
+
+### Core server
+
+- `cmd/sandboxd/main.go`
+- `internal/config/config.go`
+- `internal/config/config_test.go`
+- `internal/service/service.go`
+- `internal/service/events.go`
+- `internal/service/metrics.go`
+- `internal/store/store.go`
+- `internal/store/store_test.go`
+- `pkg/models/types.go`
+
+### API and ingress
+
+- `pkg/api/server.go`
+- `pkg/api/ingressproxy/routes.go` (new)
+- `pkg/api/ingressproxy/handlers.go` (new)
+- `pkg/api/v1/proxy.go`
+- `pkg/api/daytona/toolbox.go`
+- `pkg/api/e2b/runtime_proxy.go`
+- `pkg/api/e2b/handlers.go`
+- `pkg/api/e2b/meta.go`
+
+### Routing
+
+- `pkg/caddy/client.go`
+- `pkg/caddy/client_test.go`
+
+### SDKs and docs
+
+- `sdk/typescript/...`
+- `sdk/python/...`
+- `sdk/go/...`
+- `sdk/rust/...`
+- `sdk/java/...`
+- `docs/src/content/docs/...` (new top-level page)
+- `docs/src/content.config.ts`
+
+## Estimated scope
+
+- **Phase 1:** medium server change
+- **Phase 2:** large server/routing change
+- **Phase 3:** medium SDK/docs pass
+
+Roughly, this is one meaningful server feature, not a one-file tweak. The
+main complexity is not waking a container; it is making wake semantics coexist
+with Caddy routing, lifecycle stop logic, docker event handling, reconcile,
+and cluster forwarding.
+
+## What this plan does not close
+
+- raw TCP/TLS wake-on-connect
+- memory snapshot or near-zero cold starts
+- per-sandbox autoscaling beyond one instance
+- request buffering guarantees for extremely long uploads during cold start
+- billing or tenancy metering for sleeping versus running time
+
+## Recommendation
+
+Build this in two server phases:
+
+1. wake-aware control-plane HTTP paths first,
+2. then wake-aware exposed HTTP ingress via a loopback sandboxd proxy.
+
+That order keeps the first cut narrow, proves the lifecycle/state model,
+and avoids starting with the fragile Caddy/TCP surfaces.

--- a/setup/aocr/README.md
+++ b/setup/aocr/README.md
@@ -1,0 +1,225 @@
+# Connecting AerolVM to AOCR
+
+End-user setup guide for wiring an AerolVM cluster to an already-deployed
+[AOCR](https://github.com/aerolai/aocr) so private image pulls flow through
+the authenticated mirror and (optionally) auto-import into the cluster's
+own namespace after first pull.
+
+> **Reference:** [`AUTHENTICATED_MIRROR.md`](../../AUTHENTICATED_MIRROR.md)
+> documents every `SB_MIRROR_*` / `SB_AUTO_IMPORT_*` env var, the wrap-key
+> threat model, and the F17-F21 phase numbering. This page only covers how
+> to feed those settings into the cluster via Terraform or Ansible.
+
+## Prerequisites
+
+You need an AOCR deployment that is already up and reachable from every
+AerolVM node. From the AOCR operator, get these three values:
+
+| You need                  | Where it lives on the AOCR side                                | What it's for                                                                 |
+|---------------------------|----------------------------------------------------------------|-------------------------------------------------------------------------------|
+| **Mirror host**           | The vhost AOCR exposes for cached pulls (e.g. `mirror.aocr.example.com`) | Sandboxd rewrites `ghcr.io`/`gcr.io`/`quay.io`/`registry.k8s.io` pulls onto this host. |
+| **Upstream wrap key**     | `aocr.sh/secrets/upstream_wrap_key` (base64, 32 bytes)         | Wraps per-pull upstream credentials so the mirror — and only the mirror — can unwrap them. Required for **private** upstream pulls. |
+| **Internal API token**    | `aocr.sh/secrets/internal_api_token` (64-char string)          | Bearer token sandboxd presents on `POST /v1/internal/imports`. **Only needed for auto-import (F21).** |
+
+Plus one identifier you choose yourself:
+
+| You need        | What it's for                                                                                            |
+|-----------------|----------------------------------------------------------------------------------------------------------|
+| **Cluster ID**  | This cluster's name on the AOCR side (matches `^[A-Za-z0-9_-]{1,64}$`). Imported tags land under `cluster/<id>/_imported/...`. |
+
+The wrap key and the internal API token are real secrets. Treat them like
+`pat_token` and `cloudflare_api_token`.
+
+## Pick your path
+
+| You provision nodes with | Use                                |
+|--------------------------|------------------------------------|
+| Terraform                | [Terraform setup](#terraform-setup) |
+| Ansible only             | [Ansible setup](#ansible-setup)     |
+| Both (Terraform → Ansible later) | [Terraform setup](#terraform-setup) — Ansible's `configure-ops.yml` will read the same `/etc/sandboxd/cluster.env` and overwrite cleanly if you run it later. |
+
+---
+
+## Terraform setup
+
+Add an `aocr = { ... }` block to your `terraform.tfvars`. Everything else
+in the cluster's Terraform stays unchanged — when `enabled = false` (the
+default) no AOCR resources are templated.
+
+### Modes
+
+**Off (default).** Omit the block entirely, or:
+
+```hcl
+aocr = {
+  enabled = false
+}
+```
+
+**Mirror-only — cached + wrapped private pulls.** Three fields:
+
+```hcl
+aocr = {
+  enabled           = true
+  mirror_host       = "mirror.aocr.example.com"
+  upstream_wrap_key = "BASE64_32_BYTES_FROM_aocr.sh/secrets/upstream_wrap_key"
+}
+```
+
+Pulls of `ghcr.io/...`, `gcr.io/...`, `quay.io/...`, and `registry.k8s.io/...`
+flow through the mirror. Private pulls use wrapped credentials.
+
+**Mirror + auto-import (full F21).** Four more fields. Plan-time
+validation rejects `auto_import_enabled = true` without all three of
+`hooks_url`, `cluster_id`, and `cluster_pat`:
+
+```hcl
+aocr = {
+  enabled             = true
+  mirror_host         = "mirror.aocr.example.com"
+  upstream_wrap_key   = "BASE64_32_BYTES_FROM_aocr.sh/secrets/upstream_wrap_key"
+  auto_import_enabled = true
+  hooks_url           = "https://aocr.example.com"   # AOCR hooks service root, no trailing slash
+  cluster_id          = "prod-aerolvm-us-east-1"
+  cluster_pat         = "TOKEN_FROM_aocr.sh/secrets/internal_api_token"
+  retention_suffix    = "--idle-90d"                 # optional; default --idle-90d
+}
+```
+
+After this, each successful private pull triggers a re-mount under
+`cluster/prod-aerolvm-us-east-1/_imported/<host>/<repo>:<tag>--idle-90d`
+on the AOCR side, fully decoupled from the original upstream credential.
+
+### All available fields
+
+```hcl
+aocr = {
+  enabled             = bool          # required
+  mirror_host         = string        # default ""
+  mirror_push_host    = string        # default ""; leave empty unless AOCR exposes a separate push vhost
+  mirror_upstreams    = string        # default "ghcr.io=ghcr,gcr.io=gcr,quay.io=quay,registry.k8s.io=k8s"
+  upstream_wrap_key   = string        # default ""; base64 32-byte AES-GCM key
+  auto_import_enabled = bool          # default false
+  hooks_url           = string        # default ""
+  cluster_id          = string        # default ""; must match ^[A-Za-z0-9_-]{1,64}$
+  cluster_pat         = string        # default ""
+  retention_suffix    = string        # default "--idle-90d"
+  request_timeout     = string        # default "15s" (Go duration)
+  reconcile_interval  = string        # default "5m" (Go duration)
+  max_in_flight       = number        # default 4
+}
+```
+
+The whole variable is marked `sensitive = true`, so plan/apply output
+won't print the wrap key or PAT.
+
+### Apply
+
+```sh
+terraform apply
+```
+
+Existing nodes recycle (`user_data_replace_on_change = true`) because the
+bootstrap script content changed. The new bootstrap:
+
+1. Creates `/etc/sandboxd/secrets/` at `0700`.
+2. Writes the wrap key to `/etc/sandboxd/secrets/upstream-wrap.key` (`0600`) if `upstream_wrap_key` is non-empty.
+3. Writes the cluster PAT to `/etc/sandboxd/secrets/cluster-pat` (`0600`) if `cluster_pat` is non-empty.
+4. Appends `SB_MIRROR_*` / `SB_AUTO_IMPORT_*` to `/etc/sandboxd/cluster.env`.
+5. `systemctl restart sandboxd`.
+
+The cluster PAT is **file-sourced**, never an env var — it never appears
+in `systemctl show sandboxd` or process listings.
+
+---
+
+## Ansible setup
+
+If you provision with Ansible instead of (or alongside) Terraform, set
+the same values in `Ansible/inventory/group_vars/all.yml` (or any more
+specific group/host vars file) and run `configure-ops.yml`.
+
+```yaml
+# Mirror
+sandboxd_mirror_host:        "mirror.aocr.example.com"
+sandboxd_upstream_wrap_key_src: "/path/on/control/node/upstream_wrap_key"
+
+# + Auto-import
+sandboxd_auto_import_enabled:          true
+sandboxd_auto_import_hooks_url:        "https://aocr.example.com"
+sandboxd_auto_import_cluster_id:       "prod-aerolvm-us-east-1"
+sandboxd_auto_import_cluster_pat_src:  "/path/on/control/node/cluster_pat"
+# sandboxd_auto_import_retention_suffix: "--idle-90d"   # default
+```
+
+`*_src` paths point at files on the Ansible **control node**. The
+playbook copies them to `/etc/sandboxd/secrets/upstream-wrap.key` and
+`/etc/sandboxd/secrets/cluster-pat` on each managed host with `mode 0600`.
+Leave a `*_src` empty to skip that copy (use this if your fleet renders
+the file via Vault or another mechanism).
+
+Then:
+
+```sh
+ansible-playbook Ansible/playbooks/configure-ops.yml
+```
+
+Sandboxd restarts on each host as the env file changes (controlled by
+`sandboxd_restart_after_ops_config`).
+
+The full list of `sandboxd_mirror_*` / `sandboxd_auto_import_*` defaults
+lives in [`Ansible/inventory/group_vars/all.yml`](../../Ansible/inventory/group_vars/all.yml).
+
+---
+
+## Verifying it works
+
+After bootstrap (Terraform) or `configure-ops.yml` (Ansible) finishes,
+ssh into any node:
+
+```sh
+# 1. Env wired up
+sudo grep -E '^SB_(MIRROR|AUTO_IMPORT)_' /etc/sandboxd/cluster.env
+
+# 2. Secrets installed with correct perms
+sudo ls -l /etc/sandboxd/secrets/
+# -rw------- 1 root root  ... upstream-wrap.key
+# -rw------- 1 root root  ... cluster-pat   (auto-import only)
+
+# 3. Sandboxd picked them up
+systemctl is-active sandboxd
+curl -sf http://127.0.0.1:21212/health
+```
+
+Trigger a private pull through the SDK or `docker pull` against a
+sandbox, then on the AOCR side:
+
+```sh
+# Mirror cache populated?
+curl -sf https://mirror.aocr.example.com/v2/_catalog | jq
+
+# Auto-import landed?
+curl -sf https://aocr.example.com/v2/_catalog | jq \
+  | grep "cluster/prod-aerolvm-us-east-1/_imported/"
+```
+
+## Troubleshooting
+
+| Symptom                                                       | Likely cause                                                                                       |
+|---------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
+| Public pulls succeed but private pulls 401                    | `upstream_wrap_key` empty or doesn't match an active key in AOCR's `UPSTREAM_AUTH_WRAP_KEYS`.       |
+| `terraform plan` rejects with "hooks_url, cluster_id, cluster_pat are all required" | You set `auto_import_enabled = true` but omitted one of those three. They are mandatory together. |
+| Sandboxd refuses to boot with auto-import config              | Startup guard mirrors the same Terraform validation. Check `journalctl -u sandboxd` for the missing field. |
+| Auto-import POSTs 401                                         | `cluster_pat` doesn't match AOCR's `INTERNAL_API_TOKEN`. Re-fetch from `aocr.sh/secrets/internal_api_token`. |
+| Imported tags never appear under `cluster/<id>/_imported/...` | Check `journalctl -u sandboxd | grep auto_import` for the reconciler's per-image outcome.          |
+
+## Rotating secrets
+
+- **Wrap key:** add the new key alongside the old one in AOCR's
+  `UPSTREAM_AUTH_WRAP_KEYS` (comma-separated), then bump `upstream_wrap_key`
+  in your tfvars/group_vars and re-apply. After every node has rotated,
+  drop the old key from AOCR.
+- **Cluster PAT:** rotate AOCR's `INTERNAL_API_TOKEN` and update
+  `cluster_pat` / `sandboxd_auto_import_cluster_pat_src`, then re-apply.
+  Auto-imports queued under the old token will fail and the reconciler
+  will retry under the new one.


### PR DESCRIPTION
This pull request introduces two major features to `sandboxd`: a configurable AOCR pull-through mirror for upstream container registries, and a post-pull auto-import path for private images. These changes add new configuration options, environment variable support, and wiring for both features, as well as robust error handling and logging. The update also includes helper functions and unit tests for parsing mirror configuration.

Key changes:

**AOCR Pull-Through Mirror Support**
- Added new configuration fields to `Config` (`MirrorHost`, `MirrorPushHost`, `MirrorUpstreams`, `UpstreamWrapKeyPath`) to support AOCR pull-through mirror and upstream registry mapping. These are populated from environment variables and validated on load. (`[[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR389-R467)`, `[[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR570-R581)`)
- Implemented `configureMirror` in `main.go` to initialize the mirror configuration, including loading an optional upstream wrap-key ring for private image authentication. The function gracefully handles missing/invalid keys and logs informative warnings. (`[cmd/sandboxd/main.goR448-R602](diffhunk://#diff-85cd4174384a81cdbf87370531855ae87bcbd19bf68f36b611d73cd5d96cb4daR448-R602)`)
- Added `parseMirrorUpstreams` helper and corresponding unit tests to robustly parse and validate the upstream registry mapping configuration. (`[[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR910-R933)`, `[[2]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62R826-R858)`)

**Post-Pull Auto-Import Path**
- Introduced new configuration fields for auto-import (`AutoImportEnabled`, `AutoImportHooksBaseURL`, `AutoImportClusterID`, `AutoImportClusterPATPath`, etc.), with validation to ensure all required options are set when enabled. (`[[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR389-R467)`, `[[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR570-R581)`, `[[3]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR609-R625)`)
- Added `startAutoImportReconciler` and related types to wire up the auto-import feature: after a successful pull of a private image, a flag is set in the database and a background reconciler periodically calls AOCR to import the image for cluster-wide use. Includes error handling, logging, and bounded concurrency. (`[[1]](diffhunk://#diff-85cd4174384a81cdbf87370531855ae87bcbd19bf68f36b611d73cd5d96cb4daR282-R301)`, `[[2]](diffhunk://#diff-85cd4174384a81cdbf87370531855ae87bcbd19bf68f36b611d73cd5d96cb4daR448-R602)`)

**General Improvements**
- Updated imports and main wiring to support the new features. (`[[1]](diffhunk://#diff-85cd4174384a81cdbf87370531855ae87bcbd19bf68f36b611d73cd5d96cb4daR10)`, `[[2]](diffhunk://#diff-85cd4174384a81cdbf87370531855ae87bcbd19bf68f36b611d73cd5d96cb4daR101)`)

These changes collectively enable more robust, secure, and cluster-aware image lifecycle management in `sandboxd`.<!--
GitHub auto-fills new PR descriptions with this template. Fill in EVERY
section below. "N/A — <one-line reason>" is a valid answer; an empty answer
is not. See pr-review.md at the repo root for what each section is asking.
-->
