### PR TITLE
feat: add upstream readiness timeout for HTTP wake handler and update related configurations

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+set -eu
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+if ! command -v gofmt >/dev/null 2>&1; then
+	echo "pre-commit: gofmt is required but was not found in PATH" >&2
+	exit 1
+fi
+
+staged_go_files=$(git diff --cached --name-only --diff-filter=ACMR -- '*.go')
+
+if [ -z "$staged_go_files" ]; then
+	exit 0
+fi
+
+partially_staged_files=""
+printf '%s\n' "$staged_go_files" | while IFS= read -r file; do
+	[ -z "$file" ] && continue
+	if ! git diff --quiet -- "$file"; then
+		printf '%s\n' "$file"
+	fi
+done > /tmp/aerolvm-go-pre-commit-partial.$$ 
+
+partially_staged_files=$(cat /tmp/aerolvm-go-pre-commit-partial.$$)
+rm -f /tmp/aerolvm-go-pre-commit-partial.$$
+
+if [ -n "$partially_staged_files" ]; then
+	echo "pre-commit: refusing to auto-format partially staged Go files:" >&2
+	printf '  %s\n' "$partially_staged_files" >&2
+	echo "pre-commit: stage or stash the remaining hunks, then retry." >&2
+	exit 1
+fi
+
+printf '%s\n' "$staged_go_files" | while IFS= read -r file; do
+	[ -z "$file" ] && continue
+	gofmt -w "$file"
+	git add "$file"
+done

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
 GO ?= go
 BIN_DIR ?= bin
 
-.PHONY: fmt test build build-sandboxd build-toolboxd docs-install docs-dev docs-build clean
+.PHONY: fmt install-git-hooks test build build-sandboxd build-toolboxd docs-install docs-dev docs-build clean
 
 fmt:
 	$(GO) fmt ./...
+
+install-git-hooks:
+	git config core.hooksPath .githooks
+	chmod +x .githooks/pre-commit
+	@printf '%s\n' 'Installed git hooks from .githooks/'
 
 test:
 	$(GO) test ./...

--- a/README.md
+++ b/README.md
@@ -83,11 +83,14 @@ curl -fsSL https://github.com/aerol-ai/microvm/releases/latest/download/install.
 ## Develop and Test
 
 ```bash
+make install-git-hooks
 make build
 make test
 make docs-install
 make docs-dev
 ```
+
+Run `make install-git-hooks` once per clone to enable the repo-managed pre-commit hook. It formats staged Go files with `gofmt` and re-stages them before the commit completes.
 
 ## License
 

--- a/cmd/sandboxd/main.go
+++ b/cmd/sandboxd/main.go
@@ -355,6 +355,9 @@ func main() {
 			Logger:               logger,
 			MaxBufferBytes:       cfg.HTTPWakeMaxBuffer,
 			UpstreamReadyTimeout: cfg.HTTPWakeUpstreamReadyTimeout,
+			MaxPendingPerSandbox: cfg.HTTPWakeMaxPendingPerSandbox,
+			MaxPendingGlobal:     cfg.HTTPWakeMaxPendingGlobal,
+			MaxBufferBytesGlobal: cfg.HTTPWakeMaxBufferBytesGlobal,
 		})
 		ingressServer = &http.Server{
 			Addr:              cfg.InternalIngressAddr,

--- a/cmd/sandboxd/main.go
+++ b/cmd/sandboxd/main.go
@@ -351,9 +351,10 @@ func main() {
 	if cfg.EnableServerless && cfg.EnableCaddy {
 		ingressMux := http.NewServeMux()
 		ingressproxy.RegisterRoutes(ingressMux, ingressproxy.Deps{
-			Resolver:       svc,
-			Logger:         logger,
-			MaxBufferBytes: cfg.HTTPWakeMaxBuffer,
+			Resolver:             svc,
+			Logger:               logger,
+			MaxBufferBytes:       cfg.HTTPWakeMaxBuffer,
+			UpstreamReadyTimeout: cfg.HTTPWakeUpstreamReadyTimeout,
 		})
 		ingressServer = &http.Server{
 			Addr:              cfg.InternalIngressAddr,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -156,22 +156,27 @@ type Config struct {
 	// HTTPWakeMaxBuffer caps the request body buffered while a cold-start
 	// wake is in progress. Requests with bodies larger than this are
 	// rejected with 413 — see plan D2.
-	HTTPWakeMaxBuffer           int64
-	SSHListenAddr               string
-	SSHHostKeyPath              string
-	CredentialEncryptionKey     string
-	CredentialEncryptionKeyPath string
-	MountsRootPath              string
-	MountsCredentialsRuntimeDir string
-	MountWaitTimeout            time.Duration
-	LogLevel                    string
-	ShutdownTimeout             time.Duration
-	HTTPClientTimeout           time.Duration
-	DockerRuntimeWaitTimeout    time.Duration
-	ToolboxWaitTimeout          time.Duration
-	ReconcileInterval           time.Duration
-	NetstatsPollInterval        time.Duration
-	UploadMaxBytes              int64
+	HTTPWakeMaxBuffer int64
+	// HTTPWakeUpstreamReadyTimeout bounds how long the ingress proxy
+	// holds a caller's request waiting for the in-container service to
+	// bind its TCP port after wake. Defaults to 30s; raise for workloads
+	// with slow startups (JVM, large Python imports).
+	HTTPWakeUpstreamReadyTimeout time.Duration
+	SSHListenAddr                string
+	SSHHostKeyPath               string
+	CredentialEncryptionKey      string
+	CredentialEncryptionKeyPath  string
+	MountsRootPath               string
+	MountsCredentialsRuntimeDir  string
+	MountWaitTimeout             time.Duration
+	LogLevel                     string
+	ShutdownTimeout              time.Duration
+	HTTPClientTimeout            time.Duration
+	DockerRuntimeWaitTimeout     time.Duration
+	ToolboxWaitTimeout           time.Duration
+	ReconcileInterval            time.Duration
+	NetstatsPollInterval         time.Duration
+	UploadMaxBytes               int64
 	// OTELMetricsEnabled starts a native OTLP/HTTP metric exporter that bridges
 	// the daemon's aerolvm_* expvars into OpenTelemetry observations. It is
 	// also enabled automatically when SB_OTEL_METRICS_ENDPOINT is set.
@@ -531,58 +536,59 @@ func Load() (Config, error) {
 	defaultToolboxPath := filepath.Join(filepath.Dir(exe), "toolboxd")
 
 	cfg := Config{
-		PATToken:                    strings.TrimSpace(os.Getenv("SB_PAT_TOKEN")),
-		APIHost:                     getEnv("SB_API_HOST", "0.0.0.0"),
-		APIPort:                     getEnvInt("SB_API_PORT", 21212),
-		Domain:                      normalizeHost(os.Getenv("SB_DOMAIN")),
-		PublicHost:                  normalizeHost(getEnv("SB_PUBLIC_HOST", "127.0.0.1")),
-		CaddyAdminURL:               getEnv("SB_CADDY_ADMIN_URL", "http://127.0.0.1:2019"),
-		CaddyServerID:               getEnv("SB_CADDY_SERVER_ID", "srv0"),
-		DBPath:                      getEnv("SB_DB_PATH", "/var/lib/sandboxd/state.db"),
-		DockerNetwork:               getEnv("SB_DOCKER_NETWORK", "bridge"),
-		ToolboxBinaryPath:           getEnv("SB_TOOLBOX_BINARY_PATH", defaultToolboxPath),
-		ToolboxMountPath:            getEnv("SB_TOOLBOX_MOUNT_PATH", "/usr/local/bin/toolboxd"),
-		ToolboxPort:                 getEnvInt("SB_TOOLBOX_PORT", defaultToolboxPort),
-		IdleTimeoutMinutes:          getEnvInt("SB_IDLE_TIMEOUT_MIN", 0),
-		ContainerPrivileged:         getEnvBool("SB_CONTAINER_PRIVILEGED", false),
-		ResourceLimitsOff:           getEnvBool("SB_RESOURCE_LIMITS_DISABLED", false),
-		Runtime:                     getEnv("SB_CONTAINER_RUNTIME", models.RuntimeDocker),
-		AutoReconcile:               getEnvBool("SB_AUTO_RECONCILE", true),
-		EnableCaddy:                 getEnvBool("SB_ENABLE_CADDY", true),
-		EnableNetworkRules:          getEnvBool("SB_ENABLE_NETWORK_RULES", true),
-		EnableEventMonitor:          getEnvBool("SB_ENABLE_EVENT_MONITOR", true),
-		EnableSSHGateway:            getEnvBool("SB_ENABLE_SSH_GATEWAY", true),
-		EnableServerless:            getEnvBool("SB_ENABLE_SERVERLESS", true),
-		InternalIngressAddr:         getEnv("SB_INTERNAL_INGRESS_ADDR", "127.0.0.1:21213"),
-		InternalL4WakeAddr:          getEnv("SB_INTERNAL_L4_WAKE_ADDR", "127.0.0.1:21214"),
-		InternalL4WakeDir:           getEnv("SB_INTERNAL_L4_WAKE_DIR", "/run/sandboxd/l4wake"),
-		L4WakeMaxPendingPerSandbox:  getEnvInt("SB_L4_WAKE_MAX_PENDING_PER_SANDBOX", 256),
-		L4WakeMaxPendingGlobal:      getEnvInt("SB_L4_WAKE_MAX_PENDING_GLOBAL", 4096),
-		L4WakeMaxActivePerSandbox:   getEnvInt("SB_L4_WAKE_MAX_ACTIVE_PER_SANDBOX", 4096),
-		L4WakeMaxActiveGlobal:       getEnvInt("SB_L4_WAKE_MAX_ACTIVE_GLOBAL", 65536),
-		HTTPWakeMaxBuffer:           int64(getEnvInt("SB_HTTP_WAKE_MAX_BUFFER", 8*1024*1024)),
-		SSHListenAddr:               getEnv("SB_SSH_LISTEN_ADDR", "0.0.0.0:2220"),
-		SSHHostKeyPath:              getEnv("SB_SSH_HOST_KEY_PATH", "/var/lib/sandboxd/ssh_host_ed25519_key"),
-		CredentialEncryptionKey:     strings.TrimSpace(os.Getenv("SB_CREDENTIAL_ENCRYPTION_KEY")),
-		CredentialEncryptionKeyPath: getEnv("SB_CREDENTIAL_ENCRYPTION_KEY_PATH", "/var/lib/sandboxd/credential_encryption.key"),
-		MountsRootPath:              getEnv("SB_MOUNTS_ROOT", "/var/lib/sandboxd/mounts"),
-		MountsCredentialsRuntimeDir: getEnv("SB_MOUNTS_CRED_DIR", "/run/sandboxd"),
-		MountWaitTimeout:            getEnvDuration("SB_MOUNT_WAIT_TIMEOUT", 30*time.Second),
-		LogLevel:                    strings.ToLower(getEnv("SB_LOG_LEVEL", "info")),
-		ShutdownTimeout:             getEnvDuration("SB_SHUTDOWN_TIMEOUT", 10*time.Second),
-		HTTPClientTimeout:           getEnvDuration("SB_HTTP_CLIENT_TIMEOUT", 180*time.Second),
-		DockerRuntimeWaitTimeout:    getEnvDuration("SB_DOCKER_WAIT_TIMEOUT", 30*time.Second),
-		ToolboxWaitTimeout:          getEnvDuration("SB_TOOLBOX_WAIT_TIMEOUT", 30*time.Second),
-		ReconcileInterval:           getEnvDuration("SB_RECONCILE_INTERVAL", 5*time.Minute),
-		NetstatsPollInterval:        getEnvDuration("SB_NETSTATS_POLL_INTERVAL", 10*time.Second),
-		UploadMaxBytes:              int64(getEnvInt("SB_UPLOAD_MAX_BYTES", 256*1024*1024)),
-		OTELMetricsEnabled:          getEnvBool("SB_OTEL_METRICS_ENABLED", false),
-		OTELMetricsEndpoint:         firstNonEmpty(os.Getenv("SB_OTEL_METRICS_ENDPOINT"), os.Getenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT")),
-		OTELMetricsInterval:         getEnvDuration("SB_OTEL_METRICS_INTERVAL", 30*time.Second),
-		OTELTracesEnabled:           getEnvBool("SB_OTEL_TRACES_ENABLED", false),
-		OTELTracesEndpoint:          firstNonEmpty(os.Getenv("SB_OTEL_TRACES_ENDPOINT"), os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")),
-		OTELTracesSampleRatio:       getEnvFloat("SB_OTEL_TRACES_SAMPLE_RATIO", 0.05),
-		OTELServiceName:             getEnv("OTEL_SERVICE_NAME", "sandboxd"),
+		PATToken:                     strings.TrimSpace(os.Getenv("SB_PAT_TOKEN")),
+		APIHost:                      getEnv("SB_API_HOST", "0.0.0.0"),
+		APIPort:                      getEnvInt("SB_API_PORT", 21212),
+		Domain:                       normalizeHost(os.Getenv("SB_DOMAIN")),
+		PublicHost:                   normalizeHost(getEnv("SB_PUBLIC_HOST", "127.0.0.1")),
+		CaddyAdminURL:                getEnv("SB_CADDY_ADMIN_URL", "http://127.0.0.1:2019"),
+		CaddyServerID:                getEnv("SB_CADDY_SERVER_ID", "srv0"),
+		DBPath:                       getEnv("SB_DB_PATH", "/var/lib/sandboxd/state.db"),
+		DockerNetwork:                getEnv("SB_DOCKER_NETWORK", "bridge"),
+		ToolboxBinaryPath:            getEnv("SB_TOOLBOX_BINARY_PATH", defaultToolboxPath),
+		ToolboxMountPath:             getEnv("SB_TOOLBOX_MOUNT_PATH", "/usr/local/bin/toolboxd"),
+		ToolboxPort:                  getEnvInt("SB_TOOLBOX_PORT", defaultToolboxPort),
+		IdleTimeoutMinutes:           getEnvInt("SB_IDLE_TIMEOUT_MIN", 0),
+		ContainerPrivileged:          getEnvBool("SB_CONTAINER_PRIVILEGED", false),
+		ResourceLimitsOff:            getEnvBool("SB_RESOURCE_LIMITS_DISABLED", false),
+		Runtime:                      getEnv("SB_CONTAINER_RUNTIME", models.RuntimeDocker),
+		AutoReconcile:                getEnvBool("SB_AUTO_RECONCILE", true),
+		EnableCaddy:                  getEnvBool("SB_ENABLE_CADDY", true),
+		EnableNetworkRules:           getEnvBool("SB_ENABLE_NETWORK_RULES", true),
+		EnableEventMonitor:           getEnvBool("SB_ENABLE_EVENT_MONITOR", true),
+		EnableSSHGateway:             getEnvBool("SB_ENABLE_SSH_GATEWAY", true),
+		EnableServerless:             getEnvBool("SB_ENABLE_SERVERLESS", true),
+		InternalIngressAddr:          getEnv("SB_INTERNAL_INGRESS_ADDR", "127.0.0.1:21213"),
+		InternalL4WakeAddr:           getEnv("SB_INTERNAL_L4_WAKE_ADDR", "127.0.0.1:21214"),
+		InternalL4WakeDir:            getEnv("SB_INTERNAL_L4_WAKE_DIR", "/run/sandboxd/l4wake"),
+		L4WakeMaxPendingPerSandbox:   getEnvInt("SB_L4_WAKE_MAX_PENDING_PER_SANDBOX", 256),
+		L4WakeMaxPendingGlobal:       getEnvInt("SB_L4_WAKE_MAX_PENDING_GLOBAL", 4096),
+		L4WakeMaxActivePerSandbox:    getEnvInt("SB_L4_WAKE_MAX_ACTIVE_PER_SANDBOX", 4096),
+		L4WakeMaxActiveGlobal:        getEnvInt("SB_L4_WAKE_MAX_ACTIVE_GLOBAL", 65536),
+		HTTPWakeMaxBuffer:            int64(getEnvInt("SB_HTTP_WAKE_MAX_BUFFER", 8*1024*1024)),
+		HTTPWakeUpstreamReadyTimeout: getEnvDuration("SB_HTTP_WAKE_UPSTREAM_READY_TIMEOUT", 30*time.Second),
+		SSHListenAddr:                getEnv("SB_SSH_LISTEN_ADDR", "0.0.0.0:2220"),
+		SSHHostKeyPath:               getEnv("SB_SSH_HOST_KEY_PATH", "/var/lib/sandboxd/ssh_host_ed25519_key"),
+		CredentialEncryptionKey:      strings.TrimSpace(os.Getenv("SB_CREDENTIAL_ENCRYPTION_KEY")),
+		CredentialEncryptionKeyPath:  getEnv("SB_CREDENTIAL_ENCRYPTION_KEY_PATH", "/var/lib/sandboxd/credential_encryption.key"),
+		MountsRootPath:               getEnv("SB_MOUNTS_ROOT", "/var/lib/sandboxd/mounts"),
+		MountsCredentialsRuntimeDir:  getEnv("SB_MOUNTS_CRED_DIR", "/run/sandboxd"),
+		MountWaitTimeout:             getEnvDuration("SB_MOUNT_WAIT_TIMEOUT", 30*time.Second),
+		LogLevel:                     strings.ToLower(getEnv("SB_LOG_LEVEL", "info")),
+		ShutdownTimeout:              getEnvDuration("SB_SHUTDOWN_TIMEOUT", 10*time.Second),
+		HTTPClientTimeout:            getEnvDuration("SB_HTTP_CLIENT_TIMEOUT", 180*time.Second),
+		DockerRuntimeWaitTimeout:     getEnvDuration("SB_DOCKER_WAIT_TIMEOUT", 30*time.Second),
+		ToolboxWaitTimeout:           getEnvDuration("SB_TOOLBOX_WAIT_TIMEOUT", 30*time.Second),
+		ReconcileInterval:            getEnvDuration("SB_RECONCILE_INTERVAL", 5*time.Minute),
+		NetstatsPollInterval:         getEnvDuration("SB_NETSTATS_POLL_INTERVAL", 10*time.Second),
+		UploadMaxBytes:               int64(getEnvInt("SB_UPLOAD_MAX_BYTES", 256*1024*1024)),
+		OTELMetricsEnabled:           getEnvBool("SB_OTEL_METRICS_ENABLED", false),
+		OTELMetricsEndpoint:          firstNonEmpty(os.Getenv("SB_OTEL_METRICS_ENDPOINT"), os.Getenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT")),
+		OTELMetricsInterval:          getEnvDuration("SB_OTEL_METRICS_INTERVAL", 30*time.Second),
+		OTELTracesEnabled:            getEnvBool("SB_OTEL_TRACES_ENABLED", false),
+		OTELTracesEndpoint:           firstNonEmpty(os.Getenv("SB_OTEL_TRACES_ENDPOINT"), os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")),
+		OTELTracesSampleRatio:        getEnvFloat("SB_OTEL_TRACES_SAMPLE_RATIO", 0.05),
+		OTELServiceName:              getEnv("OTEL_SERVICE_NAME", "sandboxd"),
 
 		CPUReservationRatio:       getEnvFloat("SB_CPU_RESERVATION_RATIO", 0.9),
 		MemoryReservationRatio:    getEnvFloat("SB_MEMORY_RESERVATION_RATIO", 0.85),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -178,21 +178,34 @@ type Config struct {
 	// = 80 GB worst case without this). Required > 0 when serverless
 	// is on.
 	HTTPWakeMaxBufferBytesGlobal int64
-	SSHListenAddr                string
-	SSHHostKeyPath               string
-	CredentialEncryptionKey      string
-	CredentialEncryptionKeyPath  string
-	MountsRootPath               string
-	MountsCredentialsRuntimeDir  string
-	MountWaitTimeout             time.Duration
-	LogLevel                     string
-	ShutdownTimeout              time.Duration
-	HTTPClientTimeout            time.Duration
-	DockerRuntimeWaitTimeout     time.Duration
-	ToolboxWaitTimeout           time.Duration
-	ReconcileInterval            time.Duration
-	NetstatsPollInterval         time.Duration
-	UploadMaxBytes               int64
+	// WakeStartConcurrency caps concurrent StartSandbox invocations
+	// initiated by the wake path across the whole node. Inside the global
+	// HTTP+L4 pending caps, up to (HTTPWakeMaxPendingGlobal +
+	// L4WakeMaxPendingGlobal) different sandboxes may be in their cold-
+	// start window at once; without this cap they all hit Docker create /
+	// start and Caddy admin upserts simultaneously, overwhelming both. Per-
+	// sandbox single-flight (wakeFlights) prevents same-id duplication;
+	// this protects against cross-id storms. Default 64 — Docker daemon
+	// handles ~100 concurrent creates cleanly, Caddy admin API serializes
+	// writes but doesn't fall over. Operator-initiated StartSandbox calls
+	// (API surface) bypass this cap — only wake-driven starts are gated.
+	// Required > 0 when serverless is on.
+	WakeStartConcurrency        int
+	SSHListenAddr               string
+	SSHHostKeyPath              string
+	CredentialEncryptionKey     string
+	CredentialEncryptionKeyPath string
+	MountsRootPath              string
+	MountsCredentialsRuntimeDir string
+	MountWaitTimeout            time.Duration
+	LogLevel                    string
+	ShutdownTimeout             time.Duration
+	HTTPClientTimeout           time.Duration
+	DockerRuntimeWaitTimeout    time.Duration
+	ToolboxWaitTimeout          time.Duration
+	ReconcileInterval           time.Duration
+	NetstatsPollInterval        time.Duration
+	UploadMaxBytes              int64
 	// OTELMetricsEnabled starts a native OTLP/HTTP metric exporter that bridges
 	// the daemon's aerolvm_* expvars into OpenTelemetry observations. It is
 	// also enabled automatically when SB_OTEL_METRICS_ENDPOINT is set.
@@ -586,6 +599,7 @@ func Load() (Config, error) {
 		HTTPWakeMaxPendingPerSandbox: getEnvInt("SB_HTTP_WAKE_MAX_PENDING_PER_SANDBOX", 256),
 		HTTPWakeMaxPendingGlobal:     getEnvInt("SB_HTTP_WAKE_MAX_PENDING_GLOBAL", 4096),
 		HTTPWakeMaxBufferBytesGlobal: int64(getEnvInt("SB_HTTP_WAKE_MAX_BUFFER_GLOBAL", 1024*1024*1024)),
+		WakeStartConcurrency:         getEnvInt("SB_WAKE_START_CONCURRENCY", 64),
 		SSHListenAddr:                getEnv("SB_SSH_LISTEN_ADDR", "0.0.0.0:2220"),
 		SSHHostKeyPath:               getEnv("SB_SSH_HOST_KEY_PATH", "/var/lib/sandboxd/ssh_host_ed25519_key"),
 		CredentialEncryptionKey:      strings.TrimSpace(os.Getenv("SB_CREDENTIAL_ENCRYPTION_KEY")),
@@ -901,6 +915,9 @@ func Load() (Config, error) {
 		}
 		if cfg.HTTPWakeMaxBufferBytesGlobal <= 0 {
 			return Config{}, errors.New("SB_HTTP_WAKE_MAX_BUFFER_GLOBAL must be > 0 when SB_ENABLE_SERVERLESS=true")
+		}
+		if cfg.WakeStartConcurrency <= 0 {
+			return Config{}, errors.New("SB_WAKE_START_CONCURRENCY must be > 0 when SB_ENABLE_SERVERLESS=true")
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -162,6 +162,22 @@ type Config struct {
 	// bind its TCP port after wake. Defaults to 30s; raise for workloads
 	// with slow startups (JVM, large Python imports).
 	HTTPWakeUpstreamReadyTimeout time.Duration
+	// HTTPWakeMaxPendingPerSandbox caps cold-start HTTP requests
+	// simultaneously holding the wake + readiness window for ONE
+	// sandbox. Counterpart of L4WakeMaxPendingPerSandbox. Excess is
+	// rejected with 503 + Retry-After. Required > 0 when serverless
+	// is on.
+	HTTPWakeMaxPendingPerSandbox int
+	// HTTPWakeMaxPendingGlobal caps cold-start HTTP requests
+	// simultaneously holding the wake + readiness window across ALL
+	// sandboxes on this node. Counterpart of L4WakeMaxPendingGlobal.
+	HTTPWakeMaxPendingGlobal int
+	// HTTPWakeMaxBufferBytesGlobal caps total bytes buffered across all
+	// in-flight cold-start requests at any moment. Prevents a flood of
+	// near-MaxBuffer cold POSTs from exhausting node memory (10k × 8 MiB
+	// = 80 GB worst case without this). Required > 0 when serverless
+	// is on.
+	HTTPWakeMaxBufferBytesGlobal int64
 	SSHListenAddr                string
 	SSHHostKeyPath               string
 	CredentialEncryptionKey      string
@@ -567,6 +583,9 @@ func Load() (Config, error) {
 		L4WakeMaxActiveGlobal:        getEnvInt("SB_L4_WAKE_MAX_ACTIVE_GLOBAL", 65536),
 		HTTPWakeMaxBuffer:            int64(getEnvInt("SB_HTTP_WAKE_MAX_BUFFER", 8*1024*1024)),
 		HTTPWakeUpstreamReadyTimeout: getEnvDuration("SB_HTTP_WAKE_UPSTREAM_READY_TIMEOUT", 30*time.Second),
+		HTTPWakeMaxPendingPerSandbox: getEnvInt("SB_HTTP_WAKE_MAX_PENDING_PER_SANDBOX", 256),
+		HTTPWakeMaxPendingGlobal:     getEnvInt("SB_HTTP_WAKE_MAX_PENDING_GLOBAL", 4096),
+		HTTPWakeMaxBufferBytesGlobal: int64(getEnvInt("SB_HTTP_WAKE_MAX_BUFFER_GLOBAL", 1024*1024*1024)),
 		SSHListenAddr:                getEnv("SB_SSH_LISTEN_ADDR", "0.0.0.0:2220"),
 		SSHHostKeyPath:               getEnv("SB_SSH_HOST_KEY_PATH", "/var/lib/sandboxd/ssh_host_ed25519_key"),
 		CredentialEncryptionKey:      strings.TrimSpace(os.Getenv("SB_CREDENTIAL_ENCRYPTION_KEY")),
@@ -873,6 +892,15 @@ func Load() (Config, error) {
 		}
 		if cfg.HTTPWakeMaxBuffer <= 0 {
 			return Config{}, errors.New("SB_HTTP_WAKE_MAX_BUFFER must be > 0 when SB_ENABLE_SERVERLESS=true")
+		}
+		if cfg.HTTPWakeMaxPendingPerSandbox <= 0 {
+			return Config{}, errors.New("SB_HTTP_WAKE_MAX_PENDING_PER_SANDBOX must be > 0 when SB_ENABLE_SERVERLESS=true")
+		}
+		if cfg.HTTPWakeMaxPendingGlobal <= 0 {
+			return Config{}, errors.New("SB_HTTP_WAKE_MAX_PENDING_GLOBAL must be > 0 when SB_ENABLE_SERVERLESS=true")
+		}
+		if cfg.HTTPWakeMaxBufferBytesGlobal <= 0 {
+			return Config{}, errors.New("SB_HTTP_WAKE_MAX_BUFFER_GLOBAL must be > 0 when SB_ENABLE_SERVERLESS=true")
 		}
 	}
 

--- a/internal/service/events.go
+++ b/internal/service/events.go
@@ -137,6 +137,13 @@ func (s *Service) handleDockerEvent(ctx context.Context, event docker.DockerEven
 func (s *Service) markSandboxStopped(ctx context.Context, sandbox *models.Sandbox, event docker.DockerEvent) error {
 	previousIP := sandbox.ContainerIP
 
+	// Invalidate the warm-preflight cache the moment we observe the
+	// stop event — this is the tightest possible signal that the
+	// sandbox is no longer Started, since the Docker /events stream
+	// surfaces die/stop/oom sub-second after the container actually
+	// exits. The ingress proxy's IsSandboxStarted hot path will fall
+	// through to SQLite from here on for this id.
+	s.invalidateWarm(sandbox.ID)
 	mode := s.classifyDockerStopEvent(sandbox.ID, event)
 	arm := s.shouldArmWake(sandbox, mode)
 
@@ -198,6 +205,10 @@ func (s *Service) markSandboxStopped(ctx context.Context, sandbox *models.Sandbo
 // stuck indefinitely.
 func (s *Service) handleDestroyEvent(ctx context.Context, sandbox *models.Sandbox) error {
 	previousIP := sandbox.ContainerIP
+
+	// Mirror the API DestroySandbox path: drop the warm-preflight cache
+	// so the ingress proxy stops treating this id as Started.
+	s.invalidateWarm(sandbox.ID)
 
 	// Best-effort teardown. Order matches DestroySandbox (caddy → mounts →
 	// store.Delete → admitter → maybeRemoveImage); container destroy is

--- a/internal/service/l4wake.go
+++ b/internal/service/l4wake.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/aerol-ai/microvm/pkg/models"
@@ -20,6 +21,18 @@ const (
 	l4WakeProxyHeaderMaxBytes = 256
 	l4WakeDialTimeout         = 10 * time.Second
 	l4WakeActivityInterval    = 30 * time.Second
+	// l4WakeUpstreamReadyTimeout bounds how long we keep retrying the
+	// upstream dial on ECONNREFUSED after wake. WakeAwareL4PortTarget
+	// returns as soon as the container is running, but the user's TCP
+	// process inside (SOCKS5 server, database, etc.) typically needs
+	// another moment to bind its listening port. Without retry the
+	// kernel returns ECONNREFUSED instantly and the client connection
+	// is closed. 30s leaves headroom for slow framework boots.
+	l4WakeUpstreamReadyTimeout = 30 * time.Second
+	// l4WakeUpstreamReadyBackoffStart / Max bound the retry cadence
+	// during the readiness window; matches the HTTP ingress probe.
+	l4WakeUpstreamReadyBackoffStart = 100 * time.Millisecond
+	l4WakeUpstreamReadyBackoffMax   = 1 * time.Second
 
 	defaultL4WakeMaxPendingPerSandbox = 256
 	defaultL4WakeMaxPendingGlobal     = 4096
@@ -143,6 +156,54 @@ func (s *Service) WakeAwareL4PortTarget(ctx context.Context, id string, port int
 	return net.JoinHostPort(sandbox.ContainerIP, strconv.Itoa(port)), nil
 }
 
+// dialL4Upstream connects to addr with retry on ECONNREFUSED. This is
+// the L4 counterpart to the HTTP ingress upstream-readiness probe: the
+// wake helper returns as soon as Docker reports the container running,
+// but the user's TCP process (SOCKS5 server, database, etc.) typically
+// needs another second or two to bind its listening port. A single
+// dial fails immediately on the kernel RST and the caller's connection
+// closes. We retry only on the "not bound yet" signal — any other
+// error (network unreachable, context cancel, DNS) returns
+// immediately. Overridable in tests.
+var dialL4Upstream = func(ctx context.Context, addr string, budget time.Duration) (net.Conn, error) {
+	deadline := time.Now().Add(budget)
+	dialCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+
+	delay := l4WakeUpstreamReadyBackoffStart
+	var lastErr error
+	for {
+		if err := dialCtx.Err(); err != nil {
+			if lastErr != nil {
+				return nil, lastErr
+			}
+			return nil, err
+		}
+		dialer := net.Dialer{Timeout: l4WakeDialTimeout}
+		conn, err := dialer.DialContext(dialCtx, "tcp", addr)
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+		// Retry only on connection refused — the kernel's "port not
+		// bound yet" signal. Anything else is a real failure.
+		if !errors.Is(err, syscall.ECONNREFUSED) {
+			return nil, err
+		}
+		select {
+		case <-dialCtx.Done():
+			return nil, lastErr
+		case <-time.After(delay):
+		}
+		if delay < l4WakeUpstreamReadyBackoffMax {
+			delay *= 2
+			if delay > l4WakeUpstreamReadyBackoffMax {
+				delay = l4WakeUpstreamReadyBackoffMax
+			}
+		}
+	}
+}
+
 func (s *Service) proxyL4WakeConn(ctx context.Context, id string, port int, downstream net.Conn, buffered *bufio.Reader) {
 	releasePending, ok := s.tryAcquireL4Pending(id)
 	if !ok {
@@ -163,7 +224,7 @@ func (s *Service) proxyL4WakeConn(ctx context.Context, id string, port int, down
 	}
 	defer releaseActive()
 
-	upstream, err := net.DialTimeout("tcp", target, l4WakeDialTimeout)
+	upstream, err := dialL4Upstream(ctx, target, l4WakeUpstreamReadyTimeout)
 	if err != nil {
 		s.logger.Warn("dial l4 wake upstream failed", "sandbox_id", id, "port", port, "target", target, "error", err)
 		return

--- a/internal/service/l4wake.go
+++ b/internal/service/l4wake.go
@@ -6,12 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"net"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/aerol-ai/microvm/pkg/models"
@@ -156,21 +156,30 @@ func (s *Service) WakeAwareL4PortTarget(ctx context.Context, id string, port int
 	return net.JoinHostPort(sandbox.ContainerIP, strconv.Itoa(port)), nil
 }
 
-// dialL4Upstream connects to addr with retry on ECONNREFUSED. This is
-// the L4 counterpart to the HTTP ingress upstream-readiness probe: the
-// wake helper returns as soon as Docker reports the container running,
-// but the user's TCP process (SOCKS5 server, database, etc.) typically
-// needs another second or two to bind its listening port. A single
-// dial fails immediately on the kernel RST and the caller's connection
-// closes. We retry only on the "not bound yet" signal — any other
-// error (network unreachable, context cancel, DNS) returns
-// immediately. Overridable in tests.
+// dialL4Upstream connects to addr with retry on any transient dial
+// error. This is the L4 counterpart to the HTTP ingress upstream
+// readiness probe: the wake helper returns as soon as Docker reports
+// the container running, but the user's TCP process (SOCKS5 server,
+// database, etc.) typically needs another second or two to bind its
+// listening port. A single dial fails immediately on the kernel RST
+// and the caller's connection closes.
+//
+// Retries on any error except caller cancellation / deadline. Docker
+// bridge networks during container start can briefly emit
+// EHOSTUNREACH, ENETUNREACH, or ECONNRESET in addition to the usual
+// ECONNREFUSED — narrowing the retry to only ECONNREFUSED would
+// surface those races to the client. Initial backoff carries 0-50ms
+// jitter so a convoy of waiters released by one wake doesn't all
+// dial in lockstep. Overridable in tests.
 var dialL4Upstream = func(ctx context.Context, addr string, budget time.Duration) (net.Conn, error) {
 	deadline := time.Now().Add(budget)
 	dialCtx, cancel := context.WithDeadline(ctx, deadline)
 	defer cancel()
 
-	delay := l4WakeUpstreamReadyBackoffStart
+	// Jitter the initial delay so 10k waiters released by a wake do
+	// not all dial at exactly t+100ms. math/rand global is
+	// concurrent-safe since Go 1.20.
+	delay := l4WakeUpstreamReadyBackoffStart + time.Duration(rand.Int63n(int64(50*time.Millisecond)))
 	var lastErr error
 	for {
 		if err := dialCtx.Err(); err != nil {
@@ -184,12 +193,13 @@ var dialL4Upstream = func(ctx context.Context, addr string, budget time.Duration
 		if err == nil {
 			return conn, nil
 		}
-		lastErr = err
-		// Retry only on connection refused — the kernel's "port not
-		// bound yet" signal. Anything else is a real failure.
-		if !errors.Is(err, syscall.ECONNREFUSED) {
+		// Caller cancellation / deadline are terminal — don't keep
+		// dialling against a dead caller. Everything else is treated
+		// as the "container is up but service not bound yet" signal.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, err
 		}
+		lastErr = err
 		select {
 		case <-dialCtx.Done():
 			return nil, lastErr

--- a/internal/service/l4wake_dial_test.go
+++ b/internal/service/l4wake_dial_test.go
@@ -1,0 +1,108 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"net"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestDialL4UpstreamRetriesOnConnRefused: the kernel returns ECONNREFUSED
+// instantly when a port is not bound, so a single dial races the
+// in-container process bind on every cold start. The retry helper must
+// keep trying until the listener accepts or the budget runs out.
+//
+// Mirrors the HTTP ingress upstream-readiness probe so raw-TCP and
+// TLS-SNI L4 routes do not 502 their callers when an idle-stopped
+// sandbox is waking.
+func TestDialL4UpstreamRetriesOnConnRefused(t *testing.T) {
+	// Reserve a port without listening, so dials get ECONNREFUSED.
+	scout, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("scout listen: %v", err)
+	}
+	addr := scout.Addr().String()
+	_ = scout.Close()
+
+	// Start the real listener ~150ms later, modelling the cold-start
+	// gap between Docker reporting "running" and the user's process
+	// binding its port.
+	listenerUp := make(chan struct{})
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		ln, err := net.Listen("tcp", addr)
+		if err != nil {
+			t.Errorf("late listen: %v", err)
+			close(listenerUp)
+			return
+		}
+		t.Cleanup(func() { _ = ln.Close() })
+		close(listenerUp)
+		// Keep accepting so the dial completes cleanly.
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = c.Close()
+		}
+	}()
+
+	start := time.Now()
+	conn, err := dialL4Upstream(context.Background(), addr, 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	_ = conn.Close()
+	<-listenerUp
+	if elapsed := time.Since(start); elapsed < 100*time.Millisecond {
+		t.Fatalf("dial returned in %v — should have waited for listener to come up", elapsed)
+	}
+}
+
+// TestDialL4UpstreamReturnsLastErrOnTimeout: when the port never binds
+// within the readiness window, the helper must surface the underlying
+// ECONNREFUSED rather than swallow it as a deadline error so the
+// "dial l4 wake upstream failed" log line stays diagnostic.
+func TestDialL4UpstreamReturnsLastErrOnTimeout(t *testing.T) {
+	scout, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("scout: %v", err)
+	}
+	addr := scout.Addr().String()
+	_ = scout.Close()
+
+	_, err = dialL4Upstream(context.Background(), addr, 200*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, syscall.ECONNREFUSED) {
+		t.Fatalf("error = %v, want ECONNREFUSED", err)
+	}
+}
+
+// TestDialL4UpstreamBailsOnCancelledContext: a cancelled caller
+// context must surface immediately — the readiness retry must not
+// keep dialling against a dead caller.
+func TestDialL4UpstreamBailsOnCancelledContext(t *testing.T) {
+	scout, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("scout: %v", err)
+	}
+	addr := scout.Addr().String()
+	_ = scout.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err = dialL4Upstream(ctx, addr, 5*time.Second)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("dial took %v with cancelled context — should bail fast", elapsed)
+	}
+}

--- a/internal/service/serverless.go
+++ b/internal/service/serverless.go
@@ -144,6 +144,13 @@ func (s *Service) stopSandboxInternal(ctx context.Context, id string, mode stopM
 		return nil, err
 	}
 
+	// Drop the warm-preflight cache up front. From this moment on the
+	// ingress proxy must take the slow path (store hit → cold-start
+	// admission) for this sandbox; any in-flight request that fast-
+	// pathed before we invalidate races the actual stop, but the
+	// readiness probe / proxy error handler turn that into the same
+	// 503+Retry-After the cold-start race already produces.
+	s.invalidateWarm(id)
 	arm := s.shouldArmWake(sandbox, mode)
 	s.recordExpectedStop(id, mode)
 
@@ -500,7 +507,27 @@ func (s *Service) EnsureSandboxAwakeForHTTP(ctx context.Context, id string) (*mo
 
 	startCtx, cancel := context.WithTimeout(ctx, wakeStartTimeout)
 	defer cancel()
+
+	// Acquire a cross-sandbox start slot AFTER the per-sandbox flight
+	// lock but BEFORE invoking StartSandbox. Holding flight.mu while
+	// waiting on the sem is safe: same-id waiters are already blocked
+	// on flight.mu and will be served by the cached result of this
+	// leader's start; the sem only serializes against starts for OTHER
+	// sandbox ids. Without this, the pending caps (HTTP+L4 ~8k combined)
+	// can release up to that many concurrent first-call wakes that all
+	// hit Docker /containers/create + /start and the Caddy admin API
+	// in lockstep.
+	releaseSem, semErr := s.acquireWakeStartSlot(startCtx)
+	if semErr != nil {
+		// Caller context cancelled or wake budget elapsed before a slot
+		// became available. Treat as a wake failure for the breaker so
+		// repeated sem starvation eventually trips the circuit.
+		flight.recordFailure(time.Now())
+		finish(true, semErr)
+		return nil, semErr
+	}
 	started, startErr := s.StartSandbox(startCtx, id)
+	releaseSem()
 	if startErr != nil {
 		flight.recordFailure(time.Now())
 		finish(true, startErr)

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -141,6 +141,37 @@ type Service struct {
 	wakeFlightsMu sync.Mutex
 	wakeFlights   map[string]*wakeFlight
 
+	// wakeStartSem caps concurrent wake-driven StartSandbox calls
+	// across all sandboxes on this node. Per-sandbox single-flight
+	// (wakeFlights) already collapses same-id duplicates; this protects
+	// against cross-id storms — without it, the pending caps still admit
+	// up to ~8k different sandboxes into their cold-start window at once,
+	// and they all hit Docker create / start and Caddy admin in lockstep.
+	// Buffered chan; capacity = cfg.WakeStartConcurrency at init. Lazily
+	// created via wakeStartSemOnce so test harnesses building &Service{}
+	// directly need no rewiring. Operator-initiated StartSandbox (API
+	// surface) bypasses this — only the wake helper acquires.
+	wakeStartSem     chan struct{}
+	wakeStartSemOnce sync.Once
+
+	// warmCache is the short-TTL in-memory cache fronting IsSandboxStarted.
+	// Every warm serverless HTTP request currently pays a SQLite read here,
+	// and SQLite is single-writer in this process (MaxOpenConns=1), so at
+	// 100k QPS those reads serialize through one connection and become the
+	// bottleneck. The cache stores (id -> expiresAtUnixNano) for hits that
+	// were observed as Started; cold (Stopped/Destroyed/Error) results are
+	// NOT cached — only the hot path is optimized, and a cold sandbox
+	// always falls through to the source of truth. TTL is intentionally
+	// short (2s) so even an entirely missed invalidation self-heals
+	// quickly; we still install explicit invalidation hooks on every
+	// stop/destroy path to keep the staleness window sub-second under
+	// normal conditions. The worst-case failure of a stale-true hit is
+	// the proxy connecting to a not-yet-warm upstream and returning
+	// 503+Retry-After, which is identical to the cold-start race the
+	// readiness probe already handles.
+	warmCacheMu sync.RWMutex
+	warmCache   map[string]int64
+
 	// touchCoalescer debounces last_active_at flushes per sandbox so a
 	// burst of HTTP requests (wake-aware ingress proxy, toolbox/session/
 	// runtime proxies, SSH gateway) does not become one SQLite UPDATE
@@ -870,6 +901,7 @@ func (s *Service) StartSandbox(ctx context.Context, id string) (*models.Sandbox,
 		_ = s.mounts.UnmountAll(id)
 		releaseAdmission()
 		_ = s.store.UpdateStatus(ctx, id, models.SandboxStatusError, err.Error())
+		s.invalidateWarm(id)
 		return nil, err
 	}
 
@@ -911,6 +943,13 @@ func (s *Service) StartSandbox(ctx context.Context, id string) (*models.Sandbox,
 		return nil, err
 	}
 	s.syncAllowedPorts(ctx, refreshed)
+	// Populate the warm-preflight cache so the convoy of HTTP requests
+	// released by this wake skips the SQLite preflight on the way to
+	// the now-warm upstream. invalidateWarm fires from every stop /
+	// destroy path so a later transition out of Started invalidates.
+	if refreshed.Status == models.SandboxStatusStarted {
+		s.warmCacheSet(id)
+	}
 	return refreshed, nil
 }
 
@@ -942,6 +981,7 @@ func (s *Service) DestroySandbox(ctx context.Context, id string) error {
 		return err
 	}
 	s.forgetWakeFlight(id)
+	s.invalidateWarm(id)
 	if err := s.DeleteClusterSecrets(ctx, id); err != nil {
 		return err
 	}
@@ -1896,12 +1936,89 @@ func (s *Service) TouchSandbox(ctx context.Context, id string) error {
 // Started; any other status (Stopped, Destroyed, in-flight create)
 // returns (false, nil). store.ErrNotFound is returned unwrapped so the
 // proxy can map it to 404 without a second store hit.
+//
+// Hot path: a short-TTL cache (warmCache) lets repeated warm requests
+// to the same sandbox skip the SQLite read. The cache holds positives
+// only ("seen Started in the last warmCacheTTL"); a miss always falls
+// through to s.store.Get so cold/stopped/destroyed sandboxes never
+// short-circuit. Lifecycle transitions (StartSandbox success, every
+// stop path, every destroy path) explicitly invalidate the entry.
 func (s *Service) IsSandboxStarted(ctx context.Context, id string) (bool, error) {
+	if s.warmCacheHit(id) {
+		return true, nil
+	}
 	sb, err := s.store.Get(ctx, id)
 	if err != nil {
 		return false, err
 	}
-	return sb.Status == models.SandboxStatusStarted, nil
+	started := sb.Status == models.SandboxStatusStarted
+	if started {
+		s.warmCacheSet(id)
+	}
+	return started, nil
+}
+
+// warmCacheTTL is intentionally short (2s) so an entirely-missed
+// invalidation self-heals fast. The explicit invalidation hooks below
+// keep the normal staleness window sub-second; the TTL is the backstop
+// for the pathological case where an invalidation never fires.
+const warmCacheTTL = 2 * time.Second
+
+func (s *Service) warmCacheHit(id string) bool {
+	s.warmCacheMu.RLock()
+	exp, ok := s.warmCache[id]
+	s.warmCacheMu.RUnlock()
+	if !ok {
+		return false
+	}
+	return time.Now().UnixNano() < exp
+}
+
+func (s *Service) warmCacheSet(id string) {
+	exp := time.Now().Add(warmCacheTTL).UnixNano()
+	s.warmCacheMu.Lock()
+	if s.warmCache == nil {
+		s.warmCache = make(map[string]int64)
+	}
+	s.warmCache[id] = exp
+	s.warmCacheMu.Unlock()
+}
+
+// invalidateWarm drops id from the warm cache. Called from every state
+// transition that takes a sandbox out of Started: StartSandbox failure
+// paths, every stop path (manual, lifecycle, involuntary die/oom), and
+// every destroy path. Safe on a missing key.
+func (s *Service) invalidateWarm(id string) {
+	s.warmCacheMu.Lock()
+	delete(s.warmCache, id)
+	s.warmCacheMu.Unlock()
+}
+
+// acquireWakeStartSlot caps concurrent wake-driven StartSandbox
+// invocations across the node. Returns a release closure on success;
+// returns ctx.Err() if the caller's context is cancelled before a slot
+// becomes available. Lazily sized from cfg.WakeStartConcurrency on
+// first use so test harnesses (newCapacityHarness, cluster fixtures)
+// that build &Service{} directly don't have to thread the value
+// through. A zero or negative cfg value disables the cap entirely
+// (unbounded chan via nil send branch) to preserve pre-feature
+// behavior for tests.
+func (s *Service) acquireWakeStartSlot(ctx context.Context) (func(), error) {
+	s.wakeStartSemOnce.Do(func() {
+		cap := s.cfg.WakeStartConcurrency
+		if cap > 0 {
+			s.wakeStartSem = make(chan struct{}, cap)
+		}
+	})
+	if s.wakeStartSem == nil {
+		return func() {}, nil
+	}
+	select {
+	case s.wakeStartSem <- struct{}{}:
+		return func() { <-s.wakeStartSem }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 func (s *Service) Health(ctx context.Context) (models.HealthStatus, error) {

--- a/internal/service/wake_scale_test.go
+++ b/internal/service/wake_scale_test.go
@@ -1,0 +1,206 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/config"
+)
+
+// TestAcquireWakeStartSlotCapsConcurrency: with cfg.WakeStartConcurrency=2,
+// only 2 callers may hold a slot at once. The third must block until one
+// release fires. Without the cap, concurrent wakes for different sandboxes
+// would all hit Docker create/start + Caddy admin in lockstep — the storm
+// this guard exists to prevent.
+func TestAcquireWakeStartSlotCapsConcurrency(t *testing.T) {
+	svc := &Service{cfg: config.Config{WakeStartConcurrency: 2}}
+
+	r1, err := svc.acquireWakeStartSlot(context.Background())
+	if err != nil {
+		t.Fatalf("acquire 1: %v", err)
+	}
+	r2, err := svc.acquireWakeStartSlot(context.Background())
+	if err != nil {
+		t.Fatalf("acquire 2: %v", err)
+	}
+
+	// Third acquire must block: prove it by racing against a 50ms ctx.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if _, err := svc.acquireWakeStartSlot(ctx); err == nil {
+		t.Fatal("third acquire returned nil; expected ctx.DeadlineExceeded")
+	} else if err != context.DeadlineExceeded {
+		t.Fatalf("third acquire err = %v, want DeadlineExceeded", err)
+	}
+
+	// Releasing one slot unblocks a fresh acquire.
+	r1()
+	done := make(chan error, 1)
+	go func() {
+		_, e := svc.acquireWakeStartSlot(context.Background())
+		done <- e
+	}()
+	select {
+	case e := <-done:
+		if e != nil {
+			t.Fatalf("acquire after release: %v", e)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("acquire did not unblock after release")
+	}
+	r2()
+}
+
+// TestAcquireWakeStartSlotZeroCfgIsUnbounded: a zero or negative cfg value
+// disables the cap entirely. Test harnesses building &Service{} without
+// config rely on this — they never need to thread the new field through.
+func TestAcquireWakeStartSlotZeroCfgIsUnbounded(t *testing.T) {
+	svc := &Service{cfg: config.Config{WakeStartConcurrency: 0}}
+
+	for i := 0; i < 1000; i++ {
+		release, err := svc.acquireWakeStartSlot(context.Background())
+		if err != nil {
+			t.Fatalf("acquire %d: %v", i, err)
+		}
+		release()
+	}
+}
+
+// TestAcquireWakeStartSlotConcurrentNeverExceedsCap: under contention, the
+// in-flight count never crosses cfg.WakeStartConcurrency. This is the
+// invariant the sem protects in production — without it, the pending caps
+// can release thousands of concurrent cross-id starts.
+func TestAcquireWakeStartSlotConcurrentNeverExceedsCap(t *testing.T) {
+	const (
+		cap     = 4
+		workers = 200
+		holdNS  = int64(2 * time.Millisecond)
+	)
+	svc := &Service{cfg: config.Config{WakeStartConcurrency: cap}}
+
+	var (
+		inFlight atomic.Int64
+		maxSeen  atomic.Int64
+		wg       sync.WaitGroup
+	)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			release, err := svc.acquireWakeStartSlot(context.Background())
+			if err != nil {
+				t.Errorf("acquire: %v", err)
+				return
+			}
+			cur := inFlight.Add(1)
+			for {
+				prev := maxSeen.Load()
+				if cur <= prev || maxSeen.CompareAndSwap(prev, cur) {
+					break
+				}
+			}
+			time.Sleep(time.Duration(holdNS))
+			inFlight.Add(-1)
+			release()
+		}()
+	}
+	wg.Wait()
+	if got := maxSeen.Load(); got > int64(cap) {
+		t.Fatalf("max in-flight = %d, cap = %d (sem allowed over-subscription)", got, cap)
+	}
+}
+
+// TestWarmCacheHitsBeforeExpiry: a warmCacheSet entry is observable from
+// warmCacheHit until warmCacheTTL elapses; the hot path uses this to skip
+// the SQLite preflight on repeated warm requests to the same sandbox.
+func TestWarmCacheHitsBeforeExpiry(t *testing.T) {
+	svc := &Service{}
+	svc.warmCacheSet("sb-hot")
+	if !svc.warmCacheHit("sb-hot") {
+		t.Fatal("warmCacheHit returned false immediately after set")
+	}
+	if svc.warmCacheHit("sb-cold") {
+		t.Fatal("warmCacheHit returned true for an id never set")
+	}
+}
+
+// TestWarmCacheInvalidateClearsEntry: invalidateWarm must drop the entry
+// so a stop/destroy transition is reflected on the very next call. This
+// is the strict-invalidation guarantee that makes a stale-true hit a
+// sub-second window under normal event-stream latency.
+func TestWarmCacheInvalidateClearsEntry(t *testing.T) {
+	svc := &Service{}
+	svc.warmCacheSet("sb-1")
+	if !svc.warmCacheHit("sb-1") {
+		t.Fatal("set did not register")
+	}
+	svc.invalidateWarm("sb-1")
+	if svc.warmCacheHit("sb-1") {
+		t.Fatal("warmCacheHit still true after invalidateWarm")
+	}
+}
+
+// TestWarmCacheExpiresAfterTTL: even with no explicit invalidation, the
+// 2s TTL self-heals. We don't sleep the full TTL here — instead we plant
+// a synthetic past expiry directly to keep the test fast and
+// deterministic.
+func TestWarmCacheExpiresAfterTTL(t *testing.T) {
+	svc := &Service{}
+	svc.warmCacheMu.Lock()
+	svc.warmCache = map[string]int64{
+		"sb-stale": time.Now().Add(-1 * time.Second).UnixNano(),
+	}
+	svc.warmCacheMu.Unlock()
+	if svc.warmCacheHit("sb-stale") {
+		t.Fatal("warmCacheHit returned true for an entry whose expiry has passed")
+	}
+}
+
+// TestWarmCacheConcurrentReadsAndInvalidate: the cache is hit on every
+// warm request, so reads must not block each other and a writer
+// (invalidate / set) must not deadlock with them. This is a smoke test
+// for the RWMutex usage — it would race-detect or deadlock if reads
+// were exclusive or if a Set held the read side.
+func TestWarmCacheConcurrentReadsAndInvalidate(t *testing.T) {
+	svc := &Service{}
+	for i := 0; i < 16; i++ {
+		svc.warmCacheSet(toKey(i))
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = svc.warmCacheHit(toKey(id))
+				}
+			}
+		}(i)
+	}
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				svc.warmCacheSet(toKey(id))
+				svc.invalidateWarm(toKey(id))
+			}
+		}(i)
+	}
+	time.Sleep(20 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
+
+func toKey(i int) string {
+	return "sb-" + string(rune('a'+i%26))
+}

--- a/packaging/sandboxd.service
+++ b/packaging/sandboxd.service
@@ -15,6 +15,12 @@ ExecStart=/usr/local/bin/sandboxd
 MountFlags=shared
 Restart=always
 RestartSec=5
+# At scale (~10k concurrent serverless wakes), sandboxd holds many FDs:
+# every pending HTTP request holds a downstream conn + probe socket
+# during the cold-start window, and every L4 wake holds a similar pair.
+# 1 M is the Linux soft default for systemd units and is well within
+# kernel-side caps.
+LimitNOFILE=1048576
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/api/ingressproxy/handlers.go
+++ b/pkg/api/ingressproxy/handlers.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -76,7 +77,59 @@ func (h *handlers) httpWake(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Admission control on the cold-start path only. Warm requests pass
+	// straight through — they don't hold a wake slot and behave like a
+	// plain reverse proxy. The slot is released as soon as the readiness
+	// probe finishes (or fails); we do NOT keep it across the proxy hop,
+	// since at that point the sandbox is indistinguishable from a warm
+	// backend and shouldn't count against the wake-window budget.
+	var releasePending func()
+	if !started {
+		release, admitErr := h.state.acquirePending(id)
+		if admitErr != nil {
+			h.deps.Logger.Warn("wake admission rejected",
+				"sandbox_id", id, "port", port, "reason", admitErr.Error())
+			w.Header().Set("Retry-After", "2")
+			apihttp.WriteError(w, http.StatusServiceUnavailable, admitErr.Error())
+			return
+		}
+		releasePending = release
+		// Failsafe — if any branch below forgets to release, defer
+		// catches it on return. The closure is idempotent.
+		defer func() {
+			if releasePending != nil {
+				releasePending()
+			}
+		}()
+	}
+
 	if !started && !isUpgrade && r.Body != nil && r.ContentLength != 0 {
+		// Reserve from the global byte budget BEFORE buffering, so a
+		// flood of concurrent cold POSTs can't pin >cap bytes. The
+		// per-request cap (MaxBufferBytes) still applies; this is the
+		// cross-request cap. Use the declared ContentLength as the
+		// reservation when known; fall back to MaxBufferBytes when
+		// unknown (-1) since that's the upper bound bufferBody can
+		// produce.
+		reserve := r.ContentLength
+		if reserve < 0 || reserve > h.deps.MaxBufferBytes {
+			reserve = h.deps.MaxBufferBytes
+		}
+		releaseBuf, budgetErr := h.state.acquireBuffer(reserve)
+		if budgetErr != nil {
+			h.deps.Logger.Warn("wake buffer budget rejected",
+				"sandbox_id", id, "port", port,
+				"requested_bytes", reserve, "reason", budgetErr.Error())
+			w.Header().Set("Retry-After", "2")
+			apihttp.WriteError(w, http.StatusServiceUnavailable, budgetErr.Error())
+			return
+		}
+		// Hold the budget until the handler returns; the proxy reads
+		// from the in-memory buffer during ServeHTTP, so releasing
+		// earlier would let the global counter undershoot the real
+		// memory footprint.
+		defer releaseBuf()
+
 		buf, err := bufferBody(r.Body, h.deps.MaxBufferBytes)
 		if err != nil {
 			if errors.Is(err, errBodyTooLarge) {
@@ -115,21 +168,34 @@ func (h *handlers) httpWake(w http.ResponseWriter, r *http.Request) {
 	// We hold the caller's connection until the upstream accepts a TCP
 	// connection or the readiness budget is exhausted.
 	//
-	// Skipped when the sandbox was already started at preflight — a warm
-	// upstream is by definition already listening, and adding a dial-probe
-	// to every warm request would cost an extra round-trip per call.
+	// Single-flighted per (sandbox, port): 10k concurrent waiters
+	// produce one probe loop, not 10k. Skipped when the sandbox was
+	// already started at preflight — a warm upstream is by definition
+	// already listening.
 	if !started {
 		readyTimeout := h.deps.UpstreamReadyTimeout
 		if readyTimeout <= 0 {
 			readyTimeout = defaultUpstreamReadyTimeout
 		}
-		if err := waitForUpstreamReady(r.Context(), target.Host, readyTimeout); err != nil {
+		probeErr := h.state.probeOnce(r.Context(), id, port, readyTimeout,
+			func(probeCtx context.Context, budget time.Duration) error {
+				return waitForUpstreamReady(probeCtx, target.Host, budget)
+			})
+		if probeErr != nil {
 			h.deps.Logger.Warn("upstream not ready after wake",
-				"sandbox_id", id, "port", port, "error", err)
+				"sandbox_id", id, "port", port, "error", probeErr)
 			w.Header().Set("Retry-After", "2")
 			apihttp.WriteError(w, http.StatusServiceUnavailable, "sandbox upstream not ready")
 			return
 		}
+	}
+
+	// Release the pending slot now: probe is done, sandbox is warm,
+	// the rest of the request is just a reverse proxy hop. Setting
+	// the local handle to nil prevents the defer from double-releasing.
+	if releasePending != nil {
+		releasePending()
+		releasePending = nil
 	}
 
 	// Reconstruct the path the user originally requested. Caddy rewrote
@@ -185,29 +251,47 @@ func (h *handlers) httpWake(w http.ResponseWriter, r *http.Request) {
 // overall budget elapses. Returns nil as soon as a connection succeeds
 // (closed immediately). Returns the last dial error on budget timeout.
 //
-// Backoff starts at 100ms and doubles to a 1s cap. A typical
-// framework-process boot (Node, Python) takes 1-5 seconds, so the
-// first few retries are tight; the cap prevents busy-looping once
-// the boot drags into the multi-second range.
+// Backoff starts at 100ms (with up to 50ms jitter to spread SYN bursts
+// when many waiters converge on the same upstream simultaneously) and
+// doubles to a 1s cap. A typical framework-process boot (Node, Python)
+// takes 1-5 seconds, so the first few retries are tight; the cap
+// prevents busy-looping once the boot drags into the multi-second
+// range.
+//
+// Retries on any dial error except caller cancellation / deadline.
+// Docker bridge networks during container start can briefly emit
+// EHOSTUNREACH, ENETUNREACH, or ECONNRESET in addition to the usual
+// ECONNREFUSED — narrowing the retry to only ECONNREFUSED would
+// surface those races to the client as immediate failures.
 func waitForUpstreamReady(ctx context.Context, addr string, budget time.Duration) error {
 	deadline := time.Now().Add(budget)
 	probeCtx, cancel := context.WithDeadline(ctx, deadline)
 	defer cancel()
 
-	delay := 100 * time.Millisecond
+	// Per-call jitter on the very first delay (0-50 ms) so 10k waiters
+	// released by a single wake don't all dial at exactly t+100ms.
+	// Uses the global math/rand source — concurrent-safe since Go 1.20.
+	delay := 100*time.Millisecond + time.Duration(rand.Int63n(int64(50*time.Millisecond)))
 	const maxDelay = 1 * time.Second
 	var lastErr error
 	for {
-		if probeCtx.Err() != nil {
+		if err := probeCtx.Err(); err != nil {
 			if lastErr != nil {
 				return lastErr
 			}
-			return probeCtx.Err()
+			return err
 		}
 		conn, err := dialUpstream(probeCtx, addr)
 		if err == nil {
 			_ = conn.Close()
 			return nil
+		}
+		// Caller cancellation / deadline are terminal — don't keep
+		// dialling against a dead caller. Everything else (connection
+		// refused, host unreachable, reset by peer) is treated as the
+		// "container is up but service not bound yet" signal.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
 		}
 		lastErr = err
 		select {

--- a/pkg/api/ingressproxy/handlers.go
+++ b/pkg/api/ingressproxy/handlers.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -19,6 +20,12 @@ import (
 	"github.com/aerol-ai/microvm/pkg/api/apihttp"
 	"github.com/aerol-ai/microvm/pkg/capacity"
 )
+
+// dialUpstream is overridable in tests; in production it is net.Dialer.DialContext.
+var dialUpstream = func(ctx context.Context, addr string) (net.Conn, error) {
+	d := net.Dialer{Timeout: 2 * time.Second}
+	return d.DialContext(ctx, "tcp", addr)
+}
 
 // httpWake serves /__ingress/http/{id}/{port}[/{path...}]. The flow:
 //
@@ -100,6 +107,31 @@ func (h *handlers) httpWake(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Post-wake readiness probe. WakeAwarePortTarget returns as soon as
+	// Docker reports the container running, but the user's process inside
+	// (npm dev server, gunicorn, etc.) typically takes another moment to
+	// bind to its listening port. Without this hold the reverse proxy
+	// connects too early, gets ECONNREFUSED, and the client sees 502.
+	// We hold the caller's connection until the upstream accepts a TCP
+	// connection or the readiness budget is exhausted.
+	//
+	// Skipped when the sandbox was already started at preflight — a warm
+	// upstream is by definition already listening, and adding a dial-probe
+	// to every warm request would cost an extra round-trip per call.
+	if !started {
+		readyTimeout := h.deps.UpstreamReadyTimeout
+		if readyTimeout <= 0 {
+			readyTimeout = defaultUpstreamReadyTimeout
+		}
+		if err := waitForUpstreamReady(r.Context(), target.Host, readyTimeout); err != nil {
+			h.deps.Logger.Warn("upstream not ready after wake",
+				"sandbox_id", id, "port", port, "error", err)
+			w.Header().Set("Retry-After", "2")
+			apihttp.WriteError(w, http.StatusServiceUnavailable, "sandbox upstream not ready")
+			return
+		}
+	}
+
 	// Reconstruct the path the user originally requested. Caddy rewrote
 	// it to /__ingress/http/{id}/{port}{path}, so the captured {path}
 	// segment is the original path without its leading slash.
@@ -133,11 +165,63 @@ func (h *handlers) httpWake(w http.ResponseWriter, r *http.Request) {
 		// (SSE, chunked, long-poll) reach the client as the sandbox
 		// emits them.
 		FlushInterval: -1,
-		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, _ error) {
-			apihttp.WriteError(w, http.StatusBadGateway, "sandbox unavailable")
+		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
+			// Reached when the upstream resets / closes mid-request, or
+			// when a warm-bypass request raced an in-progress shutdown.
+			// Either way the failure is transient from the caller's view
+			// — surface 503 + Retry-After so clients and load balancers
+			// retry rather than treating it as a permanent gateway fault.
+			h.deps.Logger.Warn("proxy to sandbox upstream failed",
+				"sandbox_id", id, "port", port, "error", err)
+			w.Header().Set("Retry-After", "2")
+			apihttp.WriteError(w, http.StatusServiceUnavailable, "sandbox upstream unavailable")
 		},
 	}
 	proxy.ServeHTTP(w, r)
+}
+
+// waitForUpstreamReady polls addr (host:port) with TCP dials until it
+// accepts a connection, the caller's context is cancelled, or the
+// overall budget elapses. Returns nil as soon as a connection succeeds
+// (closed immediately). Returns the last dial error on budget timeout.
+//
+// Backoff starts at 100ms and doubles to a 1s cap. A typical
+// framework-process boot (Node, Python) takes 1-5 seconds, so the
+// first few retries are tight; the cap prevents busy-looping once
+// the boot drags into the multi-second range.
+func waitForUpstreamReady(ctx context.Context, addr string, budget time.Duration) error {
+	deadline := time.Now().Add(budget)
+	probeCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+
+	delay := 100 * time.Millisecond
+	const maxDelay = 1 * time.Second
+	var lastErr error
+	for {
+		if probeCtx.Err() != nil {
+			if lastErr != nil {
+				return lastErr
+			}
+			return probeCtx.Err()
+		}
+		conn, err := dialUpstream(probeCtx, addr)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		lastErr = err
+		select {
+		case <-probeCtx.Done():
+			return lastErr
+		case <-time.After(delay):
+		}
+		if delay < maxDelay {
+			delay *= 2
+			if delay > maxDelay {
+				delay = maxDelay
+			}
+		}
+	}
 }
 
 // writeWakeError maps a wake failure to the HTTP response the docs

--- a/pkg/api/ingressproxy/handlers_test.go
+++ b/pkg/api/ingressproxy/handlers_test.go
@@ -421,6 +421,131 @@ func TestHTTPWakeUnknownStartErrorReturns503(t *testing.T) {
 	}
 }
 
+// TestHTTPWakeHoldsUntilUpstreamPortReady: the in-container service
+// often takes another second or two to bind its TCP port after the
+// container itself reports running. The handler must hold the caller's
+// request through that gap (TCP-probe loop) instead of letting the
+// reverse proxy race the bind and emit a 502. Models a cold sandbox
+// (started=false default) whose upstream becomes available ~150ms
+// into the request — the handler should succeed, not 502.
+func TestHTTPWakeHoldsUntilUpstreamPortReady(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ready"))
+	}))
+	defer upstream.Close()
+
+	// Substitute a dialer that refuses connections for the first 150ms
+	// then delegates to the real net.Dialer. Models the container being
+	// up but the user's process not yet listening on the port.
+	prev := dialUpstream
+	t.Cleanup(func() { dialUpstream = prev })
+	start := time.Now()
+	dialUpstream = func(ctx context.Context, addr string) (net.Conn, error) {
+		if time.Since(start) < 150*time.Millisecond {
+			return nil, errors.New("connection refused")
+		}
+		var d net.Dialer
+		return d.DialContext(ctx, "tcp", addr)
+	}
+
+	resolver := &fakeResolver{target: upstream.URL}
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, Deps{
+		Resolver:             resolver,
+		Logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxBufferBytes:       1024,
+		UpstreamReadyTimeout: 2 * time.Second,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/__ingress/http/sb-cold/3000/api", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (probe should have held until upstream bound); body=%q", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != "ready" {
+		t.Fatalf("body = %q, want %q", got, "ready")
+	}
+}
+
+// TestHTTPWakeReturns503WhenUpstreamNeverReady: when the in-container
+// process never binds its port (or boots slower than the readiness
+// budget), the handler must surface 503 + Retry-After:2 rather than
+// holding the connection forever or returning the 502 the proxy's
+// ErrorHandler used to emit.
+func TestHTTPWakeReturns503WhenUpstreamNeverReady(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatalf("upstream should not be reached when port never binds")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	prev := dialUpstream
+	t.Cleanup(func() { dialUpstream = prev })
+	dialUpstream = func(_ context.Context, _ string) (net.Conn, error) {
+		return nil, errors.New("connection refused")
+	}
+
+	resolver := &fakeResolver{target: upstream.URL}
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, Deps{
+		Resolver:             resolver,
+		Logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxBufferBytes:       1024,
+		UpstreamReadyTimeout: 200 * time.Millisecond,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/__ingress/http/sb-stuck/3000/api", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body=%q", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Retry-After"); got != "2" {
+		t.Fatalf("Retry-After = %q, want 2", got)
+	}
+}
+
+// TestHTTPWakeWarmRequestSkipsReadinessProbe: a sandbox that was
+// already started at preflight is by definition listening — adding a
+// dial-probe to every warm request would cost a round-trip per call.
+// Models the warm path by setting a dialer that would block for 5s if
+// invoked; the test will fail (timeout or wrong status) if the probe
+// runs.
+func TestHTTPWakeWarmRequestSkipsReadinessProbe(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	prev := dialUpstream
+	t.Cleanup(func() { dialUpstream = prev })
+	dialUpstream = func(_ context.Context, _ string) (net.Conn, error) {
+		t.Fatalf("dialUpstream should not be called on the warm path")
+		return nil, errors.New("unreachable")
+	}
+
+	resolver := &fakeResolver{target: upstream.URL, started: true}
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, Deps{
+		Resolver:             resolver,
+		Logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxBufferBytes:       1024,
+		UpstreamReadyTimeout: 5 * time.Second,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/__ingress/http/sb-warm-skip/3000/api", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+}
+
 // TestHTTPWakeSSEResponseStreamsWithoutBuffering: D4 — FlushInterval=-1
 // must reach the client as upstream emits, even for slow streams. We
 // drive an upstream that flushes events spaced by 100ms and assert

--- a/pkg/api/ingressproxy/routes.go
+++ b/pkg/api/ingressproxy/routes.go
@@ -54,13 +54,29 @@ type PortResolver interface {
 // shrink it to run in <1s.
 var activityTickInterval = 30 * time.Second
 
+// defaultUpstreamReadyTimeout bounds how long the handler will hold a
+// caller's HTTP request after wake while polling the in-container
+// service's TCP port. The wake helper itself returns as soon as
+// StartSandbox reports the container is running, but the user's
+// process inside the container (npm dev server, gunicorn, etc.)
+// typically needs another few seconds to bind to its listening port.
+// Without this hold the reverse proxy connects too early, gets
+// ECONNREFUSED, and the ErrorHandler returns 502.
+//
+// 30s leaves headroom for slow framework boots (Rails, Spring) without
+// holding a client connection indefinitely. Operators can override via
+// Deps.UpstreamReadyTimeout if their workloads are slower.
+var defaultUpstreamReadyTimeout = 30 * time.Second
+
 // Deps wires the ingress proxy to the rest of the daemon. Resolver
 // is required; MaxBufferBytes caps how much request body is buffered
-// while a cold-start wake is in flight.
+// while a cold-start wake is in flight; UpstreamReadyTimeout bounds
+// the post-wake TCP-readiness probe (zero → defaultUpstreamReadyTimeout).
 type Deps struct {
-	Resolver       PortResolver
-	Logger         *slog.Logger
-	MaxBufferBytes int64
+	Resolver             PortResolver
+	Logger               *slog.Logger
+	MaxBufferBytes       int64
+	UpstreamReadyTimeout time.Duration
 }
 
 // RegisterRoutes mounts the ingress proxy routes onto mux. The mux is

--- a/pkg/api/ingressproxy/routes.go
+++ b/pkg/api/ingressproxy/routes.go
@@ -72,18 +72,30 @@ var defaultUpstreamReadyTimeout = 30 * time.Second
 // is required; MaxBufferBytes caps how much request body is buffered
 // while a cold-start wake is in flight; UpstreamReadyTimeout bounds
 // the post-wake TCP-readiness probe (zero → defaultUpstreamReadyTimeout).
+//
+// MaxPendingPerSandbox / MaxPendingGlobal / MaxBufferBytesGlobal cap
+// how many cold-start requests can simultaneously hold the wake window
+// and how much memory their buffered bodies may pin. Zero on any of
+// them disables that specific cap (intended for tests; production
+// wiring in cmd/sandboxd/main.go always sets all three).
 type Deps struct {
 	Resolver             PortResolver
 	Logger               *slog.Logger
 	MaxBufferBytes       int64
 	UpstreamReadyTimeout time.Duration
+	MaxPendingPerSandbox int
+	MaxPendingGlobal     int
+	MaxBufferBytesGlobal int64
 }
 
 // RegisterRoutes mounts the ingress proxy routes onto mux. The mux is
 // expected to be served on a loopback-only listener (see pkg/api/server
 // wiring in cmd/sandboxd/main.go).
 func RegisterRoutes(mux *http.ServeMux, d Deps) {
-	h := &handlers{deps: d}
+	h := &handlers{
+		deps:  d,
+		state: newProxyState(d.MaxPendingPerSandbox, d.MaxPendingGlobal, d.MaxBufferBytesGlobal),
+	}
 	// {path...} captures everything after /__ingress/http/{id}/{port}/.
 	// We register the prefix shape twice so that requests landing at
 	// /__ingress/http/{id}/{port} (no trailing path) still match.
@@ -92,5 +104,6 @@ func RegisterRoutes(mux *http.ServeMux, d Deps) {
 }
 
 type handlers struct {
-	deps Deps
+	deps  Deps
+	state *proxyState
 }

--- a/pkg/api/ingressproxy/state.go
+++ b/pkg/api/ingressproxy/state.go
@@ -1,0 +1,192 @@
+package ingressproxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// errAdmissionPerSandbox / errAdmissionGlobal / errBufferBudget are
+// the three admission-control rejections the handler maps to 503 +
+// Retry-After. They are distinguishable so logs and metrics can show
+// which limit fired without parsing message strings.
+var (
+	errAdmissionPerSandbox = errors.New("per-sandbox pending wake limit exceeded")
+	errAdmissionGlobal     = errors.New("global pending wake limit exceeded")
+	errBufferBudget        = errors.New("global wake buffer budget exhausted")
+)
+
+// proxyState holds the per-listener admission and single-flight state.
+// Embedded in handlers so every request shares the same counters.
+//
+// Two independent concerns:
+//
+//  1. Admission gating (pendingMu) — caps how many cold-start HTTP
+//     requests can simultaneously hold the wake + readiness window
+//     per sandbox and across the whole node. Mirrors the L4 admission
+//     scheme. Slots are released as soon as the readiness probe
+//     finishes; they do NOT cover the proxy hop itself, because at
+//     that point the sandbox is warm and behaves like any other
+//     reverse-proxy backend.
+//
+//  2. Probe single-flight (probeMu) — collapses 10k concurrent
+//     readiness probes for the same (sandbox, port) to one TCP dial
+//     loop with channel fan-out. The wake helper already
+//     single-flights StartSandbox; without this, the convoy that
+//     wake released would all dial the same container in lockstep.
+//
+//  3. Buffer-byte budget (bufferMu) — semaphore over the total bytes
+//     held in cold-start request buffers. Without this, 10k cold POSTs
+//     near MaxBufferBytes could pin >80 GB of memory.
+type proxyState struct {
+	pendingMu         sync.Mutex
+	pendingPerSandbox map[string]int
+	pendingGlobal     int
+	pendingPerCap     int
+	pendingGlobalCap  int
+
+	probeMu      sync.Mutex
+	probeFlights map[string]*probeFlight
+
+	bufferMu      sync.Mutex
+	bufferedBytes int64
+	bufferedCap   int64
+}
+
+// probeFlight is one in-flight readiness probe shared by all callers
+// converging on the same (sandbox, port). The leader runs the probe
+// with a detached context (so the leader's request cancellation does
+// not strand followers); followers select on done OR their own
+// caller context.
+type probeFlight struct {
+	done chan struct{}
+	err  error
+}
+
+func newProxyState(perSandboxCap, globalCap int, bufferCap int64) *proxyState {
+	return &proxyState{
+		pendingPerSandbox: make(map[string]int),
+		pendingPerCap:     perSandboxCap,
+		pendingGlobalCap:  globalCap,
+		probeFlights:      make(map[string]*probeFlight),
+		bufferedCap:       bufferCap,
+	}
+}
+
+// acquirePending reserves one pending-wake slot for id. Returns a
+// release function on success; returns the rejection sentinel
+// (errAdmissionPerSandbox / errAdmissionGlobal) when the relevant cap
+// would be exceeded. The release function is idempotent.
+//
+// A zero cap is treated as "no limit" so tests and small deployments
+// can opt out without rewiring.
+func (s *proxyState) acquirePending(id string) (func(), error) {
+	s.pendingMu.Lock()
+	defer s.pendingMu.Unlock()
+	if s.pendingGlobalCap > 0 && s.pendingGlobal >= s.pendingGlobalCap {
+		return nil, errAdmissionGlobal
+	}
+	if s.pendingPerCap > 0 && s.pendingPerSandbox[id] >= s.pendingPerCap {
+		return nil, errAdmissionPerSandbox
+	}
+	s.pendingPerSandbox[id]++
+	s.pendingGlobal++
+
+	var released bool
+	return func() {
+		s.pendingMu.Lock()
+		defer s.pendingMu.Unlock()
+		if released {
+			return
+		}
+		released = true
+		if cur := s.pendingPerSandbox[id]; cur <= 1 {
+			delete(s.pendingPerSandbox, id)
+		} else {
+			s.pendingPerSandbox[id] = cur - 1
+		}
+		if s.pendingGlobal > 0 {
+			s.pendingGlobal--
+		}
+	}, nil
+}
+
+// acquireBuffer reserves n bytes from the global buffer budget. Returns
+// a release function on success; returns errBufferBudget when the cap
+// would be exceeded. Zero cap means unbounded (tests / opt-out).
+func (s *proxyState) acquireBuffer(n int64) (func(), error) {
+	if n <= 0 {
+		return func() {}, nil
+	}
+	s.bufferMu.Lock()
+	defer s.bufferMu.Unlock()
+	if s.bufferedCap > 0 && s.bufferedBytes+n > s.bufferedCap {
+		return nil, errBufferBudget
+	}
+	s.bufferedBytes += n
+	var released bool
+	return func() {
+		s.bufferMu.Lock()
+		defer s.bufferMu.Unlock()
+		if released {
+			return
+		}
+		released = true
+		s.bufferedBytes -= n
+		if s.bufferedBytes < 0 {
+			s.bufferedBytes = 0
+		}
+	}, nil
+}
+
+// probeOnce runs the readiness probe at most once per (id, port). If a
+// flight is already in progress, all later callers wait on its result.
+// The leader runs probeFn in the foreground with a detached context so
+// its result is shared even if the leader's own caller drops; followers
+// honor their own ctx for cancellation.
+func (s *proxyState) probeOnce(
+	ctx context.Context,
+	id string, port int,
+	budget time.Duration,
+	probeFn func(context.Context, time.Duration) error,
+) error {
+	key := fmt.Sprintf("%s:%d", id, port)
+
+	s.probeMu.Lock()
+	flight, exists := s.probeFlights[key]
+	if !exists {
+		flight = &probeFlight{done: make(chan struct{})}
+		s.probeFlights[key] = flight
+		s.probeMu.Unlock()
+
+		// Leader: run with a detached context capped at budget so
+		// followers see a result even if the leader's own request
+		// context is cancelled mid-probe.
+		probeCtx, cancel := context.WithTimeout(context.Background(), budget)
+		flight.err = probeFn(probeCtx, budget)
+		cancel()
+		close(flight.done)
+
+		s.probeMu.Lock()
+		delete(s.probeFlights, key)
+		s.probeMu.Unlock()
+
+		// Leader still honors its caller's cancellation: if ctx is
+		// already dead by the time the probe returned, surface that
+		// (the caller has already given up).
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return flight.err
+	}
+	s.probeMu.Unlock()
+
+	select {
+	case <-flight.done:
+		return flight.err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/pkg/api/ingressproxy/state_test.go
+++ b/pkg/api/ingressproxy/state_test.go
@@ -1,0 +1,313 @@
+package ingressproxy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestAcquirePendingPerSandboxCap: once a sandbox holds the per-sandbox
+// cap of pending slots, further acquires for that sandbox must return
+// errAdmissionPerSandbox until a release happens, while OTHER sandboxes
+// are unaffected (the cap is per-id, not global).
+func TestAcquirePendingPerSandboxCap(t *testing.T) {
+	s := newProxyState(2 /*perSandbox*/, 10 /*global*/, 0 /*buffer disabled*/)
+
+	rel1, err := s.acquirePending("sb-a")
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	rel2, err := s.acquirePending("sb-a")
+	if err != nil {
+		t.Fatalf("second acquire: %v", err)
+	}
+	if _, err := s.acquirePending("sb-a"); !errors.Is(err, errAdmissionPerSandbox) {
+		t.Fatalf("third acquire = %v, want errAdmissionPerSandbox", err)
+	}
+	// Different sandbox unaffected.
+	if _, err := s.acquirePending("sb-b"); err != nil {
+		t.Fatalf("other-sandbox acquire: %v", err)
+	}
+	rel1()
+	if _, err := s.acquirePending("sb-a"); err != nil {
+		t.Fatalf("acquire after release: %v", err)
+	}
+	rel2() // idempotency check: double-release is a no-op
+	rel2()
+}
+
+// TestAcquirePendingGlobalCap: regardless of per-sandbox spread, once
+// the global cap is reached every further acquire must reject with
+// errAdmissionGlobal.
+func TestAcquirePendingGlobalCap(t *testing.T) {
+	s := newProxyState(0 /*perSandbox disabled*/, 3 /*global*/, 0)
+
+	for i := 0; i < 3; i++ {
+		if _, err := s.acquirePending("sb-" + string(rune('a'+i))); err != nil {
+			t.Fatalf("acquire %d: %v", i, err)
+		}
+	}
+	if _, err := s.acquirePending("sb-x"); !errors.Is(err, errAdmissionGlobal) {
+		t.Fatalf("post-cap acquire = %v, want errAdmissionGlobal", err)
+	}
+}
+
+// TestAcquireBufferBudget: the buffer-byte semaphore must reject
+// reservations that would overflow the cap and accept any reservation
+// that fits, including back-to-back after release.
+func TestAcquireBufferBudget(t *testing.T) {
+	s := newProxyState(0, 0, 100 /*100B cap*/)
+
+	rel1, err := s.acquireBuffer(60)
+	if err != nil {
+		t.Fatalf("acquire 60: %v", err)
+	}
+	if _, err := s.acquireBuffer(50); !errors.Is(err, errBufferBudget) {
+		t.Fatalf("acquire 50 (would total 110) = %v, want errBufferBudget", err)
+	}
+	// 40 fits exactly under the remaining 40.
+	rel2, err := s.acquireBuffer(40)
+	if err != nil {
+		t.Fatalf("acquire 40: %v", err)
+	}
+	rel1()
+	// Now 60 fits again.
+	if _, err := s.acquireBuffer(60); err != nil {
+		t.Fatalf("acquire 60 after release: %v", err)
+	}
+	rel2()
+}
+
+// TestProbeOnceCollapsesConcurrentCallers: 100 callers converging on
+// the same (id, port) must trigger exactly ONE probeFn invocation;
+// all 100 see the same result. This is the per-sandbox single-flight
+// that prevents 10k SYNs to one cold container.
+func TestProbeOnceCollapsesConcurrentCallers(t *testing.T) {
+	s := newProxyState(0, 0, 0)
+
+	var probeCalls atomic.Int32
+	probeFn := func(_ context.Context, _ time.Duration) error {
+		probeCalls.Add(1)
+		time.Sleep(50 * time.Millisecond) // hold the flight long enough for followers to enroll
+		return nil
+	}
+
+	const N = 100
+	var wg sync.WaitGroup
+	var errs atomic.Int32
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := s.probeOnce(context.Background(), "sb-x", 3000, time.Second, probeFn); err != nil {
+				errs.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if probeCalls.Load() != 1 {
+		t.Fatalf("probeFn invocations = %d, want 1 (single-flight broken)", probeCalls.Load())
+	}
+	if errs.Load() != 0 {
+		t.Fatalf("got %d errors, want 0", errs.Load())
+	}
+}
+
+// TestProbeOnceLeaderCancelDoesNotStrandFollowers: when the leader's
+// caller context is cancelled mid-probe, followers must still receive
+// the probe's eventual result. The leader runs with a detached context
+// derived only from the budget, so the leader's cancellation does not
+// kill the shared probe.
+func TestProbeOnceLeaderCancelDoesNotStrandFollowers(t *testing.T) {
+	s := newProxyState(0, 0, 0)
+
+	probeStarted := make(chan struct{})
+	probeFn := func(_ context.Context, _ time.Duration) error {
+		close(probeStarted)
+		time.Sleep(100 * time.Millisecond)
+		return nil
+	}
+
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	leaderDone := make(chan error, 1)
+	go func() {
+		leaderDone <- s.probeOnce(leaderCtx, "sb-x", 3000, 500*time.Millisecond, probeFn)
+	}()
+	<-probeStarted
+
+	// Enrol a follower with its own context.
+	followerDone := make(chan error, 1)
+	go func() {
+		followerDone <- s.probeOnce(context.Background(), "sb-x", 3000, 500*time.Millisecond, probeFn)
+	}()
+
+	// Cancel the leader — its own probeOnce call should surface the
+	// cancellation, but the underlying probe keeps running and the
+	// follower still gets the success result.
+	time.Sleep(20 * time.Millisecond)
+	cancelLeader()
+
+	leaderErr := <-leaderDone
+	if !errors.Is(leaderErr, context.Canceled) {
+		t.Fatalf("leader err = %v, want context.Canceled", leaderErr)
+	}
+	if followerErr := <-followerDone; followerErr != nil {
+		t.Fatalf("follower err = %v, want nil — leader cancel must not strand", followerErr)
+	}
+}
+
+// TestHTTPWakeAdmissionRejection: when the global pending cap is full,
+// the handler must reject new cold-start requests with 503 + Retry-After
+// rather than queuing them indefinitely.
+func TestHTTPWakeAdmissionRejection(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, Deps{
+		Resolver:             &fakeResolver{target: upstream.URL},
+		Logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxBufferBytes:       1024,
+		MaxPendingPerSandbox: 1,
+		MaxPendingGlobal:     1,
+		UpstreamReadyTimeout: 1 * time.Second,
+	})
+	// Substitute a dialer that blocks until released so the first
+	// request stays pending while the second tries to admit.
+	prev := dialUpstream
+	t.Cleanup(func() { dialUpstream = prev })
+	hold := make(chan struct{})
+	dialUpstream = func(ctx context.Context, _ string) (net.Conn, error) {
+		select {
+		case <-hold:
+			return nil, errors.New("released")
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	// Kick off the first request asynchronously — it will hold the
+	// pending slot for the lifetime of the (blocked) probe.
+	first := make(chan int, 1)
+	go func() {
+		req := httptest.NewRequest(http.MethodGet, "/__ingress/http/sb-cap/3000/api", nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		first <- rec.Code
+	}()
+
+	// Give the first request a moment to acquire the slot.
+	time.Sleep(50 * time.Millisecond)
+
+	// Second request must be admission-rejected. Use a DIFFERENT
+	// sandbox so the rejection comes from the global cap (1), not
+	// from the per-sandbox cap that the first request occupies for
+	// "sb-cap". We expose this distinction via separate per/global
+	// caps in the Deps wiring above.
+	req2 := httptest.NewRequest(http.MethodGet, "/__ingress/http/sb-other/3000/api", nil)
+	rec2 := httptest.NewRecorder()
+	mux.ServeHTTP(rec2, req2)
+
+	if rec2.Code != http.StatusServiceUnavailable {
+		t.Fatalf("second request status = %d, want 503 (admission)", rec2.Code)
+	}
+	if rec2.Header().Get("Retry-After") != "2" {
+		t.Fatalf("Retry-After = %q, want 2", rec2.Header().Get("Retry-After"))
+	}
+	if !strings.Contains(rec2.Body.String(), "pending wake limit") {
+		t.Fatalf("body = %q, want admission rejection text", rec2.Body.String())
+	}
+
+	close(hold)
+	<-first
+}
+
+// TestHTTPWakeBufferBudgetRejection: when the cross-request buffer
+// budget is exhausted, a cold POST must be rejected with 503 rather
+// than allowed to push the node further over its memory ceiling.
+func TestHTTPWakeBufferBudgetRejection(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatalf("upstream should not be reached when buffer budget rejects")
+	}))
+	defer upstream.Close()
+
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, Deps{
+		Resolver:             &fakeResolver{target: upstream.URL},
+		Logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxBufferBytes:       100,
+		MaxPendingPerSandbox: 10,
+		MaxPendingGlobal:     10,
+		MaxBufferBytesGlobal: 50, // budget too small for the request
+		UpstreamReadyTimeout: 1 * time.Second,
+	})
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/__ingress/http/sb-budget/3000/api",
+		strings.NewReader(strings.Repeat("x", 80)))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body=%q", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "buffer budget") {
+		t.Fatalf("body = %q, want buffer-budget rejection", rec.Body.String())
+	}
+}
+
+// TestHTTPWakeRetriesOnNonRefusedErrors: the widened retry policy
+// must hold the request when the dial returns ECONNRESET / generic
+// network errors during the container's brief boot window, then
+// succeed once the upstream is bound. Before the widening this would
+// have surfaced immediately as 503 / closed connection.
+func TestHTTPWakeRetriesOnNonRefusedErrors(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	prev := dialUpstream
+	t.Cleanup(func() { dialUpstream = prev })
+	start := time.Now()
+	dialUpstream = func(ctx context.Context, addr string) (net.Conn, error) {
+		if time.Since(start) < 100*time.Millisecond {
+			// Pretend the kernel briefly returns a "host unreachable"
+			// or "reset by peer" during container start.
+			return nil, errors.New("connect: host unreachable")
+		}
+		d := net.Dialer{Timeout: 500 * time.Millisecond}
+		return d.DialContext(ctx, "tcp", addr)
+	}
+
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, Deps{
+		Resolver:             &fakeResolver{target: upstream.URL},
+		Logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxBufferBytes:       1024,
+		MaxPendingPerSandbox: 10,
+		MaxPendingGlobal:     10,
+		MaxBufferBytesGlobal: 1024,
+		UpstreamReadyTimeout: 1 * time.Second,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/__ingress/http/sb-rst/3000/api", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (probe should retry through non-ECONNREFUSED errors); body=%q", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
This pull request enhances the reliability of the HTTP ingress proxy during sandbox cold starts by adding a post-wake TCP readiness probe. This ensures that the proxy only forwards requests once the in-container service is actually listening on its port, preventing premature connections that would otherwise result in transient 502 errors. The readiness probe is configurable and includes new tests to verify correct behavior in various scenarios.

**HTTP Ingress Proxy Reliability Improvements:**

- Added a TCP readiness probe after sandbox wake: The handler now waits for the in-container service to bind its TCP port before proxying the request, avoiding premature connections that would return 502 errors. This probe is skipped for warm sandboxes. [[1]](diffhunk://#diff-04fde7b7f15875083d5680d326d282d2f412a723e2aa2bb38a858f2d4c118f5fR110-R134) [[2]](diffhunk://#diff-04fde7b7f15875083d5680d326d282d2f412a723e2aa2bb38a858f2d4c118f5fL136-R226)
- Introduced a configurable `UpstreamReadyTimeout` parameter (default 30s) to control how long the handler waits for the upstream service to become ready. This is exposed in the configuration, dependency injection, and environment variables. [[1]](diffhunk://#diff-85cd4174384a81cdbf87370531855ae87bcbd19bf68f36b611d73cd5d96cb4daR357) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR160-R164) [[3]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR569) [[4]](diffhunk://#diff-a54ea6f0af491a6ae854dd87e2d74298c301b471a728ec16b0ca9e6c917cd935R57-R79)

**Error Handling Enhancements:**

- Updated the proxy's error handler to return a 503 Service Unavailable (with `Retry-After: 2`) instead of a 502 Bad Gateway when the upstream is not ready, signaling clients to retry.

**Testing Improvements:**

- Added comprehensive tests to verify that:
  - The handler waits for the upstream port to become ready before proxying (`TestHTTPWakeHoldsUntilUpstreamPortReady`).
  - The handler returns a 503 if the upstream never becomes ready (`TestHTTPWakeReturns503WhenUpstreamNeverReady`).
  - Warm requests skip the readiness probe (`TestHTTPWakeWarmRequestSkipsReadinessProbe`).

**Internal Refactoring:**

- Refactored dial logic to allow test overrides, making readiness probe logic testable.

These changes improve the robustness of cold-start handling, reduce transient errors, and make the system more configurable and testable.Introduce an upstream readiness timeout for the HTTP wake handler to prevent premature connections to in-container services. This change allows the handler to hold the caller's request until the service is ready, reducing the likelihood of encountering connection errors. Update related configurations to support this feature.

