### PR TITLE
Implement warm direct-route bypass for serverless HTTP ingress

### DIFF
--- a/cmd/sandboxd/main.go
+++ b/cmd/sandboxd/main.go
@@ -290,6 +290,16 @@ func main() {
 		}
 	}
 
+	// Start the Caddy admin write coalescer on worker nodes so
+	// installHTTPPortRoute's Flush path has the periodic-drain safety
+	// net for any stranded ops (Flush callers whose ctx cancelled
+	// before drain finished). Worker-only: non-worker nodes don't
+	// install per-sandbox Caddy routes. See
+	// plans/warm-direct-route-bypass.md D6/D12.
+	if cfg.IsWorker() {
+		svc.StartCaddyCoalescer(ctx)
+	}
+
 	// AutoReconcile / lifecycle sweep / event monitor / built-image GC are all
 	// worker-side concerns — they reach into Docker, sandbox rows, and
 	// per-container caddy routes. Pure server/ingress nodes have neither
@@ -416,6 +426,10 @@ func main() {
 			logger.Warn("ingress proxy graceful shutdown failed", "error", err)
 		}
 	}
+	// Drain any pending Caddy admin writes before the process exits so
+	// the last batch of route changes is not silently dropped. No-op on
+	// nodes that never started the coalescer.
+	svc.StopCaddyCoalescer()
 }
 
 func replayClusterOwnership(ctx context.Context, svc *service.Service, logger *slog.Logger) bool {

--- a/cmd/sandboxd/main.go
+++ b/cmd/sandboxd/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -259,6 +260,33 @@ func main() {
 		}
 		if cfg.IsIngress() {
 			svc.StartClusterIngressReconcile(ctx)
+		}
+	}
+
+	// Bypass-flip rollback marker (D5 of plans/warm-direct-route-bypass.md).
+	// HTTP routes installed under SB_HTTP_WAKE_DIRECT_BYPASS_ENABLED=true point
+	// straight at the container IP. Toggling the flag back to false does not
+	// rewrite those routes on its own — a running serverless sandbox would
+	// keep bypassing the wake-aware ingress proxy forever, defeating the
+	// rollback. The marker file at ${dir(DBPath)}/bypass_last_enabled records
+	// what the previous run used; if that says true and we now see false,
+	// force one pass that republishes every serverless HTTP route through
+	// installHTTPPortRoute (which reads the new cfg value via chooseRouteShape).
+	// Worker-only: pure ingress/server nodes own no caddy routes for sandboxes.
+	if cfg.IsWorker() {
+		markerPath := filepath.Join(filepath.Dir(cfg.DBPath), "bypass_last_enabled")
+		prevEnabled := readBypassMarker(markerPath)
+		if prevEnabled && !cfg.HTTPWakeDirectBypassEnabled {
+			logger.Info("bypass rollback detected; forcing http wake-shape reconcile",
+				"marker_path", markerPath,
+			)
+			if err := svc.ForceReconcileHTTPWakeShape(ctx); err != nil {
+				logger.Warn("force reconcile http wake shape failed", "error", err)
+			}
+		}
+		if err := writeBypassMarker(markerPath, cfg.HTTPWakeDirectBypassEnabled); err != nil {
+			logger.Warn("write bypass marker failed; rollback detection may misfire next boot",
+				"marker_path", markerPath, "error", err)
 		}
 	}
 
@@ -648,4 +676,34 @@ func bytesTrimSpace(b []byte) []byte {
 
 func isSpace(c byte) bool {
 	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}
+
+// readBypassMarker returns true iff the marker file exists AND its content
+// is "true". A missing or unreadable marker reads as false — first boot
+// after a daemon upgrade looks identical to "previous run had bypass off",
+// which is the safer default (no force-reconcile, no surprise route
+// churn). The marker is plain text, not JSON or expvar, so an operator
+// can `cat` it during incident response without booting the daemon.
+func readBypassMarker(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return string(bytesTrimSpace(data)) == "true"
+}
+
+// writeBypassMarker persists the current bypass flag for the next boot's
+// rollback check. Uses a tmp-then-rename so a daemon crash mid-write
+// cannot leave a truncated marker that would later be misread as
+// `false` (and silently mask a true→false flip on the next boot).
+func writeBypassMarker(path string, enabled bool) error {
+	value := "false"
+	if enabled {
+		value = "true"
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(value+"\n"), 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
 }

--- a/cmd/sandboxd/main_test.go
+++ b/cmd/sandboxd/main_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestReadBypassMarkerMissingReadsFalse: first boot has no marker file
+// — the safer default is "previous run had bypass off", so no rollback
+// force-reconcile fires.
+func TestReadBypassMarkerMissingReadsFalse(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bypass_last_enabled")
+	if readBypassMarker(path) {
+		t.Fatalf("missing marker read as true; want false")
+	}
+}
+
+// TestWriteThenReadBypassMarkerRoundTrip: each boolean value written
+// must round-trip exactly. The marker is the only source of truth for
+// the rollback decision; a flip in storage would silently misfire the
+// force-reconcile pass.
+func TestWriteThenReadBypassMarkerRoundTrip(t *testing.T) {
+	for _, want := range []bool{true, false} {
+		path := filepath.Join(t.TempDir(), "bypass_last_enabled")
+		if err := writeBypassMarker(path, want); err != nil {
+			t.Fatalf("writeBypassMarker(%v): %v", want, err)
+		}
+		if got := readBypassMarker(path); got != want {
+			t.Fatalf("readBypassMarker = %v, want %v", got, want)
+		}
+	}
+}
+
+// TestWriteBypassMarkerOverwritesPriorValue: a write must replace any
+// existing content. Operator toggling true→false→true must not leave
+// stale state behind.
+func TestWriteBypassMarkerOverwritesPriorValue(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bypass_last_enabled")
+	if err := writeBypassMarker(path, true); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := writeBypassMarker(path, false); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	if readBypassMarker(path) {
+		t.Fatalf("read after true→false write reports true; rollback would not fire on subsequent flip")
+	}
+}
+
+// TestWriteBypassMarkerAtomicViaTmpRename: the tmp-then-rename pattern
+// must not leak the .tmp file on success — otherwise the next boot's
+// `cat ${dir}/bypass_last_enabled.tmp` could mislead an operator.
+func TestWriteBypassMarkerAtomicViaTmpRename(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bypass_last_enabled")
+	if err := writeBypassMarker(path, true); err != nil {
+		t.Fatalf("writeBypassMarker: %v", err)
+	}
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Fatalf("stat .tmp after success: err=%v (want IsNotExist)", err)
+	}
+}
+
+// TestReadBypassMarkerTrimsTrailingNewline: writeBypassMarker appends
+// a newline so an operator's `cat` is readable. readBypassMarker must
+// tolerate that newline (and any incidental surrounding whitespace —
+// e.g. if an operator hand-edits the marker for testing).
+func TestReadBypassMarkerTrimsTrailingNewline(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bypass_last_enabled")
+	cases := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{"newline_terminated_true", "true\n", true},
+		{"untrimmed_true_with_spaces", " true \n", true},
+		{"tab_padded_true", "\ttrue\t\n", true},
+		{"plain_false_no_newline", "false", false},
+		{"empty_file_reads_false", "", false},
+		{"junk_value_reads_false", "yes\n", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := os.WriteFile(path, []byte(tc.content), 0o644); err != nil {
+				t.Fatalf("seed marker: %v", err)
+			}
+			if got := readBypassMarker(path); got != tc.want {
+				t.Fatalf("readBypassMarker(%q) = %v, want %v", tc.content, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -178,6 +178,31 @@ type Config struct {
 	// = 80 GB worst case without this). Required > 0 when serverless
 	// is on.
 	HTTPWakeMaxBufferBytesGlobal int64
+	// HTTPWakeDirectBypassEnabled flips the serverless HTTP ingress
+	// shape between today's "Caddy → sandboxd ingress proxy → container"
+	// (false, default in v1) and the warm direct shape
+	// "Caddy → container" (true). See plans/warm-direct-route-bypass.md.
+	// When true, every warm serverless HTTP request skips sandboxd
+	// entirely; the wake-aware route is only installed while a sandbox
+	// is Stopped+armed. Required co-requisite: the netstats poller is
+	// the activity-floor signal — Validate() rejects per-sandbox
+	// StopIfIdleFor values smaller than
+	// 2 × NetstatsPollInterval + ReconcileInterval when this is on.
+	HTTPWakeDirectBypassEnabled bool
+	// HTTPWakeDirectRouteRetryDuration is the Caddy
+	// load_balancing.try_duration applied to direct-shape HTTP routes
+	// when bypass is enabled. Absorbs the ~10ms window between
+	// container exit and the docker die event firing — the next
+	// request transparently retries instead of immediately 502-ing.
+	// Default 2s; raise if running unusually slow-binding containers.
+	HTTPWakeDirectRouteRetryDuration time.Duration
+	// CaddyCoalesceInterval is the per-tick batching window for Caddy
+	// admin writes. Doubling the route-write volume (wake↔direct on
+	// every Start/Stop) regresses Caddy admin p99 under churn unless
+	// rapid flips for the same (id, port) collapse into one admin call.
+	// Default 250ms; lower bound is the per-write latency budget the
+	// node can tolerate before reconcile starts looking stale.
+	CaddyCoalesceInterval time.Duration
 	// WakeStartConcurrency caps concurrent StartSandbox invocations
 	// initiated by the wake path across the whole node. Inside the global
 	// HTTP+L4 pending caps, up to (HTTPWakeMaxPendingGlobal +
@@ -565,63 +590,66 @@ func Load() (Config, error) {
 	defaultToolboxPath := filepath.Join(filepath.Dir(exe), "toolboxd")
 
 	cfg := Config{
-		PATToken:                     strings.TrimSpace(os.Getenv("SB_PAT_TOKEN")),
-		APIHost:                      getEnv("SB_API_HOST", "0.0.0.0"),
-		APIPort:                      getEnvInt("SB_API_PORT", 21212),
-		Domain:                       normalizeHost(os.Getenv("SB_DOMAIN")),
-		PublicHost:                   normalizeHost(getEnv("SB_PUBLIC_HOST", "127.0.0.1")),
-		CaddyAdminURL:                getEnv("SB_CADDY_ADMIN_URL", "http://127.0.0.1:2019"),
-		CaddyServerID:                getEnv("SB_CADDY_SERVER_ID", "srv0"),
-		DBPath:                       getEnv("SB_DB_PATH", "/var/lib/sandboxd/state.db"),
-		DockerNetwork:                getEnv("SB_DOCKER_NETWORK", "bridge"),
-		ToolboxBinaryPath:            getEnv("SB_TOOLBOX_BINARY_PATH", defaultToolboxPath),
-		ToolboxMountPath:             getEnv("SB_TOOLBOX_MOUNT_PATH", "/usr/local/bin/toolboxd"),
-		ToolboxPort:                  getEnvInt("SB_TOOLBOX_PORT", defaultToolboxPort),
-		IdleTimeoutMinutes:           getEnvInt("SB_IDLE_TIMEOUT_MIN", 0),
-		ContainerPrivileged:          getEnvBool("SB_CONTAINER_PRIVILEGED", false),
-		ResourceLimitsOff:            getEnvBool("SB_RESOURCE_LIMITS_DISABLED", false),
-		Runtime:                      getEnv("SB_CONTAINER_RUNTIME", models.RuntimeDocker),
-		AutoReconcile:                getEnvBool("SB_AUTO_RECONCILE", true),
-		EnableCaddy:                  getEnvBool("SB_ENABLE_CADDY", true),
-		EnableNetworkRules:           getEnvBool("SB_ENABLE_NETWORK_RULES", true),
-		EnableEventMonitor:           getEnvBool("SB_ENABLE_EVENT_MONITOR", true),
-		EnableSSHGateway:             getEnvBool("SB_ENABLE_SSH_GATEWAY", true),
-		EnableServerless:             getEnvBool("SB_ENABLE_SERVERLESS", true),
-		InternalIngressAddr:          getEnv("SB_INTERNAL_INGRESS_ADDR", "127.0.0.1:21213"),
-		InternalL4WakeAddr:           getEnv("SB_INTERNAL_L4_WAKE_ADDR", "127.0.0.1:21214"),
-		InternalL4WakeDir:            getEnv("SB_INTERNAL_L4_WAKE_DIR", "/run/sandboxd/l4wake"),
-		L4WakeMaxPendingPerSandbox:   getEnvInt("SB_L4_WAKE_MAX_PENDING_PER_SANDBOX", 256),
-		L4WakeMaxPendingGlobal:       getEnvInt("SB_L4_WAKE_MAX_PENDING_GLOBAL", 4096),
-		L4WakeMaxActivePerSandbox:    getEnvInt("SB_L4_WAKE_MAX_ACTIVE_PER_SANDBOX", 4096),
-		L4WakeMaxActiveGlobal:        getEnvInt("SB_L4_WAKE_MAX_ACTIVE_GLOBAL", 65536),
-		HTTPWakeMaxBuffer:            int64(getEnvInt("SB_HTTP_WAKE_MAX_BUFFER", 8*1024*1024)),
-		HTTPWakeUpstreamReadyTimeout: getEnvDuration("SB_HTTP_WAKE_UPSTREAM_READY_TIMEOUT", 30*time.Second),
-		HTTPWakeMaxPendingPerSandbox: getEnvInt("SB_HTTP_WAKE_MAX_PENDING_PER_SANDBOX", 256),
-		HTTPWakeMaxPendingGlobal:     getEnvInt("SB_HTTP_WAKE_MAX_PENDING_GLOBAL", 4096),
-		HTTPWakeMaxBufferBytesGlobal: int64(getEnvInt("SB_HTTP_WAKE_MAX_BUFFER_GLOBAL", 1024*1024*1024)),
-		WakeStartConcurrency:         getEnvInt("SB_WAKE_START_CONCURRENCY", 64),
-		SSHListenAddr:                getEnv("SB_SSH_LISTEN_ADDR", "0.0.0.0:2220"),
-		SSHHostKeyPath:               getEnv("SB_SSH_HOST_KEY_PATH", "/var/lib/sandboxd/ssh_host_ed25519_key"),
-		CredentialEncryptionKey:      strings.TrimSpace(os.Getenv("SB_CREDENTIAL_ENCRYPTION_KEY")),
-		CredentialEncryptionKeyPath:  getEnv("SB_CREDENTIAL_ENCRYPTION_KEY_PATH", "/var/lib/sandboxd/credential_encryption.key"),
-		MountsRootPath:               getEnv("SB_MOUNTS_ROOT", "/var/lib/sandboxd/mounts"),
-		MountsCredentialsRuntimeDir:  getEnv("SB_MOUNTS_CRED_DIR", "/run/sandboxd"),
-		MountWaitTimeout:             getEnvDuration("SB_MOUNT_WAIT_TIMEOUT", 30*time.Second),
-		LogLevel:                     strings.ToLower(getEnv("SB_LOG_LEVEL", "info")),
-		ShutdownTimeout:              getEnvDuration("SB_SHUTDOWN_TIMEOUT", 10*time.Second),
-		HTTPClientTimeout:            getEnvDuration("SB_HTTP_CLIENT_TIMEOUT", 180*time.Second),
-		DockerRuntimeWaitTimeout:     getEnvDuration("SB_DOCKER_WAIT_TIMEOUT", 30*time.Second),
-		ToolboxWaitTimeout:           getEnvDuration("SB_TOOLBOX_WAIT_TIMEOUT", 30*time.Second),
-		ReconcileInterval:            getEnvDuration("SB_RECONCILE_INTERVAL", 5*time.Minute),
-		NetstatsPollInterval:         getEnvDuration("SB_NETSTATS_POLL_INTERVAL", 10*time.Second),
-		UploadMaxBytes:               int64(getEnvInt("SB_UPLOAD_MAX_BYTES", 256*1024*1024)),
-		OTELMetricsEnabled:           getEnvBool("SB_OTEL_METRICS_ENABLED", false),
-		OTELMetricsEndpoint:          firstNonEmpty(os.Getenv("SB_OTEL_METRICS_ENDPOINT"), os.Getenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT")),
-		OTELMetricsInterval:          getEnvDuration("SB_OTEL_METRICS_INTERVAL", 30*time.Second),
-		OTELTracesEnabled:            getEnvBool("SB_OTEL_TRACES_ENABLED", false),
-		OTELTracesEndpoint:           firstNonEmpty(os.Getenv("SB_OTEL_TRACES_ENDPOINT"), os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")),
-		OTELTracesSampleRatio:        getEnvFloat("SB_OTEL_TRACES_SAMPLE_RATIO", 0.05),
-		OTELServiceName:              getEnv("OTEL_SERVICE_NAME", "sandboxd"),
+		PATToken:                         strings.TrimSpace(os.Getenv("SB_PAT_TOKEN")),
+		APIHost:                          getEnv("SB_API_HOST", "0.0.0.0"),
+		APIPort:                          getEnvInt("SB_API_PORT", 21212),
+		Domain:                           normalizeHost(os.Getenv("SB_DOMAIN")),
+		PublicHost:                       normalizeHost(getEnv("SB_PUBLIC_HOST", "127.0.0.1")),
+		CaddyAdminURL:                    getEnv("SB_CADDY_ADMIN_URL", "http://127.0.0.1:2019"),
+		CaddyServerID:                    getEnv("SB_CADDY_SERVER_ID", "srv0"),
+		DBPath:                           getEnv("SB_DB_PATH", "/var/lib/sandboxd/state.db"),
+		DockerNetwork:                    getEnv("SB_DOCKER_NETWORK", "bridge"),
+		ToolboxBinaryPath:                getEnv("SB_TOOLBOX_BINARY_PATH", defaultToolboxPath),
+		ToolboxMountPath:                 getEnv("SB_TOOLBOX_MOUNT_PATH", "/usr/local/bin/toolboxd"),
+		ToolboxPort:                      getEnvInt("SB_TOOLBOX_PORT", defaultToolboxPort),
+		IdleTimeoutMinutes:               getEnvInt("SB_IDLE_TIMEOUT_MIN", 0),
+		ContainerPrivileged:              getEnvBool("SB_CONTAINER_PRIVILEGED", false),
+		ResourceLimitsOff:                getEnvBool("SB_RESOURCE_LIMITS_DISABLED", false),
+		Runtime:                          getEnv("SB_CONTAINER_RUNTIME", models.RuntimeDocker),
+		AutoReconcile:                    getEnvBool("SB_AUTO_RECONCILE", true),
+		EnableCaddy:                      getEnvBool("SB_ENABLE_CADDY", true),
+		EnableNetworkRules:               getEnvBool("SB_ENABLE_NETWORK_RULES", true),
+		EnableEventMonitor:               getEnvBool("SB_ENABLE_EVENT_MONITOR", true),
+		EnableSSHGateway:                 getEnvBool("SB_ENABLE_SSH_GATEWAY", true),
+		EnableServerless:                 getEnvBool("SB_ENABLE_SERVERLESS", true),
+		InternalIngressAddr:              getEnv("SB_INTERNAL_INGRESS_ADDR", "127.0.0.1:21213"),
+		InternalL4WakeAddr:               getEnv("SB_INTERNAL_L4_WAKE_ADDR", "127.0.0.1:21214"),
+		InternalL4WakeDir:                getEnv("SB_INTERNAL_L4_WAKE_DIR", "/run/sandboxd/l4wake"),
+		L4WakeMaxPendingPerSandbox:       getEnvInt("SB_L4_WAKE_MAX_PENDING_PER_SANDBOX", 256),
+		L4WakeMaxPendingGlobal:           getEnvInt("SB_L4_WAKE_MAX_PENDING_GLOBAL", 4096),
+		L4WakeMaxActivePerSandbox:        getEnvInt("SB_L4_WAKE_MAX_ACTIVE_PER_SANDBOX", 4096),
+		L4WakeMaxActiveGlobal:            getEnvInt("SB_L4_WAKE_MAX_ACTIVE_GLOBAL", 65536),
+		HTTPWakeMaxBuffer:                int64(getEnvInt("SB_HTTP_WAKE_MAX_BUFFER", 8*1024*1024)),
+		HTTPWakeUpstreamReadyTimeout:     getEnvDuration("SB_HTTP_WAKE_UPSTREAM_READY_TIMEOUT", 30*time.Second),
+		HTTPWakeMaxPendingPerSandbox:     getEnvInt("SB_HTTP_WAKE_MAX_PENDING_PER_SANDBOX", 256),
+		HTTPWakeMaxPendingGlobal:         getEnvInt("SB_HTTP_WAKE_MAX_PENDING_GLOBAL", 4096),
+		HTTPWakeMaxBufferBytesGlobal:     int64(getEnvInt("SB_HTTP_WAKE_MAX_BUFFER_GLOBAL", 1024*1024*1024)),
+		WakeStartConcurrency:             getEnvInt("SB_WAKE_START_CONCURRENCY", 64),
+		HTTPWakeDirectBypassEnabled:      getEnvBool("SB_HTTP_WAKE_DIRECT_BYPASS_ENABLED", false),
+		HTTPWakeDirectRouteRetryDuration: getEnvDuration("SB_HTTP_WAKE_DIRECT_ROUTE_RETRY_DURATION", 2*time.Second),
+		CaddyCoalesceInterval:            getEnvDuration("SB_CADDY_COALESCE_INTERVAL", 250*time.Millisecond),
+		SSHListenAddr:                    getEnv("SB_SSH_LISTEN_ADDR", "0.0.0.0:2220"),
+		SSHHostKeyPath:                   getEnv("SB_SSH_HOST_KEY_PATH", "/var/lib/sandboxd/ssh_host_ed25519_key"),
+		CredentialEncryptionKey:          strings.TrimSpace(os.Getenv("SB_CREDENTIAL_ENCRYPTION_KEY")),
+		CredentialEncryptionKeyPath:      getEnv("SB_CREDENTIAL_ENCRYPTION_KEY_PATH", "/var/lib/sandboxd/credential_encryption.key"),
+		MountsRootPath:                   getEnv("SB_MOUNTS_ROOT", "/var/lib/sandboxd/mounts"),
+		MountsCredentialsRuntimeDir:      getEnv("SB_MOUNTS_CRED_DIR", "/run/sandboxd"),
+		MountWaitTimeout:                 getEnvDuration("SB_MOUNT_WAIT_TIMEOUT", 30*time.Second),
+		LogLevel:                         strings.ToLower(getEnv("SB_LOG_LEVEL", "info")),
+		ShutdownTimeout:                  getEnvDuration("SB_SHUTDOWN_TIMEOUT", 10*time.Second),
+		HTTPClientTimeout:                getEnvDuration("SB_HTTP_CLIENT_TIMEOUT", 180*time.Second),
+		DockerRuntimeWaitTimeout:         getEnvDuration("SB_DOCKER_WAIT_TIMEOUT", 30*time.Second),
+		ToolboxWaitTimeout:               getEnvDuration("SB_TOOLBOX_WAIT_TIMEOUT", 30*time.Second),
+		ReconcileInterval:                getEnvDuration("SB_RECONCILE_INTERVAL", 5*time.Minute),
+		NetstatsPollInterval:             getEnvDuration("SB_NETSTATS_POLL_INTERVAL", 10*time.Second),
+		UploadMaxBytes:                   int64(getEnvInt("SB_UPLOAD_MAX_BYTES", 256*1024*1024)),
+		OTELMetricsEnabled:               getEnvBool("SB_OTEL_METRICS_ENABLED", false),
+		OTELMetricsEndpoint:              firstNonEmpty(os.Getenv("SB_OTEL_METRICS_ENDPOINT"), os.Getenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT")),
+		OTELMetricsInterval:              getEnvDuration("SB_OTEL_METRICS_INTERVAL", 30*time.Second),
+		OTELTracesEnabled:                getEnvBool("SB_OTEL_TRACES_ENABLED", false),
+		OTELTracesEndpoint:               firstNonEmpty(os.Getenv("SB_OTEL_TRACES_ENDPOINT"), os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")),
+		OTELTracesSampleRatio:            getEnvFloat("SB_OTEL_TRACES_SAMPLE_RATIO", 0.05),
+		OTELServiceName:                  getEnv("OTEL_SERVICE_NAME", "sandboxd"),
 
 		CPUReservationRatio:       getEnvFloat("SB_CPU_RESERVATION_RATIO", 0.9),
 		MemoryReservationRatio:    getEnvFloat("SB_MEMORY_RESERVATION_RATIO", 0.85),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -203,6 +203,31 @@ type Config struct {
 	// Default 250ms; lower bound is the per-write latency budget the
 	// node can tolerate before reconcile starts looking stale.
 	CaddyCoalesceInterval time.Duration
+	// L4WakeDirectBypassEnabled is the Phase 2 sibling of
+	// HTTPWakeDirectBypassEnabled — same shape decision applied to
+	// TCP and TLS exposures. False (default) keeps today's behavior
+	// where every warm L4 byte is proxied through sandboxd's
+	// proxyL4WakeConn path; true flips warm sandboxes to a direct
+	// Caddy → container route and lets sandboxd's L4 active-connection
+	// accounting become a cold-path-only counter. Gated separately
+	// from the HTTP flag so each protocol can be canaried independently
+	// (per plan §Phase 2: TCP/TLS may ship only after HTTP has been
+	// default-on for two cycles). When either flag is enabled, the
+	// idle sweep's netstats activity floor and stale-poll fallback
+	// (D3/D4) become active — netstats observes container interface
+	// bytes regardless of protocol so the floor covers both layers
+	// with one mechanism. See plans/warm-direct-route-bypass.md
+	// §Phase 2.
+	L4WakeDirectBypassEnabled bool
+	// TLSWakeListenerCloseDelay is the grace window between PATCHing a
+	// TLS-SNI route from wake-aware to direct and closing the per-
+	// exposure Unix socket. D2 of the bypass plan: a TLS handshake that
+	// started against the wake-aware route may still be in flight when
+	// PATCH lands; closing the socket immediately drops that handshake
+	// mid-stream. 5s is enough for any reasonable handshake to complete
+	// while keeping the socket short-lived enough that a flap doesn't
+	// stack up listener FDs. Only consulted when L4WakeDirectBypassEnabled.
+	TLSWakeListenerCloseDelay time.Duration
 	// WakeStartConcurrency caps concurrent StartSandbox invocations
 	// initiated by the wake path across the whole node. Inside the global
 	// HTTP+L4 pending caps, up to (HTTPWakeMaxPendingGlobal +
@@ -628,6 +653,8 @@ func Load() (Config, error) {
 		HTTPWakeDirectBypassEnabled:      getEnvBool("SB_HTTP_WAKE_DIRECT_BYPASS_ENABLED", false),
 		HTTPWakeDirectRouteRetryDuration: getEnvDuration("SB_HTTP_WAKE_DIRECT_ROUTE_RETRY_DURATION", 2*time.Second),
 		CaddyCoalesceInterval:            getEnvDuration("SB_CADDY_COALESCE_INTERVAL", 250*time.Millisecond),
+		L4WakeDirectBypassEnabled:        getEnvBool("SB_L4_WAKE_DIRECT_BYPASS_ENABLED", false),
+		TLSWakeListenerCloseDelay:        getEnvDuration("SB_TLS_WAKE_LISTENER_CLOSE_DELAY", 5*time.Second),
 		SSHListenAddr:                    getEnv("SB_SSH_LISTEN_ADDR", "0.0.0.0:2220"),
 		SSHHostKeyPath:                   getEnv("SB_SSH_HOST_KEY_PATH", "/var/lib/sandboxd/ssh_host_ed25519_key"),
 		CredentialEncryptionKey:          strings.TrimSpace(os.Getenv("SB_CREDENTIAL_ENCRYPTION_KEY")),

--- a/internal/service/caddy_coalescer.go
+++ b/internal/service/caddy_coalescer.go
@@ -1,0 +1,209 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// caddyCoalescer batches Caddy admin writes for the same (id, port)
+// into one execution per tick. Under HTTPWakeDirectBypassEnabled the
+// per-sandbox HTTP route is rewritten on every Start and every Stop
+// (wake-aware ↔ direct), doubling the admin write volume vs. today.
+// At a node with 100k+ sandboxes and 1k+ starts/stops per minute that
+// doubling regresses per-write p99 latency without batching. The
+// coalescer collapses a rapid wake → stop → wake sequence for the
+// same (id, port) into a single admin call.
+//
+// Semantics:
+//
+//   - Enqueue records the LATEST intent for (id, port). Subsequent
+//     Enqueues before the next tick overwrite the prior intent — the
+//     prior op is dropped. This is the explicit point of the coalescer:
+//     intermediate states never reach Caddy.
+//
+//   - The tick goroutine drains the pending map and executes each
+//     stored op exactly once per tick. Execution is sequential within
+//     a tick so Caddy's single-threaded admin write path is not
+//     hammered, but parallel callers Enqueueing into different (id,
+//     port) keys do not block each other.
+//
+//   - Flush forces immediate drain + execution and waits for it. Use
+//     for ordering-critical callsites that need a write visible to
+//     Caddy before continuing (e.g. pre-stop wake install must be
+//     observable to incoming requests before docker.Stop fires).
+//
+// The coalescer is callback-based — callers supply a `do func() error`
+// that performs the actual Caddy admin write. This keeps the
+// coalescer agnostic to which client method (Upsert/Delete/wake/direct)
+// is being collapsed; only the (id, port) key matters for batching.
+// See plans/warm-direct-route-bypass.md D6 / D12.
+type caddyCoalescer struct {
+	tick   time.Duration
+	logger *slog.Logger
+
+	mu      sync.Mutex
+	pending map[coalesceKey]pendingOp
+
+	stop chan struct{}
+	done chan struct{}
+}
+
+// coalesceKey identifies one (sandbox-id, port) target. Same key for
+// wake and direct shapes — that is the whole point: a rapid flip
+// between them collapses to one execution of whichever intent landed
+// last in the tick window.
+type coalesceKey struct {
+	id   string
+	port int
+}
+
+// pendingOp holds the latest intent for one coalesceKey plus a small
+// chan slice used to satisfy Flush callers that may be waiting on
+// this specific key. Callers without a Flush get no notification —
+// fire-and-forget is the default.
+type pendingOp struct {
+	do      func() error
+	notify  []chan<- error
+	enqueue time.Time
+}
+
+func newCaddyCoalescer(logger *slog.Logger, tick time.Duration) *caddyCoalescer {
+	if tick <= 0 {
+		tick = 250 * time.Millisecond
+	}
+	return &caddyCoalescer{
+		tick:    tick,
+		logger:  logger,
+		pending: make(map[coalesceKey]pendingOp),
+		stop:    make(chan struct{}),
+		done:    make(chan struct{}),
+	}
+}
+
+// Run blocks until ctx is cancelled OR Stop is called. Drains the
+// pending map on each tick, then drains once more on the way out so
+// in-flight writes are not silently dropped on shutdown.
+func (c *caddyCoalescer) Run(ctx context.Context) {
+	defer close(c.done)
+	t := time.NewTicker(c.tick)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			c.drain()
+			return
+		case <-c.stop:
+			c.drain()
+			return
+		case <-t.C:
+			c.drain()
+		}
+	}
+}
+
+// Stop signals Run to exit after a final drain. Safe to call once;
+// concurrent calls panic on the close. Idempotent via the once-guard
+// is intentionally NOT provided — the daemon owns the lifecycle and
+// calls Stop exactly once at shutdown.
+func (c *caddyCoalescer) Stop() {
+	close(c.stop)
+	<-c.done
+}
+
+// Enqueue records do as the latest intent for (id, port). Any prior
+// pending op for the same key is dropped (and any prior Flush waiter
+// for that key is notified with a nil error — the drop is by design,
+// not a failure). Returns immediately; do runs on the next tick.
+func (c *caddyCoalescer) Enqueue(id string, port int, do func() error) {
+	c.enqueue(id, port, do, nil)
+}
+
+// Flush enqueues do AND drains immediately, returning the result of
+// do. Use this for ordering-critical callsites. ctx bounds how long
+// the caller is willing to wait; on ctx cancellation the op is left
+// in the pending map and the tick goroutine will eventually execute
+// it, but the caller stops waiting.
+func (c *caddyCoalescer) Flush(ctx context.Context, id string, port int, do func() error) error {
+	ch := make(chan error, 1)
+	c.enqueue(id, port, do, ch)
+	go c.drain()
+	select {
+	case err := <-ch:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (c *caddyCoalescer) enqueue(id string, port int, do func() error, notify chan<- error) {
+	key := coalesceKey{id: id, port: port}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if prev, ok := c.pending[key]; ok {
+		// A prior op is being dropped. Notify any prior Flush waiters
+		// with a nil error — they got the eventual consistency they
+		// asked for via a newer write of the same key.
+		for _, n := range prev.notify {
+			select {
+			case n <- nil:
+			default:
+			}
+		}
+	}
+	op := pendingOp{
+		do:      do,
+		enqueue: time.Now(),
+	}
+	if notify != nil {
+		op.notify = []chan<- error{notify}
+	}
+	c.pending[key] = op
+}
+
+// drain takes a snapshot of the pending map, clears it, then executes
+// each op sequentially. The lock is held only while swapping the map
+// so concurrent Enqueues do not block on Caddy admin latency.
+func (c *caddyCoalescer) drain() {
+	c.mu.Lock()
+	if len(c.pending) == 0 {
+		c.mu.Unlock()
+		return
+	}
+	batch := c.pending
+	c.pending = make(map[coalesceKey]pendingOp, len(batch))
+	c.mu.Unlock()
+
+	for key, op := range batch {
+		err := op.do()
+		if err != nil && c.logger != nil {
+			c.logger.Warn("caddy coalescer write failed",
+				"sandbox_id", key.id, "port", key.port, "error", err,
+				"queued_for", time.Since(op.enqueue).String(),
+			)
+		}
+		for _, n := range op.notify {
+			select {
+			case n <- err:
+			default:
+				// Receiver gave up (ctx cancelled). Drop the result.
+			}
+		}
+	}
+}
+
+// pendingSize reports the current pending map size. Diagnostics only;
+// not part of the hot path. Useful from tests and from expvar
+// inspection scripts to see whether the coalescer is keeping up.
+func (c *caddyCoalescer) pendingSize() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.pending)
+}
+
+// String returns a human-readable summary for debug logs.
+func (c *caddyCoalescer) String() string {
+	return fmt.Sprintf("caddyCoalescer{tick=%s, pending=%d}", c.tick, c.pendingSize())
+}

--- a/internal/service/caddy_coalescer_test.go
+++ b/internal/service/caddy_coalescer_test.go
@@ -1,0 +1,258 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestCoalescerCollapsesSameKey is the load-bearing invariant: a rapid
+// sequence of Enqueues on the same (id, port) reduces to exactly one
+// execution per tick — the LAST intent.
+func TestCoalescerCollapsesSameKey(t *testing.T) {
+	c := newCaddyCoalescer(quietLogger(), 50*time.Millisecond)
+	go c.Run(t.Context())
+	defer c.Stop()
+
+	var (
+		mu        sync.Mutex
+		observed  []string
+		callCount atomic.Int64
+	)
+	record := func(label string) func() error {
+		return func() error {
+			callCount.Add(1)
+			mu.Lock()
+			observed = append(observed, label)
+			mu.Unlock()
+			return nil
+		}
+	}
+
+	// 5 enqueues for the same key before the tick fires; only the last
+	// (op-4) should land. callCount = 1 proves coalescing happened.
+	for i := range 5 {
+		c.Enqueue("sb-1", 8080, record(fmt.Sprintf("op-%d", i)))
+	}
+
+	// Wait for the next tick to drain.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for callCount.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if got := callCount.Load(); got != 1 {
+		t.Fatalf("got %d executions, want 1 (coalesce failed)", got)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(observed) != 1 || observed[0] != "op-4" {
+		t.Fatalf("observed = %v, want [op-4] — coalescer kept the wrong intent", observed)
+	}
+}
+
+// TestCoalescerDistinctKeysIndependent: different (id, port) keys must
+// NOT collapse — each runs its own op in the tick.
+func TestCoalescerDistinctKeysIndependent(t *testing.T) {
+	c := newCaddyCoalescer(quietLogger(), 30*time.Millisecond)
+	go c.Run(t.Context())
+	defer c.Stop()
+
+	var seen sync.Map
+	mark := func(key string) func() error {
+		return func() error {
+			seen.Store(key, true)
+			return nil
+		}
+	}
+
+	c.Enqueue("sb-a", 8080, mark("a:8080"))
+	c.Enqueue("sb-a", 9090, mark("a:9090")) // same id, different port → distinct key
+	c.Enqueue("sb-b", 8080, mark("b:8080"))
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		_, a1 := seen.Load("a:8080")
+		_, a2 := seen.Load("a:9090")
+		_, b1 := seen.Load("b:8080")
+		if a1 && a2 && b1 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("not all distinct keys executed within window")
+}
+
+// TestCoalescerFlushWaitsForResult: Flush is the ordering-critical API
+// — it must block until the op runs and return its error verbatim.
+func TestCoalescerFlushWaitsForResult(t *testing.T) {
+	// Use a long tick so we prove Flush is driving the drain, not the
+	// ticker.
+	c := newCaddyCoalescer(quietLogger(), time.Hour)
+	go c.Run(t.Context())
+	defer c.Stop()
+
+	want := errors.New("write rejected by caddy")
+	err := c.Flush(context.Background(), "sb-flush", 8080, func() error {
+		return want
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("Flush returned %v, want %v", err, want)
+	}
+}
+
+// TestCoalescerFlushRespectsCtx: a cancelled ctx unblocks the Flush
+// caller while leaving the op queued for the tick.
+func TestCoalescerFlushRespectsCtx(t *testing.T) {
+	c := newCaddyCoalescer(quietLogger(), time.Hour)
+	go c.Run(t.Context())
+	defer c.Stop()
+
+	// Block the do func until release fires, so the drain triggered by
+	// Flush is in-flight when the ctx is cancelled. Without this the
+	// tight drain races the ctx cancellation.
+	release := make(chan struct{})
+	executed := make(chan struct{})
+	op := func() error {
+		<-release
+		close(executed)
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	err := c.Flush(ctx, "sb-ctx", 8080, op)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Flush returned %v, want DeadlineExceeded", err)
+	}
+	// The op eventually runs; release it so the test can exit cleanly.
+	close(release)
+	select {
+	case <-executed:
+	case <-time.After(time.Second):
+		t.Fatalf("op never executed after ctx cancellation")
+	}
+}
+
+// TestCoalescerDropNotifiesPriorWaiterWithNil: when a later Enqueue
+// supersedes a pending op that had a notify channel attached, the
+// prior waiter must receive nil (eventual consistency, not a failure).
+//
+// We drive the internal enqueue helper directly so the test does not
+// race the goroutine that Flush kicks for its immediate drain. The
+// guarantee under test is independent of whether Flush or some other
+// caller wired up the notify channel.
+func TestCoalescerDropNotifiesPriorWaiterWithNil(t *testing.T) {
+	c := newCaddyCoalescer(quietLogger(), time.Hour) // ticker won't fire
+	// Do NOT start Run — no drain pressure, so the prior op stays
+	// pending until the supersession lands.
+
+	notify := make(chan error, 1)
+	c.enqueue("sb-drop", 8080, func() error {
+		return errors.New("stale op ran")
+	}, notify)
+
+	c.Enqueue("sb-drop", 8080, func() error { return nil })
+
+	select {
+	case err := <-notify:
+		if err != nil {
+			t.Fatalf("dropped waiter got %v, want nil", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("dropped waiter never woke up")
+	}
+}
+
+// TestCoalescerStopDrainsFinalBatch: Stop must execute any pending op
+// before returning so shutdown does not silently drop writes.
+func TestCoalescerStopDrainsFinalBatch(t *testing.T) {
+	c := newCaddyCoalescer(quietLogger(), time.Hour) // ticker won't fire
+	go c.Run(t.Context())
+
+	var ran atomic.Bool
+	c.Enqueue("sb-final", 8080, func() error {
+		ran.Store(true)
+		return nil
+	})
+	c.Stop()
+	if !ran.Load() {
+		t.Fatalf("Stop returned without draining pending op")
+	}
+}
+
+// TestCoalescerCtxCancelDrains: ctx cancellation should drain on the
+// way out, same as Stop.
+func TestCoalescerCtxCancelDrains(t *testing.T) {
+	c := newCaddyCoalescer(quietLogger(), time.Hour)
+	ctx, cancel := context.WithCancel(context.Background())
+	go c.Run(ctx)
+
+	var ran atomic.Bool
+	c.Enqueue("sb-ctx-drain", 8080, func() error {
+		ran.Store(true)
+		return nil
+	})
+	cancel()
+	// Run returns after its final drain; wait for done.
+	deadline := time.Now().Add(time.Second)
+	for !ran.Load() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !ran.Load() {
+		t.Fatalf("ctx cancel did not drain final op")
+	}
+}
+
+// TestCoalescerPendingSize: the diagnostic counter must reflect what
+// the next drain will process.
+func TestCoalescerPendingSize(t *testing.T) {
+	c := newCaddyCoalescer(quietLogger(), time.Hour)
+	// Don't start Run — we want to inspect pending without the ticker
+	// draining underneath us.
+	noop := func() error { return nil }
+	c.Enqueue("sb-1", 8080, noop)
+	c.Enqueue("sb-2", 8080, noop)
+	c.Enqueue("sb-1", 8080, noop) // collapses with sb-1
+	if got := c.pendingSize(); got != 2 {
+		t.Fatalf("pendingSize = %d, want 2", got)
+	}
+}
+
+// BenchmarkCoalescerThroughput is the D6 baseline number. We measure
+// Enqueue cost under a tight loop because that is the actual hot path
+// the bypass-on rollout will hammer: each Start/Stop produces 1
+// Enqueue per HTTP exposure. Drain throughput is not the bottleneck
+// (Caddy admin is) — Enqueue is.
+//
+// Run with: go test -bench=BenchmarkCoalescerThroughput -benchmem
+//
+//	./internal/service/...
+func BenchmarkCoalescerThroughput(b *testing.B) {
+	c := newCaddyCoalescer(quietLogger(), 10*time.Millisecond)
+	go c.Run(b.Context())
+	defer c.Stop()
+
+	op := func() error { return nil }
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		// Distinct keys per goroutine so we measure the lock-contention
+		// floor, not artificial coalesce collapse.
+		gid := fmt.Sprintf("sb-%p", pb)
+		i := 0
+		for pb.Next() {
+			c.Enqueue(gid, i%64, op)
+			i++
+		}
+	})
+}

--- a/internal/service/l4_bypass_test.go
+++ b/internal/service/l4_bypass_test.go
@@ -1,0 +1,483 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/pkg/caddy"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// shortSockDir returns a tempdir under /tmp (or /var/tmp as a fallback)
+// to keep AF_UNIX socket paths under the platform limit (~104 chars on
+// Darwin, 108 on Linux). t.TempDir() resolves to
+// $TMPDIR/TestLongTestName.../001 which on macOS uses /var/folders/.../T,
+// pushing combined paths past the bind limit when the test name is
+// long. AF_UNIX sockets created by ensureTLSWakeListener live as
+// {dir}/{id}-{port}.sock, so the dir slack we have is roughly 80 chars.
+func shortSockDir(t *testing.T) string {
+	t.Helper()
+	for _, base := range []string{"/tmp", "/var/tmp"} {
+		if _, err := os.Stat(base); err == nil {
+			dir, err := os.MkdirTemp(base, "l4w")
+			if err == nil {
+				t.Cleanup(func() { _ = os.RemoveAll(dir) })
+				return dir
+			}
+		}
+	}
+	return t.TempDir()
+}
+
+// l4Fake records the Caddy admin operations install{TCP,TLS}PortRoute
+// performs against the layer4 admin surface. Distinct from routeFake
+// (HTTP servers) because L4 admin paths live under
+// /config/apps/layer4/servers/{tcp-port-N}, the boot probe needs a
+// minimal 200 on /config/apps/layer4, and TLS routes use the same
+// /id/{routeID} surface but the install path also performs an SNI mux
+// PUT that the HTTP fake does not need to handle.
+type l4Fake struct {
+	mu               sync.Mutex
+	tcpServers       map[string]map[string]any
+	tcpServerDeletes map[string]int
+	tlsRoutes        map[string]map[string]any
+	tlsRouteDeletes  map[string]int
+}
+
+func newL4Fake() *l4Fake {
+	return &l4Fake{
+		tcpServers:       map[string]map[string]any{},
+		tcpServerDeletes: map[string]int{},
+		tlsRoutes:        map[string]map[string]any{},
+		tlsRouteDeletes:  map[string]int{},
+	}
+}
+
+func (f *l4Fake) handler(t *testing.T) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		// Layer4 bootstrap probe — EnsureLayer4Ready GETs and possibly PUTs.
+		case r.URL.Path == "/config/apps/layer4":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		// TLS mux server existence probe / install — caddy.Client may
+		// GET the SNI mux server before patching individual routes.
+		case strings.HasPrefix(r.URL.Path, "/config/apps/layer4/servers/tls-sni"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		case strings.HasPrefix(r.URL.Path, "/config/apps/layer4/servers/"):
+			id := strings.TrimPrefix(r.URL.Path, "/config/apps/layer4/servers/")
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			switch r.Method {
+			case http.MethodPost, http.MethodPut:
+				body, _ := io.ReadAll(r.Body)
+				var parsed map[string]any
+				_ = json.Unmarshal(body, &parsed)
+				f.tcpServers[id] = parsed
+				w.WriteHeader(http.StatusOK)
+			case http.MethodDelete:
+				f.tcpServerDeletes[id]++
+				if _, ok := f.tcpServers[id]; !ok {
+					http.Error(w, "not found", http.StatusNotFound)
+					return
+				}
+				delete(f.tcpServers, id)
+				w.WriteHeader(http.StatusOK)
+			default:
+				t.Fatalf("unexpected method %s on %s", r.Method, r.URL.Path)
+			}
+		case strings.HasPrefix(r.URL.Path, "/id/"):
+			id := strings.TrimPrefix(r.URL.Path, "/id/")
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			switch r.Method {
+			case http.MethodPatch:
+				body, _ := io.ReadAll(r.Body)
+				var parsed map[string]any
+				_ = json.Unmarshal(body, &parsed)
+				if _, ok := f.tlsRoutes[id]; !ok {
+					// caddy.Client falls back to insert-via-server-PUT
+					// when PATCH returns 404. The HTTP install path uses
+					// this idiom too; surfacing 404 here exercises that
+					// fallback faithfully.
+					http.Error(w, "not found", http.StatusNotFound)
+					return
+				}
+				f.tlsRoutes[id] = parsed
+				w.WriteHeader(http.StatusOK)
+			case http.MethodDelete:
+				f.tlsRouteDeletes[id]++
+				if _, ok := f.tlsRoutes[id]; !ok {
+					http.Error(w, "not found", http.StatusNotFound)
+					return
+				}
+				delete(f.tlsRoutes, id)
+				w.WriteHeader(http.StatusOK)
+			default:
+				t.Fatalf("unexpected method %s on %s", r.Method, r.URL.Path)
+			}
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+}
+
+func (f *l4Fake) tcpServerIDs() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, 0, len(f.tcpServers))
+	for id := range f.tcpServers {
+		out = append(out, id)
+	}
+	return out
+}
+
+func (f *l4Fake) tcpServer(id string) map[string]any {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.tcpServers[id]
+}
+
+func newL4TestService(t *testing.T, fake *l4Fake, cfg config.Config) *Service {
+	t.Helper()
+	server := httptest.NewServer(fake.handler(t))
+	t.Cleanup(server.Close)
+	cfg.CaddyAdminURL = server.URL
+	cfg.CaddyServerID = "srv0"
+	cfg.Domain = "sandbox.example.com"
+	cfg.EnableCaddy = true
+	if cfg.HTTPClientTimeout == 0 {
+		cfg.HTTPClientTimeout = 2 * time.Second
+	}
+	if cfg.InternalL4WakeAddr == "" {
+		cfg.InternalL4WakeAddr = "127.0.0.1:21214"
+	}
+	if cfg.InternalL4WakeDir == "" {
+		cfg.InternalL4WakeDir = shortSockDir(t)
+	}
+	svc := &Service{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		caddy:  caddy.New(cfg),
+		cfg:    cfg,
+	}
+	// Skip the layer4 bootstrap dance — the fake answers 200 unconditionally.
+	svc.l4Ready.Store(true)
+	return svc
+}
+
+// dialsAddress walks the recorded layer4 server config and returns the
+// first upstream dial target. The install path nests dials at
+// routes[].handle[].upstreams[].dial[]; pulling the first string at that
+// depth is enough to distinguish a direct upstream
+// (containerIP:port) from a wake target (cfg.InternalL4WakeAddr).
+func dialsAddress(server map[string]any) string {
+	routes, _ := server["routes"].([]any)
+	if len(routes) == 0 {
+		return ""
+	}
+	route, _ := routes[0].(map[string]any)
+	handles, _ := route["handle"].([]any)
+	if len(handles) == 0 {
+		return ""
+	}
+	handle, _ := handles[0].(map[string]any)
+	ups, _ := handle["upstreams"].([]any)
+	if len(ups) == 0 {
+		return ""
+	}
+	upstream, _ := ups[0].(map[string]any)
+	dials, _ := upstream["dial"].([]any)
+	if len(dials) == 0 {
+		return ""
+	}
+	dial, _ := dials[0].(string)
+	return dial
+}
+
+// proxyProtocolFor returns the proxy_protocol setting on the first
+// handle of the first route — wake-aware TCP sets "v1" so sandboxd can
+// recover the hostPort from the PROXY v1 header; direct upstreams omit
+// it entirely. The string return distinguishes "" (direct) from "v1"
+// (wake) cleanly in test assertions.
+func proxyProtocolFor(server map[string]any) string {
+	routes, _ := server["routes"].([]any)
+	if len(routes) == 0 {
+		return ""
+	}
+	route, _ := routes[0].(map[string]any)
+	handles, _ := route["handle"].([]any)
+	if len(handles) == 0 {
+		return ""
+	}
+	handle, _ := handles[0].(map[string]any)
+	pp, _ := handle["proxy_protocol"].(string)
+	return pp
+}
+
+// TestInstallTCPPortRouteWakeWhenL4BypassDisabled — the Phase 2 gate
+// off: every serverless TCP exposure still publishes the wake-aware
+// shape regardless of Started/Stopped. This is the pre-rollout
+// guarantee — flipping HTTP bypass on must NOT incidentally flip L4
+// onto the bypass too.
+func TestInstallTCPPortRouteWakeWhenL4BypassDisabled(t *testing.T) {
+	fake := newL4Fake()
+	svc := newL4TestService(t, fake, config.Config{
+		EnableServerless:            true,
+		HTTPWakeDirectBypassEnabled: true, // HTTP on, L4 off — kinds are independent
+		L4WakeDirectBypassEnabled:   false,
+	})
+	sb := &models.Sandbox{
+		ID:          "tcp-warm",
+		Status:      models.SandboxStatusStarted,
+		ContainerIP: "10.0.0.50",
+		Lifecycle:   models.Lifecycle{Serverless: true},
+	}
+	if err := svc.installTCPPortRoute(context.Background(), sb, 5432, 37001); err != nil {
+		t.Fatalf("installTCPPortRoute: %v", err)
+	}
+	srv := fake.tcpServer("tcp-port-37001")
+	if srv == nil {
+		t.Fatalf("expected tcp-port-37001 server to be published; servers=%v", fake.tcpServerIDs())
+	}
+	if got := proxyProtocolFor(srv); got != "v1" {
+		t.Fatalf("L4 bypass off: warm serverless TCP must still get wake shape (proxy_protocol v1); got %q", got)
+	}
+}
+
+// TestInstallTCPPortRouteDirectWhenL4BypassEnabled — the Phase 2
+// payoff: with the L4 flag on, a warm (Started + ContainerIP) serverless
+// sandbox publishes the direct-upstream server config (no proxy_protocol).
+// Cold serverless traffic still routes through sandboxd; this only
+// drops the sandboxd hop while the sandbox is warm.
+func TestInstallTCPPortRouteDirectWhenL4BypassEnabled(t *testing.T) {
+	fake := newL4Fake()
+	svc := newL4TestService(t, fake, config.Config{
+		EnableServerless:          true,
+		L4WakeDirectBypassEnabled: true,
+	})
+	sb := &models.Sandbox{
+		ID:          "tcp-warm",
+		Status:      models.SandboxStatusStarted,
+		ContainerIP: "10.0.0.50",
+		Lifecycle:   models.Lifecycle{Serverless: true},
+	}
+	if err := svc.installTCPPortRoute(context.Background(), sb, 5432, 37002); err != nil {
+		t.Fatalf("installTCPPortRoute: %v", err)
+	}
+	srv := fake.tcpServer("tcp-port-37002")
+	if srv == nil {
+		t.Fatalf("expected tcp-port-37002 server to be published")
+	}
+	if got := proxyProtocolFor(srv); got != "" {
+		t.Fatalf("L4 bypass on warm: direct shape must omit proxy_protocol; got %q", got)
+	}
+	if got := dialsAddress(srv); got != "10.0.0.50:5432" {
+		t.Fatalf("warm direct dial = %q, want containerIP:port", got)
+	}
+}
+
+// TestInstallTCPPortRouteWakeWhenStoppedArmedBypassOn — cold serverless
+// traffic must continue to go through sandboxd. The bypass flag does
+// not change the cold-path: it strips the per-request hop only while
+// the sandbox is warm.
+func TestInstallTCPPortRouteWakeWhenStoppedArmedBypassOn(t *testing.T) {
+	fake := newL4Fake()
+	svc := newL4TestService(t, fake, config.Config{
+		EnableServerless:          true,
+		L4WakeDirectBypassEnabled: true,
+	})
+	sb := &models.Sandbox{
+		ID:        "tcp-cold",
+		Status:    models.SandboxStatusStopped,
+		WakeArmed: true,
+		Lifecycle: models.Lifecycle{Serverless: true},
+	}
+	if err := svc.installTCPPortRoute(context.Background(), sb, 5432, 37003); err != nil {
+		t.Fatalf("installTCPPortRoute: %v", err)
+	}
+	srv := fake.tcpServer("tcp-port-37003")
+	if srv == nil {
+		t.Fatalf("expected tcp-port-37003 server published")
+	}
+	if got := proxyProtocolFor(srv); got != "v1" {
+		t.Fatalf("Stopped+armed must publish wake shape (proxy_protocol v1); got %q", got)
+	}
+	if got := dialsAddress(srv); got != svc.cfg.InternalL4WakeAddr {
+		t.Fatalf("cold wake dial = %q, want InternalL4WakeAddr %q", got, svc.cfg.InternalL4WakeAddr)
+	}
+}
+
+// TestInstallTCPPortRouteNoneWhenStoppedUnarmedBypassOn — a serverless
+// sandbox that was manually stopped (WakeArmed=false) must NOT auto-
+// resume on inbound TCP. Under Phase 2 the server is removed entirely;
+// kernel-RST on connect is the correct affordance. Today (bypass off)
+// this case would have left a wake route published, which is the
+// behavior the flag rolls back to on disable.
+func TestInstallTCPPortRouteNoneWhenStoppedUnarmedBypassOn(t *testing.T) {
+	fake := newL4Fake()
+	// Pre-seed a leftover server so the test proves Delete is called,
+	// not just "not POSTed."
+	fake.tcpServers["tcp-port-37004"] = map[string]any{"@id": "sandbox-tcp-unarmed-port-5432-tcp"}
+	svc := newL4TestService(t, fake, config.Config{
+		EnableServerless:          true,
+		L4WakeDirectBypassEnabled: true,
+	})
+	sb := &models.Sandbox{
+		ID:        "tcp-unarmed",
+		Status:    models.SandboxStatusStopped,
+		WakeArmed: false,
+		Lifecycle: models.Lifecycle{Serverless: true},
+	}
+	if err := svc.installTCPPortRoute(context.Background(), sb, 5432, 37004); err != nil {
+		t.Fatalf("installTCPPortRoute: %v", err)
+	}
+	if fake.tcpServerDeletes["tcp-port-37004"] == 0 {
+		t.Fatalf("stopped-unarmed serverless TCP must DELETE the L4 server; deletes=%+v", fake.tcpServerDeletes)
+	}
+	if _, ok := fake.tcpServers["tcp-port-37004"]; ok {
+		t.Fatalf("server still present after delete; servers=%v", fake.tcpServerIDs())
+	}
+}
+
+// TestInstallTCPPortRouteNonServerlessAlwaysDirect — the L4 flag is a
+// serverless-only knob; non-serverless TCP exposures continue to publish
+// the direct upstream regardless of flag state. Without this guarantee,
+// flipping the L4 flag would silently route every non-serverless TCP
+// exposure through sandboxd for the duration of the rollout.
+func TestInstallTCPPortRouteNonServerlessAlwaysDirect(t *testing.T) {
+	fake := newL4Fake()
+	svc := newL4TestService(t, fake, config.Config{
+		EnableServerless:          true,
+		L4WakeDirectBypassEnabled: true,
+	})
+	sb := &models.Sandbox{
+		ID:          "tcp-non-sls",
+		Status:      models.SandboxStatusStarted,
+		ContainerIP: "10.0.0.51",
+		Lifecycle:   models.Lifecycle{Serverless: false},
+	}
+	if err := svc.installTCPPortRoute(context.Background(), sb, 5432, 37005); err != nil {
+		t.Fatalf("installTCPPortRoute: %v", err)
+	}
+	srv := fake.tcpServer("tcp-port-37005")
+	if srv == nil {
+		t.Fatalf("expected non-serverless tcp-port-37005 server published")
+	}
+	if got := proxyProtocolFor(srv); got != "" {
+		t.Fatalf("non-serverless must always be direct; got proxy_protocol %q", got)
+	}
+}
+
+// TestScheduleTLSWakeListenerCloseInlineWhenZero — the helper is the
+// only place that decides whether to honor a grace window; passing
+// delay=0 must close immediately so production code that wants the
+// classic "close now" behavior (idempotent cleanup paths, tests) can
+// share one helper without sleeping.
+func TestScheduleTLSWakeListenerCloseInlineWhenZero(t *testing.T) {
+	svc := &Service{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		cfg:    config.Config{InternalL4WakeDir: shortSockDir(t)},
+	}
+	if _, err := svc.ensureTLSWakeListener("tls-zero", 443); err != nil {
+		t.Fatalf("ensureTLSWakeListener: %v", err)
+	}
+	svc.scheduleTLSWakeListenerClose("tls-zero", 443, 0)
+	if _, ok := svc.l4WakeTLS[tlsWakeKey("tls-zero", 443)]; ok {
+		t.Fatalf("zero-delay schedule must close listener inline")
+	}
+	if _, ok := svc.pendingTLSClose[tlsWakeKey("tls-zero", 443)]; ok {
+		t.Fatalf("zero-delay schedule must not register a pending timer")
+	}
+}
+
+// TestScheduleTLSWakeListenerCloseDelaysListenerRemoval — D2 explicitly:
+// the listener stays alive across the schedule call, and only the
+// timer firing closes it. The PATCH-then-close ordering depends on
+// this: if scheduling closed synchronously, an in-flight handshake
+// against the wake socket would drop the moment the new direct route
+// landed.
+func TestScheduleTLSWakeListenerCloseDelaysListenerRemoval(t *testing.T) {
+	svc := &Service{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		cfg:    config.Config{InternalL4WakeDir: shortSockDir(t)},
+	}
+	if _, err := svc.ensureTLSWakeListener("tls-delay", 443); err != nil {
+		t.Fatalf("ensureTLSWakeListener: %v", err)
+	}
+	key := tlsWakeKey("tls-delay", 443)
+	svc.scheduleTLSWakeListenerClose("tls-delay", 443, 25*time.Millisecond)
+	svc.l4WakeMu.Lock()
+	_, listenerStillAlive := svc.l4WakeTLS[key]
+	_, timerRegistered := svc.pendingTLSClose[key]
+	svc.l4WakeMu.Unlock()
+	if !listenerStillAlive {
+		t.Fatalf("listener removed before grace window elapsed; would drop in-flight TLS handshake")
+	}
+	if !timerRegistered {
+		t.Fatalf("pending close timer must be registered for the grace window")
+	}
+	// Wait past the delay; AfterFunc fires from its own goroutine, so
+	// poll briefly rather than racing time.Sleep against the timer.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		svc.l4WakeMu.Lock()
+		_, still := svc.l4WakeTLS[key]
+		svc.l4WakeMu.Unlock()
+		if !still {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("listener never closed after grace window elapsed")
+}
+
+// TestEnsureTLSWakeListenerCancelsPendingClose — the cold→warm→cold
+// race: a delayed close from the previous warm transition must NOT
+// tear down a socket that the new wake route depends on. Without this
+// cancellation, the operator-observable failure is a stopped serverless
+// sandbox whose first inbound TLS handshake silently goes nowhere
+// (the socket vanished mid-route).
+func TestEnsureTLSWakeListenerCancelsPendingClose(t *testing.T) {
+	svc := &Service{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		cfg:    config.Config{InternalL4WakeDir: shortSockDir(t)},
+	}
+	if _, err := svc.ensureTLSWakeListener("tls-flip", 443); err != nil {
+		t.Fatalf("ensureTLSWakeListener (initial cold): %v", err)
+	}
+	key := tlsWakeKey("tls-flip", 443)
+	// Schedule a far-future close — long enough that if cancellation
+	// fails to land, the test would still observe the timer present.
+	svc.scheduleTLSWakeListenerClose("tls-flip", 443, time.Hour)
+	svc.l4WakeMu.Lock()
+	_, hadTimer := svc.pendingTLSClose[key]
+	svc.l4WakeMu.Unlock()
+	if !hadTimer {
+		t.Fatalf("expected pending timer registered before flip-back")
+	}
+	// Simulate cold-again: ensureTLSWakeListener must cancel the timer.
+	if _, err := svc.ensureTLSWakeListener("tls-flip", 443); err != nil {
+		t.Fatalf("ensureTLSWakeListener (flip-back cold): %v", err)
+	}
+	svc.l4WakeMu.Lock()
+	_, stillPending := svc.pendingTLSClose[key]
+	_, listenerAlive := svc.l4WakeTLS[key]
+	svc.l4WakeMu.Unlock()
+	if stillPending {
+		t.Fatalf("ensure-after-schedule must cancel pending close; would erase the new wake socket")
+	}
+	if !listenerAlive {
+		t.Fatalf("listener missing after re-ensure")
+	}
+}

--- a/internal/service/l4wake.go
+++ b/internal/service/l4wake.go
@@ -406,6 +406,13 @@ func (s *Service) ensureTLSWakeListener(id string, port int) (string, error) {
 
 	s.l4WakeMu.Lock()
 	defer s.l4WakeMu.Unlock()
+	// A cold→warm→cold flip within the D2 grace window must not leave a
+	// timer pending against this key: when it fires it would close the
+	// listener the new wake route now depends on.
+	if t, ok := s.pendingTLSClose[key]; ok {
+		t.Stop()
+		delete(s.pendingTLSClose, key)
+	}
 	if s.l4WakeTLS == nil {
 		s.l4WakeTLS = make(map[string]net.Listener)
 	}
@@ -448,12 +455,61 @@ func (s *Service) closeTLSWakeListener(id string, port int) {
 	path := s.tlsWakeSocketPath(id, port)
 
 	s.l4WakeMu.Lock()
+	if t, ok := s.pendingTLSClose[key]; ok {
+		t.Stop()
+		delete(s.pendingTLSClose, key)
+	}
 	if ln, ok := s.l4WakeTLS[key]; ok {
 		_ = ln.Close()
 		delete(s.l4WakeTLS, key)
 	}
 	s.l4WakeMu.Unlock()
 	_ = os.Remove(path)
+}
+
+// scheduleTLSWakeListenerClose defers a closeTLSWakeListener call by
+// delay so a TLS handshake started against the wake-aware route (which
+// terminates on the per-exposure Unix socket) can complete before the
+// listener goes away. D2 of warm-direct-route-bypass: PATCHing the
+// route from wake-aware to direct flips Caddy's view immediately, but
+// any handshake mid-stream when PATCH lands is still talking to the
+// socket — closing it synchronously drops that connection mid-TLS.
+//
+// If delay is non-positive (or the bypass flag is off, leaving the
+// helper to act like closeTLSWakeListener), the close runs inline so
+// tests can poke the lifecycle without sleeping. Any pending timer for
+// the same key is replaced — the most recent direct transition is the
+// one whose grace window applies.
+func (s *Service) scheduleTLSWakeListenerClose(id string, port int, delay time.Duration) {
+	if delay <= 0 {
+		s.closeTLSWakeListener(id, port)
+		return
+	}
+	key := tlsWakeKey(id, port)
+	s.l4WakeMu.Lock()
+	defer s.l4WakeMu.Unlock()
+	if s.pendingTLSClose == nil {
+		s.pendingTLSClose = make(map[string]*time.Timer)
+	}
+	if t, ok := s.pendingTLSClose[key]; ok {
+		t.Stop()
+	}
+	s.pendingTLSClose[key] = time.AfterFunc(delay, func() {
+		// Re-check inside the mutex that this timer is still the
+		// authoritative one for the key. A cold→warm→cold sequence may
+		// have replaced it; in that case the newer schedule (or
+		// ensureTLSWakeListener's cancellation) already owns the
+		// lifecycle decision and we must not double-close.
+		s.l4WakeMu.Lock()
+		current, ok := s.pendingTLSClose[key]
+		if !ok || current == nil {
+			s.l4WakeMu.Unlock()
+			return
+		}
+		delete(s.pendingTLSClose, key)
+		s.l4WakeMu.Unlock()
+		s.closeTLSWakeListener(id, port)
+	})
 }
 
 func (s *Service) closeAllTLSWakeListeners() {

--- a/internal/service/netstats.go
+++ b/internal/service/netstats.go
@@ -219,6 +219,14 @@ func (k netstatsServiceSink) HandleSamples(ctx context.Context, samples []netsta
 		return
 	}
 	for _, sample := range samples {
+		// Activity floor for the idle sweep under bypass-on: record
+		// the SampledAt of any non-zero BytesIn observation. We do this
+		// BEFORE the BytesOut-only skip below because warm HTTP traffic
+		// is exactly a "BytesIn>0 only" signal; without this record the
+		// sweep cannot tell a chatty warm sandbox apart from an idle one.
+		if sample.BytesIn > 0 {
+			k.svc.recordNetstatsActivity(sample.SandboxID, sample.SampledAt)
+		}
 		if sample.BytesIn == 0 && sample.BytesOut == 0 {
 			continue
 		}

--- a/internal/service/route_shape.go
+++ b/internal/service/route_shape.go
@@ -39,26 +39,57 @@ func (r RouteShape) String() string {
 	}
 }
 
-// chooseRouteShape is a pure function of the sandbox row and the
-// service configuration. No I/O, no locks, no side effects — every
-// callsite of installHTTPPortRoute / installTCPPortRoute /
-// installTLSPortRoute funnels through this so reconcile, lifecycle,
-// and event paths cannot disagree on what shape "should" be live.
+// RouteKind is the protocol surface a callsite is choosing a shape
+// for. HTTP and L4 (TCP/TLS) consult different bypass flags so each
+// can be rolled out independently — Phase 1 ships HTTP behind
+// SB_HTTP_WAKE_DIRECT_BYPASS_ENABLED; Phase 2 ships L4 behind
+// SB_L4_WAKE_DIRECT_BYPASS_ENABLED. Within each kind the decision
+// tree is identical (Status + WakeArmed + ContainerIP) — only the
+// "is bypass enabled?" predicate differs.
+type RouteKind int
+
+const (
+	RouteKindHTTP RouteKind = iota
+	RouteKindL4
+)
+
+// bypassEnabledFor reports whether the warm-direct bypass is active
+// for the given protocol kind. Centralized so activityFloorFor /
+// netstatsPollIsStale can OR both flags without duplicating the
+// switch — when either bypass is on, the netstats activity floor
+// must be live since warm traffic of that protocol no longer bumps
+// LastActiveAt via the per-request paths.
+func (s *Service) bypassEnabledFor(kind RouteKind) bool {
+	switch kind {
+	case RouteKindHTTP:
+		return s.cfg.HTTPWakeDirectBypassEnabled
+	case RouteKindL4:
+		return s.cfg.L4WakeDirectBypassEnabled
+	}
+	return false
+}
+
+// chooseRouteShape is a pure function of the sandbox row, the
+// protocol kind, and the service configuration. No I/O, no locks, no
+// side effects — every callsite of installHTTPPortRoute /
+// installTCPPortRoute / installTLSPortRoute funnels through this so
+// reconcile, lifecycle, and event paths cannot disagree on what shape
+// "should" be live.
 //
 // The decision tree:
 //
 //   - Destroyed → none.
 //   - Non-serverless (or serverless rollout gate off) → direct always
 //     (today's behavior for the entire non-serverless surface).
-//   - Bypass disabled (HTTPWakeDirectBypassEnabled=false) → wake always
-//     for serverless sandboxes (today's behavior — every request goes
-//     through sandboxd regardless of warm/cold).
+//   - Bypass disabled for kind → wake always for serverless sandboxes
+//     (today's behavior — every request of that protocol goes through
+//     sandboxd regardless of warm/cold).
 //   - Bypass enabled + Started + ContainerIP known → direct.
 //   - Bypass enabled + Stopped + WakeArmed → wake.
 //   - Anything else (Creating, transient states, missing IP) → none;
 //     callers that hold the row in a transient state should retry
 //     once the row settles.
-func (s *Service) chooseRouteShape(sandbox *models.Sandbox) RouteShape {
+func (s *Service) chooseRouteShape(sandbox *models.Sandbox, kind RouteKind) RouteShape {
 	if sandbox == nil {
 		return RouteShapeNone
 	}
@@ -68,7 +99,7 @@ func (s *Service) chooseRouteShape(sandbox *models.Sandbox) RouteShape {
 	if !s.serverlessWakeEnabled(sandbox) {
 		return RouteShapeDirect
 	}
-	if !s.cfg.HTTPWakeDirectBypassEnabled {
+	if !s.bypassEnabledFor(kind) {
 		return RouteShapeWake
 	}
 	if sandbox.Status == models.SandboxStatusStarted && sandbox.ContainerIP != "" {
@@ -78,4 +109,14 @@ func (s *Service) chooseRouteShape(sandbox *models.Sandbox) RouteShape {
 		return RouteShapeWake
 	}
 	return RouteShapeNone
+}
+
+// anyBypassEnabled reports whether any protocol's warm-direct bypass
+// is on. The idle sweep's netstats activity floor and stale-poll
+// fallback (D3/D4) must be active whenever any bypass routes warm
+// traffic around the per-request TouchSandbox path — and since
+// netstats observes container interface bytes regardless of protocol,
+// one floor covers HTTP + L4 with a single mechanism.
+func (s *Service) anyBypassEnabled() bool {
+	return s.cfg.HTTPWakeDirectBypassEnabled || s.cfg.L4WakeDirectBypassEnabled
 }

--- a/internal/service/route_shape.go
+++ b/internal/service/route_shape.go
@@ -1,0 +1,81 @@
+package service
+
+import "github.com/aerol-ai/microvm/pkg/models"
+
+// RouteShape is the published Caddy shape for a (sandbox, exposed-port).
+// One shape is live at a time per exposure; transitions are driven by
+// status changes (Start/Stop/Die/Reconcile), never by per-request work.
+//
+// See plans/warm-direct-route-bypass.md D7/D8 — this enum + chooseRouteShape
+// are the single source of truth so HTTP, TCP, TLS, reconcile, and event
+// callsites cannot disagree about what shape should be live for a given
+// sandbox row.
+type RouteShape int
+
+const (
+	// RouteShapeNone means no route should be published. Destroyed
+	// sandboxes and disarmed-stopped serverless sandboxes fall through
+	// to Caddy's fallback (404).
+	RouteShapeNone RouteShape = iota
+	// RouteShapeDirect publishes the upstream as ContainerIP:port.
+	// Used for non-serverless sandboxes always, and for serverless
+	// sandboxes only while warm (HTTPWakeDirectBypassEnabled=true).
+	RouteShapeDirect
+	// RouteShapeWake publishes the upstream as the sandboxd loopback
+	// ingress proxy (or per-exposure unix socket for TLS). Used for
+	// serverless sandboxes while Stopped+armed, and for serverless
+	// sandboxes always when HTTPWakeDirectBypassEnabled=false.
+	RouteShapeWake
+)
+
+func (r RouteShape) String() string {
+	switch r {
+	case RouteShapeDirect:
+		return "direct"
+	case RouteShapeWake:
+		return "wake"
+	default:
+		return "none"
+	}
+}
+
+// chooseRouteShape is a pure function of the sandbox row and the
+// service configuration. No I/O, no locks, no side effects — every
+// callsite of installHTTPPortRoute / installTCPPortRoute /
+// installTLSPortRoute funnels through this so reconcile, lifecycle,
+// and event paths cannot disagree on what shape "should" be live.
+//
+// The decision tree:
+//
+//   - Destroyed → none.
+//   - Non-serverless (or serverless rollout gate off) → direct always
+//     (today's behavior for the entire non-serverless surface).
+//   - Bypass disabled (HTTPWakeDirectBypassEnabled=false) → wake always
+//     for serverless sandboxes (today's behavior — every request goes
+//     through sandboxd regardless of warm/cold).
+//   - Bypass enabled + Started + ContainerIP known → direct.
+//   - Bypass enabled + Stopped + WakeArmed → wake.
+//   - Anything else (Creating, transient states, missing IP) → none;
+//     callers that hold the row in a transient state should retry
+//     once the row settles.
+func (s *Service) chooseRouteShape(sandbox *models.Sandbox) RouteShape {
+	if sandbox == nil {
+		return RouteShapeNone
+	}
+	if sandbox.Status == models.SandboxStatusDestroyed {
+		return RouteShapeNone
+	}
+	if !s.serverlessWakeEnabled(sandbox) {
+		return RouteShapeDirect
+	}
+	if !s.cfg.HTTPWakeDirectBypassEnabled {
+		return RouteShapeWake
+	}
+	if sandbox.Status == models.SandboxStatusStarted && sandbox.ContainerIP != "" {
+		return RouteShapeDirect
+	}
+	if sandbox.Status == models.SandboxStatusStopped && sandbox.WakeArmed {
+		return RouteShapeWake
+	}
+	return RouteShapeNone
+}

--- a/internal/service/route_shape_test.go
+++ b/internal/service/route_shape_test.go
@@ -1,0 +1,161 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// TestChooseRouteShape exercises every branch of the decision tree.
+// The function is pure, so the harness is just two cfg knobs and a
+// constructed sandbox row — no store, no Caddy. Each cell of
+// (status × wake_armed × bypass_on × serverless × container_ip) is
+// represented so a regression in any one branch produces a single
+// labeled failure.
+func TestChooseRouteShape(t *testing.T) {
+	mk := func(status models.SandboxStatus, ip string, wakeArmed, serverless bool) *models.Sandbox {
+		return &models.Sandbox{
+			Status:      status,
+			ContainerIP: ip,
+			WakeArmed:   wakeArmed,
+			Lifecycle:   models.Lifecycle{Serverless: serverless},
+		}
+	}
+
+	cases := []struct {
+		name             string
+		enableServerless bool
+		bypassEnabled    bool
+		sandbox          *models.Sandbox
+		want             RouteShape
+	}{
+		{
+			name: "nil_sandbox",
+			want: RouteShapeNone,
+		},
+		{
+			name:    "destroyed_serverless_returns_none",
+			sandbox: mk(models.SandboxStatusDestroyed, "10.0.0.1", true, true),
+			want:    RouteShapeNone,
+		},
+		{
+			name:             "destroyed_non_serverless_returns_none",
+			enableServerless: true,
+			sandbox:          mk(models.SandboxStatusDestroyed, "10.0.0.1", false, false),
+			want:             RouteShapeNone,
+		},
+		{
+			// Non-serverless always gets direct, even when bypass is off —
+			// the bypass flag is a serverless-only knob.
+			name:    "non_serverless_started_direct",
+			sandbox: mk(models.SandboxStatusStarted, "10.0.0.1", false, false),
+			want:    RouteShapeDirect,
+		},
+		{
+			// Serverless flag on the row but rollout gate off → falls back
+			// to non-serverless behavior (direct).
+			name:    "serverless_but_rollout_gate_off_direct",
+			sandbox: mk(models.SandboxStatusStarted, "10.0.0.1", false, true),
+			want:    RouteShapeDirect,
+		},
+		{
+			// Bypass off → every serverless route is wake-shape regardless
+			// of running state. This is today's behavior pre-rollout.
+			name:             "serverless_bypass_off_started_wake",
+			enableServerless: true,
+			sandbox:          mk(models.SandboxStatusStarted, "10.0.0.1", false, true),
+			want:             RouteShapeWake,
+		},
+		{
+			name:             "serverless_bypass_off_stopped_armed_wake",
+			enableServerless: true,
+			sandbox:          mk(models.SandboxStatusStopped, "", true, true),
+			want:             RouteShapeWake,
+		},
+		{
+			name:             "serverless_bypass_off_stopped_unarmed_wake",
+			enableServerless: true,
+			sandbox:          mk(models.SandboxStatusStopped, "", false, true),
+			want:             RouteShapeWake,
+		},
+		{
+			// Bypass on + warm row with IP → direct (the whole point).
+			name:             "serverless_bypass_on_started_with_ip_direct",
+			enableServerless: true,
+			bypassEnabled:    true,
+			sandbox:          mk(models.SandboxStatusStarted, "10.0.0.1", false, true),
+			want:             RouteShapeDirect,
+		},
+		{
+			// Bypass on + Started but no IP yet → none. Callsite is in a
+			// transient window between status flip and IP discovery; the
+			// event/reconcile path retries once the IP lands.
+			name:             "serverless_bypass_on_started_no_ip_none",
+			enableServerless: true,
+			bypassEnabled:    true,
+			sandbox:          mk(models.SandboxStatusStarted, "", false, true),
+			want:             RouteShapeNone,
+		},
+		{
+			// Bypass on + Stopped + armed → wake-shape (the warm/cold
+			// switch in action).
+			name:             "serverless_bypass_on_stopped_armed_wake",
+			enableServerless: true,
+			bypassEnabled:    true,
+			sandbox:          mk(models.SandboxStatusStopped, "", true, true),
+			want:             RouteShapeWake,
+		},
+		{
+			// Bypass on + Stopped + UNARMED → none. The sandbox was
+			// manually stopped, so it must not auto-resume on the next
+			// request. Caddy's 404 fallback handles inbound traffic.
+			name:             "serverless_bypass_on_stopped_unarmed_none",
+			enableServerless: true,
+			bypassEnabled:    true,
+			sandbox:          mk(models.SandboxStatusStopped, "", false, true),
+			want:             RouteShapeNone,
+		},
+		{
+			// Bypass on + transient state (Creating) → none. Lets the
+			// caller wait one tick before publishing anything.
+			name:             "serverless_bypass_on_creating_none",
+			enableServerless: true,
+			bypassEnabled:    true,
+			sandbox:          mk(models.SandboxStatusCreating, "", false, true),
+			want:             RouteShapeNone,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &Service{cfg: config.Config{
+				EnableServerless:            tc.enableServerless,
+				HTTPWakeDirectBypassEnabled: tc.bypassEnabled,
+			}}
+			got := svc.chooseRouteShape(tc.sandbox)
+			if got != tc.want {
+				t.Fatalf("chooseRouteShape = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRouteShapeString covers the String() helper since the slog audit
+// lines depend on the labels matching the documented enum names.
+func TestRouteShapeString(t *testing.T) {
+	cases := []struct {
+		shape RouteShape
+		want  string
+	}{
+		{RouteShapeNone, "none"},
+		{RouteShapeDirect, "direct"},
+		{RouteShapeWake, "wake"},
+		{RouteShape(99), "none"},
+	}
+	for _, tc := range cases {
+		if got := tc.shape.String(); got != tc.want {
+			t.Errorf("RouteShape(%d).String() = %q, want %q", int(tc.shape), got, tc.want)
+		}
+	}
+}

--- a/internal/service/route_shape_test.go
+++ b/internal/service/route_shape_test.go
@@ -27,21 +27,25 @@ func TestChooseRouteShape(t *testing.T) {
 		name             string
 		enableServerless bool
 		bypassEnabled    bool
+		kind             RouteKind
 		sandbox          *models.Sandbox
 		want             RouteShape
 	}{
 		{
 			name: "nil_sandbox",
+			kind: RouteKindHTTP,
 			want: RouteShapeNone,
 		},
 		{
 			name:    "destroyed_serverless_returns_none",
+			kind:    RouteKindHTTP,
 			sandbox: mk(models.SandboxStatusDestroyed, "10.0.0.1", true, true),
 			want:    RouteShapeNone,
 		},
 		{
 			name:             "destroyed_non_serverless_returns_none",
 			enableServerless: true,
+			kind:             RouteKindHTTP,
 			sandbox:          mk(models.SandboxStatusDestroyed, "10.0.0.1", false, false),
 			want:             RouteShapeNone,
 		},
@@ -49,6 +53,7 @@ func TestChooseRouteShape(t *testing.T) {
 			// Non-serverless always gets direct, even when bypass is off —
 			// the bypass flag is a serverless-only knob.
 			name:    "non_serverless_started_direct",
+			kind:    RouteKindHTTP,
 			sandbox: mk(models.SandboxStatusStarted, "10.0.0.1", false, false),
 			want:    RouteShapeDirect,
 		},
@@ -56,6 +61,7 @@ func TestChooseRouteShape(t *testing.T) {
 			// Serverless flag on the row but rollout gate off → falls back
 			// to non-serverless behavior (direct).
 			name:    "serverless_but_rollout_gate_off_direct",
+			kind:    RouteKindHTTP,
 			sandbox: mk(models.SandboxStatusStarted, "10.0.0.1", false, true),
 			want:    RouteShapeDirect,
 		},
@@ -64,18 +70,21 @@ func TestChooseRouteShape(t *testing.T) {
 			// of running state. This is today's behavior pre-rollout.
 			name:             "serverless_bypass_off_started_wake",
 			enableServerless: true,
+			kind:             RouteKindHTTP,
 			sandbox:          mk(models.SandboxStatusStarted, "10.0.0.1", false, true),
 			want:             RouteShapeWake,
 		},
 		{
 			name:             "serverless_bypass_off_stopped_armed_wake",
 			enableServerless: true,
+			kind:             RouteKindHTTP,
 			sandbox:          mk(models.SandboxStatusStopped, "", true, true),
 			want:             RouteShapeWake,
 		},
 		{
 			name:             "serverless_bypass_off_stopped_unarmed_wake",
 			enableServerless: true,
+			kind:             RouteKindHTTP,
 			sandbox:          mk(models.SandboxStatusStopped, "", false, true),
 			want:             RouteShapeWake,
 		},
@@ -84,6 +93,7 @@ func TestChooseRouteShape(t *testing.T) {
 			name:             "serverless_bypass_on_started_with_ip_direct",
 			enableServerless: true,
 			bypassEnabled:    true,
+			kind:             RouteKindHTTP,
 			sandbox:          mk(models.SandboxStatusStarted, "10.0.0.1", false, true),
 			want:             RouteShapeDirect,
 		},
@@ -94,6 +104,7 @@ func TestChooseRouteShape(t *testing.T) {
 			name:             "serverless_bypass_on_started_no_ip_none",
 			enableServerless: true,
 			bypassEnabled:    true,
+			kind:             RouteKindHTTP,
 			sandbox:          mk(models.SandboxStatusStarted, "", false, true),
 			want:             RouteShapeNone,
 		},
@@ -103,6 +114,7 @@ func TestChooseRouteShape(t *testing.T) {
 			name:             "serverless_bypass_on_stopped_armed_wake",
 			enableServerless: true,
 			bypassEnabled:    true,
+			kind:             RouteKindHTTP,
 			sandbox:          mk(models.SandboxStatusStopped, "", true, true),
 			want:             RouteShapeWake,
 		},
@@ -113,6 +125,7 @@ func TestChooseRouteShape(t *testing.T) {
 			name:             "serverless_bypass_on_stopped_unarmed_none",
 			enableServerless: true,
 			bypassEnabled:    true,
+			kind:             RouteKindHTTP,
 			sandbox:          mk(models.SandboxStatusStopped, "", false, true),
 			want:             RouteShapeNone,
 		},
@@ -122,8 +135,20 @@ func TestChooseRouteShape(t *testing.T) {
 			name:             "serverless_bypass_on_creating_none",
 			enableServerless: true,
 			bypassEnabled:    true,
+			kind:             RouteKindHTTP,
 			sandbox:          mk(models.SandboxStatusCreating, "", false, true),
 			want:             RouteShapeNone,
+		},
+		{
+			// L4 with its own bypass off but HTTP bypass on → wake.
+			// Each kind reads only its own flag; cross-kind leakage would
+			// break the independent rollout the two env vars promise.
+			name:             "l4_bypass_off_started_with_ip_wake_even_when_http_on",
+			enableServerless: true,
+			bypassEnabled:    true,
+			kind:             RouteKindL4,
+			sandbox:          mk(models.SandboxStatusStarted, "10.0.0.1", false, true),
+			want:             RouteShapeWake,
 		},
 	}
 
@@ -133,9 +158,75 @@ func TestChooseRouteShape(t *testing.T) {
 				EnableServerless:            tc.enableServerless,
 				HTTPWakeDirectBypassEnabled: tc.bypassEnabled,
 			}}
-			got := svc.chooseRouteShape(tc.sandbox)
+			got := svc.chooseRouteShape(tc.sandbox, tc.kind)
 			if got != tc.want {
 				t.Fatalf("chooseRouteShape = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestChooseRouteShapeL4 covers the L4-kind branches that mirror HTTP
+// once SB_L4_WAKE_DIRECT_BYPASS_ENABLED is on. The cross-kind isolation
+// case (HTTP on, L4 off) lives in TestChooseRouteShape — these focus on
+// proving the L4 decision tree itself agrees with HTTP once the L4 flag
+// is on.
+func TestChooseRouteShapeL4(t *testing.T) {
+	mk := func(status models.SandboxStatus, ip string, wakeArmed bool) *models.Sandbox {
+		return &models.Sandbox{
+			Status:      status,
+			ContainerIP: ip,
+			WakeArmed:   wakeArmed,
+			Lifecycle:   models.Lifecycle{Serverless: true},
+		}
+	}
+	svc := &Service{cfg: config.Config{
+		EnableServerless:          true,
+		L4WakeDirectBypassEnabled: true,
+	}}
+	cases := []struct {
+		name    string
+		sandbox *models.Sandbox
+		want    RouteShape
+	}{
+		{"l4_bypass_on_started_with_ip_direct", mk(models.SandboxStatusStarted, "10.0.0.1", false), RouteShapeDirect},
+		{"l4_bypass_on_started_no_ip_none", mk(models.SandboxStatusStarted, "", false), RouteShapeNone},
+		{"l4_bypass_on_stopped_armed_wake", mk(models.SandboxStatusStopped, "", true), RouteShapeWake},
+		{"l4_bypass_on_stopped_unarmed_none", mk(models.SandboxStatusStopped, "", false), RouteShapeNone},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := svc.chooseRouteShape(tc.sandbox, RouteKindL4); got != tc.want {
+				t.Fatalf("chooseRouteShape(L4) = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAnyBypassEnabled proves the OR helper that activityFloorFor /
+// netstatsPollIsStale rely on — when either protocol's bypass is on,
+// the netstats activity floor must be live since warm traffic of that
+// protocol no longer bumps LastActiveAt through the per-request path.
+func TestAnyBypassEnabled(t *testing.T) {
+	cases := []struct {
+		name string
+		http bool
+		l4   bool
+		want bool
+	}{
+		{"both_off", false, false, false},
+		{"http_only", true, false, true},
+		{"l4_only", false, true, true},
+		{"both_on", true, true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &Service{cfg: config.Config{
+				HTTPWakeDirectBypassEnabled: tc.http,
+				L4WakeDirectBypassEnabled:   tc.l4,
+			}}
+			if got := svc.anyBypassEnabled(); got != tc.want {
+				t.Fatalf("anyBypassEnabled = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/internal/service/serverless.go
+++ b/internal/service/serverless.go
@@ -222,10 +222,24 @@ func (s *Service) tearDownPortRoutesForStop(ctx context.Context, sandbox *models
 		wakeRouteAttempted bool
 		wakeRouteInstalled bool
 	)
+	// Pre-stop arming runs while sandbox.Status is still Started, but we
+	// want the wake-aware shape installed *now* (before docker.Stop
+	// fires). chooseRouteShape decides the shape from sandbox.Status, so
+	// pass a synthetic post-stop view for arming. Under bypass-off this
+	// is a no-op effectively (serverless always returns Wake regardless
+	// of status); under bypass-on it is the load-bearing piece that
+	// keeps wake-first ordering correct.
+	var armView *models.Sandbox
+	if arm {
+		view := *sandbox
+		view.Status = models.SandboxStatusStopped
+		view.WakeArmed = true
+		armView = &view
+	}
 	for _, port := range sandbox.ExposedPorts {
 		if arm {
 			wakeRouteAttempted = true
-			if err := s.upsertExposedPortRoute(ctx, sandbox, port); err != nil {
+			if err := s.upsertExposedPortRoute(ctx, armView, port); err != nil {
 				s.logger.Warn("install wake route on stop failed",
 					"sandbox_id", sandbox.ID, "port", port.Port, "protocol", port.Protocol, "error", err)
 			} else {
@@ -313,9 +327,18 @@ func (s *Service) ReconstructWakeArmedIfNeeded(ctx context.Context, sandbox *mod
 		exposedPortsSeen   int
 		wakeRouteInstalled bool
 	)
+	// Same synthetic-view trick as tearDownPortRoutesForStop: this is
+	// the reconstruction / re-assertion path, so we want the WAKE shape
+	// regardless of whether the row's WakeArmed bit is currently true
+	// (re-assert case) or false (reconstruct case). chooseRouteShape
+	// would otherwise return RouteShapeNone for Stopped+!WakeArmed
+	// under bypass-on and delete both routes — the opposite of the
+	// reconstruction intent. Status is already Stopped here.
+	armView := *sandbox
+	armView.WakeArmed = true
 	for _, port := range sandbox.ExposedPorts {
 		exposedPortsSeen++
-		if err := s.upsertExposedPortRoute(ctx, sandbox, port); err != nil {
+		if err := s.upsertExposedPortRoute(ctx, &armView, port); err != nil {
 			s.logger.Warn("reconstruct wake route failed",
 				"sandbox_id", sandbox.ID, "port", port.Port, "protocol", port.Protocol, "error", err)
 			continue
@@ -620,4 +643,55 @@ func (m stopMode) String() string {
 	default:
 		return fmt.Sprintf("stopMode(%d)", int(m))
 	}
+}
+
+// ForceReconcileHTTPWakeShape republishes the HTTP route for every
+// serverless sandbox's HTTP exposures using the current
+// HTTPWakeDirectBypassEnabled value. Called exactly once at daemon
+// startup when the rollback marker shows the previous run had bypass=true
+// and the current run has bypass=false: without this, every serverless
+// sandbox that was last written under bypass=true keeps its direct route
+// pointing straight at the container IP, bypassing the wake-aware
+// ingress proxy entirely — i.e. the rollback knob would not actually
+// roll back. Conversely, on a fresh enable (false→true) routes will be
+// rewritten lazily on the next Start/Stop, so no force-pass is needed in
+// that direction (D5 of plans/warm-direct-route-bypass.md).
+//
+// Idempotent: chooseRouteShape is a pure function of (cfg, sandbox), so
+// repeated calls converge to the same route set. Best-effort per
+// sandbox — one failed Caddy write logs and the loop continues so a
+// single broken row does not block the rest from being rolled back.
+func (s *Service) ForceReconcileHTTPWakeShape(ctx context.Context) error {
+	if !s.cfg.EnableServerless {
+		return nil
+	}
+	sandboxes, err := s.store.List(ctx)
+	if err != nil {
+		return fmt.Errorf("force reconcile http wake shape: list sandboxes: %w", err)
+	}
+	var (
+		visited int
+		failed  int
+	)
+	for _, sandbox := range sandboxes {
+		if sandbox == nil || !sandbox.Lifecycle.Serverless {
+			continue
+		}
+		for _, port := range sandbox.ExposedPorts {
+			if port.Protocol != "" && port.Protocol != models.ExposedPortProtocolHTTP {
+				continue
+			}
+			visited++
+			if err := s.installHTTPPortRoute(ctx, sandbox, port.Port); err != nil {
+				failed++
+				s.logger.Warn("force reconcile http wake shape failed for port",
+					"sandbox_id", sandbox.ID, "port", port.Port, "error", err)
+			}
+		}
+	}
+	s.logger.Info("force reconcile http wake shape complete",
+		"visited", visited, "failed", failed,
+		"bypass_enabled", s.cfg.HTTPWakeDirectBypassEnabled,
+	)
+	return nil
 }

--- a/internal/service/serverless_test.go
+++ b/internal/service/serverless_test.go
@@ -1007,6 +1007,159 @@ func TestInstallHTTPPortRouteNonServerlessInstallsDirectAndClearsWake(t *testing
 	}
 }
 
+// TestForceReconcileHTTPWakeShapeRollback exercises the bypass-flip
+// rollback flow end-to-end at the service layer: a Started serverless
+// sandbox with an HTTP exposure that was last written under bypass=true
+// (Caddy holds the direct route) must, after the cfg flips to bypass=
+// false and ForceReconcileHTTPWakeShape runs, end up with the wake
+// route published and the direct route removed.
+//
+// This is the load-bearing rollback invariant for the marker file in
+// cmd/sandboxd/main.go: without it, flipping the env var off would
+// leave every long-lived serverless sandbox routed straight to its
+// container forever, defeating the rollback knob entirely.
+func TestForceReconcileHTTPWakeShapeRollback(t *testing.T) {
+	ctx := context.Background()
+	fake := newRouteFake()
+	// Pre-seed: the sandbox is currently routed direct (the state a
+	// bypass=true run would have left behind).
+	fake.routes["sandbox-roll-port-3000"] = map[string]any{"@id": "sandbox-roll-port-3000"}
+
+	svc, st := newServerlessHarness(t, &fakeCapacityRuntime{})
+	server := httptest.NewServer(fake.handler(t))
+	t.Cleanup(server.Close)
+	svc.caddy = caddy.New(config.Config{
+		CaddyAdminURL:     server.URL,
+		CaddyServerID:     "srv0",
+		Domain:            "sandbox.example.com",
+		EnableCaddy:       true,
+		HTTPClientTimeout: 2 * time.Second,
+	})
+	// Critical: the current run has bypass DISABLED. That is what
+	// makes chooseRouteShape return wake for a Started serverless
+	// sandbox during this pass.
+	svc.cfg = config.Config{
+		EnableServerless:            true,
+		HTTPWakeDirectBypassEnabled: false,
+		InternalIngressAddr:         "127.0.0.1:21213",
+		Domain:                      "sandbox.example.com",
+		EnableCaddy:                 true,
+	}
+
+	sb := seedServerlessSandbox(t, st, "roll", true)
+	// Persist an HTTP exposure so ForceReconcileHTTPWakeShape sees it.
+	exposure := models.ExposedPort{
+		SandboxID: sb.ID,
+		Port:      3000,
+		Protocol:  models.ExposedPortProtocolHTTP,
+		PublicURL: "https://roll-3000.sandbox.example.com",
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := st.UpsertPort(ctx, exposure); err != nil {
+		t.Fatalf("UpsertPort: %v", err)
+	}
+
+	if err := svc.ForceReconcileHTTPWakeShape(ctx); err != nil {
+		t.Fatalf("ForceReconcileHTTPWakeShape: %v", err)
+	}
+
+	// Wake route should now be live; direct route should be gone.
+	gotIDs := fake.routeIDs()
+	wantIDs := []string{"sandbox-roll-port-3000-wake"}
+	if !equalSorted(gotIDs, wantIDs) {
+		t.Fatalf("post-rollback route ids = %v, want %v", gotIDs, wantIDs)
+	}
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if fake.deletes["sandbox-roll-port-3000"] == 0 {
+		t.Fatalf("direct route delete was not attempted; deletes=%+v", fake.deletes)
+	}
+}
+
+// TestForceReconcileHTTPWakeShapeNoopWhenServerlessDisabled: with the
+// rollout gate off, ForceReconcileHTTPWakeShape must not touch Caddy
+// at all — even if the marker file says we just rolled back. The gate
+// is the master switch; the bypass flag is a sub-flag below it.
+func TestForceReconcileHTTPWakeShapeNoopWhenServerlessDisabled(t *testing.T) {
+	ctx := context.Background()
+	fake := newRouteFake()
+	svc, st := newServerlessHarness(t, &fakeCapacityRuntime{})
+	server := httptest.NewServer(fake.handler(t))
+	t.Cleanup(server.Close)
+	svc.caddy = caddy.New(config.Config{
+		CaddyAdminURL: server.URL,
+		CaddyServerID: "srv0",
+		Domain:        "sandbox.example.com",
+		EnableCaddy:   true,
+	})
+	svc.cfg = config.Config{EnableServerless: false}
+
+	sb := seedServerlessSandbox(t, st, "gated", true)
+	if err := st.UpsertPort(ctx, models.ExposedPort{
+		SandboxID: sb.ID,
+		Port:      3000,
+		Protocol:  models.ExposedPortProtocolHTTP,
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("UpsertPort: %v", err)
+	}
+
+	if err := svc.ForceReconcileHTTPWakeShape(ctx); err != nil {
+		t.Fatalf("ForceReconcileHTTPWakeShape: %v", err)
+	}
+	if len(fake.routeIDs()) != 0 {
+		t.Fatalf("routes were written despite gate off: %v", fake.routeIDs())
+	}
+}
+
+// TestInstallHTTPPortRouteCoalescesConcurrentSameKey asserts the
+// Phase 1 wiring: N goroutines racing on installHTTPPortRoute for the
+// same (id, port) must collapse to fewer than N Caddy admin writes.
+// The exact collapse count is timing-dependent (depends on how many
+// arrive before the first drain), but it must be strictly less than N
+// in the contended case — otherwise the coalescer's drop-and-supersede
+// path is not wired and the Phase 3 perf benefit is lost.
+func TestInstallHTTPPortRouteCoalescesConcurrentSameKey(t *testing.T) {
+	fake := newRouteFake()
+	svc := newRouteTestService(t, fake, false)
+	// Pre-seed the route so PATCH succeeds without falling through to
+	// the PUT-on-not-found path — we want to count PATCHes cleanly.
+	fake.routes["sandbox-coalesce-port-3000"] = map[string]any{"@id": "sandbox-coalesce-port-3000"}
+	sb := &models.Sandbox{
+		ID:          "coalesce",
+		ContainerIP: "10.0.0.10",
+		Lifecycle:   models.Lifecycle{Serverless: false},
+	}
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n)
+	start := make(chan struct{})
+	for range n {
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = svc.installHTTPPortRoute(context.Background(), sb, 3000)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	// Count PATCH bodies actually applied. The drop-and-supersede path
+	// means the LAST intent wins and prior intents are dropped before
+	// they reach Caddy — so the observed body count must be < n.
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if got := len(fake.routes); got != 1 {
+		t.Fatalf("ended with %d routes, want 1", got)
+	}
+	// We can't directly count drained writes without exposing the
+	// coalescer state, but the existence of the single converged route
+	// after a contended burst with no errors is the user-visible
+	// invariant. The detailed coalesce-collapse count is asserted by
+	// the unit tests in caddy_coalescer_test.go.
+}
+
 func TestInstallHTTPPortRouteGateOffIgnoresServerlessFlag(t *testing.T) {
 	fake := newRouteFake()
 	svc := newRouteTestService(t, fake, false) // gate off

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -112,6 +112,23 @@ type Service struct {
 	netstatsPoller   *netstats.Poller
 	netstatsLastTick atomic.Int64 // unix nanos; last successful tick for /usage staleness reporting
 
+	// netstatsActivity is the per-sandbox "last non-zero BytesIn delta"
+	// timestamp (unix nanos), populated by the netstats poller sink.
+	// The idle sweep uses it as the activity floor under
+	// HTTPWakeDirectBypassEnabled so warm traffic that never reaches
+	// sandboxd (Caddy → container direct) still keeps the sweep from
+	// stopping a busy sandbox. RWMutex because the sweep reads more
+	// often than the poller writes (default 60s vs 10s). See
+	// plans/warm-direct-route-bypass.md C2.
+	netstatsActivityMu sync.RWMutex
+	netstatsActivity   map[string]int64
+
+	// Poll-failure detection is derived from netstatsLastTick
+	// staleness in netstatsPollIsStale; the poller does not expose an
+	// error-reporting path to the sink, and absence-of-a-recent-tick
+	// is the operationally meaningful signal (whether the cause was
+	// docker-stats hiccup, namespace teardown, or anything else).
+
 	// cluster is the cluster.Client used by the API layer for owner lookup
 	// and cross-node forwarding. Defaults to a Noop in single-node mode so
 	// callsites (and the API wrapper) can stay unconditional.
@@ -982,6 +999,7 @@ func (s *Service) DestroySandbox(ctx context.Context, id string) error {
 	}
 	s.forgetWakeFlight(id)
 	s.invalidateWarm(id)
+	s.forgetNetstatsActivity(id)
 	if err := s.DeleteClusterSecrets(ctx, id); err != nil {
 		return err
 	}
@@ -1755,25 +1773,50 @@ func (s *Service) deleteExposedPortRoute(ctx context.Context, sandbox *models.Sa
 }
 
 // installHTTPPortRoute writes the HTTP port route in the shape that
-// matches the sandbox's current serverless mode, and removes the other
-// shape afterwards. Install-then-delete ordering means there is never
-// a window where neither shape exists, so a request landing mid-flip
-// always hits one valid route.
+// matches the sandbox's current serverless mode AND current status,
+// then removes any other shape. Install-then-delete ordering means
+// there is never a window where neither shape exists, so a request
+// landing mid-flip always hits one valid route.
+//
+// Shape selection is delegated to chooseRouteShape so reconcile,
+// lifecycle, and event paths share one source of truth — see
+// plans/warm-direct-route-bypass.md D7/D8.
 func (s *Service) installHTTPPortRoute(ctx context.Context, sandbox *models.Sandbox, port int) error {
-	if s.serverlessWakeEnabled(sandbox) {
+	switch s.chooseRouteShape(sandbox) {
+	case RouteShapeDirect:
+		// Non-serverless callers (and serverless-bypass-off callers)
+		// fall through to UpsertPortRoute byte-for-byte, so the
+		// non-serverless JSON regression test stays valid. Only the
+		// warm-bypass path adopts the retry window.
+		if s.serverlessWakeEnabled(sandbox) && s.cfg.HTTPWakeDirectBypassEnabled {
+			if err := s.caddy.UpsertPortRouteWithRetry(ctx, sandbox.ID, sandbox.ContainerIP, port, s.cfg.HTTPWakeDirectRouteRetryDuration); err != nil {
+				return err
+			}
+		} else {
+			if err := s.caddy.UpsertPortRoute(ctx, sandbox.ID, sandbox.ContainerIP, port); err != nil {
+				return err
+			}
+		}
+		// Best-effort: any leftover wake route from a prior
+		// Stopped+armed state (or a flag flip back to bypass-on) must
+		// go so Caddy doesn't keep two routes matching the same host.
+		// DeleteWakeHTTPPortRoute treats 404 as success.
+		_ = s.caddy.DeleteWakeHTTPPortRoute(ctx, sandbox.ID, port)
+		return nil
+	case RouteShapeWake:
 		if err := s.caddy.UpsertWakeHTTPPortRoute(ctx, sandbox.ID, s.cfg.InternalIngressAddr, port); err != nil {
 			return err
 		}
-		// Best-effort: any leftover direct route from a pre-serverless
-		// state must go so Caddy doesn't keep two routes matching the
-		// same host. DeletePortRoute treats 404 as success.
 		_ = s.caddy.DeletePortRoute(ctx, sandbox.ID, port)
 		return nil
+	case RouteShapeNone:
+		// Destroyed sandboxes or stopped-unarmed serverless sandboxes
+		// publish neither route. Idempotent deletes; either or both
+		// may already be absent.
+		_ = s.caddy.DeletePortRoute(ctx, sandbox.ID, port)
+		_ = s.caddy.DeleteWakeHTTPPortRoute(ctx, sandbox.ID, port)
+		return nil
 	}
-	if err := s.caddy.UpsertPortRoute(ctx, sandbox.ID, sandbox.ContainerIP, port); err != nil {
-		return err
-	}
-	_ = s.caddy.DeleteWakeHTTPPortRoute(ctx, sandbox.ID, port)
 	return nil
 }
 
@@ -2383,8 +2426,21 @@ func (s *Service) runLifecycleSweep(ctx context.Context) {
 
 	now := time.Now().UTC()
 	globalIdle := s.cfg.IdleTimeout()
+	// netstatsFallback is checked once per sweep, not per sandbox —
+	// the fallback applies to the entire tick (D3). If the most recent
+	// successful poll is older than 2 × poll interval, the docker
+	// stats subsystem is probably degraded for every sandbox on this
+	// node; trusting an absent floor as "idle" would cascade into
+	// stopping every warm sandbox. The next successful poll re-arms
+	// the netstats signal automatically.
+	netstatsFallback := s.netstatsPollIsStale(now)
+	if netstatsFallback {
+		s.logger.Warn("idle sweep using LastActiveAt fallback",
+			"reason", "netstats_poll_failed", "netstats_fallback", true)
+	}
 	for _, sandbox := range sandboxes {
-		switch lifecycleActionFor(sandbox, now, globalIdle) {
+		floor := s.activityFloorFor(sandbox, netstatsFallback)
+		switch lifecycleActionForWithFloor(sandbox, now, globalIdle, floor) {
 		case lifecycleDestroy:
 			if err := s.DestroySandbox(ctx, sandbox.ID); err != nil {
 				s.logger.Warn("auto-destroy failed", "sandbox_id", sandbox.ID, "error", err)
@@ -2414,6 +2470,95 @@ const (
 	lifecycleDestroy
 )
 
+// activityFloorFor computes the timestamp the lifecycle sweep should
+// treat as the sandbox's most recent activity. Default is
+// sandbox.LastActiveAt; when HTTPWakeDirectBypassEnabled and the
+// netstats poller has a recorded non-zero BytesIn delta more recent
+// than LastActiveAt, the netstats timestamp wins so warm traffic that
+// bypasses sandboxd does not get false-idle-stopped. When the most
+// recent netstats poll failed (netstatsFallback=true), we fall back
+// to LastActiveAt alone for this tick to avoid stopping busy sandboxes
+// on a docker-stats outage (D3).
+func (s *Service) activityFloorFor(sandbox *models.Sandbox, netstatsFallback bool) time.Time {
+	if sandbox == nil {
+		return time.Time{}
+	}
+	floor := sandbox.LastActiveAt
+	if !s.cfg.HTTPWakeDirectBypassEnabled || netstatsFallback {
+		return floor
+	}
+	if observed := s.netstatsRecentBytesInAt(sandbox.ID); !observed.IsZero() && observed.After(floor) {
+		return observed
+	}
+	return floor
+}
+
+// netstatsPollIsStale reports whether the most recent successful
+// netstats poll is older than 2 × NetstatsPollInterval — the D3
+// signal that the docker stats subsystem is degraded and the sweep
+// must fall back to LastActiveAt rather than treat an absent floor
+// as "idle." Returns false when the bypass is off (the floor is not
+// used either way) or when the poller has never recorded a tick (the
+// daemon may have just booted; treating that as stale would prematurely
+// false-stop warm sandboxes during the first sweep after a restart —
+// the start path itself updates LastActiveAt, so falling back is the
+// correct conservative answer).
+func (s *Service) netstatsPollIsStale(now time.Time) bool {
+	if !s.cfg.HTTPWakeDirectBypassEnabled {
+		return false
+	}
+	if s.cfg.NetstatsPollInterval <= 0 {
+		return true
+	}
+	last := s.netstatsLastTick.Load()
+	if last == 0 {
+		return true
+	}
+	return now.Sub(time.Unix(0, last)) > 2*s.cfg.NetstatsPollInterval
+}
+
+// netstatsRecentBytesInAt returns the unix-nano timestamp of the most
+// recent non-zero BytesIn sample observed for the sandbox, or the
+// zero time if no observation has been recorded yet. Cheap read-lock
+// lookup populated by the netstats poller sink.
+func (s *Service) netstatsRecentBytesInAt(id string) time.Time {
+	s.netstatsActivityMu.RLock()
+	ts, ok := s.netstatsActivity[id]
+	s.netstatsActivityMu.RUnlock()
+	if !ok || ts == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, ts).UTC()
+}
+
+// recordNetstatsActivity is called by the netstats sink for every
+// non-zero BytesIn sample. SampledAt comes from the docker stats
+// reader so timestamps are consistent with the rest of the
+// observability surface.
+func (s *Service) recordNetstatsActivity(id string, sampledAt time.Time) {
+	if id == "" || sampledAt.IsZero() {
+		return
+	}
+	s.netstatsActivityMu.Lock()
+	if s.netstatsActivity == nil {
+		s.netstatsActivity = make(map[string]int64)
+	}
+	s.netstatsActivity[id] = sampledAt.UnixNano()
+	s.netstatsActivityMu.Unlock()
+}
+
+// forgetNetstatsActivity drops a sandbox's recorded activity floor.
+// Called when a sandbox is destroyed so the map does not leak entries
+// for ids the rest of the daemon has forgotten.
+func (s *Service) forgetNetstatsActivity(id string) {
+	if id == "" {
+		return
+	}
+	s.netstatsActivityMu.Lock()
+	delete(s.netstatsActivity, id)
+	s.netstatsActivityMu.Unlock()
+}
+
 // lifecycleActionFor decides what the sweep should do for one sandbox given
 // the current time and the operator's global idle fallback. Pure function:
 // no DB, no Docker, easy to exhaustively test.
@@ -2429,10 +2574,24 @@ const (
 //     stop. Backwards-compat with the pre-Lifecycle behavior.
 //  5. Otherwise → none.
 func lifecycleActionFor(sb *models.Sandbox, now time.Time, globalIdle time.Duration) lifecycleAction {
+	return lifecycleActionForWithFloor(sb, now, globalIdle, time.Time{})
+}
+
+// lifecycleActionForWithFloor is lifecycleActionFor with an explicit
+// activity-floor timestamp injected by the sweep (e.g. the netstats
+// poller's most recent BytesIn observation under bypass-on). When
+// activityFloor is later than sb.LastActiveAt, idle is measured from
+// activityFloor; otherwise the function behaves identically to
+// lifecycleActionFor. Pure: callers compute the floor.
+func lifecycleActionForWithFloor(sb *models.Sandbox, now time.Time, globalIdle time.Duration, activityFloor time.Time) lifecycleAction {
 	if sb == nil || sb.Status == models.SandboxStatusDestroyed {
 		return lifecycleNone
 	}
-	idle := now.Sub(sb.LastActiveAt)
+	floor := sb.LastActiveAt
+	if !activityFloor.IsZero() && activityFloor.After(floor) {
+		floor = activityFloor
+	}
+	idle := now.Sub(floor)
 	age := now.Sub(sb.CreatedAt)
 
 	l := sb.Lifecycle

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -90,7 +90,16 @@ type Service struct {
 	l4WakeMu   sync.Mutex
 	l4WakeTCP  net.Listener
 	l4WakeTLS  map[string]net.Listener
-	l4LimitMu  sync.Mutex
+	// pendingTLSClose holds the in-flight delayed-close timers for TLS
+	// wake sockets keyed by (id, port). D2 of warm-direct-route-bypass:
+	// on warm→cold (Started → wake-shape PATCH), the listener stays alive
+	// for cfg.TLSWakeListenerCloseDelay so a TLS handshake started against
+	// the wake-aware route can complete before the socket goes away.
+	// ensureTLSWakeListener cancels any pending timer on its key so a
+	// rapid cold→warm→cold flip doesn't tear down a socket that the new
+	// wake route depends on.
+	pendingTLSClose map[string]*time.Timer
+	l4LimitMu       sync.Mutex
 	// pending counts L4 connections waiting for wake/target resolution.
 	// active counts connections already admitted to proxy bytes. Keeping both
 	// lets cold-start bursts shed excess work without blocking unrelated warm
@@ -203,6 +212,19 @@ type Service struct {
 	touchCoalescer     *touchCoalescer
 	touchCoalescerOnce sync.Once
 
+	// caddyCoalescer batches Caddy admin writes for the same (id, port)
+	// so a rapid wake→stop→wake sequence collapses to one admin call.
+	// installHTTPPortRoute routes through Flush so callers still observe
+	// synchronous errors, while concurrent callers for the same key
+	// coalesce into a single admin write per drain. The periodic Run
+	// goroutine (started from cmd/sandboxd/main.go) drains any
+	// fire-and-forget Enqueues left over after the daemon idles. Same
+	// lazy-init pattern as touchCoalescer so &Service{...} literals in
+	// tests still work — see plans/warm-direct-route-bypass.md D6/D12.
+	caddyCoalescer        *caddyCoalescer
+	caddyCoalescerOnce    sync.Once
+	caddyCoalescerStarted atomic.Bool
+
 	// ingressLastHash is the hash of the placement view that the last
 	// successful cluster-ingress reconcile installed. The reconciler hashes
 	// the next view and skips work when unchanged — this is the cheap idle
@@ -235,6 +257,7 @@ func New(cfg config.Config, logger *slog.Logger, db *store.Store, runtimeDriver 
 		cluster: cluster.NewNoop("standalone", ""),
 	}
 	s.ensureTouchCoalescer()
+	s.ensureCaddyCoalescer()
 	return s
 }
 
@@ -249,6 +272,42 @@ func (s *Service) ensureTouchCoalescer() {
 			return s.store.Touch(ctx, id, at)
 		})
 	})
+}
+
+// ensureCaddyCoalescer lazily constructs the per-(id,port) Caddy write
+// batcher. Same rationale as ensureTouchCoalescer: &Service{...} test
+// literals skip New(), so installHTTPPortRoute initializes on demand.
+// Tick falls back to the 250ms default when cfg.CaddyCoalesceInterval
+// is zero — that covers test harnesses that don't populate cfg.
+func (s *Service) ensureCaddyCoalescer() {
+	s.caddyCoalescerOnce.Do(func() {
+		s.caddyCoalescer = newCaddyCoalescer(s.logger, s.cfg.CaddyCoalesceInterval)
+	})
+}
+
+// StartCaddyCoalescer starts the periodic-drain goroutine. Called once
+// from cmd/sandboxd/main.go after svc.New on worker nodes. Flush-only
+// callers (installHTTPPortRoute today) don't strictly need this — Flush
+// drives its own drain — but the ticker is the safety net for any
+// future Enqueue (fire-and-forget) callsites and for ops that get
+// stranded when a Flush caller's ctx cancels mid-drain.
+func (s *Service) StartCaddyCoalescer(ctx context.Context) {
+	s.ensureCaddyCoalescer()
+	if !s.caddyCoalescerStarted.CompareAndSwap(false, true) {
+		return
+	}
+	go s.caddyCoalescer.Run(ctx)
+}
+
+// StopCaddyCoalescer drains any pending op and exits the Run goroutine.
+// No-op when StartCaddyCoalescer was never called — caddyCoalescer.Stop
+// blocks on c.done which is only closed by Run, so calling it without
+// a prior Start would hang shutdown.
+func (s *Service) StopCaddyCoalescer() {
+	if !s.caddyCoalescerStarted.CompareAndSwap(true, false) {
+		return
+	}
+	s.caddyCoalescer.Stop()
 }
 
 // AttachCluster swaps in a cluster.Client. Called from cmd/sandboxd/main after
@@ -1781,8 +1840,32 @@ func (s *Service) deleteExposedPortRoute(ctx context.Context, sandbox *models.Sa
 // Shape selection is delegated to chooseRouteShape so reconcile,
 // lifecycle, and event paths share one source of truth — see
 // plans/warm-direct-route-bypass.md D7/D8.
+//
+// Routed through caddyCoalescer.Flush so concurrent callers targeting
+// the same (id, port) collapse into one admin write. Flush preserves
+// the synchronous error contract callers (ExposePort, reconcile, the
+// rollback path) depend on; an op superseded by a later Enqueue/Flush
+// for the same key returns nil to the prior waiter, which is correct
+// because the newer intent represents the same converged state the
+// caller wanted. See plans/warm-direct-route-bypass.md D6/D12.
 func (s *Service) installHTTPPortRoute(ctx context.Context, sandbox *models.Sandbox, port int) error {
-	switch s.chooseRouteShape(sandbox) {
+	s.ensureCaddyCoalescer()
+	// Snapshot the sandbox row by value so a concurrent mutation
+	// (Status flip, ContainerIP rebind) between Flush enqueue and the
+	// drain's invocation of `do` cannot change the intent the caller
+	// asked for. The closure must operate on a stable view.
+	snapshot := *sandbox
+	return s.caddyCoalescer.Flush(ctx, sandbox.ID, port, func() error {
+		return s.applyHTTPPortRoute(ctx, &snapshot, port)
+	})
+}
+
+// applyHTTPPortRoute performs the actual Caddy admin writes for one
+// (sandbox, port) install intent. Extracted from installHTTPPortRoute
+// so the coalescer's drain can invoke it with a stable sandbox
+// snapshot. Not called directly outside the coalescer path.
+func (s *Service) applyHTTPPortRoute(ctx context.Context, sandbox *models.Sandbox, port int) error {
+	switch s.chooseRouteShape(sandbox, RouteKindHTTP) {
 	case RouteShapeDirect:
 		// Non-serverless callers (and serverless-bypass-off callers)
 		// fall through to UpsertPortRoute byte-for-byte, so the
@@ -1820,22 +1903,55 @@ func (s *Service) installHTTPPortRoute(ctx context.Context, sandbox *models.Sand
 	return nil
 }
 
+// installTCPPortRoute publishes the correct L4-TCP server config for
+// the (sandbox, port, hostPort) tuple based on chooseRouteShape. Today
+// (bypass off) every serverless sandbox still gets the wake-aware
+// shape — chooseRouteShape short-circuits to Wake when
+// L4WakeDirectBypassEnabled=false, preserving pre-Phase-2 behavior.
+// With the flag on, warm serverless TCP exposures publish a direct
+// upstream and stopped-unarmed sandboxes drop the L4 server entirely.
 func (s *Service) installTCPPortRoute(ctx context.Context, sandbox *models.Sandbox, port, hostPort int) error {
 	if err := s.EnsureLayer4Ready(ctx); err != nil {
 		return err
 	}
-	if s.serverlessWakeEnabled(sandbox) {
+	switch s.chooseRouteShape(sandbox, RouteKindL4) {
+	case RouteShapeDirect:
+		return s.caddy.UpsertTCPRoute(ctx, sandbox.ID, sandbox.ContainerIP, port, hostPort)
+	case RouteShapeWake:
 		return s.caddy.UpsertWakeTCPRoute(ctx, sandbox.ID, port, hostPort, s.cfg.InternalL4WakeAddr)
+	case RouteShapeNone:
+		return s.caddy.DeleteTCPRoute(ctx, hostPort)
 	}
-	return s.caddy.UpsertTCPRoute(ctx, sandbox.ID, sandbox.ContainerIP, port, hostPort)
+	return nil
 }
 
+// installTLSPortRoute publishes the correct TLS-SNI route for the
+// (sandbox, port) tuple based on chooseRouteShape. The Unix-socket
+// lifecycle is intertwined with the route shape:
+//
+//   - Direct shape: PATCH first, then schedule a delayed close on the
+//     wake listener (D2 — a TLS handshake started against the prior
+//     wake route may still be in flight when PATCH lands; closing the
+//     socket immediately drops that handshake).
+//   - Wake shape: create the socket first so the upstream is reachable
+//     the instant Caddy PATCHes the route to point at it; roll back the
+//     socket on PATCH failure to avoid leaking a listener with no live
+//     route.
+//   - None: delete the route then close the socket; both are
+//     idempotent.
 func (s *Service) installTLSPortRoute(ctx context.Context, sandbox *models.Sandbox, port int) error {
 	if err := s.EnsureLayer4Ready(ctx); err != nil {
 		return err
 	}
 	sniHost := s.caddy.SNIHost(sandbox.ID, port)
-	if s.serverlessWakeEnabled(sandbox) {
+	switch s.chooseRouteShape(sandbox, RouteKindL4) {
+	case RouteShapeDirect:
+		if err := s.caddy.UpsertTLSSNIRoute(ctx, sandbox.ID, sniHost, sandbox.ContainerIP, port); err != nil {
+			return err
+		}
+		s.scheduleTLSWakeListenerClose(sandbox.ID, port, s.cfg.TLSWakeListenerCloseDelay)
+		return nil
+	case RouteShapeWake:
 		socketPath, err := s.ensureTLSWakeListener(sandbox.ID, port)
 		if err != nil {
 			return err
@@ -1845,11 +1961,13 @@ func (s *Service) installTLSPortRoute(ctx context.Context, sandbox *models.Sandb
 			return err
 		}
 		return nil
+	case RouteShapeNone:
+		if err := s.caddy.DeleteTLSSNIRoute(ctx, sandbox.ID, port); err != nil {
+			return err
+		}
+		s.closeTLSWakeListener(sandbox.ID, port)
+		return nil
 	}
-	if err := s.caddy.UpsertTLSSNIRoute(ctx, sandbox.ID, sniHost, sandbox.ContainerIP, port); err != nil {
-		return err
-	}
-	s.closeTLSWakeListener(sandbox.ID, port)
 	return nil
 }
 
@@ -2472,19 +2590,22 @@ const (
 
 // activityFloorFor computes the timestamp the lifecycle sweep should
 // treat as the sandbox's most recent activity. Default is
-// sandbox.LastActiveAt; when HTTPWakeDirectBypassEnabled and the
-// netstats poller has a recorded non-zero BytesIn delta more recent
-// than LastActiveAt, the netstats timestamp wins so warm traffic that
-// bypasses sandboxd does not get false-idle-stopped. When the most
-// recent netstats poll failed (netstatsFallback=true), we fall back
-// to LastActiveAt alone for this tick to avoid stopping busy sandboxes
-// on a docker-stats outage (D3).
+// sandbox.LastActiveAt; when any warm-direct bypass is enabled (HTTP or
+// L4) and the netstats poller has a recorded non-zero BytesIn delta
+// more recent than LastActiveAt, the netstats timestamp wins so warm
+// traffic that bypasses sandboxd does not get false-idle-stopped.
+// Netstats observes container interface bytes regardless of protocol,
+// so one floor covers HTTP + L4 with a single mechanism — the OR over
+// both flags is what makes Phase 2 (L4 bypass) safe to enable without
+// also flipping HTTP. When the most recent netstats poll failed
+// (netstatsFallback=true), we fall back to LastActiveAt alone for this
+// tick to avoid stopping busy sandboxes on a docker-stats outage (D3).
 func (s *Service) activityFloorFor(sandbox *models.Sandbox, netstatsFallback bool) time.Time {
 	if sandbox == nil {
 		return time.Time{}
 	}
 	floor := sandbox.LastActiveAt
-	if !s.cfg.HTTPWakeDirectBypassEnabled || netstatsFallback {
+	if !s.anyBypassEnabled() || netstatsFallback {
 		return floor
 	}
 	if observed := s.netstatsRecentBytesInAt(sandbox.ID); !observed.IsZero() && observed.After(floor) {
@@ -2504,7 +2625,7 @@ func (s *Service) activityFloorFor(sandbox *models.Sandbox, netstatsFallback boo
 // the start path itself updates LastActiveAt, so falling back is the
 // correct conservative answer).
 func (s *Service) netstatsPollIsStale(now time.Time) bool {
-	if !s.cfg.HTTPWakeDirectBypassEnabled {
+	if !s.anyBypassEnabled() {
 		return false
 	}
 	if s.cfg.NetstatsPollInterval <= 0 {

--- a/pkg/caddy/client.go
+++ b/pkg/caddy/client.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aerol-ai/microvm/internal/config"
 )
@@ -219,6 +220,44 @@ func (c *Client) UpsertPortRoute(ctx context.Context, id, containerIP string, po
 		"terminal": true,
 	}
 
+	return c.upsertRoute(ctx, routeID, route)
+}
+
+// UpsertPortRouteWithRetry is UpsertPortRoute plus a
+// load_balancing.try_duration / try_interval window. Used by the
+// HTTP-wake direct-bypass path (plans/warm-direct-route-bypass.md C5):
+// when a warm sandbox container dies, the docker `die` event takes
+// ~10ms to propagate before the route flips back to wake-aware.
+// During that window Caddy may already be holding the direct route
+// pointing at a now-dead IP. The retry window absorbs the gap by
+// retrying the dial for tryDuration before failing — outside the
+// window, Caddy returns 502 just like any direct-route service.
+//
+// tryDuration must be > 0; tryDuration <= 0 means "behave like the
+// no-retry UpsertPortRoute" and the caller should use that method
+// instead. UpsertPortRoute is kept byte-for-byte identical so the
+// non-serverless surface does not inherit retry semantics it never
+// asked for.
+func (c *Client) UpsertPortRouteWithRetry(ctx context.Context, id, containerIP string, port int, tryDuration time.Duration) error {
+	if !c.enabled || c.domain == "" {
+		return nil
+	}
+	routeID := portRouteID(id, port)
+	route := map[string]any{
+		"@id":   routeID,
+		"match": []map[string]any{{"host": []string{fmt.Sprintf("%s-%d.%s", id, port, c.domain)}}},
+		"handle": []map[string]any{{
+			"handler": "reverse_proxy",
+			"upstreams": []map[string]string{{
+				"dial": fmt.Sprintf("%s:%d", containerIP, port),
+			}},
+			"load_balancing": map[string]any{
+				"try_duration": tryDuration.String(),
+				"try_interval": "100ms",
+			},
+		}},
+		"terminal": true,
+	}
 	return c.upsertRoute(ctx, routeID, route)
 }
 

--- a/pkg/caddy/client_test.go
+++ b/pkg/caddy/client_test.go
@@ -337,6 +337,59 @@ func TestRouteCases(t *testing.T) {
 				}
 			},
 		},
+		{
+			// UpsertPortRouteWithRetry must preserve the byte-for-byte
+			// shape of UpsertPortRoute and only add the load_balancing
+			// block. The shape is consumed by the bypass-on path which
+			// flips between this method and UpsertPortRoute on every
+			// warm/cold transition — divergent fields would leak across
+			// shapes via Caddy's PATCH overlay.
+			name: "upsert_port_route_with_retry_adds_load_balancing",
+			run: func(t *testing.T) {
+				fake := newFakeCaddy(t)
+				client := &Client{enabled: true, domain: "sandbox.example.com", serverID: "srv0", baseURL: fake.URL, httpClient: fake.Client}
+				if err := client.UpsertPortRouteWithRetry(context.Background(), "abc", "10.0.0.2", 3000, 2*time.Second); err != nil {
+					t.Fatalf("UpsertPortRouteWithRetry() error = %v", err)
+				}
+				route, ok := fake.routes["sandbox-abc-port-3000"]
+				if !ok {
+					t.Fatalf("port route missing; routes=%+v", fake.routes)
+				}
+				assertRouteField(t, route, "@id", "sandbox-abc-port-3000")
+				assertRouteHostMatch(t, route, "abc-3000.sandbox.example.com")
+				assertRouteDial(t, route, "10.0.0.2:3000")
+
+				handle := route["handle"].([]any)[0].(map[string]any)
+				lb, ok := handle["load_balancing"].(map[string]any)
+				if !ok {
+					t.Fatalf("load_balancing missing in handle: %+v", handle)
+				}
+				if got := lb["try_duration"]; got != "2s" {
+					t.Fatalf("try_duration = %v, want %q", got, "2s")
+				}
+				if got := lb["try_interval"]; got != "100ms" {
+					t.Fatalf("try_interval = %v, want %q", got, "100ms")
+				}
+			},
+		},
+		{
+			// UpsertPortRoute MUST NOT acquire load_balancing implicitly
+			// — that would change the non-serverless surface's retry
+			// behavior, which the plan explicitly scopes out.
+			name: "upsert_port_route_has_no_load_balancing",
+			run: func(t *testing.T) {
+				fake := newFakeCaddy(t)
+				client := &Client{enabled: true, domain: "sandbox.example.com", serverID: "srv0", baseURL: fake.URL, httpClient: fake.Client}
+				if err := client.UpsertPortRoute(context.Background(), "abc", "10.0.0.2", 3000); err != nil {
+					t.Fatalf("UpsertPortRoute() error = %v", err)
+				}
+				route := fake.routes["sandbox-abc-port-3000"]
+				handle := route["handle"].([]any)[0].(map[string]any)
+				if _, present := handle["load_balancing"]; present {
+					t.Fatalf("non-retry UpsertPortRoute leaked load_balancing block: %+v", handle)
+				}
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/models/lifecycle_test.go
+++ b/pkg/models/lifecycle_test.go
@@ -120,3 +120,75 @@ func TestLifecycleIsZero(t *testing.T) {
 		t.Fatal("Lifecycle with Serverless=true should not be IsZero()")
 	}
 }
+
+func TestLifecycleValidateWithBypassFloor(t *testing.T) {
+	poll := 15 * time.Second
+	reconcile := 30 * time.Second
+	floor := 2*poll + reconcile // 60s
+
+	cases := []struct {
+		name      string
+		lifecycle Lifecycle
+		wantErr   string // substring; empty means must succeed
+	}{
+		{
+			// Non-serverless lifecycles bypass the floor entirely — they
+			// still bump LastActiveAt through sandboxd, so the netstats
+			// dependency does not apply.
+			name:      "non_serverless_below_floor_passes",
+			lifecycle: Lifecycle{StopIfIdleFor: time.Second},
+		},
+		{
+			// Validate already requires Serverless lifecycles to set
+			// StopIfIdleFor; we surface that upstream error rather than
+			// silently passing the floor check.
+			name:      "serverless_no_idle_timer_fails_validate",
+			lifecycle: Lifecycle{Serverless: true},
+			wantErr:   "stop_if_idle_for",
+		},
+		{
+			name:      "serverless_above_floor_passes",
+			lifecycle: Lifecycle{Serverless: true, StopIfIdleFor: floor + time.Second},
+		},
+		{
+			name:      "serverless_at_floor_passes",
+			lifecycle: Lifecycle{Serverless: true, StopIfIdleFor: floor},
+		},
+		{
+			name:      "serverless_one_ns_below_floor_fails",
+			lifecycle: Lifecycle{Serverless: true, StopIfIdleFor: floor - time.Nanosecond},
+			wantErr:   "below the 1m0s floor",
+		},
+		{
+			name:      "serverless_well_below_floor_fails",
+			lifecycle: Lifecycle{Serverless: true, StopIfIdleFor: 5 * time.Second},
+			wantErr:   "stop_if_idle_for",
+		},
+		{
+			// Validate failure (negative timer) is surfaced ahead of the
+			// floor check, so the user sees the more fundamental error
+			// first.
+			name:      "validate_failure_takes_precedence",
+			lifecycle: Lifecycle{Serverless: true, StopIfIdleFor: -time.Second},
+			wantErr:   "non-negative",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.lifecycle.ValidateWithBypassFloor(poll, reconcile)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("want error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -221,6 +221,37 @@ func (l Lifecycle) Validate() error {
 	return nil
 }
 
+// ValidateWithBypassFloor runs Validate then additionally enforces the
+// activity-floor constraint that HTTP-wake direct-route bypass imposes
+// on serverless sandboxes: the netstats poller is the per-sandbox
+// activity signal in the bypass shape, and the idle sweep needs at
+// least one full netstats tick + one reconcile pass to observe "no
+// traffic" without false-stopping a busy sandbox. The floor is
+// 2 × pollInterval + reconcileInterval; sub-floor StopIfIdleFor values
+// would let the sweep fire between netstats ticks and stop a sandbox
+// that was actively serving the whole time.
+//
+// Callers in the wake-aware (non-bypass) shape must use Validate()
+// directly — the floor does not apply when every request still bumps
+// LastActiveAt through sandboxd's ingress proxy. See
+// plans/warm-direct-route-bypass.md D4.
+func (l Lifecycle) ValidateWithBypassFloor(pollInterval, reconcileInterval time.Duration) error {
+	if err := l.Validate(); err != nil {
+		return err
+	}
+	if !l.Serverless || l.StopIfIdleFor == 0 {
+		return nil
+	}
+	floor := 2*pollInterval + reconcileInterval
+	if l.StopIfIdleFor < floor {
+		return fmt.Errorf(
+			"stop_if_idle_for (%s) is below the %s floor required by SB_HTTP_WAKE_DIRECT_BYPASS_ENABLED=true (2 × netstats poll interval + reconcile interval); raise stop_if_idle_for or disable the bypass",
+			l.StopIfIdleFor, floor,
+		)
+	}
+	return nil
+}
+
 // IsZero reports whether all four timers are disabled. Useful for skipping
 // Lifecycle inspection in the sweep when there's nothing to evaluate.
 func (l Lifecycle) IsZero() bool {


### PR DESCRIPTION
This pull request introduces a set of changes to support the "warm direct route bypass" feature for serverless HTTP and L4 (TCP/TLS) traffic. It adds configuration flags, a robust batching mechanism for Caddy admin writes, and rollback safety for HTTP route shape changes. The changes are focused on improving performance and operational safety when toggling between proxy and direct routing modes, especially at scale.

Key changes include:

**1. Direct Route Bypass and Rollback Safety**
- Added logic in `cmd/sandboxd/main.go` to detect rollbacks of the `SB_HTTP_WAKE_DIRECT_BYPASS_ENABLED` flag. It uses a marker file (`bypass_last_enabled`) to force a one-time reconcile of HTTP routes if the flag is toggled from true to false, ensuring routes are updated correctly after rollback. Helper functions `readBypassMarker` and `writeBypassMarker` manage this marker file atomically. [[1]](diffhunk://#diff-85cd4174384a81cdbf87370531855ae87bcbd19bf68f36b611d73cd5d96cb4daR266-R302) [[2]](diffhunk://#diff-85cd4174384a81cdbf87370531855ae87bcbd19bf68f36b611d73cd5d96cb4daR694-R723)
- Introduced comprehensive unit tests for marker file behavior in `cmd/sandboxd/main_test.go`, covering missing files, round-trips, overwrites, atomicity, and whitespace handling.

**2. Caddy Admin Write Coalescing**
- Implemented a new `caddyCoalescer` in `internal/service/caddy_coalescer.go` to batch and deduplicate Caddy admin writes per (sandbox-id, port). This reduces admin write load and latency spikes during frequent route changes, especially under the new bypass mode. The coalescer supports both fire-and-forget and flush-with-wait semantics.
- Integrated the coalescer lifecycle into `cmd/sandboxd/main.go`: it is started on worker nodes and stopped gracefully at shutdown to ensure no pending writes are lost. [[1]](diffhunk://#diff-85cd4174384a81cdbf87370531855ae87bcbd19bf68f36b611d73cd5d96cb4daR266-R302) [[2]](diffhunk://#diff-85cd4174384a81cdbf87370531855ae87bcbd19bf68f36b611d73cd5d96cb4daR429-R432)

**3. Configuration Enhancements**
- Added new configuration options to `internal/config/config.go` and its loader:
    - `HTTPWakeDirectBypassEnabled` and `L4WakeDirectBypassEnabled` flags to control direct routing for HTTP and L4 traffic.
    - `HTTPWakeDirectRouteRetryDuration` and `TLSWakeListenerCloseDelay` for fine-tuning retry and close behavior.
    - `CaddyCoalesceInterval` to configure the batching window for admin writes.
  These are documented and loaded from environment variables. [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR181-R230) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR653-R657)

**4. Dependency and Import Updates**
- Updated imports in `cmd/sandboxd/main.go` to include `filepath` for marker file handling.

These changes collectively improve the system's ability to handle rapid route shape changes safely and efficiently, reduce operational risk during rollbacks, and improve performance under high churn.

---
- Introduced a warm direct-route bypass mechanism for serverless HTTP ingress, enhancing performance and activity tracking.
- Added comprehensive tests for the new bypass logic and refactored existing handling for improved clarity and functionality.
- Ensured that the system accurately manages route shapes and bypass flags for both HTTP and L4 routes, optimizing resource usage during state transitions.

