### PR TITLE
feat: Implement background snapshot push reconciler and enhance snapshot handling

### DIFF
--- a/cmd/sandboxd/main.go
+++ b/cmd/sandboxd/main.go
@@ -280,6 +280,7 @@ func main() {
 		svc.StartEventMonitor(ctx)
 		svc.StartBuiltImageGC(ctx)
 		startAutoImportReconciler(ctx, logger, cfg, db, svc)
+		startSnapshotPushReconciler(ctx, logger, cfg, db, svc, dockerClient)
 		if cfg.AutoImportEnabled {
 			// Wire the post-pull trigger: when the docker client finishes a
 			// successful pull that BOTH used the mirror AND carried private
@@ -559,6 +560,72 @@ func startAutoImportReconciler(ctx context.Context, logger *slog.Logger, cfg con
 					continue
 				}
 				logger.Info("auto-import reconcile sweep",
+					"scanned", stats.Scanned,
+					"succeeded", stats.Succeeded,
+					"failed", stats.Failed,
+					"skipped", stats.Skipped,
+				)
+			}
+		}
+	}()
+}
+
+// startSnapshotPushReconciler builds the optional AOCR snapshot pusher +
+// reconciler and starts a ticker goroutine if the feature is enabled. When
+// disabled (or when the pusher fails to build) we log and return without
+// scheduling anything — the snapshot path runs unchanged.
+//
+// Push host falls back to ImageDistributionAOCRHost when MirrorPushHost is
+// unset; both have non-empty defaults so the destination is always
+// resolvable. Auth reuses the auto-import cluster PAT path (re-read on
+// every push so rotation works without a restart).
+func startSnapshotPushReconciler(ctx context.Context, logger *slog.Logger, cfg config.Config, db *store.Store, svc *service.Service, dockerClient *docker.Client) {
+	if !cfg.SnapshotPushEnabled {
+		return
+	}
+	host := strings.TrimSpace(cfg.MirrorPushHost)
+	if host == "" {
+		host = strings.TrimSpace(cfg.ImageDistributionAOCRHost)
+	}
+	pusher, err := service.NewSnapshotPusher(service.SnapshotPushConfig{
+		Enabled:   true,
+		Host:      host,
+		ClusterID: cfg.AutoImportClusterID,
+		PATPath:   cfg.AutoImportClusterPATPath,
+	}, dockerClient, logger)
+	if err != nil {
+		logger.Warn("snapshot push: pusher build failed; feature stays off",
+			"error", err)
+		return
+	}
+	r := service.NewSnapshotPushReconciler(pusher, db, logger, cfg.SnapshotPushMaxInFlight)
+	if r == nil {
+		return
+	}
+	svc.AttachSnapshotPusher(pusher, r)
+	logger.Info("snapshot push reconciler started",
+		"host", host,
+		"cluster_id", cfg.AutoImportClusterID,
+		"interval", cfg.SnapshotPushReconcileInterval,
+		"max_in_flight", cfg.SnapshotPushMaxInFlight,
+	)
+	go func() {
+		t := time.NewTicker(cfg.SnapshotPushReconcileInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				stats, err := r.RunOnce(ctx)
+				if err != nil {
+					logger.Warn("snapshot push reconcile sweep failed", "error", err)
+					continue
+				}
+				if stats.Scanned == 0 {
+					continue
+				}
+				logger.Info("snapshot push reconcile sweep",
 					"scanned", stats.Scanned,
 					"succeeded", stats.Succeeded,
 					"failed", stats.Failed,

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -124,6 +124,12 @@ const getDocsSidebarConfig = (): NavigationGroup[] => [
       },
       {
         type: 'link',
+        href: '/snapshots',
+        label: 'Snapshots',
+        description: 'Capture a running sandbox or register an image as a named, reusable template.',
+      },
+      {
+        type: 'link',
         href: '/preview',
         label: 'Preview',
         description: 'Expose container ports publicly over HTTPS through Caddy routes.',
@@ -254,7 +260,7 @@ const getDocsSidebarConfig = (): NavigationGroup[] => [
         type: 'link',
         href: '/dashboard',
         label: 'Dashboard',
-        description: 'Built-in operator dashboard for cluster, capacity, placements, and metrics — sign in with your PAT.',
+        description: 'Built-in operator dashboard for cluster, capacity, placements, and metrics - sign in with your PAT.',
       },
       {
         type: 'link',

--- a/docs/src/content/docs/dashboard.mdx
+++ b/docs/src/content/docs/dashboard.mdx
@@ -29,7 +29,7 @@ INFO starting sandboxd version=... addr=...
 INFO dashboard available url=http://0.0.0.0:8080/ui
 ```
 
-The dashboard works on every node — server, worker, or ingress. Cluster
+The dashboard works on every node - server, worker, or ingress. Cluster
 status endpoints already forward to the right node internally, so opening
 the dashboard against any node gives you the cluster-wide view instead of
 only the node your DNS record happened to pick.
@@ -50,7 +50,7 @@ If your token is wrong the form rejects it with an inline error; no
 ## What each panel shows
 
 Every panel reads from an existing v1 endpoint. The dashboard does not
-introduce any new business logic — it just renders what the API already
+introduce any new business logic - it just renders what the API already
 exposes.
 
 | Panel | Endpoint | What it shows |
@@ -78,7 +78,7 @@ around an existing v1 endpoint.
 | **Drain** | Cluster panel, per-row | `POST /v1/cluster/nodes/{id}/drain` | Marks the node so future placement decisions exclude it. Idempotent. Existing sandboxes on the node keep running. |
 | **Uncordon** | Cluster panel, per-row when drained | `POST /v1/cluster/nodes/{id}/uncordon` | Clears the drain mark so the node becomes eligible for placement again. Idempotent. |
 | **Reclaim local** | Placements panel, on `orphaned` rows | `POST /v1/cluster/orphans/{id}/reclaim-local` | Recovery for a false-positive owner death: only succeeds when the local sandbox row is still present on this node and the placement was orphaned from this node. |
-| **Force delete** | Placements panel, on `orphaned` rows | `DELETE /v1/cluster/orphans/{id}` | Removes the FSM placement record for an orphan. Used when the previous owner is gone for good. Does not destroy any local sandbox — there is, by definition, no live owner to act on. |
+| **Force delete** | Placements panel, on `orphaned` rows | `DELETE /v1/cluster/orphans/{id}` | Removes the FSM placement record for an orphan. Used when the previous owner is gone for good. Does not destroy any local sandbox - there is, by definition, no live owner to act on. |
 
 There are no create / destroy / resize buttons. Those mutations stay on
 the SDKs and CLI where they go through the same auth and idempotency
@@ -92,8 +92,8 @@ A short summary, because there are two related but distinct surfaces:
   JavaScript with no embedded credentials and no server data. The
   sign-in form prompts for the PAT before any API call fires. This
   matches how every standard login page works.
-- Every API call the page makes — `GET /health`, `GET /v1/...`,
-  `GET /debug/vars`, `GET /v1/metrics`, the action endpoints — sends the PAT as
+- Every API call the page makes - `GET /health`, `GET /v1/...`,
+  `GET /debug/vars`, `GET /v1/metrics`, the action endpoints - sends the PAT as
   `Authorization: Bearer <token>` and goes through the same
   middleware as a curl or SDK call. Including `/debug/vars`: the
   expvar counters carry operational shape (lease state, queue depths,
@@ -104,7 +104,7 @@ A short summary, because there are two related but distinct surfaces:
 
 If you want the dashboard reachable only on a trusted network, expose
 sandboxd on the listener you already use for the API. The dashboard
-inherits whatever network controls protect that listener — TLS,
+inherits whatever network controls protect that listener - TLS,
 reverse-proxy auth, IP allowlists, all apply.
 
 ## Multi-node and clustered setups
@@ -115,7 +115,7 @@ the dashboard against any reachable node gives you the cluster-wide
 view. The action buttons forward through the same path.
 
 The metrics panel is intentionally local to the node you opened the
-dashboard against — it reads the in-process expvar counters of *that*
+dashboard against - it reads the in-process expvar counters of *that*
 sandboxd process. To compare nodes side-by-side, open one tab per
 node.
 

--- a/docs/src/content/docs/snapshots.mdx
+++ b/docs/src/content/docs/snapshots.mdx
@@ -1,0 +1,299 @@
+---
+title: Snapshots
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+A snapshot is a named, reusable image you can launch sandboxes from. AerolVM gives you three ways to make one and a single way to use it.
+
+- **Capture a running sandbox** - `createSnapshot` commits the live container (writable layer + installed packages + entrypoint metadata) into a Docker image and persists a row pointing at it. Useful for "save where I am, give it a name, let me spin clones of this state".
+- **Register a pre-built image** - `registerSnapshot` with `image` records a snapshot row that points at a registry reference (e.g. `python:3.12-slim`) so the rest of your fleet can address it by a short name.
+- **Build from a Dockerfile** - `registerSnapshot` with `dockerfileContent` (or the `registerSnapshotFromImage` helper that compiles an `Image` builder) hands the daemon a Dockerfile, builds it on the host, and stores the resulting content-addressed tag as the snapshot's image.
+
+In all three cases you launch a sandbox from the snapshot by passing its name to `create` as the `image` argument - the server resolves the name to the underlying image at create time.
+
+## Capture a running sandbox
+
+The container's writable layer is committed into a new image and a snapshot row is persisted with that image. The original container keeps running; the snapshot is independent.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    const sandbox = await client.create({ image: 'ubuntu:22.04' });
+    await sandbox.exec(['apt-get', 'update']);
+    await sandbox.exec(['apt-get', 'install', '-y', 'python3-pip']);
+
+    const snapshot = await client.createSnapshot(sandbox.id, 'py-ready');
+    console.log(snapshot.name, snapshot.image);
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    sandbox = client.create({'image': 'ubuntu:22.04'})
+    sandbox.exec(['apt-get', 'update'])
+    sandbox.exec(['apt-get', 'install', '-y', 'python3-pip'])
+
+    snapshot = sandbox.create_snapshot('py-ready')
+    print(snapshot['name'], snapshot['image'])
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    sandbox, err := client.Create(ctx, sdktypes.CreateSandboxOptions{Image: "ubuntu:22.04"})
+    if err != nil {
+        log.Fatal(err)
+    }
+    if _, err := sandbox.Exec(ctx, []string{"apt-get", "update"}); err != nil {
+        log.Fatal(err)
+    }
+    if _, err := sandbox.Exec(ctx, []string{"apt-get", "install", "-y", "python3-pip"}); err != nil {
+        log.Fatal(err)
+    }
+
+    snapshot, err := client.CreateSnapshot(ctx, sandbox.ID(), "py-ready")
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println(snapshot.Name, snapshot.Image)
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let sandbox = client.create(CreateOptions {
+        image: "ubuntu:22.04".to_string(),
+        ..Default::default()
+    })?;
+    sandbox.exec(&["apt-get", "update"])?;
+    sandbox.exec(&["apt-get", "install", "-y", "python3-pip"])?;
+
+    let snapshot = client.create_snapshot(&sandbox.id, "py-ready")?;
+    println!("{} {}", snapshot.name, snapshot.image);
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    Sandbox sandbox = client.create(new CreateOptions().setImage("ubuntu:22.04"));
+    sandbox.exec(List.of("apt-get", "update"));
+    sandbox.exec(List.of("apt-get", "install", "-y", "python3-pip"));
+
+    SandboxSnapshot snapshot = client.createSnapshot(sandbox.getId(), "py-ready");
+    System.out.println(snapshot.getName() + " " + snapshot.getImage());
+    ```
+  </TabItem>
+</Tabs>
+
+Snapshot names are globally unique within a deployment and become the address you pass to `create` later. Calling `createSnapshot` twice with the same name on different sandboxes is rejected - pick a versioned name (`py-ready-2026-05`) if you re-snapshot after changes.
+
+## Register a snapshot from an image
+
+When the image already exists in a registry, skip the build/commit step and just record a row that points at it. The image is **not** pulled until the first sandbox that references it gets created.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    await client.registerSnapshot({
+      name:    'py-base',
+      image:   'python:3.12-slim',
+      cpu:     2,
+      memoryMB: 4096,
+      diskGB:   10,
+    });
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    client.register_snapshot({
+        'name':     'py-base',
+        'image':    'python:3.12-slim',
+        'cpu':      2,
+        'memoryMB': 4096,
+        'diskGB':   10,
+    })
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    if _, err := client.RegisterSnapshot(ctx, sdktypes.RegisterSnapshotOptions{
+        Name:     "py-base",
+        Image:    "python:3.12-slim",
+        CPU:      2,
+        MemoryMB: 4096,
+        DiskGB:   10,
+    }); err != nil {
+        log.Fatal(err)
+    }
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    client.register_snapshot(RegisterSnapshotOptions {
+        name:     "py-base".to_string(),
+        image:    Some("python:3.12-slim".to_string()),
+        cpu:      Some(2.0),
+        memory_mb: Some(4096),
+        disk_gb:  Some(10),
+        ..Default::default()
+    })?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    client.registerSnapshot(
+        new RegisterSnapshotOptions()
+            .setName("py-base")
+            .setImage("python:3.12-slim")
+            .setCpu(2)
+            .setMemoryMb(4096)
+            .setDiskGb(10)
+    );
+    ```
+  </TabItem>
+</Tabs>
+
+The resource hints (`cpu`, `memoryMB`, `diskGB`) are surfaced back when the snapshot is referenced - useful for client UIs that want to render reasonable defaults without hard-coding them.
+
+## Build a snapshot from a Dockerfile
+
+For images that don't exist in a registry yet, hand the daemon a Dockerfile. The build runs on the host using the configured image builder; the resulting content-addressed tag is what the snapshot row points at.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    await client.registerSnapshot({
+      name: 'data-tools',
+      dockerfileContent: `
+        FROM python:3.12-slim
+        RUN pip install --no-cache-dir pandas duckdb polars
+      `.trim(),
+    });
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    client.register_snapshot({
+        'name': 'data-tools',
+        'dockerfileContent': """
+            FROM python:3.12-slim
+            RUN pip install --no-cache-dir pandas duckdb polars
+        """.strip(),
+    })
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    if _, err := client.RegisterSnapshot(ctx, sdktypes.RegisterSnapshotOptions{
+        Name: "data-tools",
+        DockerfileContent: `FROM python:3.12-slim
+RUN pip install --no-cache-dir pandas duckdb polars`,
+    }); err != nil {
+        log.Fatal(err)
+    }
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    client.register_snapshot(RegisterSnapshotOptions {
+        name: "data-tools".to_string(),
+        dockerfile_content: Some(
+            "FROM python:3.12-slim\nRUN pip install --no-cache-dir pandas duckdb polars".to_string(),
+        ),
+        ..Default::default()
+    })?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    client.registerSnapshot(
+        new RegisterSnapshotOptions()
+            .setName("data-tools")
+            .setDockerfileContent(
+                "FROM python:3.12-slim\n" +
+                "RUN pip install --no-cache-dir pandas duckdb polars"
+            )
+    );
+    ```
+  </TabItem>
+</Tabs>
+
+A single-line `FROM` is a fast-path: the daemon notices the Dockerfile only pins a base image and registers it without running a build. Multi-step Dockerfiles go through the full build pipeline and are content-hashed, so an identical Dockerfile re-registered later hits the build cache.
+
+`image` and `dockerfileContent` are mutually exclusive - pass exactly one.
+
+## Launch a sandbox from a snapshot
+
+Once a snapshot exists, pass its name where you would normally pass an image. The server resolves the name to the underlying image, inherits the snapshot's resource hints if you don't override them, and runs the create through the same path it would for a bare image reference.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    const sandbox = await client.create({
+      image: 'py-ready',
+    });
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    sandbox = client.create({'image': 'py-ready'})
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    sandbox, err := client.Create(ctx, sdktypes.CreateSandboxOptions{Image: "py-ready"})
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let sandbox = client.create(CreateOptions {
+        image: "py-ready".to_string(),
+        ..Default::default()
+    })?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    Sandbox sandbox = client.create(new CreateOptions().setImage("py-ready"));
+    ```
+  </TabItem>
+</Tabs>
+
+Snapshot resolution happens server-side, so the snapshot name and a registry reference are interchangeable in `image`. If `py-ready` is also a valid image reference (it usually isn't - snapshot names are short identifiers, not registry paths), the snapshot wins.
+
+## Snapshot distribution in cluster mode
+
+On a single-node deployment, a snapshot lives only on the host that created it - which is fine, because that host runs every sandbox. In cluster mode, a snapshot taken on one node is invisible to the others by default: the local commit produced an image only the originating node holds. Without help, a sandbox launched from that snapshot can only land on the node where the snapshot was taken, and a host failure takes the snapshot with it.
+
+AerolVM ships an optional background push that promotes a snapshot from "local only" to a cluster-distributable AOCR (Aerol OCI Registry) reference. When enabled, the snapshot create path does not change: the API still returns immediately with the local row, and a reconciler pushes the image in the background. Once the push completes, the row's distribution metadata flips to `aocr` and any node in the cluster can pull the image when scheduling a sandbox from it. Combined with `failover.policy = "recreate"` (see [Durability and Failover](/durability)), this makes snapshot-backed sandboxes survive owner-node death.
+
+Operators enable it at the daemon level - there is no SDK toggle, because the choice is operational, not per-call:
+
+| Env var | Purpose |
+|---|---|
+| `SB_SNAPSHOT_PUSH_ENABLED` | Gates the entire feature. When `false` (default), snapshots stay local-only and behave as they always have. |
+| `SB_AUTO_IMPORT_CLUSTER_ID` | Tenant namespace under AOCR (`cluster/<id>/snapshots/<name>:latest`). Reused from the auto-import setup. |
+| `SB_AUTO_IMPORT_CLUSTER_PAT_PATH` | File holding the bearer token used as the registry password. Re-read on every push, so rotation is just a file write. |
+| `SB_MIRROR_PUSH_HOST` | Push destination (e.g. `aocr.aerol.ai`). Falls back to `SB_IMAGE_DISTRIBUTION_AOCR_HOST` when unset. |
+| `SB_SNAPSHOT_PUSH_RECONCILE_INTERVAL` | Reconciler tick. Default `5m`. |
+| `SB_SNAPSHOT_PUSH_MAX_IN_FLIGHT` | Per-tick fan-out cap. Default `2`. |
+
+Each snapshot row carries a `pushState` field you can read back to watch the lifecycle: `active` (no push needed, or push complete), `pending` / `pushing` (queued for the reconciler), or `error` (last push attempt failed; the reconciler will retry on the next tick and the `pushError` field will explain why).
+
+A snapshot that fails to push is still usable on the originating node - push failure is non-fatal. Pre-existing snapshot rows from before the feature was enabled remain `active`; no backfill push is implied.
+
+## What goes into a snapshot
+
+A snapshot captures the container image, not the runtime state around it. Specifically:
+
+| Captured | Not captured |
+|---|---|
+| Container writable layer (files, installed packages) | Mounted volumes (they live outside the container by design - see [Volumes](/external-storage)) |
+| Image entrypoint and default working directory | Running processes, open sessions, in-memory state |
+| OS user, env vars baked at image build time | Sandbox-level env vars set at create time (`env`), unless the snapshot's `entrypoint` reads them at start |
+| Resource hints (cpu, memoryMB, diskGB) when provided | Network/firewall rules, exposed ports, public URLs |
+
+If you need to ship state alongside the image, write it under a [mount target](/external-storage) before snapshotting - the mount stays declared on the new sandbox the next time you `create`, and the data lives independently of any single container.
+
+## Common patterns
+
+- **Golden base image per workload.** Register a `py-base` / `node-base` / `cuda-base` snapshot once during deploy, then `create({ image: 'py-base' })` everywhere. Faster than re-running `apt-get install` per sandbox, and centralizes the version bump.
+- **User-bound fork point.** Snapshot a sandbox after a setup step (clone, build, seed), then spin per-user sandboxes from that snapshot. Each user gets a fresh writable layer rooted at the same baseline.
+- **Failover-ready snapshots in cluster mode.** Combine `SB_SNAPSHOT_PUSH_ENABLED=true` with `failover.policy = "recreate"` on the sandbox. When the owner dies, the cluster recreates the sandbox on a surviving node from the AOCR-distributed snapshot image - without it, the recreate is rejected because the local image is unreachable.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -456,6 +456,28 @@ type Config struct {
 	// unreadable, the mirror falls back to anonymous pulls — fine for
 	// public images, but private images will 401. SB_UPSTREAM_WRAP_KEY_PATH.
 	UpstreamWrapKeyPath string
+
+	// SnapshotPushEnabled gates the optional background push of sandbox
+	// snapshots to the AOCR registry. When false (the default), snapshots
+	// stay local-only — identical to pre-feature behavior. When true,
+	// snapshots whose distribution mode is `local_only` (sandbox commits
+	// and aerolvm-build/* tags) are pushed in the background to
+	// `<MirrorPushHost|ImageDistributionAOCRHost>/cluster/<ClusterID>/snapshots/<name>`,
+	// reusing the cluster PAT as the registry password. Requires
+	// AutoImportClusterID and AutoImportClusterPATPath to be set —
+	// validated at startup. SB_SNAPSHOT_PUSH_ENABLED.
+	SnapshotPushEnabled bool
+	// SnapshotPushReconcileInterval is the tick period for the background
+	// retry of failed snapshot pushes. Default 5m — shorter wastes credit
+	// when a registry is flapping; longer leaves new snapshots stuck in
+	// `pending` for longer than necessary on cold paths.
+	// SB_SNAPSHOT_PUSH_RECONCILE_INTERVAL.
+	SnapshotPushReconcileInterval time.Duration
+	// SnapshotPushMaxInFlight bounds per-tick fan-out so a burst of newly
+	// created snapshots cannot saturate the local Docker daemon or the
+	// AOCR registry. Default 2 — pushes are I/O-heavy per snapshot.
+	// SB_SNAPSHOT_PUSH_MAX_IN_FLIGHT.
+	SnapshotPushMaxInFlight int
 }
 
 // MirrorUpstreamMapping is a single host=shortname pair parsed from
@@ -579,6 +601,9 @@ func Load() (Config, error) {
 		MirrorPushHost:                   strings.TrimSpace(os.Getenv("SB_MIRROR_PUSH_HOST")),
 		MirrorUpstreams:                  parseMirrorUpstreams(getEnv("SB_MIRROR_UPSTREAMS", "ghcr.io=ghcr,gcr.io=gcr,quay.io=quay,registry.k8s.io=k8s")),
 		UpstreamWrapKeyPath:              strings.TrimSpace(os.Getenv("SB_UPSTREAM_WRAP_KEY_PATH")),
+		SnapshotPushEnabled:              getEnvBool("SB_SNAPSHOT_PUSH_ENABLED", false),
+		SnapshotPushReconcileInterval:    getEnvDuration("SB_SNAPSHOT_PUSH_RECONCILE_INTERVAL", 5*time.Minute),
+		SnapshotPushMaxInFlight:          getEnvInt("SB_SNAPSHOT_PUSH_MAX_IN_FLIGHT", 2),
 	}
 	if cfg.OTELMetricsEndpoint != "" || strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")) != "" {
 		cfg.OTELMetricsEnabled = true
@@ -621,6 +646,27 @@ func Load() (Config, error) {
 		}
 		if cfg.AutoImportRetentionSuffix != "" && !strings.HasPrefix(cfg.AutoImportRetentionSuffix, "--") {
 			return Config{}, fmt.Errorf("SB_AUTO_IMPORT_RETENTION_SUFFIX must start with `--`, got %q", cfg.AutoImportRetentionSuffix)
+		}
+	}
+
+	if cfg.SnapshotPushEnabled {
+		// Reuse the auto-import cluster identity + PAT. This is deliberate:
+		// the AOCR registry endpoint accepts the same bearer the hooks API
+		// does, so operators don't manage two credentials for the same
+		// cluster. Push host falls back to ImageDistributionAOCRHost when
+		// MirrorPushHost is unset — both have non-empty defaults so the
+		// destination is always resolvable.
+		if cfg.AutoImportClusterID == "" {
+			return Config{}, errors.New("SB_AUTO_IMPORT_CLUSTER_ID is required when SB_SNAPSHOT_PUSH_ENABLED=true")
+		}
+		if cfg.AutoImportClusterPATPath == "" {
+			return Config{}, errors.New("SB_AUTO_IMPORT_CLUSTER_PAT_PATH is required when SB_SNAPSHOT_PUSH_ENABLED=true")
+		}
+		if cfg.SnapshotPushReconcileInterval <= 0 {
+			return Config{}, errors.New("SB_SNAPSHOT_PUSH_RECONCILE_INTERVAL must be > 0 when snapshot push is enabled")
+		}
+		if cfg.SnapshotPushMaxInFlight <= 0 {
+			return Config{}, errors.New("SB_SNAPSHOT_PUSH_MAX_IN_FLIGHT must be > 0 when snapshot push is enabled")
 		}
 	}
 

--- a/internal/service/auto_import.go
+++ b/internal/service/auto_import.go
@@ -130,12 +130,12 @@ func NewAutoImporter(cfg AutoImportConfig) (*AutoImporter, error) {
 // 400 `invalid_request` — there is a regression test on both sides that
 // pins these names.
 type importBody struct {
-	UpstreamHost     string `json:"upstream_host"`
-	UpstreamRepo     string `json:"upstream_repo"`
-	UpstreamTag      string `json:"upstream_tag,omitempty"`
-	UpstreamDigest   string `json:"upstream_digest"`
-	ClusterID        string `json:"cluster_id"`
-	TargetTagSuffix  string `json:"target_tag_suffix,omitempty"`
+	UpstreamHost    string `json:"upstream_host"`
+	UpstreamRepo    string `json:"upstream_repo"`
+	UpstreamTag     string `json:"upstream_tag,omitempty"`
+	UpstreamDigest  string `json:"upstream_digest"`
+	ClusterID       string `json:"cluster_id"`
+	TargetTagSuffix string `json:"target_tag_suffix,omitempty"`
 }
 
 // importResponse is the success shape. status is one of "imported" /

--- a/internal/service/auto_import_test.go
+++ b/internal/service/auto_import_test.go
@@ -31,10 +31,10 @@ func TestAutoImportConfig_ValidateDisabledAlwaysOK(t *testing.T) {
 
 func TestAutoImportConfig_ValidateRequiresFields(t *testing.T) {
 	cases := map[string]AutoImportConfig{
-		"no host":   {Enabled: true, ClusterID: "x", ClusterPAT: "y"},
-		"no id":     {Enabled: true, HooksBaseURL: "https://x", ClusterPAT: "y"},
-		"no pat":    {Enabled: true, HooksBaseURL: "https://x", ClusterID: "y"},
-		"bad suffix":{Enabled: true, HooksBaseURL: "https://x", ClusterID: "y", ClusterPAT: "z", RetentionSuffix: "idle-90d"},
+		"no host":    {Enabled: true, ClusterID: "x", ClusterPAT: "y"},
+		"no id":      {Enabled: true, HooksBaseURL: "https://x", ClusterPAT: "y"},
+		"no pat":     {Enabled: true, HooksBaseURL: "https://x", ClusterID: "y"},
+		"bad suffix": {Enabled: true, HooksBaseURL: "https://x", ClusterID: "y", ClusterPAT: "z", RetentionSuffix: "idle-90d"},
 	}
 	for name, cfg := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/service/image_distribution.go
+++ b/internal/service/image_distribution.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"context"
+	"errors"
 	"strings"
 
+	"github.com/aerol-ai/microvm/internal/store"
 	"github.com/aerol-ai/microvm/pkg/docker"
 	"github.com/aerol-ai/microvm/pkg/models"
 )
@@ -62,12 +64,34 @@ func (s *Service) NormalizeCreateImageDistribution(ctx context.Context, req *mod
 	req.Image = strings.TrimSpace(req.Image)
 
 	if s != nil && s.store != nil && req.Image != "" {
-		if snapshot, err := s.store.GetSnapshot(ctx, req.Image); err == nil && snapshot != nil {
+		snapshot, err := s.store.GetSnapshot(ctx, req.Image)
+		switch {
+		case err == nil && snapshot != nil:
 			if image := strings.TrimSpace(snapshot.Image); image != "" {
 				req.Image = image
 			}
 			if req.ImageDistribution().IsZero() {
 				req.ApplyImageDistribution(snapshot.ImageDistribution())
+			}
+		case errors.Is(err, store.ErrNotFound) && s.snapshotPusher != nil:
+			// Cross-node snapshot lookup: a peer node took the snapshot,
+			// pushed it under the deterministic AOCR namespace, but the
+			// local store has never seen the row (we don't replicate
+			// snapshot rows through the FSM). Construct the canonical
+			// AOCR ref and let the docker pull act as the existence
+			// check. Only applies to bare identifiers — anything that
+			// looks like a registry ref or a local-only build tag goes
+			// through the normal classifier below.
+			if imageRegistryHost(req.Image) == "" && !docker.IsLocalOnlyImageRef(req.Image) {
+				if dest := s.snapshotPusher.DestRefFor(req.Image); dest != "" {
+					req.Image = dest
+					if req.ImageDistribution().IsZero() {
+						req.ApplyImageDistribution(models.ImageDistributionMetadata{
+							Mode:        models.ImageDistributionAOCR,
+							RegistryRef: dest,
+						})
+					}
+				}
 			}
 		}
 	}

--- a/internal/service/image_distribution_test.go
+++ b/internal/service/image_distribution_test.go
@@ -138,6 +138,81 @@ func TestCreateSnapshotWithOwnershipMarksLocalOnly(t *testing.T) {
 	}
 }
 
+func TestNormalizeCreateImageDistributionAOCRFallback(t *testing.T) {
+	// When a peer node took a snapshot and pushed it under the
+	// cluster's deterministic AOCR namespace, this node may receive a
+	// create request naming a snapshot it has never seen locally.
+	// Rather than wire snapshot rows through the FSM, the normalizer
+	// rewrites the image to the canonical AOCR ref so the docker pull
+	// acts as the existence check.
+	ctx := context.Background()
+	st := openImageDistributionStore(t)
+	defer st.Close()
+
+	patPath := writePATFile(t, "token")
+	pusher, err := NewSnapshotPusher(SnapshotPushConfig{
+		Enabled:   true,
+		Host:      "aocr.test",
+		ClusterID: "cluster-7",
+		PATPath:   patPath,
+	}, &fakeSnapshotPushDocker{}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("NewSnapshotPusher: %v", err)
+	}
+
+	cases := []struct {
+		name      string
+		image     string
+		pusher    *SnapshotPusher
+		wantImage string
+		wantMode  string
+	}{
+		{
+			name:      "bare name with pusher rewrites to AOCR ref",
+			image:     "my-snap",
+			pusher:    pusher,
+			wantImage: "aocr.test/cluster/cluster-7/snapshots/my-snap:latest",
+			wantMode:  models.ImageDistributionAOCR,
+		},
+		{
+			name:      "bare name without pusher is left to classifier",
+			image:     "my-snap",
+			pusher:    nil,
+			wantImage: "my-snap",
+			wantMode:  models.ImageDistributionExternalRegistry,
+		},
+		{
+			name:      "registry ref is left alone",
+			image:     "ghcr.io/org/img:latest",
+			pusher:    pusher,
+			wantImage: "ghcr.io/org/img:latest",
+			wantMode:  models.ImageDistributionExternalRegistry,
+		},
+		{
+			name:      "local-only build tag is left alone",
+			image:     docker.BuiltImageNamespace + "/abc123:latest",
+			pusher:    pusher,
+			wantImage: docker.BuiltImageNamespace + "/abc123:latest",
+			wantMode:  models.ImageDistributionLocalOnly,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &Service{store: st, snapshotPusher: tc.pusher}
+			req := models.CreateSandboxRequest{Image: tc.image}
+			if err := svc.NormalizeCreateImageDistribution(ctx, &req); err != nil {
+				t.Fatalf("NormalizeCreateImageDistribution: %v", err)
+			}
+			if req.Image != tc.wantImage {
+				t.Fatalf("Image = %q, want %q", req.Image, tc.wantImage)
+			}
+			if req.ImageDistributionMode != tc.wantMode {
+				t.Fatalf("ImageDistributionMode = %q, want %q", req.ImageDistributionMode, tc.wantMode)
+			}
+		})
+	}
+}
+
 func openImageDistributionStore(t *testing.T) *store.Store {
 	t.Helper()
 	st, err := store.Open(filepath.Join(t.TempDir(), "state.db"))

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -71,6 +71,14 @@ type Service struct {
 	mounts   *mounts.Manager
 	admitter *capacity.Admitter
 	images   ImageDistributionProvider
+	// snapshotPusher + snapshotPushReconciler are non-nil only when
+	// cfg.SnapshotPushEnabled is true. The snapshot-create path checks
+	// snapshotPusher for nil to decide whether to mark a new row as
+	// "pending" vs straight-to-"active", and kicks the reconciler once
+	// (best-effort, in a goroutine) so callers don't always wait for the
+	// next reconciler tick.
+	snapshotPusher         *SnapshotPusher
+	snapshotPushReconciler *SnapshotPushReconciler
 	// l4Ready latches true once caddy.EnsureLayer4 has succeeded — either at
 	// boot or lazily on the first TCP/TLS expose call. Boot bootstrap is
 	// best-effort (caddy may not be reachable yet on a cold start), so the
@@ -139,6 +147,25 @@ func (s *Service) AttachCluster(c cluster.Client) {
 	s.clusterMu.Lock()
 	defer s.clusterMu.Unlock()
 	s.cluster = c
+}
+
+// AttachSnapshotPusher wires in the optional AOCR snapshot-push pipeline.
+// Both arguments must be non-nil to activate the feature; passing nil
+// leaves the service in the legacy local-only snapshot mode. Called once
+// from main() after cfg.SnapshotPushEnabled validation.
+func (s *Service) AttachSnapshotPusher(pusher *SnapshotPusher, reconciler *SnapshotPushReconciler) {
+	if pusher == nil || reconciler == nil {
+		return
+	}
+	s.snapshotPusher = pusher
+	s.snapshotPushReconciler = reconciler
+}
+
+// SnapshotPushReconciler exposes the reconciler so main.go can drive it
+// from a ticker. Returns nil when snapshot push is disabled — the ticker
+// wrapper should no-op cleanly in that case.
+func (s *Service) SnapshotPushReconciler() *SnapshotPushReconciler {
+	return s.snapshotPushReconciler
 }
 
 // Cluster returns the attached cluster.Client. Always non-nil.
@@ -957,9 +984,11 @@ func (s *Service) RegisterSnapshot(ctx context.Context, snapshot *models.Sandbox
 		snapshot.CreatedAt = time.Now().UTC()
 	}
 	snapshot.Name = name
+	snapshot.PushState = s.initialSnapshotPushState(snapshot)
 	if err := s.store.CreateSnapshot(ctx, snapshot); err != nil {
 		return nil, err
 	}
+	s.kickSnapshotPushReconciler(snapshot)
 	return snapshot, nil
 }
 
@@ -1004,6 +1033,7 @@ func (s *Service) CreateSnapshotWithOwnership(ctx context.Context, sandboxID str
 	if err := s.normalizeSnapshotImageDistribution(ctx, snapshot, true); err != nil {
 		return nil, false, err
 	}
+	snapshot.PushState = s.initialSnapshotPushState(snapshot)
 	if err := s.store.CreateSnapshot(ctx, snapshot); err != nil {
 		if errors.Is(err, store.ErrSnapshotNameConflict) {
 			existing, getErr := s.store.GetSnapshot(ctx, name)
@@ -1013,7 +1043,46 @@ func (s *Service) CreateSnapshotWithOwnership(ctx context.Context, sandboxID str
 		}
 		return nil, false, err
 	}
+	s.kickSnapshotPushReconciler(snapshot)
 	return snapshot, true, nil
+}
+
+// initialSnapshotPushState picks the push_state value to write for a
+// newly-created snapshot row. When the feature is off (or the image is
+// already remote), the value is "active" — identical to pre-feature
+// behavior. When the feature is on and the image is local_only, the
+// row starts as "pending" so the reconciler picks it up.
+func (s *Service) initialSnapshotPushState(snapshot *models.SandboxSnapshot) string {
+	if s.snapshotPusher == nil {
+		return models.SnapshotPushStateActive
+	}
+	if !SnapshotNeedsPush(snapshot) {
+		return models.SnapshotPushStateActive
+	}
+	return models.SnapshotPushStatePending
+}
+
+// kickSnapshotPushReconciler runs the reconciler once in a background
+// goroutine after a snapshot was just inserted in 'pending' state. This
+// is purely a latency optimization — without it, the caller would have
+// to wait up to SnapshotPushReconcileInterval before the push begins.
+// The reconciler is safe to invoke concurrently; the 'pushing' state
+// guards against double-claim.
+func (s *Service) kickSnapshotPushReconciler(snapshot *models.SandboxSnapshot) {
+	if s.snapshotPushReconciler == nil || snapshot == nil {
+		return
+	}
+	if snapshot.PushState != models.SnapshotPushStatePending {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+		defer cancel()
+		if _, err := s.snapshotPushReconciler.RunOnce(ctx); err != nil && s.logger != nil {
+			s.logger.Warn("snapshot push: post-create reconciler tick failed",
+				"snapshot", snapshot.Name, "error", err)
+		}
+	}()
 }
 
 func (s *Service) GetSnapshot(ctx context.Context, idOrName string) (*models.SandboxSnapshot, error) {

--- a/internal/service/snapshot_push.go
+++ b/internal/service/snapshot_push.go
@@ -71,6 +71,12 @@ type SnapshotPushDocker interface {
 // will see when they decide where to start a sandbox from this snapshot.
 type SnapshotPushResult struct {
 	RegistryRef string
+	// Digest is the manifest digest (`sha256:...`) the registry assigned
+	// to the pushed tag, as reported by Docker's push stream `aux`
+	// payload. Empty when the daemon did not surface one — older daemons
+	// or registries that don't return a manifest digest will leave this
+	// blank and the reconciler stores "" rather than fabricating a value.
+	Digest string
 }
 
 // SnapshotPusher pushes a locally-committed snapshot image to AOCR. It
@@ -137,6 +143,7 @@ func (p *SnapshotPusher) PushOnce(ctx context.Context, snapshot *models.SandboxS
 
 	dest := snapshotAOCRRef(p.cfg.Host, p.cfg.ClusterID, name)
 
+	var digest string
 	pushed, err := p.docker.PushImage(ctx, docker.PushImageRequest{
 		SourceTag: source,
 		DestRef:   dest,
@@ -150,6 +157,9 @@ func (p *SnapshotPusher) PushOnce(ctx context.Context, snapshot *models.SandboxS
 				p.logger.Debug("snapshot push", "snapshot", name, "dest", dest, "line", line)
 			}
 		},
+		OnDigest: func(d string) {
+			digest = d
+		},
 	})
 	if err != nil {
 		return SnapshotPushResult{}, fmt.Errorf("snapshot push %s -> %s: %w", source, dest, err)
@@ -160,7 +170,24 @@ func (p *SnapshotPusher) PushOnce(ctx context.Context, snapshot *models.SandboxS
 		// snapshot row still gets a usable ref.
 		pushed = dest
 	}
-	return SnapshotPushResult{RegistryRef: pushed}, nil
+	return SnapshotPushResult{RegistryRef: pushed, Digest: digest}, nil
+}
+
+// DestRefFor returns the AOCR destination ref this pusher would write
+// for the given snapshot name. Used by callers that need the canonical
+// ref without actually pushing — e.g. cross-node snapshot lookup, where
+// a peer node took the snapshot and we want to pull from AOCR without
+// asking the FSM whether the snapshot exists. Returns "" when the
+// pusher is nil so callers can no-op cleanly when push is disabled.
+func (p *SnapshotPusher) DestRefFor(snapshotName string) string {
+	if p == nil {
+		return ""
+	}
+	name := strings.TrimSpace(snapshotName)
+	if name == "" {
+		return ""
+	}
+	return snapshotAOCRRef(p.cfg.Host, p.cfg.ClusterID, name)
 }
 
 // snapshotAOCRRef is the AOCR destination convention for cluster-local

--- a/internal/service/snapshot_push.go
+++ b/internal/service/snapshot_push.go
@@ -1,0 +1,203 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/aerol-ai/microvm/pkg/docker"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// SnapshotPushConfig wires the optional background AOCR push to a specific
+// registry endpoint. A zero value disables push; the snapshot path runs
+// exactly as before. main() validates that PATPath, ClusterID, and Host
+// are non-empty when Enabled=true.
+//
+// Auth reuses the auto-import cluster PAT (same secret, same rotation
+// surface). The PAT file is re-read on every call so an operator can
+// rotate it without restarting sandboxd — there's no in-memory cache.
+type SnapshotPushConfig struct {
+	// Enabled gates the whole feature. When false the snapshot-create
+	// path stays byte-identical to today (no push, no state transitions).
+	Enabled bool
+	// Host is the AOCR registry vhost the daemon pushes to
+	// (e.g. `aocr.aerol.ai`). Falls back to ImageDistributionAOCRHost
+	// at the wiring layer when MirrorPushHost is unset.
+	Host string
+	// ClusterID is the AOCR-scoped tenant the snapshot ends up under.
+	// Used both as the registry-auth username (by convention; AOCR
+	// validates the PAT, not the username) and as the path namespace
+	// `cluster/<id>/snapshots/<name>`.
+	ClusterID string
+	// PATPath is the file path to the bearer token presented as the
+	// Docker registry password. File-sourced so rotation is just a
+	// file write; never logged.
+	PATPath string
+}
+
+// Validate enforces the consistency rules the snapshot pusher relies on.
+// Returns nil for a disabled config so callers can validate unconditionally.
+func (c SnapshotPushConfig) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	if strings.TrimSpace(c.Host) == "" {
+		return errors.New("SnapshotPushConfig: Host required when Enabled")
+	}
+	if strings.TrimSpace(c.ClusterID) == "" {
+		return errors.New("SnapshotPushConfig: ClusterID required when Enabled")
+	}
+	if strings.TrimSpace(c.PATPath) == "" {
+		return errors.New("SnapshotPushConfig: PATPath required when Enabled")
+	}
+	return nil
+}
+
+// SnapshotPushDocker is the narrow Docker surface the pusher needs.
+// Pulled out so tests can inject a fake without instantiating a real
+// Docker client, and so the dependency surface of the pusher stays
+// readable at a glance.
+type SnapshotPushDocker interface {
+	PushImage(ctx context.Context, req docker.PushImageRequest) (string, error)
+}
+
+// SnapshotPushResult is what PushOnce returns on success. The destination
+// ref is what the reconciler writes onto the snapshot row's
+// ImageRegistryRef field — and what cluster placement on other nodes
+// will see when they decide where to start a sandbox from this snapshot.
+type SnapshotPushResult struct {
+	RegistryRef string
+}
+
+// SnapshotPusher pushes a locally-committed snapshot image to AOCR. It
+// holds no per-snapshot state; instantiate once at boot and reuse.
+// Safe for concurrent use.
+type SnapshotPusher struct {
+	cfg    SnapshotPushConfig
+	docker SnapshotPushDocker
+	logger *slog.Logger
+}
+
+// NewSnapshotPusher builds a pusher. Returns nil if cfg.Enabled is false
+// so callers can do `if pusher == nil { return }` on the snapshot-create
+// path without an extra config check.
+func NewSnapshotPusher(cfg SnapshotPushConfig, docker SnapshotPushDocker, logger *slog.Logger) (*SnapshotPusher, error) {
+	if !cfg.Enabled {
+		return nil, nil
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	if docker == nil {
+		return nil, errors.New("SnapshotPusher: docker is required when SnapshotPushConfig.Enabled=true")
+	}
+	return &SnapshotPusher{
+		cfg:    cfg,
+		docker: docker,
+		logger: logger,
+	}, nil
+}
+
+// PushOnce tags the snapshot's local image as the AOCR destination ref
+// and pushes via the Docker daemon. Returns the destination ref on
+// success — used by the reconciler to fill ImageRegistryRef and flip
+// ImageDistributionMode to "aocr".
+//
+// Idempotent: re-pushing the same `cluster/<id>/snapshots/<name>:latest`
+// tag is safe; the registry treats the layer set as already-present and
+// the daemon's push completes without error.
+//
+// The PAT is read fresh from disk on every call so an operator can
+// rotate it without restarting sandboxd. The PAT never appears in the
+// returned error message — only the registry's response body does.
+func (p *SnapshotPusher) PushOnce(ctx context.Context, snapshot *models.SandboxSnapshot) (SnapshotPushResult, error) {
+	if p == nil {
+		return SnapshotPushResult{}, errors.New("snapshot push disabled (pusher is nil)")
+	}
+	if snapshot == nil {
+		return SnapshotPushResult{}, errors.New("snapshot push: snapshot is required")
+	}
+	source := strings.TrimSpace(snapshot.Image)
+	if source == "" {
+		return SnapshotPushResult{}, errors.New("snapshot push: snapshot has no image to push")
+	}
+	name := strings.TrimSpace(snapshot.Name)
+	if name == "" {
+		return SnapshotPushResult{}, errors.New("snapshot push: snapshot has no name")
+	}
+
+	pat, err := readPATFile(p.cfg.PATPath)
+	if err != nil {
+		return SnapshotPushResult{}, fmt.Errorf("snapshot push: read PAT: %w", err)
+	}
+
+	dest := snapshotAOCRRef(p.cfg.Host, p.cfg.ClusterID, name)
+
+	pushed, err := p.docker.PushImage(ctx, docker.PushImageRequest{
+		SourceTag: source,
+		DestRef:   dest,
+		Auth: models.RegistryAuth{
+			Server:   p.cfg.Host,
+			Username: p.cfg.ClusterID,
+			Password: pat,
+		},
+		OnLog: func(line string) {
+			if p.logger != nil {
+				p.logger.Debug("snapshot push", "snapshot", name, "dest", dest, "line", line)
+			}
+		},
+	})
+	if err != nil {
+		return SnapshotPushResult{}, fmt.Errorf("snapshot push %s -> %s: %w", source, dest, err)
+	}
+	if strings.TrimSpace(pushed) == "" {
+		// Defensive: PushImage promises the canonical repo:tag on success.
+		// If it ever returns empty, fall back to the planned dest so the
+		// snapshot row still gets a usable ref.
+		pushed = dest
+	}
+	return SnapshotPushResult{RegistryRef: pushed}, nil
+}
+
+// snapshotAOCRRef is the AOCR destination convention for cluster-local
+// snapshots: `<host>/cluster/<id>/snapshots/<name>:latest`. Mirrors the
+// auto-import path's `cluster/<id>/_imported/...` namespace pattern.
+// Tag is always "latest" — snapshot names are themselves unique (the
+// store enforces a PRIMARY KEY on `name`).
+func snapshotAOCRRef(host, clusterID, snapshotName string) string {
+	host = strings.TrimRight(strings.TrimSpace(host), "/")
+	clusterID = strings.TrimSpace(clusterID)
+	snapshotName = strings.ToLower(strings.TrimSpace(snapshotName))
+	return fmt.Sprintf("%s/cluster/%s/snapshots/%s:latest", host, clusterID, snapshotName)
+}
+
+// readPATFile reads the bearer token from disk. Trailing whitespace
+// (including newlines from `echo "..." > /tmp/pat`) is trimmed so an
+// operator using a text editor doesn't end up with a token the registry
+// rejects.
+func readPATFile(path string) (string, error) {
+	raw, err := os.ReadFile(strings.TrimSpace(path))
+	if err != nil {
+		return "", err
+	}
+	token := strings.TrimSpace(string(raw))
+	if token == "" {
+		return "", fmt.Errorf("PAT file %s is empty", path)
+	}
+	return token, nil
+}
+
+// SnapshotNeedsPush reports whether a snapshot row is a candidate for
+// background push. Only local_only snapshots benefit — anything already
+// in a remote registry is already distributable, and pushing it would
+// just double-store the image.
+func SnapshotNeedsPush(snapshot *models.SandboxSnapshot) bool {
+	if snapshot == nil {
+		return false
+	}
+	return snapshot.ImageDistributionMode == models.ImageDistributionLocalOnly
+}

--- a/internal/service/snapshot_push_retry.go
+++ b/internal/service/snapshot_push_retry.go
@@ -1,0 +1,198 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// SnapshotPushStore is the narrow store surface the reconciler needs.
+// Pulled out as an interface so the reconciler is testable without a
+// real SQLite store and so future store backends can satisfy it
+// without growing the reconciler's dependency surface.
+type SnapshotPushStore interface {
+	ListSnapshotsPendingPush(ctx context.Context) ([]*models.SandboxSnapshot, error)
+	SetSnapshotPushState(ctx context.Context, name, state, errMsg string) error
+	UpdateSnapshotImageDistribution(ctx context.Context, name, mode, registryRef, digest string) error
+}
+
+// SnapshotPushReconciler walks rows the snapshot-create path flagged
+// `push_state IN ('pending', 'error')` and re-tries them. One ticker
+// per node; fan-out inside a single tick is capped to keep a recovery
+// storm from saturating the local Docker daemon or AOCR.
+//
+// Like AutoImportReconciler, the type does not own a goroutine — RunOnce
+// is the unit of work and the ticker lives in main.go. That keeps the
+// type fully testable (table-driven, no time.Tick) and lets an operator
+// trigger an immediate retry from a debug endpoint if they want.
+type SnapshotPushReconciler struct {
+	pusher      *SnapshotPusher
+	store       SnapshotPushStore
+	logger      *slog.Logger
+	maxInFlight int
+}
+
+// NewSnapshotPushReconciler builds the reconciler. Returns nil if the
+// pusher is nil (snapshot push disabled) so callers can
+// `if r == nil { return }` cheaply. maxInFlight clamps fan-out per
+// tick; pass 0 for the safe default (2 — pushes are I/O-heavy).
+func NewSnapshotPushReconciler(pusher *SnapshotPusher, store SnapshotPushStore, logger *slog.Logger, maxInFlight int) *SnapshotPushReconciler {
+	if pusher == nil || store == nil {
+		return nil
+	}
+	if maxInFlight <= 0 {
+		maxInFlight = 2
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &SnapshotPushReconciler{
+		pusher:      pusher,
+		store:       store,
+		logger:      logger,
+		maxInFlight: maxInFlight,
+	}
+}
+
+// SnapshotPushReconcileStats is what RunOnce reports back. Used by tests
+// and by the metrics-collection wrapper in main.go.
+type SnapshotPushReconcileStats struct {
+	Scanned   int
+	Succeeded int
+	Failed    int
+	Skipped   int
+}
+
+// RunOnce processes one sweep of the push-pending queue. Blocks until
+// all per-snapshot attempts have returned (success, failure, or context
+// cancel). The bounded semaphore caps in-flight Docker push streams;
+// the AOCR side is usually fine with the load but the local daemon's
+// network/IO is not infinitely parallel.
+func (r *SnapshotPushReconciler) RunOnce(ctx context.Context) (SnapshotPushReconcileStats, error) {
+	if r == nil {
+		return SnapshotPushReconcileStats{}, nil
+	}
+	pending, err := r.store.ListSnapshotsPendingPush(ctx)
+	if err != nil {
+		return SnapshotPushReconcileStats{}, err
+	}
+	stats := SnapshotPushReconcileStats{Scanned: len(pending)}
+	if len(pending) == 0 {
+		return stats, nil
+	}
+
+	sem := make(chan struct{}, r.maxInFlight)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+
+	for _, snapshot := range pending {
+		if err := ctx.Err(); err != nil {
+			return stats, err
+		}
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(snapshot *models.SandboxSnapshot) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			outcome := r.pushOne(ctx, snapshot)
+			mu.Lock()
+			switch outcome {
+			case snapshotPushSucceeded:
+				stats.Succeeded++
+			case snapshotPushFailed:
+				stats.Failed++
+			case snapshotPushSkipped:
+				stats.Skipped++
+			}
+			mu.Unlock()
+		}(snapshot)
+	}
+	wg.Wait()
+	return stats, nil
+}
+
+type snapshotPushOutcome int
+
+const (
+	snapshotPushSucceeded snapshotPushOutcome = iota
+	snapshotPushFailed
+	snapshotPushSkipped
+)
+
+// pushOne pushes a single snapshot. Errors are logged and turned into
+// `snapshotPushFailed` (the row stays in 'error' for the next tick);
+// they are not propagated up because one bad snapshot should not abort
+// the whole sweep. The retry is best-effort by design — the snapshot
+// is still usable on the originating node either way.
+func (r *SnapshotPushReconciler) pushOne(ctx context.Context, snapshot *models.SandboxSnapshot) snapshotPushOutcome {
+	if snapshot == nil {
+		return snapshotPushSkipped
+	}
+	name := snapshot.Name
+
+	// Defensive guard: a concurrent reconcile (or operator-cleared row)
+	// may have moved the snapshot to a terminal state between the scan
+	// and this goroutine running. The 'pushing' state is the visible
+	// signal that someone has claimed this row.
+	if !SnapshotNeedsPush(snapshot) {
+		// Already non-local (e.g. someone re-registered with a remote ref).
+		// Treat as already-distributed; flip state to active so the
+		// reconciler stops picking it up.
+		if err := r.store.SetSnapshotPushState(ctx, name, models.SnapshotPushStateActive, ""); err != nil {
+			r.logger.Warn("snapshot push: clear non-local row failed",
+				"snapshot", name, "error", err)
+		}
+		return snapshotPushSkipped
+	}
+
+	// Move to 'pushing' so a concurrent RunOnce won't double-claim. This
+	// is the moral equivalent of the AutoImporter's flag-clear-before-call:
+	// state machine guards against duplicate work.
+	if err := r.store.SetSnapshotPushState(ctx, name, models.SnapshotPushStatePushing, ""); err != nil {
+		r.logger.Warn("snapshot push: claim row failed",
+			"snapshot", name, "error", err)
+		return snapshotPushFailed
+	}
+
+	result, err := r.pusher.PushOnce(ctx, snapshot)
+	if err != nil {
+		// Persist the error so the operator can see why retries are
+		// failing (surfaced via the Daytona facade's errorReason field).
+		if setErr := r.store.SetSnapshotPushState(ctx, name, models.SnapshotPushStateError, err.Error()); setErr != nil {
+			r.logger.Warn("snapshot push: record failure failed",
+				"snapshot", name, "error", setErr, "push_error", err)
+		}
+		r.logger.Warn("snapshot push: failed",
+			"snapshot", name, "error", err)
+		return snapshotPushFailed
+	}
+
+	// Success — flip the distribution metadata first (so a crash between
+	// the two updates leaves the row still reachable by `aocr` mode), then
+	// clear the push state. Digest is empty for now — the Docker push API
+	// does not surface RepoDigests without an extra Inspect call; the
+	// ImageVerifiedAt timestamp written below is enough to prove the push
+	// completed for downstream consumers.
+	if err := r.store.UpdateSnapshotImageDistribution(ctx, name, models.ImageDistributionAOCR, result.RegistryRef, ""); err != nil {
+		// Mark error so we re-attempt next tick rather than silently leaving
+		// the row in 'pushing' forever.
+		if setErr := r.store.SetSnapshotPushState(ctx, name, models.SnapshotPushStateError, err.Error()); setErr != nil {
+			r.logger.Warn("snapshot push: record post-success metadata failure failed",
+				"snapshot", name, "error", setErr)
+		}
+		r.logger.Warn("snapshot push: succeeded but metadata update failed",
+			"snapshot", name, "error", err)
+		return snapshotPushFailed
+	}
+	if err := r.store.SetSnapshotPushState(ctx, name, models.SnapshotPushStateActive, ""); err != nil {
+		r.logger.Warn("snapshot push: succeeded but state-clear failed",
+			"snapshot", name, "error", err)
+		return snapshotPushFailed
+	}
+	r.logger.Info("snapshot push: succeeded",
+		"snapshot", name, "registry_ref", result.RegistryRef)
+	return snapshotPushSucceeded
+}

--- a/internal/service/snapshot_push_retry.go
+++ b/internal/service/snapshot_push_retry.go
@@ -172,11 +172,11 @@ func (r *SnapshotPushReconciler) pushOne(ctx context.Context, snapshot *models.S
 
 	// Success — flip the distribution metadata first (so a crash between
 	// the two updates leaves the row still reachable by `aocr` mode), then
-	// clear the push state. Digest is empty for now — the Docker push API
-	// does not surface RepoDigests without an extra Inspect call; the
-	// ImageVerifiedAt timestamp written below is enough to prove the push
-	// completed for downstream consumers.
-	if err := r.store.UpdateSnapshotImageDistribution(ctx, name, models.ImageDistributionAOCR, result.RegistryRef, ""); err != nil {
+	// clear the push state. Digest comes from the push stream's `aux`
+	// payload; older daemons may leave it empty, in which case we store ""
+	// rather than fabricating a value (downstream consumers treat absent
+	// digest as "ref is the source of truth").
+	if err := r.store.UpdateSnapshotImageDistribution(ctx, name, models.ImageDistributionAOCR, result.RegistryRef, result.Digest); err != nil {
 		// Mark error so we re-attempt next tick rather than silently leaving
 		// the row in 'pushing' forever.
 		if setErr := r.store.SetSnapshotPushState(ctx, name, models.SnapshotPushStateError, err.Error()); setErr != nil {

--- a/internal/service/snapshot_push_retry_test.go
+++ b/internal/service/snapshot_push_retry_test.go
@@ -1,0 +1,235 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// fakePushStore covers only the surface SnapshotPushReconciler needs.
+// Concurrent-safe so the reconciler's bounded fan-out doesn't race the
+// test.
+type fakePushStore struct {
+	mu           sync.Mutex
+	rows         map[string]*models.SandboxSnapshot
+	stateUpdates atomic.Int64
+	distUpdates  atomic.Int64
+}
+
+func newFakePushStore() *fakePushStore {
+	return &fakePushStore{rows: map[string]*models.SandboxSnapshot{}}
+}
+
+func (f *fakePushStore) seed(snap *models.SandboxSnapshot) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	cp := *snap
+	f.rows[snap.Name] = &cp
+}
+
+func (f *fakePushStore) ListSnapshotsPendingPush(_ context.Context) ([]*models.SandboxSnapshot, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]*models.SandboxSnapshot, 0)
+	for _, r := range f.rows {
+		if r.PushState == models.SnapshotPushStatePending || r.PushState == models.SnapshotPushStateError {
+			cp := *r
+			out = append(out, &cp)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakePushStore) SetSnapshotPushState(_ context.Context, name, state, errMsg string) error {
+	f.stateUpdates.Add(1)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	r, ok := f.rows[name]
+	if !ok {
+		return errors.New("not found")
+	}
+	r.PushState = state
+	r.PushError = errMsg
+	return nil
+}
+
+func (f *fakePushStore) UpdateSnapshotImageDistribution(_ context.Context, name, mode, ref, digest string) error {
+	f.distUpdates.Add(1)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	r, ok := f.rows[name]
+	if !ok {
+		return errors.New("not found")
+	}
+	r.ImageDistributionMode = mode
+	r.ImageRegistryRef = ref
+	r.ImageDigest = digest
+	return nil
+}
+
+func (f *fakePushStore) get(name string) *models.SandboxSnapshot {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	r, ok := f.rows[name]
+	if !ok {
+		return nil
+	}
+	cp := *r
+	return &cp
+}
+
+func newTestReconciler(t *testing.T, store SnapshotPushStore, fakeDocker SnapshotPushDocker) *SnapshotPushReconciler {
+	t.Helper()
+	patPath := writePATFile(t, "token")
+	pusher, err := NewSnapshotPusher(SnapshotPushConfig{
+		Enabled:   true,
+		Host:      "aocr.test",
+		ClusterID: "cluster-1",
+		PATPath:   patPath,
+	}, fakeDocker, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("NewSnapshotPusher: %v", err)
+	}
+	return NewSnapshotPushReconciler(pusher, store, slog.New(slog.NewTextHandler(io.Discard, nil)), 2)
+}
+
+func TestReconciler_NoPendingIsNoop(t *testing.T) {
+	store := newFakePushStore()
+	store.seed(&models.SandboxSnapshot{
+		Name:                  "done",
+		Image:                 "img:1",
+		PushState:             models.SnapshotPushStateActive,
+		ImageDistributionMode: models.ImageDistributionAOCR,
+	})
+	rec := newTestReconciler(t, store, &fakeSnapshotPushDocker{})
+
+	stats, err := rec.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if stats.Scanned != 0 {
+		t.Fatalf("Scanned = %d, want 0", stats.Scanned)
+	}
+	if store.distUpdates.Load() != 0 || store.stateUpdates.Load() != 0 {
+		t.Fatalf("unexpected writes: dist=%d state=%d",
+			store.distUpdates.Load(), store.stateUpdates.Load())
+	}
+}
+
+func TestReconciler_PendingToActive(t *testing.T) {
+	store := newFakePushStore()
+	store.seed(&models.SandboxSnapshot{
+		Name:                  "snap",
+		Image:                 "aerolvm-build/abc:latest",
+		PushState:             models.SnapshotPushStatePending,
+		ImageDistributionMode: models.ImageDistributionLocalOnly,
+	})
+	rec := newTestReconciler(t, store, &fakeSnapshotPushDocker{})
+
+	stats, err := rec.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if stats.Succeeded != 1 || stats.Failed != 0 {
+		t.Fatalf("stats = %+v", stats)
+	}
+
+	row := store.get("snap")
+	if row.PushState != models.SnapshotPushStateActive {
+		t.Fatalf("PushState = %q, want active", row.PushState)
+	}
+	if row.ImageDistributionMode != models.ImageDistributionAOCR {
+		t.Fatalf("ImageDistributionMode = %q, want aocr", row.ImageDistributionMode)
+	}
+	wantRef := "aocr.test/cluster/cluster-1/snapshots/snap:latest"
+	if row.ImageRegistryRef != wantRef {
+		t.Fatalf("ImageRegistryRef = %q, want %q", row.ImageRegistryRef, wantRef)
+	}
+}
+
+func TestReconciler_PendingToErrorEligibleNextTick(t *testing.T) {
+	store := newFakePushStore()
+	store.seed(&models.SandboxSnapshot{
+		Name:                  "snap",
+		Image:                 "aerolvm-build/abc:latest",
+		PushState:             models.SnapshotPushStatePending,
+		ImageDistributionMode: models.ImageDistributionLocalOnly,
+	})
+	docker := &fakeSnapshotPushDocker{err: errors.New("registry 500")}
+	rec := newTestReconciler(t, store, docker)
+
+	stats, err := rec.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if stats.Failed != 1 || stats.Succeeded != 0 {
+		t.Fatalf("stats = %+v", stats)
+	}
+
+	row := store.get("snap")
+	if row.PushState != models.SnapshotPushStateError {
+		t.Fatalf("PushState = %q, want error", row.PushState)
+	}
+	if row.PushError == "" {
+		t.Fatal("PushError should carry the registry error")
+	}
+	if row.ImageDistributionMode != models.ImageDistributionLocalOnly {
+		t.Fatalf("ImageDistributionMode flipped to %q on failure", row.ImageDistributionMode)
+	}
+
+	// Second tick must still pick the row up (error → retry-eligible).
+	docker.err = nil
+	if _, err := rec.RunOnce(context.Background()); err != nil {
+		t.Fatalf("second RunOnce: %v", err)
+	}
+	row = store.get("snap")
+	if row.PushState != models.SnapshotPushStateActive {
+		t.Fatalf("after recovery PushState = %q, want active", row.PushState)
+	}
+}
+
+func TestReconciler_SkipsNonLocalRow(t *testing.T) {
+	// A row whose distribution mode is already remote (e.g. someone
+	// re-registered with an existing registry ref) but whose push_state
+	// is still 'pending' for whatever reason. The reconciler should
+	// recognize there's nothing to push and flip state to active without
+	// calling the docker daemon.
+	store := newFakePushStore()
+	store.seed(&models.SandboxSnapshot{
+		Name:                  "remote",
+		Image:                 "ghcr.io/org/img:latest",
+		PushState:             models.SnapshotPushStatePending,
+		ImageDistributionMode: models.ImageDistributionExternalRegistry,
+	})
+	docker := &fakeSnapshotPushDocker{}
+	rec := newTestReconciler(t, store, docker)
+
+	stats, err := rec.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if stats.Skipped != 1 {
+		t.Fatalf("stats = %+v, want Skipped=1", stats)
+	}
+	if len(docker.calls) != 0 {
+		t.Fatalf("docker called %d times for a non-local row", len(docker.calls))
+	}
+	row := store.get("remote")
+	if row.PushState != models.SnapshotPushStateActive {
+		t.Fatalf("non-local row left in PushState=%q", row.PushState)
+	}
+}
+
+func TestReconciler_NewReconcilerNilWhenPusherNil(t *testing.T) {
+	store := newFakePushStore()
+	rec := NewSnapshotPushReconciler(nil, store, nil, 0)
+	if rec != nil {
+		t.Fatal("nil pusher must produce nil reconciler")
+	}
+}

--- a/internal/service/snapshot_push_test.go
+++ b/internal/service/snapshot_push_test.go
@@ -1,0 +1,210 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/aerol-ai/microvm/pkg/docker"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// fakeSnapshotPushDocker captures push calls so tests can assert on the
+// rendered destination ref and the registry auth that would have hit
+// the Docker daemon. Concurrent-safe because the reconciler tests
+// invoke PushOnce from goroutines.
+type fakeSnapshotPushDocker struct {
+	mu     sync.Mutex
+	calls  []docker.PushImageRequest
+	result string
+	err    error
+}
+
+func (f *fakeSnapshotPushDocker) PushImage(_ context.Context, req docker.PushImageRequest) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, req)
+	if f.err != nil {
+		return "", f.err
+	}
+	if f.result != "" {
+		return f.result, nil
+	}
+	return req.DestRef, nil
+}
+
+func (f *fakeSnapshotPushDocker) lastCall() docker.PushImageRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.calls) == 0 {
+		return docker.PushImageRequest{}
+	}
+	return f.calls[len(f.calls)-1]
+}
+
+func writePATFile(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pat")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write PAT: %v", err)
+	}
+	return path
+}
+
+func newTestPusher(t *testing.T, patPath string, docker SnapshotPushDocker) *SnapshotPusher {
+	t.Helper()
+	pusher, err := NewSnapshotPusher(SnapshotPushConfig{
+		Enabled:   true,
+		Host:      "aocr.test",
+		ClusterID: "cluster-42",
+		PATPath:   patPath,
+	}, docker, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("NewSnapshotPusher: %v", err)
+	}
+	return pusher
+}
+
+func TestSnapshotPusher_HappyPath(t *testing.T) {
+	patPath := writePATFile(t, "secret-token\n")
+	fake := &fakeSnapshotPushDocker{}
+	pusher := newTestPusher(t, patPath, fake)
+
+	result, err := pusher.PushOnce(context.Background(), &models.SandboxSnapshot{
+		Name:  "my-snap",
+		Image: "aerolvm-build/abc123:latest",
+	})
+	if err != nil {
+		t.Fatalf("PushOnce: %v", err)
+	}
+
+	want := "aocr.test/cluster/cluster-42/snapshots/my-snap:latest"
+	if result.RegistryRef != want {
+		t.Fatalf("RegistryRef = %q, want %q", result.RegistryRef, want)
+	}
+	call := fake.lastCall()
+	if call.SourceTag != "aerolvm-build/abc123:latest" {
+		t.Fatalf("SourceTag = %q", call.SourceTag)
+	}
+	if call.DestRef != want {
+		t.Fatalf("DestRef = %q", call.DestRef)
+	}
+	if call.Auth.Username != "cluster-42" || call.Auth.Password != "secret-token" {
+		t.Fatalf("Auth = %+v", call.Auth)
+	}
+	if call.Auth.Server != "aocr.test" {
+		t.Fatalf("Auth.Server = %q", call.Auth.Server)
+	}
+}
+
+func TestSnapshotPusher_PATRotation(t *testing.T) {
+	patPath := writePATFile(t, "first-token")
+	fake := &fakeSnapshotPushDocker{}
+	pusher := newTestPusher(t, patPath, fake)
+
+	if _, err := pusher.PushOnce(context.Background(), &models.SandboxSnapshot{
+		Name: "a", Image: "img:1",
+	}); err != nil {
+		t.Fatalf("first PushOnce: %v", err)
+	}
+	if got := fake.lastCall().Auth.Password; got != "first-token" {
+		t.Fatalf("first Password = %q", got)
+	}
+
+	if err := os.WriteFile(patPath, []byte("second-token\n"), 0o600); err != nil {
+		t.Fatalf("rotate PAT: %v", err)
+	}
+	if _, err := pusher.PushOnce(context.Background(), &models.SandboxSnapshot{
+		Name: "b", Image: "img:2",
+	}); err != nil {
+		t.Fatalf("second PushOnce: %v", err)
+	}
+	if got := fake.lastCall().Auth.Password; got != "second-token" {
+		t.Fatalf("rotated Password = %q, want second-token", got)
+	}
+}
+
+func TestSnapshotPusher_RegistryError(t *testing.T) {
+	patPath := writePATFile(t, "token")
+	fake := &fakeSnapshotPushDocker{err: errors.New("registry 401 unauthorized")}
+	pusher := newTestPusher(t, patPath, fake)
+
+	_, err := pusher.PushOnce(context.Background(), &models.SandboxSnapshot{
+		Name: "snap", Image: "img:1",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// The error must mention the registry response so operators can
+	// triage from the reconciler logs without re-running.
+	if !strings.Contains(err.Error(), "registry 401") {
+		t.Fatalf("error %q missing registry response", err.Error())
+	}
+	// The PAT must never appear in the surfaced error message.
+	if strings.Contains(err.Error(), "token") {
+		t.Fatalf("error leaks PAT: %q", err.Error())
+	}
+}
+
+func TestSnapshotPusher_MissingFields(t *testing.T) {
+	patPath := writePATFile(t, "token")
+	fake := &fakeSnapshotPushDocker{}
+	pusher := newTestPusher(t, patPath, fake)
+
+	cases := []struct {
+		name string
+		snap *models.SandboxSnapshot
+	}{
+		{"nil snapshot", nil},
+		{"missing image", &models.SandboxSnapshot{Name: "snap"}},
+		{"missing name", &models.SandboxSnapshot{Image: "img:1"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := pusher.PushOnce(context.Background(), tc.snap); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+	if len(fake.calls) != 0 {
+		t.Fatalf("expected no docker calls, got %d", len(fake.calls))
+	}
+}
+
+func TestNewSnapshotPusher_DisabledReturnsNil(t *testing.T) {
+	pusher, err := NewSnapshotPusher(SnapshotPushConfig{Enabled: false}, nil, nil)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if pusher != nil {
+		t.Fatal("disabled config must return nil pusher")
+	}
+}
+
+func TestSnapshotNeedsPush(t *testing.T) {
+	cases := []struct {
+		name string
+		snap *models.SandboxSnapshot
+		want bool
+	}{
+		{"nil", nil, false},
+		{"local-only", &models.SandboxSnapshot{ImageDistributionMode: models.ImageDistributionLocalOnly}, true},
+		{"aocr", &models.SandboxSnapshot{ImageDistributionMode: models.ImageDistributionAOCR}, false},
+		{"external", &models.SandboxSnapshot{ImageDistributionMode: models.ImageDistributionExternalRegistry}, false},
+		{"unset", &models.SandboxSnapshot{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SnapshotNeedsPush(tc.snap); got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/service/snapshot_push_test.go
+++ b/internal/service/snapshot_push_test.go
@@ -23,6 +23,7 @@ type fakeSnapshotPushDocker struct {
 	mu     sync.Mutex
 	calls  []docker.PushImageRequest
 	result string
+	digest string
 	err    error
 }
 
@@ -32,6 +33,9 @@ func (f *fakeSnapshotPushDocker) PushImage(_ context.Context, req docker.PushIma
 	f.calls = append(f.calls, req)
 	if f.err != nil {
 		return "", f.err
+	}
+	if f.digest != "" && req.OnDigest != nil {
+		req.OnDigest(f.digest)
 	}
 	if f.result != "" {
 		return f.result, nil
@@ -101,6 +105,22 @@ func TestSnapshotPusher_HappyPath(t *testing.T) {
 	}
 	if call.Auth.Server != "aocr.test" {
 		t.Fatalf("Auth.Server = %q", call.Auth.Server)
+	}
+}
+
+func TestSnapshotPusher_CapturesDigestFromAux(t *testing.T) {
+	patPath := writePATFile(t, "token")
+	fake := &fakeSnapshotPushDocker{digest: "sha256:deadbeef"}
+	pusher := newTestPusher(t, patPath, fake)
+
+	result, err := pusher.PushOnce(context.Background(), &models.SandboxSnapshot{
+		Name: "snap", Image: "aerolvm-build/x:latest",
+	})
+	if err != nil {
+		t.Fatalf("PushOnce: %v", err)
+	}
+	if result.Digest != "sha256:deadbeef" {
+		t.Fatalf("Digest = %q, want sha256:deadbeef", result.Digest)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -139,7 +139,9 @@ func Open(path string) (*Store, error) {
 			image_distribution_mode TEXT NOT NULL DEFAULT '',
 			image_digest TEXT NOT NULL DEFAULT '',
 			image_registry_ref TEXT NOT NULL DEFAULT '',
-			image_verified_at DATETIME
+			image_verified_at DATETIME,
+			push_state TEXT NOT NULL DEFAULT 'active',
+			push_error TEXT NOT NULL DEFAULT ''
 		);`,
 		// sandbox_compat_state holds opaque facade-private state that has
 		// no native meaning. One row per (sandbox, facade). state_json is
@@ -270,6 +272,13 @@ func Open(path string) (*Store, error) {
 		`ALTER TABLE sandbox_snapshots ADD COLUMN image_digest TEXT NOT NULL DEFAULT '';`,
 		`ALTER TABLE sandbox_snapshots ADD COLUMN image_registry_ref TEXT NOT NULL DEFAULT '';`,
 		`ALTER TABLE sandbox_snapshots ADD COLUMN image_verified_at DATETIME;`,
+		// Background-push lifecycle for the SB_SNAPSHOT_PUSH_ENABLED feature.
+		// Default 'active' so warm-upgrade rows (created before this feature
+		// existed) are treated as terminal — the reconciler ignores them.
+		// New rows that need push start at 'pending' and transition through
+		// 'pushing' to 'active' or 'error'.
+		`ALTER TABLE sandbox_snapshots ADD COLUMN push_state TEXT NOT NULL DEFAULT 'active';`,
+		`ALTER TABLE sandbox_snapshots ADD COLUMN push_error TEXT NOT NULL DEFAULT '';`,
 		// auto_import_pending is set when the post-pull AOCR auto-import
 		// (F21) failed and a background reconciler should retry. It is
 		// local-node bookkeeping only — never replicated, never user-visible.
@@ -1316,11 +1325,16 @@ func (s *Store) CreateSnapshot(ctx context.Context, snapshot *models.SandboxSnap
 	if snapshot.ImageVerifiedAt != nil {
 		imageVerifiedAt = snapshot.ImageVerifiedAt.UTC()
 	}
+	pushState := strings.TrimSpace(snapshot.PushState)
+	if pushState == "" {
+		pushState = models.SnapshotPushStateActive
+	}
 	_, err = s.db.ExecContext(ctx, `
 		INSERT INTO sandbox_snapshots (name, image, image_id, source_sandbox_id, created_at,
 			entrypoint_json, region_id, cpu, memory_mb, disk_gb, gpu,
-			image_distribution_mode, image_digest, image_registry_ref, image_verified_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			image_distribution_mode, image_digest, image_registry_ref, image_verified_at,
+			push_state, push_error)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		strings.TrimSpace(snapshot.Name),
 		strings.TrimSpace(snapshot.Image),
@@ -1337,6 +1351,8 @@ func (s *Store) CreateSnapshot(ctx context.Context, snapshot *models.SandboxSnap
 		strings.TrimSpace(snapshot.ImageDigest),
 		strings.TrimSpace(snapshot.ImageRegistryRef),
 		imageVerifiedAt,
+		pushState,
+		strings.TrimSpace(snapshot.PushError),
 	)
 	if err != nil {
 		if isSQLiteUniqueConstraint(err) {
@@ -1351,7 +1367,8 @@ func (s *Store) GetSnapshot(ctx context.Context, name string) (*models.SandboxSn
 	row := s.db.QueryRowContext(ctx, `
 		SELECT name, image, image_id, source_sandbox_id, created_at,
 			entrypoint_json, region_id, cpu, memory_mb, disk_gb, gpu,
-			image_distribution_mode, image_digest, image_registry_ref, image_verified_at
+			image_distribution_mode, image_digest, image_registry_ref, image_verified_at,
+			push_state, push_error
 		FROM sandbox_snapshots
 		WHERE name = ?
 	`, strings.TrimSpace(name))
@@ -1369,7 +1386,8 @@ func (s *Store) ListSnapshots(ctx context.Context) ([]*models.SandboxSnapshot, e
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT name, image, image_id, source_sandbox_id, created_at,
 			entrypoint_json, region_id, cpu, memory_mb, disk_gb, gpu,
-			image_distribution_mode, image_digest, image_registry_ref, image_verified_at
+			image_distribution_mode, image_digest, image_registry_ref, image_verified_at,
+			push_state, push_error
 		FROM sandbox_snapshots
 		ORDER BY created_at DESC, name ASC
 	`)
@@ -1396,6 +1414,89 @@ func (s *Store) DeleteSnapshot(ctx context.Context, name string) error {
 	result, err := s.db.ExecContext(ctx, `DELETE FROM sandbox_snapshots WHERE name = ?`, strings.TrimSpace(name))
 	if err != nil {
 		return fmt.Errorf("delete snapshot: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err == nil && affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ListSnapshotsPendingPush returns snapshots the reconciler should retry —
+// 'pending' is the brand-new state set by the snapshot-create path, 'error'
+// is what a failed previous attempt left behind. 'pushing' is intentionally
+// excluded so a row currently being processed by another reconciler tick
+// (or a still-running goroutine kicked off by snapshot-create) is not
+// re-claimed before its terminal state lands.
+func (s *Store) ListSnapshotsPendingPush(ctx context.Context) ([]*models.SandboxSnapshot, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT name, image, image_id, source_sandbox_id, created_at,
+			entrypoint_json, region_id, cpu, memory_mb, disk_gb, gpu,
+			image_distribution_mode, image_digest, image_registry_ref, image_verified_at,
+			push_state, push_error
+		FROM sandbox_snapshots
+		WHERE push_state IN ('pending', 'error')
+		ORDER BY created_at ASC, name ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list snapshots pending push: %w", err)
+	}
+	defer rows.Close()
+
+	var items []*models.SandboxSnapshot
+	for rows.Next() {
+		snapshot, err := scanSnapshot(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan snapshot: %w", err)
+		}
+		items = append(items, snapshot)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate snapshots: %w", err)
+	}
+	return items, nil
+}
+
+// SetSnapshotPushState is a narrow single-column update used by the push
+// reconciler. errMsg is overwritten unconditionally (including to empty
+// on success transitions) so callers don't have to remember to clear it.
+func (s *Store) SetSnapshotPushState(ctx context.Context, name, state, errMsg string) error {
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE sandbox_snapshots
+		SET push_state = ?, push_error = ?
+		WHERE name = ?
+	`, strings.TrimSpace(state), errMsg, strings.TrimSpace(name))
+	if err != nil {
+		return fmt.Errorf("set snapshot push state: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err == nil && affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// UpdateSnapshotImageDistribution flips the distribution metadata on a
+// snapshot row after a successful AOCR push — local_only → aocr. Called
+// from the reconciler success path together with SetSnapshotPushState.
+// VerifiedAt records when the push completed; cluster placement on other
+// nodes uses this together with the new mode to decide the snapshot is
+// fan-outable.
+func (s *Store) UpdateSnapshotImageDistribution(ctx context.Context, name, mode, registryRef, digest string) error {
+	now := time.Now().UTC()
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE sandbox_snapshots
+		SET image_distribution_mode = ?, image_registry_ref = ?, image_digest = ?, image_verified_at = ?
+		WHERE name = ?
+	`,
+		strings.TrimSpace(mode),
+		strings.TrimSpace(registryRef),
+		strings.TrimSpace(digest),
+		now,
+		strings.TrimSpace(name),
+	)
+	if err != nil {
+		return fmt.Errorf("update snapshot image distribution: %w", err)
 	}
 	affected, err := result.RowsAffected()
 	if err == nil && affected == 0 {
@@ -1799,6 +1900,8 @@ func scanSnapshot(scanner interface {
 		&snapshot.ImageDigest,
 		&snapshot.ImageRegistryRef,
 		&imageVerifiedAt,
+		&snapshot.PushState,
+		&snapshot.PushError,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -812,6 +812,10 @@ func TestStoreCases(t *testing.T) {
 					ImageDigest:           "sha256:abc",
 					ImageRegistryRef:      "registry.example.com/demo@sha256:abc",
 					ImageVerifiedAt:       &verifiedAt,
+					// Mirror what CreateSnapshot writes when push_state is
+					// unset: schema default is 'active', so a read-back will
+					// have it filled in even though the input did not.
+					PushState: models.SnapshotPushStateActive,
 				}
 				if err := st.CreateSnapshot(ctx, snapshot); err != nil {
 					t.Fatalf("CreateSnapshot() error = %v", err)
@@ -879,6 +883,7 @@ func TestStoreCases(t *testing.T) {
 					ImageID:         "sha256:alpha",
 					SourceSandboxID: "sb-alpha",
 					CreatedAt:       time.Now().UTC().Add(-time.Hour).Round(0),
+					PushState:       models.SnapshotPushStateActive,
 				}
 				newer := &models.SandboxSnapshot{
 					Name:            "beta",
@@ -886,6 +891,7 @@ func TestStoreCases(t *testing.T) {
 					ImageID:         "sha256:beta",
 					SourceSandboxID: "sb-beta",
 					CreatedAt:       time.Now().UTC().Round(0),
+					PushState:       models.SnapshotPushStateActive,
 				}
 				if err := st.CreateSnapshot(ctx, older); err != nil {
 					t.Fatalf("CreateSnapshot(older) error = %v", err)

--- a/pkg/api/daytona/handlers.go
+++ b/pkg/api/daytona/handlers.go
@@ -913,25 +913,52 @@ func (h *handlers) toSnapshotResponse(r *http.Request, snapshot *models.SandboxS
 		memGB = float32(snapshot.MemoryMB) / 1024
 	}
 
+	state, errorReason := daytonaSnapshotState(snapshot)
+
 	return snapshotResponse{
 		ID:             id,
 		OrganizationID: nonEmptyStringPtr(&organizationID),
 		General:        false,
 		Name:           snapshot.Name,
 		ImageName:      imageName,
-		State:          "active",
+		State:          state,
 		Size:           nil,
 		Entrypoint:     entrypoint,
 		CPU:            float32(snapshot.CPU),
 		GPU:            float32(snapshot.GPU),
 		Mem:            memGB,
 		Disk:           float32(snapshot.DiskGB),
-		ErrorReason:    nil,
+		ErrorReason:    errorReason,
 		CreatedAt:      createdAt,
 		UpdatedAt:      createdAt,
 		LastUsedAt:     nil,
 		Ref:            cloneStringPtr(imageName),
 		RegionIDs:      regionIDs,
+	}
+}
+
+// daytonaSnapshotState maps the internal snapshot push lifecycle to
+// Daytona's published snapshot states. The Daytona SDK polls until state
+// reaches "active" or "error" — `pulling_image` keeps it in the polling
+// loop without surfacing a transient error to the caller.
+//
+// Pre-feature snapshot rows that exist on warm-upgrade disks have an empty
+// PushState; the store migration defaults them to "active", so the empty
+// case here only fires for rows constructed in-memory without going
+// through the store (e.g. some test setups). Treating empty as "active"
+// keeps the response identical to today's behavior.
+func daytonaSnapshotState(snapshot *models.SandboxSnapshot) (string, *string) {
+	switch snapshot.PushState {
+	case models.SnapshotPushStatePending, models.SnapshotPushStatePushing:
+		return "pulling_image", nil
+	case models.SnapshotPushStateError:
+		reason := strings.TrimSpace(snapshot.PushError)
+		if reason == "" {
+			reason = "snapshot push failed"
+		}
+		return "error", &reason
+	default:
+		return "active", nil
 	}
 }
 

--- a/pkg/api/daytona/snapshot_create_test.go
+++ b/pkg/api/daytona/snapshot_create_test.go
@@ -15,7 +15,51 @@ import (
 	"github.com/aerol-ai/microvm/internal/service"
 	"github.com/aerol-ai/microvm/internal/store"
 	"github.com/aerol-ai/microvm/pkg/docker"
+	"github.com/aerol-ai/microvm/pkg/models"
 )
+
+// TestDaytonaSnapshotStateMapping pins the Daytona-facing state translation
+// for every push-lifecycle value the snapshot row can hold. The SDK's poll
+// loop exits only on "active" or "error" — getting any of these wrong
+// either hangs the client or fails it early, so we lock in the table.
+func TestDaytonaSnapshotStateMapping(t *testing.T) {
+	cases := []struct {
+		name        string
+		pushState   string
+		pushError   string
+		wantState   string
+		wantReason  string
+		reasonNil   bool
+	}{
+		{"empty (legacy row) is active", "", "", "active", "", true},
+		{"active", models.SnapshotPushStateActive, "", "active", "", true},
+		{"pending → pulling_image", models.SnapshotPushStatePending, "", "pulling_image", "", true},
+		{"pushing → pulling_image", models.SnapshotPushStatePushing, "", "pulling_image", "", true},
+		{"error surfaces push error", models.SnapshotPushStateError, "registry 500", "error", "registry 500", false},
+		{"error without message gets fallback reason", models.SnapshotPushStateError, "", "error", "snapshot push failed", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			snap := &models.SandboxSnapshot{PushState: tc.pushState, PushError: tc.pushError}
+			state, reason := daytonaSnapshotState(snap)
+			if state != tc.wantState {
+				t.Fatalf("state = %q, want %q", state, tc.wantState)
+			}
+			if tc.reasonNil {
+				if reason != nil {
+					t.Fatalf("reason = %q, want nil", *reason)
+				}
+				return
+			}
+			if reason == nil {
+				t.Fatalf("reason = nil, want %q", tc.wantReason)
+			}
+			if *reason != tc.wantReason {
+				t.Fatalf("reason = %q, want %q", *reason, tc.wantReason)
+			}
+		})
+	}
+}
 
 // snapshotCreateTestEnv bundles the moving parts a snapshot-create test
 // needs. Tests that only drive HTTP use .handler; tests that want to call

--- a/pkg/api/v1/snapshot_test.go
+++ b/pkg/api/v1/snapshot_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -98,6 +99,72 @@ func TestRegisterSnapshotFromImage(t *testing.T) {
 	if len(env.builder.builds) != 0 {
 		t.Errorf("image path must not invoke builder, got %d builds", len(env.builder.builds))
 	}
+	// External registry refs need no AOCR push — the response must surface
+	// push_state="active" immediately so a polling client doesn't wait.
+	if resp.PushState != models.SnapshotPushStateActive {
+		t.Errorf("resp.PushState = %q, want %q (external image needs no push)",
+			resp.PushState, models.SnapshotPushStateActive)
+	}
+}
+
+// TestRegisterSnapshotWithPusherMarksPending exercises the wiring that flips
+// new rows to push_state="pending" when the pusher is attached. Reading the
+// row back from the store (rather than relying on the response body) keeps
+// this test isolated from the goroutine the service kicks after CreateSnapshot
+// — we just want to prove the persisted state is what the reconciler will
+// pick up on its next tick.
+func TestRegisterSnapshotWithPusherMarksPending(t *testing.T) {
+	env := newSnapshotV1TestEnv(t, nil, BuildConfig{})
+
+	patPath := filepath.Join(t.TempDir(), "pat")
+	if err := writeTestFile(patPath, "token"); err != nil {
+		t.Fatalf("write pat: %v", err)
+	}
+	pusher, err := service.NewSnapshotPusher(service.SnapshotPushConfig{
+		Enabled:   true,
+		Host:      "aocr.test",
+		ClusterID: "cluster-v1",
+		PATPath:   patPath,
+	}, &v1NoopPushDocker{}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("NewSnapshotPusher: %v", err)
+	}
+	reconciler := service.NewSnapshotPushReconciler(pusher, env.store, slog.New(slog.NewTextHandler(io.Discard, nil)), 1)
+	env.svc.AttachSnapshotPusher(pusher, reconciler)
+
+	body := `{"name":"locally-built","dockerfile_content":"FROM debian:bookworm-slim\nRUN true"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/snapshots", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	env.handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d; body=%s", rr.Code, rr.Body.String())
+	}
+
+	stored, err := env.svc.GetSnapshot(context.Background(), "locally-built")
+	if err != nil {
+		t.Fatalf("GetSnapshot: %v", err)
+	}
+	// Built dockerfile snapshots land as local_only and therefore need a push;
+	// the row must be queued (pending) so the reconciler picks it up.
+	if stored.ImageDistributionMode != models.ImageDistributionLocalOnly {
+		t.Fatalf("ImageDistributionMode = %q, want %q", stored.ImageDistributionMode, models.ImageDistributionLocalOnly)
+	}
+	if stored.PushState != models.SnapshotPushStatePending {
+		t.Fatalf("PushState = %q, want %q", stored.PushState, models.SnapshotPushStatePending)
+	}
+}
+
+// v1NoopPushDocker is a stand-in for the snapshot pusher's docker dep that
+// never gets invoked in this test (we assert on the queued state, not on
+// the reconciler outcome). Declaring it here keeps the test self-contained.
+type v1NoopPushDocker struct{}
+
+func (v1NoopPushDocker) PushImage(_ context.Context, req docker.PushImageRequest) (string, error) {
+	return req.DestRef, nil
+}
+
+func writeTestFile(path, contents string) error {
+	return os.WriteFile(path, []byte(contents), 0o600)
 }
 
 // TestRegisterSnapshotFromDockerfile covers the multi-line dockerfile path:

--- a/pkg/docker/build.go
+++ b/pkg/docker/build.go
@@ -247,6 +247,11 @@ type PushImageRequest struct {
 	DestRef   string
 	Auth      models.RegistryAuth
 	OnLog     func(line string)
+	// OnDigest is invoked once with the manifest digest the registry
+	// returned for the pushed tag (e.g. "sha256:abc..."), if the daemon
+	// surfaced one in the push stream's `aux` payload. Optional —
+	// callers that don't care about the digest can leave it nil.
+	OnDigest func(digest string)
 }
 
 // PushImage tags SourceTag as DestRef and pushes the result to the
@@ -318,7 +323,7 @@ func (c *Client) PushImage(ctx context.Context, req PushImageRequest) (string, e
 		return "", fmt.Errorf("docker API POST /images/%s/push failed with status %d: %s",
 			repo, response.StatusCode, strings.TrimSpace(string(data)))
 	}
-	if err := decodePushStream(response.Body, req.OnLog); err != nil {
+	if err := decodePushStream(response.Body, req.OnLog, req.OnDigest); err != nil {
 		return "", err
 	}
 	return repo + ":" + tag, nil
@@ -352,7 +357,7 @@ func (c *Client) tagImage(ctx context.Context, sourceRef, repo, tag string) erro
 	return nil
 }
 
-func decodePushStream(body io.Reader, onLog func(line string)) error {
+func decodePushStream(body io.Reader, onLog func(line string), onDigest func(digest string)) error {
 	decoder := json.NewDecoder(body)
 	for {
 		var msg struct {
@@ -361,6 +366,12 @@ func decodePushStream(body io.Reader, onLog func(line string)) error {
 			ErrorDetail struct {
 				Message string `json:"message"`
 			} `json:"errorDetail"`
+			// Aux carries the manifest digest the registry assigned to the
+			// pushed tag. Docker emits this exactly once near the end of a
+			// successful push; absent on failure paths.
+			Aux *struct {
+				Digest string `json:"Digest"`
+			} `json:"aux"`
 		}
 		if err := decoder.Decode(&msg); err != nil {
 			if errors.Is(err, io.EOF) {
@@ -376,6 +387,9 @@ func decodePushStream(body io.Reader, onLog func(line string)) error {
 		}
 		if onLog != nil && msg.Status != "" {
 			onLog(msg.Status)
+		}
+		if onDigest != nil && msg.Aux != nil && strings.TrimSpace(msg.Aux.Digest) != "" {
+			onDigest(strings.TrimSpace(msg.Aux.Digest))
 		}
 	}
 }

--- a/pkg/docker/build_test.go
+++ b/pkg/docker/build_test.go
@@ -178,11 +178,25 @@ func TestDecodePushStreamForwardsStatuses(t *testing.T) {
 			`{"status":"v1: digest: sha256:abc size: 123"}` + "\n",
 	)
 	var lines []string
-	if err := decodePushStream(body, func(line string) { lines = append(lines, line) }); err != nil {
+	if err := decodePushStream(body, func(line string) { lines = append(lines, line) }, nil); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 	if len(lines) != 2 {
 		t.Fatalf("statuses = %v", lines)
+	}
+}
+
+func TestDecodePushStreamCapturesAuxDigest(t *testing.T) {
+	body := strings.NewReader(
+		`{"status":"Pushing"}` + "\n" +
+			`{"progressDetail":{},"aux":{"Tag":"latest","Digest":"sha256:abc123","Size":42}}` + "\n",
+	)
+	var digest string
+	if err := decodePushStream(body, nil, func(d string) { digest = d }); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if digest != "sha256:abc123" {
+		t.Fatalf("digest = %q, want sha256:abc123", digest)
 	}
 }
 
@@ -191,7 +205,7 @@ func TestDecodePushStreamPromotesError(t *testing.T) {
 		`{"status":"Pushing"}` + "\n" +
 			`{"errorDetail":{"message":"unauthorized: authentication required"}}` + "\n",
 	)
-	err := decodePushStream(body, nil)
+	err := decodePushStream(body, nil, nil)
 	if err == nil || !strings.Contains(err.Error(), "unauthorized") {
 		t.Fatalf("expected push error, got %v", err)
 	}

--- a/pkg/docker/mirror_rewrite_test.go
+++ b/pkg/docker/mirror_rewrite_test.go
@@ -19,8 +19,8 @@ func defaultMirrorCfg() MirrorConfig {
 
 func TestRewriteImageRefForMirror_DisabledConfig(t *testing.T) {
 	for name, cfg := range map[string]MirrorConfig{
-		"zero":       {},
-		"no-host":    {Upstreams: []MirrorUpstream{{Host: "ghcr.io", Shortname: "ghcr"}}},
+		"zero":         {},
+		"no-host":      {Upstreams: []MirrorUpstream{{Host: "ghcr.io", Shortname: "ghcr"}}},
 		"no-upstreams": {Host: "mirror.aocr.aerol.ai"},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -247,6 +247,22 @@ const (
 	ImageDistributionAOCRImported = "aocr_imported"
 )
 
+// SnapshotPushState tracks the lifecycle of the optional background push of a
+// local snapshot to the AOCR registry. The two terminal states a polling SDK
+// cares about are "active" (snapshot is ready everywhere it can be) and
+// "error" (push failed; the snapshot is still usable on the originating node
+// and the reconciler will retry). "pending" / "pushing" are transient.
+//
+// When SB_SNAPSHOT_PUSH_ENABLED is false, or when the snapshot's image already
+// lives in a remote registry, new rows are written with state "active"
+// directly — making the response shape identical to today's behavior.
+const (
+	SnapshotPushStateActive  = "active"
+	SnapshotPushStatePending = "pending"
+	SnapshotPushStatePushing = "pushing"
+	SnapshotPushStateError   = "error"
+)
+
 const (
 	FailoverPolicyNone     = "none"
 	FailoverPolicyRecreate = "recreate"
@@ -557,6 +573,17 @@ type SandboxSnapshot struct {
 	MemoryMB int     `json:"memory_mb,omitempty"`
 	DiskGB   int     `json:"disk_gb,omitempty"`
 	GPU      float64 `json:"gpu,omitempty"`
+
+	// PushState reflects the AOCR-push lifecycle for this snapshot. See the
+	// SnapshotPushState* constants above. When push is disabled (or the image
+	// already lives in a remote registry) this is "active" from the moment
+	// the row is inserted, matching pre-feature behavior. Otherwise it
+	// transitions pending → pushing → active|error, and the cluster placement
+	// path treats the snapshot as locally-pinned until it hits "active".
+	PushState string `json:"push_state,omitempty"`
+	// PushError is populated only when PushState is "error" — the last error
+	// the reconciler saw, surfaced to the Daytona facade's errorReason field.
+	PushError string `json:"push_error,omitempty"`
 }
 
 func (s SandboxSnapshot) ImageDistribution() ImageDistributionMetadata {


### PR DESCRIPTION
This pull request introduces a new background feature for pushing sandbox snapshots to the AOCR registry, adds comprehensive documentation for snapshot usage, and updates the documentation sidebar to include this new topic. It also makes minor consistency edits to the dashboard documentation.

**Snapshot Push Feature and Configuration:**

* Adds a new background reconciler (`startSnapshotPushReconciler`) in `cmd/sandboxd/main.go` to push sandbox snapshots to the AOCR registry when enabled, including error handling, logging, and periodic reconciliation. [[1]](diffhunk://#diff-85cd4174384a81cdbf87370531855ae87bcbd19bf68f36b611d73cd5d96cb4daR573-R638) [[2]](diffhunk://#diff-85cd4174384a81cdbf87370531855ae87bcbd19bf68f36b611d73cd5d96cb4daR283)
* Extends the `Config` struct in `internal/config/config.go` with new fields to control snapshot push behavior: `SnapshotPushEnabled`, `SnapshotPushReconcileInterval`, and `SnapshotPushMaxInFlight`, with detailed comments and environment variable mappings.

**Documentation Improvements:**

* Adds a new `Snapshots` documentation page (`docs/src/content/docs/snapshots.mdx`) covering how to create, register, build, and use snapshots, including multi-language code examples and operational details about cluster distribution and failover.
* Updates the documentation sidebar in `docs/src/content.config.ts` to include the new Snapshots page and minor text consistency fixes. [[1]](diffhunk://#diff-3c77bd19d81880d0f5739e83a4ae589c80940aedc6e4208018361c53ae761d56R125-R130) [[2]](diffhunk://#diff-3c77bd19d81880d0f5739e83a4ae589c80940aedc6e4208018361c53ae761d56L257-R263)

**Dashboard Documentation Consistency:**

* Standardizes the use of dashes instead of em-dashes in several places in the dashboard documentation for consistency and readability. [[1]](diffhunk://#diff-634f7b989e84e5d6b1cf91b86aa3df9646e91f9a0eca878b4a87784a4b91fe16L32-R32) [[2]](diffhunk://#diff-634f7b989e84e5d6b1cf91b86aa3df9646e91f9a0eca878b4a87784a4b91fe16L53-R53) [[3]](diffhunk://#diff-634f7b989e84e5d6b1cf91b86aa3df9646e91f9a0eca878b4a87784a4b91fe16L81-R81) [[4]](diffhunk://#diff-634f7b989e84e5d6b1cf91b86aa3df9646e91f9a0eca878b4a87784a4b91fe16L95-R96) [[5]](diffhunk://#diff-634f7b989e84e5d6b1cf91b86aa3df9646e91f9a0eca878b4a87784a4b91fe16L107-R107) [[6]](diffhunk://#diff-634f7b989e84e5d6b1cf91b86aa3df9646e91f9a0eca878b4a87784a4b91fe16L118-R118)- Introduced a reconciler to manage the lifecycle of snapshot pushes, improving handling of states and errors.
- Enhanced snapshot handling with a fallback mechanism and added support for capturing digests.
- Updated documentation and sidebar links to reflect new snapshot features.

