### PR TITLE
bug: Update AOCR mirror paths and add Docker Hub setup

### DIFF
--- a/AUTHENTICATED_MIRROR.md
+++ b/AUTHENTICATED_MIRROR.md
@@ -53,7 +53,7 @@ to function — everything else is additive.
 |------------------------------|--------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `SB_MIRROR_HOST`             | *(empty — disables rewrite)*                                       | Mirror vhost for cached pulls, e.g. `mirror.aocr.aerol.ai`. When empty, all upstream refs are passed through unchanged.                               |
 | `SB_MIRROR_PUSH_HOST`        | *(empty)*                                                          | Push vhost for the same AOCR cluster (e.g. `aocr.aerol.ai`). Refs already pointing here are left alone so they are not double-rewritten.              |
-| `SB_MIRROR_UPSTREAMS`        | `ghcr.io=ghcr,gcr.io=gcr,quay.io=quay,registry.k8s.io=k8s`         | Comma-separated `host=shortname` map controlling which upstreams get rewritten and the short name used in the rewritten ref (`mirror/_/<short>/...`). |
+| `SB_MIRROR_UPSTREAMS`        | `ghcr.io=ghcr,gcr.io=gcr,quay.io=quay,registry.k8s.io=k8s`         | Comma-separated `host=shortname` map controlling which upstreams get rewritten and the short name used in the rewritten ref (`<mirrorHost>/aocr/<short>/...`). |
 | `SB_UPSTREAM_WRAP_KEY_PATH`  | *(empty — soft-fail to raw creds)*                                 | Path to the base64-encoded 32-byte upstream wrap key. When unset, pulls are still rewritten but creds go to the mirror unwrapped (public images only). |
 
 `SB_UPSTREAM_WRAP_KEY_PATH` is intentionally **soft-fail**: a missing key

--- a/Terraform/DOCKER_HUB_MIRROR.md
+++ b/Terraform/DOCKER_HUB_MIRROR.md
@@ -1,0 +1,133 @@
+# Docker Hub mirror via AOCR — day-0 setup
+
+This document explains why Docker Hub pulls bypass the AOCR mirror by
+default, what Terraform now does about it automatically, and how to
+retrofit existing hosts that were provisioned before this change.
+
+## Why Docker Hub is the odd one out
+
+Sandboxd ships a client-side rewriter (`pkg/docker/mirror_rewrite.go`)
+that turns refs like `ghcr.io/aerol-ai/sandbox:v1` into
+`<mirror_host>/aocr/ghcr/aerol-ai/sandbox:v1` before handing them to
+the Docker daemon. That works for any registry whose name appears in
+`SB_MIRROR_UPSTREAMS` — `ghcr.io`, `gcr.io`, `quay.io`,
+`registry.k8s.io` — because rewriting the URL is enough to redirect
+the pull.
+
+Docker Hub is intentionally **not** in that list. The reason is a
+quirk in dockerd itself: Hub-style short refs (`alpine`,
+`library/redis`) are resolved by the daemon's built-in Hub client, and
+the daemon will only consult a mirror for that client if you set
+`registry-mirrors` in `/etc/docker/daemon.json`. URL rewriting from
+userspace doesn't intercept it.
+
+**Net effect of doing nothing**: Hub pulls go straight to
+`registry-1.docker.io`, skipping the AOCR cache and any rate-limit
+protection it would have provided.
+
+## What Terraform now does (day-0)
+
+When `var.aocr.enabled = true` **and** `var.aocr.mirror_host != ""`,
+`templates/bootstrap.sh.tftpl` writes `/etc/docker/daemon.json` before
+`install.sh` runs:
+
+```json
+{
+  "registry-mirrors": ["https://<mirror_host>"],
+  "live-restore": true
+}
+```
+
+Two things to know:
+
+1. **`registry-mirrors`** routes Hub pulls through AOCR. The mirror
+   recognises Hub paths (`/v2/library/alpine/...`,
+   `/v2/<org>/<repo>/...`) and proxies them.
+2. **`live-restore: true`** lets the daemon restart in the future
+   (cert rotation, package upgrades) without killing running
+   sandboxes. The first apply doesn't need the flag yet — no
+   containers exist at provision time — but turning it on now means
+   you don't have to remember later.
+
+If a pre-baked AMI already contains `/etc/docker/daemon.json` with
+other keys, the bootstrap merges (`jq '. + {...}'`) instead of
+clobbering.
+
+No additional Terraform variables. Reusing the existing
+`var.aocr.mirror_host`.
+
+## Retrofitting existing hosts
+
+For a fleet provisioned **before** this change, run the one-shot
+script below on each host. It's idempotent and safe to re-run.
+
+```bash
+#!/usr/bin/env bash
+# Usage: sudo MIRROR_HOST=mirror.aocr.aerol.ai ./enable-aocr-hub-mirror.sh
+set -euo pipefail
+
+: "${MIRROR_HOST:?MIRROR_HOST is required, e.g. mirror.aocr.aerol.ai}"
+
+command -v jq >/dev/null || { apt-get update -y && apt-get install -y jq; }
+
+install -d -m 0755 /etc/docker
+if [ -s /etc/docker/daemon.json ]; then
+  jq --arg mirror "https://${MIRROR_HOST}" \
+     '. + {"registry-mirrors": [$mirror], "live-restore": true}' \
+     /etc/docker/daemon.json > /etc/docker/daemon.json.new
+else
+  jq -n --arg mirror "https://${MIRROR_HOST}" \
+     '{"registry-mirrors": [$mirror], "live-restore": true}' \
+     > /etc/docker/daemon.json.new
+fi
+mv /etc/docker/daemon.json.new /etc/docker/daemon.json
+chmod 0644 /etc/docker/daemon.json
+
+systemctl restart docker
+echo "[ok] daemon.json updated; mirror=${MIRROR_HOST}"
+```
+
+> **Caveat on running hosts**: `systemctl restart docker` will kill
+> running containers on a daemon that doesn't already have
+> `live-restore: true` set *and active*. The first run on a legacy
+> host writes the flag but the restart still happens without it
+> (kernel state). Plan to drain the node first, or accept the
+> sandbox eviction. Subsequent restarts will be transparent.
+
+## Verification
+
+After provisioning or retrofit, on the host:
+
+```bash
+# 1. Mirror is registered.
+docker info 2>/dev/null | grep -A2 'Registry Mirrors'
+# Expect: https://<mirror_host>/
+
+# 2. live-restore is on.
+docker info 2>/dev/null | grep -i 'Live Restore'
+# Expect: Live Restore Enabled: true
+
+# 3. Pull through the mirror.
+docker pull alpine:3.20
+# Check the mirror access log — you should see a /v2/library/alpine/...
+# request from this host's IP. Hub itself should NOT see a hit.
+```
+
+## Why not Ansible?
+
+This is a one-time, deterministic day-0 setting that piggybacks on
+existing user_data. Ansible would add an extra moving part for what
+amounts to "write one JSON file before dockerd starts." If you later
+need fleet-wide rotation (changing `mirror_host`), the right move is
+to roll the launch template and replace nodes — same operational
+profile as any other AMI/user-data change.
+
+## Sources
+
+- Docker daemon mirror behavior:
+  <https://docs.docker.com/engine/registry/recipes/mirror/> —
+  "registry-mirrors" only applies to Docker Hub.
+- `live-restore`: <https://docs.docker.com/config/containers/live-restore/>
+- Sandboxd rewriter (non-Hub registries):
+  `pkg/docker/mirror_rewrite.go`
+- AOCR mirror router (Hub path handling): `aocr.sh/mirror/router.go`

--- a/Terraform/templates/bootstrap.sh.tftpl
+++ b/Terraform/templates/bootstrap.sh.tftpl
@@ -26,6 +26,43 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
 apt-get install -y curl jq awscli openssl ca-certificates
 
+%{ if aocr_enabled && aocr_mirror_host != "" ~}
+###############################################################################
+# 0. Docker Hub mirror (AOCR) — day-0 daemon.json
+#
+# Sandboxd's client-side rewriter handles ghcr.io / gcr.io / quay.io /
+# registry.k8s.io by URL substitution, but Docker Hub is special: dockerd
+# *only* honours a mirror for Hub via /etc/docker/daemon.json
+# `registry-mirrors`. Without this block, `docker pull alpine` bypasses
+# the AOCR mirror entirely (same name "library/alpine" exists upstream).
+#
+# Written before install.sh so dockerd starts with the setting on its
+# very first boot — no restart-races, no containers to evict.
+# `live-restore: true` is set proactively so future daemon restarts
+# (cert rotation, package upgrades) don't kill running sandboxes.
+#
+# jq-merges into any pre-existing daemon.json (e.g. baked into a custom
+# AMI) instead of clobbering it.
+###############################################################################
+install -d -m 0755 /etc/docker
+if [ -s /etc/docker/daemon.json ]; then
+  jq --arg mirror "https://${aocr_mirror_host}" \
+     '. + {"registry-mirrors": [$mirror], "live-restore": true}' \
+     /etc/docker/daemon.json > /etc/docker/daemon.json.new
+else
+  jq -n --arg mirror "https://${aocr_mirror_host}" \
+     '{"registry-mirrors": [$mirror], "live-restore": true}' \
+     > /etc/docker/daemon.json.new
+fi
+mv /etc/docker/daemon.json.new /etc/docker/daemon.json
+chmod 0644 /etc/docker/daemon.json
+# Restart only if dockerd is already running (custom AMI); otherwise
+# install.sh will start it and pick the config up on its first boot.
+if systemctl is-active --quiet docker; then
+  systemctl restart docker
+fi
+%{ endif ~}
+
 ###############################################################################
 # 1. install.sh
 #

--- a/internal/service/auto_import_retry.go
+++ b/internal/service/auto_import_retry.go
@@ -281,7 +281,7 @@ func autoImportRequestFromSpec(spec *models.CreateSandboxRequest) (AutoImportReq
 // is optional — the digest is what makes the import authoritative.
 //
 // This deliberately does NOT understand AOCR mirror-prefix rewriting
-// (`mirror.aocr.aerol.ai/_/ghcr/...`): the AutoImport path runs against
+// (`mirror.aocr.aerol.ai/aocr/ghcr/...`): the AutoImport path runs against
 // the *original* upstream ref, not the mirror-rewritten one. The mirror
 // rewrite is a pull-time concern only.
 func parseUpstreamFromRegistryRef(registryRef, image string) (host, repo, tag string) {

--- a/pkg/docker/mirror_rewrite.go
+++ b/pkg/docker/mirror_rewrite.go
@@ -9,10 +9,17 @@ import (
 //
 // Example: `{Host: "ghcr.io", Shortname: "ghcr"}` causes
 // `ghcr.io/aerol-ai/sandbox:v1` to be rewritten to
-// `mirror.aocr.aerol.ai/_/ghcr/aerol-ai/sandbox:v1`. The `_/` prefix is the
-// Distribution-v2 reserved-namespace convention; AOCR's auth route helper
-// (`auth/src/upstreamAuth/route.ts`) strips `_/<short>/` back off when
-// routing scope strings to the upstream probe.
+// `mirror.aocr.aerol.ai/aocr/ghcr/aerol-ai/sandbox:v1`. The `aocr/` prefix
+// is a reserved namespace owned by the AOCR mirror; AOCR's auth route
+// helper (`auth/src/upstreamAuth/route.ts`) strips `aocr/<short>/` back off
+// when routing scope strings to the upstream probe.
+//
+// Why `aocr` and not `_`: Docker's reference grammar
+// (distribution/reference) requires each path component to match
+// `[a-z0-9]+([._-][a-z0-9]+)*`. The bare `_` segment that early drafts of
+// the mirror used is NOT a valid component, and Docker daemon rejects refs
+// like `mirror.aocr.aerol.ai/_/ghcr/...` with "invalid reference format"
+// before they ever leave the client.
 //
 // Docker Hub is intentionally absent from this list: it's handled by the
 // Docker daemon's `registry-mirrors` daemon.json setting (which only
@@ -61,7 +68,7 @@ type MirrorRewrite struct {
 	// upstream. They are populated only when Rewritten=true.
 	UpstreamHost string
 	// UpstreamRepo is the *mirror-side* repo path, e.g.
-	// `_/ghcr/aerol-ai/sandbox` — this matches the Distribution scope
+	// `aocr/ghcr/aerol-ai/sandbox` — this matches the Distribution scope
 	// string AOCR's `route.ts` parses. For Docker Hub passthrough or
 	// non-rewritten refs this is empty.
 	UpstreamRepo string
@@ -77,7 +84,7 @@ type MirrorRewrite struct {
 //  2. Refs that already point at the mirror or push vhost are passed
 //     through (idempotency — re-running a rewrite is a no-op).
 //  3. Refs whose host matches a configured `MirrorUpstream.Host` are
-//     rewritten to `<mirrorHost>/_/<short>/<repo>:<tag>`.
+//     rewritten to `<mirrorHost>/aocr/<short>/<repo>:<tag>`.
 //  4. Docker Hub refs (host=docker.io, or no host prefix at all) pass
 //     through — the Docker daemon handles them via `registry-mirrors`.
 //  5. Refs with an unknown host pass through, so private registries the
@@ -126,7 +133,7 @@ func RewriteImageRefForMirror(ref string, cfg MirrorConfig) MirrorRewrite {
 		return pass
 	}
 
-	mirrorRepo := "_/" + short + "/" + repoOnly
+	mirrorRepo := "aocr/" + short + "/" + repoOnly
 	rewrittenRef := mirrorHost + "/" + mirrorRepo
 	if tag != "" {
 		rewrittenRef += ":" + tag

--- a/pkg/docker/mirror_rewrite_test.go
+++ b/pkg/docker/mirror_rewrite_test.go
@@ -50,7 +50,7 @@ func TestRewriteImageRefForMirror_GHCRWithTag(t *testing.T) {
 	if !r.Rewritten {
 		t.Fatalf("expected rewrite, got %+v", r)
 	}
-	if r.RewrittenRef != "mirror.aocr.aerol.ai/_/ghcr/aerol-ai/sandbox:v1.2.3" {
+	if r.RewrittenRef != "mirror.aocr.aerol.ai/aocr/ghcr/aerol-ai/sandbox:v1.2.3" {
 		t.Fatalf("unexpected rewritten ref: %s", r.RewrittenRef)
 	}
 	if r.OriginalRef != "ghcr.io/aerol-ai/sandbox:v1.2.3" {
@@ -59,7 +59,7 @@ func TestRewriteImageRefForMirror_GHCRWithTag(t *testing.T) {
 	if r.UpstreamHost != "ghcr.io" {
 		t.Fatalf("UpstreamHost: %s", r.UpstreamHost)
 	}
-	if r.UpstreamRepo != "_/ghcr/aerol-ai/sandbox" {
+	if r.UpstreamRepo != "aocr/ghcr/aerol-ai/sandbox" {
 		t.Fatalf("UpstreamRepo: %s", r.UpstreamRepo)
 	}
 	if r.UpstreamTag != "v1.2.3" {
@@ -73,7 +73,7 @@ func TestRewriteImageRefForMirror_DigestRef(t *testing.T) {
 	if !r.Rewritten {
 		t.Fatalf("expected rewrite, got %+v", r)
 	}
-	want := "mirror.aocr.aerol.ai/_/gcr/distroless/base@" + digest
+	want := "mirror.aocr.aerol.ai/aocr/gcr/distroless/base@" + digest
 	if r.RewrittenRef != want {
 		t.Fatalf("rewritten ref: got %s want %s", r.RewrittenRef, want)
 	}
@@ -87,7 +87,7 @@ func TestRewriteImageRefForMirror_NoTag(t *testing.T) {
 	if !r.Rewritten {
 		t.Fatalf("expected rewrite, got %+v", r)
 	}
-	if r.RewrittenRef != "mirror.aocr.aerol.ai/_/quay/prometheus/node-exporter" {
+	if r.RewrittenRef != "mirror.aocr.aerol.ai/aocr/quay/prometheus/node-exporter" {
 		t.Fatalf("rewritten ref: %s", r.RewrittenRef)
 	}
 	if r.UpstreamTag != "" {
@@ -102,10 +102,10 @@ func TestRewriteImageRefForMirror_K8sSingleSegment(t *testing.T) {
 	if !r.Rewritten {
 		t.Fatalf("expected rewrite, got %+v", r)
 	}
-	if r.RewrittenRef != "mirror.aocr.aerol.ai/_/k8s/pause:3.9" {
+	if r.RewrittenRef != "mirror.aocr.aerol.ai/aocr/k8s/pause:3.9" {
 		t.Fatalf("rewritten ref: %s", r.RewrittenRef)
 	}
-	if r.UpstreamRepo != "_/k8s/pause" {
+	if r.UpstreamRepo != "aocr/k8s/pause" {
 		t.Fatalf("UpstreamRepo: %s", r.UpstreamRepo)
 	}
 }
@@ -146,7 +146,7 @@ func TestRewriteImageRefForMirror_UnknownHostPassesThrough(t *testing.T) {
 
 func TestRewriteImageRefForMirror_IdempotentOnAlreadyRewritten(t *testing.T) {
 	cfg := defaultMirrorCfg()
-	ref := "mirror.aocr.aerol.ai/_/ghcr/aerol-ai/sandbox:v1"
+	ref := "mirror.aocr.aerol.ai/aocr/ghcr/aerol-ai/sandbox:v1"
 	r := RewriteImageRefForMirror(ref, cfg)
 	if r.Rewritten {
 		t.Fatalf("already-rewritten ref must pass through, got %+v", r)
@@ -172,7 +172,7 @@ func TestRewriteImageRefForMirror_HostCaseInsensitive(t *testing.T) {
 		t.Fatalf("uppercase host should still match, got %+v", r)
 	}
 	// Host gets lowercased but repo + tag are preserved verbatim.
-	if r.RewrittenRef != "mirror.aocr.aerol.ai/_/ghcr/Aerol-AI/Sandbox:V1" {
+	if r.RewrittenRef != "mirror.aocr.aerol.ai/aocr/ghcr/Aerol-AI/Sandbox:V1" {
 		t.Fatalf("rewritten ref: %s", r.RewrittenRef)
 	}
 }

--- a/pkg/docker/pull_mirror_test.go
+++ b/pkg/docker/pull_mirror_test.go
@@ -89,7 +89,7 @@ func TestPullImage_MirrorEnabled_RewritesURL(t *testing.T) {
 	if err := cap.client.pullImage(context.Background(), "ghcr.io/aerol-ai/sandbox:v1", auth); err != nil {
 		t.Fatalf("pullImage: %v", err)
 	}
-	if want := "mirror.aocr.aerol.ai/_/ghcr/aerol-ai/sandbox:v1"; cap.from() != want {
+	if want := "mirror.aocr.aerol.ai/aocr/ghcr/aerol-ai/sandbox:v1"; cap.from() != want {
 		t.Fatalf("fromImage: got %q want %q", cap.from(), want)
 	}
 	a := cap.auth()
@@ -115,7 +115,7 @@ func TestPullImage_MirrorEnabled_NoWrapKeyRing_FallsBackToRawAuth(t *testing.T) 
 	if err := cap.client.pullImage(context.Background(), "ghcr.io/aerol-ai/sandbox:v1", auth); err != nil {
 		t.Fatalf("pullImage: %v", err)
 	}
-	if cap.from() != "mirror.aocr.aerol.ai/_/ghcr/aerol-ai/sandbox:v1" {
+	if cap.from() != "mirror.aocr.aerol.ai/aocr/ghcr/aerol-ai/sandbox:v1" {
 		t.Fatalf("fromImage: %q", cap.from())
 	}
 	a := cap.auth()
@@ -135,7 +135,7 @@ func TestPullImage_MirrorEnabled_NoAuth_NoIdentityToken(t *testing.T) {
 	if err := cap.client.pullImage(context.Background(), "ghcr.io/aerol-ai/sandbox:v1", nil); err != nil {
 		t.Fatalf("pullImage: %v", err)
 	}
-	if cap.from() != "mirror.aocr.aerol.ai/_/ghcr/aerol-ai/sandbox:v1" {
+	if cap.from() != "mirror.aocr.aerol.ai/aocr/ghcr/aerol-ai/sandbox:v1" {
 		t.Fatalf("fromImage: %q", cap.from())
 	}
 	if cap.lastAuthB64.Load().(string) != "" {

--- a/pkg/secrets/upstream_wrap.go
+++ b/pkg/secrets/upstream_wrap.go
@@ -17,7 +17,7 @@ import (
 // match `auth/src/upstreamAuth/wrap.ts` exactly or the round-trip breaks.
 //
 // `Scope` pins the wrap to a specific Distribution token-server scope
-// string (e.g. `repository:_/ghcr/org/repo:pull`). AOCR cross-checks the
+// string (e.g. `repository:aocr/ghcr/org/repo:pull`). AOCR cross-checks the
 // scope inside the blob against the scope on the `/v2/token` request, so
 // a leaked blob cannot be reused for a different repo.
 type UpstreamCredentials struct {

--- a/pkg/secrets/upstream_wrap_test.go
+++ b/pkg/secrets/upstream_wrap_test.go
@@ -15,7 +15,7 @@ func sampleCreds() UpstreamCredentials {
 		UpstreamHost: "ghcr.io",
 		Username:     "octocat",
 		Password:     "ghp_xxxxxxxxxxxx",
-		Scope:        "repository:_/ghcr/aerol-ai/sandbox:pull",
+		Scope:        "repository:aocr/ghcr/aerol-ai/sandbox:pull",
 	}
 }
 


### PR DESCRIPTION
This pull request standardizes the AOCR mirror path convention across the codebase, replacing the old `_/short/...` prefix with the new `aocr/short/...` format for all non-Docker Hub registry image references. It also introduces a new day-0 setup for Docker Hub mirroring via AOCR, ensuring that Docker Hub pulls are routed through the mirror by default using Docker's `registry-mirrors` configuration. Documentation, implementation, and tests have all been updated to reflect these changes.

**AOCR Mirror Path Convention Update**

* Updated all code, documentation, and tests to use the `aocr/short/...` prefix (e.g., `mirror.aocr.aerol.ai/aocr/ghcr/...`) instead of the previous `_/short/...` convention for AOCR mirror-rewritten image references, ensuring compliance with Docker reference grammar and eliminating invalid reference errors. [[1]](diffhunk://#diff-d33a18a060c5f9b30d0b4490d4c12a88df0948345e2861c6b1ffd39cb64508e5L12-R22) [[2]](diffhunk://#diff-d33a18a060c5f9b30d0b4490d4c12a88df0948345e2861c6b1ffd39cb64508e5L64-R71) [[3]](diffhunk://#diff-d33a18a060c5f9b30d0b4490d4c12a88df0948345e2861c6b1ffd39cb64508e5L80-R87) [[4]](diffhunk://#diff-d33a18a060c5f9b30d0b4490d4c12a88df0948345e2861c6b1ffd39cb64508e5L129-R136) [[5]](diffhunk://#diff-25af25c3fe8230259cb22acb98c0d9cf0c6c226fdfb74fa7406b400a35d8fceaL56-R56) [[6]](diffhunk://#diff-42e8ea14fc88de2381bd0366a514d32381e26987ff53a7b7b605f097536129b0L284-R284) [[7]](diffhunk://#diff-277f593074b10a64f3b15c9421b2e3af1fc3f455df34fa1e199e5a9bb63d4013L20-R20) [[8]](diffhunk://#diff-bf3f05ad81b86ac1ca760e7761b9e4e583fdb158f3b5514fda179839a0b2017eL18-R18)

* Updated all related test cases in `pkg/docker/mirror_rewrite_test.go` and `pkg/docker/pull_mirror_test.go` to use the new `aocr/short/...` path convention. [[1]](diffhunk://#diff-34b116d548c7ff5c6f45b8477cf945ec8c6851bebb995105630f4303d7aaa038L53-R53) [[2]](diffhunk://#diff-34b116d548c7ff5c6f45b8477cf945ec8c6851bebb995105630f4303d7aaa038L62-R62) [[3]](diffhunk://#diff-34b116d548c7ff5c6f45b8477cf945ec8c6851bebb995105630f4303d7aaa038L76-R76) [[4]](diffhunk://#diff-34b116d548c7ff5c6f45b8477cf945ec8c6851bebb995105630f4303d7aaa038L90-R90) [[5]](diffhunk://#diff-34b116d548c7ff5c6f45b8477cf945ec8c6851bebb995105630f4303d7aaa038L105-R108) [[6]](diffhunk://#diff-34b116d548c7ff5c6f45b8477cf945ec8c6851bebb995105630f4303d7aaa038L149-R149) [[7]](diffhunk://#diff-34b116d548c7ff5c6f45b8477cf945ec8c6851bebb995105630f4303d7aaa038L175-R175) [[8]](diffhunk://#diff-469a9ff5cc3ea4e144d850b2c7445ed20be0a87706fa38e45a30b4294b50e9d7L92-R92) [[9]](diffhunk://#diff-469a9ff5cc3ea4e144d850b2c7445ed20be0a87706fa38e45a30b4294b50e9d7L118-R118) [[10]](diffhunk://#diff-469a9ff5cc3ea4e144d850b2c7445ed20be0a87706fa38e45a30b4294b50e9d7L138-R138)

**Docker Hub Mirroring via AOCR**

* Added a new document, `Terraform/DOCKER_HUB_MIRROR.md`, explaining why Docker Hub is handled differently, how Terraform now sets up Docker Hub mirroring via AOCR automatically on day-0, and how to retrofit existing hosts.

* Modified the Terraform bootstrap script (`Terraform/templates/bootstrap.sh.tftpl`) to automatically configure Docker's `daemon.json` with the AOCR mirror as a `registry-mirrors` entry and enable `live-restore`, ensuring Docker Hub pulls are cached and protected from rate limits from the start.

**Documentation and Comments**

* Updated inline comments and documentation throughout the codebase to clarify the new `aocr/short/...` convention, the rationale for the change (Docker reference grammar compliance), and the special handling for Docker Hub. [[1]](diffhunk://#diff-d33a18a060c5f9b30d0b4490d4c12a88df0948345e2861c6b1ffd39cb64508e5L12-R22) [[2]](diffhunk://#diff-d33a18a060c5f9b30d0b4490d4c12a88df0948345e2861c6b1ffd39cb64508e5L64-R71) [[3]](diffhunk://#diff-42e8ea14fc88de2381bd0366a514d32381e26987ff53a7b7b605f097536129b0L284-R284) [[4]](diffhunk://#diff-277f593074b10a64f3b15c9421b2e3af1fc3f455df34fa1e199e5a9bb63d4013L20-R20)