### PR TITLE
feat: enhance serverless sandbox wake behavior and dashboard runtime status display

### DIFF
--- a/internal/service/serverless.go
+++ b/internal/service/serverless.go
@@ -256,29 +256,38 @@ func (s *Service) shouldArmWake(sandbox *models.Sandbox, mode stopMode) bool {
 }
 
 // ReconstructWakeArmedIfNeeded is the D1 reconstruction rule from
-// plans/serverless-sandbox-http-wake.md. A serverless sandbox can land
-// in `stopped + wake_armed=false` on a node that does not own the
-// arming history — typically after a cluster owner change (the old
-// owner's SQLite wake_armed bit doesn't migrate) or after a daemon
-// restart that lost the in-memory expected-stop bookkeeping and saw a
-// crash event arrive before the row got an armed value. In both cases
-// the conservative default is the same as the involuntary-stop policy:
-// arm wake so the next HTTP request resurrects the sandbox, instead of
-// leaving a stopped serverless sandbox permanently dark until an
-// operator notices.
+// plans/serverless-sandbox-http-wake.md, extended to also self-heal
+// Caddy state. A serverless sandbox can land in `stopped + wake_armed=false`
+// on a node that does not own the arming history — typically after a
+// cluster owner change (the old owner's SQLite wake_armed bit doesn't
+// migrate) or after a daemon restart that lost the in-memory expected-stop
+// bookkeeping and saw a crash event arrive before the row got an armed
+// value. In those cases the conservative default is the same as the
+// involuntary-stop policy: arm wake so the next HTTP request resurrects
+// the sandbox.
+//
+// It ALSO re-upserts wake routes when wake_armed=true is already set.
+// Caddy's admin-API routes are dynamic and do not survive a Caddy
+// restart (only certs persist via S3 storage), so the daemon must
+// treat wake_armed=true as a goal state to reassert against Caddy on
+// every reconcile pass, not as a witness that routes still exist.
+// Without this, a Caddy restart between auto-stop and the next wake
+// request leaves the wildcard 404 fallback serving requests forever
+// even though the DB looks correct.
 //
 // Reconstruction is a no-op unless ALL of:
 //   - cfg.EnableServerless is on
 //   - sandbox is Lifecycle.Serverless
 //   - sandbox is in Stopped status
-//   - sandbox.WakeArmed is currently false
 //   - the sandbox has at least one exposed port that can receive an inbound
 //     wake request or connection
 //
 // Caddy-first per D5: install wake routes for every exposure
 // before flipping the store bit. If every wake route install fails we
-// leave wake_armed=false to keep route state and the bit in sync —
-// the next reconcile pass will retry.
+// leave wake_armed unchanged (false stays false, true stays true) so
+// route state and the bit remain in sync — the next reconcile pass
+// will retry. The store write is skipped when wake_armed is already
+// true so steady-state reconcile passes do not churn the row.
 func (s *Service) ReconstructWakeArmedIfNeeded(ctx context.Context, sandbox *models.Sandbox) {
 	if sandbox == nil {
 		return
@@ -290,9 +299,6 @@ func (s *Service) ReconstructWakeArmedIfNeeded(ctx context.Context, sandbox *mod
 		return
 	}
 	if sandbox.Status != models.SandboxStatusStopped {
-		return
-	}
-	if sandbox.WakeArmed {
 		return
 	}
 
@@ -316,6 +322,11 @@ func (s *Service) ReconstructWakeArmedIfNeeded(ctx context.Context, sandbox *mod
 		return
 	}
 
+	if sandbox.WakeArmed {
+		// Already armed; this pass only re-asserted the Caddy routes to
+		// heal post-restart state. No store write, no audit log.
+		return
+	}
 	if err := s.store.SetWakeArmed(ctx, sandbox.ID, true); err != nil && !errors.Is(err, store.ErrNotFound) {
 		s.logger.Warn("reconstruct wake_armed store update failed",
 			"sandbox_id", sandbox.ID, "error", err)

--- a/internal/service/serverless_test.go
+++ b/internal/service/serverless_test.go
@@ -1484,12 +1484,16 @@ func TestReconstructWakeArmedIsNoOpForNonServerless(t *testing.T) {
 	}
 }
 
-// TestReconstructWakeArmedIsNoOpWhenAlreadyArmed proves the helper
-// does not re-install routes (or touch the store) for sandboxes that
-// already have wake_armed=true — covers the steady-state reconcile
-// pass where most stopped serverless sandboxes were already armed by
-// the lifecycle sweep.
-func TestReconstructWakeArmedIsNoOpWhenAlreadyArmed(t *testing.T) {
+// TestReconstructWakeArmedReinstallsRoutesWhenAlreadyArmed proves the
+// helper re-upserts wake routes even when wake_armed=true is already set.
+// Caddy's admin-API routes do not survive a Caddy restart, so the daemon
+// must treat wake_armed=true as a goal state to reassert against Caddy
+// on every reconcile pass — without this, a Caddy restart between
+// auto-stop and the next wake request would leave the wildcard 404
+// fallback serving requests forever even though the DB looks correct.
+// The store, however, must not be touched (the bit is already true and
+// pointless writes churn the row on every reconcile tick).
+func TestReconstructWakeArmedReinstallsRoutesWhenAlreadyArmed(t *testing.T) {
 	ctx := context.Background()
 	fake := newRouteFake()
 	svc, st := newServerlessHarness(t, &fakeCapacityRuntime{})
@@ -1526,8 +1530,17 @@ func TestReconstructWakeArmedIsNoOpWhenAlreadyArmed(t *testing.T) {
 
 	svc.ReconstructWakeArmedIfNeeded(ctx, reloaded)
 
-	if len(fake.routeIDs()) != 0 {
-		t.Fatalf("already-armed sandbox should not trigger a wake route install; got %v", fake.routeIDs())
+	ids := fake.routeIDs()
+	want := []string{"sandbox-sb-armed-port-3000-wake"}
+	if !equalSorted(ids, want) {
+		t.Fatalf("already-armed sandbox should still re-install wake route to self-heal Caddy; routes = %v, want %v", ids, want)
+	}
+	final, err := st.Get(ctx, sb.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !final.WakeArmed {
+		t.Fatalf("wake_armed must remain true after reassert pass")
 	}
 }
 

--- a/pkg/api/dashboard.html
+++ b/pkg/api/dashboard.html
@@ -227,13 +227,14 @@ details[open] > summary { margin-bottom: 6px; }
             <th>Sandbox</th>
             <th>Owner</th>
             <th>State</th>
+            <th>Runtime</th>
             <th class="num">Version</th>
             <th>Created</th>
             <th>Updated</th>
             <th></th>
           </tr>
         </thead>
-        <tbody id="placements-tbody"><tr><td colspan="7" class="empty">loading…</td></tr></tbody>
+        <tbody id="placements-tbody"><tr><td colspan="8" class="empty">loading…</td></tr></tbody>
       </table>
       <div class="pager">
         <button id="next-page-btn" type="button" disabled>Next page</button>
@@ -631,7 +632,7 @@ async function loadPlacements() {
       p = await apiJSON("/v1/cluster/sandbox-index" + q);
     } catch (err) {
       if (String(err.message).startsWith("503")) {
-        el("placements-tbody").innerHTML = `<tr><td colspan="7" class="empty">cluster not enabled on this node</td></tr>`;
+        el("placements-tbody").innerHTML = `<tr><td colspan="8" class="empty">cluster not enabled on this node</td></tr>`;
         el("placements-meta").textContent = "";
         el("page-info").textContent = "";
         el("next-page-btn").disabled = true;
@@ -645,21 +646,43 @@ async function loadPlacements() {
       : `${rows.length} on this page`;
 
     if (rows.length === 0) {
-      el("placements-tbody").innerHTML = `<tr><td colspan="7" class="empty">no placements${token ? " on this page" : ""}</td></tr>`;
+      el("placements-tbody").innerHTML = `<tr><td colspan="8" class="empty">no placements${token ? " on this page" : ""}</td></tr>`;
     } else {
       el("placements-tbody").innerHTML = rows.map((pl) => {
         const orphaned = pl.owner_state === "orphaned";
         const stateLabel = pl.state ? pl.state : (orphaned ? "orphaned" : "placed");
         const stateKind = orphaned ? "bad" : (pl.state === "reserved" ? "warn" : "ok");
+        // runtime_status comes from the per-node sandbox store overlay
+        // (cluster_handler.go). Empty means the row lives on another
+        // node, so the dashboard can't act on it from here.
+        const runtime = pl.runtime_status || "";
+        const isStarted = runtime === "started";
+        const isStopped = runtime === "stopped";
+        const runtimePill = runtime
+          ? pill(runtime, isStarted ? "ok" : isStopped ? "warn" : "bad")
+          : `<span class="muted">remote</span>`;
         let actions = "";
         if (orphaned) {
           actions = `
             <button data-action="reclaim" data-id="${escapeHTML(pl.sandbox_id)}">Reclaim local</button>
             <button class="danger" data-action="delete-orphan" data-id="${escapeHTML(pl.sandbox_id)}">Force delete</button>
           `;
-        } else {
+        } else if (isStopped) {
+          // Context-aware: a stopped sandbox cannot meaningfully be
+          // "Stopped" again. Offer Start (resume) + Delete instead.
+          actions = `
+            <button data-action="start-sandbox" data-id="${escapeHTML(pl.sandbox_id)}">Start</button>
+            <button class="danger" data-action="delete-sandbox" data-id="${escapeHTML(pl.sandbox_id)}">Delete</button>
+          `;
+        } else if (isStarted) {
           actions = `
             <button data-action="stop-sandbox" data-id="${escapeHTML(pl.sandbox_id)}">Stop</button>
+            <button class="danger" data-action="delete-sandbox" data-id="${escapeHTML(pl.sandbox_id)}">Delete</button>
+          `;
+        } else {
+          // Unknown runtime (remote placement, in-flux, destroyed
+          // row already gone): only delete is safe to expose.
+          actions = `
             <button class="danger" data-action="delete-sandbox" data-id="${escapeHTML(pl.sandbox_id)}">Delete</button>
           `;
         }
@@ -668,6 +691,7 @@ async function loadPlacements() {
             <td class="id">${escapeHTML(pl.sandbox_id)}</td>
             <td><span class="mono muted">${escapeHTML(pl.owner_node_id || "—")}</span></td>
             <td>${pill(stateLabel, stateKind)}</td>
+            <td>${runtimePill}</td>
             <td class="num">${fmtNum(pl.version)}</td>
             <td class="num" title="${escapeHTML(fmtUnix(pl.created_unix))}"><span class="muted">${fmtAge(pl.created_unix)}</span></td>
             <td class="num" title="${escapeHTML(fmtUnix(pl.updated_unix))}"><span class="muted">${fmtAge(pl.updated_unix)}</span></td>
@@ -680,7 +704,7 @@ async function loadPlacements() {
     el("next-page-btn").disabled = !p.next_page_token;
     state.nextPageToken = p.next_page_token || "";
   } catch (err) {
-    el("placements-tbody").innerHTML = `<tr><td colspan="7" class="error">${escapeHTML(err.message)}</td></tr>`;
+    el("placements-tbody").innerHTML = `<tr><td colspan="8" class="error">${escapeHTML(err.message)}</td></tr>`;
   }
 }
 
@@ -753,6 +777,8 @@ document.addEventListener("click", (e) => {
     postAction("POST", `/v1/cluster/orphans/${encodeURIComponent(id)}/reclaim-local`, "Reclaim orphan locally", id);
   } else if (action === "delete-orphan") {
     postAction("DELETE", `/v1/cluster/orphans/${encodeURIComponent(id)}`, "Force-delete orphan placement", id);
+  } else if (action === "start-sandbox") {
+    postAction("POST", `/v1/sandboxes/${encodeURIComponent(id)}/start`, "Start sandbox", id);
   } else if (action === "stop-sandbox") {
     postAction("POST", `/v1/sandboxes/${encodeURIComponent(id)}/stop`, "Stop sandbox", id);
   } else if (action === "delete-sandbox") {

--- a/pkg/api/v1/cluster_handler.go
+++ b/pkg/api/v1/cluster_handler.go
@@ -576,6 +576,24 @@ func (h *handlers) clusterIngressRoute(w http.ResponseWriter, r *http.Request) {
 	apihttp.WriteJSON(w, http.StatusOK, route)
 }
 
+// sandboxIndexPlacement extends the cluster.Placement (FSM/Raft state) with
+// the local sandbox row's runtime status. The FSM tracks ownership and
+// scheduling intent; runtime status (started/stopped/destroyed) lives in
+// the per-node store. The dashboard needs runtime status to render
+// Start vs Stop action buttons, so the index handler overlays it here
+// rather than forcing the UI to fan out an extra GET per row.
+// RuntimeStatus is empty for placements owned by another node (we only
+// see this node's store) — the UI treats that as "view-only / remote".
+type sandboxIndexPlacement struct {
+	cluster.Placement
+	RuntimeStatus models.SandboxStatus `json:"runtime_status,omitempty"`
+}
+
+type sandboxIndexResponse struct {
+	Placements    []sandboxIndexPlacement `json:"placements"`
+	NextPageToken string                  `json:"next_page_token,omitempty"`
+}
+
 func (h *handlers) writeClusterSandboxIndex(w http.ResponseWriter, r *http.Request) {
 	if h.deps.Service == nil {
 		apihttp.WriteError(w, http.StatusServiceUnavailable, "cluster: not enabled on this node")
@@ -595,10 +613,32 @@ func (h *handlers) writeClusterSandboxIndex(w http.ResponseWriter, r *http.Reque
 		},
 	}
 	resp := c.PlacementPage(req)
+
+	// One List call to build the id→status overlay so we don't issue N
+	// store.Get calls per page. ListSandboxes already returns local-only
+	// rows; placements pointing to another owner stay with empty runtime
+	// status and the UI treats them as remote.
+	statusByID := map[string]models.SandboxStatus{}
+	if locals, err := h.deps.Service.ListSandboxes(r.Context(), nil); err == nil {
+		for _, sb := range locals {
+			statusByID[sb.ID] = sb.Status
+		}
+	} else {
+		h.deps.Logger.Warn("sandbox-index: local list failed; runtime_status will be empty", "err", err)
+	}
+
+	out := sandboxIndexResponse{
+		Placements:    make([]sandboxIndexPlacement, len(resp.Placements)),
+		NextPageToken: resp.NextPageToken,
+	}
 	for i := range resp.Placements {
 		redactPlacementSecretFields(&resp.Placements[i])
+		out.Placements[i] = sandboxIndexPlacement{
+			Placement:     resp.Placements[i],
+			RuntimeStatus: statusByID[resp.Placements[i].SandboxID],
+		}
 	}
-	apihttp.WriteJSON(w, http.StatusOK, resp)
+	apihttp.WriteJSON(w, http.StatusOK, out)
 }
 
 func redactPlacementSecretFields(p *cluster.Placement) {


### PR DESCRIPTION
This pull request enhances the serverless sandbox reconciliation logic and improves the dashboard UI for managing sandboxes. The main changes ensure that HTTP wake routes are always reasserted after a Caddy restart, preventing sandboxes from getting stuck in an unreachable state. The dashboard now displays the runtime status of each sandbox and provides context-aware action buttons (Start/Stop/Delete) based on the sandbox's current state. These improvements make the system more robust and the UI more user-friendly.

**Serverless sandbox reconciliation improvements:**

- Updated the `ReconstructWakeArmedIfNeeded` logic to always reassert wake routes with Caddy when `wake_armed=true`, ensuring that sandboxes remain accessible after a Caddy restart. The store is only updated if the bit was previously false, avoiding unnecessary writes. [[1]](diffhunk://#diff-11829a554d81d2c6fd94ada3c20d27a6a3ba7789c3f6e8f3e02248d57b3f8a93L259-R290) [[2]](diffhunk://#diff-11829a554d81d2c6fd94ada3c20d27a6a3ba7789c3f6e8f3e02248d57b3f8a93L295-L297) [[3]](diffhunk://#diff-11829a554d81d2c6fd94ada3c20d27a6a3ba7789c3f6e8f3e02248d57b3f8a93R325-R329)
- Revised and expanded the related test to verify that wake routes are reinstalled for already-armed sandboxes, and that the store is not redundantly updated. [[1]](diffhunk://#diff-c0bd65b7b26d1659535fec313c2c4eb4e04f063ee914ea987aa6a736c3b860d5L1487-R1496) [[2]](diffhunk://#diff-c0bd65b7b26d1659535fec313c2c4eb4e04f063ee914ea987aa6a736c3b860d5L1529-R1543)

**Dashboard UI and API enhancements:**

- The dashboard now displays a new "Runtime" column showing each sandbox's runtime status (started/stopped/remote) using colored pills, and adapts the action buttons to the current state (e.g., offering "Start" for stopped sandboxes and "Stop" for started ones). [[1]](diffhunk://#diff-d9b28647ac47d86370ca11cad4e676f051de89f52308f6f94c560d0aec0c0524R230-R237) [[2]](diffhunk://#diff-d9b28647ac47d86370ca11cad4e676f051de89f52308f6f94c560d0aec0c0524L634-R635) [[3]](diffhunk://#diff-d9b28647ac47d86370ca11cad4e676f051de89f52308f6f94c560d0aec0c0524L648-R694) [[4]](diffhunk://#diff-d9b28647ac47d86370ca11cad4e676f051de89f52308f6f94c560d0aec0c0524R780-R781)
- Adjusted table column counts and error messages in the dashboard to match the new "Runtime" column.
- The `/v1/cluster/sandbox-index` API endpoint now includes the runtime status for each placement, overlaying local store state onto the cluster placement view for more informative UI rendering. [[1]](diffhunk://#diff-4a49edd446f9211f5db5ed8769aa72cab26c2a821298c8f59d97dc5b8ecacc3bR579-R596) [[2]](diffhunk://#diff-4a49edd446f9211f5db5ed8769aa72cab26c2a821298c8f59d97dc5b8ecacc3bR616-R641)