### PR TITLE
feat: Implement custom domain support with API endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GO ?= go
 BIN_DIR ?= bin
 
-.PHONY: fmt install-git-hooks test build build-sandboxd build-toolboxd docs-install docs-dev docs-build clean
+.PHONY: fmt install-git-hooks test test-acme-e2e build build-sandboxd build-toolboxd docs-install docs-dev docs-build clean
 
 fmt:
 	$(GO) fmt ./...
@@ -13,6 +13,12 @@ install-git-hooks:
 
 test:
 	$(GO) test ./...
+
+# Operator-runnable ACME end-to-end test. Requires a local Docker daemon;
+# pulls Pebble + localstack images and builds Caddy via xcaddy on first run.
+# Not wired into CI — gated by the e2e build tag.
+test-acme-e2e:
+	$(GO) test -tags=e2e -count=1 -timeout=10m ./internal/service -run TestACME
 
 build: build-sandboxd build-toolboxd
 

--- a/cmd/sandboxd/cluster_resolver_test.go
+++ b/cmd/sandboxd/cluster_resolver_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/cluster"
+	"github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// stubClusterResolver embeds *cluster.Noop so the full cluster.Client surface
+// is satisfied by Noop's empty stubs — we override only ResolveCustomDomain
+// to drive the "cluster has it" branch without standing up a real raft.
+type stubClusterResolver struct {
+	*cluster.Noop
+	hits map[string]string
+}
+
+func (s *stubClusterResolver) ResolveCustomDomain(hostname string) (string, bool) {
+	id, ok := s.hits[hostname]
+	return id, ok
+}
+
+// TestClusterAwareDomainResolver_ClusterHitSkipsStore: an FSM-known hostname
+// must short-circuit the store. The hot path for SNI floods has to stay
+// in-memory once the cluster has the mapping; falling through to SQLite per
+// packet defeats the whole point of the FSM index.
+func TestClusterAwareDomainResolver_ClusterHitSkipsStore(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "state.db")
+	st, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	resolver := clusterAwareDomainResolver{
+		cluster: &stubClusterResolver{
+			Noop: cluster.NewNoop("test", "http://test"),
+			hits: map[string]string{"api.acme.com": "sb-from-cluster"},
+		},
+		store: st,
+	}
+
+	got, err := resolver.ResolveCustomDomain(context.Background(), "api.acme.com")
+	if err != nil {
+		t.Fatalf("ResolveCustomDomain: %v", err)
+	}
+	if got != "sb-from-cluster" {
+		t.Fatalf("got %q, want sb-from-cluster", got)
+	}
+}
+
+// TestClusterAwareDomainResolver_NoopFallsBackToStore: Noop always reports
+// miss (no FSM in single-node mode), so we must consult the store. This is
+// the single-node regression guard required by CLAUDE.md.
+func TestClusterAwareDomainResolver_NoopFallsBackToStore(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "state.db")
+	st, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	// sandbox_custom_domains has an FK on sandbox_id; seed a minimal row.
+	if err := st.Create(ctx, &models.Sandbox{
+		ID:        "sb-local",
+		Image:     "ubuntu:22.04",
+		Status:    models.SandboxStatusStarted,
+		Runtime:   models.RuntimeGvisor,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("store.Create: %v", err)
+	}
+	if err := st.AddCustomDomain(ctx, "sb-local", "api.local.example"); err != nil {
+		t.Fatalf("AddCustomDomain: %v", err)
+	}
+
+	resolver := clusterAwareDomainResolver{
+		cluster: cluster.NewNoop("test", "http://test"),
+		store:   st,
+	}
+
+	got, err := resolver.ResolveCustomDomain(ctx, "api.local.example")
+	if err != nil {
+		t.Fatalf("ResolveCustomDomain: %v", err)
+	}
+	if got != "sb-local" {
+		t.Fatalf("got %q, want sb-local", got)
+	}
+}
+
+// TestClusterAwareDomainResolver_MissReturnsErrNotFound: when neither layer
+// knows the hostname, the adapter must surface store.ErrNotFound so the
+// TLSAsk handler folds it into the negative cache + 403 path without
+// emitting a resolver-outage warning.
+func TestClusterAwareDomainResolver_MissReturnsErrNotFound(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "state.db")
+	st, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	resolver := clusterAwareDomainResolver{
+		cluster: cluster.NewNoop("test", "http://test"),
+		store:   st,
+	}
+
+	_, err = resolver.ResolveCustomDomain(context.Background(), "unknown.example")
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("got %v, want store.ErrNotFound", err)
+	}
+}

--- a/cmd/sandboxd/main.go
+++ b/cmd/sandboxd/main.go
@@ -404,8 +404,15 @@ func main() {
 		// call surface still works because the handler is mounted, and
 		// an operator-driven reconcile can re-install the policy later.
 		if cfg.EnableCustomDomains {
+			// Cluster-aware resolver: try the in-process FSM hostname index
+			// first (PK lookup, no I/O) and fall back to the SQLite store on
+			// miss. Under Noop the cluster lookup always returns ("", false)
+			// so single-node mode keeps the existing PK-lookup behavior.
+			// Under Cluster/Agent a hit short-circuits the disk read and
+			// keeps the on-demand TLS ask path fully in-memory across the
+			// cluster.
 			askHandler := ingressproxy.NewTLSAskHandler(ingressproxy.TLSAskDeps{
-				Resolver:    db,
+				Resolver:    clusterAwareDomainResolver{cluster: svc.Cluster(), store: db},
 				BaseDomain:  cfg.Domain,
 				NegCacheTTL: 60 * time.Second,
 				NegCacheCap: 10000,
@@ -707,6 +714,32 @@ func (r autoImportSpecResolver) GetSandboxSpec(sandboxID string) (*models.Create
 		return nil, false
 	}
 	return spec, true
+}
+
+// clusterAwareDomainResolver answers TLS-ask lookups from the cluster FSM
+// first and falls back to the local store on miss. The cluster path is an
+// in-memory map lookup (placementFSM.customHostnameIndex) so the hot path
+// for an SNI flood does not hit SQLite once the FSM is populated. The
+// store fallback covers two cases: (a) Noop / single-node mode where the
+// cluster always reports miss, and (b) the brief window after a leader
+// change before the local FSM has caught up on a fresh peer.
+//
+// We return store.ErrNotFound on miss so the handler's existing branching
+// (negative-cache + 403) treats both backends identically. A nil cluster
+// can't happen in practice (svc.Cluster() always returns at least Noop),
+// but we null-check defensively rather than panic from the ask path.
+type clusterAwareDomainResolver struct {
+	cluster cluster.Client
+	store   *store.Store
+}
+
+func (r clusterAwareDomainResolver) ResolveCustomDomain(ctx context.Context, hostname string) (string, error) {
+	if r.cluster != nil {
+		if id, ok := r.cluster.ResolveCustomDomain(hostname); ok {
+			return id, nil
+		}
+	}
+	return r.store.ResolveCustomDomain(ctx, hostname)
 }
 
 // bytesTrimSpace is a tiny helper so we don't pull `strings` for one call —

--- a/cmd/sandboxd/main.go
+++ b/cmd/sandboxd/main.go
@@ -378,38 +378,72 @@ func main() {
 	}()
 
 	// Wake-aware HTTP ingress proxy: a loopback-only listener Caddy
-	// dials when forwarding a wake-aware port route. Only stood up
-	// when both the serverless feature and Caddy itself are enabled —
-	// without Caddy in front, nothing would route to this listener.
+	// dials when forwarding a wake-aware port route. Stood up when
+	// serverless OR custom-domains is enabled (and Caddy is in front —
+	// without Caddy nothing routes to this listener). Both features
+	// share the same mux so they share one loopback listener.
 	var ingressServer *http.Server
-	if cfg.EnableServerless && cfg.EnableCaddy {
+	if (cfg.EnableServerless || cfg.EnableCustomDomains) && cfg.EnableCaddy {
 		ingressMux := http.NewServeMux()
-		ingressproxy.RegisterRoutes(ingressMux, ingressproxy.Deps{
-			Resolver:             svc,
-			Logger:               logger,
-			MaxBufferBytes:       cfg.HTTPWakeMaxBuffer,
-			UpstreamReadyTimeout: cfg.HTTPWakeUpstreamReadyTimeout,
-			MaxPendingPerSandbox: cfg.HTTPWakeMaxPendingPerSandbox,
-			MaxPendingGlobal:     cfg.HTTPWakeMaxPendingGlobal,
-			MaxBufferBytesGlobal: cfg.HTTPWakeMaxBufferBytesGlobal,
-		})
+		if cfg.EnableServerless {
+			ingressproxy.RegisterRoutes(ingressMux, ingressproxy.Deps{
+				Resolver:             svc,
+				Logger:               logger,
+				MaxBufferBytes:       cfg.HTTPWakeMaxBuffer,
+				UpstreamReadyTimeout: cfg.HTTPWakeUpstreamReadyTimeout,
+				MaxPendingPerSandbox: cfg.HTTPWakeMaxPendingPerSandbox,
+				MaxPendingGlobal:     cfg.HTTPWakeMaxPendingGlobal,
+				MaxBufferBytesGlobal: cfg.HTTPWakeMaxBufferBytesGlobal,
+			})
+		}
+		// Caddy on-demand TLS ask callback (plans/custom-domains.md).
+		// db.ResolveCustomDomain is a PK lookup; the LRU negative cache
+		// in the handler keeps SNI floods from hitting SQLite per packet.
+		// Boot-time EnsureOnDemandTLS is best-effort — if Caddy is not
+		// yet reachable we log and continue; the next AddCustomDomain
+		// call surface still works because the handler is mounted, and
+		// an operator-driven reconcile can re-install the policy later.
+		if cfg.EnableCustomDomains {
+			askHandler := ingressproxy.NewTLSAskHandler(ingressproxy.TLSAskDeps{
+				Resolver:    db,
+				BaseDomain:  cfg.Domain,
+				NegCacheTTL: 60 * time.Second,
+				NegCacheCap: 10000,
+				Logger:      logger,
+			})
+			ingressproxy.RegisterTLSAsk(ingressMux, askHandler)
+			svc.AttachCustomDomainCacheEvicter(askHandler)
+			askURL := "http://" + cfg.InternalIngressAddr + ingressproxy.TLSAskPath
+			if err := caddyClient.EnsureOnDemandTLS(ctx, askURL, cfg.TLSOnDemandBurst, cfg.TLSOnDemandInterval); err != nil {
+				logger.Warn("failed to install caddy on-demand TLS policy; will retry on next reconcile",
+					"error", err, "ask_url", askURL)
+			} else {
+				logger.Info("caddy on-demand TLS policy installed",
+					"ask_url", askURL, "burst", cfg.TLSOnDemandBurst, "interval", cfg.TLSOnDemandInterval)
+			}
+		}
 		ingressServer = &http.Server{
 			Addr:              cfg.InternalIngressAddr,
 			Handler:           ingressMux,
 			ReadHeaderTimeout: 10 * time.Second,
 		}
-		logger.Info("wake-aware ingress proxy listening", "addr", cfg.InternalIngressAddr)
+		logger.Info("ingress proxy listening",
+			"addr", cfg.InternalIngressAddr,
+			"serverless", cfg.EnableServerless,
+			"custom_domains", cfg.EnableCustomDomains)
 		go func() {
 			if err := ingressServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 				logger.Error("ingress proxy stopped unexpectedly", "error", err)
 				cancel()
 			}
 		}()
-		if err := svc.StartL4WakeProxy(ctx); err != nil {
-			logger.Error("l4 wake proxy failed to start", "error", err)
-			cancel()
-		} else {
-			logger.Info("wake-aware l4 proxy listening", "addr", cfg.InternalL4WakeAddr, "socket_dir", cfg.InternalL4WakeDir)
+		if cfg.EnableServerless {
+			if err := svc.StartL4WakeProxy(ctx); err != nil {
+				logger.Error("l4 wake proxy failed to start", "error", err)
+				cancel()
+			} else {
+				logger.Info("wake-aware l4 proxy listening", "addr", cfg.InternalL4WakeAddr, "socket_dir", cfg.InternalL4WakeDir)
+			}
 		}
 	}
 

--- a/cmd/sandboxd/main.go
+++ b/cmd/sandboxd/main.go
@@ -411,12 +411,27 @@ func main() {
 			// Under Cluster/Agent a hit short-circuits the disk read and
 			// keeps the on-demand TLS ask path fully in-memory across the
 			// cluster.
+			// Daemon-wide ACME budget (OV5A): a per-node sliding window
+			// over Let's Encrypt's per-account new-orders limit (300 / 3h
+			// by default). One misconfigured tenant adding 100 custom
+			// domains can drain the LE window for the whole cluster, so
+			// every TLSAsk that would trigger a new issuance passes
+			// through Reserve; a nil budget is allowed but disables the
+			// brake — we wire one whenever custom domains are on.
+			acmeBudget := service.NewACMEBudget(service.ACMEBudgetConfig{
+				Capacity: cfg.ACMEDaemonBudgetCapacity,
+				Window:   cfg.ACMEDaemonBudgetWindow,
+				Fraction: cfg.ACMEDaemonBudgetFraction,
+				Logger:   logger,
+			})
 			askHandler := ingressproxy.NewTLSAskHandler(ingressproxy.TLSAskDeps{
 				Resolver:    clusterAwareDomainResolver{cluster: svc.Cluster(), store: db},
 				BaseDomain:  cfg.Domain,
 				NegCacheTTL: 60 * time.Second,
 				NegCacheCap: 10000,
 				Logger:      logger,
+				Budget:      acmeBudget,
+				Tracker:     ingressproxy.DefaultIssuanceTracker(),
 			})
 			ingressproxy.RegisterTLSAsk(ingressMux, askHandler)
 			svc.AttachCustomDomainCacheEvicter(askHandler)

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -210,6 +210,12 @@ const getDocsSidebarConfig = (): NavigationGroup[] => [
         label: 'Port Allowlist',
         description: 'Require explicit exposure before public traffic reaches a sandbox port.',
       },
+      {
+        type: 'link',
+        href: '/custom-domains',
+        label: 'Custom Domains',
+        description: 'Attach arbitrary public hostnames to a sandbox with automatic per-host HTTPS via ACME.',
+      },
     ],
   },
   {

--- a/docs/src/content/docs/custom-domains.mdx
+++ b/docs/src/content/docs/custom-domains.mdx
@@ -1,0 +1,196 @@
+---
+title: Custom Domains
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+Attach an arbitrary public hostname (`api.acme.com`, `acme.com`) to a sandbox so traffic to that host reaches the sandbox's root service over HTTPS. Certificates are issued automatically per hostname via ACME HTTP-01 — the wildcard cert that covers `*.<SB_DOMAIN>` is **not** reused.
+
+## Prerequisites
+
+1. **Domain mode is required.** The server must be started with `SB_DOMAIN` set. In IP / path-mode deployments the API returns `412 Precondition Failed`.
+2. **DNS must already point at the cluster's ingress host.** Create a `CNAME` (or `ALIAS` / `ANAME` for apex) from the custom hostname to the same target your sandbox URLs resolve to. AerolVM does not host DNS; if the record is missing when the first HTTPS request arrives, ACME issuance will fail and the domain stays in `issuing` until DNS is fixed.
+3. **HTTP / HTTPS only.** Custom domains attach to the sandbox root (the toolbox-proxied URL). Raw `tcp://` and `tls://` port exposures are out of scope — they reject with `400 Bad Request` if a custom domain is configured.
+
+## Attach at create time
+
+Pass `customDomains` on the create call. Up to 5 hostnames per request; the server validates each one and rejects the entire create with `400` if any is malformed or already taken.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    const sb = await microvm.sandboxes.create({
+      image: "node:20",
+      customDomains: ["api.acme.com", "acme.com"],
+    });
+    for (const d of sb.customDomains ?? []) {
+      console.log(d.hostname, d.status); // "api.acme.com" "pending_dns"
+    }
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    sb = microvm.create(CreateOptions(
+        image="node:20",
+        customDomains=["api.acme.com", "acme.com"],
+    ))
+    for d in sb.get("customDomains", []):
+        print(d["hostname"], d["status"])
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    sb, err := client.CreateSandbox(ctx, &microvm.CreateOptions{
+        Image:         "node:20",
+        CustomDomains: []string{"api.acme.com", "acme.com"},
+    })
+    if err != nil { log.Fatal(err) }
+    for _, d := range sb.CustomDomains {
+        fmt.Println(d.Hostname, d.Status)
+    }
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let sb = client.create_sandbox(CreateOptions {
+        image: Some("node:20".into()),
+        custom_domains: Some(vec!["api.acme.com".into(), "acme.com".into()]),
+        ..Default::default()
+    })?;
+    for d in sb.custom_domains.unwrap_or_default() {
+        println!("{} {:?}", d.hostname, d.status);
+    }
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    Sandbox sb = client.create(new CreateOptions()
+        .setImage("node:20")
+        .setCustomDomains(List.of("api.acme.com", "acme.com")));
+    for (CustomDomain d : sb.customDomains) {
+        System.out.println(d.hostname + " " + d.status);
+    }
+    ```
+  </TabItem>
+</Tabs>
+
+## Attach to a running sandbox
+
+The add call returns the post-attach list with the new row's `status` so callers don't need a follow-up `list`.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    const domains = await sandbox.customDomains.add("staging.acme.com");
+    console.log(domains.map(d => d.hostname));
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    domains = sandbox.add_custom_domain("staging.acme.com")
+    print([d["hostname"] for d in domains])
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    domains, err := sandbox.AddCustomDomain(ctx, "staging.acme.com")
+    if err != nil { log.Fatal(err) }
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let domains = sandbox.add_custom_domain("staging.acme.com")?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    List<CustomDomain> domains = sandbox.addCustomDomain("staging.acme.com");
+    ```
+  </TabItem>
+</Tabs>
+
+## Detach
+
+Detach removes the Caddy route and deletes the row. The issued certificate stays in Caddy's storage and ages out on renewal. Returns `404` if the hostname is not attached to this sandbox.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    await sandbox.customDomains.remove("acme.com");
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    sandbox.remove_custom_domain("acme.com")
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    err := sandbox.RemoveCustomDomain(ctx, "acme.com")
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    sandbox.remove_custom_domain("acme.com")?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    sandbox.removeCustomDomain("acme.com");
+    ```
+  </TabItem>
+</Tabs>
+
+## List
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    const domains = await sandbox.customDomains.list();
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    domains = sandbox.list_custom_domains()
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    domains, err := sandbox.ListCustomDomains(ctx)
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let domains = sandbox.list_custom_domains()?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    List<CustomDomain> domains = sandbox.listCustomDomains();
+    ```
+  </TabItem>
+</Tabs>
+
+## Status lifecycle
+
+Each attached hostname carries a `status` that reflects where Caddy is in the per-host ACME flow. Poll `list` (or re-read the sandbox) to observe transitions — there is no push notification.
+
+| Status | Meaning |
+|---|---|
+| `pending_dns` | Row exists, no TLS handshake seen for this host yet. Either DNS isn't pointed yet, or no client has connected. |
+| `issuing` | Caddy has started the ACME flow (first HTTPS hit arrived). HTTP-01 challenge in progress. |
+| `ready` | Certificate is in Caddy storage and serving traffic. |
+| `failed` | ACME gave up. `lastError` carries the reason — usually DNS still wrong, or LE rate-limited. Detach + reattach after fixing DNS to retry. |
+
+## Errors
+
+| Status | When |
+|---|---|
+| `400 Bad Request` | Hostname is malformed, includes a port, or matches a TCP/TLS-only sandbox port. |
+| `409 Conflict` | The hostname is already attached to a different sandbox. Hostnames are globally unique across the cluster. |
+| `412 Precondition Failed` | The server runs in IP mode (`SB_DOMAIN` unset). Custom domains require domain mode. |
+| `429 Too Many Requests` | The daemon-wide ACME issuance budget is exhausted (LE `new-orders` per-account limit nearing 80% of 300/3h). Honour `Retry-After` and try again. |
+
+## Cluster mode
+
+In multi-node clusters the hostname-to-sandbox mapping is replicated through Raft, so any ingress node accepts traffic for a custom domain regardless of which node owns the sandbox. Non-owner ingress nodes pass TLS through to the owner over SNI. The shared `certmagic-s3` cert store means only one node performs the ACME flow per hostname — see [multi-node cert sharing](https://github.com/aerol-ai/microvm/blob/main/setup/multi-node-cert-sharing.md) for the storage / lock layout.

--- a/docs/src/content/docs/custom-domains.mdx
+++ b/docs/src/content/docs/custom-domains.mdx
@@ -193,9 +193,9 @@ Each attached hostname carries a `status` that reflects where Caddy is in the pe
 
 | Status | When |
 |---|---|
-| `400 Bad Request` | Hostname is malformed, includes a port, or matches a TCP/TLS-only sandbox port. |
-| `409 Conflict` | The hostname is already attached to a different sandbox. Hostnames are globally unique across the cluster. |
-| `412 Precondition Failed` | The server runs in IP mode (`SB_DOMAIN` unset). Custom domains require domain mode. |
+| `400 Bad Request` | Hostname is malformed or includes a port. |
+| `409 Conflict` | The hostname is already attached to a different sandbox (hostnames are globally unique across the cluster), the sandbox already exposes a `tcp://` / `tls://` port (the IRON RULE — custom domains and L4 exposures can't coexist on one sandbox), or the per-sandbox cap is reached. |
+| `412 Precondition Failed` | Custom domains are disabled (`SB_ENABLE_CUSTOM_DOMAINS=false`) or the server runs in IP mode (`SB_DOMAIN` unset). |
 | `429 Too Many Requests` | The daemon-wide ACME issuance budget is exhausted (LE `new-orders` per-account limit nearing 80% of 300/3h). Honour `Retry-After` and try again. |
 
 ## Cluster mode

--- a/docs/src/content/docs/custom-domains.mdx
+++ b/docs/src/content/docs/custom-domains.mdx
@@ -10,7 +10,14 @@ Attach an arbitrary public hostname (`api.acme.com`, `acme.com`) to a sandbox so
 
 1. **Domain mode is required.** The server must be started with `SB_DOMAIN` set. In IP / path-mode deployments the API returns `412 Precondition Failed`.
 2. **DNS must already point at the cluster's ingress host.** Create a `CNAME` (or `ALIAS` / `ANAME` for apex) from the custom hostname to the same target your sandbox URLs resolve to. AerolVM does not host DNS; if the record is missing when the first HTTPS request arrives, ACME issuance will fail and the domain stays in `issuing` until DNS is fixed.
-3. **HTTP / HTTPS only.** Custom domains attach to the sandbox root (the toolbox-proxied URL). Raw `tcp://` and `tls://` port exposures are out of scope — they reject with `400 Bad Request` if a custom domain is configured.
+3. **Port 80 must be reachable from Let's Encrypt.** Issuance uses HTTP-01, so LE's validation servers need to reach `http://<host>/.well-known/acme-challenge/...` on the ingress. If a firewall blocks inbound `:80`, the status sticks at `issuing` and eventually flips to `failed`.
+4. **HTTP / HTTPS only.** Custom domains attach to the sandbox root (the toolbox-proxied URL). Raw `tcp://` and `tls://` port exposures are out of scope — they reject with `400 Bad Request` if a custom domain is configured.
+
+### Cloudflare: turn the proxy off
+
+If your DNS lives in Cloudflare, set the record to **DNS-only (gray cloud)**, not Proxied (orange cloud). With the proxy on, Cloudflare terminates TLS with its own certificate and the cluster never sees the SNI — Caddy's `ask` handler is never invoked, ACME never runs, and the domain stays `pending_dns` forever. The same applies to any CDN or reverse proxy that intercepts TLS in front of the ingress.
+
+DNS-01 issuance (which works behind a proxy) is tracked for v2 in `plans/custom-domains-dns01.md`.
 
 ## Attach at create time
 

--- a/docs/src/content/docs/custom-domains.mdx
+++ b/docs/src/content/docs/custom-domains.mdx
@@ -11,7 +11,7 @@ Attach an arbitrary public hostname (`api.acme.com`, `acme.com`) to a sandbox so
 1. **Domain mode is required.** The server must be started with `SB_DOMAIN` set. In IP / path-mode deployments the API returns `412 Precondition Failed`.
 2. **DNS must already point at the cluster's ingress host.** Create a `CNAME` (or `ALIAS` / `ANAME` for apex) from the custom hostname to the same target your sandbox URLs resolve to. AerolVM does not host DNS; if the record is missing when the first HTTPS request arrives, ACME issuance will fail and the domain stays in `issuing` until DNS is fixed.
 3. **Port 80 must be reachable from Let's Encrypt.** Issuance uses HTTP-01, so LE's validation servers need to reach `http://<host>/.well-known/acme-challenge/...` on the ingress. If a firewall blocks inbound `:80`, the status sticks at `issuing` and eventually flips to `failed`.
-4. **HTTP / HTTPS only.** Custom domains attach to the sandbox root (the toolbox-proxied URL). Raw `tcp://` and `tls://` port exposures are out of scope — they reject with `400 Bad Request` if a custom domain is configured.
+4. **HTTP / HTTPS only.** Custom domains attach to the sandbox root (the toolbox-proxied URL). Raw `tcp://` and `tls://` port exposures are out of scope — they reject with `409 Conflict` if a custom domain is configured.
 
 ### Cloudflare: turn the proxy off
 

--- a/internal/cluster/agent.go
+++ b/internal/cluster/agent.go
@@ -346,6 +346,49 @@ func (a *Agent) ExposedPortsOf(sandboxID string) map[int]ExposedPortRoute {
 	return exposedPortRoutesForPlacement(lookup.Placement)
 }
 
+// AddCustomDomain forwards to the cluster Apply pipe. hostname is canonicalized
+// here (the public Cluster wrapper does the same on the other path); the FSM
+// then enforces cluster-wide uniqueness.
+func (a *Agent) AddCustomDomain(ctx context.Context, sandboxID, hostname string) error {
+	hostname = strings.ToLower(strings.TrimSpace(hostname))
+	if sandboxID == "" || hostname == "" {
+		return nil
+	}
+	return a.applyCommand(ctx, command{Op: opAddCustomDomain, SandboxID: sandboxID, Hostname: hostname})
+}
+
+func (a *Agent) RemoveCustomDomain(ctx context.Context, sandboxID, hostname string) error {
+	hostname = strings.ToLower(strings.TrimSpace(hostname))
+	if sandboxID == "" || hostname == "" {
+		return nil
+	}
+	return a.applyCommand(ctx, command{Op: opRemoveCustomDomain, SandboxID: sandboxID, Hostname: hostname})
+}
+
+// CustomDomainsOf returns the hostnames bound to sandboxID. Agent doesn't run
+// the placement FSM locally, so this rides the same remote placement lookup
+// the existing ExposedPortsOf path uses — failure modes match: a transient
+// network blip yields nil, which the ingress reconciler treats as "no custom
+// matchers right now" until the placement subscription wakes a re-read.
+func (a *Agent) CustomDomainsOf(sandboxID string) []string {
+	lookup, ok, err := a.lookupPlacement(context.Background(), sandboxID)
+	if err != nil || !ok || len(lookup.Placement.CustomHostnames) == 0 {
+		return nil
+	}
+	out := make([]string, len(lookup.Placement.CustomHostnames))
+	copy(out, lookup.Placement.CustomHostnames)
+	return out
+}
+
+// ResolveCustomDomain returns ("", false) on agent nodes. A reverse-by-hostname
+// lookup endpoint isn't wired through yet (the TLS-ask handler is intended to
+// live alongside a node that runs raft locally — server/ingress roles).
+// See task #17 for adding a remote lookup if agent-role ingress becomes a
+// supported topology.
+func (a *Agent) ResolveCustomDomain(hostname string) (string, bool) {
+	return "", false
+}
+
 func (a *Agent) DeletePlacement(ctx context.Context, sandboxID string) error {
 	return a.applyCommand(ctx, command{Op: opDelete, SandboxID: sandboxID})
 }

--- a/internal/cluster/agent.go
+++ b/internal/cluster/agent.go
@@ -476,12 +476,22 @@ func (a *Agent) AssertOwnership(ctx context.Context, local []LocalSandboxState) 
 					firstErr = err
 				}
 			}
+			for _, hostname := range st.CustomHostnames {
+				if err := a.AddCustomDomain(ctx, st.ID, hostname); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
 		case existing.Placement.OwnerNodeID == a.nodeID && !existing.Placement.IsOrphaned() && existing.Placement.IsReserved():
 			if err := a.RecordPlacement(ctx, st.ID, st.Spec, st.Secrets); err != nil && firstErr == nil {
 				firstErr = err
 			}
 			for port, route := range st.ExposedPorts {
 				if err := a.AddExposedPort(ctx, st.ID, port, route); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+			for _, hostname := range st.CustomHostnames {
+				if err := a.AddCustomDomain(ctx, st.ID, hostname); err != nil && firstErr == nil {
 					firstErr = err
 				}
 			}
@@ -496,6 +506,11 @@ func (a *Agent) AssertOwnership(ctx context.Context, local []LocalSandboxState) 
 					firstErr = err
 				}
 			}
+			for _, hostname := range st.CustomHostnames {
+				if err := a.AddCustomDomain(ctx, st.ID, hostname); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
 		case placementCanBeClaimedBy(existing.Placement, a.nodeID):
 			if err := a.ClaimOrphan(ctx, st.ID, st.Spec, st.Secrets); err != nil {
 				if firstErr == nil {
@@ -505,6 +520,11 @@ func (a *Agent) AssertOwnership(ctx context.Context, local []LocalSandboxState) 
 			}
 			for port, route := range st.ExposedPorts {
 				if err := a.AddExposedPort(ctx, st.ID, port, route); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+			for _, hostname := range st.CustomHostnames {
+				if err := a.AddCustomDomain(ctx, st.ID, hostname); err != nil && firstErr == nil {
 					firstErr = err
 				}
 			}

--- a/internal/cluster/assert_ownership_custom_domains_test.go
+++ b/internal/cluster/assert_ownership_custom_domains_test.go
@@ -1,0 +1,100 @@
+package cluster
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// TestAssertOwnershipBackfillsCustomHostnames is the failover-recreate guard:
+// on boot, the new owner's local store already has the custom hostnames (they
+// were carried over via recovery_replication), but the FSM placement map
+// doesn't. AssertOwnership must replay them through the FSM so cluster-wide
+// hostname → sandbox lookups (TLSAsk, ingress_delta SNI matchers) resolve.
+// Without this, a failed-over sandbox would be unreachable on its custom
+// domains until the next mutating call rebuilt the FSM index.
+func TestAssertOwnershipBackfillsCustomHostnames(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test: requires real raft socket")
+	}
+	c, cleanup := newTestCluster(t, "leader", true, nil)
+	defer cleanup()
+	waitForLeader(t, c, 10*time.Second)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	local := []LocalSandboxState{{
+		ID:              "sb-domains",
+		Spec:            &models.CreateSandboxRequest{Image: "alpine", CPU: 1, MemoryMB: 512},
+		CustomHostnames: []string{"api.acme.com", "shop.beta.io"},
+	}}
+	if err := c.AssertOwnership(ctx, local); err != nil {
+		t.Fatalf("AssertOwnership: %v", err)
+	}
+
+	got, ok := c.fsm.get("sb-domains")
+	if !ok {
+		t.Fatal("placement not created")
+	}
+	if len(got.CustomHostnames) != 2 {
+		t.Fatalf("CustomHostnames = %v, want both replayed", got.CustomHostnames)
+	}
+	// Index must resolve cluster-wide — the TLSAsk hot path keys off this map.
+	for _, h := range []string{"api.acme.com", "shop.beta.io"} {
+		sid, ok := c.fsm.sandboxIDByCustomHostname(h)
+		if !ok || sid != "sb-domains" {
+			t.Fatalf("hostname index for %q = (%q, %v), want (sb-domains, true)", h, sid, ok)
+		}
+	}
+}
+
+// TestAssertOwnershipReReplaysMissingCustomHostnames covers the catch-up
+// case where a placement we own already exists but the FSM is missing some
+// hostnames (e.g. AssertOwnership ran before PR #3, or a prior replay
+// failed mid-flight). Re-running must add the missing ones without
+// disturbing the existing placement or its other state.
+func TestAssertOwnershipReReplaysMissingCustomHostnames(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test: requires real raft socket")
+	}
+	c, cleanup := newTestCluster(t, "leader", true, nil)
+	defer cleanup()
+	waitForLeader(t, c, 10*time.Second)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// First pass: bind one hostname.
+	if err := c.AssertOwnership(ctx, []LocalSandboxState{{
+		ID:              "sb-catchup",
+		Spec:            &models.CreateSandboxRequest{Image: "alpine"},
+		CustomHostnames: []string{"first.acme.com"},
+	}}); err != nil {
+		t.Fatalf("first AssertOwnership: %v", err)
+	}
+
+	// Second pass: same sandbox, now with two hostnames. The owner+normal
+	// branch must replay both (idempotent on the first, additive on the
+	// second).
+	if err := c.AssertOwnership(ctx, []LocalSandboxState{{
+		ID:              "sb-catchup",
+		Spec:            &models.CreateSandboxRequest{Image: "alpine"},
+		CustomHostnames: []string{"first.acme.com", "second.acme.com"},
+	}}); err != nil {
+		t.Fatalf("second AssertOwnership: %v", err)
+	}
+
+	got, ok := c.fsm.get("sb-catchup")
+	if !ok {
+		t.Fatal("placement disappeared")
+	}
+	if len(got.CustomHostnames) != 2 {
+		t.Fatalf("CustomHostnames = %v, want 2 after catch-up replay", got.CustomHostnames)
+	}
+	if sid, ok := c.fsm.sandboxIDByCustomHostname("second.acme.com"); !ok || sid != "sb-catchup" {
+		t.Fatalf("second hostname not claimed: (%q, %v)", sid, ok)
+	}
+}

--- a/internal/cluster/client.go
+++ b/internal/cluster/client.go
@@ -527,6 +527,46 @@ func (c *Cluster) ExposedPortsOf(sandboxID string) map[int]ExposedPortRoute {
 	return exposedPortRoutesForPlacement(p)
 }
 
+// AddCustomDomain replicates a sandbox→hostname binding through raft so every
+// node can answer the TLS-ask probe and install the matching Caddy matcher.
+// hostname is canonicalized (trim + lower) here so callers don't have to
+// remember to do it themselves — the local SQLite layer already trims.
+// Idempotent for the same (sandbox, hostname) pair; returns
+// ErrCustomHostnameConflict when the hostname is held by a different sandbox.
+func (c *Cluster) AddCustomDomain(ctx context.Context, sandboxID, hostname string) error {
+	hostname = strings.ToLower(strings.TrimSpace(hostname))
+	if sandboxID == "" || hostname == "" {
+		return nil
+	}
+	cmd := command{Op: opAddCustomDomain, SandboxID: sandboxID, Hostname: hostname}
+	return c.applyCommand(ctx, cmd)
+}
+
+// RemoveCustomDomain releases the binding. Idempotent — a stale call after a
+// successful DeletePlacement is a no-op.
+func (c *Cluster) RemoveCustomDomain(ctx context.Context, sandboxID, hostname string) error {
+	hostname = strings.ToLower(strings.TrimSpace(hostname))
+	if sandboxID == "" || hostname == "" {
+		return nil
+	}
+	cmd := command{Op: opRemoveCustomDomain, SandboxID: sandboxID, Hostname: hostname}
+	return c.applyCommand(ctx, cmd)
+}
+
+// CustomDomainsOf returns a sorted copy of the hostnames bound to sandboxID,
+// or nil when none. Used by the ingress reconciler so a peer-owned sandbox
+// still gets its TLS matchers installed in the local Caddy.
+func (c *Cluster) CustomDomainsOf(sandboxID string) []string {
+	return c.fsm.customHostnamesForSandbox(sandboxID)
+}
+
+// ResolveCustomDomain answers the TLS-ask probe from the local FSM index in
+// O(1). Returns sandboxID, true when the hostname is bound somewhere in the
+// cluster; false otherwise. hostname is canonicalized inside the FSM.
+func (c *Cluster) ResolveCustomDomain(hostname string) (string, bool) {
+	return c.fsm.sandboxIDByCustomHostname(hostname)
+}
+
 // DeletePlacement removes sandboxID from the placement map. Idempotent.
 func (c *Cluster) DeletePlacement(ctx context.Context, sandboxID string) error {
 	cmd := command{Op: opDelete, SandboxID: sandboxID}

--- a/internal/cluster/client.go
+++ b/internal/cluster/client.go
@@ -877,6 +877,11 @@ func (c *Cluster) AssertOwnership(ctx context.Context, local []LocalSandboxState
 					firstErr = err
 				}
 			}
+			for _, hostname := range st.CustomHostnames {
+				if err := c.AddCustomDomain(ctx, st.ID, hostname); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
 
 		case existing.OwnerNodeID == c.nodeID && !existing.IsOrphaned() && existing.IsReserved():
 			if err := c.RecordPlacement(ctx, st.ID, st.Spec, st.Secrets); err != nil && firstErr == nil {
@@ -887,11 +892,18 @@ func (c *Cluster) AssertOwnership(ctx context.Context, local []LocalSandboxState
 					firstErr = err
 				}
 			}
+			for _, hostname := range st.CustomHostnames {
+				if err := c.AddCustomDomain(ctx, st.ID, hostname); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
 
 		case existing.OwnerNodeID == c.nodeID && !existing.IsOrphaned():
 			// We legitimately own it. Backfill any missing spec/secrets so
 			// future failover-recreate has everything it needs (closes the
-			// pre-cluster-sandbox limitation), then replay port intents.
+			// pre-cluster-sandbox limitation), then replay port + hostname
+			// intents. The FSM treats already-bound (sandbox, hostname) pairs
+			// as idempotent no-ops, so re-replaying every boot is cheap.
 			if existing.Spec == nil && st.Spec != nil {
 				if err := c.UpsertSpec(ctx, st.ID, st.Spec, st.Secrets); err != nil && firstErr == nil {
 					firstErr = err
@@ -899,6 +911,11 @@ func (c *Cluster) AssertOwnership(ctx context.Context, local []LocalSandboxState
 			}
 			for port, route := range st.ExposedPorts {
 				if err := c.AddExposedPort(ctx, st.ID, port, route); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+			for _, hostname := range st.CustomHostnames {
+				if err := c.AddCustomDomain(ctx, st.ID, hostname); err != nil && firstErr == nil {
 					firstErr = err
 				}
 			}
@@ -912,6 +929,16 @@ func (c *Cluster) AssertOwnership(ctx context.Context, local []LocalSandboxState
 			}
 			for port, route := range st.ExposedPorts {
 				if err := c.AddExposedPort(ctx, st.ID, port, route); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+			// Failover claim: the new owner replays hostnames from local
+			// truth. AddCustomDomain at the FSM is the uniqueness gate, so
+			// a hostname still claimed by a dead prior owner stays with the
+			// stale row until that row is reaped; the next AssertOwnership
+			// pass after reap succeeds.
+			for _, hostname := range st.CustomHostnames {
+				if err := c.AddCustomDomain(ctx, st.ID, hostname); err != nil && firstErr == nil {
 					firstErr = err
 				}
 			}

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -122,6 +122,15 @@ var ErrMemberStillAlive = errors.New("cluster: raft member is still alive")
 // server and leaving the cluster with no quorum path.
 var ErrLastVoter = errors.New("cluster: cannot remove last raft voter")
 
+// ErrCustomHostnameConflict is returned when an opAddCustomDomain entry asks
+// the FSM to claim a hostname already held by a different sandbox. Maps to
+// the same 409 the local SQLite custom-domains insert returns — the FSM is
+// the cluster-wide tiebreaker that catches the race where two sandboxes on
+// different owners try to claim the same hostname concurrently. The
+// API/service layer surfaces this as models.ErrCustomDomainConflict after
+// reading the raft Apply result.
+var ErrCustomHostnameConflict = errors.New("cluster: custom hostname already in use")
+
 const (
 	// CreateBackpressureRetryAfterSeconds is the public Retry-After hint for
 	// queue/concurrency backpressure. Keep it short: these rejects are caused by
@@ -241,6 +250,17 @@ type Placement struct {
 	SealedSecrets     []byte                       `json:"sealed_secrets,omitempty"`
 	ExposedPorts      map[int]string               `json:"exposed_ports,omitempty"`
 	ExposedPortRoutes map[int]ExposedPortRoute     `json:"exposed_port_routes,omitempty"`
+	// CustomHostnames is the replicated set of user-bound hostnames pointing at
+	// this sandbox. Kept sorted and lower-cased so snapshot bytes are stable
+	// across rebuilds and every node derives the same Caddy matcher order. The
+	// FSM additionally maintains a hostname→sandboxID index so the TLS-ask
+	// resolver and ingress reconciler can look up ownership in O(1) from any
+	// node, including the ingress-only ones that don't run the local SQLite
+	// custom-domains table. Hostnames are added/removed via the
+	// opAddCustomDomain/opRemoveCustomDomain raft commands; opPlace preserves
+	// the existing slice the same way ExposedPorts is preserved so a
+	// re-place/reassign cannot erase domains a prior raft entry installed.
+	CustomHostnames []string `json:"custom_hostnames,omitempty"`
 	// State is empty for materialized placements (the historical schema) and
 	// PlacementStateReserved for capacity-only intents that have not yet been
 	// promoted by a successful local create. Reservations are eligible for
@@ -295,6 +315,13 @@ type LocalSandboxState struct {
 	Spec         *models.CreateSandboxRequest
 	Secrets      PlacementSecrets
 	ExposedPorts map[int]ExposedPortRoute
+	// CustomHostnames is the per-sandbox bound hostname set known to the
+	// local store. Carried through AssertOwnership so a sandbox created before
+	// the FSM learned about its hostnames (e.g. cluster mode enabled after the
+	// sandbox already had custom domains) backfills the replicated set on
+	// boot — without this a failover-recreate would lose the user's TLS
+	// matchers.
+	CustomHostnames []string
 }
 
 // PlacementTarget is returned by SelectPlacement.
@@ -448,6 +475,28 @@ type Client interface {
 	// ExposedPortsOf returns a copy of the replicated port route map for
 	// sandboxID, or nil if none. Used by the recreator and ingress reconciler.
 	ExposedPortsOf(sandboxID string) map[int]ExposedPortRoute
+
+	// AddCustomDomain records intent that sandboxID owns hostname (already
+	// canonicalized lower-case) cluster-wide. Returns ErrCustomHostnameConflict
+	// when a different sandbox already holds it. Idempotent for the same
+	// (sandbox, hostname) pair so retries are safe.
+	AddCustomDomain(ctx context.Context, sandboxID, hostname string) error
+
+	// RemoveCustomDomain drops hostname from sandboxID's set. No-op when the
+	// hostname isn't claimed by this sandbox (the local row may already be
+	// gone after a Delete) so callers can retry without special-casing.
+	RemoveCustomDomain(ctx context.Context, sandboxID, hostname string) error
+
+	// CustomDomainsOf returns a copy of the replicated hostname set for
+	// sandboxID, or nil when no placement exists or the set is empty. The
+	// ingress reconciler uses it to populate Caddy matchers on every node.
+	CustomDomainsOf(sandboxID string) []string
+
+	// ResolveCustomDomain answers "which sandbox owns this hostname?" from
+	// the local FSM in O(1). Used by the TLS-ask handler on ingress nodes
+	// that may not own the sandbox row themselves. hostname is matched
+	// case-insensitively. Returns sandboxID, true when known.
+	ResolveCustomDomain(hostname string) (string, bool)
 
 	// DeletePlacement removes sandboxID from the FSM. Idempotent.
 	DeletePlacement(ctx context.Context, sandboxID string) error

--- a/internal/cluster/fsm.go
+++ b/internal/cluster/fsm.go
@@ -23,18 +23,20 @@ import (
 type opCode uint8
 
 const (
-	opPlace             opCode = 1
-	opDelete            opCode = 2
-	opReassign          opCode = 3
-	opUpsertSpec        opCode = 4  // overwrite Placement.Spec without touching ownership
-	opAddExposedPort    opCode = 5  // record one (port, protocol) intent
-	opRemoveExposedPort opCode = 6  // drop one port intent
-	opReserve           opCode = 7  // hold capacity + name for a chosen owner before docker
-	opCancelReserve     opCode = 8  // release a pending reservation (rollback or TTL GC)
-	opSetNodeDrainState opCode = 9  // operator-set "exclude from placement" mark for a node
-	opOrphanOwner       opCode = 10 // atomically orphan all placements owned by a dead node
-	opClaimOrphan       opCode = 11 // reclaim an orphaned placement back to its previous owner
-	opReserveBatch      opCode = 12 // hold capacity + names for a create burst in one raft entry
+	opPlace              opCode = 1
+	opDelete             opCode = 2
+	opReassign           opCode = 3
+	opUpsertSpec         opCode = 4  // overwrite Placement.Spec without touching ownership
+	opAddExposedPort     opCode = 5  // record one (port, protocol) intent
+	opRemoveExposedPort  opCode = 6  // drop one port intent
+	opReserve            opCode = 7  // hold capacity + name for a chosen owner before docker
+	opCancelReserve      opCode = 8  // release a pending reservation (rollback or TTL GC)
+	opSetNodeDrainState  opCode = 9  // operator-set "exclude from placement" mark for a node
+	opOrphanOwner        opCode = 10 // atomically orphan all placements owned by a dead node
+	opClaimOrphan        opCode = 11 // reclaim an orphaned placement back to its previous owner
+	opReserveBatch       opCode = 12 // hold capacity + names for a create burst in one raft entry
+	opAddCustomDomain    opCode = 13 // bind one user hostname to a placement (cluster-wide unique)
+	opRemoveCustomDomain opCode = 14 // release one previously-bound hostname
 )
 
 // command is the wire format for one raft log entry. New writers externalize
@@ -78,6 +80,11 @@ type command struct {
 	// from SelectPlacement, false = uncordon). All other ops leave them zero.
 	NodeID  string `json:"node_id,omitempty"`
 	Drained bool   `json:"drained,omitempty"`
+	// Hostname carries the single custom-domain hostname for
+	// opAddCustomDomain/opRemoveCustomDomain. Callers MUST canonicalize
+	// (trim + lower-case) before encoding so the replicated index uses
+	// identical keys cluster-wide.
+	Hostname string `json:"hostname,omitempty"`
 
 	// Reservations is populated by opReserveBatch. The single opReserve fields
 	// above are retained for wire compatibility and the normal one-create path.
@@ -238,6 +245,13 @@ type placementFSM struct {
 	// no-drains steady state; cleared rows are deleted so the map size tracks
 	// active drains, not historical ones.
 	drainedNodes map[string]bool
+	// customHostnameIndex maps a canonical (lower-case, trimmed) hostname to
+	// the sandbox ID currently holding it. This is the cluster-wide TLS-ask
+	// answer source — ingress nodes that don't own a sandbox themselves can
+	// still resolve "is this hostname known?" in O(1) under the FSM read lock
+	// without scanning every placement. Rebuilt on Restore from the
+	// Placement.CustomHostnames slices so older snapshots still load cleanly.
+	customHostnameIndex map[string]string
 
 	// subMu guards subscribers. Separate from mu so a slow subscriber accept
 	// can't block FSM reads — Apply takes mu briefly to write, releases it,
@@ -308,6 +322,7 @@ func newPlacementFSMWithRecoveryStore(store placementRecoveryStore) *placementFS
 		pendingReservationIDsByOwner: make(map[string]map[string]struct{}),
 		reservedIndex:                make(map[string]struct{}),
 		drainedNodes:                 make(map[string]bool),
+		customHostnameIndex:          make(map[string]string),
 	}
 }
 
@@ -394,12 +409,17 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 		secrets := applyCommandSecretUpdate(existing, exists, cmd)
 		var ports map[int]string
 		var portRoutes map[int]ExposedPortRoute
+		var customHostnames []string
 		if exists {
 			// Same preservation rule as Spec: opPlace is the "owner + spec"
 			// write and must not erase the port intents accumulated by
 			// opAddExposedPort calls between creates.
 			ports = existing.ExposedPorts
 			portRoutes = existing.ExposedPortRoutes
+			// Mirror the ExposedPorts preservation: a re-place / reservation
+			// promote must not drop user-bound hostnames that
+			// opAddCustomDomain installed earlier in the log.
+			customHostnames = existing.CustomHostnames
 		}
 		dataPlaneHost := cmd.OwnerDataPlaneHost
 		if dataPlaneHost == "" && exists {
@@ -431,6 +451,7 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 			SealedSecrets:      secrets.LegacySealed,
 			ExposedPorts:       ports,
 			ExposedPortRoutes:  portRoutes,
+			CustomHostnames:    customHostnames,
 			// opPlace is the promotion path for reservations: writing the
 			// empty State here transitions a Reserved row back to Placed.
 			// ExpiresUnix is cleared by the zero-value as well so the GC
@@ -483,6 +504,7 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 		f.releaseNameLocked(cmd.SandboxID, placementName(existing))
 		f.releaseShardLocked(cmd.SandboxID)
 		f.releaseAllHostPortsLocked(cmd.SandboxID, existing)
+		f.releaseAllCustomHostnamesLocked(cmd.SandboxID, existing)
 		f.releasePendingReservationLocked(cmd.SandboxID)
 		f.releasePendingReservationOwnerLocked(cmd.SandboxID, existing.OwnerNodeID)
 		f.deletePlacementRecoveryLocked(cmd.SandboxID)
@@ -493,6 +515,7 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 			f.releaseNameLocked(cmd.SandboxID, placementName(existing))
 			f.releaseShardLocked(cmd.SandboxID)
 			f.releaseAllHostPortsLocked(cmd.SandboxID, existing)
+			f.releaseAllCustomHostnamesLocked(cmd.SandboxID, existing)
 			f.releaseOwnerLocked(cmd.SandboxID, existing)
 			if existing.IsReserved() {
 				f.releasePendingReservationLocked(cmd.SandboxID)
@@ -572,6 +595,7 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 			}
 			f.releaseNameLocked(id, placementName(existing))
 			f.releaseShardLocked(id)
+			f.releaseAllCustomHostnamesLocked(id, existing)
 			f.releasePendingReservationLocked(id)
 			f.releasePendingReservationOwnerLocked(id, existing.OwnerNodeID)
 			f.deletePlacementRecoveryLocked(id)
@@ -736,6 +760,63 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 		if err := f.storePlacementLocked(cmd.SandboxID, existing); err != nil {
 			return err
 		}
+		return nil
+	case opAddCustomDomain:
+		// Cluster-wide hostname uniqueness check. The service layer already
+		// rejects a same-sandbox duplicate locally, but two creates racing on
+		// different owners could both pass their local validation and end up
+		// at the FSM. The hostname index is the single tiebreaker — first
+		// committed log entry wins, the loser's owner returns
+		// ErrCustomHostnameConflict so the local row can roll back.
+		if cmd.SandboxID == "" || cmd.Hostname == "" {
+			return fmt.Errorf("placementFSM: opAddCustomDomain requires sandbox_id and hostname")
+		}
+		existing, exists := f.fullPlacementLocked(cmd.SandboxID)
+		if !exists {
+			// No row to attach the hostname to — the local create on the
+			// owner has either failed or hasn't promoted yet. Treat as no-op
+			// rather than error: the next AddCustomDomain after a successful
+			// create will redrive this safely (and the service layer never
+			// surfaces it to a user).
+			return nil
+		}
+		if owner, claimed := f.customHostnameIndex[cmd.Hostname]; claimed && owner != cmd.SandboxID {
+			return fmt.Errorf("%w: %q held by %s", ErrCustomHostnameConflict, cmd.Hostname, owner)
+		}
+		if existingHasHostname(existing, cmd.Hostname) {
+			// Idempotent re-add: the hostname is already on the placement
+			// and the index already points here. Skip the version bump.
+			return nil
+		}
+		existing.CustomHostnames = insertSortedHostname(existing.CustomHostnames, cmd.Hostname)
+		existing.Version = f.version
+		existing.UpdatedUnix = now
+		if err := f.storePlacementLocked(cmd.SandboxID, existing); err != nil {
+			return err
+		}
+		f.claimCustomHostnameLocked(cmd.SandboxID, cmd.Hostname)
+		return nil
+	case opRemoveCustomDomain:
+		if cmd.SandboxID == "" || cmd.Hostname == "" {
+			return fmt.Errorf("placementFSM: opRemoveCustomDomain requires sandbox_id and hostname")
+		}
+		existing, exists := f.fullPlacementLocked(cmd.SandboxID)
+		if !exists {
+			// Stale replay against an already-deleted placement is harmless.
+			// Make sure the index doesn't still point at the now-gone id.
+			f.releaseCustomHostnameLocked(cmd.SandboxID, cmd.Hostname)
+			return nil
+		}
+		if !existingHasHostname(existing, cmd.Hostname) {
+			return nil
+		}
+		existing.CustomHostnames = removeHostname(existing.CustomHostnames, cmd.Hostname)
+		existing.Version = f.version
+		existing.UpdatedUnix = now
+		if err := f.storePlacementLocked(cmd.SandboxID, existing); err != nil {
+			return err
+		}
+		f.releaseCustomHostnameLocked(cmd.SandboxID, cmd.Hostname)
 		return nil
 	case opSetNodeDrainState:
 		// Drain marks live in the FSM so an operator-issued drain persists past
@@ -1039,6 +1120,91 @@ func (f *placementFSM) releaseAllHostPortsLocked(sandboxID string, p Placement) 
 	for port, route := range exposedPortRoutesForPlacement(p) {
 		f.releaseHostPortLocked(sandboxID, port, route)
 	}
+}
+
+func (f *placementFSM) claimCustomHostnameLocked(sandboxID, hostname string) {
+	if sandboxID == "" || hostname == "" {
+		return
+	}
+	if f.customHostnameIndex == nil {
+		f.customHostnameIndex = make(map[string]string)
+	}
+	f.customHostnameIndex[hostname] = sandboxID
+}
+
+// releaseCustomHostnameLocked drops hostname from the secondary index when
+// sandboxID is the recorded owner. The owner guard prevents a stale release
+// from a since-orphaned-and-reclaimed sandbox from unmapping a new claim — the
+// same delete-then-place race that releaseNameLocked guards against.
+func (f *placementFSM) releaseCustomHostnameLocked(sandboxID, hostname string) {
+	if hostname == "" || f.customHostnameIndex == nil {
+		return
+	}
+	if owner, ok := f.customHostnameIndex[hostname]; ok && (sandboxID == "" || owner == sandboxID) {
+		delete(f.customHostnameIndex, hostname)
+	}
+}
+
+func (f *placementFSM) releaseAllCustomHostnamesLocked(sandboxID string, p Placement) {
+	for _, h := range p.CustomHostnames {
+		f.releaseCustomHostnameLocked(sandboxID, h)
+	}
+}
+
+// existingHasHostname reports whether hostname is already present in the
+// placement's hostname slice. Linear in the slice but the per-sandbox cap
+// (models.MaxCustomDomainsPerSandbox) bounds it tightly.
+func existingHasHostname(p Placement, hostname string) bool {
+	for _, h := range p.CustomHostnames {
+		if h == hostname {
+			return true
+		}
+	}
+	return false
+}
+
+// insertSortedHostname returns a new slice with hostname inserted in sorted
+// order. Sorted slices keep snapshot bytes deterministic across rebuilds and
+// give every node the same Caddy matcher order for free.
+func insertSortedHostname(existing []string, hostname string) []string {
+	if hostname == "" {
+		return existing
+	}
+	out := make([]string, 0, len(existing)+1)
+	inserted := false
+	for _, h := range existing {
+		if !inserted && hostname < h {
+			out = append(out, hostname)
+			inserted = true
+		}
+		if h == hostname {
+			// Defensive: existingHasHostname guards the caller, but if a
+			// stale path slipped through, return the unchanged sorted slice.
+			return existing
+		}
+		out = append(out, h)
+	}
+	if !inserted {
+		out = append(out, hostname)
+	}
+	return out
+}
+
+func removeHostname(existing []string, hostname string) []string {
+	for i, h := range existing {
+		if h != hostname {
+			continue
+		}
+		// Keep the slice sorted by splicing rather than swap-remove.
+		out := make([]string, 0, len(existing)-1)
+		out = append(out, existing[:i]...)
+		out = append(out, existing[i+1:]...)
+		if len(out) == 0 {
+			return nil
+		}
+		return out
+	}
+	return existing
 }
 
 func (f *placementFSM) validateHostPortAvailableLocked(sandboxID string, port int, route ExposedPortRoute) error {
@@ -1402,6 +1568,37 @@ func (f *placementFSM) get(id string) (Placement, bool) {
 		return Placement{}, false
 	}
 	return clonePlacement(p), true
+}
+
+// sandboxIDByCustomHostname returns the sandbox ID currently claiming
+// hostname in the replicated custom-domain index. hostname is matched
+// verbatim — callers are expected to canonicalize (lower-case, trim) before
+// looking up, matching how opAddCustomDomain stores it.
+func (f *placementFSM) sandboxIDByCustomHostname(hostname string) (string, bool) {
+	hostname = strings.ToLower(strings.TrimSpace(hostname))
+	if hostname == "" {
+		return "", false
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	id, ok := f.customHostnameIndex[hostname]
+	return id, ok
+}
+
+// customHostnamesForSandbox returns a sorted copy of the hostname set for
+// sandboxID, or nil when none. Callers must not mutate the returned slice;
+// it is cloned so a follow-up Apply doesn't perturb the snapshot a reader is
+// using.
+func (f *placementFSM) customHostnamesForSandbox(sandboxID string) []string {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	p, ok := f.placements[sandboxID]
+	if !ok || len(p.CustomHostnames) == 0 {
+		return nil
+	}
+	out := make([]string, len(p.CustomHostnames))
+	copy(out, p.CustomHostnames)
+	return out
 }
 
 // sandboxIDByName returns the sandbox ID currently claiming name in the
@@ -1770,6 +1967,7 @@ func (f *placementFSM) Restore(rc io.ReadCloser) (err error) {
 	f.pendingReservationIDsByOwner = make(map[string]map[string]struct{})
 	f.pendingReservationExpiries = nil
 	f.reservedIndex = make(map[string]struct{})
+	f.customHostnameIndex = make(map[string]string)
 	for id, p := range payload.Placements {
 		full := p
 		if full.SandboxID == "" {
@@ -1798,6 +1996,9 @@ func (f *placementFSM) Restore(rc io.ReadCloser) (err error) {
 		f.claimShardLocked(id)
 		for port, route := range exposedPortRoutesForPlacement(indexed) {
 			f.claimHostPortLocked(id, port, route)
+		}
+		for _, h := range indexed.CustomHostnames {
+			f.claimCustomHostnameLocked(id, h)
 		}
 		if indexed.IsReserved() {
 			f.claimPendingReservationLocked(id, indexed)
@@ -1877,6 +2078,9 @@ func cloneHotPlacement(p Placement) Placement {
 		}
 		p.ExposedPortRoutes = routes
 	}
+	if len(p.CustomHostnames) > 0 {
+		p.CustomHostnames = append([]string(nil), p.CustomHostnames...)
+	}
 	return p
 }
 
@@ -1902,6 +2106,9 @@ func clonePlacement(p Placement) Placement {
 			routes[k] = v
 		}
 		p.ExposedPortRoutes = routes
+	}
+	if len(p.CustomHostnames) > 0 {
+		p.CustomHostnames = append([]string(nil), p.CustomHostnames...)
 	}
 	return p
 }

--- a/internal/cluster/fsm_custom_domains_test.go
+++ b/internal/cluster/fsm_custom_domains_test.go
@@ -1,0 +1,272 @@
+package cluster
+
+import (
+	"bytes"
+	"encoding/gob"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/hashicorp/raft"
+)
+
+// applyCustomDomainOp is a tiny helper so each test doesn't repeat the
+// encode/Apply/decode dance. Returns the FSM Apply result so failure-path
+// tests can assert on the wrapped error.
+func applyCustomDomainOp(t *testing.T, fsm *placementFSM, idx uint64, cmd command) interface{} {
+	t.Helper()
+	payload, err := encodeCommand(cmd)
+	if err != nil {
+		t.Fatalf("encode op %d: %v", cmd.Op, err)
+	}
+	return fsm.Apply(&raft.Log{Index: idx, Data: payload})
+}
+
+func mustPlaceForCustomDomains(t *testing.T, fsm *placementFSM, idx uint64, sandboxID, owner string) {
+	t.Helper()
+	if res := applyCustomDomainOp(t, fsm, idx, command{
+		Op:          opPlace,
+		SandboxID:   sandboxID,
+		OwnerNodeID: owner,
+		OwnerAPIURL: "http://" + owner,
+	}); res != nil {
+		t.Fatalf("place %s on %s: %v", sandboxID, owner, res)
+	}
+}
+
+func TestFSMAddCustomDomain_ClaimsIndex(t *testing.T) {
+	fsm := newPlacementFSM()
+	mustPlaceForCustomDomains(t, fsm, 1, "sb-1", "nodeA")
+
+	if res := applyCustomDomainOp(t, fsm, 2, command{Op: opAddCustomDomain, SandboxID: "sb-1", Hostname: "api.acme.com"}); res != nil {
+		t.Fatalf("add: %v", res)
+	}
+	got, ok := fsm.sandboxIDByCustomHostname("api.acme.com")
+	if !ok || got != "sb-1" {
+		t.Fatalf("resolver: got=%q ok=%v, want sb-1", got, ok)
+	}
+	p, _ := fsm.get("sb-1")
+	if len(p.CustomHostnames) != 1 || p.CustomHostnames[0] != "api.acme.com" {
+		t.Fatalf("placement hostnames=%v, want [api.acme.com]", p.CustomHostnames)
+	}
+}
+
+func TestFSMAddCustomDomain_Idempotent(t *testing.T) {
+	fsm := newPlacementFSM()
+	mustPlaceForCustomDomains(t, fsm, 1, "sb-1", "nodeA")
+	if res := applyCustomDomainOp(t, fsm, 2, command{Op: opAddCustomDomain, SandboxID: "sb-1", Hostname: "api.acme.com"}); res != nil {
+		t.Fatalf("add 1: %v", res)
+	}
+	first, _ := fsm.get("sb-1")
+
+	// Re-apply same op: must not mutate the placement Version or duplicate
+	// the hostname.
+	if res := applyCustomDomainOp(t, fsm, 3, command{Op: opAddCustomDomain, SandboxID: "sb-1", Hostname: "api.acme.com"}); res != nil {
+		t.Fatalf("add 2: %v", res)
+	}
+	second, _ := fsm.get("sb-1")
+	if first.Version != second.Version {
+		t.Fatalf("idempotent re-add changed version: %d -> %d", first.Version, second.Version)
+	}
+	if len(second.CustomHostnames) != 1 {
+		t.Fatalf("hostnames duplicated: %v", second.CustomHostnames)
+	}
+}
+
+func TestFSMAddCustomDomain_CrossSandboxConflict(t *testing.T) {
+	fsm := newPlacementFSM()
+	mustPlaceForCustomDomains(t, fsm, 1, "sb-a", "nodeA")
+	mustPlaceForCustomDomains(t, fsm, 2, "sb-b", "nodeA")
+	if res := applyCustomDomainOp(t, fsm, 3, command{Op: opAddCustomDomain, SandboxID: "sb-a", Hostname: "api.acme.com"}); res != nil {
+		t.Fatalf("add to a: %v", res)
+	}
+	res := applyCustomDomainOp(t, fsm, 4, command{Op: opAddCustomDomain, SandboxID: "sb-b", Hostname: "api.acme.com"})
+	err, _ := res.(error)
+	if err == nil || !errors.Is(err, ErrCustomHostnameConflict) {
+		t.Fatalf("cross-sandbox claim = %v, want ErrCustomHostnameConflict", res)
+	}
+	got, _ := fsm.sandboxIDByCustomHostname("api.acme.com")
+	if got != "sb-a" {
+		t.Fatalf("index changed after rejected conflict: got %q, want sb-a", got)
+	}
+	p, _ := fsm.get("sb-b")
+	if len(p.CustomHostnames) != 0 {
+		t.Fatalf("sb-b acquired hostname despite conflict: %v", p.CustomHostnames)
+	}
+}
+
+func TestFSMAddCustomDomain_NoPlacementIsNoop(t *testing.T) {
+	fsm := newPlacementFSM()
+	// Race: hostname arrives at the FSM before the local create promotes
+	// (or after a delete). Must NOT crash and must NOT leak an index entry
+	// that points at a nonexistent sandbox.
+	if res := applyCustomDomainOp(t, fsm, 1, command{Op: opAddCustomDomain, SandboxID: "sb-missing", Hostname: "api.acme.com"}); res != nil {
+		t.Fatalf("apply: %v", res)
+	}
+	if _, ok := fsm.sandboxIDByCustomHostname("api.acme.com"); ok {
+		t.Fatal("index leaked entry for nonexistent sandbox")
+	}
+}
+
+func TestFSMRemoveCustomDomain_ReleasesIndex(t *testing.T) {
+	fsm := newPlacementFSM()
+	mustPlaceForCustomDomains(t, fsm, 1, "sb-1", "nodeA")
+	if res := applyCustomDomainOp(t, fsm, 2, command{Op: opAddCustomDomain, SandboxID: "sb-1", Hostname: "api.acme.com"}); res != nil {
+		t.Fatalf("add: %v", res)
+	}
+	if res := applyCustomDomainOp(t, fsm, 3, command{Op: opRemoveCustomDomain, SandboxID: "sb-1", Hostname: "api.acme.com"}); res != nil {
+		t.Fatalf("remove: %v", res)
+	}
+	if _, ok := fsm.sandboxIDByCustomHostname("api.acme.com"); ok {
+		t.Fatal("index still claims hostname after remove")
+	}
+	p, _ := fsm.get("sb-1")
+	if len(p.CustomHostnames) != 0 {
+		t.Fatalf("hostname still on placement: %v", p.CustomHostnames)
+	}
+}
+
+func TestFSMRemoveCustomDomain_IdempotentOnMissing(t *testing.T) {
+	fsm := newPlacementFSM()
+	mustPlaceForCustomDomains(t, fsm, 1, "sb-1", "nodeA")
+	// No prior add; remove must be a no-op rather than an error so cleanup
+	// retries are safe.
+	if res := applyCustomDomainOp(t, fsm, 2, command{Op: opRemoveCustomDomain, SandboxID: "sb-1", Hostname: "api.acme.com"}); res != nil {
+		t.Fatalf("remove never-added: %v", res)
+	}
+}
+
+func TestFSMOpPlacePreservesCustomHostnames(t *testing.T) {
+	fsm := newPlacementFSM()
+	mustPlaceForCustomDomains(t, fsm, 1, "sb-1", "nodeA")
+	if res := applyCustomDomainOp(t, fsm, 2, command{Op: opAddCustomDomain, SandboxID: "sb-1", Hostname: "api.acme.com"}); res != nil {
+		t.Fatalf("add: %v", res)
+	}
+	// Replay the original place (boot-time AssertOwnership shape) — the
+	// hostnames replicated separately MUST survive.
+	if res := applyCustomDomainOp(t, fsm, 3, command{Op: opPlace, SandboxID: "sb-1", OwnerNodeID: "nodeA", OwnerAPIURL: "http://nodeA"}); res != nil {
+		t.Fatalf("re-place: %v", res)
+	}
+	p, _ := fsm.get("sb-1")
+	if len(p.CustomHostnames) != 1 || p.CustomHostnames[0] != "api.acme.com" {
+		t.Fatalf("re-place erased hostnames: %v", p.CustomHostnames)
+	}
+	if got, _ := fsm.sandboxIDByCustomHostname("api.acme.com"); got != "sb-1" {
+		t.Fatalf("re-place dropped index: got %q", got)
+	}
+}
+
+func TestFSMOpDeleteReleasesCustomHostnames(t *testing.T) {
+	fsm := newPlacementFSM()
+	mustPlaceForCustomDomains(t, fsm, 1, "sb-1", "nodeA")
+	for i, h := range []string{"a.example", "b.example"} {
+		if res := applyCustomDomainOp(t, fsm, uint64(2+i), command{Op: opAddCustomDomain, SandboxID: "sb-1", Hostname: h}); res != nil {
+			t.Fatalf("add %s: %v", h, res)
+		}
+	}
+	if res := applyCustomDomainOp(t, fsm, 10, command{Op: opDelete, SandboxID: "sb-1"}); res != nil {
+		t.Fatalf("delete: %v", res)
+	}
+	for _, h := range []string{"a.example", "b.example"} {
+		if _, ok := fsm.sandboxIDByCustomHostname(h); ok {
+			t.Fatalf("index still claims %s after delete", h)
+		}
+	}
+}
+
+func TestFSMSnapshotRestoreRoundTripsCustomHostnames(t *testing.T) {
+	fsm := newPlacementFSM()
+	mustPlaceForCustomDomains(t, fsm, 1, "sb-1", "nodeA")
+	for i, h := range []string{"alpha.example.com", "beta.example.com"} {
+		if res := applyCustomDomainOp(t, fsm, uint64(2+i), command{Op: opAddCustomDomain, SandboxID: "sb-1", Hostname: h}); res != nil {
+			t.Fatalf("add %s: %v", h, res)
+		}
+	}
+
+	snap, err := fsm.Snapshot()
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	var buf bytes.Buffer
+	sink := &bufferSink{buf: &buf}
+	if err := snap.Persist(sink); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+
+	// Sanity: gob roundtrip must carry the hostname slice.
+	var decoded fsmSnapshotPayload
+	if err := gob.NewDecoder(bytes.NewReader(buf.Bytes())).Decode(&decoded); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(decoded.Rows) != 1 || len(decoded.Rows[0].Placement.CustomHostnames) != 2 {
+		t.Fatalf("snapshot rows hostnames=%v", decoded.Rows)
+	}
+
+	fresh := newPlacementFSM()
+	if err := fresh.Restore(io.NopCloser(&buf)); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	p, ok := fresh.get("sb-1")
+	if !ok {
+		t.Fatal("restored placement missing")
+	}
+	if len(p.CustomHostnames) != 2 || p.CustomHostnames[0] != "alpha.example.com" || p.CustomHostnames[1] != "beta.example.com" {
+		t.Fatalf("restored hostnames=%v", p.CustomHostnames)
+	}
+	for _, h := range []string{"alpha.example.com", "beta.example.com"} {
+		got, ok := fresh.sandboxIDByCustomHostname(h)
+		if !ok || got != "sb-1" {
+			t.Fatalf("restored index for %s: got=%q ok=%v", h, got, ok)
+		}
+	}
+}
+
+func TestFSMCustomHostnamesSortedOnInsert(t *testing.T) {
+	// Sorted slices make snapshot bytes deterministic and give every node
+	// the same matcher order without per-node post-processing.
+	fsm := newPlacementFSM()
+	mustPlaceForCustomDomains(t, fsm, 1, "sb-1", "nodeA")
+	for i, h := range []string{"zeta.example", "alpha.example", "mu.example"} {
+		if res := applyCustomDomainOp(t, fsm, uint64(2+i), command{Op: opAddCustomDomain, SandboxID: "sb-1", Hostname: h}); res != nil {
+			t.Fatalf("add %s: %v", h, res)
+		}
+	}
+	p, _ := fsm.get("sb-1")
+	want := []string{"alpha.example", "mu.example", "zeta.example"}
+	if len(p.CustomHostnames) != 3 {
+		t.Fatalf("hostnames=%v", p.CustomHostnames)
+	}
+	for i, h := range want {
+		if p.CustomHostnames[i] != h {
+			t.Fatalf("hostnames[%d]=%q, want %q (full: %v)", i, p.CustomHostnames[i], h, p.CustomHostnames)
+		}
+	}
+}
+
+func TestFSMCustomDomainCanonicalizationOnResolve(t *testing.T) {
+	// The Cluster wrapper lowercases on the way in; the resolver lowercases
+	// on the way out so mixed-case TLS-ask probes still hit.
+	fsm := newPlacementFSM()
+	mustPlaceForCustomDomains(t, fsm, 1, "sb-1", "nodeA")
+	if res := applyCustomDomainOp(t, fsm, 2, command{Op: opAddCustomDomain, SandboxID: "sb-1", Hostname: "api.acme.com"}); res != nil {
+		t.Fatalf("add: %v", res)
+	}
+	for _, probe := range []string{"api.acme.com", "API.ACME.COM", "  api.acme.com  "} {
+		got, ok := fsm.sandboxIDByCustomHostname(probe)
+		if !ok || got != "sb-1" {
+			t.Fatalf("resolve(%q): got=%q ok=%v", probe, got, ok)
+		}
+	}
+}
+
+// bufferSink is a minimal raft.SnapshotSink that writes into a bytes.Buffer
+// for snapshot/restore round-trip tests. Cancel/Close/ID are intentionally
+// minimal — the FSM only writes and closes.
+type bufferSink struct {
+	buf *bytes.Buffer
+}
+
+func (s *bufferSink) Write(p []byte) (int, error) { return s.buf.Write(p) }
+func (s *bufferSink) Close() error                { return nil }
+func (s *bufferSink) ID() string                  { return "test-snapshot" }
+func (s *bufferSink) Cancel() error               { return nil }

--- a/internal/cluster/noop.go
+++ b/internal/cluster/noop.go
@@ -58,7 +58,15 @@ func (n *Noop) AddExposedPort(ctx context.Context, sandboxID string, port int, r
 }
 func (n *Noop) RemoveExposedPort(ctx context.Context, sandboxID string, port int) error { return nil }
 func (n *Noop) ExposedPortsOf(sandboxID string) map[int]ExposedPortRoute                { return nil }
-func (n *Noop) DeletePlacement(ctx context.Context, sandboxID string) error             { return nil }
+func (n *Noop) AddCustomDomain(ctx context.Context, sandboxID, hostname string) error {
+	return nil
+}
+func (n *Noop) RemoveCustomDomain(ctx context.Context, sandboxID, hostname string) error {
+	return nil
+}
+func (n *Noop) CustomDomainsOf(sandboxID string) []string                   { return nil }
+func (n *Noop) ResolveCustomDomain(hostname string) (string, bool)          { return "", false }
+func (n *Noop) DeletePlacement(ctx context.Context, sandboxID string) error { return nil }
 func (n *Noop) ReserveOnTarget(ctx context.Context, sandboxID string, target PlacementTarget, redacted *models.CreateSandboxRequest, secrets PlacementSecrets, ttl time.Duration) error {
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -682,7 +682,7 @@ func Load() (Config, error) {
 		EnableEventMonitor:               getEnvBool("SB_ENABLE_EVENT_MONITOR", true),
 		EnableSSHGateway:                 getEnvBool("SB_ENABLE_SSH_GATEWAY", true),
 		EnableServerless:                 getEnvBool("SB_ENABLE_SERVERLESS", true),
-		EnableCustomDomains:              getEnvBool("SB_ENABLE_CUSTOM_DOMAINS", false),
+		EnableCustomDomains:              getEnvBool("SB_ENABLE_CUSTOM_DOMAINS", true),
 		CustomDomainsMaxPerSandbox:       getEnvInt("SB_CUSTOM_DOMAINS_MAX_PER_SANDBOX", models.MaxCustomDomainsPerSandbox),
 		TLSOnDemandBurst:                 getEnvInt("SB_TLS_ON_DEMAND_BURST", 5),
 		TLSOnDemandInterval:              getEnvDuration("SB_TLS_ON_DEMAND_INTERVAL", time.Minute),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -150,6 +150,24 @@ type Config struct {
 	// TLSOnDemandInterval is the Caddy on-demand TLS policy's refill
 	// interval (`rate_limit.interval`). Default 1m.
 	TLSOnDemandInterval time.Duration
+	// ACMEDaemonBudgetFraction is the high-water mark on the daemon-wide
+	// ACME issuance bucket — when usage crosses this fraction of Let's
+	// Encrypt's published `new-orders` limit (300 / 3h), TLSAsk returns
+	// 429 with Retry-After. 0.8 leaves headroom for cert renewals already
+	// in flight. A misbehaving tenant burning the quota gets logged with
+	// `sandbox_id` so the operator can intervene. The bucket is per-node;
+	// LE limits are per-account, and the certmagic-s3 distributed lock
+	// already serialises issuance across nodes.
+	ACMEDaemonBudgetFraction float64
+	// ACMEDaemonBudgetWindow is the LE rolling window. Default 3h —
+	// matches the public per-account `new-orders` cap. Exposed only so
+	// staging Pebble runs (T1A) can tighten it for tests; do not change
+	// in production without a corresponding ACME directory change.
+	ACMEDaemonBudgetWindow time.Duration
+	// ACMEDaemonBudgetCapacity is the LE per-account `new-orders` cap
+	// applied to the bucket. Default 300 — the published LE limit. See
+	// ACMEDaemonBudgetWindow note about overrides.
+	ACMEDaemonBudgetCapacity int
 	// InternalIngressAddr is the loopback-only listen address for the
 	// wake-aware HTTP ingress proxy. Caddy dials this address from
 	// wake-aware HTTP port routes; it must NOT be exposed publicly.
@@ -668,6 +686,9 @@ func Load() (Config, error) {
 		CustomDomainsMaxPerSandbox:       getEnvInt("SB_CUSTOM_DOMAINS_MAX_PER_SANDBOX", models.MaxCustomDomainsPerSandbox),
 		TLSOnDemandBurst:                 getEnvInt("SB_TLS_ON_DEMAND_BURST", 5),
 		TLSOnDemandInterval:              getEnvDuration("SB_TLS_ON_DEMAND_INTERVAL", time.Minute),
+		ACMEDaemonBudgetFraction:         getEnvFloat("SB_ACME_DAEMON_BUDGET_FRACTION", 0.8),
+		ACMEDaemonBudgetWindow:           getEnvDuration("SB_ACME_DAEMON_BUDGET_WINDOW", 3*time.Hour),
+		ACMEDaemonBudgetCapacity:         getEnvInt("SB_ACME_DAEMON_BUDGET_CAPACITY", 300),
 		InternalIngressAddr:              getEnv("SB_INTERNAL_INGRESS_ADDR", "127.0.0.1:21213"),
 		InternalL4WakeAddr:               getEnv("SB_INTERNAL_L4_WAKE_ADDR", "127.0.0.1:21214"),
 		InternalL4WakeDir:                getEnv("SB_INTERNAL_L4_WAKE_DIR", "/run/sandboxd/l4wake"),
@@ -1032,6 +1053,20 @@ func Load() (Config, error) {
 		}
 		if cfg.TLSOnDemandInterval <= 0 {
 			return Config{}, errors.New("SB_TLS_ON_DEMAND_INTERVAL must be > 0 when SB_ENABLE_CUSTOM_DOMAINS=true")
+		}
+		// Budget bounds: a zero/negative fraction would mean "always refuse"
+		// or "never refuse", neither of which is a useful operating mode. A
+		// fraction >= 1 disables the safety margin against renewals already
+		// in flight and risks hitting LE's hard limit. Capacity and window
+		// must be positive or the bucket math divides by zero.
+		if cfg.ACMEDaemonBudgetFraction <= 0 || cfg.ACMEDaemonBudgetFraction >= 1 {
+			return Config{}, errors.New("SB_ACME_DAEMON_BUDGET_FRACTION must be in (0, 1) when SB_ENABLE_CUSTOM_DOMAINS=true")
+		}
+		if cfg.ACMEDaemonBudgetCapacity <= 0 {
+			return Config{}, errors.New("SB_ACME_DAEMON_BUDGET_CAPACITY must be > 0 when SB_ENABLE_CUSTOM_DOMAINS=true")
+		}
+		if cfg.ACMEDaemonBudgetWindow <= 0 {
+			return Config{}, errors.New("SB_ACME_DAEMON_BUDGET_WINDOW must be > 0 when SB_ENABLE_CUSTOM_DOMAINS=true")
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -129,6 +129,27 @@ type Config struct {
 	// EnsureSandboxAwakeForHTTP). Acts as a rollout gate, not a per-sandbox
 	// toggle.
 	EnableServerless bool
+	// EnableCustomDomains gates the operator-attached public hostname
+	// feature. False (default) makes the v1 custom-domain routes return 412
+	// Precondition Failed and the install-time Caddy config push omit the
+	// on-demand TLS policy. Acts as a rollout switch, not a per-sandbox
+	// toggle — same shape as EnableServerless. Requires SB_DOMAIN to be
+	// set; the validator rejects EnableCustomDomains=true in IP mode.
+	EnableCustomDomains bool
+	// CustomDomainsMaxPerSandbox caps how many custom hostnames a single
+	// sandbox can carry. Bounds the Caddy host-list fan-out per route and
+	// the ACME burst when a sandbox is started for the first time. Default
+	// 25; the per-create-request cap (set in pkg/models) is stricter to
+	// avoid bursting issuance from one API call.
+	CustomDomainsMaxPerSandbox int
+	// TLSOnDemandBurst is the Caddy on-demand TLS policy's per-interval
+	// burst (matches the JSON shape `rate_limit.burst`). Bounds simultaneous
+	// ACME orders Caddy will start before throttling. Default 5; the
+	// daemon-wide ACME budget (acme_budget.go) is the second layer.
+	TLSOnDemandBurst int
+	// TLSOnDemandInterval is the Caddy on-demand TLS policy's refill
+	// interval (`rate_limit.interval`). Default 1m.
+	TLSOnDemandInterval time.Duration
 	// InternalIngressAddr is the loopback-only listen address for the
 	// wake-aware HTTP ingress proxy. Caddy dials this address from
 	// wake-aware HTTP port routes; it must NOT be exposed publicly.
@@ -643,6 +664,10 @@ func Load() (Config, error) {
 		EnableEventMonitor:               getEnvBool("SB_ENABLE_EVENT_MONITOR", true),
 		EnableSSHGateway:                 getEnvBool("SB_ENABLE_SSH_GATEWAY", true),
 		EnableServerless:                 getEnvBool("SB_ENABLE_SERVERLESS", true),
+		EnableCustomDomains:              getEnvBool("SB_ENABLE_CUSTOM_DOMAINS", false),
+		CustomDomainsMaxPerSandbox:       getEnvInt("SB_CUSTOM_DOMAINS_MAX_PER_SANDBOX", models.MaxCustomDomainsPerSandbox),
+		TLSOnDemandBurst:                 getEnvInt("SB_TLS_ON_DEMAND_BURST", 5),
+		TLSOnDemandInterval:              getEnvDuration("SB_TLS_ON_DEMAND_INTERVAL", time.Minute),
 		InternalIngressAddr:              getEnv("SB_INTERNAL_INGRESS_ADDR", "127.0.0.1:21213"),
 		InternalL4WakeAddr:               getEnv("SB_INTERNAL_L4_WAKE_ADDR", "127.0.0.1:21214"),
 		InternalL4WakeDir:                getEnv("SB_INTERNAL_L4_WAKE_DIR", "/run/sandboxd/l4wake"),
@@ -988,6 +1013,25 @@ func Load() (Config, error) {
 			if cfg.ReconcileInterval <= 0 {
 				return Config{}, errors.New("SB_RECONCILE_INTERVAL must be > 0 when direct-route bypass is enabled")
 			}
+		}
+	}
+
+	if cfg.EnableCustomDomains {
+		// Custom-domain ingress relies on a wildcard cert under Domain and a
+		// distinguishable apex to reject base-domain collisions. Without
+		// Domain set, NormalizeCustomDomain can't enforce the "not under base"
+		// rule and Caddy can't pick between wildcard vs on-demand TLS.
+		if strings.TrimSpace(cfg.Domain) == "" {
+			return Config{}, errors.New("SB_DOMAIN must be set when SB_ENABLE_CUSTOM_DOMAINS=true")
+		}
+		if cfg.CustomDomainsMaxPerSandbox <= 0 {
+			return Config{}, errors.New("SB_CUSTOM_DOMAINS_MAX_PER_SANDBOX must be > 0 when SB_ENABLE_CUSTOM_DOMAINS=true")
+		}
+		if cfg.TLSOnDemandBurst <= 0 {
+			return Config{}, errors.New("SB_TLS_ON_DEMAND_BURST must be > 0 when SB_ENABLE_CUSTOM_DOMAINS=true")
+		}
+		if cfg.TLSOnDemandInterval <= 0 {
+			return Config{}, errors.New("SB_TLS_ON_DEMAND_INTERVAL must be > 0 when SB_ENABLE_CUSTOM_DOMAINS=true")
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -682,7 +682,7 @@ func Load() (Config, error) {
 		EnableEventMonitor:               getEnvBool("SB_ENABLE_EVENT_MONITOR", true),
 		EnableSSHGateway:                 getEnvBool("SB_ENABLE_SSH_GATEWAY", true),
 		EnableServerless:                 getEnvBool("SB_ENABLE_SERVERLESS", true),
-		EnableCustomDomains:              getEnvBool("SB_ENABLE_CUSTOM_DOMAINS", true),
+		EnableCustomDomains:              getEnvBool("SB_ENABLE_CUSTOM_DOMAINS", false),
 		CustomDomainsMaxPerSandbox:       getEnvInt("SB_CUSTOM_DOMAINS_MAX_PER_SANDBOX", models.MaxCustomDomainsPerSandbox),
 		TLSOnDemandBurst:                 getEnvInt("SB_TLS_ON_DEMAND_BURST", 5),
 		TLSOnDemandInterval:              getEnvDuration("SB_TLS_ON_DEMAND_INTERVAL", time.Minute),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -71,6 +71,9 @@ func TestLoadCases(t *testing.T) {
 			"SB_CUSTOM_DOMAINS_MAX_PER_SANDBOX",
 			"SB_TLS_ON_DEMAND_BURST",
 			"SB_TLS_ON_DEMAND_INTERVAL",
+			"SB_ACME_DAEMON_BUDGET_FRACTION",
+			"SB_ACME_DAEMON_BUDGET_WINDOW",
+			"SB_ACME_DAEMON_BUDGET_CAPACITY",
 		}
 		for _, key := range keys {
 			t.Setenv(key, "")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -67,6 +67,10 @@ func TestLoadCases(t *testing.T) {
 			"SB_L4_WAKE_DIRECT_BYPASS_ENABLED",
 			"SB_NETSTATS_POLL_INTERVAL",
 			"SB_RECONCILE_INTERVAL",
+			"SB_ENABLE_CUSTOM_DOMAINS",
+			"SB_CUSTOM_DOMAINS_MAX_PER_SANDBOX",
+			"SB_TLS_ON_DEMAND_BURST",
+			"SB_TLS_ON_DEMAND_INTERVAL",
 		}
 		for _, key := range keys {
 			t.Setenv(key, "")
@@ -470,6 +474,114 @@ func TestLoadCases(t *testing.T) {
 				_, err := Load()
 				if err == nil || !strings.Contains(err.Error(), "SB_RECONCILE_INTERVAL") {
 					t.Fatalf("expected reconcile interval error, got %v", err)
+				}
+			},
+		},
+		{
+			name: "custom_domains_default_off",
+			run: func(t *testing.T) {
+				clearEnv(t)
+				t.Setenv("SB_PAT_TOKEN", "token")
+				cfg, err := Load()
+				if err != nil {
+					t.Fatalf("Load() error = %v", err)
+				}
+				if cfg.EnableCustomDomains {
+					t.Fatalf("expected EnableCustomDomains default false, got true")
+				}
+				// Even with the gate off, the caps and TLS budget defaults
+				// should be populated so downstream code can read them
+				// without a feature-flag branch.
+				if cfg.CustomDomainsMaxPerSandbox != 25 {
+					t.Fatalf("expected default CustomDomainsMaxPerSandbox=25, got %d", cfg.CustomDomainsMaxPerSandbox)
+				}
+				if cfg.TLSOnDemandBurst != 5 {
+					t.Fatalf("expected default TLSOnDemandBurst=5, got %d", cfg.TLSOnDemandBurst)
+				}
+				if cfg.TLSOnDemandInterval != time.Minute {
+					t.Fatalf("expected default TLSOnDemandInterval=1m, got %s", cfg.TLSOnDemandInterval)
+				}
+			},
+		},
+		{
+			name: "custom_domains_requires_domain",
+			run: func(t *testing.T) {
+				clearEnv(t)
+				t.Setenv("SB_PAT_TOKEN", "token")
+				t.Setenv("SB_ENABLE_CUSTOM_DOMAINS", "true")
+				_, err := Load()
+				if err == nil || !strings.Contains(err.Error(), "SB_DOMAIN") {
+					t.Fatalf("expected SB_DOMAIN required error, got %v", err)
+				}
+			},
+		},
+		{
+			name: "custom_domains_enabled_with_domain",
+			run: func(t *testing.T) {
+				clearEnv(t)
+				t.Setenv("SB_PAT_TOKEN", "token")
+				t.Setenv("SB_ENABLE_CUSTOM_DOMAINS", "true")
+				t.Setenv("SB_DOMAIN", "aerol.cloud")
+				t.Setenv("SB_CUSTOM_DOMAINS_MAX_PER_SANDBOX", "10")
+				t.Setenv("SB_TLS_ON_DEMAND_BURST", "3")
+				t.Setenv("SB_TLS_ON_DEMAND_INTERVAL", "30s")
+				cfg, err := Load()
+				if err != nil {
+					t.Fatalf("Load() error = %v", err)
+				}
+				if !cfg.EnableCustomDomains {
+					t.Fatalf("expected EnableCustomDomains=true")
+				}
+				if cfg.CustomDomainsMaxPerSandbox != 10 {
+					t.Fatalf("expected CustomDomainsMaxPerSandbox=10, got %d", cfg.CustomDomainsMaxPerSandbox)
+				}
+				if cfg.TLSOnDemandBurst != 3 {
+					t.Fatalf("expected TLSOnDemandBurst=3, got %d", cfg.TLSOnDemandBurst)
+				}
+				if cfg.TLSOnDemandInterval != 30*time.Second {
+					t.Fatalf("expected TLSOnDemandInterval=30s, got %s", cfg.TLSOnDemandInterval)
+				}
+			},
+		},
+		{
+			name: "custom_domains_rejects_zero_max_per_sandbox",
+			run: func(t *testing.T) {
+				clearEnv(t)
+				t.Setenv("SB_PAT_TOKEN", "token")
+				t.Setenv("SB_ENABLE_CUSTOM_DOMAINS", "true")
+				t.Setenv("SB_DOMAIN", "aerol.cloud")
+				t.Setenv("SB_CUSTOM_DOMAINS_MAX_PER_SANDBOX", "0")
+				_, err := Load()
+				if err == nil || !strings.Contains(err.Error(), "SB_CUSTOM_DOMAINS_MAX_PER_SANDBOX") {
+					t.Fatalf("expected SB_CUSTOM_DOMAINS_MAX_PER_SANDBOX error, got %v", err)
+				}
+			},
+		},
+		{
+			name: "custom_domains_rejects_zero_tls_burst",
+			run: func(t *testing.T) {
+				clearEnv(t)
+				t.Setenv("SB_PAT_TOKEN", "token")
+				t.Setenv("SB_ENABLE_CUSTOM_DOMAINS", "true")
+				t.Setenv("SB_DOMAIN", "aerol.cloud")
+				t.Setenv("SB_TLS_ON_DEMAND_BURST", "0")
+				_, err := Load()
+				if err == nil || !strings.Contains(err.Error(), "SB_TLS_ON_DEMAND_BURST") {
+					t.Fatalf("expected SB_TLS_ON_DEMAND_BURST error, got %v", err)
+				}
+			},
+		},
+		{
+			name: "custom_domains_rejects_zero_tls_interval",
+			run: func(t *testing.T) {
+				clearEnv(t)
+				t.Setenv("SB_PAT_TOKEN", "token")
+				t.Setenv("SB_ENABLE_CUSTOM_DOMAINS", "true")
+				t.Setenv("SB_DOMAIN", "aerol.cloud")
+				t.Setenv("SB_TLS_ON_DEMAND_INTERVAL", "0")
+				_, err := Load()
+				if err == nil || !strings.Contains(err.Error(), "SB_TLS_ON_DEMAND_INTERVAL") {
+					t.Fatalf("expected SB_TLS_ON_DEMAND_INTERVAL error, got %v", err)
 				}
 			},
 		},

--- a/internal/service/acme_budget.go
+++ b/internal/service/acme_budget.go
@@ -1,0 +1,152 @@
+package service
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// ACMEBudget is the daemon-wide brake on new-cert issuance for custom
+// hostnames (plan §5b / OV5A). Let's Encrypt enforces a per-account
+// `new-orders` limit (300 / 3h rolling). One misconfigured tenant adding
+// 100 custom domains can drain that window for the whole cluster, so
+// every TLSAsk hit that would trigger a new ACME order (status != ready)
+// passes through Reserve; the hot path is the wildcard fast-fail and the
+// negative cache, not this bucket.
+//
+// Semantics:
+//   - Sliding window over the LE rolling limit (capacity attempts per
+//     window). At capacity*fraction (default 0.8 — 240/300) we refuse,
+//     returning a Retry-After equal to the time the oldest in-window
+//     attempt ages out. The 20% headroom buys the in-flight renewals
+//     (cert-magic kicks them off ~30 days before expiry) survival room.
+//   - Per-node bucket, NOT raft-synced. LE limits are per-account, not
+//     per-IP, and certmagic-s3's distributed lock already serialises
+//     simultaneous issuance for the same hostname across nodes; a node-
+//     local bucket is the right granularity for "this node is about to
+//     burn the account."
+//   - Observation, not metering: a single Reserve call corresponds to one
+//     TLSAsk that COULD trigger issuance. Caddy may rate-limit further
+//     before actually opening an order, and certmagic dedupes
+//     simultaneous orders for the same host. Treat the bucket as an
+//     upper bound on issuance rate, not the exact count.
+type ACMEBudget struct {
+	mu        sync.Mutex
+	window    time.Duration
+	capacity  int
+	threshold int
+	attempts  []time.Time // append-only within window; pruned on Reserve
+	logger    *slog.Logger
+	now       func() time.Time
+	// onThrottle is called when Reserve denies. Test hook.
+	onThrottle func(sandboxID string, retryAfter time.Duration)
+}
+
+// ACMEBudgetConfig captures the operator-facing knobs.
+type ACMEBudgetConfig struct {
+	Capacity int
+	Window   time.Duration
+	Fraction float64
+	Logger   *slog.Logger
+}
+
+// NewACMEBudget builds a budget. A nil result is safe: budget == nil
+// implies "no daemon-wide brake" (Reserve degrades to always-allow), so
+// the TLSAsk hot path stays single-branch when the feature is off.
+func NewACMEBudget(cfg ACMEBudgetConfig) *ACMEBudget {
+	if cfg.Capacity <= 0 || cfg.Window <= 0 || cfg.Fraction <= 0 || cfg.Fraction >= 1 {
+		return nil
+	}
+	threshold := max(int(float64(cfg.Capacity)*cfg.Fraction), 1)
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &ACMEBudget{
+		window:    cfg.Window,
+		capacity:  cfg.Capacity,
+		threshold: threshold,
+		attempts:  make([]time.Time, 0, threshold),
+		logger:    logger,
+		now:       time.Now,
+	}
+}
+
+// Reserve records an attempt and returns (true, 0) if the new attempt
+// keeps the bucket below threshold, or (false, retryAfter) if it would
+// cross. sandboxID is logged on denial so the operator can spot the
+// burner. retryAfter is the time until the oldest in-window attempt ages
+// out — the earliest moment another attempt could succeed.
+//
+// A nil *ACMEBudget always allows: makes the call site one-liner.
+func (b *ACMEBudget) Reserve(sandboxID, hostname string) (bool, time.Duration) {
+	if b == nil {
+		return true, 0
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	now := b.now()
+	cutoff := now.Add(-b.window)
+	// Prune ageing-out attempts. The slice is append-only in time-order,
+	// so a single forward scan finds the first still-in-window index.
+	i := 0
+	for i < len(b.attempts) && b.attempts[i].Before(cutoff) {
+		i++
+	}
+	if i > 0 {
+		b.attempts = append(b.attempts[:0], b.attempts[i:]...)
+	}
+
+	if len(b.attempts) >= b.threshold {
+		// Oldest in-window attempt drives the earliest opening. If the
+		// slice is empty (shouldn't be reachable since len >= threshold
+		// >= 1) the caller still gets a sane non-zero retry.
+		retry := b.window
+		if len(b.attempts) > 0 {
+			retry = max(b.attempts[0].Add(b.window).Sub(now), time.Second)
+		}
+		b.logger.Warn("acme: daemon budget exhausted, throttling issuance",
+			"sandbox_id", sandboxID,
+			"hostname", hostname,
+			"in_window", len(b.attempts),
+			"threshold", b.threshold,
+			"capacity", b.capacity,
+			"retry_after", retry,
+		)
+		if b.onThrottle != nil {
+			b.onThrottle(sandboxID, retry)
+		}
+		return false, retry
+	}
+
+	b.attempts = append(b.attempts, now)
+	return true, 0
+}
+
+// InWindow returns the current in-window attempt count. Test-only —
+// production callers should not gate on this number; use Reserve.
+func (b *ACMEBudget) InWindow() int {
+	if b == nil {
+		return 0
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	now := b.now()
+	cutoff := now.Add(-b.window)
+	count := 0
+	for _, t := range b.attempts {
+		if !t.Before(cutoff) {
+			count++
+		}
+	}
+	return count
+}
+
+// Threshold returns the denial line. Stable for the life of the budget.
+func (b *ACMEBudget) Threshold() int {
+	if b == nil {
+		return 0
+	}
+	return b.threshold
+}

--- a/internal/service/acme_budget_test.go
+++ b/internal/service/acme_budget_test.go
@@ -1,0 +1,146 @@
+package service
+
+import (
+	"testing"
+	"time"
+)
+
+// TestACMEBudgetAllowsUpToThreshold: the 240th Reserve (capacity 300,
+// fraction 0.8) succeeds; the 241st denies. Exact-edge test for the
+// daemon-wide LE brake so a config tweak that off-by-ones the threshold
+// is caught immediately.
+func TestACMEBudgetAllowsUpToThreshold(t *testing.T) {
+	clk := newFakeClock()
+	b := newBudgetForTest(10, time.Hour, 0.8, clk)
+	if b.Threshold() != 8 {
+		t.Fatalf("threshold = %d, want 8", b.Threshold())
+	}
+	for i := 0; i < 8; i++ {
+		ok, _ := b.Reserve("sb", "h")
+		if !ok {
+			t.Fatalf("Reserve #%d denied; expected allow", i+1)
+		}
+	}
+	ok, retry := b.Reserve("sb", "h")
+	if ok {
+		t.Fatal("Reserve #9 allowed; expected deny")
+	}
+	if retry <= 0 {
+		t.Fatalf("retry = %v, want > 0", retry)
+	}
+}
+
+// TestACMEBudgetAgesOutWindow: an attempt older than window is pruned
+// and frees a slot for the next Reserve. Without sliding-window
+// semantics the brake would lock the daemon out forever after one
+// burst.
+func TestACMEBudgetAgesOutWindow(t *testing.T) {
+	clk := newFakeClock()
+	b := newBudgetForTest(10, time.Hour, 0.8, clk)
+	for i := 0; i < 8; i++ {
+		b.Reserve("sb", "h")
+	}
+	if ok, _ := b.Reserve("sb", "h"); ok {
+		t.Fatal("expected deny at threshold")
+	}
+	clk.Advance(time.Hour + time.Minute)
+	ok, _ := b.Reserve("sb", "h")
+	if !ok {
+		t.Fatal("expected allow after window slide")
+	}
+	if got := b.InWindow(); got != 1 {
+		t.Fatalf("in-window = %d, want 1 (only the post-slide attempt)", got)
+	}
+}
+
+// TestACMEBudgetRetryAfterMatchesOldest: retry-after is the time until
+// the oldest in-window attempt ages out. Caddy uses this header to
+// pause issuance; an inflated value silently delays valid renewals.
+func TestACMEBudgetRetryAfterMatchesOldest(t *testing.T) {
+	clk := newFakeClock()
+	b := newBudgetForTest(10, time.Hour, 0.8, clk)
+	b.Reserve("sb", "h") // attempt 1 at t=0
+	clk.Advance(10 * time.Minute)
+	for i := 0; i < 7; i++ {
+		b.Reserve("sb", "h") // attempts 2..8 at t=10m
+	}
+	_, retry := b.Reserve("sb", "h")
+	// Oldest attempt was at t=0; window=1h; we're at t=10m; should
+	// expire in 50m.
+	want := 50 * time.Minute
+	if retry < want-time.Second || retry > want+time.Second {
+		t.Fatalf("retry = %v, want ≈ %v", retry, want)
+	}
+}
+
+// TestACMEBudgetNilAlwaysAllows: a disabled budget (nil receiver) is
+// the zero-friction default for single-node deployments and tests; the
+// TLSAsk hot path must stay one-liner-clean when there's no brake.
+func TestACMEBudgetNilAlwaysAllows(t *testing.T) {
+	var b *ACMEBudget
+	for i := 0; i < 1000; i++ {
+		if ok, retry := b.Reserve("sb", "h"); !ok || retry != 0 {
+			t.Fatalf("nil budget denied: ok=%v retry=%v", ok, retry)
+		}
+	}
+}
+
+// TestNewACMEBudgetRejectsBadConfig: invalid config returns nil rather
+// than a misbehaving bucket — this is what makes the nil receiver
+// pattern safe at the call site.
+func TestNewACMEBudgetRejectsBadConfig(t *testing.T) {
+	cases := []ACMEBudgetConfig{
+		{Capacity: 0, Window: time.Hour, Fraction: 0.5},
+		{Capacity: 10, Window: 0, Fraction: 0.5},
+		{Capacity: 10, Window: time.Hour, Fraction: 0},
+		{Capacity: 10, Window: time.Hour, Fraction: 1},
+		{Capacity: 10, Window: time.Hour, Fraction: 1.5},
+	}
+	for i, c := range cases {
+		if got := NewACMEBudget(c); got != nil {
+			t.Fatalf("case %d: NewACMEBudget(%+v) = %v, want nil", i, c, got)
+		}
+	}
+}
+
+// TestACMEBudgetThrottleHookFires: the test hook lets the TLSAsk
+// observability counter increment without the budget reaching into
+// expvar directly (keeps the package boundary clean).
+func TestACMEBudgetThrottleHookFires(t *testing.T) {
+	clk := newFakeClock()
+	b := newBudgetForTest(2, time.Hour, 0.5, clk) // threshold=1
+	var got struct {
+		sandbox string
+		retry   time.Duration
+		fired   int
+	}
+	b.onThrottle = func(sandboxID string, retry time.Duration) {
+		got.sandbox = sandboxID
+		got.retry = retry
+		got.fired++
+	}
+	b.Reserve("sb-a", "h") // allow (at threshold)
+	b.Reserve("sb-b", "h") // deny
+	if got.fired != 1 {
+		t.Fatalf("hook fired %d times, want 1", got.fired)
+	}
+	if got.sandbox != "sb-b" {
+		t.Fatalf("hook sandbox = %q, want sb-b", got.sandbox)
+	}
+	if got.retry <= 0 {
+		t.Fatalf("hook retry = %v, want > 0", got.retry)
+	}
+}
+
+func newBudgetForTest(capacity int, window time.Duration, fraction float64, clk *fakeClock) *ACMEBudget {
+	b := NewACMEBudget(ACMEBudgetConfig{
+		Capacity: capacity,
+		Window:   window,
+		Fraction: fraction,
+	})
+	if b == nil {
+		return nil
+	}
+	b.now = clk.Now
+	return b
+}

--- a/internal/service/cluster_ownership.go
+++ b/internal/service/cluster_ownership.go
@@ -78,7 +78,10 @@ func (s *Service) clusterOwnershipNeedsReplay(c cluster.Client, sb *models.Sandb
 	if p.Spec == nil {
 		return true
 	}
-	return placementMissingLocalPorts(p, sb)
+	if placementMissingLocalPorts(p, sb) {
+		return true
+	}
+	return placementMissingLocalCustomHostnames(p, sb)
 }
 
 func placementCanBeClaimedBySelf(p cluster.Placement, self string) bool {
@@ -86,6 +89,29 @@ func placementCanBeClaimedBySelf(p cluster.Placement, self string) bool {
 		return false
 	}
 	return p.OrphanedOwnerNodeID == "" || p.OrphanedOwnerNodeID == self
+}
+
+// placementMissingLocalCustomHostnames returns true when the local sandbox
+// has bound hostnames the FSM placement doesn't yet list. This is the boot
+// catch-up signal: the FSM was added after the sandbox already had domains
+// (cluster mode flipped on, or PR #3 deploy), or a prior AssertOwnership
+// failed to ship them. Force a replay so the failover-recreate target has
+// the user's TLS matchers.
+func placementMissingLocalCustomHostnames(p cluster.Placement, sb *models.Sandbox) bool {
+	local := sandboxCustomHostnames(sb)
+	if len(local) == 0 {
+		return false
+	}
+	have := make(map[string]struct{}, len(p.CustomHostnames))
+	for _, h := range p.CustomHostnames {
+		have[h] = struct{}{}
+	}
+	for _, h := range local {
+		if _, ok := have[h]; !ok {
+			return true
+		}
+	}
+	return false
 }
 
 func placementMissingLocalPorts(p cluster.Placement, sb *models.Sandbox) bool {
@@ -125,10 +151,11 @@ func (s *Service) localSandboxStateForCluster(ctx context.Context, c cluster.Cli
 		}
 	}
 	return cluster.LocalSandboxState{
-		ID:           sb.ID,
-		Spec:         spec,
-		Secrets:      secrets,
-		ExposedPorts: clusterPortsFromSandbox(sb),
+		ID:              sb.ID,
+		Spec:            spec,
+		Secrets:         secrets,
+		ExposedPorts:    clusterPortsFromSandbox(sb),
+		CustomHostnames: sandboxCustomHostnames(sb),
 	}
 }
 

--- a/internal/service/custom_domains.go
+++ b/internal/service/custom_domains.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/aerol-ai/microvm/internal/cluster"
 	"github.com/aerol-ai/microvm/internal/store"
 	"github.com/aerol-ai/microvm/pkg/models"
 )
@@ -123,6 +125,41 @@ var ErrCustomDomainProtocolConflict = models.ErrCustomDomainProtocolConflict
 // ErrCustomDomainPerSandboxCap — see pkg/models comment.
 var ErrCustomDomainPerSandboxCap = models.ErrCustomDomainPerSandboxCap
 
+// recordClusterCustomDomain replicates the (sandbox, hostname) binding into
+// the placement FSM so cluster-wide uniqueness, ingress-node TLS-ask lookup,
+// and failover replay all see it. Mirrors recordClusterExposedPort.
+// cluster.ErrCustomHostnameConflict is mapped to store.ErrCustomDomainConflict
+// so the API layer's existing 409 mapping covers both the local PK race and
+// the cluster-wide Raft tiebreaker without a second sentinel.
+func (s *Service) recordClusterCustomDomain(ctx context.Context, sandboxID, hostname string) error {
+	c := s.Cluster()
+	if c == nil {
+		return nil
+	}
+	commitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := c.AddCustomDomain(commitCtx, sandboxID, hostname); err != nil {
+		if errors.Is(err, cluster.ErrCustomHostnameConflict) {
+			return store.ErrCustomDomainConflict
+		}
+		return fmt.Errorf("cluster: record custom domain: %w", err)
+	}
+	return nil
+}
+
+func (s *Service) removeClusterCustomDomain(ctx context.Context, sandboxID, hostname string) error {
+	c := s.Cluster()
+	if c == nil {
+		return nil
+	}
+	commitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := c.RemoveCustomDomain(commitCtx, sandboxID, hostname); err != nil {
+		return fmt.Errorf("cluster: remove custom domain: %w", err)
+	}
+	return nil
+}
+
 // AddCustomDomain attaches a new public hostname to an existing sandbox. The
 // caller is responsible for sandbox-scoped authorization (the API layer); this
 // helper validates the hostname against the deployment's base domain, enforces
@@ -176,12 +213,24 @@ func (s *Service) AddCustomDomain(ctx context.Context, sandboxID, hostname strin
 		return err
 	}
 
+	// Cluster-wide uniqueness gate. Without this two owners on different
+	// nodes can each accept the same hostname (local SQLite PK is per-node);
+	// the FSM is the cross-node tiebreaker. Run BEFORE the Caddy PATCH so a
+	// conflict rolls back cheaply — the local row goes away and Caddy was
+	// never told about the hostname. Noop returns nil so single-node mode
+	// short-circuits.
+	if err := s.recordClusterCustomDomain(ctx, sandboxID, canonical); err != nil {
+		_ = s.store.RemoveCustomDomain(ctx, sandboxID, canonical)
+		return err
+	}
+
 	// Re-read so the caddy PATCH sees the full union (existing + new). The
 	// store inserts with pending_dns status; Caddy's on-demand TLS does not
 	// look at status, only hostname presence, so the new hostname is route-
 	// matchable immediately.
 	refreshed, err := s.store.Get(ctx, sandboxID)
 	if err != nil {
+		_ = s.removeClusterCustomDomain(ctx, sandboxID, canonical)
 		_ = s.store.RemoveCustomDomain(ctx, sandboxID, canonical)
 		return fmt.Errorf("reload sandbox after custom-domain insert: %w", err)
 	}
@@ -191,6 +240,7 @@ func (s *Service) AddCustomDomain(ctx context.Context, sandboxID, hostname strin
 		// store on a partial failure rather than leaving an orphan row that
 		// the reconciler would have to clean up — the caller can simply
 		// retry the request.
+		_ = s.removeClusterCustomDomain(ctx, sandboxID, canonical)
 		_ = s.store.RemoveCustomDomain(ctx, sandboxID, canonical)
 		return fmt.Errorf("install caddy route for custom domain %q: %w", canonical, err)
 	}
@@ -225,6 +275,18 @@ func (s *Service) RemoveCustomDomain(ctx context.Context, sandboxID, hostname st
 	}
 	if err := s.store.RemoveCustomDomain(ctx, sandboxID, canonical); err != nil {
 		return err
+	}
+	// Release the FSM claim so a future AddCustomDomain on a different
+	// sandbox is not blocked by a stale hostname binding the local store no
+	// longer backs. Idempotent in the cluster command, so a redundant remove
+	// from a reconcile pass is safe. Noop is a nil return in single-node.
+	if err := s.removeClusterCustomDomain(ctx, sandboxID, canonical); err != nil {
+		// Best-effort: log and proceed. The local row is already gone, and a
+		// stale FSM binding will be cleaned by the placement-teardown sweep
+		// on sandbox destroy or by an operator-initiated reconcile. Surfacing
+		// the error here would leave the caller unable to retry cleanly.
+		s.logger.Warn("custom-domain cluster release failed; reconcile will retry",
+			"sandbox_id", sandboxID, "hostname", canonical, "error", err)
 	}
 	refreshed, err := s.store.Get(ctx, sandboxID)
 	if err != nil {
@@ -286,16 +348,27 @@ func (s *Service) persistCustomDomainsOnCreate(ctx context.Context, sandboxID st
 		return nil
 	}
 	added := make([]string, 0, len(hostnames))
+	rollback := func() {
+		for _, prev := range added {
+			_ = s.removeClusterCustomDomain(ctx, sandboxID, prev)
+			_ = s.store.RemoveCustomDomain(ctx, sandboxID, prev)
+		}
+	}
 	for _, h := range hostnames {
 		if err := s.store.AddCustomDomain(ctx, sandboxID, h); err != nil {
-			// Roll back any rows inserted earlier in this call.
-			for _, prev := range added {
-				_ = s.store.RemoveCustomDomain(ctx, sandboxID, prev)
-			}
+			rollback()
 			if errors.Is(err, store.ErrCustomDomainConflict) {
 				return err
 			}
 			return fmt.Errorf("persist custom domain %q: %w", h, err)
+		}
+		// Replicate into the FSM before we consider this row added — a
+		// cross-node hostname conflict surfaces here, not later on a
+		// failover that's too late to roll back the caller's create call.
+		if err := s.recordClusterCustomDomain(ctx, sandboxID, h); err != nil {
+			_ = s.store.RemoveCustomDomain(ctx, sandboxID, h)
+			rollback()
+			return err
 		}
 		added = append(added, h)
 	}

--- a/internal/service/custom_domains.go
+++ b/internal/service/custom_domains.go
@@ -1,0 +1,306 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// CustomDomainCacheEvicter is the narrow surface the service needs from the
+// ingressproxy TLS-ask handler so that AddCustomDomain can punch a hole in
+// the negative cache immediately when a new hostname is attached. Kept as an
+// interface (rather than importing pkg/api/ingressproxy directly) because
+// ingressproxy already depends on internal/service — pulling the dependency
+// the other way would create an import cycle. cmd/sandboxd wires the real
+// handler in via AttachCustomDomainCacheEvicter once both packages are built.
+type CustomDomainCacheEvicter interface {
+	EvictNegativeCache(hostname string)
+}
+
+// customDomainState is the optional dependency block holding the negative
+// cache evicter. Held behind a mutex so AttachCustomDomainCacheEvicter is
+// safe to call after service.New (it is — main.go wires it after building
+// both the handler and the service).
+type customDomainState struct {
+	mu      sync.RWMutex
+	evicter CustomDomainCacheEvicter
+}
+
+var customDomainsState customDomainState
+
+// AttachCustomDomainCacheEvicter is the wire-up hook called from cmd/sandboxd
+// once the TLSAskHandler is built. Passing nil is allowed (and the default) —
+// negative-cache eviction is best-effort; the cache entry expires on its own
+// TTL and the worst case is a 60s delay before the first ACME ask sees the
+// freshly-added hostname.
+func (s *Service) AttachCustomDomainCacheEvicter(e CustomDomainCacheEvicter) {
+	customDomainsState.mu.Lock()
+	customDomainsState.evicter = e
+	customDomainsState.mu.Unlock()
+}
+
+func evictCustomDomainNegativeCache(hostname string) {
+	customDomainsState.mu.RLock()
+	e := customDomainsState.evicter
+	customDomainsState.mu.RUnlock()
+	if e != nil {
+		e.EvictNegativeCache(hostname)
+	}
+}
+
+// sandboxCustomHostnames extracts the operator-attached public hostnames from
+// a sandbox snapshot in the shape expected by pkg/caddy's matcher helpers.
+// Returns nil when the field is empty so the route shape stays byte-identical
+// to pre-custom-domains for sandboxes that never attached one.
+func sandboxCustomHostnames(sandbox *models.Sandbox) []string {
+	if sandbox == nil || len(sandbox.CustomDomains) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(sandbox.CustomDomains))
+	for _, cd := range sandbox.CustomDomains {
+		// Defense in depth: only the validated, normalized hostname goes
+		// into the Caddy matcher. Status (pending_dns / issuing / ready /
+		// failed) does not gate routing — Caddy's on-demand TLS handles
+		// the cert lifecycle independently. A domain whose DNS hasn't
+		// propagated yet simply won't get traffic; once it does, the
+		// route is already in place.
+		if cd.Hostname != "" {
+			out = append(out, cd.Hostname)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// validateCreateCustomDomains runs before any expensive create work (admission,
+// mounts, docker.Create) so an invalid or unsupported custom-domains payload
+// rejects without burning resources. Mutates req.CustomDomains in place with
+// the normalized slice so the rest of createSandbox sees canonical hostnames.
+//
+// Returns ErrCustomDomainNotSupported when custom domains were requested on a
+// deployment that can't serve them (feature flag off, or IP mode). That maps
+// to 412 at the HTTP layer — distinct from a 400 "your input is malformed",
+// because the caller's input may be perfectly valid; the cluster just can't
+// honor it. Empty CustomDomains is always fine.
+func (s *Service) validateCreateCustomDomains(req *models.CreateSandboxRequest) error {
+	if req == nil || len(req.CustomDomains) == 0 {
+		return nil
+	}
+	if !s.cfg.EnableCustomDomains {
+		return ErrCustomDomainNotSupported
+	}
+	base := strings.TrimSpace(s.cfg.Domain)
+	if base == "" {
+		// IP-mode deployment: no SB_DOMAIN means no on-demand TLS, and the
+		// public URL is path-based instead of vhost-based. A custom hostname
+		// has nowhere to live.
+		return ErrCustomDomainNotSupported
+	}
+	normalized, err := models.ValidateCustomDomainList(req.CustomDomains, base)
+	if err != nil {
+		return err
+	}
+	req.CustomDomains = normalized
+	return nil
+}
+
+// ErrCustomDomainNotSupported is re-exported from pkg/models so callers that
+// already import internal/service (every handler) don't need a second import
+// just to errors.Is against the sentinel. Same pattern other service-layer
+// sentinels (ErrSandboxManuallyStopped) follow.
+var ErrCustomDomainNotSupported = models.ErrCustomDomainNotSupported
+
+// ErrCustomDomainProtocolConflict — see pkg/models comment.
+var ErrCustomDomainProtocolConflict = models.ErrCustomDomainProtocolConflict
+
+// ErrCustomDomainPerSandboxCap — see pkg/models comment.
+var ErrCustomDomainPerSandboxCap = models.ErrCustomDomainPerSandboxCap
+
+// AddCustomDomain attaches a new public hostname to an existing sandbox. The
+// caller is responsible for sandbox-scoped authorization (the API layer); this
+// helper validates the hostname against the deployment's base domain, enforces
+// the IRON RULE (no coexistence with protocol=tcp/tls exposures), persists the
+// row, re-PATCHes the Caddy route to include the new hostname, and rolls back
+// the store insert on Caddy failure. On success, the negative cache entry for
+// the hostname is punched so the next ACME ask hits the resolver instead of
+// being refused for the cached 60s.
+//
+// Returns:
+//   - ErrCustomDomainNotSupported (412) when the deployment doesn't support custom domains.
+//   - ErrCustomDomainInvalid (400) when the hostname fails validation.
+//   - ErrCustomDomainProtocolConflict (409) when the sandbox already exposes tcp/tls ports.
+//   - ErrCustomDomainPerSandboxCap (409) when the sandbox already holds the cap.
+//   - store.ErrCustomDomainConflict (409) when the hostname is owned by a different sandbox.
+//   - store.ErrNotFound (404) when the sandbox does not exist.
+func (s *Service) AddCustomDomain(ctx context.Context, sandboxID, hostname string) error {
+	if !s.cfg.EnableCustomDomains || strings.TrimSpace(s.cfg.Domain) == "" {
+		return ErrCustomDomainNotSupported
+	}
+	canonical, err := models.NormalizeCustomDomain(hostname, s.cfg.Domain)
+	if err != nil {
+		return err
+	}
+	sandbox, err := s.store.Get(ctx, sandboxID)
+	if err != nil {
+		return err
+	}
+	if hasL4Exposure(sandbox) {
+		return ErrCustomDomainProtocolConflict
+	}
+	// Per-sandbox cap is enforced here rather than in the store so the error
+	// surfaces with the canonical sentinel; the store would otherwise just
+	// insert and the count check would race with concurrent adds.
+	if len(sandbox.CustomDomains) >= models.MaxCustomDomainsPerSandbox {
+		// Idempotent re-add of an existing hostname must NOT trip the cap —
+		// the same row already counts in the slice.
+		alreadyHeld := false
+		for _, cd := range sandbox.CustomDomains {
+			if cd.Hostname == canonical {
+				alreadyHeld = true
+				break
+			}
+		}
+		if !alreadyHeld {
+			return ErrCustomDomainPerSandboxCap
+		}
+	}
+
+	if err := s.store.AddCustomDomain(ctx, sandboxID, canonical); err != nil {
+		return err
+	}
+
+	// Re-read so the caddy PATCH sees the full union (existing + new). The
+	// store inserts with pending_dns status; Caddy's on-demand TLS does not
+	// look at status, only hostname presence, so the new hostname is route-
+	// matchable immediately.
+	refreshed, err := s.store.Get(ctx, sandboxID)
+	if err != nil {
+		_ = s.store.RemoveCustomDomain(ctx, sandboxID, canonical)
+		return fmt.Errorf("reload sandbox after custom-domain insert: %w", err)
+	}
+	if err := s.caddy.UpsertSandboxRoute(ctx, refreshed.ID, refreshed.ContainerIP, s.cfg.ToolboxPort, sandboxCustomHostnames(refreshed)); err != nil {
+		// Store first / caddy second with rollback on caddy failure. Same
+		// shape as the create path. We deliberately keep the row OUT of the
+		// store on a partial failure rather than leaving an orphan row that
+		// the reconciler would have to clean up — the caller can simply
+		// retry the request.
+		_ = s.store.RemoveCustomDomain(ctx, sandboxID, canonical)
+		return fmt.Errorf("install caddy route for custom domain %q: %w", canonical, err)
+	}
+	evictCustomDomainNegativeCache(canonical)
+	return nil
+}
+
+// RemoveCustomDomain detaches a hostname. Order is caddy-first then store —
+// the inverse of Add — so an interrupted call leaves a still-routable host
+// the reconciler can either keep (matches the store) or strip on the next
+// pass. Cross-sandbox removal returns store.ErrNotFound (the store layer
+// scopes the DELETE to (sandbox, hostname)), so a tenant cannot rip a domain
+// out of someone else's route by guessing the hostname.
+func (s *Service) RemoveCustomDomain(ctx context.Context, sandboxID, hostname string) error {
+	canonical, err := models.NormalizeCustomDomain(hostname, s.cfg.Domain)
+	if err != nil {
+		return err
+	}
+	sandbox, err := s.store.Get(ctx, sandboxID)
+	if err != nil {
+		return err
+	}
+	owned := false
+	for _, cd := range sandbox.CustomDomains {
+		if cd.Hostname == canonical {
+			owned = true
+			break
+		}
+	}
+	if !owned {
+		return store.ErrNotFound
+	}
+	if err := s.store.RemoveCustomDomain(ctx, sandboxID, canonical); err != nil {
+		return err
+	}
+	refreshed, err := s.store.Get(ctx, sandboxID)
+	if err != nil {
+		return fmt.Errorf("reload sandbox after custom-domain delete: %w", err)
+	}
+	if err := s.caddy.UpsertSandboxRoute(ctx, refreshed.ID, refreshed.ContainerIP, s.cfg.ToolboxPort, sandboxCustomHostnames(refreshed)); err != nil {
+		// Caddy is the source of truth for routing; if we couldn't strip the
+		// host matcher entry, the row is gone from the store but Caddy still
+		// serves the hostname. The next ingress reconcile (or AddCustomDomain
+		// re-attaching the same hostname elsewhere) will converge it.
+		return fmt.Errorf("update caddy route after custom-domain delete %q: %w", canonical, err)
+	}
+	return nil
+}
+
+// ListCustomDomains returns the canonical rows for one sandbox. Empty slice
+// (nil) when none are attached.
+func (s *Service) ListCustomDomains(ctx context.Context, sandboxID string) ([]models.CustomDomain, error) {
+	if _, err := s.store.Get(ctx, sandboxID); err != nil {
+		return nil, err
+	}
+	return s.store.ListCustomDomains(ctx, sandboxID)
+}
+
+// hasL4Exposure reports whether sandbox has any protocol=tcp/tls exposed port.
+// Used by AddCustomDomain to enforce the IRON RULE and (in the future) by the
+// expose-port path to reject tcp/tls when a custom domain already exists.
+func hasL4Exposure(sandbox *models.Sandbox) bool {
+	if sandbox == nil {
+		return false
+	}
+	for _, ep := range sandbox.ExposedPorts {
+		switch ep.Protocol {
+		case models.ExposedPortProtocolTCP, models.ExposedPortProtocolTLS:
+			return true
+		}
+	}
+	return false
+}
+
+// hasCustomDomains reports whether sandbox holds any custom-domain row. The
+// expose-port path (ExposePort with protocol=tcp/tls) uses this to enforce
+// the IRON RULE from the other side.
+func hasCustomDomains(sandbox *models.Sandbox) bool {
+	return sandbox != nil && len(sandbox.CustomDomains) > 0
+}
+
+// persistCustomDomainsOnCreate writes each validated hostname row after the
+// caddy route is installed and the sandbox row is persisted. Called from
+// createSandbox right after store.Create. On any single failure, every row
+// inserted so far in this call is rolled back so the caller's create path
+// can unwind cleanly without leaving partial rows.
+//
+// We deliberately do NOT re-PATCH caddy per hostname here — the initial
+// UpsertSandboxRoute already included sandboxCustomHostnames(sandbox) with
+// the full set, so the route matcher is in place before this runs.
+func (s *Service) persistCustomDomainsOnCreate(ctx context.Context, sandboxID string, hostnames []string) error {
+	if len(hostnames) == 0 {
+		return nil
+	}
+	added := make([]string, 0, len(hostnames))
+	for _, h := range hostnames {
+		if err := s.store.AddCustomDomain(ctx, sandboxID, h); err != nil {
+			// Roll back any rows inserted earlier in this call.
+			for _, prev := range added {
+				_ = s.store.RemoveCustomDomain(ctx, sandboxID, prev)
+			}
+			if errors.Is(err, store.ErrCustomDomainConflict) {
+				return err
+			}
+			return fmt.Errorf("persist custom domain %q: %w", h, err)
+		}
+		added = append(added, h)
+	}
+	for _, h := range added {
+		evictCustomDomainNegativeCache(h)
+	}
+	return nil
+}

--- a/internal/service/custom_domains.go
+++ b/internal/service/custom_domains.go
@@ -193,8 +193,15 @@ func (s *Service) AddCustomDomain(ctx context.Context, sandboxID, hostname strin
 	}
 	// Per-sandbox cap is enforced here rather than in the store so the error
 	// surfaces with the canonical sentinel; the store would otherwise just
-	// insert and the count check would race with concurrent adds.
-	if len(sandbox.CustomDomains) >= models.MaxCustomDomainsPerSandbox {
+	// insert and the count check would race with concurrent adds. Reads
+	// the operator-tunable cap from config (SB_CUSTOM_DOMAINS_MAX_PER_SANDBOX)
+	// with the compile-time default as a safety floor when the config wasn't
+	// validated (tests, embedded callers).
+	maxDomains := s.cfg.CustomDomainsMaxPerSandbox
+	if maxDomains <= 0 {
+		maxDomains = models.MaxCustomDomainsPerSandbox
+	}
+	if len(sandbox.CustomDomains) >= maxDomains {
 		// Idempotent re-add of an existing hostname must NOT trip the cap —
 		// the same row already counts in the slice.
 		alreadyHeld := false
@@ -256,6 +263,13 @@ func (s *Service) AddCustomDomain(ctx context.Context, sandboxID, hostname strin
 // hostname)), so a tenant cannot rip a domain out of someone else's route
 // by guessing the hostname.
 func (s *Service) RemoveCustomDomain(ctx context.Context, sandboxID, hostname string) error {
+	// Mirror AddCustomDomain's deployment-capability gate. routes.go documents
+	// that disabled-feature / IP-mode deployments surface 412 here too — the
+	// route is mounted unconditionally so callers can tell "this cluster does
+	// not do custom domains" apart from "the route does not exist".
+	if !s.cfg.EnableCustomDomains || strings.TrimSpace(s.cfg.Domain) == "" {
+		return ErrCustomDomainNotSupported
+	}
 	canonical, err := models.NormalizeCustomDomain(hostname, s.cfg.Domain)
 	if err != nil {
 		return err
@@ -304,8 +318,14 @@ func (s *Service) RemoveCustomDomain(ctx context.Context, sandboxID, hostname st
 }
 
 // ListCustomDomains returns the canonical rows for one sandbox. Empty slice
-// (nil) when none are attached.
+// (nil) when none are attached. Same deployment-capability gate as
+// Add/Remove: disabled-feature or IP-mode returns ErrCustomDomainNotSupported
+// (412) rather than an empty list, so callers can distinguish "this sandbox
+// has no domains" from "this cluster does not do custom domains".
 func (s *Service) ListCustomDomains(ctx context.Context, sandboxID string) ([]models.CustomDomain, error) {
+	if !s.cfg.EnableCustomDomains || strings.TrimSpace(s.cfg.Domain) == "" {
+		return nil, ErrCustomDomainNotSupported
+	}
 	if _, err := s.store.Get(ctx, sandboxID); err != nil {
 		return nil, err
 	}

--- a/internal/service/custom_domains.go
+++ b/internal/service/custom_domains.go
@@ -248,12 +248,13 @@ func (s *Service) AddCustomDomain(ctx context.Context, sandboxID, hostname strin
 	return nil
 }
 
-// RemoveCustomDomain detaches a hostname. Order is caddy-first then store —
-// the inverse of Add — so an interrupted call leaves a still-routable host
-// the reconciler can either keep (matches the store) or strip on the next
-// pass. Cross-sandbox removal returns store.ErrNotFound (the store layer
-// scopes the DELETE to (sandbox, hostname)), so a tenant cannot rip a domain
-// out of someone else's route by guessing the hostname.
+// RemoveCustomDomain detaches a hostname. Order is store-first then Caddy.
+// If the store delete succeeds but the Caddy patch fails, the hostname is
+// gone from the store while Caddy may still serve it until the next
+// reconcile pass converges routing. Cross-sandbox removal returns
+// store.ErrNotFound (the store layer scopes the DELETE to (sandbox,
+// hostname)), so a tenant cannot rip a domain out of someone else's route
+// by guessing the hostname.
 func (s *Service) RemoveCustomDomain(ctx context.Context, sandboxID, hostname string) error {
 	canonical, err := models.NormalizeCustomDomain(hostname, s.cfg.Domain)
 	if err != nil {

--- a/internal/service/custom_domains_e2e_test.go
+++ b/internal/service/custom_domains_e2e_test.go
@@ -1,0 +1,543 @@
+//go:build e2e
+
+// Custom-domains end-to-end ACME test. Operator-runnable only (not CI) —
+// invoked via `make test-acme-e2e`. Closes the gap that all our unit and
+// integration tests leave: nothing exercises the full TLS handshake →
+// Caddy on-demand → ask handler → ACME-against-Pebble → store-in-S3 flow.
+//
+// The test asserts three things, in order:
+//
+//  1. First HTTPS hit to a custom hostname triggers exactly one ACME issuance.
+//  2. Second hit reuses the cert (zero new orders).
+//  3. Killing Caddy and starting a fresh instance pointed at the same S3
+//     bucket reuses the cert (zero new orders) — proves the shared-storage
+//     guarantee that multi-node clusters depend on.
+//
+// Lives in package service_test (not service) to break the import cycle
+// with pkg/api/ingressproxy. Construction helpers that need the unexported
+// Service fields are exposed via export_e2e_test.go.
+//
+// Pebble runs with PEBBLE_VA_ALWAYS_VALID=1 so HTTP-01 validation is short-
+// circuited at the VA; the test still exercises the order/finalize/download
+// cycle that produces a "Signing certificate" log line per issuance, which
+// is what we count to assert (1).
+package service_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/internal/service"
+	"github.com/aerol-ai/microvm/internal/service/testfixtures/caddyfx"
+	"github.com/aerol-ai/microvm/internal/service/testfixtures/dockerfx"
+	"github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/api/ingressproxy"
+	"github.com/aerol-ai/microvm/pkg/caddy"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+const (
+	e2eNetwork    = "aerolvm-e2e"
+	e2eS3Bucket   = "caddy-certs"
+	e2eAKID       = "test"
+	e2eSecret     = "test"
+	e2eHostname   = "api.test.local"
+	e2eSandboxID  = "sb-e2e-1"
+	pebbleImage   = "letsencrypt/pebble:v2.5.1"
+	localstackImg = "localstack/localstack:3.4"
+	caddyBaseImg  = "alpine:3.19"
+)
+
+func TestACME_FirstIssueAndS3Reuse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("acme e2e: skipping in -short mode")
+	}
+	cli := dockerfx.Require(t)
+	cli.EnsureNetwork(t, e2eNetwork)
+
+	ls := cli.Start(t, localstackSpec())
+	pebble := cli.Start(t, pebbleSpec())
+	createS3Bucket(t, ls)
+
+	pebbleRoots := fetchPebbleRoots(t, pebble)
+	caddyBin := caddyfx.Build(t)
+
+	// In-test HTTP backend so Caddy's reverse_proxy has something to reach
+	// once it's terminated TLS. Started ONCE, reused across both Caddy
+	// instances so the failover phase doesn't introduce a second backend
+	// variable to keep in sync.
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(backend.Close)
+	backendPort := portFromURL(t, backend.URL)
+	configBytes := caddyfx.Render(t, caddyfx.Config{
+		S3Endpoint:   "localstack:4566",
+		S3Bucket:     e2eS3Bucket,
+		AKID:         e2eAKID,
+		Secret:       e2eSecret,
+		UpstreamAddr: "host.docker.internal:" + backendPort,
+	})
+
+	// Phase 1 — first issuance + cache hit.
+	caddy1 := cli.Start(t, caddyContainerSpec(caddyBin))
+	loadCaddyConfig(t, caddy1, configBytes)
+
+	h := startInProcessSandboxd(t, caddy1)
+	mustCreateE2ESandboxRow(t, h.store, e2eSandboxID)
+	if err := h.svc.AddCustomDomain(context.Background(), e2eSandboxID, e2eHostname); err != nil {
+		t.Fatalf("AddCustomDomain: %v", err)
+	}
+	patchPebbleACME(t, caddy1, pebbleRoots)
+
+	client := httpsClientForCaddy(t, caddy1, pebbleRoots)
+
+	if got := mustGet(t, client, "https://"+e2eHostname+"/").StatusCode; got != http.StatusOK {
+		t.Fatalf("first hit: status = %d, want 200\nlogs:\n%s", got, caddy1.LogTail(200))
+	}
+	if n := pebbleIssuanceCount(pebble); n != 1 {
+		t.Fatalf("after first hit: issuance count = %d, want 1\npebble logs:\n%s", n, pebble.LogTail(400))
+	}
+
+	if got := mustGet(t, client, "https://"+e2eHostname+"/").StatusCode; got != http.StatusOK {
+		t.Fatalf("second hit: status = %d, want 200", got)
+	}
+	if n := pebbleIssuanceCount(pebble); n != 1 {
+		t.Fatalf("after second hit (cache): issuance count = %d, want 1 — cert should have been reused", n)
+	}
+
+	// Phase 2 — failover. New Caddy, same S3 bucket. Must reuse cert.
+	caddy1.Stop()
+	caddy2 := cli.Start(t, caddyContainerSpec(caddyBin))
+	loadCaddyConfig(t, caddy2, configBytes)
+	rewireSandboxdAt(t, h, caddy2)
+	patchPebbleACME(t, caddy2, pebbleRoots)
+
+	client2 := httpsClientForCaddy(t, caddy2, pebbleRoots)
+	if got := mustGet(t, client2, "https://"+e2eHostname+"/").StatusCode; got != http.StatusOK {
+		t.Fatalf("failover hit: status = %d, want 200\nlogs:\n%s", got, caddy2.LogTail(200))
+	}
+	if n := pebbleIssuanceCount(pebble); n != 1 {
+		t.Fatalf("after failover: issuance count = %d, want 1 — S3 cert should have been reused", n)
+	}
+}
+
+// --- container specs -------------------------------------------------------
+
+func localstackSpec() dockerfx.Spec {
+	return dockerfx.Spec{
+		Image:       localstackImg,
+		Name:        "aerolvm-e2e-localstack",
+		Env:         []string{"SERVICES=s3", "DEBUG=0"},
+		ExposePorts: []string{"4566/tcp"},
+		Network:     e2eNetwork,
+		ReadyProbe: func(c *dockerfx.Container) error {
+			port := c.HostPort("4566/tcp")
+			if port == "" {
+				return dockerfx.ErrNotReady
+			}
+			resp, err := http.Get("http://127.0.0.1:" + port + "/_localstack/health")
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+			if !strings.Contains(string(body), `"s3"`) {
+				return fmt.Errorf("s3 not ready: %s", body)
+			}
+			return nil
+		},
+	}
+}
+
+func pebbleSpec() dockerfx.Spec {
+	return dockerfx.Spec{
+		Image: pebbleImage,
+		Name:  "aerolvm-e2e-pebble",
+		Env: []string{
+			"PEBBLE_VA_ALWAYS_VALID=1",
+			"PEBBLE_AUTHZREUSE=0",
+			"PEBBLE_WFE_NONCEREJECT=0",
+		},
+		ExposePorts: []string{"14000/tcp", "15000/tcp"},
+		Network:     e2eNetwork,
+		ReadyProbe: func(c *dockerfx.Container) error {
+			port := c.HostPort("14000/tcp")
+			if port == "" {
+				return dockerfx.ErrNotReady
+			}
+			tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+			cli := &http.Client{Transport: tr, Timeout: 2 * time.Second}
+			resp, err := cli.Get("https://127.0.0.1:" + port + "/dir")
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("dir status %d", resp.StatusCode)
+			}
+			return nil
+		},
+	}
+}
+
+func caddyContainerSpec(binPath string) dockerfx.Spec {
+	return dockerfx.Spec{
+		Image:       caddyBaseImg,
+		Cmd:         []string{"/usr/bin/caddy", "run", "--config", "/dev/null"},
+		HostBinds:   []string{caddyfx.HostMount(binPath)},
+		ExposePorts: []string{"443/tcp", "2019/tcp"},
+		ExtraHosts:  []string{"host.docker.internal:host-gateway"},
+		Network:     e2eNetwork,
+		ReadyProbe: func(c *dockerfx.Container) error {
+			port := c.HostPort("2019/tcp")
+			if port == "" {
+				return dockerfx.ErrNotReady
+			}
+			resp, err := http.Get("http://127.0.0.1:" + port + "/config/")
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("admin status %d", resp.StatusCode)
+			}
+			return nil
+		},
+	}
+}
+
+// --- helpers ---------------------------------------------------------------
+
+// loadCaddyConfig POSTs the JSON config to Caddy's /load endpoint. After this
+// returns Caddy has the storage backend, the catch-all reverse proxy, and the
+// placeholder on_demand block — EnsureOnDemandTLS rewrites the ask URL and
+// appends the on-demand policy.
+func loadCaddyConfig(t testing.TB, c *dockerfx.Container, body []byte) {
+	t.Helper()
+	port := c.HostPort("2019/tcp")
+	req, _ := http.NewRequest(http.MethodPost, "http://127.0.0.1:"+port+"/load", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("caddy /load: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+		t.Fatalf("caddy /load failed: %d %s", resp.StatusCode, raw)
+	}
+}
+
+// patchPebbleACME points the on-demand policy's ACME issuer at Pebble and
+// pins Pebble's root as a trusted root. Must be called AFTER AddCustomDomain
+// has driven EnsureOnDemandTLS — the policy at index 0 only exists after that.
+func patchPebbleACME(t testing.TB, c *dockerfx.Container, rootsPEM []byte) {
+	t.Helper()
+	adminPort := c.HostPort("2019/tcp")
+	dockerCpToContainer(t, c, rootsPEM, "/etc/pebble-root.pem")
+
+	issuer := map[string]any{
+		"module":                  "acme",
+		"ca":                      "https://pebble:14000/dir",
+		"trusted_roots_pem_files": []string{"/etc/pebble-root.pem"},
+	}
+	body, _ := json.Marshal([]any{issuer})
+	req, _ := http.NewRequest(http.MethodPatch,
+		"http://127.0.0.1:"+adminPort+"/config/apps/tls/automation/policies/0/issuers",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("patch issuers: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+		t.Fatalf("patch issuers failed: %d %s", resp.StatusCode, raw)
+	}
+}
+
+// dockerCpToContainer uploads a small file into a running container via the
+// Docker daemon's /containers/{id}/archive endpoint. We tar the single file
+// and PUT it at the destination directory.
+func dockerCpToContainer(t testing.TB, c *dockerfx.Container, content []byte, dstPath string) {
+	t.Helper()
+	dir, name := filepath.Split(dstPath)
+	if dir == "" {
+		dir = "/"
+	}
+	tarBuf := makeSingleFileTar(name, content)
+	q := url.Values{}
+	q.Set("path", dir)
+	u := "http://docker/containers/" + c.ID + "/archive?" + q.Encode()
+	req, _ := http.NewRequest(http.MethodPut, u, bytes.NewReader(tarBuf))
+	req.Header.Set("Content-Type", "application/x-tar")
+	tr := &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", "/var/run/docker.sock")
+		},
+	}
+	cli := &http.Client{Transport: tr, Timeout: 10 * time.Second}
+	resp, err := cli.Do(req)
+	if err != nil {
+		t.Fatalf("docker cp: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+		t.Fatalf("docker cp %s failed: %d %s", dstPath, resp.StatusCode, raw)
+	}
+}
+
+func makeSingleFileTar(name string, content []byte) []byte {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: name,
+		Mode: 0o644,
+		Size: int64(len(content)),
+	}); err != nil {
+		panic(err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		panic(err)
+	}
+	if err := tw.Close(); err != nil {
+		panic(err)
+	}
+	return buf.Bytes()
+}
+
+func createS3Bucket(t testing.TB, ls *dockerfx.Container) {
+	t.Helper()
+	port := ls.HostPort("4566/tcp")
+	req, _ := http.NewRequest(http.MethodPut, "http://127.0.0.1:"+port+"/"+e2eS3Bucket, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 && resp.StatusCode != http.StatusConflict {
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+		t.Fatalf("create bucket failed: %d %s", resp.StatusCode, raw)
+	}
+}
+
+func fetchPebbleRoots(t testing.TB, pebble *dockerfx.Container) []byte {
+	t.Helper()
+	port := pebble.HostPort("15000/tcp")
+	tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+	cli := &http.Client{Transport: tr, Timeout: 5 * time.Second}
+	resp, err := cli.Get("https://127.0.0.1:" + port + "/roots/0")
+	if err != nil {
+		t.Fatalf("fetch pebble roots: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("fetch pebble roots: status %d", resp.StatusCode)
+	}
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	return raw
+}
+
+// pebbleIssuanceCount counts "Signing certificate" lines in Pebble's logs.
+// Combined with PEBBLE_AUTHZREUSE=0 every cache miss produces a fresh order
+// and a fresh log line — a reliable proxy for "new certs issued".
+func pebbleIssuanceCount(pebble *dockerfx.Container) int {
+	return pebble.LogContains("Signing certificate")
+}
+
+func mustGet(t testing.TB, c *http.Client, urlStr string) *http.Response {
+	t.Helper()
+	resp, err := c.Get(urlStr)
+	if err != nil {
+		t.Fatalf("GET %s: %v", urlStr, err)
+	}
+	io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
+	resp.Body.Close()
+	return resp
+}
+
+// httpsClientForCaddy returns an http.Client whose TLS config trusts Pebble's
+// root and whose dialer rewrites the custom hostname to the Caddy container's
+// host-mapped 443 port.
+func httpsClientForCaddy(t testing.TB, c *dockerfx.Container, rootsPEM []byte) *http.Client {
+	t.Helper()
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(rootsPEM) {
+		t.Fatalf("pebble root PEM did not parse")
+	}
+	hostPort := c.HostPort("443/tcp")
+	if hostPort == "" {
+		t.Fatalf("caddy 443 host port missing")
+	}
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{RootCAs: pool, ServerName: e2eHostname},
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			if addr == e2eHostname+":443" {
+				addr = "127.0.0.1:" + hostPort
+			}
+			return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, addr)
+		},
+	}
+	return &http.Client{Transport: tr, Timeout: 30 * time.Second}
+}
+
+// --- in-process sandboxd ---------------------------------------------------
+
+type e2eHarness struct {
+	svc        *service.Service
+	store      *store.Store
+	ingressSrv *http.Server
+	ingressLn  net.Listener
+	caddy      *caddy.Client
+	cfg        config.Config
+}
+
+// startInProcessSandboxd builds a Service + TLS-ask handler bound to an
+// ephemeral 0.0.0.0 port (so the Caddy container reaches it via
+// host.docker.internal) and installs the on-demand TLS policy on Caddy.
+func startInProcessSandboxd(t testing.TB, caddyCont *dockerfx.Container) *e2eHarness {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "state.db")
+	st, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	cfg := config.Config{
+		EnableCustomDomains:        true,
+		Domain:                     "aerol.cloud",
+		CustomDomainsMaxPerSandbox: models.MaxCustomDomainsPerSandbox,
+		TLSOnDemandBurst:           5,
+		TLSOnDemandInterval:        5 * time.Second,
+		HTTPClientTimeout:          5 * time.Second,
+		EnableCaddy:                true,
+		CaddyAdminURL:              "http://127.0.0.1:" + caddyCont.HostPort("2019/tcp"),
+	}
+	caddyClient := caddy.New(cfg)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	svc := service.NewForE2ETest(cfg, logger, st, caddyClient)
+
+	resolver := storeResolver{st: st}
+	askHandler := ingressproxy.NewTLSAskHandler(ingressproxy.TLSAskDeps{
+		Resolver:    resolver,
+		BaseDomain:  cfg.Domain,
+		NegCacheTTL: 60 * time.Second,
+		NegCacheCap: 10000,
+		Logger:      logger,
+	})
+	svc.AttachCustomDomainCacheEvicter(askHandler)
+
+	mux := http.NewServeMux()
+	ingressproxy.RegisterTLSAsk(mux, askHandler)
+
+	ln, err := net.Listen("tcp", "0.0.0.0:0")
+	if err != nil {
+		t.Fatalf("listen ingress: %v", err)
+	}
+	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	go func() {
+		if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			t.Logf("ingress server stopped: %v", err)
+		}
+	}()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+
+	askURL := fmt.Sprintf("http://host.docker.internal:%d%s",
+		ln.Addr().(*net.TCPAddr).Port, ingressproxy.TLSAskPath)
+	if err := caddyClient.EnsureOnDemandTLS(context.Background(), askURL,
+		cfg.TLSOnDemandBurst, cfg.TLSOnDemandInterval); err != nil {
+		t.Fatalf("EnsureOnDemandTLS: %v", err)
+	}
+
+	return &e2eHarness{
+		svc:        svc,
+		store:      st,
+		ingressSrv: srv,
+		ingressLn:  ln,
+		caddy:      caddyClient,
+		cfg:        cfg,
+	}
+}
+
+// rewireSandboxdAt repoints the Service at a fresh Caddy container (the
+// failover instance) and re-installs the on-demand TLS policy on it. The
+// in-process ask handler keeps serving on the same loopback port.
+func rewireSandboxdAt(t testing.TB, h *e2eHarness, caddyCont *dockerfx.Container) {
+	t.Helper()
+	newCfg := h.cfg
+	newCfg.CaddyAdminURL = "http://127.0.0.1:" + caddyCont.HostPort("2019/tcp")
+	newClient := caddy.New(newCfg)
+	h.svc.SetCaddyClientForE2ETest(newClient)
+	h.caddy = newClient
+	h.cfg = newCfg
+
+	askURL := fmt.Sprintf("http://host.docker.internal:%d%s",
+		h.ingressLn.Addr().(*net.TCPAddr).Port, ingressproxy.TLSAskPath)
+	if err := newClient.EnsureOnDemandTLS(context.Background(), askURL,
+		newCfg.TLSOnDemandBurst, newCfg.TLSOnDemandInterval); err != nil {
+		t.Fatalf("rewire EnsureOnDemandTLS: %v", err)
+	}
+}
+
+// storeResolver is the single-node CustomDomainResolver — a thin shim over
+// store.ResolveCustomDomain. The cluster-aware variant lives in
+// cmd/sandboxd/main.go and isn't needed here.
+type storeResolver struct{ st *store.Store }
+
+func (r storeResolver) ResolveCustomDomain(ctx context.Context, hostname string) (string, error) {
+	return r.st.ResolveCustomDomain(ctx, hostname)
+}
+
+func mustCreateE2ESandboxRow(t testing.TB, st *store.Store, id string) {
+	t.Helper()
+	now := time.Now().UTC()
+	sb := &models.Sandbox{
+		ID:           id,
+		Image:        "test-image",
+		Status:       models.SandboxStatusStarted,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		LastActiveAt: now,
+	}
+	if err := st.Create(context.Background(), sb); err != nil {
+		t.Fatalf("store.Create: %v", err)
+	}
+}
+
+func portFromURL(t testing.TB, raw string) string {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse url %q: %v", raw, err)
+	}
+	_, port, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		t.Fatalf("split %q: %v", u.Host, err)
+	}
+	return port
+}

--- a/internal/service/custom_domains_test.go
+++ b/internal/service/custom_domains_test.go
@@ -215,15 +215,13 @@ func TestAddCustomDomain_CrossSandboxConflict(t *testing.T) {
 }
 
 func TestAddCustomDomain_PerSandboxCap(t *testing.T) {
+	const perSandboxCap = 2
 	svc, st := newCustomDomainsHarness(t, func(c *config.Config) {
-		c.CustomDomainsMaxPerSandbox = 2 // override so the test doesn't need 26 inserts
+		c.CustomDomainsMaxPerSandbox = perSandboxCap // exercise the SB_CUSTOM_DOMAINS_MAX_PER_SANDBOX override path
 	})
 	mustCreateSandboxRow(t, st, "sb-1")
 	ctx := context.Background()
-	// The service uses models.MaxCustomDomainsPerSandbox (a compile-time
-	// const) rather than the cfg override today; this test drives the cap
-	// via the actual sentinel value. Drive enough hostnames to hit it.
-	for i := range models.MaxCustomDomainsPerSandbox {
+	for i := range perSandboxCap {
 		host := "h" + itoa(i) + ".acme.com"
 		if err := svc.AddCustomDomain(ctx, "sb-1", host); err != nil {
 			t.Fatalf("add %d (%s): %v", i, host, err)

--- a/internal/service/custom_domains_test.go
+++ b/internal/service/custom_domains_test.go
@@ -1,0 +1,354 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/caddy"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// newCustomDomainsHarness builds a minimal Service wired with an enabled
+// feature flag and a base domain so the validate/add/remove paths exercise
+// the real branches. Caddy is disabled so UpsertSandboxRoute is a no-op —
+// these tests assert on the service+store layer; the matcher shape is
+// covered separately in pkg/caddy/custom_domains_test.go.
+func newCustomDomainsHarness(t *testing.T, cfgOverride func(*config.Config)) (*Service, *store.Store) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "state.db")
+	st, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	cfg := config.Config{
+		EnableCustomDomains:        true,
+		Domain:                     "aerol.cloud",
+		CustomDomainsMaxPerSandbox: models.MaxCustomDomainsPerSandbox,
+	}
+	if cfgOverride != nil {
+		cfgOverride(&cfg)
+	}
+	svc := &Service{
+		cfg:    cfg,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		store:  st,
+		caddy: caddy.New(config.Config{
+			EnableCaddy:       false,
+			HTTPClientTimeout: time.Second,
+		}),
+	}
+	return svc, st
+}
+
+func mustCreateSandboxRow(t *testing.T, st *store.Store, id string, exposed ...models.ExposedPort) *models.Sandbox {
+	t.Helper()
+	now := time.Now().UTC()
+	sandbox := &models.Sandbox{
+		ID:           id,
+		Image:        "test-image",
+		Status:       models.SandboxStatusStarted,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		LastActiveAt: now,
+		Lifecycle:    models.Lifecycle{},
+		ExposedPorts: exposed,
+	}
+	if err := st.Create(context.Background(), sandbox); err != nil {
+		t.Fatalf("store.Create: %v", err)
+	}
+	for _, ep := range exposed {
+		ep.SandboxID = id
+		ep.CreatedAt = now
+		if err := st.UpsertPort(context.Background(), ep); err != nil {
+			t.Fatalf("store.UpsertPort: %v", err)
+		}
+	}
+	got, err := st.Get(context.Background(), id)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	return got
+}
+
+func TestValidateCreateCustomDomains_DisabledRejects(t *testing.T) {
+	svc, _ := newCustomDomainsHarness(t, func(c *config.Config) {
+		c.EnableCustomDomains = false
+	})
+	req := models.CreateSandboxRequest{CustomDomains: []string{"api.acme.com"}}
+	if err := svc.validateCreateCustomDomains(&req); !errors.Is(err, models.ErrCustomDomainNotSupported) {
+		t.Fatalf("disabled: got %v, want ErrCustomDomainNotSupported", err)
+	}
+}
+
+func TestValidateCreateCustomDomains_IPModeRejects(t *testing.T) {
+	svc, _ := newCustomDomainsHarness(t, func(c *config.Config) {
+		c.Domain = ""
+	})
+	req := models.CreateSandboxRequest{CustomDomains: []string{"api.acme.com"}}
+	if err := svc.validateCreateCustomDomains(&req); !errors.Is(err, models.ErrCustomDomainNotSupported) {
+		t.Fatalf("ip mode: got %v, want ErrCustomDomainNotSupported", err)
+	}
+}
+
+func TestValidateCreateCustomDomains_EmptyIsFine(t *testing.T) {
+	// Even when disabled, a request with no custom_domains must pass —
+	// otherwise every existing CreateSandbox path would break in deployments
+	// that haven't turned the feature on.
+	svc, _ := newCustomDomainsHarness(t, func(c *config.Config) {
+		c.EnableCustomDomains = false
+		c.Domain = ""
+	})
+	req := models.CreateSandboxRequest{}
+	if err := svc.validateCreateCustomDomains(&req); err != nil {
+		t.Fatalf("empty: got %v, want nil", err)
+	}
+}
+
+func TestValidateCreateCustomDomains_NormalizesAndDedupes(t *testing.T) {
+	svc, _ := newCustomDomainsHarness(t, nil)
+	req := models.CreateSandboxRequest{CustomDomains: []string{"API.Acme.com", "api.acme.com."}}
+	if err := svc.validateCreateCustomDomains(&req); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(req.CustomDomains) != 1 || req.CustomDomains[0] != "api.acme.com" {
+		t.Fatalf("normalized=%v, want [api.acme.com]", req.CustomDomains)
+	}
+}
+
+func TestValidateCreateCustomDomains_InvalidHostnameRejects(t *testing.T) {
+	svc, _ := newCustomDomainsHarness(t, nil)
+	req := models.CreateSandboxRequest{CustomDomains: []string{"single-label"}}
+	if err := svc.validateCreateCustomDomains(&req); !errors.Is(err, models.ErrCustomDomainInvalid) {
+		t.Fatalf("got %v, want ErrCustomDomainInvalid", err)
+	}
+}
+
+func TestValidateCreateCustomDomains_UnderBaseDomainRejects(t *testing.T) {
+	svc, _ := newCustomDomainsHarness(t, nil)
+	req := models.CreateSandboxRequest{CustomDomains: []string{"x.aerol.cloud"}}
+	if err := svc.validateCreateCustomDomains(&req); !errors.Is(err, models.ErrCustomDomainInvalid) {
+		t.Fatalf("got %v, want ErrCustomDomainInvalid", err)
+	}
+}
+
+func TestAddCustomDomain_DisabledRejects(t *testing.T) {
+	svc, st := newCustomDomainsHarness(t, func(c *config.Config) {
+		c.EnableCustomDomains = false
+	})
+	mustCreateSandboxRow(t, st, "sb-1")
+	err := svc.AddCustomDomain(context.Background(), "sb-1", "api.acme.com")
+	if !errors.Is(err, models.ErrCustomDomainNotSupported) {
+		t.Fatalf("got %v, want ErrCustomDomainNotSupported", err)
+	}
+}
+
+func TestAddCustomDomain_HappyPath(t *testing.T) {
+	svc, st := newCustomDomainsHarness(t, nil)
+	mustCreateSandboxRow(t, st, "sb-1")
+	if err := svc.AddCustomDomain(context.Background(), "sb-1", "API.Acme.com"); err != nil {
+		t.Fatalf("AddCustomDomain: %v", err)
+	}
+	domains, err := svc.ListCustomDomains(context.Background(), "sb-1")
+	if err != nil {
+		t.Fatalf("ListCustomDomains: %v", err)
+	}
+	if len(domains) != 1 || domains[0].Hostname != "api.acme.com" {
+		t.Fatalf("after add: %v", domains)
+	}
+	if domains[0].Status != models.CustomDomainPendingDNS {
+		t.Fatalf("status=%v, want pending_dns", domains[0].Status)
+	}
+}
+
+func TestAddCustomDomain_IronRuleRejectsTCPExposure(t *testing.T) {
+	svc, st := newCustomDomainsHarness(t, nil)
+	mustCreateSandboxRow(t, st, "sb-1", models.ExposedPort{
+		SandboxID: "sb-1",
+		Port:      5432,
+		Protocol:  models.ExposedPortProtocolTCP,
+		HostPort:  22001,
+	})
+	err := svc.AddCustomDomain(context.Background(), "sb-1", "api.acme.com")
+	if !errors.Is(err, models.ErrCustomDomainProtocolConflict) {
+		t.Fatalf("got %v, want ErrCustomDomainProtocolConflict", err)
+	}
+}
+
+func TestAddCustomDomain_IdempotentReadd(t *testing.T) {
+	svc, st := newCustomDomainsHarness(t, nil)
+	mustCreateSandboxRow(t, st, "sb-1")
+	ctx := context.Background()
+	if err := svc.AddCustomDomain(ctx, "sb-1", "api.acme.com"); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	if err := svc.AddCustomDomain(ctx, "sb-1", "API.Acme.com."); err != nil {
+		t.Fatalf("idempotent re-add: %v", err)
+	}
+	domains, _ := svc.ListCustomDomains(ctx, "sb-1")
+	if len(domains) != 1 {
+		t.Fatalf("expected 1 row after idempotent re-add, got %d", len(domains))
+	}
+}
+
+func TestAddCustomDomain_CrossSandboxConflict(t *testing.T) {
+	svc, st := newCustomDomainsHarness(t, nil)
+	mustCreateSandboxRow(t, st, "sb-a")
+	mustCreateSandboxRow(t, st, "sb-b")
+	ctx := context.Background()
+	if err := svc.AddCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	err := svc.AddCustomDomain(ctx, "sb-b", "api.acme.com")
+	if !errors.Is(err, store.ErrCustomDomainConflict) {
+		t.Fatalf("got %v, want ErrCustomDomainConflict", err)
+	}
+}
+
+func TestAddCustomDomain_PerSandboxCap(t *testing.T) {
+	svc, st := newCustomDomainsHarness(t, func(c *config.Config) {
+		c.CustomDomainsMaxPerSandbox = 2 // override so the test doesn't need 26 inserts
+	})
+	mustCreateSandboxRow(t, st, "sb-1")
+	ctx := context.Background()
+	// The service uses models.MaxCustomDomainsPerSandbox (a compile-time
+	// const) rather than the cfg override today; this test drives the cap
+	// via the actual sentinel value. Drive enough hostnames to hit it.
+	for i := range models.MaxCustomDomainsPerSandbox {
+		host := "h" + itoa(i) + ".acme.com"
+		if err := svc.AddCustomDomain(ctx, "sb-1", host); err != nil {
+			t.Fatalf("add %d (%s): %v", i, host, err)
+		}
+	}
+	err := svc.AddCustomDomain(ctx, "sb-1", "extra.acme.com")
+	if !errors.Is(err, models.ErrCustomDomainPerSandboxCap) {
+		t.Fatalf("got %v, want ErrCustomDomainPerSandboxCap", err)
+	}
+}
+
+func TestAddCustomDomain_MissingSandboxReturns404(t *testing.T) {
+	svc, _ := newCustomDomainsHarness(t, nil)
+	err := svc.AddCustomDomain(context.Background(), "nope", "api.acme.com")
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("got %v, want ErrNotFound", err)
+	}
+}
+
+func TestRemoveCustomDomain_HappyPath(t *testing.T) {
+	svc, st := newCustomDomainsHarness(t, nil)
+	mustCreateSandboxRow(t, st, "sb-1")
+	ctx := context.Background()
+	if err := svc.AddCustomDomain(ctx, "sb-1", "api.acme.com"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := svc.RemoveCustomDomain(ctx, "sb-1", "API.Acme.com"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	domains, _ := svc.ListCustomDomains(ctx, "sb-1")
+	if len(domains) != 0 {
+		t.Fatalf("after remove: %v", domains)
+	}
+}
+
+func TestRemoveCustomDomain_CrossSandboxReturns404(t *testing.T) {
+	svc, st := newCustomDomainsHarness(t, nil)
+	mustCreateSandboxRow(t, st, "sb-a")
+	mustCreateSandboxRow(t, st, "sb-b")
+	ctx := context.Background()
+	if err := svc.AddCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	err := svc.RemoveCustomDomain(ctx, "sb-b", "api.acme.com")
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("got %v, want ErrNotFound", err)
+	}
+}
+
+func TestSandboxCustomHostnames(t *testing.T) {
+	if got := sandboxCustomHostnames(nil); got != nil {
+		t.Fatalf("nil sandbox: got %v, want nil", got)
+	}
+	sb := &models.Sandbox{}
+	if got := sandboxCustomHostnames(sb); got != nil {
+		t.Fatalf("empty CustomDomains: got %v, want nil", got)
+	}
+	sb.CustomDomains = []models.CustomDomain{
+		{Hostname: "api.acme.com"},
+		{Hostname: ""}, // tolerated but skipped
+		{Hostname: "admin.acme.com"},
+	}
+	got := sandboxCustomHostnames(sb)
+	if len(got) != 2 || got[0] != "api.acme.com" || got[1] != "admin.acme.com" {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestHasL4Exposure(t *testing.T) {
+	if hasL4Exposure(nil) {
+		t.Fatalf("nil sandbox: want false")
+	}
+	if hasL4Exposure(&models.Sandbox{ExposedPorts: []models.ExposedPort{{Protocol: models.ExposedPortProtocolHTTP}}}) {
+		t.Fatalf("http-only: want false")
+	}
+	if !hasL4Exposure(&models.Sandbox{ExposedPorts: []models.ExposedPort{{Protocol: models.ExposedPortProtocolTCP}}}) {
+		t.Fatalf("tcp: want true")
+	}
+	if !hasL4Exposure(&models.Sandbox{ExposedPorts: []models.ExposedPort{{Protocol: models.ExposedPortProtocolTLS}}}) {
+		t.Fatalf("tls: want true")
+	}
+}
+
+// fakeEvicter captures the hostnames the service hands to the negative cache
+// so we can assert AddCustomDomain punches the cache on success.
+type fakeEvicter struct {
+	mu   sync.Mutex
+	hits []string
+}
+
+func (f *fakeEvicter) EvictNegativeCache(host string) {
+	f.mu.Lock()
+	f.hits = append(f.hits, host)
+	f.mu.Unlock()
+}
+
+func TestAddCustomDomain_EvictsNegativeCacheOnSuccess(t *testing.T) {
+	svc, st := newCustomDomainsHarness(t, nil)
+	mustCreateSandboxRow(t, st, "sb-1")
+	evict := &fakeEvicter{}
+	svc.AttachCustomDomainCacheEvicter(evict)
+	t.Cleanup(func() { svc.AttachCustomDomainCacheEvicter(nil) })
+
+	if err := svc.AddCustomDomain(context.Background(), "sb-1", "api.acme.com"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	evict.mu.Lock()
+	defer evict.mu.Unlock()
+	if len(evict.hits) != 1 || evict.hits[0] != "api.acme.com" {
+		t.Fatalf("evict hits = %v, want [api.acme.com]", evict.hits)
+	}
+}
+
+// itoa is a tiny stand-in so the cap test doesn't pull strconv in only for
+// generating sequential hostnames. Test-local; not used elsewhere.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}

--- a/internal/service/events.go
+++ b/internal/service/events.go
@@ -297,7 +297,7 @@ func (s *Service) handleStartEvent(ctx context.Context, sandbox *models.Sandbox)
 		s.admitter.Reserve(sandbox.ID, capacityRequestFromSandbox(sandbox))
 	}
 
-	if err := s.caddy.UpsertSandboxRoute(ctx, sandbox.ID, sandbox.ContainerIP, s.cfg.ToolboxPort); err != nil {
+	if err := s.caddy.UpsertSandboxRoute(ctx, sandbox.ID, sandbox.ContainerIP, s.cfg.ToolboxPort, sandboxCustomHostnames(sandbox)); err != nil {
 		return fmt.Errorf("upsert sandbox route: %w", err)
 	}
 	for _, port := range sandbox.ExposedPorts {

--- a/internal/service/export_e2e_test.go
+++ b/internal/service/export_e2e_test.go
@@ -1,0 +1,43 @@
+//go:build e2e
+
+// Test-only exports used by the cross-package e2e ACME test
+// (custom_domains_e2e_test.go lives in package service_test to break the
+// import cycle with pkg/api/ingressproxy). Everything here is gated by the
+// e2e build tag and never reaches production builds.
+package service
+
+import (
+	"log/slog"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/caddy"
+)
+
+// NewForE2ETest builds a minimal Service with just the surface the ACME e2e
+// test needs: store + caddy client + cfg. Bypasses service.New (no runtime,
+// admitter, cipher, mounts, events, image distribution). The custom-domain
+// path is the only path exercised through this; calling lifecycle methods on
+// the resulting Service will panic.
+func NewForE2ETest(cfg config.Config, logger *slog.Logger, st *store.Store, caddyClient *caddy.Client) *Service {
+	return &Service{
+		cfg:    cfg,
+		logger: logger,
+		store:  st,
+		caddy:  caddyClient,
+	}
+}
+
+// SetCaddyClientForE2ETest re-points the Caddy client mid-test, used by the
+// failover phase that stops the original Caddy container and brings up a
+// fresh one against the same shared-storage S3 bucket.
+func (s *Service) SetCaddyClientForE2ETest(c *caddy.Client) {
+	s.caddy = c
+}
+
+// CfgForE2ETest exposes a read-only copy of cfg so the e2e test can pull
+// TLSOnDemandBurst / TLSOnDemandInterval back out without duplicating the
+// values it just installed.
+func (s *Service) CfgForE2ETest() config.Config {
+	return s.cfg
+}

--- a/internal/service/ingress_delta.go
+++ b/internal/service/ingress_delta.go
@@ -73,16 +73,44 @@ func (s *Service) buildClusterIngressIntents(placements []cluster.Placement, sel
 						return s.caddy.DeleteRouteByID(ctx, routeID)
 					},
 				}
+				// Per-custom-hostname SNI passthrough so cluster ingress on a
+				// non-owner node forwards `api.acme.com` straight to the owner's
+				// L4 TLS listener; the owner runs on-demand TLS and terminates
+				// locally. Hostnames come from the FSM (replicated by Raft) so
+				// every ingress node converges on the same matcher set without
+				// per-node state. Version is in the fingerprint so add/remove
+				// of a hostname triggers a single PATCH on the next delta tick.
+				for _, hostname := range p.CustomHostnames {
+					hostname := hostname
+					customRouteID := caddy.IngressCustomDomainSNIRouteID(p.SandboxID, hostname)
+					intents[ingressIntentKey(ingressSurfaceTLS, customRouteID)] = ingressRouteIntent{
+						key:         ingressIntentKey(ingressSurfaceTLS, customRouteID),
+						surface:     ingressSurfaceTLS,
+						routeID:     customRouteID,
+						fingerprint: ingressFingerprint("live-sni-custom", p.SandboxID, ownerHost, hostname, strconv.Itoa(tlsPeerPort), strconv.FormatUint(p.Version, 10)),
+						apply: func(ctx context.Context) error {
+							return s.caddy.UpsertSNIPassthroughRoute(ctx, customRouteID, hostname, ownerHost, tlsPeerPort)
+						},
+						delete: func(ctx context.Context) error {
+							return s.caddy.DeleteRouteByID(ctx, customRouteID)
+						},
+					}
+				}
 			}
 		} else {
 			routeID := "sandbox-" + p.SandboxID
+			// p.CustomHostnames is plumbed through for parity with
+			// UpsertSandboxRoute, but the IP-mode peer-forwarding path is
+			// path-based, not host-based; the service layer also rejects
+			// custom domains in IP mode, so this set is always empty today.
+			customHostnames := p.CustomHostnames
 			intents[ingressIntentKey(ingressSurfaceHTTP, routeID)] = ingressRouteIntent{
 				key:         ingressIntentKey(ingressSurfaceHTTP, routeID),
 				surface:     ingressSurfaceHTTP,
 				routeID:     routeID,
-				fingerprint: ingressFingerprint("live-http-sandbox", p.SandboxID, ownerHost, strconv.FormatUint(p.Version, 10)),
+				fingerprint: ingressFingerprint("live-http-sandbox", p.SandboxID, ownerHost, strings.Join(customHostnames, ","), strconv.FormatUint(p.Version, 10)),
 				apply: func(ctx context.Context) error {
-					return s.caddy.UpsertSandboxRouteToPeer(ctx, p.SandboxID, ownerHost, nil)
+					return s.caddy.UpsertSandboxRouteToPeer(ctx, p.SandboxID, ownerHost, customHostnames)
 				},
 				delete: func(ctx context.Context) error {
 					return s.caddy.DeleteSandboxRoute(ctx, p.SandboxID)

--- a/internal/service/ingress_delta.go
+++ b/internal/service/ingress_delta.go
@@ -82,7 +82,7 @@ func (s *Service) buildClusterIngressIntents(placements []cluster.Placement, sel
 				routeID:     routeID,
 				fingerprint: ingressFingerprint("live-http-sandbox", p.SandboxID, ownerHost, strconv.FormatUint(p.Version, 10)),
 				apply: func(ctx context.Context) error {
-					return s.caddy.UpsertSandboxRouteToPeer(ctx, p.SandboxID, ownerHost)
+					return s.caddy.UpsertSandboxRouteToPeer(ctx, p.SandboxID, ownerHost, nil)
 				},
 				delete: func(ctx context.Context) error {
 					return s.caddy.DeleteSandboxRoute(ctx, p.SandboxID)

--- a/internal/service/ingress_delta_custom_domains_test.go
+++ b/internal/service/ingress_delta_custom_domains_test.go
@@ -1,0 +1,133 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/aerol-ai/microvm/internal/cluster"
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/pkg/caddy"
+)
+
+// TestBuildClusterIngressIntents_DomainModeAddsPerCustomHostnameSNI:
+// cluster ingress on a non-owner node must install one SNI passthrough
+// route per FSM-known custom hostname so a TLS connection for
+// `api.acme.com` lands on this node and forwards raw to the owner's L4
+// TLS listener. Without this, custom-domain requests that hit a
+// non-owner node have no matcher and fail to route.
+func TestBuildClusterIngressIntents_DomainModeAddsPerCustomHostnameSNI(t *testing.T) {
+	svc := &Service{
+		cfg: config.Config{
+			EnableCluster: true,
+			Domain:        "sb.example.com",
+			L4TLSListen:   ":8443",
+		},
+	}
+
+	placement := cluster.Placement{
+		SandboxID:       "sb-alpha",
+		OwnerNodeID:     "peer-1",
+		OwnerAPIURL:     "http://10.0.0.7:21212",
+		Version:         1,
+		CustomHostnames: []string{"api.acme.com", "shop.beta.io"},
+	}
+
+	intents, needL4 := svc.buildClusterIngressIntents([]cluster.Placement{placement}, "self")
+	if !needL4 {
+		t.Fatal("needL4 = false; domain mode must request L4 bootstrap")
+	}
+
+	// Default SNI route must still be present.
+	defaultKey := ingressIntentKey(ingressSurfaceTLS, caddy.IngressSandboxSNIRouteID("sb-alpha"))
+	if _, ok := intents[defaultKey]; !ok {
+		t.Fatalf("default SNI intent missing: %s", defaultKey)
+	}
+
+	// One SNI intent per custom hostname.
+	for _, h := range placement.CustomHostnames {
+		key := ingressIntentKey(ingressSurfaceTLS, caddy.IngressCustomDomainSNIRouteID("sb-alpha", h))
+		if _, ok := intents[key]; !ok {
+			t.Fatalf("custom-hostname SNI intent missing for %q: %s", h, key)
+		}
+	}
+}
+
+// TestBuildClusterIngressIntents_CustomHostnameDeltaFiresApply: a
+// hostname added on the next FSM version must produce a single new
+// intent (and bump the placement version so the delta planner emits an
+// apply for it). Catches the "added hostname but route never installed"
+// failure mode where the version doesn't carry into the fingerprint.
+func TestBuildClusterIngressIntents_CustomHostnameDeltaFiresApply(t *testing.T) {
+	svc := &Service{
+		cfg: config.Config{
+			EnableCluster: true,
+			Domain:        "sb.example.com",
+			L4TLSListen:   ":8443",
+		},
+		ingressRouteCache: map[string]ingressRouteIntent{},
+	}
+
+	base := cluster.Placement{
+		SandboxID:       "sb-alpha",
+		OwnerNodeID:     "peer-1",
+		OwnerAPIURL:     "http://10.0.0.7:21212",
+		Version:         1,
+		CustomHostnames: []string{"api.acme.com"},
+	}
+	initial, _ := svc.buildClusterIngressIntents([]cluster.Placement{base}, "self")
+	ops, commit := svc.planClusterIngressDelta(initial)
+	if len(ops) != len(initial) {
+		t.Fatalf("initial delta ops=%d, want %d", len(ops), len(initial))
+	}
+	commit()
+
+	// Add a second custom hostname; bump version so the FSM signals a
+	// route-affecting change.
+	next := base
+	next.Version = 2
+	next.CustomHostnames = []string{"api.acme.com", "shop.beta.io"}
+	updated, _ := svc.buildClusterIngressIntents([]cluster.Placement{next}, "self")
+	ops, _ = svc.planClusterIngressDelta(updated)
+
+	// Two ops expected: default SNI route's fingerprint changed (version
+	// bump), and one new custom-hostname SNI route appears. The first
+	// custom hostname's route was cached and the fingerprint includes
+	// hostname so it also reapplies — 3 ops total.
+	if len(ops) < 1 {
+		t.Fatalf("delta produced 0 ops; expected at least 1 for added hostname")
+	}
+
+	newKey := ingressIntentKey(ingressSurfaceTLS, caddy.IngressCustomDomainSNIRouteID("sb-alpha", "shop.beta.io"))
+	if _, ok := updated[newKey]; !ok {
+		t.Fatalf("added hostname missing from desired intents: %s", newKey)
+	}
+}
+
+// TestBuildClusterIngressIntents_IPModePropagatesHostnamesInFingerprint:
+// IP mode doesn't host-match cross-node, but the fingerprint must
+// include CustomHostnames so a future FSM hostname change still triggers
+// a reapply (caddy.UpsertSandboxRouteToPeer is idempotent — the cost of
+// an unnecessary apply is one PATCH, but a missed apply silently leaves
+// stale state). Guards the plumbing even though current configs reject
+// custom domains in IP mode at the service layer.
+func TestBuildClusterIngressIntents_IPModePropagatesHostnamesInFingerprint(t *testing.T) {
+	svc := &Service{cfg: config.Config{EnableCluster: true, Domain: ""}}
+
+	base := cluster.Placement{
+		SandboxID:       "sb-ip",
+		OwnerNodeID:     "peer-1",
+		OwnerAPIURL:     "http://10.0.0.7:21212",
+		Version:         1,
+		CustomHostnames: nil,
+	}
+	without, _ := svc.buildClusterIngressIntents([]cluster.Placement{base}, "self")
+
+	hosted := base
+	hosted.CustomHostnames = []string{"api.acme.com"}
+	with, _ := svc.buildClusterIngressIntents([]cluster.Placement{hosted}, "self")
+
+	key := ingressIntentKey(ingressSurfaceHTTP, "sandbox-sb-ip")
+	if withFP, withoutFP := with[key].fingerprint, without[key].fingerprint; withFP == withoutFP {
+		t.Fatalf("fingerprint did not change when CustomHostnames went nil → [%q]; without=%d with=%d",
+			"api.acme.com", withoutFP, withFP)
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -616,6 +616,12 @@ func (s *Service) createSandbox(ctx context.Context, req models.CreateSandboxReq
 	if req.Image == "" {
 		return nil, errors.New("image is required")
 	}
+	// Custom-domain validation runs early so an invalid or unsupported
+	// payload fails before admission/mounts/docker.Create burn resources.
+	// On success req.CustomDomains is rewritten with the canonical slice.
+	if err := s.validateCreateCustomDomains(&req); err != nil {
+		return nil, err
+	}
 
 	// Validate the requested runtime and resolve "" to the host default. We
 	// write the resolved value back into req so the runtime layer sees an
@@ -772,8 +778,22 @@ func (s *Service) createSandbox(ctx context.Context, req models.CreateSandboxReq
 		NetworkBytesInLimit:  req.NetworkBytesInLimit,
 		NetworkBytesOutLimit: req.NetworkBytesOutLimit,
 	}
+	// Populate the in-memory CustomDomains slice so the initial route
+	// matcher sees the full hostname union. Status is pending_dns until
+	// the first ACME ask flips it; the per-row store inserts happen below.
+	if len(req.CustomDomains) > 0 {
+		sandbox.CustomDomains = make([]models.CustomDomain, 0, len(req.CustomDomains))
+		for _, h := range req.CustomDomains {
+			sandbox.CustomDomains = append(sandbox.CustomDomains, models.CustomDomain{
+				Hostname:  h,
+				Status:    models.CustomDomainPendingDNS,
+				CreatedAt: now,
+				UpdatedAt: now,
+			})
+		}
+	}
 
-	if err := s.caddy.UpsertSandboxRoute(ctx, sandbox.ID, sandbox.ContainerIP, s.cfg.ToolboxPort); err != nil {
+	if err := s.caddy.UpsertSandboxRoute(ctx, sandbox.ID, sandbox.ContainerIP, s.cfg.ToolboxPort, sandboxCustomHostnames(sandbox)); err != nil {
 		_ = s.docker.Destroy(ctx, sandbox)
 		cleanupMounts()
 		releaseAdmission()
@@ -797,6 +817,17 @@ func (s *Service) createSandbox(ctx context.Context, req models.CreateSandboxReq
 			releaseAdmission()
 			return nil, fmt.Errorf("persist sandbox mounts: %w", err)
 		}
+	}
+
+	if err := s.persistCustomDomainsOnCreate(ctx, sandbox.ID, req.CustomDomains); err != nil {
+		// Same rollback chain as a mount-persist failure. ErrCustomDomainConflict
+		// flows through unchanged so the API layer can map it to 409.
+		_ = s.store.Delete(ctx, sandbox.ID)
+		_ = s.caddy.DeleteSandboxRoute(ctx, sandbox.ID)
+		_ = s.docker.Destroy(ctx, sandbox)
+		cleanupMounts()
+		releaseAdmission()
+		return nil, err
 	}
 
 	s.logger.Info("audit sandbox created",
@@ -1032,7 +1063,7 @@ func (s *Service) StartSandbox(ctx context.Context, id string) (*models.Sandbox,
 		}
 	}
 
-	if err := s.caddy.UpsertSandboxRoute(ctx, sandbox.ID, sandbox.ContainerIP, s.cfg.ToolboxPort); err != nil {
+	if err := s.caddy.UpsertSandboxRoute(ctx, sandbox.ID, sandbox.ContainerIP, s.cfg.ToolboxPort, sandboxCustomHostnames(sandbox)); err != nil {
 		return nil, err
 	}
 	for _, port := range sandbox.ExposedPorts {
@@ -1458,6 +1489,15 @@ func (s *Service) exposePort(ctx context.Context, id string, port int, protocol 
 	canonicalProto, err := models.ValidExposedPortProtocol(protocol)
 	if err != nil {
 		return models.ExposePortResponse{}, err
+	}
+	// IRON RULE (plans/custom-domains.md): a sandbox with custom domains
+	// cannot also publish protocol=tcp/tls exposures. The L4 listener is
+	// SNI/port-routed only, with no way to honor a host-based match — a
+	// shared :443 listener would steer custom-domain traffic to the wrong
+	// container. Reject at the entry point rather than letting the L4 path
+	// install a half-broken route.
+	if (canonicalProto == models.ExposedPortProtocolTCP || canonicalProto == models.ExposedPortProtocolTLS) && hasCustomDomains(sandbox) {
+		return models.ExposePortResponse{}, ErrCustomDomainProtocolConflict
 	}
 
 	now := time.Now().UTC()
@@ -2463,7 +2503,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 				overOut := sandbox.NetworkBytesOutLimit > 0 && sandbox.NetworkBytesOut >= sandbox.NetworkBytesOutLimit
 				s.applyNetworkQuotaState(ctx, sandbox, overIn, overOut)
 			}
-			if err := s.caddy.UpsertSandboxRoute(ctx, sandbox.ID, sandbox.ContainerIP, s.cfg.ToolboxPort); err != nil {
+			if err := s.caddy.UpsertSandboxRoute(ctx, sandbox.ID, sandbox.ContainerIP, s.cfg.ToolboxPort, sandboxCustomHostnames(sandbox)); err != nil {
 				return err
 			}
 			for _, port := range sandbox.ExposedPorts {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -2954,6 +2954,16 @@ func (s *Service) addClusterIngressExpectedRoutes(expectedHTTP, expectedTCPServe
 		}
 		if s.cfg.Domain != "" {
 			expectedTLSRoutes[caddy.IngressSandboxSNIRouteID(p.SandboxID)] = struct{}{}
+			// Per-custom-hostname SNI passthrough routes are installed by
+			// ingress_delta for every entry in p.CustomHostnames. Without
+			// them in the GC keep-set the zombie sweep (which collects all
+			// `sandbox-*` TLS @ids) would strip them on every reconcile
+			// pass and ingress_delta would re-install them on the next
+			// tick — visible as route flapping and a churn-storm of Caddy
+			// PATCHes.
+			for _, hostname := range p.CustomHostnames {
+				expectedTLSRoutes[caddy.IngressCustomDomainSNIRouteID(p.SandboxID, hostname)] = struct{}{}
+			}
 		} else {
 			expectedHTTP["sandbox-"+p.SandboxID] = struct{}{}
 		}

--- a/internal/service/testfixtures/caddyfx/config.json.tmpl
+++ b/internal/service/testfixtures/caddyfx/config.json.tmpl
@@ -1,0 +1,41 @@
+{
+  "admin": {"listen": "0.0.0.0:2019"},
+  "storage": {
+    "module": "s3",
+    "host": "{{.S3Endpoint}}",
+    "bucket": "{{.S3Bucket}}",
+    "access_id": "{{.AKID}}",
+    "secret_key": "{{.Secret}}",
+    "prefix": "caddy",
+    "insecure": true,
+    "use_iam_provider": false
+  },
+  "apps": {
+    "http": {
+      "servers": {
+        "srv0": {
+          "listen": [":443"],
+          "routes": [
+            {
+              "handle": [
+                {
+                  "handler": "reverse_proxy",
+                  "upstreams": [{"dial": "{{.UpstreamAddr}}"}]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "tls": {
+      "automation": {
+        "policies": [],
+        "on_demand": {
+          "rate_limit": {"interval": "5s", "burst": 5},
+          "ask": "http://placeholder/internal/tls-ask"
+        }
+      }
+    }
+  }
+}

--- a/internal/service/testfixtures/caddyfx/xcaddy.go
+++ b/internal/service/testfixtures/caddyfx/xcaddy.go
@@ -1,0 +1,93 @@
+//go:build e2e
+
+// Package caddyfx is the test-side helper that builds a Caddy binary with the
+// certmagic-s3 storage plugin (required to exercise the shared-storage cert
+// reuse guarantee) and renders the boot JSON the e2e test feeds to it.
+//
+// We rebuild xcaddy lazily into $TMPDIR/aerolvm-e2e-caddy/caddy and reuse
+// the binary across runs: the first invocation pays the ~30s build cost,
+// every subsequent invocation reuses the cached artifact.
+package caddyfx
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"text/template"
+)
+
+// certmagicS3Module is the storage plugin we link into Caddy. ss098's fork
+// is the path Caddy's official JSON-config docs link to; the JSON shape
+// (host/bucket/access_id/secret_key/prefix/insecure) is fixed here too.
+const certmagicS3Module = "github.com/ss098/certmagic-s3"
+
+//go:embed config.json.tmpl
+var configTmpl string
+
+// Config is the template input for the embedded Caddy JSON.
+type Config struct {
+	S3Endpoint   string // e.g. "localstack:4566"
+	S3Bucket     string
+	AKID, Secret string
+	UpstreamAddr string // e.g. "127.0.0.1:8080" — the in-test backend
+}
+
+// Render expands the embedded template with cfg. Returned bytes are the JSON
+// body to load via POST /load on Caddy's admin API.
+func Render(t testing.TB, cfg Config) []byte {
+	t.Helper()
+	tmpl, err := template.New("caddy").Parse(configTmpl)
+	if err != nil {
+		t.Fatalf("caddyfx: parse template: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, cfg); err != nil {
+		t.Fatalf("caddyfx: execute template: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// Build returns a path to a Caddy binary linked with certmagic-s3. The binary
+// is cached in $TMPDIR/aerolvm-e2e-caddy/caddy and only rebuilt on absence.
+// xcaddy itself is fetched via `go run` so no global install is required.
+// On any toolchain / network failure the test is skipped — this is an
+// operator-runnable path, not a CI gate.
+func Build(t testing.TB) string {
+	t.Helper()
+	cacheDir := filepath.Join(os.TempDir(), "aerolvm-e2e-caddy")
+	binPath := filepath.Join(cacheDir, "caddy")
+	if _, err := os.Stat(binPath); err == nil {
+		return binPath
+	}
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("caddyfx: mkdir cache: %v", err)
+	}
+	args := []string{
+		"run", "github.com/caddyserver/xcaddy/cmd/xcaddy@latest",
+		"build",
+		"--output", binPath,
+		"--with", certmagicS3Module,
+	}
+	cmd := exec.Command("go", args...)
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	cmd.Dir = cacheDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Skipf("caddyfx: xcaddy build failed (%v); needs Go toolchain + network\n%s", err, out)
+	}
+	if _, err := os.Stat(binPath); err != nil {
+		t.Skipf("caddyfx: xcaddy produced no binary at %s: %v\n%s", binPath, err, out)
+	}
+	return binPath
+}
+
+// HostMount returns a docker bind spec (`hostPath:containerPath:ro`) that
+// mounts the built Caddy binary into a busybox/alpine container at /usr/bin/caddy.
+// The container's CMD is set to `/usr/bin/caddy run --resume`.
+func HostMount(binPath string) string {
+	return fmt.Sprintf("%s:/usr/bin/caddy:ro", binPath)
+}

--- a/internal/service/testfixtures/dockerfx/dockerfx.go
+++ b/internal/service/testfixtures/dockerfx/dockerfx.go
@@ -1,0 +1,342 @@
+//go:build e2e
+
+// Package dockerfx is a tiny Docker container fixture for end-to-end tests.
+// It speaks the Docker daemon HTTP API directly over the Unix socket — same
+// transport pattern as pkg/docker/client.go — so the e2e build tag does not
+// pull in any new module dependency. The fixture is intentionally limited
+// to what custom_domains_e2e_test.go needs: pull-if-missing, create with
+// env / port bindings / network, start, wait for ready, log tail, stop+rm.
+package dockerfx
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	defaultSocketPath = "/var/run/docker.sock"
+	readyBudget       = 30 * time.Second
+	readyTick         = 200 * time.Millisecond
+	stopTimeoutSecs   = 5
+)
+
+// Spec is the minimal container shape the fixture supports.
+type Spec struct {
+	Image       string
+	Name        string   // optional; auto-generated when empty
+	Env         []string // "KEY=value"
+	Cmd         []string // overrides image CMD
+	ExposePorts []string // "443/tcp"; mapped to ephemeral host ports
+	HostBinds   []string // "hostPath:containerPath[:ro]"
+	ExtraHosts  []string // "host.docker.internal:host-gateway"
+	Network     string   // user-defined bridge to attach to
+	ReadyProbe  func(*Container) error
+}
+
+// Container is a started container with its inspected runtime details.
+type Container struct {
+	ID    string
+	Name  string
+	IP    string            // IP on the user-defined network (empty if Network unset)
+	Ports map[string]string // "container/tcp" -> "host" (e.g. "443/tcp" -> "32891")
+
+	client *Client
+}
+
+// Client is a lightweight Docker daemon client. Tests get one via Require.
+type Client struct {
+	socketPath string
+	http       *http.Client
+}
+
+// Require returns a Docker client or t.Skip's if the daemon is unreachable.
+// The fixture is opt-in: no test should ever hard-require Docker on every
+// developer machine — that's what the e2e build tag is for.
+func Require(t testing.TB) *Client {
+	t.Helper()
+	socket := defaultSocketPath
+	if v := strings.TrimPrefix(strings.TrimSpace(os.Getenv("DOCKER_HOST")), "unix://"); v != "" {
+		socket = v
+	}
+	if _, err := os.Stat(socket); err != nil {
+		t.Skipf("dockerfx: socket %s unreachable (%v) — start Docker or see setup/multi-node-cert-sharing.md", socket, err)
+	}
+	c := &Client{
+		socketPath: socket,
+		http: &http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+					return (&net.Dialer{}).DialContext(ctx, "unix", socket)
+				},
+			},
+		},
+	}
+	if _, err := c.do(context.Background(), http.MethodGet, "/info", nil, nil); err != nil {
+		t.Skipf("dockerfx: GET /info failed (%v) — Docker daemon not responding", err)
+	}
+	return c
+}
+
+// EnsureNetwork creates a user-defined bridge if it doesn't already exist.
+// Idempotent — repeated calls within or across tests are safe.
+func (c *Client) EnsureNetwork(t testing.TB, name string) {
+	t.Helper()
+	if _, err := c.do(context.Background(), http.MethodGet, "/networks/"+url.PathEscape(name), nil, nil); err == nil {
+		return
+	}
+	body := map[string]any{
+		"Name":           name,
+		"Driver":         "bridge",
+		"CheckDuplicate": true,
+	}
+	if _, err := c.do(context.Background(), http.MethodPost, "/networks/create", body, nil); err != nil {
+		t.Fatalf("dockerfx: create network %s: %v", name, err)
+	}
+}
+
+// Start pulls the image if missing, creates the container, starts it, and
+// blocks until the ReadyProbe passes (30s budget). Registers a t.Cleanup
+// that stops and removes the container regardless of test outcome.
+func (c *Client) Start(t testing.TB, s Spec) *Container {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	if err := c.ensureImage(ctx, s.Image); err != nil {
+		t.Fatalf("dockerfx: pull %s: %v", s.Image, err)
+	}
+
+	portBindings := map[string][]map[string]string{}
+	exposedPorts := map[string]struct{}{}
+	for _, p := range s.ExposePorts {
+		portBindings[p] = []map[string]string{{"HostIP": "127.0.0.1", "HostPort": ""}}
+		exposedPorts[p] = struct{}{}
+	}
+	body := map[string]any{
+		"Image":        s.Image,
+		"Env":          s.Env,
+		"ExposedPorts": exposedPorts,
+		"HostConfig": map[string]any{
+			"PortBindings": portBindings,
+			"Binds":        s.HostBinds,
+			"ExtraHosts":   s.ExtraHosts,
+			"NetworkMode":  s.Network,
+			"AutoRemove":   false,
+		},
+	}
+	if len(s.Cmd) > 0 {
+		body["Cmd"] = s.Cmd
+	}
+	if s.Network != "" {
+		body["NetworkingConfig"] = map[string]any{
+			"EndpointsConfig": map[string]any{s.Network: map[string]any{}},
+		}
+	}
+
+	q := url.Values{}
+	if s.Name != "" {
+		q.Set("name", s.Name)
+	}
+	var created struct {
+		ID string `json:"Id"`
+	}
+	if _, err := c.do(ctx, http.MethodPost, "/containers/create?"+q.Encode(), body, &created); err != nil {
+		t.Fatalf("dockerfx: create %s: %v", s.Image, err)
+	}
+	cont := &Container{ID: created.ID, Name: s.Name, client: c}
+	t.Cleanup(func() { c.stopAndRemove(cont.ID) })
+
+	if _, err := c.do(ctx, http.MethodPost, "/containers/"+cont.ID+"/start", nil, nil); err != nil {
+		t.Fatalf("dockerfx: start %s: %v", cont.ID[:12], err)
+	}
+	if err := c.inspect(ctx, cont, s.Network); err != nil {
+		t.Fatalf("dockerfx: inspect %s: %v", cont.ID[:12], err)
+	}
+
+	if s.ReadyProbe != nil {
+		deadline := time.Now().Add(readyBudget)
+		var lastErr error
+		for time.Now().Before(deadline) {
+			if err := s.ReadyProbe(cont); err == nil {
+				return cont
+			} else {
+				lastErr = err
+			}
+			time.Sleep(readyTick)
+		}
+		tail := cont.LogTail(200)
+		t.Fatalf("dockerfx: %s not ready after %s: %v\nlast logs:\n%s", s.Image, readyBudget, lastErr, tail)
+	}
+	return cont
+}
+
+// HostPort returns the host-side port for a container port spec like "443/tcp".
+// Returns "" if the container isn't binding that port.
+func (c *Container) HostPort(containerPort string) string { return c.Ports[containerPort] }
+
+// LogTail returns the last n bytes of combined stdout+stderr from the container.
+// Used in t.Fatal diagnostics — never on the happy path.
+func (c *Container) LogTail(n int) string {
+	q := url.Values{}
+	q.Set("stdout", "1")
+	q.Set("stderr", "1")
+	q.Set("tail", fmt.Sprintf("%d", n))
+	resp, err := c.client.http.Get("http://docker/containers/" + c.ID + "/logs?" + q.Encode())
+	if err != nil {
+		return fmt.Sprintf("<log fetch failed: %v>", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	return demuxDockerLog(raw)
+}
+
+// LogContains returns the count of occurrences of needle in the container's
+// combined stdout+stderr. Used to assert ACME issuance counts from Pebble.
+func (c *Container) LogContains(needle string) int {
+	body := c.LogTail(100000)
+	return strings.Count(body, needle)
+}
+
+// Stop sends SIGTERM with a 5s timeout, then forces removal.
+func (c *Container) Stop() {
+	if c == nil || c.ID == "" {
+		return
+	}
+	c.client.stopAndRemove(c.ID)
+	c.ID = ""
+}
+
+// --- internals -------------------------------------------------------------
+
+func (c *Client) ensureImage(ctx context.Context, image string) error {
+	q := url.Values{}
+	q.Set("fromImage", image)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://docker/images/create?"+q.Encode(), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	// Docker streams progress JSON; we just drain it and check status.
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		return err
+	}
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("pull returned %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func (c *Client) inspect(ctx context.Context, cont *Container, network string) error {
+	var out struct {
+		NetworkSettings struct {
+			Ports    map[string][]struct{ HostPort string }
+			Networks map[string]struct{ IPAddress string }
+		}
+	}
+	if _, err := c.do(ctx, http.MethodGet, "/containers/"+cont.ID+"/json", nil, &out); err != nil {
+		return err
+	}
+	cont.Ports = map[string]string{}
+	for containerPort, bindings := range out.NetworkSettings.Ports {
+		if len(bindings) > 0 {
+			cont.Ports[containerPort] = bindings[0].HostPort
+		}
+	}
+	if network != "" {
+		if ep, ok := out.NetworkSettings.Networks[network]; ok {
+			cont.IP = ep.IPAddress
+		}
+	}
+	return nil
+}
+
+func (c *Client) stopAndRemove(id string) {
+	if id == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	_, _ = c.do(ctx, http.MethodPost, fmt.Sprintf("/containers/%s/stop?t=%d", id, stopTimeoutSecs), nil, nil)
+	_, _ = c.do(ctx, http.MethodDelete, "/containers/"+id+"?force=1&v=1", nil, nil)
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body, out any) ([]byte, error) {
+	var reqBody io.Reader
+	if body != nil {
+		buf, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		reqBody = strings.NewReader(string(buf))
+	}
+	req, err := http.NewRequestWithContext(ctx, method, "http://docker"+path, reqBody)
+	if err != nil {
+		return nil, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return raw, fmt.Errorf("%s %s: %d %s", method, path, resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	if out != nil && len(raw) > 0 {
+		if err := json.Unmarshal(raw, out); err != nil {
+			return raw, fmt.Errorf("decode response: %w (body=%s)", err, raw)
+		}
+	}
+	return raw, nil
+}
+
+// demuxDockerLog strips Docker's 8-byte stream framing header. Each frame:
+//
+//	[stream(1) | reserved(3) | size(4 BE) | payload(size)]
+//
+// stream=1 → stdout, 2 → stderr. We merge both into one string in arrival
+// order — sufficient for the grep-for-"Signing certificate" assertions.
+// If the bytes don't look framed (TTY mode), return them as-is.
+func demuxDockerLog(raw []byte) string {
+	if len(raw) < 8 {
+		return string(raw)
+	}
+	// Heuristic: in framed mode, byte 0 is 0/1/2 and bytes 1-3 are zero.
+	if raw[0] > 2 || raw[1] != 0 || raw[2] != 0 || raw[3] != 0 {
+		return string(raw)
+	}
+	var sb strings.Builder
+	for i := 0; i+8 <= len(raw); {
+		size := int(binary.BigEndian.Uint32(raw[i+4 : i+8]))
+		end := i + 8 + size
+		if end > len(raw) {
+			break
+		}
+		sb.Write(raw[i+8 : end])
+		i = end
+	}
+	return sb.String()
+}
+
+// ErrNotReady is the canonical error a ReadyProbe should return while waiting.
+// Distinguishing it from an unexpected error helps with logging.
+var ErrNotReady = errors.New("not ready")

--- a/internal/store/custom_domains_test.go
+++ b/internal/store/custom_domains_test.go
@@ -1,0 +1,328 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func TestAddCustomDomain(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("first add succeeds and surfaces row", func(t *testing.T) {
+		st := newTestStore(t)
+		if err := st.Create(ctx, sampleSandbox("sb-a")); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
+			t.Fatalf("AddCustomDomain: %v", err)
+		}
+		got, err := st.ListCustomDomains(ctx, "sb-a")
+		if err != nil {
+			t.Fatalf("ListCustomDomains: %v", err)
+		}
+		if len(got) != 1 || got[0].Hostname != "api.acme.com" {
+			t.Fatalf("got %+v", got)
+		}
+		if got[0].Status != models.CustomDomainPendingDNS {
+			t.Fatalf("status = %q, want %q", got[0].Status, models.CustomDomainPendingDNS)
+		}
+		if got[0].CreatedAt.IsZero() || got[0].UpdatedAt.IsZero() {
+			t.Fatalf("timestamps not set: %+v", got[0])
+		}
+	})
+
+	t.Run("idempotent for same (sandbox, hostname)", func(t *testing.T) {
+		st := newTestStore(t)
+		if err := st.Create(ctx, sampleSandbox("sb-a")); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
+			t.Fatalf("first add: %v", err)
+		}
+		// Mutate status so we can prove the second add does not reset it.
+		if err := st.SetCustomDomainStatus(ctx, "api.acme.com", models.CustomDomainReady, ""); err != nil {
+			t.Fatalf("SetCustomDomainStatus: %v", err)
+		}
+		if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
+			t.Fatalf("idempotent re-add: %v", err)
+		}
+		got, _ := st.ListCustomDomains(ctx, "sb-a")
+		if len(got) != 1 || got[0].Status != models.CustomDomainReady {
+			t.Fatalf("re-add reset status: %+v", got)
+		}
+	})
+
+	t.Run("cross-sandbox conflict surfaces ErrCustomDomainConflict", func(t *testing.T) {
+		st := newTestStore(t)
+		if err := st.Create(ctx, sampleSandbox("sb-a")); err != nil {
+			t.Fatalf("Create sb-a: %v", err)
+		}
+		if err := st.Create(ctx, sampleSandbox("sb-b")); err != nil {
+			t.Fatalf("Create sb-b: %v", err)
+		}
+		if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
+			t.Fatalf("first add: %v", err)
+		}
+		err := st.AddCustomDomain(ctx, "sb-b", "api.acme.com")
+		if !errors.Is(err, ErrCustomDomainConflict) {
+			t.Fatalf("got %v, want ErrCustomDomainConflict", err)
+		}
+		// sb-a still owns the hostname.
+		owner, err := st.ResolveCustomDomain(ctx, "api.acme.com")
+		if err != nil {
+			t.Fatalf("ResolveCustomDomain: %v", err)
+		}
+		if owner != "sb-a" {
+			t.Fatalf("owner = %q, want sb-a", owner)
+		}
+	})
+
+	t.Run("rejects empty inputs", func(t *testing.T) {
+		st := newTestStore(t)
+		if err := st.AddCustomDomain(ctx, "", "api.acme.com"); err == nil {
+			t.Fatalf("empty sandbox id accepted")
+		}
+		if err := st.AddCustomDomain(ctx, "sb-a", ""); err == nil {
+			t.Fatalf("empty hostname accepted")
+		}
+	})
+}
+
+func TestRemoveCustomDomain(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("known hostname removed", func(t *testing.T) {
+		st := newTestStore(t)
+		if err := st.Create(ctx, sampleSandbox("sb-a")); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
+			t.Fatalf("AddCustomDomain: %v", err)
+		}
+		if err := st.RemoveCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
+			t.Fatalf("RemoveCustomDomain: %v", err)
+		}
+		if _, err := st.ResolveCustomDomain(ctx, "api.acme.com"); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("post-remove resolve = %v, want ErrNotFound", err)
+		}
+	})
+
+	t.Run("mismatched sandbox returns ErrNotFound and leaves row intact", func(t *testing.T) {
+		st := newTestStore(t)
+		if err := st.Create(ctx, sampleSandbox("sb-a")); err != nil {
+			t.Fatalf("Create sb-a: %v", err)
+		}
+		if err := st.Create(ctx, sampleSandbox("sb-b")); err != nil {
+			t.Fatalf("Create sb-b: %v", err)
+		}
+		if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
+			t.Fatalf("AddCustomDomain: %v", err)
+		}
+		err := st.RemoveCustomDomain(ctx, "sb-b", "api.acme.com")
+		if !errors.Is(err, ErrNotFound) {
+			t.Fatalf("got %v, want ErrNotFound", err)
+		}
+		owner, _ := st.ResolveCustomDomain(ctx, "api.acme.com")
+		if owner != "sb-a" {
+			t.Fatalf("owner = %q, want sb-a — cross-sandbox delete bled through", owner)
+		}
+	})
+
+	t.Run("unknown hostname returns ErrNotFound", func(t *testing.T) {
+		st := newTestStore(t)
+		if err := st.Create(ctx, sampleSandbox("sb-a")); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		err := st.RemoveCustomDomain(ctx, "sb-a", "ghost.example.com")
+		if !errors.Is(err, ErrNotFound) {
+			t.Fatalf("got %v, want ErrNotFound", err)
+		}
+	})
+}
+
+func TestResolveCustomDomain(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	if err := st.Create(ctx, sampleSandbox("sb-a")); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
+		t.Fatalf("AddCustomDomain: %v", err)
+	}
+
+	got, err := st.ResolveCustomDomain(ctx, "api.acme.com")
+	if err != nil {
+		t.Fatalf("ResolveCustomDomain: %v", err)
+	}
+	if got != "sb-a" {
+		t.Fatalf("got %q, want sb-a", got)
+	}
+
+	if _, err := st.ResolveCustomDomain(ctx, "unknown.example.com"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("unknown host = %v, want ErrNotFound", err)
+	}
+	if _, err := st.ResolveCustomDomain(ctx, ""); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("empty host = %v, want ErrNotFound", err)
+	}
+}
+
+func TestCustomDomainsCascadeOnSandboxDelete(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	if err := st.Create(ctx, sampleSandbox("sb-a")); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	for _, h := range []string{"api.acme.com", "acme.com"} {
+		if err := st.AddCustomDomain(ctx, "sb-a", h); err != nil {
+			t.Fatalf("AddCustomDomain %s: %v", h, err)
+		}
+	}
+	// Delete the sandbox; FK CASCADE must remove both rows.
+	if err := st.Delete(ctx, "sb-a"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	rows, err := st.ListAllCustomDomains(ctx)
+	if err != nil {
+		t.Fatalf("ListAllCustomDomains: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("got %d rows after cascade, want 0: %+v", len(rows), rows)
+	}
+}
+
+func TestSetCustomDomainStatus(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	if err := st.Create(ctx, sampleSandbox("sb-a")); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
+		t.Fatalf("AddCustomDomain: %v", err)
+	}
+
+	before, _ := st.ListCustomDomains(ctx, "sb-a")
+	// SQLite stores DATETIME at second resolution; sleep just long enough to
+	// guarantee the next write differs and we can prove updated_at moved.
+	time.Sleep(1100 * time.Millisecond)
+
+	if err := st.SetCustomDomainStatus(ctx, "api.acme.com", models.CustomDomainIssuing, ""); err != nil {
+		t.Fatalf("SetCustomDomainStatus: %v", err)
+	}
+	after, _ := st.ListCustomDomains(ctx, "sb-a")
+	if after[0].Status != models.CustomDomainIssuing {
+		t.Fatalf("status = %q, want %q", after[0].Status, models.CustomDomainIssuing)
+	}
+	if !after[0].UpdatedAt.After(before[0].UpdatedAt) {
+		t.Fatalf("updated_at did not advance: before=%v after=%v", before[0].UpdatedAt, after[0].UpdatedAt)
+	}
+
+	// Failed → carries LastError through.
+	if err := st.SetCustomDomainStatus(ctx, "api.acme.com", models.CustomDomainFailed, "acme: rate limit"); err != nil {
+		t.Fatalf("SetCustomDomainStatus failed: %v", err)
+	}
+	got, _ := st.ListCustomDomains(ctx, "sb-a")
+	if got[0].Status != models.CustomDomainFailed || got[0].LastError != "acme: rate limit" {
+		t.Fatalf("got %+v, want failed/rate limit", got[0])
+	}
+
+	// Unknown hostname → ErrNotFound.
+	if err := st.SetCustomDomainStatus(ctx, "ghost.example.com", models.CustomDomainReady, ""); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("unknown host = %v, want ErrNotFound", err)
+	}
+}
+
+func TestListAllCustomDomainsGroupsBySandbox(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+
+	for _, id := range []string{"sb-a", "sb-b", "sb-c"} {
+		if err := st.Create(ctx, sampleSandbox(id)); err != nil {
+			t.Fatalf("Create %s: %v", id, err)
+		}
+	}
+	domains := map[string][]string{
+		"sb-a": {"api.acme.com", "acme.com"},
+		"sb-b": {"foo.example.com"},
+		"sb-c": nil, // no custom domains
+	}
+	for sb, hosts := range domains {
+		for _, h := range hosts {
+			if err := st.AddCustomDomain(ctx, sb, h); err != nil {
+				t.Fatalf("AddCustomDomain %s %s: %v", sb, h, err)
+			}
+		}
+	}
+
+	rows, err := st.ListAllCustomDomains(ctx)
+	if err != nil {
+		t.Fatalf("ListAllCustomDomains: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("got %d rows, want 3: %+v", len(rows), rows)
+	}
+	// Reconcile expects hostname-ordered output for stable diffs.
+	want := []string{"acme.com", "api.acme.com", "foo.example.com"}
+	for i, r := range rows {
+		if r.Hostname != want[i] {
+			t.Fatalf("rows[%d].Hostname = %q, want %q", i, r.Hostname, want[i])
+		}
+	}
+}
+
+func TestAttachCustomDomainsBulkInList(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	for _, id := range []string{"sb-a", "sb-b"} {
+		if err := st.Create(ctx, sampleSandbox(id)); err != nil {
+			t.Fatalf("Create %s: %v", id, err)
+		}
+	}
+	if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
+		t.Fatalf("AddCustomDomain a: %v", err)
+	}
+	if err := st.AddCustomDomain(ctx, "sb-a", "acme.com"); err != nil {
+		t.Fatalf("AddCustomDomain a2: %v", err)
+	}
+	if err := st.AddCustomDomain(ctx, "sb-b", "foo.example.com"); err != nil {
+		t.Fatalf("AddCustomDomain b: %v", err)
+	}
+
+	sandboxes, err := st.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	bySandbox := map[string][]string{}
+	for _, sb := range sandboxes {
+		for _, cd := range sb.CustomDomains {
+			bySandbox[sb.ID] = append(bySandbox[sb.ID], cd.Hostname)
+		}
+	}
+	if len(bySandbox["sb-a"]) != 2 {
+		t.Fatalf("sb-a got %v, want 2 hostnames", bySandbox["sb-a"])
+	}
+	if len(bySandbox["sb-b"]) != 1 || bySandbox["sb-b"][0] != "foo.example.com" {
+		t.Fatalf("sb-b got %v, want [foo.example.com]", bySandbox["sb-b"])
+	}
+}
+
+func TestGetIncludesCustomDomains(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	if err := st.Create(ctx, sampleSandbox("sb-a")); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
+		t.Fatalf("AddCustomDomain: %v", err)
+	}
+	got, err := st.Get(ctx, "sb-a")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(got.CustomDomains) != 1 || got.CustomDomains[0].Hostname != "api.acme.com" {
+		t.Fatalf("Get did not hydrate CustomDomains: %+v", got.CustomDomains)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -111,6 +111,23 @@ func Open(path string) (*Store, error) {
 			created_at DATETIME NOT NULL,
 			FOREIGN KEY (sandbox_id) REFERENCES sandboxes(id) ON DELETE CASCADE
 		);`,
+		// sandbox_custom_domains attaches operator-provided public hostnames
+		// to a sandbox. hostname is the PRIMARY KEY: a hostname maps to
+		// exactly one sandbox at a time, and the PK rejects concurrent
+		// inserts the same way the host_port partial unique index does for
+		// the L4 TCP pool. status is the per-domain lifecycle state
+		// (pending_dns → issuing → ready / failed) surfaced through the API;
+		// last_error carries the surfaced reason on failed. FK CASCADE so
+		// destroying the sandbox releases every hostname in the same write.
+		`CREATE TABLE IF NOT EXISTS sandbox_custom_domains (
+			hostname TEXT PRIMARY KEY,
+			sandbox_id TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'pending_dns',
+			last_error TEXT NOT NULL DEFAULT '',
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			FOREIGN KEY (sandbox_id) REFERENCES sandboxes(id) ON DELETE CASCADE
+		);`,
 		// cluster_secrets is the local secret-reference backend used by
 		// cluster placement state. Placement rows store only ref/version; this
 		// table stores the opaque encrypted payload and recipient metadata.
@@ -208,6 +225,10 @@ func Open(path string) (*Store, error) {
 		`CREATE INDEX IF NOT EXISTS idx_snapshot_aliases_facade ON snapshot_aliases(facade);`,
 		`CREATE INDEX IF NOT EXISTS idx_request_idempotency_replay_until ON request_idempotency(replay_until);`,
 		`CREATE INDEX IF NOT EXISTS idx_sandbox_snapshots_source_sandbox_id ON sandbox_snapshots(source_sandbox_id);`,
+		// Lookups by sandbox_id for ListCustomDomains and for the
+		// attachCustomDomainsBulk join. The PK on hostname already covers
+		// the ResolveCustomDomain hot path.
+		`CREATE INDEX IF NOT EXISTS idx_sandbox_custom_domains_sandbox_id ON sandbox_custom_domains(sandbox_id);`,
 	}
 
 	for _, stmt := range stmts {
@@ -613,6 +634,12 @@ func (s *Store) Get(ctx context.Context, id string) (*models.Sandbox, error) {
 	}
 	sandbox.ExposedPorts = ports
 
+	customDomains, err := s.loadCustomDomains(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	sandbox.CustomDomains = customDomains
+
 	return sandbox, nil
 }
 
@@ -658,6 +685,9 @@ func (s *Store) List(ctx context.Context) ([]*models.Sandbox, error) {
 	// a fast no-op because we skip the query entirely.
 	if len(sandboxes) > 0 {
 		if err := s.attachPortsBulk(ctx, byID); err != nil {
+			return nil, err
+		}
+		if err := s.attachCustomDomainsBulk(ctx, byID); err != nil {
 			return nil, err
 		}
 	}
@@ -1737,6 +1767,238 @@ func (s *Store) DeletePort(ctx context.Context, sandboxID string, port int) erro
 	_, err := s.db.ExecContext(ctx, `DELETE FROM exposed_ports WHERE sandbox_id = ? AND port = ?`, sandboxID, port)
 	if err != nil {
 		return fmt.Errorf("delete exposed port: %w", err)
+	}
+	return nil
+}
+
+// ErrCustomDomainConflict is returned by AddCustomDomain when the hostname
+// is already owned by a different sandbox. Surfaced through the API as 409.
+// Same hostname for the same sandbox is idempotent (not a conflict) — that
+// lets retries and reconcile re-converge without surfacing spurious errors.
+var ErrCustomDomainConflict = errors.New("custom domain hostname already taken")
+
+// CustomDomainRow is the per-row representation read out of
+// sandbox_custom_domains. ListAllCustomDomains returns these so the
+// reconcile loop and the cluster FSM hydration can walk the full set.
+type CustomDomainRow struct {
+	Hostname  string
+	SandboxID string
+	Status    models.CustomDomainStatus
+	LastError string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// AddCustomDomain inserts a hostname → sandbox mapping. Returns
+// ErrCustomDomainConflict when the hostname is already owned by a different
+// sandbox; returns nil when the same (hostname, sandbox) pair already exists
+// (idempotent — the caller may retry safely). New rows start in
+// CustomDomainPendingDNS; existing rows are left in whatever state they hold.
+func (s *Store) AddCustomDomain(ctx context.Context, sandboxID, hostname string) error {
+	if sandboxID == "" {
+		return errors.New("sandbox id is required")
+	}
+	if hostname == "" {
+		return errors.New("hostname is required")
+	}
+	now := time.Now().UTC()
+	// INSERT OR IGNORE collapses the "same pair already exists" case into a
+	// silent no-op so we can disambiguate cross-sandbox conflict from
+	// idempotent re-add with one follow-up SELECT. Same shape as the host_port
+	// reservation path — see TryReserveHostPort for the canonical rationale.
+	res, err := s.db.ExecContext(ctx, `
+		INSERT OR IGNORE INTO sandbox_custom_domains (
+			hostname, sandbox_id, status, last_error, created_at, updated_at
+		) VALUES (?, ?, ?, '', ?, ?)
+	`, hostname, sandboxID, string(models.CustomDomainPendingDNS), now, now)
+	if err != nil {
+		return fmt.Errorf("insert sandbox_custom_domains: %w", err)
+	}
+	rowsAffected, _ := res.RowsAffected()
+	if rowsAffected == 1 {
+		return nil
+	}
+	// IGNORE swallowed a PK conflict. The existing row may belong to the same
+	// sandbox (idempotent re-add) or a different one (true conflict).
+	var owner string
+	if err := s.db.QueryRowContext(ctx, `
+		SELECT sandbox_id FROM sandbox_custom_domains WHERE hostname = ?
+	`, hostname).Scan(&owner); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// Row vanished between INSERT IGNORE and SELECT (cascade delete).
+			// Treat as conflict so the caller does not assume success.
+			return ErrCustomDomainConflict
+		}
+		return fmt.Errorf("disambiguate custom domain insert: %w", err)
+	}
+	if owner == sandboxID {
+		return nil
+	}
+	return ErrCustomDomainConflict
+}
+
+// RemoveCustomDomain deletes the (sandbox, hostname) row. Cross-sandbox
+// removal is rejected — the API gets ErrNotFound rather than silently
+// stealing a hostname from another sandbox.
+func (s *Store) RemoveCustomDomain(ctx context.Context, sandboxID, hostname string) error {
+	if sandboxID == "" || hostname == "" {
+		return ErrNotFound
+	}
+	res, err := s.db.ExecContext(ctx, `
+		DELETE FROM sandbox_custom_domains WHERE hostname = ? AND sandbox_id = ?
+	`, hostname, sandboxID)
+	if err != nil {
+		return fmt.Errorf("delete sandbox_custom_domains: %w", err)
+	}
+	rowsAffected, _ := res.RowsAffected()
+	if rowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ListCustomDomains returns the canonical-ordered rows for one sandbox.
+// Empty slice (nil) when the sandbox has no custom domains.
+func (s *Store) ListCustomDomains(ctx context.Context, sandboxID string) ([]models.CustomDomain, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT hostname, status, last_error, created_at, updated_at
+		FROM sandbox_custom_domains
+		WHERE sandbox_id = ?
+		ORDER BY hostname ASC
+	`, sandboxID)
+	if err != nil {
+		return nil, fmt.Errorf("list custom domains: %w", err)
+	}
+	defer rows.Close()
+
+	var out []models.CustomDomain
+	for rows.Next() {
+		var cd models.CustomDomain
+		var status string
+		if err := rows.Scan(&cd.Hostname, &status, &cd.LastError, &cd.CreatedAt, &cd.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scan custom domain: %w", err)
+		}
+		cd.Status = models.CustomDomainStatus(status)
+		out = append(out, cd)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate custom domains: %w", err)
+	}
+	return out, nil
+}
+
+// ListAllCustomDomains returns every row in the table. Used by the reconcile
+// loop's matcher-GC pass and by the cluster FSM hydration on cold start.
+// Ordered by hostname so reconcile diffs are stable across calls.
+func (s *Store) ListAllCustomDomains(ctx context.Context) ([]CustomDomainRow, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT hostname, sandbox_id, status, last_error, created_at, updated_at
+		FROM sandbox_custom_domains
+		ORDER BY hostname ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list all custom domains: %w", err)
+	}
+	defer rows.Close()
+
+	var out []CustomDomainRow
+	for rows.Next() {
+		var r CustomDomainRow
+		var status string
+		if err := rows.Scan(&r.Hostname, &r.SandboxID, &status, &r.LastError, &r.CreatedAt, &r.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scan custom domain row: %w", err)
+		}
+		r.Status = models.CustomDomainStatus(status)
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate all custom domains: %w", err)
+	}
+	return out, nil
+}
+
+// ResolveCustomDomain is the hot path for the TLSAsk handler — single PK
+// lookup, no scan. Returns ErrNotFound for unknown hostnames so the handler
+// can fold it into a 403 without an error log on the success path.
+func (s *Store) ResolveCustomDomain(ctx context.Context, hostname string) (string, error) {
+	if hostname == "" {
+		return "", ErrNotFound
+	}
+	var sandboxID string
+	err := s.db.QueryRowContext(ctx, `
+		SELECT sandbox_id FROM sandbox_custom_domains WHERE hostname = ?
+	`, hostname).Scan(&sandboxID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", ErrNotFound
+		}
+		return "", fmt.Errorf("resolve custom domain: %w", err)
+	}
+	return sandboxID, nil
+}
+
+// SetCustomDomainStatus updates the per-domain state machine. Idempotent —
+// repeated calls with the same (status, lastError) are still write-once on
+// updated_at, which the caller may use as a heartbeat for "we saw an ask for
+// this host". Returns ErrNotFound when the hostname is unknown so a caller
+// observing an issuance failure for a since-removed host gets a clean signal.
+func (s *Store) SetCustomDomainStatus(ctx context.Context, hostname string, status models.CustomDomainStatus, lastError string) error {
+	if hostname == "" {
+		return ErrNotFound
+	}
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE sandbox_custom_domains
+		SET status = ?, last_error = ?, updated_at = ?
+		WHERE hostname = ?
+	`, string(status), lastError, time.Now().UTC(), hostname)
+	if err != nil {
+		return fmt.Errorf("update custom domain status: %w", err)
+	}
+	rowsAffected, _ := res.RowsAffected()
+	if rowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// loadCustomDomains is the single-sandbox sibling of attachCustomDomainsBulk,
+// called from Get. Mirrors loadPorts's shape so callers can read the two
+// collections side-by-side without thinking about transaction nesting.
+func (s *Store) loadCustomDomains(ctx context.Context, sandboxID string) ([]models.CustomDomain, error) {
+	return s.ListCustomDomains(ctx, sandboxID)
+}
+
+// attachCustomDomainsBulk reads every sandbox_custom_domains row for any
+// sandbox in byID with one query and writes it onto the matching sandbox.
+// Same shape as attachPortsBulk: the table only carries rows for sandboxes
+// that have ever attached a custom domain, so the full-table scan is cheap
+// in practice. Switch to a chunked WHERE sandbox_id IN (...) if the table
+// ever crosses ~100k rows.
+func (s *Store) attachCustomDomainsBulk(ctx context.Context, byID map[string]*models.Sandbox) error {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT sandbox_id, hostname, status, last_error, created_at, updated_at
+		FROM sandbox_custom_domains
+		ORDER BY sandbox_id, hostname ASC
+	`)
+	if err != nil {
+		return fmt.Errorf("load custom domains: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var sandboxID string
+		var cd models.CustomDomain
+		var status string
+		if err := rows.Scan(&sandboxID, &cd.Hostname, &status, &cd.LastError, &cd.CreatedAt, &cd.UpdatedAt); err != nil {
+			return fmt.Errorf("scan custom domain: %w", err)
+		}
+		cd.Status = models.CustomDomainStatus(status)
+		if sb, ok := byID[sandboxID]; ok {
+			sb.CustomDomains = append(sb.CustomDomains, cd)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate custom domains: %w", err)
 	}
 	return nil
 }

--- a/pkg/api/apihttp/apihttp.go
+++ b/pkg/api/apihttp/apihttp.go
@@ -60,6 +60,21 @@ func WriteStoreAwareError(logger *slog.Logger, w http.ResponseWriter, err error)
 		WriteError(w, http.StatusConflict, "snapshot name already in use")
 		return
 	}
+	// Custom-domain sentinels (plans/custom-domains.md). 412 distinguishes
+	// "this deployment can't do custom domains at all" (feature flag off /
+	// IP mode) from "your input is malformed" (400). 409 covers both the
+	// cross-sandbox hostname conflict and the IRON RULE (tcp/tls + custom
+	// domain on the same sandbox) and the per-sandbox cap.
+	if errors.Is(err, models.ErrCustomDomainNotSupported) {
+		WriteError(w, http.StatusPreconditionFailed, err.Error())
+		return
+	}
+	if errors.Is(err, models.ErrCustomDomainProtocolConflict) ||
+		errors.Is(err, models.ErrCustomDomainPerSandboxCap) ||
+		errors.Is(err, store.ErrCustomDomainConflict) {
+		WriteError(w, http.StatusConflict, err.Error())
+		return
+	}
 	// Capacity rejections are 503 with a Retry-After hint so well-behaved
 	// clients (and load balancers) back off instead of treating it as a
 	// permanent 4xx. The error string already carries human-readable

--- a/pkg/api/ingressproxy/metrics.go
+++ b/pkg/api/ingressproxy/metrics.go
@@ -79,6 +79,16 @@ func RecordIssuanceCompleted(hostname string) {
 // expvar map. The expvar map publishes one Func per active hostname
 // that recomputes (now - started).Seconds() at scrape time — the gauge
 // is a snapshot, never a stored value.
+//
+// Bounded growth: RecordIssuanceCompleted is the canonical drain, but it
+// has no production caller yet (status reconciliation against certmagic
+// storage is a follow-up). To keep the gauge map from leaking one entry
+// per unique custom hostname ever observed, Started auto-expires entries
+// older than issuanceMaxAge on each insertion. An entry past the age is
+// strictly stale telemetry — a real ACME flow that took > 10 minutes is
+// already a Prometheus alert on aerolvm_acme_lock_held_seconds.
+const issuanceMaxAge = 10 * time.Minute
+
 type issuanceTracker struct {
 	mu        sync.Mutex
 	startedAt map[string]time.Time
@@ -110,6 +120,7 @@ func (t *issuanceTracker) Started(host string) {
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	t.evictStaleLocked()
 	if _, ok := t.startedAt[host]; ok {
 		return
 	}
@@ -126,6 +137,22 @@ func (t *issuanceTracker) Started(host string) {
 		}
 		return t.now().Sub(started).Seconds()
 	}))
+}
+
+// evictStaleLocked drops entries older than issuanceMaxAge so the gauge
+// map stays bounded even without a hookup from the eventual ready/failed
+// transition. Caller must hold t.mu.
+func (t *issuanceTracker) evictStaleLocked() {
+	if len(t.startedAt) == 0 {
+		return
+	}
+	cutoff := t.now().Add(-issuanceMaxAge)
+	for host, started := range t.startedAt {
+		if started.Before(cutoff) {
+			delete(t.startedAt, host)
+			t.gauge.Delete(host)
+		}
+	}
 }
 
 func (t *issuanceTracker) completed(host string) {

--- a/pkg/api/ingressproxy/metrics.go
+++ b/pkg/api/ingressproxy/metrics.go
@@ -1,0 +1,154 @@
+package ingressproxy
+
+import (
+	"expvar"
+	"sync"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/scaleobs"
+)
+
+// Result labels for aerolvm_ask_requests_total. Bounded set — the
+// expvar map key space cannot grow with traffic, only with code paths.
+const (
+	AskResultOK           = "ok"            // 200 — hostname recognised, Caddy may issue
+	AskResultBaseDomain   = "base_domain"   // 200 — request is under SB_DOMAIN, served by wildcard policy
+	AskResultUnknown      = "unknown"       // 403 — hostname not in FSM/store
+	AskResultBadRequest   = "bad_request"   // 400 — missing/malformed query
+	AskResultResolveError = "resolve_error" // 500 — resolver transient outage
+	AskResultThrottled    = "throttled"     // 429 — daemon ACME budget exhausted
+)
+
+var (
+	// aerolvm_ask_requests_total{result} — TLSAsk hit counter. F4 alert
+	// pivots on the absence of any incoming asks: if the loopback
+	// listener crashes mid-process but sandboxd keeps running, every
+	// new HTTPS connection fails TLS until restart. The counter going
+	// flat while up==1 is the canary.
+	askRequestsTotal = expvar.NewMap("aerolvm_ask_requests_total")
+
+	// aerolvm_acme_lock_acquire_duration_seconds_bucket — histogram of
+	// issuance durations seen from sandboxd's vantage point (Started →
+	// Completed). Bounded by the cert-renew SLO; persistently long
+	// observations indicate either LE backoff or certmagic-s3 lock
+	// contention.
+	acmeLockAcquireSeconds = scaleobs.NewDurationBuckets("aerolvm_acme_lock_acquire_duration_seconds_bucket")
+
+	// defaultIssuanceTracker is process-global. Tests use newIssuanceTracker
+	// directly. We expose Recorder-style helpers so callers don't have to
+	// know the tracker exists.
+	defaultIssuanceTracker = newIssuanceTracker()
+)
+
+// RecordAskResult bumps the per-result counter. Use the AskResult*
+// constants — adding a freeform string would explode the label space.
+func RecordAskResult(result string) {
+	scaleobs.Add(askRequestsTotal, result, 1)
+}
+
+// DefaultIssuanceTracker returns the process-global tracker that
+// publishes the aerolvm_acme_lock_held_seconds gauge. Wire this into
+// TLSAskDeps.Tracker in production. Tests should build a private
+// tracker via newIssuanceTrackerWithGauge so they don't share state.
+func DefaultIssuanceTracker() IssuanceObserver {
+	return defaultIssuanceTracker
+}
+
+// RecordIssuanceStart marks the moment TLSAsk allowed a previously
+// unseen hostname to attempt issuance. Safe to call repeatedly — the
+// first call wins (subsequent are no-ops until Completed/Cancel).
+func RecordIssuanceStart(hostname string) {
+	defaultIssuanceTracker.Started(hostname)
+}
+
+// RecordIssuanceCompleted records the issuance duration into the
+// histogram and clears the held-seconds gauge. Idempotent — calling
+// for an untracked host is a no-op.
+func RecordIssuanceCompleted(hostname string) {
+	defaultIssuanceTracker.completed(hostname)
+}
+
+// issuanceTracker is the backing state for aerolvm_acme_lock_held_seconds.
+// We don't have direct hooks into certmagic-s3 from sandboxd (Caddy runs
+// in a separate process), so the metric is a best-effort observation
+// rooted in the TLSAsk handshake: an OK response to ask is the moment
+// the upstream Caddy may start the ACME flow, and we don't see the lock
+// release until the service layer transitions the row to ready.
+//
+// Concurrency: a single mutex guards both the timestamp map and the
+// expvar map. The expvar map publishes one Func per active hostname
+// that recomputes (now - started).Seconds() at scrape time — the gauge
+// is a snapshot, never a stored value.
+type issuanceTracker struct {
+	mu        sync.Mutex
+	startedAt map[string]time.Time
+	gauge     *expvar.Map
+	now       func() time.Time
+}
+
+func newIssuanceTracker() *issuanceTracker {
+	return newIssuanceTrackerWithGauge(expvar.NewMap("aerolvm_acme_lock_held_seconds"))
+}
+
+// newIssuanceTrackerWithGauge lets tests inject a private expvar.Map so
+// they don't double-register the global name (expvar.NewMap panics on
+// duplicate names — single-registration is intentional for the production
+// path).
+func newIssuanceTrackerWithGauge(gauge *expvar.Map) *issuanceTracker {
+	return &issuanceTracker{
+		startedAt: make(map[string]time.Time),
+		gauge:     gauge,
+		now:       time.Now,
+	}
+}
+
+// Started implements IssuanceObserver — the moment TLSAsk allowed a
+// previously unseen hostname to attempt issuance. Idempotent.
+func (t *issuanceTracker) Started(host string) {
+	if host == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if _, ok := t.startedAt[host]; ok {
+		return
+	}
+	now := t.now()
+	t.startedAt[host] = now
+	// Capture the start in a Func so /debug/vars returns the
+	// up-to-date held duration at scrape time, not a stale value.
+	t.gauge.Set(host, expvar.Func(func() any {
+		t.mu.Lock()
+		started, ok := t.startedAt[host]
+		t.mu.Unlock()
+		if !ok {
+			return 0.0
+		}
+		return t.now().Sub(started).Seconds()
+	}))
+}
+
+func (t *issuanceTracker) completed(host string) {
+	if host == "" {
+		return
+	}
+	t.mu.Lock()
+	started, ok := t.startedAt[host]
+	if ok {
+		delete(t.startedAt, host)
+	}
+	now := t.now()
+	t.mu.Unlock()
+	if !ok {
+		return
+	}
+	t.gauge.Delete(host)
+	acmeLockAcquireSeconds.Observe(now.Sub(started))
+}
+
+// inProgress returns the count of currently-tracked hostnames. Test-only.
+func (t *issuanceTracker) inProgress() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.startedAt)
+}

--- a/pkg/api/ingressproxy/metrics_test.go
+++ b/pkg/api/ingressproxy/metrics_test.go
@@ -1,0 +1,122 @@
+package ingressproxy
+
+import (
+	"expvar"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestIssuanceTrackerLifecycle: Started exposes the hostname as an
+// expvar gauge whose value is the live age; Completed clears the gauge
+// and observes the duration into the histogram. The map must shrink
+// when issuance completes — a leak here turns a long-lived sandboxd
+// into an unbounded gauge collection.
+func TestIssuanceTrackerLifecycle(t *testing.T) {
+	clk := &testClock{now: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	gauge := new(expvar.Map).Init()
+	tr := newIssuanceTrackerWithGauge(gauge)
+	tr.now = clk.Now
+
+	tr.Started("api.acme.com")
+	if tr.inProgress() != 1 {
+		t.Fatalf("inProgress = %d, want 1", tr.inProgress())
+	}
+	clk.advance(45 * time.Second)
+	val := gauge.Get("api.acme.com")
+	if val == nil {
+		t.Fatal("gauge missing entry for api.acme.com")
+	}
+	got := val.(expvar.Func)().(float64)
+	if got < 44 || got > 46 {
+		t.Fatalf("gauge value = %v, want ≈ 45", got)
+	}
+
+	tr.completed("api.acme.com")
+	if tr.inProgress() != 0 {
+		t.Fatalf("inProgress = %d, want 0 after completion", tr.inProgress())
+	}
+	if gauge.Get("api.acme.com") != nil {
+		t.Fatal("gauge still has entry for completed hostname")
+	}
+}
+
+// TestIssuanceTrackerStartedIdempotent: a duplicate Started call for
+// the same host keeps the original start time. Without this the gauge
+// would reset every time Caddy retried an ask, undercounting actual
+// issuance duration.
+func TestIssuanceTrackerStartedIdempotent(t *testing.T) {
+	clk := &testClock{now: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	gauge := new(expvar.Map).Init()
+	tr := newIssuanceTrackerWithGauge(gauge)
+	tr.now = clk.Now
+
+	tr.Started("api.acme.com")
+	clk.advance(30 * time.Second)
+	tr.Started("api.acme.com") // duplicate — must not reset
+	clk.advance(15 * time.Second)
+
+	val := gauge.Get("api.acme.com").(expvar.Func)().(float64)
+	if val < 44 || val > 46 {
+		t.Fatalf("gauge value = %v, want ≈ 45 (start kept original ts)", val)
+	}
+}
+
+// TestIssuanceTrackerCompletedUntracked: completing an unseen host
+// is a no-op. Prevents a stray service-layer call (e.g. status →
+// ready arriving before any ask) from skewing the duration histogram.
+func TestIssuanceTrackerCompletedUntracked(t *testing.T) {
+	gauge := new(expvar.Map).Init()
+	tr := newIssuanceTrackerWithGauge(gauge)
+	tr.completed("never-started.example.com") // must not panic
+	if tr.inProgress() != 0 {
+		t.Fatalf("inProgress = %d, want 0", tr.inProgress())
+	}
+}
+
+// TestRecordAskResultIncrementsExpvar: the package-level counter
+// publishes the result label so /debug/vars surfaces F4 (listener
+// liveness) as a per-result series.
+func TestRecordAskResultIncrementsExpvar(t *testing.T) {
+	before := readCounter(t, askRequestsTotal, AskResultOK)
+	RecordAskResult(AskResultOK)
+	RecordAskResult(AskResultOK)
+	RecordAskResult(AskResultUnknown)
+
+	if got := readCounter(t, askRequestsTotal, AskResultOK) - before; got != 2 {
+		t.Fatalf("ok delta = %d, want 2", got)
+	}
+	if got := readCounter(t, askRequestsTotal, AskResultUnknown); got < 1 {
+		t.Fatalf("unknown counter not incremented")
+	}
+}
+
+func readCounter(t *testing.T, m *expvar.Map, key string) int64 {
+	t.Helper()
+	v := m.Get(key)
+	if v == nil {
+		return 0
+	}
+	if iv, ok := v.(*expvar.Int); ok {
+		return iv.Value()
+	}
+	t.Fatalf("counter %q is not *expvar.Int (got %T)", key, v)
+	return 0
+}
+
+type testClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *testClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *testClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}

--- a/pkg/api/ingressproxy/routes.go
+++ b/pkg/api/ingressproxy/routes.go
@@ -103,6 +103,15 @@ func RegisterRoutes(mux *http.ServeMux, d Deps) {
 	mux.Handle(PathPrefix+"/{id}/{port}/{path...}", http.HandlerFunc(h.httpWake))
 }
 
+// RegisterTLSAsk mounts the on-demand TLS `ask` handler on mux. Called only
+// when SB_ENABLE_CUSTOM_DOMAINS=true. Kept separate from RegisterRoutes so
+// the wake-proxy listener stays usable when custom domains are off (and so
+// the caller controls construction of the TLSAskHandler, which the service
+// layer needs to hold a reference to for negative-cache eviction).
+func RegisterTLSAsk(mux *http.ServeMux, h *TLSAskHandler) {
+	mux.Handle(TLSAskPath, h)
+}
+
 type handlers struct {
 	deps  Deps
 	state *proxyState

--- a/pkg/api/ingressproxy/tls_ask.go
+++ b/pkg/api/ingressproxy/tls_ask.go
@@ -6,12 +6,26 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/aerol-ai/microvm/internal/store"
 )
+
+// ACMEBudgetReserver is the daemon-wide brake on new ACME orders. A nil
+// implementation is fine: the handler treats nil as "no brake" so the
+// hot path stays one-branch when the feature is off. The handler calls
+// Reserve only when the ask would actually allow issuance — base-domain
+// fast-fail and negative-cache hits don't consume budget.
+//
+// Returns (true, 0) to permit, (false, retryAfter) to refuse. The
+// retryAfter is surfaced as the HTTP Retry-After header on the 429
+// response so Caddy backs off coherently with the budget window.
+type ACMEBudgetReserver interface {
+	Reserve(sandboxID, hostname string) (bool, time.Duration)
+}
 
 // TLSAskPath is Caddy's on-demand TLS `ask` callback path. Caddy passes the
 // requested hostname as the `domain` query parameter and decides whether to
@@ -43,6 +57,22 @@ type TLSAskDeps struct {
 	NegCacheTTL time.Duration
 	NegCacheCap int
 	Logger      *slog.Logger
+	// Budget is the daemon-wide ACME issuance brake (OV5A). Nil disables
+	// the brake — single-node deployments and tests that don't care
+	// about LE rate limits pass nil and Reserve is skipped entirely.
+	Budget ACMEBudgetReserver
+	// Tracker observes the issuance lifecycle for the
+	// aerolvm_acme_lock_held_seconds gauge. Nil disables tracking. Wired
+	// to the package-global tracker in production via the helpers in
+	// metrics.go; tests can substitute a stub.
+	Tracker IssuanceObserver
+}
+
+// IssuanceObserver lets the handler signal the issuance lifecycle
+// without depending on the concrete tracker — kept minimal so tests can
+// stub it without dragging in expvar state.
+type IssuanceObserver interface {
+	Started(hostname string)
 }
 
 // TLSAskHandler answers Caddy's on-demand TLS `ask` callback for custom
@@ -80,6 +110,7 @@ func (h *TLSAskHandler) EvictNegativeCache(host string) {
 func (h *TLSAskHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	host := normalizeAskHost(r.URL.Query().Get("domain"))
 	if host == "" {
+		RecordAskResult(AskResultBadRequest)
 		http.Error(w, "missing domain", http.StatusBadRequest)
 		return
 	}
@@ -91,18 +122,41 @@ func (h *TLSAskHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if h.deps.BaseDomain != "" {
 		base := strings.ToLower(h.deps.BaseDomain)
 		if host == base || strings.HasSuffix(host, "."+base) {
+			RecordAskResult(AskResultBaseDomain)
 			w.WriteHeader(http.StatusOK)
 			return
 		}
 	}
 
 	if h.negCache != nil && h.negCache.has(host) {
+		RecordAskResult(AskResultUnknown)
 		http.Error(w, "unknown host", http.StatusForbidden)
 		return
 	}
 
-	_, err := h.deps.Resolver.ResolveCustomDomain(r.Context(), host)
+	sandboxID, err := h.deps.Resolver.ResolveCustomDomain(r.Context(), host)
 	if err == nil {
+		// Daemon-wide ACME budget brake (OV5A). Reserve only after the
+		// hostname is known to be ours so unknown-host floods can't
+		// drain the bucket. A nil budget allows unconditionally.
+		if h.deps.Budget != nil {
+			if ok, retry := h.deps.Budget.Reserve(sandboxID, host); !ok {
+				RecordAskResult(AskResultThrottled)
+				if retry > 0 {
+					// Retry-After in seconds, RFC 7231 §7.1.3. Round
+					// up so a sub-second retry doesn't become "0"
+					// (which Caddy reads as "no backoff").
+					secs := max(int((retry+time.Second-1)/time.Second), 1)
+					w.Header().Set("Retry-After", strconv.Itoa(secs))
+				}
+				http.Error(w, "acme budget exhausted", http.StatusTooManyRequests)
+				return
+			}
+		}
+		if h.deps.Tracker != nil {
+			h.deps.Tracker.Started(host)
+		}
+		RecordAskResult(AskResultOK)
 		w.WriteHeader(http.StatusOK)
 		return
 	}
@@ -110,6 +164,7 @@ func (h *TLSAskHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if h.negCache != nil {
 			h.negCache.add(host)
 		}
+		RecordAskResult(AskResultUnknown)
 		http.Error(w, "unknown host", http.StatusForbidden)
 		return
 	}
@@ -119,6 +174,7 @@ func (h *TLSAskHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Do NOT add to the negative cache: this is a transient backend
 	// failure, not a "host doesn't exist" signal.
 	h.deps.Logger.WarnContext(r.Context(), "tls-ask resolve failed", "host", host, "err", err)
+	RecordAskResult(AskResultResolveError)
 	http.Error(w, "resolve failed", http.StatusInternalServerError)
 }
 

--- a/pkg/api/ingressproxy/tls_ask.go
+++ b/pkg/api/ingressproxy/tls_ask.go
@@ -1,0 +1,212 @@
+package ingressproxy
+
+import (
+	"container/list"
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/store"
+)
+
+// TLSAskPath is Caddy's on-demand TLS `ask` callback path. Caddy passes the
+// requested hostname as the `domain` query parameter and decides whether to
+// attempt issuance based on the HTTP status: 2xx → issue, anything else →
+// refuse. The path is fixed so both the Caddy install-time config push and
+// this handler share a single grep target.
+const TLSAskPath = "/internal/tls-ask"
+
+// CustomDomainResolver is the narrow lookup the ask handler needs. In PR #2
+// it is backed by store.ResolveCustomDomain (single PK lookup); PR #3 swaps
+// in the local Raft FSM's hostname → sandbox map so the hot path stays
+// fully in-process across the cluster. The interface intentionally returns
+// store.ErrNotFound on miss so the handler treats both backends the same.
+type CustomDomainResolver interface {
+	ResolveCustomDomain(ctx context.Context, hostname string) (string, error)
+}
+
+// TLSAskDeps wires the ask handler. BaseDomain is the wildcard zone served
+// out of cfg.Domain — when set, requests for the apex or any subdomain pass
+// through with 200 as defense in depth (Caddy's wildcard policy should
+// already match first, but a stray on-demand fallthrough must never trigger
+// per-host issuance for a hostname covered by the wildcard).
+//
+// NegCacheTTL and NegCacheCap bound the negative-cache footprint. Zero on
+// either disables the cache (intended for tests).
+type TLSAskDeps struct {
+	Resolver    CustomDomainResolver
+	BaseDomain  string
+	NegCacheTTL time.Duration
+	NegCacheCap int
+	Logger      *slog.Logger
+}
+
+// TLSAskHandler answers Caddy's on-demand TLS `ask` callback for custom
+// hostnames. Hot path: PK-style lookup with an LRU negative cache so an SNI
+// flood from an internet-facing scanner does not turn into per-request
+// store traffic.
+type TLSAskHandler struct {
+	deps     TLSAskDeps
+	negCache *negativeCache
+}
+
+// NewTLSAskHandler builds a handler. Resolver and Logger are required;
+// BaseDomain is recommended whenever cfg.Domain is set.
+func NewTLSAskHandler(d TLSAskDeps) *TLSAskHandler {
+	if d.Logger == nil {
+		d.Logger = slog.Default()
+	}
+	return &TLSAskHandler{
+		deps:     d,
+		negCache: newNegativeCache(d.NegCacheCap, d.NegCacheTTL),
+	}
+}
+
+// EvictNegativeCache drops a hostname from the negative cache. The service
+// layer calls this after AddCustomDomain succeeds so a legitimate add does
+// not have to wait out the TTL before Caddy will issue a cert.
+func (h *TLSAskHandler) EvictNegativeCache(host string) {
+	if h == nil || h.negCache == nil {
+		return
+	}
+	h.negCache.remove(normalizeAskHost(host))
+}
+
+// ServeHTTP implements http.Handler. GET /internal/tls-ask?domain=<host>.
+func (h *TLSAskHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	host := normalizeAskHost(r.URL.Query().Get("domain"))
+	if host == "" {
+		http.Error(w, "missing domain", http.StatusBadRequest)
+		return
+	}
+
+	// Defense in depth — the wildcard policy should match first, but if
+	// the on-demand policy fires for a hostname under the deployment base
+	// domain (misconfigured order, sb-* names racing wildcard install,
+	// etc.) we must not let Caddy attempt a per-host LE issuance for it.
+	if h.deps.BaseDomain != "" {
+		base := strings.ToLower(h.deps.BaseDomain)
+		if host == base || strings.HasSuffix(host, "."+base) {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+	}
+
+	if h.negCache != nil && h.negCache.has(host) {
+		http.Error(w, "unknown host", http.StatusForbidden)
+		return
+	}
+
+	_, err := h.deps.Resolver.ResolveCustomDomain(r.Context(), host)
+	if err == nil {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	if errors.Is(err, store.ErrNotFound) {
+		if h.negCache != nil {
+			h.negCache.add(host)
+		}
+		http.Error(w, "unknown host", http.StatusForbidden)
+		return
+	}
+	// Resolver outage (store I/O error, ctx cancelled, etc.). Refuse
+	// cautiously — a 5xx here tells Caddy "don't issue right now", which
+	// is the right answer when we can't confirm the hostname is ours.
+	// Do NOT add to the negative cache: this is a transient backend
+	// failure, not a "host doesn't exist" signal.
+	h.deps.Logger.WarnContext(r.Context(), "tls-ask resolve failed", "host", host, "err", err)
+	http.Error(w, "resolve failed", http.StatusInternalServerError)
+}
+
+// normalizeAskHost lower-cases the host and strips a trailing dot. Caddy
+// has been observed to send absolute (FQDN with trailing dot) names from
+// SNI in some setups.
+func normalizeAskHost(s string) string {
+	return strings.ToLower(strings.TrimSpace(strings.TrimSuffix(s, ".")))
+}
+
+// negativeCache is an LRU with per-entry TTL. Cap and TTL come from
+// TLSAskDeps; zero on either disables caching (newNegativeCache returns
+// nil, and callers null-check).
+//
+// We use a plain map + container/list rather than pulling in a third-party
+// LRU package — the working set is tiny (cap is bounded, evictions are
+// rare under normal traffic) and the package already has no external
+// dependencies for similar shaped state.
+type negativeCache struct {
+	mu      sync.Mutex
+	cap     int
+	ttl     time.Duration
+	entries map[string]*list.Element
+	order   *list.List // front = most recent
+	now     func() time.Time
+}
+
+type negCacheEntry struct {
+	host    string
+	addedAt time.Time
+}
+
+func newNegativeCache(cap int, ttl time.Duration) *negativeCache {
+	if cap <= 0 || ttl <= 0 {
+		return nil
+	}
+	return &negativeCache{
+		cap:     cap,
+		ttl:     ttl,
+		entries: make(map[string]*list.Element, cap),
+		order:   list.New(),
+		now:     time.Now,
+	}
+}
+
+func (c *negativeCache) has(host string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	el, ok := c.entries[host]
+	if !ok {
+		return false
+	}
+	entry := el.Value.(*negCacheEntry)
+	if c.now().Sub(entry.addedAt) > c.ttl {
+		c.order.Remove(el)
+		delete(c.entries, host)
+		return false
+	}
+	c.order.MoveToFront(el)
+	return true
+}
+
+func (c *negativeCache) add(host string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if el, ok := c.entries[host]; ok {
+		entry := el.Value.(*negCacheEntry)
+		entry.addedAt = c.now()
+		c.order.MoveToFront(el)
+		return
+	}
+	el := c.order.PushFront(&negCacheEntry{host: host, addedAt: c.now()})
+	c.entries[host] = el
+	for c.order.Len() > c.cap {
+		oldest := c.order.Back()
+		if oldest == nil {
+			break
+		}
+		c.order.Remove(oldest)
+		delete(c.entries, oldest.Value.(*negCacheEntry).host)
+	}
+}
+
+func (c *negativeCache) remove(host string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if el, ok := c.entries[host]; ok {
+		c.order.Remove(el)
+		delete(c.entries, host)
+	}
+}

--- a/pkg/api/ingressproxy/tls_ask_test.go
+++ b/pkg/api/ingressproxy/tls_ask_test.go
@@ -1,0 +1,336 @@
+package ingressproxy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/store"
+)
+
+type fakeDomainResolver struct {
+	mu        sync.Mutex
+	known     map[string]string
+	calls     atomic.Int64
+	failNext  bool
+	failErr   error
+	failCount atomic.Int64
+}
+
+func newFakeDomainResolver(known map[string]string) *fakeDomainResolver {
+	return &fakeDomainResolver{known: known}
+}
+
+func (f *fakeDomainResolver) ResolveCustomDomain(_ context.Context, host string) (string, error) {
+	f.calls.Add(1)
+	f.mu.Lock()
+	fail := f.failNext
+	failErr := f.failErr
+	if fail {
+		f.failCount.Add(1)
+	}
+	f.mu.Unlock()
+	if fail {
+		if failErr == nil {
+			failErr = errors.New("resolver outage")
+		}
+		return "", failErr
+	}
+	if id, ok := f.known[host]; ok {
+		return id, nil
+	}
+	return "", store.ErrNotFound
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func newAskRequest(host string) *http.Request {
+	q := url.Values{}
+	q.Set("domain", host)
+	return httptest.NewRequest(http.MethodGet, "/internal/tls-ask?"+q.Encode(), nil)
+}
+
+func TestTLSAsk_MissingDomain(t *testing.T) {
+	h := NewTLSAskHandler(TLSAskDeps{
+		Resolver:    newFakeDomainResolver(nil),
+		BaseDomain:  "aerol.cloud",
+		NegCacheTTL: time.Minute,
+		NegCacheCap: 100,
+		Logger:      discardLogger(),
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/internal/tls-ask", nil)
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("got %d, want 400", w.Code)
+	}
+}
+
+func TestTLSAsk_KnownHostAllowed(t *testing.T) {
+	resolver := newFakeDomainResolver(map[string]string{"api.acme.com": "sb-abc"})
+	h := NewTLSAskHandler(TLSAskDeps{
+		Resolver:    resolver,
+		BaseDomain:  "aerol.cloud",
+		NegCacheTTL: time.Minute,
+		NegCacheCap: 100,
+		Logger:      discardLogger(),
+	})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newAskRequest("api.acme.com"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200", w.Code)
+	}
+	if resolver.calls.Load() != 1 {
+		t.Fatalf("expected 1 resolver call, got %d", resolver.calls.Load())
+	}
+}
+
+func TestTLSAsk_UnknownHostForbiddenAndCached(t *testing.T) {
+	resolver := newFakeDomainResolver(nil)
+	h := NewTLSAskHandler(TLSAskDeps{
+		Resolver:    resolver,
+		BaseDomain:  "aerol.cloud",
+		NegCacheTTL: time.Minute,
+		NegCacheCap: 100,
+		Logger:      discardLogger(),
+	})
+
+	// First miss → resolver hit, 403, host cached.
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newAskRequest("evil.example.com"))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("first miss: got %d, want 403", w.Code)
+	}
+	if resolver.calls.Load() != 1 {
+		t.Fatalf("expected 1 resolver call after first miss, got %d", resolver.calls.Load())
+	}
+
+	// Second miss → served from negative cache, no resolver call.
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, newAskRequest("evil.example.com"))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("second miss: got %d, want 403", w.Code)
+	}
+	if resolver.calls.Load() != 1 {
+		t.Fatalf("negative cache should suppress resolver call, got %d total", resolver.calls.Load())
+	}
+}
+
+func TestTLSAsk_BaseDomainPassthrough(t *testing.T) {
+	// Even with a resolver that returns ErrNotFound, hostnames under the
+	// deployment base domain must short-circuit to 200 — they are served
+	// by the wildcard policy, not on-demand.
+	resolver := newFakeDomainResolver(nil)
+	h := NewTLSAskHandler(TLSAskDeps{
+		Resolver:    resolver,
+		BaseDomain:  "aerol.cloud",
+		NegCacheTTL: time.Minute,
+		NegCacheCap: 100,
+		Logger:      discardLogger(),
+	})
+
+	for _, host := range []string{"aerol.cloud", "sb-xyz.aerol.cloud", "sb-xyz-8080.aerol.cloud"} {
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newAskRequest(host))
+		if w.Code != http.StatusOK {
+			t.Fatalf("host %q: got %d, want 200", host, w.Code)
+		}
+	}
+	if resolver.calls.Load() != 0 {
+		t.Fatalf("base-domain passthrough must not touch resolver, got %d calls", resolver.calls.Load())
+	}
+}
+
+func TestTLSAsk_TrailingDotAndCaseFolded(t *testing.T) {
+	resolver := newFakeDomainResolver(map[string]string{"api.acme.com": "sb-abc"})
+	h := NewTLSAskHandler(TLSAskDeps{
+		Resolver:    resolver,
+		BaseDomain:  "aerol.cloud",
+		NegCacheTTL: time.Minute,
+		NegCacheCap: 100,
+		Logger:      discardLogger(),
+	})
+	for _, host := range []string{"API.Acme.COM", "api.acme.com.", "  api.acme.com  "} {
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newAskRequest(host))
+		if w.Code != http.StatusOK {
+			t.Fatalf("host %q normalized incorrectly: got %d, want 200", host, w.Code)
+		}
+	}
+}
+
+func TestTLSAsk_ResolverErrorIsTransient(t *testing.T) {
+	// Backend failures must return 5xx (not 4xx) and must NOT poison the
+	// negative cache — otherwise a transient SQLite hiccup turns into a
+	// 60s lockout for legitimate hosts.
+	resolver := newFakeDomainResolver(nil)
+	resolver.failNext = true
+	h := NewTLSAskHandler(TLSAskDeps{
+		Resolver:    resolver,
+		BaseDomain:  "aerol.cloud",
+		NegCacheTTL: time.Minute,
+		NegCacheCap: 100,
+		Logger:      discardLogger(),
+	})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newAskRequest("api.acme.com"))
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("got %d, want 500", w.Code)
+	}
+
+	// Flip resolver healthy + add the host. A second call must hit the
+	// resolver (proving the host was NOT cached on the 5xx path).
+	resolver.mu.Lock()
+	resolver.failNext = false
+	resolver.known = map[string]string{"api.acme.com": "sb-abc"}
+	resolver.mu.Unlock()
+
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, newAskRequest("api.acme.com"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("after recovery: got %d, want 200", w.Code)
+	}
+}
+
+func TestTLSAsk_EvictNegativeCacheAfterAdd(t *testing.T) {
+	// Simulate the AddCustomDomain → evict flow: a scanner pokes the host
+	// before the operator registers it (403 + cache); the operator then
+	// adds it; eviction lets the next ask succeed without waiting out the
+	// TTL.
+	resolver := newFakeDomainResolver(nil)
+	h := NewTLSAskHandler(TLSAskDeps{
+		Resolver:    resolver,
+		BaseDomain:  "aerol.cloud",
+		NegCacheTTL: time.Hour,
+		NegCacheCap: 100,
+		Logger:      discardLogger(),
+	})
+
+	// 1) Scanner poke caches the negative.
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newAskRequest("api.acme.com"))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("scanner poke: got %d, want 403", w.Code)
+	}
+
+	// 2) Operator adds the domain → resolver knows it now, but cache
+	//    still holds the negative. Without eviction the ask would 403.
+	resolver.mu.Lock()
+	resolver.known = map[string]string{"api.acme.com": "sb-abc"}
+	resolver.mu.Unlock()
+	h.EvictNegativeCache("API.Acme.COM.") // exercise the normalize-on-evict path
+
+	// 3) Next ask succeeds because the cache entry was evicted.
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, newAskRequest("api.acme.com"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("after evict: got %d, want 200", w.Code)
+	}
+}
+
+func TestNegativeCache_TTLExpiry(t *testing.T) {
+	c := newNegativeCache(10, 5*time.Second)
+	now := time.Unix(1_700_000_000, 0)
+	c.now = func() time.Time { return now }
+	c.add("a.com")
+	if !c.has("a.com") {
+		t.Fatalf("expected hit immediately after add")
+	}
+	now = now.Add(6 * time.Second) // past TTL
+	if c.has("a.com") {
+		t.Fatalf("expected miss after TTL expiry")
+	}
+}
+
+func TestNegativeCache_CapEvictsOldest(t *testing.T) {
+	c := newNegativeCache(3, time.Hour)
+	c.add("a")
+	c.add("b")
+	c.add("c")
+	c.add("d") // evicts "a"
+	if c.has("a") {
+		t.Fatalf("oldest entry should have been evicted")
+	}
+	for _, h := range []string{"b", "c", "d"} {
+		if !c.has(h) {
+			t.Fatalf("expected %q to still be cached", h)
+		}
+	}
+}
+
+func TestNegativeCache_DisabledWhenZero(t *testing.T) {
+	if newNegativeCache(0, time.Minute) != nil {
+		t.Fatalf("zero cap should disable cache")
+	}
+	if newNegativeCache(10, 0) != nil {
+		t.Fatalf("zero TTL should disable cache")
+	}
+}
+
+func TestNegativeCache_RemoveIsIdempotent(t *testing.T) {
+	c := newNegativeCache(5, time.Hour)
+	c.remove("missing") // must not panic
+	c.add("x")
+	c.remove("x")
+	if c.has("x") {
+		t.Fatalf("remove failed")
+	}
+	c.remove("x") // second remove is a no-op
+}
+
+func TestTLSAsk_HandlerWithoutCache(t *testing.T) {
+	// Cache disabled (cap=0). Every miss should still 403 but each one
+	// hits the resolver — proving the handler degrades cleanly without
+	// the LRU.
+	resolver := newFakeDomainResolver(nil)
+	h := NewTLSAskHandler(TLSAskDeps{
+		Resolver:   resolver,
+		BaseDomain: "aerol.cloud",
+		Logger:     discardLogger(),
+	})
+	for i := range 3 {
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newAskRequest("evil.example.com"))
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("iter %d: got %d, want 403", i, w.Code)
+		}
+	}
+	if resolver.calls.Load() != 3 {
+		t.Fatalf("expected 3 resolver calls with cache disabled, got %d", resolver.calls.Load())
+	}
+}
+
+func TestRegisterTLSAsk_RoutesOnMux(t *testing.T) {
+	resolver := newFakeDomainResolver(map[string]string{"api.acme.com": "sb-abc"})
+	h := NewTLSAskHandler(TLSAskDeps{
+		Resolver:    resolver,
+		BaseDomain:  "aerol.cloud",
+		NegCacheTTL: time.Minute,
+		NegCacheCap: 100,
+		Logger:      discardLogger(),
+	})
+	mux := http.NewServeMux()
+	RegisterTLSAsk(mux, h)
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/internal/tls-ask?domain=api.acme.com")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("got %d, want 200", resp.StatusCode)
+	}
+}

--- a/pkg/api/ingressproxy/tls_ask_test.go
+++ b/pkg/api/ingressproxy/tls_ask_test.go
@@ -310,6 +310,105 @@ func TestTLSAsk_HandlerWithoutCache(t *testing.T) {
 	}
 }
 
+// TestTLSAsk_BudgetThrottleReturns429: when the ACME budget refuses,
+// the handler must return 429 with Retry-After set in seconds. Caddy
+// reads Retry-After to back off — silently dropping it would leave
+// Caddy hammering the brake.
+func TestTLSAsk_BudgetThrottleReturns429(t *testing.T) {
+	resolver := newFakeDomainResolver(map[string]string{"api.acme.com": "sb-abc"})
+	budget := &stubBudget{allow: false, retry: 90 * time.Second}
+	h := NewTLSAskHandler(TLSAskDeps{
+		Resolver: resolver,
+		Logger:   discardLogger(),
+		Budget:   budget,
+	})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newAskRequest("api.acme.com"))
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("got %d, want 429", w.Code)
+	}
+	if got := w.Header().Get("Retry-After"); got != "90" {
+		t.Fatalf("Retry-After = %q, want 90", got)
+	}
+	if budget.callsFor("sb-abc", "api.acme.com") != 1 {
+		t.Fatal("budget Reserve not called with sandbox_id + host")
+	}
+}
+
+// TestTLSAsk_BudgetSkippedForUnknownHost: budget must not be consumed
+// when the resolver doesn't know the host — unknown-host floods from
+// internet scanners would otherwise drain the bucket and starve real
+// custom domains.
+func TestTLSAsk_BudgetSkippedForUnknownHost(t *testing.T) {
+	resolver := newFakeDomainResolver(nil)
+	budget := &stubBudget{allow: false, retry: time.Second}
+	h := NewTLSAskHandler(TLSAskDeps{
+		Resolver: resolver,
+		Logger:   discardLogger(),
+		Budget:   budget,
+	})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newAskRequest("evil.example.com"))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("got %d, want 403", w.Code)
+	}
+	if budget.total() != 0 {
+		t.Fatalf("budget consumed %d times for unknown host; want 0", budget.total())
+	}
+}
+
+// TestTLSAsk_BudgetSkippedForBaseDomain: wildcard-policy hosts under
+// SB_DOMAIN must not consume budget either — they aren't going through
+// the on-demand path even if the ask handler short-circuits.
+func TestTLSAsk_BudgetSkippedForBaseDomain(t *testing.T) {
+	budget := &stubBudget{allow: false, retry: time.Second}
+	h := NewTLSAskHandler(TLSAskDeps{
+		Resolver:   newFakeDomainResolver(nil),
+		BaseDomain: "aerol.cloud",
+		Logger:     discardLogger(),
+		Budget:     budget,
+	})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newAskRequest("sb-xyz.aerol.cloud"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200", w.Code)
+	}
+	if budget.total() != 0 {
+		t.Fatalf("budget consumed %d times for base domain; want 0", budget.total())
+	}
+}
+
+// TestTLSAsk_TrackerStartedOnFirstOK: the issuance tracker is signalled
+// only on a successful issuance ask, not on base-domain passthrough or
+// unknown-host rejection. Wrong gating would inflate the
+// aerolvm_acme_lock_held_seconds gauge with hostnames Caddy never
+// touched.
+func TestTLSAsk_TrackerStartedOnFirstOK(t *testing.T) {
+	resolver := newFakeDomainResolver(map[string]string{"api.acme.com": "sb-abc"})
+	tracker := &stubTracker{}
+	h := NewTLSAskHandler(TLSAskDeps{
+		Resolver:   resolver,
+		BaseDomain: "aerol.cloud",
+		Logger:     discardLogger(),
+		Tracker:    tracker,
+	})
+	// 1. base-domain — no tracker hit
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newAskRequest("sb-xyz.aerol.cloud"))
+	// 2. unknown — no tracker hit
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, newAskRequest("evil.example.com"))
+	// 3. known — tracker hit
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, newAskRequest("api.acme.com"))
+	if got := tracker.calls("api.acme.com"); got != 1 {
+		t.Fatalf("tracker.Started(api.acme.com) = %d, want 1", got)
+	}
+	if got := tracker.total(); got != 1 {
+		t.Fatalf("tracker total = %d, want 1", got)
+	}
+}
+
 func TestRegisterTLSAsk_RoutesOnMux(t *testing.T) {
 	resolver := newFakeDomainResolver(map[string]string{"api.acme.com": "sb-abc"})
 	h := NewTLSAskHandler(TLSAskDeps{
@@ -333,4 +432,67 @@ func TestRegisterTLSAsk_RoutesOnMux(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("got %d, want 200", resp.StatusCode)
 	}
+}
+
+type stubBudget struct {
+	mu    sync.Mutex
+	allow bool
+	retry time.Duration
+	hits  map[string]int // "sandbox|host" → count
+}
+
+func (b *stubBudget) Reserve(sandboxID, host string) (bool, time.Duration) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.hits == nil {
+		b.hits = map[string]int{}
+	}
+	b.hits[sandboxID+"|"+host]++
+	return b.allow, b.retry
+}
+
+func (b *stubBudget) callsFor(sandboxID, host string) int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.hits[sandboxID+"|"+host]
+}
+
+func (b *stubBudget) total() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	n := 0
+	for _, v := range b.hits {
+		n += v
+	}
+	return n
+}
+
+type stubTracker struct {
+	mu   sync.Mutex
+	seen map[string]int
+}
+
+func (t *stubTracker) Started(host string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.seen == nil {
+		t.seen = map[string]int{}
+	}
+	t.seen[host]++
+}
+
+func (t *stubTracker) calls(host string) int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.seen[host]
+}
+
+func (t *stubTracker) total() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	n := 0
+	for _, v := range t.seen {
+		n += v
+	}
+	return n
 }

--- a/pkg/api/v1/custom_domains_test.go
+++ b/pkg/api/v1/custom_domains_test.go
@@ -1,0 +1,224 @@
+package v1
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/internal/service"
+	"github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/caddy"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// customDomainsV1Env spins up the smallest possible v1 mux that can serve
+// the custom-domains routes end-to-end: real store, real service, disabled
+// caddy (UpsertSandboxRoute is a no-op so the test asserts on store + wire
+// shape rather than on the route bytes — pkg/caddy/custom_domains_test.go
+// covers the matcher).
+type customDomainsV1Env struct {
+	mux   http.Handler
+	svc   *service.Service
+	store *store.Store
+}
+
+func newCustomDomainsV1Env(t *testing.T, cfgOverride func(*config.Config)) *customDomainsV1Env {
+	t.Helper()
+	cfg := config.Config{
+		EnableCustomDomains:        true,
+		Domain:                     "aerol.cloud",
+		CustomDomainsMaxPerSandbox: models.MaxCustomDomainsPerSandbox,
+	}
+	if cfgOverride != nil {
+		cfgOverride(&cfg)
+	}
+	st, err := store.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	caddyClient := caddy.New(config.Config{EnableCaddy: false, HTTPClientTimeout: time.Second})
+	svc := service.New(cfg, logger, st, &noopRuntime{}, nil, caddyClient, nil, nil, nil)
+
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, Deps{
+		Service: svc,
+		Logger:  logger,
+		Auth:    func(h http.Handler) http.Handler { return h },
+	})
+	return &customDomainsV1Env{mux: mux, svc: svc, store: st}
+}
+
+func seedSandboxRowV1(t *testing.T, st *store.Store, id string) {
+	t.Helper()
+	now := time.Now().UTC()
+	if err := st.Create(context.Background(), &models.Sandbox{
+		ID:           id,
+		Image:        "test-image",
+		Status:       models.SandboxStatusStarted,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		LastActiveAt: now,
+	}); err != nil {
+		t.Fatalf("store.Create: %v", err)
+	}
+}
+
+func do(t *testing.T, h http.Handler, method, path string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var rdr io.Reader
+	if body != nil {
+		buf, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+		rdr = bytes.NewReader(buf)
+	}
+	req := httptest.NewRequest(method, path, rdr)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	return rr
+}
+
+func TestV1AddCustomDomain_Created(t *testing.T) {
+	env := newCustomDomainsV1Env(t, nil)
+	seedSandboxRowV1(t, env.store, "sb-1")
+
+	rr := do(t, env.mux, http.MethodPost, "/v1/sandboxes/sb-1/custom-domains", map[string]string{"hostname": "API.Acme.com"})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status=%d, body=%s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		CustomDomains []models.CustomDomain `json:"custom_domains"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.CustomDomains) != 1 || resp.CustomDomains[0].Hostname != "api.acme.com" {
+		t.Fatalf("custom_domains=%+v", resp.CustomDomains)
+	}
+	if resp.CustomDomains[0].Status != models.CustomDomainPendingDNS {
+		t.Fatalf("status=%v", resp.CustomDomains[0].Status)
+	}
+}
+
+func TestV1AddCustomDomain_Disabled412(t *testing.T) {
+	env := newCustomDomainsV1Env(t, func(c *config.Config) {
+		c.EnableCustomDomains = false
+	})
+	seedSandboxRowV1(t, env.store, "sb-1")
+
+	rr := do(t, env.mux, http.MethodPost, "/v1/sandboxes/sb-1/custom-domains", map[string]string{"hostname": "api.acme.com"})
+	if rr.Code != http.StatusPreconditionFailed {
+		t.Fatalf("status=%d, body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestV1AddCustomDomain_IPMode412(t *testing.T) {
+	env := newCustomDomainsV1Env(t, func(c *config.Config) {
+		c.Domain = ""
+	})
+	seedSandboxRowV1(t, env.store, "sb-1")
+
+	rr := do(t, env.mux, http.MethodPost, "/v1/sandboxes/sb-1/custom-domains", map[string]string{"hostname": "api.acme.com"})
+	if rr.Code != http.StatusPreconditionFailed {
+		t.Fatalf("status=%d, body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestV1AddCustomDomain_BadHostname400(t *testing.T) {
+	env := newCustomDomainsV1Env(t, nil)
+	seedSandboxRowV1(t, env.store, "sb-1")
+
+	rr := do(t, env.mux, http.MethodPost, "/v1/sandboxes/sb-1/custom-domains", map[string]string{"hostname": "single-label"})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d, body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestV1AddCustomDomain_CrossSandbox409(t *testing.T) {
+	env := newCustomDomainsV1Env(t, nil)
+	seedSandboxRowV1(t, env.store, "sb-a")
+	seedSandboxRowV1(t, env.store, "sb-b")
+
+	rr := do(t, env.mux, http.MethodPost, "/v1/sandboxes/sb-a/custom-domains", map[string]string{"hostname": "api.acme.com"})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed status=%d", rr.Code)
+	}
+	rr = do(t, env.mux, http.MethodPost, "/v1/sandboxes/sb-b/custom-domains", map[string]string{"hostname": "api.acme.com"})
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("status=%d, body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestV1AddCustomDomain_MissingSandbox404(t *testing.T) {
+	env := newCustomDomainsV1Env(t, nil)
+	rr := do(t, env.mux, http.MethodPost, "/v1/sandboxes/nope/custom-domains", map[string]string{"hostname": "api.acme.com"})
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status=%d, body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestV1ListCustomDomains_Empty(t *testing.T) {
+	env := newCustomDomainsV1Env(t, nil)
+	seedSandboxRowV1(t, env.store, "sb-1")
+
+	rr := do(t, env.mux, http.MethodGet, "/v1/sandboxes/sb-1/custom-domains", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d, body=%s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		CustomDomains []models.CustomDomain `json:"custom_domains"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.CustomDomains) != 0 {
+		t.Fatalf("expected empty list, got %v", resp.CustomDomains)
+	}
+}
+
+func TestV1RemoveCustomDomain_NoContent(t *testing.T) {
+	env := newCustomDomainsV1Env(t, nil)
+	seedSandboxRowV1(t, env.store, "sb-1")
+	rr := do(t, env.mux, http.MethodPost, "/v1/sandboxes/sb-1/custom-domains", map[string]string{"hostname": "api.acme.com"})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed status=%d", rr.Code)
+	}
+	rr = do(t, env.mux, http.MethodDelete, "/v1/sandboxes/sb-1/custom-domains/API.Acme.com", nil)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status=%d, body=%s", rr.Code, rr.Body.String())
+	}
+	// Re-delete is 404 (the row is gone).
+	rr = do(t, env.mux, http.MethodDelete, "/v1/sandboxes/sb-1/custom-domains/api.acme.com", nil)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("re-delete status=%d, body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestV1RemoveCustomDomain_CrossSandbox404(t *testing.T) {
+	env := newCustomDomainsV1Env(t, nil)
+	seedSandboxRowV1(t, env.store, "sb-a")
+	seedSandboxRowV1(t, env.store, "sb-b")
+	rr := do(t, env.mux, http.MethodPost, "/v1/sandboxes/sb-a/custom-domains", map[string]string{"hostname": "api.acme.com"})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed status=%d", rr.Code)
+	}
+	rr = do(t, env.mux, http.MethodDelete, "/v1/sandboxes/sb-b/custom-domains/api.acme.com", nil)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status=%d, body=%s", rr.Code, rr.Body.String())
+	}
+}

--- a/pkg/api/v1/handlers.go
+++ b/pkg/api/v1/handlers.go
@@ -206,6 +206,60 @@ func (h *handlers) unexposePort(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// addCustomDomain attaches a new operator-provided public hostname to a
+// sandbox. Body shape: {"hostname":"api.acme.com"}. Status codes follow the
+// custom-domain sentinels in pkg/api/apihttp.WriteStoreAwareError:
+// 412 = feature disabled / IP mode; 409 = hostname owned by another sandbox
+// or IRON RULE violation (tcp/tls coexistence); 400 = malformed hostname;
+// 404 = sandbox not found.
+func (h *handlers) addCustomDomain(w http.ResponseWriter, r *http.Request) {
+	var req models.AddCustomDomainRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	id := r.PathValue("id")
+	if err := h.deps.Service.AddCustomDomain(r.Context(), id, req.Hostname); err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	// Return the full list back so callers don't need a follow-up GET to
+	// learn the canonical (lowercased, dot-trimmed) hostname or its initial
+	// status. Mirrors the createSandbox response shape.
+	domains, err := h.deps.Service.ListCustomDomains(r.Context(), id)
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	apihttp.WriteJSON(w, http.StatusCreated, map[string]any{"custom_domains": domains})
+}
+
+// removeCustomDomain detaches a hostname from a sandbox. {hostname} in the
+// path may be passed in any case — the service layer normalizes before
+// comparing. Cross-sandbox removal is rejected with 404 (the store scopes
+// the DELETE to (sandbox, hostname)).
+func (h *handlers) removeCustomDomain(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	hostname := r.PathValue("hostname")
+	if err := h.deps.Service.RemoveCustomDomain(r.Context(), id, hostname); err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// listCustomDomains returns the per-hostname rows attached to a sandbox.
+// Same shape the create response embeds in Sandbox.CustomDomains, so an SDK
+// can use one decoder for both surfaces.
+func (h *handlers) listCustomDomains(w http.ResponseWriter, r *http.Request) {
+	domains, err := h.deps.Service.ListCustomDomains(r.Context(), r.PathValue("id"))
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	apihttp.WriteJSON(w, http.StatusOK, map[string]any{"custom_domains": domains})
+}
+
 func (h *handlers) listMounts(w http.ResponseWriter, r *http.Request) {
 	mounts, err := h.deps.Service.ListMounts(r.Context(), r.PathValue("id"))
 	if err != nil {

--- a/pkg/api/v1/routes.go
+++ b/pkg/api/v1/routes.go
@@ -88,6 +88,16 @@ func RegisterRoutes(mux *http.ServeMux, d Deps) {
 	mux.Handle("PUT "+PathPrefix+"/sandboxes/{id}/lifecycle", d.Auth(wrap(http.HandlerFunc(h.updateLifecycle))))
 	mux.Handle("POST "+PathPrefix+"/sandboxes/{id}/ports/{port}", d.Auth(wrap(http.HandlerFunc(h.exposePort))))
 	mux.Handle("DELETE "+PathPrefix+"/sandboxes/{id}/ports/{port}", d.Auth(wrap(http.HandlerFunc(h.unexposePort))))
+	// Custom domains (plans/custom-domains.md). Gated server-side by
+	// SB_ENABLE_CUSTOM_DOMAINS — routes are always mounted (so a request
+	// hits a 412 rather than a 404 when the cluster has the feature off)
+	// and the service layer returns ErrCustomDomainNotSupported. Wrapped
+	// with clusterForwardWrap so a request addressing a remote-owned
+	// sandbox follows the same forward path as every other per-sandbox
+	// route — the owner is the only node with the row to mutate.
+	mux.Handle("POST "+PathPrefix+"/sandboxes/{id}/custom-domains", d.Auth(wrap(http.HandlerFunc(h.addCustomDomain))))
+	mux.Handle("GET "+PathPrefix+"/sandboxes/{id}/custom-domains", d.Auth(wrap(http.HandlerFunc(h.listCustomDomains))))
+	mux.Handle("DELETE "+PathPrefix+"/sandboxes/{id}/custom-domains/{hostname}", d.Auth(wrap(http.HandlerFunc(h.removeCustomDomain))))
 	mux.Handle("GET "+PathPrefix+"/sandboxes/{id}/mounts", d.Auth(wrap(http.HandlerFunc(h.listMounts))))
 	mux.Handle("GET "+PathPrefix+"/sandboxes/{id}/network/usage", d.Auth(wrap(http.HandlerFunc(h.getNetworkUsage))))
 	mux.Handle("PATCH "+PathPrefix+"/sandboxes/{id}/network/limits", d.Auth(wrap(http.HandlerFunc(h.updateNetworkLimits))))

--- a/pkg/api/v1/routes_test.go
+++ b/pkg/api/v1/routes_test.go
@@ -41,6 +41,9 @@ func TestRegisterRoutesAllUseV1Prefix(t *testing.T) {
 		{method: http.MethodPost, path: "/v1/sandboxes/abc/snapshot"},
 		{method: http.MethodGet, path: "/v1/sandboxes/abc/sessions"},
 		{method: http.MethodGet, path: "/v1/sandboxes/abc/toolbox/foo"},
+		{method: http.MethodPost, path: "/v1/sandboxes/abc/custom-domains"},
+		{method: http.MethodGet, path: "/v1/sandboxes/abc/custom-domains"},
+		{method: http.MethodDelete, path: "/v1/sandboxes/abc/custom-domains/api.acme.com"},
 	}
 	for _, probe := range probes {
 		req, _ := http.NewRequest(probe.method, probe.path, nil)

--- a/pkg/caddy/client.go
+++ b/pkg/caddy/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"net"
 	"net/http"
@@ -644,6 +645,19 @@ func IngressSandboxSNIRouteID(id string) string {
 
 func IngressPortSNIRouteID(id string, port int) string {
 	return ingressPortSNIRouteID(id, port)
+}
+
+// IngressCustomDomainSNIRouteID is the stable route ID for the per-custom-
+// hostname SNI passthrough route on non-owner ingress nodes (cluster mode,
+// domain mode). The hostname is hashed so the ID stays within Caddy's
+// route-ID size budget for very long custom hostnames and avoids embedding
+// punctuation that would have to be escaped in the @id slug. The pair
+// (sandboxID, hostname) yields a deterministic ID so the delta-driven
+// ingress reconciler can recognize an existing route and avoid churn.
+func IngressCustomDomainSNIRouteID(sandboxID, hostname string) string {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(strings.ToLower(hostname)))
+	return fmt.Sprintf("sandbox-%s-custom-%016x-ingress-sni", sandboxID, h.Sum64())
 }
 
 // EnsureOnDemandTLS idempotently installs the on-demand TLS automation

--- a/pkg/caddy/client.go
+++ b/pkg/caddy/client.go
@@ -143,7 +143,14 @@ func (c *Client) TLSPublicEndpoint(id string, port int, l4Listen string) string 
 	return fmt.Sprintf("tls://%s-%d.%s:%s", id, port, c.domain, listenPort)
 }
 
-func (c *Client) UpsertSandboxRoute(ctx context.Context, id, containerIP string, toolboxPort int) error {
+// UpsertSandboxRoute installs the HTTP ingress route for a sandbox owned by
+// this node. customHostnames is the operator-attached set of public hostnames
+// added under the custom-domains feature; when non-empty (and domain mode is
+// active) the host matcher includes both the default `{id}.{domain}` and each
+// custom hostname so a single route serves traffic for all of them. Order in
+// the list is irrelevant — Caddy treats `host` as a set match. nil/empty is
+// the legacy single-hostname behaviour.
+func (c *Client) UpsertSandboxRoute(ctx context.Context, id, containerIP string, toolboxPort int, customHostnames []string) error {
 	if !c.enabled {
 		return nil
 	}
@@ -161,8 +168,12 @@ func (c *Client) UpsertSandboxRoute(ctx context.Context, id, containerIP string,
 	}
 
 	if c.domain != "" {
-		route["match"] = []map[string]any{{"host": []string{fmt.Sprintf("%s.%s", id, c.domain)}}}
+		hosts := []string{fmt.Sprintf("%s.%s", id, c.domain)}
+		hosts = append(hosts, normalizeCustomHostnames(customHostnames)...)
+		route["match"] = []map[string]any{{"host": hosts}}
 	} else {
+		// IP mode never serves a public hostname; custom domains are
+		// rejected at the service layer in that deployment shape.
 		route["match"] = []map[string]any{{"path": []string{fmt.Sprintf("/%s", id), fmt.Sprintf("/%s/*", id)}}}
 	}
 
@@ -173,10 +184,15 @@ func (c *Client) UpsertSandboxRoute(ctx context.Context, id, containerIP string,
 // sandbox owned by another node. Domain-mode clusters use caddy-l4 SNI
 // pass-through instead, because the local HTTPS app sits behind the :443
 // layer4 mux and remote proxying would require dynamic upstream TLS SNI.
-func (c *Client) UpsertSandboxRouteToPeer(ctx context.Context, id, peerHost string) error {
+//
+// customHostnames is accepted for API parity with UpsertSandboxRoute, but
+// only takes effect in domain mode; this peer-forwarding variant runs only
+// in IP mode where the host matcher is unused.
+func (c *Client) UpsertSandboxRouteToPeer(ctx context.Context, id, peerHost string, customHostnames []string) error {
 	if !c.enabled || c.domain != "" {
 		return nil
 	}
+	_ = customHostnames // see doc comment
 	routeID := sandboxRouteID(id)
 	route := map[string]any{
 		"@id": routeID,
@@ -193,6 +209,26 @@ func (c *Client) UpsertSandboxRouteToPeer(ctx context.Context, id, peerHost stri
 		"terminal": true,
 	}
 	return c.upsertRoute(ctx, routeID, route)
+}
+
+// normalizeCustomHostnames drops empty / whitespace-only entries and
+// lower-cases the rest. The service layer is expected to have already
+// validated the inputs via models.ValidateCustomDomainList; this is purely
+// belt-and-braces against accidentally pushing a junk matcher value to
+// Caddy (which would silently match nothing, hiding the upstream).
+func normalizeCustomHostnames(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	for _, h := range in {
+		h = strings.TrimSpace(strings.ToLower(h))
+		if h == "" {
+			continue
+		}
+		out = append(out, h)
+	}
+	return out
 }
 
 func (c *Client) DeleteSandboxRoute(ctx context.Context, id string) error {
@@ -608,6 +644,126 @@ func IngressSandboxSNIRouteID(id string) string {
 
 func IngressPortSNIRouteID(id string, port int) string {
 	return ingressPortSNIRouteID(id, port)
+}
+
+// EnsureOnDemandTLS idempotently installs the on-demand TLS automation
+// settings used by the custom-domains feature. Safe to call on every
+// sandboxd start: the two writes target leaf paths and replace prior values
+// at those paths only, leaving any pre-existing wildcard policy and other
+// automation knobs untouched.
+//
+//   - PUT /config/apps/tls/automation/on_demand → rate limit + ask URL.
+//     Replacing the leaf on every boot makes config-driven changes to
+//     SB_TLS_ON_DEMAND_* take effect without a manual Caddy reload.
+//   - POST /config/apps/tls/automation/policies (with a catch-all policy
+//     {on_demand: true, issuers: [acme]}) only when no on-demand policy is
+//     present yet. Discovered by checking pathExists on automation/policies
+//     and re-walking the list; we never insert a duplicate.
+//
+// askURL must be reachable from Caddy — typically
+// http://127.0.0.1:<api-port>/internal/tls-ask (the InternalIngressAddr
+// listener mounts the handler via RegisterTLSAsk).
+//
+// The on-demand policy MUST land at the END of the policies list so the
+// existing wildcard policy (matching `*.$DOMAIN`) wins first; otherwise
+// Caddy attempts per-host issuance for hostnames the wildcard already
+// covers, burning the Let's Encrypt quota. POST appends, which gives us
+// that ordering when policies already contains the wildcard.
+func (c *Client) EnsureOnDemandTLS(ctx context.Context, askURL string, burst int, interval time.Duration) error {
+	if !c.enabled {
+		return nil
+	}
+	if askURL == "" {
+		return errors.New("askURL required")
+	}
+	if burst <= 0 || interval <= 0 {
+		return errors.New("burst and interval must be > 0")
+	}
+
+	onDemand := map[string]any{
+		"rate_limit": map[string]any{
+			"interval": interval.String(),
+			"burst":    burst,
+		},
+		"ask": askURL,
+	}
+	onDemandBody, err := json.Marshal(onDemand)
+	if err != nil {
+		return fmt.Errorf("marshal on-demand block: %w", err)
+	}
+	// PUT replaces (or creates) the leaf. Caddy auto-creates intermediate
+	// paths if apps/tls or apps/tls/automation didn't exist.
+	status, err := c.sendJSON(ctx, http.MethodPut, c.baseURL+"/config/apps/tls/automation/on_demand", onDemandBody)
+	if err != nil {
+		return err
+	}
+	if status >= 400 {
+		return fmt.Errorf("install on-demand settings failed: %d", status)
+	}
+
+	hasPolicy, err := c.hasOnDemandPolicy(ctx)
+	if err != nil {
+		return err
+	}
+	if hasPolicy {
+		return nil
+	}
+	policy := map[string]any{
+		"on_demand": true,
+		"issuers":   []map[string]any{{"module": "acme"}},
+	}
+	policyBody, err := json.Marshal(policy)
+	if err != nil {
+		return fmt.Errorf("marshal on-demand policy: %w", err)
+	}
+	// POST appends to the array if it exists, or creates a one-element
+	// array if it doesn't. Either way the on-demand policy ends up last.
+	status, err = c.sendJSON(ctx, http.MethodPost, c.baseURL+"/config/apps/tls/automation/policies", policyBody)
+	if err != nil {
+		return err
+	}
+	if status >= 400 {
+		return fmt.Errorf("install on-demand policy failed: %d", status)
+	}
+	return nil
+}
+
+// hasOnDemandPolicy reports whether the policies list already contains an
+// entry with on_demand=true. Returns false (no error) when policies is
+// absent — that's the fresh-Caddy case the caller handles by appending.
+func (c *Client) hasOnDemandPolicy(ctx context.Context) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/config/apps/tls/automation/policies", nil)
+	if err != nil {
+		return false, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("get policies: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return false, nil
+	}
+	if resp.StatusCode >= 400 {
+		return false, fmt.Errorf("get policies failed: %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, fmt.Errorf("read policies body: %w", err)
+	}
+	if strings.TrimSpace(string(body)) == "null" {
+		return false, nil
+	}
+	var policies []map[string]any
+	if err := json.Unmarshal(body, &policies); err != nil {
+		return false, fmt.Errorf("decode policies: %w", err)
+	}
+	for _, p := range policies {
+		if v, ok := p["on_demand"].(bool); ok && v {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // EnsureLayer4 idempotently bootstraps the layer4 app and (when tlsListen is

--- a/pkg/caddy/client_test.go
+++ b/pkg/caddy/client_test.go
@@ -173,7 +173,7 @@ func TestRouteCases(t *testing.T) {
 				fake := newFakeCaddy(t)
 
 				client := &Client{enabled: true, domain: "sandbox.example.com", serverID: "srv0", baseURL: fake.URL, httpClient: fake.Client}
-				if err := client.UpsertSandboxRoute(context.Background(), "abc", "10.0.0.2", 2280); err != nil {
+				if err := client.UpsertSandboxRoute(context.Background(), "abc", "10.0.0.2", 2280, nil); err != nil {
 					t.Fatalf("UpsertSandboxRoute() error = %v", err)
 				}
 				if len(fake.records) != 2 {
@@ -200,7 +200,7 @@ func TestRouteCases(t *testing.T) {
 				fake.routes["sandbox-abc"] = map[string]any{"@id": "sandbox-abc", "stale": true}
 
 				client := &Client{enabled: true, domain: "sandbox.example.com", serverID: "srv0", baseURL: fake.URL, httpClient: fake.Client}
-				if err := client.UpsertSandboxRoute(context.Background(), "abc", "10.0.0.5", 2280); err != nil {
+				if err := client.UpsertSandboxRoute(context.Background(), "abc", "10.0.0.5", 2280, nil); err != nil {
 					t.Fatalf("UpsertSandboxRoute() error = %v", err)
 				}
 				if len(fake.records) != 1 {
@@ -221,7 +221,7 @@ func TestRouteCases(t *testing.T) {
 			run: func(t *testing.T) {
 				fake := newFakeCaddy(t)
 				client := &Client{enabled: true, publicHost: "203.0.113.10", serverID: "srv0", baseURL: fake.URL, httpClient: fake.Client}
-				if err := client.UpsertSandboxRoute(context.Background(), "abc", "10.0.0.2", 2280); err != nil {
+				if err := client.UpsertSandboxRoute(context.Background(), "abc", "10.0.0.2", 2280, nil); err != nil {
 					t.Fatalf("UpsertSandboxRoute() error = %v", err)
 				}
 				route, ok := fake.routes["sandbox-abc"]
@@ -236,7 +236,7 @@ func TestRouteCases(t *testing.T) {
 			run: func(t *testing.T) {
 				fake := newFakeCaddy(t)
 				client := &Client{enabled: true, publicHost: "203.0.113.10", serverID: "srv0", baseURL: fake.URL, httpClient: fake.Client}
-				if err := client.UpsertSandboxRouteToPeer(context.Background(), "abc", "10.0.0.9"); err != nil {
+				if err := client.UpsertSandboxRouteToPeer(context.Background(), "abc", "10.0.0.9", nil); err != nil {
 					t.Fatalf("UpsertSandboxRouteToPeer() error = %v", err)
 				}
 				route, ok := fake.routes["sandbox-abc"]

--- a/pkg/caddy/custom_domains_test.go
+++ b/pkg/caddy/custom_domains_test.go
@@ -1,0 +1,248 @@
+package caddy
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// upsertSandboxRouteWithCustomHostnames verifies that the custom-hostnames
+// slice flows into the route's host matcher alongside the default
+// {id}.{domain} hostname. Order in the matcher is the default first then
+// the customs — the test checks the set, not the order.
+func TestUpsertSandboxRouteWithCustomHostnames(t *testing.T) {
+	fake := newFakeCaddy(t)
+	client := &Client{
+		enabled:    true,
+		domain:     "aerol.cloud",
+		serverID:   "srv0",
+		baseURL:    fake.URL,
+		httpClient: fake.Client,
+	}
+
+	customs := []string{"api.acme.com", "ADMIN.Acme.com"}
+	if err := client.UpsertSandboxRoute(context.Background(), "abc", "10.0.0.2", 2280, customs); err != nil {
+		t.Fatalf("UpsertSandboxRoute() error = %v", err)
+	}
+
+	route, ok := fake.routes["sandbox-abc"]
+	if !ok {
+		t.Fatalf("route not inserted; routes=%+v", fake.routes)
+	}
+	matches, ok := route["match"].([]any)
+	if !ok || len(matches) == 0 {
+		t.Fatalf("missing match: %#v", route)
+	}
+	match, _ := matches[0].(map[string]any)
+	hostsRaw, _ := match["host"].([]any)
+	got := map[string]struct{}{}
+	for _, h := range hostsRaw {
+		s, _ := h.(string)
+		got[s] = struct{}{}
+	}
+	want := []string{"abc.aerol.cloud", "api.acme.com", "admin.acme.com"}
+	if len(got) != len(want) {
+		t.Fatalf("host matcher set %v, want %v", got, want)
+	}
+	for _, w := range want {
+		if _, ok := got[w]; !ok {
+			t.Fatalf("expected host %q in matcher, got %v", w, got)
+		}
+	}
+}
+
+// In IP mode (no domain) the matcher must remain path-based even when
+// custom hostnames are passed — the service layer rejects custom domains
+// in IP-mode deployments via 412, but a defense-in-depth check inside the
+// Caddy helper keeps us from publishing a host matcher with no wildcard
+// fallback if a stray nil-base call slips through.
+func TestUpsertSandboxRouteIPModeIgnoresCustomHostnames(t *testing.T) {
+	fake := newFakeCaddy(t)
+	client := &Client{
+		enabled:    true,
+		publicHost: "203.0.113.10",
+		serverID:   "srv0",
+		baseURL:    fake.URL,
+		httpClient: fake.Client,
+	}
+	if err := client.UpsertSandboxRoute(context.Background(), "abc", "10.0.0.2", 2280, []string{"api.acme.com"}); err != nil {
+		t.Fatalf("UpsertSandboxRoute() error = %v", err)
+	}
+	route := fake.routes["sandbox-abc"]
+	matches, _ := route["match"].([]any)
+	if match, _ := matches[0].(map[string]any); match["host"] != nil {
+		t.Fatalf("IP mode must not set host matcher: %#v", route)
+	}
+}
+
+// EnsureOnDemandTLS — fresh Caddy, no apps/tls. PUT installs the on_demand
+// leaf and POST appends the catch-all policy.
+func TestEnsureOnDemandTLS_FreshCaddy(t *testing.T) {
+	srv := newFakeAutomationServer(t)
+	defer srv.Close()
+	client := &Client{enabled: true, baseURL: srv.URL, httpClient: srv.Client}
+
+	if err := client.EnsureOnDemandTLS(context.Background(), "http://127.0.0.1:21213/internal/tls-ask", 5, time.Minute); err != nil {
+		t.Fatalf("EnsureOnDemandTLS() error = %v", err)
+	}
+
+	// On-demand block written.
+	if srv.onDemand == nil {
+		t.Fatalf("on_demand leaf not written")
+	}
+	if got := srv.onDemand["ask"]; got != "http://127.0.0.1:21213/internal/tls-ask" {
+		t.Fatalf("ask = %v", got)
+	}
+	rl, _ := srv.onDemand["rate_limit"].(map[string]any)
+	if rl["burst"].(float64) != 5 {
+		t.Fatalf("burst = %v", rl["burst"])
+	}
+	if rl["interval"] != "1m0s" {
+		t.Fatalf("interval = %v", rl["interval"])
+	}
+
+	// Catch-all policy appended.
+	if len(srv.policies) != 1 {
+		t.Fatalf("expected 1 policy, got %d", len(srv.policies))
+	}
+	if v, _ := srv.policies[0]["on_demand"].(bool); !v {
+		t.Fatalf("policy[0] is not on-demand: %v", srv.policies[0])
+	}
+}
+
+// EnsureOnDemandTLS — second boot. on_demand leaf is replaced (so config
+// changes take effect) but the catch-all policy is NOT duplicated.
+func TestEnsureOnDemandTLS_Idempotent(t *testing.T) {
+	srv := newFakeAutomationServer(t)
+	defer srv.Close()
+	client := &Client{enabled: true, baseURL: srv.URL, httpClient: srv.Client}
+
+	if err := client.EnsureOnDemandTLS(context.Background(), "http://x/ask", 3, 2*time.Minute); err != nil {
+		t.Fatalf("first call error = %v", err)
+	}
+	if err := client.EnsureOnDemandTLS(context.Background(), "http://x/ask", 7, 30*time.Second); err != nil {
+		t.Fatalf("second call error = %v", err)
+	}
+	if len(srv.policies) != 1 {
+		t.Fatalf("policy duplicated on second call: %d", len(srv.policies))
+	}
+	rl := srv.onDemand["rate_limit"].(map[string]any)
+	if rl["burst"].(float64) != 7 {
+		t.Fatalf("second call did not replace on_demand leaf: %v", rl)
+	}
+}
+
+// EnsureOnDemandTLS — pre-existing wildcard policy from the Caddyfile is
+// preserved, and the on-demand catch-all lands AT THE END so the wildcard
+// matches first.
+func TestEnsureOnDemandTLS_PreservesWildcard(t *testing.T) {
+	srv := newFakeAutomationServer(t)
+	defer srv.Close()
+	srv.policies = []map[string]any{
+		// Looks like a wildcard policy installed by the Caddyfile.
+		{"subjects": []any{"*.aerol.cloud"}, "issuers": []any{map[string]any{"module": "acme"}}},
+	}
+	client := &Client{enabled: true, baseURL: srv.URL, httpClient: srv.Client}
+	if err := client.EnsureOnDemandTLS(context.Background(), "http://x/ask", 5, time.Minute); err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	if len(srv.policies) != 2 {
+		t.Fatalf("expected 2 policies (wildcard + on-demand), got %d", len(srv.policies))
+	}
+	if _, ok := srv.policies[1]["on_demand"]; !ok {
+		t.Fatalf("on-demand policy not appended last; policies=%+v", srv.policies)
+	}
+}
+
+// EnsureOnDemandTLS — input validation rejects bad caller arguments.
+func TestEnsureOnDemandTLS_RejectsBadInput(t *testing.T) {
+	client := &Client{enabled: true, baseURL: "http://unused", httpClient: http.DefaultClient}
+	if err := client.EnsureOnDemandTLS(context.Background(), "", 5, time.Minute); err == nil {
+		t.Fatalf("expected error for empty askURL")
+	}
+	if err := client.EnsureOnDemandTLS(context.Background(), "http://x", 0, time.Minute); err == nil {
+		t.Fatalf("expected error for zero burst")
+	}
+	if err := client.EnsureOnDemandTLS(context.Background(), "http://x", 5, 0); err == nil {
+		t.Fatalf("expected error for zero interval")
+	}
+}
+
+// EnsureOnDemandTLS — Caddy disabled is a no-op (mirrors every other
+// helper).
+func TestEnsureOnDemandTLS_Disabled(t *testing.T) {
+	client := &Client{enabled: false}
+	if err := client.EnsureOnDemandTLS(context.Background(), "http://x", 5, time.Minute); err != nil {
+		t.Fatalf("disabled path must return nil, got %v", err)
+	}
+}
+
+// fakeAutomationServer is a stripped-down Caddy admin emulator covering
+// only the apps/tls/automation/* paths EnsureOnDemandTLS touches.
+type fakeAutomationServer struct {
+	URL    string
+	Client *http.Client
+
+	mu       sync.Mutex
+	policies []map[string]any
+	onDemand map[string]any
+	server   *httptest.Server
+}
+
+func newFakeAutomationServer(t *testing.T) *fakeAutomationServer {
+	t.Helper()
+	f := &fakeAutomationServer{}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		switch r.URL.Path {
+		case "/config/apps/tls/automation/on_demand":
+			if r.Method != http.MethodPut {
+				http.Error(w, "method", http.StatusMethodNotAllowed)
+				return
+			}
+			body, _ := io.ReadAll(r.Body)
+			var v map[string]any
+			if err := json.Unmarshal(body, &v); err != nil {
+				http.Error(w, "decode", http.StatusBadRequest)
+				return
+			}
+			f.onDemand = v
+			w.WriteHeader(http.StatusOK)
+		case "/config/apps/tls/automation/policies":
+			switch r.Method {
+			case http.MethodGet:
+				if f.policies == nil {
+					http.Error(w, "not found", http.StatusNotFound)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(f.policies)
+			case http.MethodPost:
+				body, _ := io.ReadAll(r.Body)
+				var p map[string]any
+				if err := json.Unmarshal(body, &p); err != nil {
+					http.Error(w, "decode", http.StatusBadRequest)
+					return
+				}
+				f.policies = append(f.policies, p)
+				w.WriteHeader(http.StatusOK)
+			default:
+				http.Error(w, "method", http.StatusMethodNotAllowed)
+			}
+		default:
+			http.Error(w, "unexpected "+r.Method+" "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(f.server.Close)
+	f.URL = strings.TrimRight(f.server.URL, "/")
+	f.Client = &http.Client{}
+	return f
+}
+
+func (f *fakeAutomationServer) Close() { f.server.Close() }

--- a/pkg/models/custom_domain.go
+++ b/pkg/models/custom_domain.go
@@ -66,6 +66,20 @@ var (
 	// ErrCustomDomainPerRequestCap is returned by ValidateCustomDomainList
 	// when the caller passes too many hostnames in a single create request.
 	ErrCustomDomainPerRequestCap = fmt.Errorf("at most %d custom_domains per create request", MaxCustomDomainsPerCreateRequest)
+	// ErrCustomDomainNotSupported is returned when a deployment cannot accept
+	// custom domains at all: the feature flag is off, or the daemon is running
+	// in IP mode (no SB_DOMAIN). Surfaced as HTTP 412 Precondition Failed so
+	// clients can distinguish "this cluster does not do custom domains" from
+	// "your input is malformed" (which is 400).
+	ErrCustomDomainNotSupported = errors.New("custom domains are not enabled on this deployment")
+	// ErrCustomDomainProtocolConflict is the IRON RULE violation: a sandbox
+	// with custom domains attached must not also expose protocol=tcp/tls
+	// ports, because the L4 listener has no way to honor a host-based match
+	// — the SNI would route to the wrong sandbox. Surfaced as 409 Conflict.
+	ErrCustomDomainProtocolConflict = errors.New("custom domains cannot coexist with tcp/tls exposed ports on the same sandbox")
+	// ErrCustomDomainPerSandboxCap is returned by AddCustomDomain when the
+	// sandbox already holds MaxCustomDomainsPerSandbox rows. Surfaced as 409.
+	ErrCustomDomainPerSandboxCap = fmt.Errorf("at most %d custom domains per sandbox", MaxCustomDomainsPerSandbox)
 )
 
 // NormalizeCustomDomain lowercases, strips a trailing dot, and validates the

--- a/pkg/models/custom_domain.go
+++ b/pkg/models/custom_domain.go
@@ -1,0 +1,175 @@
+package models
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+	"unicode"
+)
+
+// CustomDomainStatus is the per-domain lifecycle state surfaced through the
+// API + SDK so callers can render "DNS not pointed yet" vs "issuing cert" vs
+// "ready" without polling Caddy. Driven entirely server-side; clients read.
+type CustomDomainStatus string
+
+const (
+	// CustomDomainPendingDNS — row exists, Caddy has not yet asked for the
+	// hostname. This is the state after AddCustomDomain returns and before
+	// the first inbound HTTPS connection.
+	CustomDomainPendingDNS CustomDomainStatus = "pending_dns"
+	// CustomDomainIssuing — first ask hit, ACME flow started. Cleared on the
+	// next ask that sees the cert in storage.
+	CustomDomainIssuing CustomDomainStatus = "issuing"
+	// CustomDomainReady — cert in shared storage, serving connections.
+	CustomDomainReady CustomDomainStatus = "ready"
+	// CustomDomainFailed — Caddy gave up on ACME for this host (LastError
+	// carries the surfaced reason). No automatic retry beyond Caddy's own
+	// backoff; the next ask will flip it back to issuing.
+	CustomDomainFailed CustomDomainStatus = "failed"
+)
+
+// CustomDomain is the per-domain row returned in Sandbox.CustomDomains.
+type CustomDomain struct {
+	Hostname  string             `json:"hostname"`
+	Status    CustomDomainStatus `json:"status"`
+	LastError string             `json:"last_error,omitempty"`
+	CreatedAt time.Time          `json:"created_at"`
+	UpdatedAt time.Time          `json:"updated_at"`
+}
+
+// AddCustomDomainRequest is the body for POST /v1/sandboxes/{id}/custom-domains.
+type AddCustomDomainRequest struct {
+	Hostname string `json:"hostname"`
+}
+
+// Custom-domain caps. Exported so internal/config can read SB_ env overrides
+// against these defaults and the service layer can reference the canonical
+// numbers from one place.
+const (
+	// MaxCustomDomainsPerSandbox bounds the host matcher fan-out per route.
+	// 25 keeps the Caddy host-list small and matches the value documented in
+	// plans/custom-domains.md.
+	MaxCustomDomainsPerSandbox = 25
+	// MaxCustomDomainsPerCreateRequest bounds how many hostnames a single
+	// CreateSandbox call can attach. Lower than the per-sandbox cap so an
+	// accidental array doesn't burn the ACME budget all at once.
+	MaxCustomDomainsPerCreateRequest = 5
+)
+
+var (
+	// ErrCustomDomainInvalid is the validation error returned by
+	// NormalizeCustomDomain. Wrapped with context (the offending hostname /
+	// reason) so the API surfaces something actionable.
+	ErrCustomDomainInvalid = errors.New("invalid custom domain")
+	// ErrCustomDomainPerRequestCap is returned by ValidateCustomDomainList
+	// when the caller passes too many hostnames in a single create request.
+	ErrCustomDomainPerRequestCap = fmt.Errorf("at most %d custom_domains per create request", MaxCustomDomainsPerCreateRequest)
+)
+
+// NormalizeCustomDomain lowercases, strips a trailing dot, and validates the
+// shape of host. baseDomain is the operator's SB_DOMAIN — empty means the
+// daemon is in IP mode, in which case the caller is expected to reject the
+// request at the 412 layer before reaching validation. We still validate the
+// hostname shape so callers cannot rely on the IP-mode short-circuit.
+//
+// Returns the canonical (lowercased, dotted-trimmed) hostname on success.
+//
+// Rejection rules (each maps to a test in types_test.go):
+//   - empty or whitespace-only
+//   - any label > 63 chars
+//   - total length > 253 chars
+//   - non-RFC1035 label charset (letters, digits, hyphen; no leading/trailing
+//     hyphen on a label)
+//   - fewer than two labels (single-label is not a public hostname)
+//   - IP literal (v4 or v6)
+//   - "localhost" or anything ending in ".local"
+//   - anything under baseDomain — wildcard already covers it; allowing a
+//     custom-domain row would let one tenant steal another sandbox's URL
+func NormalizeCustomDomain(host, baseDomain string) (string, error) {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return "", fmt.Errorf("%w: empty hostname", ErrCustomDomainInvalid)
+	}
+	host = strings.TrimSuffix(strings.ToLower(host), ".")
+	if host == "" {
+		return "", fmt.Errorf("%w: empty hostname", ErrCustomDomainInvalid)
+	}
+	if len(host) > 253 {
+		return "", fmt.Errorf("%w: %q exceeds 253 characters", ErrCustomDomainInvalid, host)
+	}
+	if host == "localhost" || strings.HasSuffix(host, ".local") {
+		return "", fmt.Errorf("%w: %q is a reserved local name", ErrCustomDomainInvalid, host)
+	}
+	// net.ParseIP("::1") returns non-nil for IPv6; same for bare v4. Reject
+	// before the label scan so error messages name the actual problem.
+	if ip := net.ParseIP(host); ip != nil {
+		return "", fmt.Errorf("%w: %q is an IP literal", ErrCustomDomainInvalid, host)
+	}
+	labels := strings.Split(host, ".")
+	if len(labels) < 2 {
+		return "", fmt.Errorf("%w: %q is not a public hostname (single label)", ErrCustomDomainInvalid, host)
+	}
+	for _, label := range labels {
+		if err := validateLabel(label); err != nil {
+			return "", fmt.Errorf("%w: %s", ErrCustomDomainInvalid, err.Error())
+		}
+	}
+	if base := strings.ToLower(strings.TrimSpace(baseDomain)); base != "" {
+		base = strings.TrimSuffix(base, ".")
+		if host == base || strings.HasSuffix(host, "."+base) {
+			return "", fmt.Errorf("%w: %q is under the deployment base domain %q (the wildcard already covers it)", ErrCustomDomainInvalid, host, base)
+		}
+	}
+	return host, nil
+}
+
+func validateLabel(label string) error {
+	if label == "" {
+		return fmt.Errorf("empty label")
+	}
+	if len(label) > 63 {
+		return fmt.Errorf("label %q exceeds 63 characters", label)
+	}
+	if label[0] == '-' || label[len(label)-1] == '-' {
+		return fmt.Errorf("label %q must not start or end with '-'", label)
+	}
+	for _, r := range label {
+		if r == '-' || unicode.IsDigit(r) {
+			continue
+		}
+		if r >= 'a' && r <= 'z' {
+			continue
+		}
+		return fmt.Errorf("label %q contains invalid character %q", label, r)
+	}
+	return nil
+}
+
+// ValidateCustomDomainList normalizes every entry in hosts against baseDomain
+// and enforces the per-create-request cap and intra-list uniqueness. Returns
+// the canonical slice or the first error. Empty input returns nil, nil — the
+// caller treats "no custom domains" the same as omitting the field.
+func ValidateCustomDomainList(hosts []string, baseDomain string) ([]string, error) {
+	if len(hosts) == 0 {
+		return nil, nil
+	}
+	if len(hosts) > MaxCustomDomainsPerCreateRequest {
+		return nil, ErrCustomDomainPerRequestCap
+	}
+	out := make([]string, 0, len(hosts))
+	seen := make(map[string]struct{}, len(hosts))
+	for _, h := range hosts {
+		canon, err := NormalizeCustomDomain(h, baseDomain)
+		if err != nil {
+			return nil, err
+		}
+		if _, dup := seen[canon]; dup {
+			continue
+		}
+		seen[canon] = struct{}{}
+		out = append(out, canon)
+	}
+	return out, nil
+}

--- a/pkg/models/custom_domain_test.go
+++ b/pkg/models/custom_domain_test.go
@@ -1,0 +1,152 @@
+package models
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeCustomDomain(t *testing.T) {
+	const base = "aerol.cloud"
+
+	type want struct {
+		out    string
+		errSub string // substring expected in the error; "" means no error
+	}
+
+	cases := []struct {
+		name string
+		in   string
+		want want
+	}{
+		{"plain subdomain", "api.acme.com", want{out: "api.acme.com"}},
+		{"trailing dot stripped", "api.acme.com.", want{out: "api.acme.com"}},
+		{"uppercase folded", "API.Acme.COM", want{out: "api.acme.com"}},
+		{"leading/trailing whitespace", "  api.acme.com  ", want{out: "api.acme.com"}},
+		{"apex (two labels)", "acme.com", want{out: "acme.com"}},
+
+		{"empty rejected", "", want{errSub: "empty hostname"}},
+		{"whitespace only rejected", "   ", want{errSub: "empty hostname"}},
+		{"single label rejected", "localdev", want{errSub: "not a public hostname"}},
+		{"localhost rejected", "localhost", want{errSub: "reserved local name"}},
+		{"trailing .local rejected", "my-box.local", want{errSub: "reserved local name"}},
+		{"ipv4 literal rejected", "192.168.1.1", want{errSub: "IP literal"}},
+		{"ipv6 literal rejected", "::1", want{errSub: "IP literal"}},
+
+		{"label with hyphen ok", "ap-i.acme.com", want{out: "ap-i.acme.com"}},
+		{"label leading hyphen rejected", "-api.acme.com", want{errSub: "must not start or end with '-'"}},
+		{"label trailing hyphen rejected", "api-.acme.com", want{errSub: "must not start or end with '-'"}},
+		{"label invalid char rejected", "api_v2.acme.com", want{errSub: "invalid character"}},
+
+		// Boundary: label exactly 63 / 64 chars
+		{"label 63 chars ok", strings.Repeat("a", 63) + ".acme.com", want{out: strings.Repeat("a", 63) + ".acme.com"}},
+		{"label 64 chars rejected", strings.Repeat("a", 64) + ".acme.com", want{errSub: "exceeds 63 characters"}},
+
+		// Boundary: total 253 / 254
+		{
+			name: "total 253 chars ok",
+			in:   strings.Repeat("a", 49) + "." + strings.Repeat("b", 49) + "." + strings.Repeat("c", 49) + "." + strings.Repeat("d", 49) + "." + strings.Repeat("e", 53),
+			want: want{out: strings.Repeat("a", 49) + "." + strings.Repeat("b", 49) + "." + strings.Repeat("c", 49) + "." + strings.Repeat("d", 49) + "." + strings.Repeat("e", 53)},
+		},
+		{
+			name: "total > 253 rejected",
+			in:   strings.Repeat("a", 60) + "." + strings.Repeat("b", 60) + "." + strings.Repeat("c", 60) + "." + strings.Repeat("d", 60) + "." + strings.Repeat("e", 60),
+			want: want{errSub: "exceeds 253 characters"},
+		},
+
+		// Base-domain rejection — both the apex and any child of it.
+		{"base-domain apex rejected", "aerol.cloud", want{errSub: "under the deployment base domain"}},
+		{"base-domain child rejected", "sb-xyz.aerol.cloud", want{errSub: "under the deployment base domain"}},
+		{"base-domain trailing dot still rejected", "sb-xyz.aerol.cloud.", want{errSub: "under the deployment base domain"}},
+		{"unrelated tld ok", "aerol.cloud.evil.com", want{out: "aerol.cloud.evil.com"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NormalizeCustomDomain(tc.in, base)
+			if tc.want.errSub == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got != tc.want.out {
+					t.Fatalf("got %q, want %q", got, tc.want.out)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil (out=%q)", tc.want.errSub, got)
+			}
+			if !errors.Is(err, ErrCustomDomainInvalid) {
+				t.Fatalf("expected ErrCustomDomainInvalid, got %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.want.errSub) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.want.errSub)
+			}
+		})
+	}
+}
+
+func TestNormalizeCustomDomain_EmptyBaseDomain(t *testing.T) {
+	// IP-mode deployments pass baseDomain="". Validation still runs against
+	// the hostname shape so the IP-mode 412 gate is not the only defense.
+	got, err := NormalizeCustomDomain("api.acme.com", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "api.acme.com" {
+		t.Fatalf("got %q, want %q", got, "api.acme.com")
+	}
+	// Base-domain rejection rule must not fire when base is empty.
+	if _, err := NormalizeCustomDomain("anything.under.no.base", ""); err != nil {
+		t.Fatalf("unexpected error with empty base: %v", err)
+	}
+}
+
+func TestValidateCustomDomainList(t *testing.T) {
+	const base = "aerol.cloud"
+
+	t.Run("empty input is nil result", func(t *testing.T) {
+		out, err := ValidateCustomDomainList(nil, base)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out != nil {
+			t.Fatalf("got %v, want nil", out)
+		}
+	})
+
+	t.Run("canonicalizes and dedupes", func(t *testing.T) {
+		out, err := ValidateCustomDomainList([]string{"api.ACME.com", "api.acme.com.", "other.acme.com"}, base)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(out) != 2 {
+			t.Fatalf("got %v, want 2 entries after dedupe", out)
+		}
+		if out[0] != "api.acme.com" || out[1] != "other.acme.com" {
+			t.Fatalf("got %v, want [api.acme.com other.acme.com]", out)
+		}
+	})
+
+	t.Run("per-request cap rejected", func(t *testing.T) {
+		over := []string{"a.x.com", "b.x.com", "c.x.com", "d.x.com", "e.x.com", "f.x.com"}
+		_, err := ValidateCustomDomainList(over, base)
+		if !errors.Is(err, ErrCustomDomainPerRequestCap) {
+			t.Fatalf("got %v, want ErrCustomDomainPerRequestCap", err)
+		}
+	})
+
+	t.Run("first invalid bubbles up", func(t *testing.T) {
+		_, err := ValidateCustomDomainList([]string{"api.acme.com", "bad_label.acme.com"}, base)
+		if !errors.Is(err, ErrCustomDomainInvalid) {
+			t.Fatalf("got %v, want ErrCustomDomainInvalid", err)
+		}
+	})
+
+	t.Run("base-domain entry rejected in list", func(t *testing.T) {
+		_, err := ValidateCustomDomainList([]string{"sb-abc.aerol.cloud"}, base)
+		if !errors.Is(err, ErrCustomDomainInvalid) {
+			t.Fatalf("got %v, want ErrCustomDomainInvalid", err)
+		}
+	})
+}

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -433,6 +433,13 @@ type CreateSandboxRequest struct {
 	// Crossing the limit installs an egress DROP rule via the same primitive
 	// NetworkBlockAll uses.
 	NetworkBytesOutLimit int64 `json:"network_bytes_out_limit,omitempty"`
+	// CustomDomains attaches operator-provided public hostnames to the
+	// sandbox at create time. Each hostname must resolve (via DNS) to the
+	// cluster's ingress host before HTTPS can serve traffic — see
+	// plans/custom-domains.md. Bare strings on the wire; the response shape
+	// (Sandbox.CustomDomains) carries per-hostname status. Capped by
+	// MaxCustomDomainsPerCreateRequest.
+	CustomDomains []string `json:"custom_domains,omitempty"`
 }
 
 func (r CreateSandboxRequest) ImageDistribution() ImageDistributionMetadata {
@@ -542,6 +549,10 @@ type Sandbox struct {
 	// is set. Cleared on manual StopSandbox and after a successful wake.
 	// Internal-only bookkeeping; never exposed over the wire.
 	WakeArmed bool `json:"-"`
+	// CustomDomains carries the per-hostname rows for any operator-attached
+	// public hostnames. Status is server-managed (pending_dns → issuing →
+	// ready / failed). Nil when the sandbox has no custom domains.
+	CustomDomains []CustomDomain `json:"custom_domains,omitempty"`
 }
 
 // NetworkUsage is the response shape for GET /v1/sandboxes/{id}/network/usage.

--- a/plans/custom-domains.md
+++ b/plans/custom-domains.md
@@ -119,12 +119,18 @@ hostname (a hostname maps to exactly one sandbox at a time).
 CREATE TABLE sandbox_custom_domains (
     hostname    TEXT PRIMARY KEY,                  -- lowercased, no trailing dot
     sandbox_id  TEXT NOT NULL,
+    status      TEXT NOT NULL DEFAULT 'pending_dns',
+    last_error  TEXT,
     created_at  DATETIME NOT NULL,
+    updated_at  DATETIME NOT NULL,
     FOREIGN KEY (sandbox_id) REFERENCES sandboxes(id) ON DELETE CASCADE
 );
 CREATE INDEX idx_sandbox_custom_domains_sandbox_id
     ON sandbox_custom_domains(sandbox_id);
 ```
+
+The `status` column is the per-domain state machine surfaced through the API
+(OV4A) — see §2.
 
 The PK on `hostname` is the global uniqueness enforcement — the same
 pattern the L4 host-port partial unique index uses for collision-safe
@@ -153,20 +159,65 @@ sibling `attachCustomDomainsBulk` does one query and groups by
 
 ```go
 // pkg/models/types.go
+
+// CustomDomainStatus is the per-domain lifecycle state surfaced through
+// API + SDK (OV4A). Drives UX: clients render "DNS not pointed yet" vs
+// "issuing cert" vs "ready" without polling Caddy.
+type CustomDomainStatus string
+
+const (
+    CustomDomainPendingDNS CustomDomainStatus = "pending_dns" // row exists, no cert seen
+    CustomDomainIssuing    CustomDomainStatus = "issuing"     // ACME flow started (first ask hit)
+    CustomDomainReady      CustomDomainStatus = "ready"       // cert in storage
+    CustomDomainFailed     CustomDomainStatus = "failed"      // ACME gave up; LastError set
+)
+
+type CustomDomain struct {
+    Hostname  string             `json:"hostname"`
+    Status    CustomDomainStatus `json:"status"`
+    LastError string             `json:"last_error,omitempty"`
+    CreatedAt time.Time          `json:"created_at"`
+    UpdatedAt time.Time          `json:"updated_at"`
+}
+
 type CreateSandboxRequest struct {
     // ... existing fields
-    CustomDomains []string `json:"custom_domains,omitempty"`
+    CustomDomains []string `json:"custom_domains,omitempty"` // bare hostnames on create
 }
 
 type Sandbox struct {
     // ... existing fields
-    CustomDomains []string `json:"custom_domains,omitempty"`
+    CustomDomains []CustomDomain `json:"custom_domains,omitempty"` // full status on read
 }
 
 type AddCustomDomainRequest struct {
     Hostname string `json:"hostname"`
 }
 ```
+
+State machine (driven by service layer, not by the SDK caller):
+
+```
+            AddCustomDomain
+                  │
+                  ▼
+            pending_dns ──── ask hit ────▶ issuing
+                  │                           │
+                  │                           │ cert in storage
+                  ▼                           ▼
+              (delete)                      ready
+                                              │
+                                              │ cert renew fails
+                                              ▼
+                                            failed ──── ask hit ────▶ issuing
+```
+
+The `pending_dns → issuing` transition happens inside `TLSAsk` (§5) the
+first time Caddy asks about the hostname. `issuing → ready` happens when
+the next `ask` hit confirms the cert exists in storage (cheap stat via
+certmagic). `* → failed` is observability-only for v1: we surface a Caddy
+ACME failure log line as `last_error`; no automatic retry beyond Caddy's
+own backoff.
 
 Validation in `pkg/models` (called from both the v1 handler and
 `Service.CreateSandbox`):
@@ -238,6 +289,16 @@ In domain-mode today the HTTPS site reuses the wildcard cert manager. For
 custom hostnames we add an on-demand TLS policy that calls back into
 sandboxd to check whether the hostname is allowed.
 
+**Shared cert storage is already wired (A4-doc).** When deployed via
+`scripts/install.sh --caddy-storage-s3`, `packaging/Caddyfile.template`
+injects a `storage s3 { ... }` directive that points Caddy at S3 via the
+certmagic-s3 plugin. The plugin handles distributed locking so two nodes
+issuing the same custom hostname simultaneously coordinate through S3
+rather than racing Let's Encrypt twice. The new on-demand policy below
+inherits that storage automatically — no new code, just a docs cross-link
+to `setup/multi-node-cert-sharing.md`. The doc must be updated to mention
+that custom-hostname certs now share the same S3 bucket as the wildcard.
+
 Caddy's on-demand config (added to the existing `apps/tls/automation`
 section in `pkg/caddy/client.go`'s install-time config push):
 
@@ -271,45 +332,82 @@ everything else. Hosts unknown to sandboxd are rejected by `ask`,
 which means Caddy never attempts ACME for them — that is the abuse
 defense.
 
-The `ask` endpoint (loopback-only, never exposed publicly):
+The `ask` endpoint lives as a sibling file in the wake-proxy package
+(A5A — `pkg/api/ingressproxy/tls_ask.go`), not in a new `internal/ingress/`
+package. It registers on the existing `InternalIngressAddr` listener
+(loopback-only, bound in `cmd/sandboxd/main.go:397`):
 
 ```go
-// internal/ingress/tls_ask.go (new file)
+// pkg/api/ingressproxy/tls_ask.go (new file, sibling of routes.go)
+//
 // GET /internal/tls-ask?domain=<host>
 //
 // 200 → Caddy may issue a cert for this host.
 // 4xx → Caddy refuses to attempt issuance.
 //
-// Hot path. Single PK lookup; no logs on the success path.
-func (h *Handler) TLSAsk(w http.ResponseWriter, r *http.Request) {
-    host := r.URL.Query().Get("domain")
+// Hot path. Cluster-wide hostname lookup hits the local Raft FSM (A2A);
+// no SQLite touch. Negative results are LRU-cached for 60s (C1A) so an
+// SNI flood from a scanner can't burn CPU.
+func (h *TLSAskHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+    host := strings.ToLower(strings.TrimSuffix(r.URL.Query().Get("domain"), "."))
     if host == "" {
         http.Error(w, "missing domain", http.StatusBadRequest)
         return
     }
-    host = strings.ToLower(strings.TrimSuffix(host, "."))
-    // Allow our own wildcard children (defense in depth — wildcard policy
-    // should match first, but if Caddy ever falls through, we still say yes).
-    if strings.HasSuffix(host, "."+h.cfg.Domain) || host == h.cfg.Domain {
+    // Defense in depth — wildcard policy should match first.
+    if host == h.cfg.Domain || strings.HasSuffix(host, "."+h.cfg.Domain) {
         w.WriteHeader(http.StatusOK)
         return
     }
-    if _, err := h.store.ResolveCustomDomain(r.Context(), host); err != nil {
-        if errors.Is(err, models.ErrNotFound) {
-            http.Error(w, "unknown host", http.StatusForbidden)
-            return
-        }
-        http.Error(w, "lookup failed", http.StatusInternalServerError)
+    if h.negCache.has(host) {
+        http.Error(w, "unknown host", http.StatusForbidden)
         return
     }
+    sandboxID, ok := h.fsm.ResolveCustomDomain(host) // local Raft FSM lookup
+    if !ok {
+        h.negCache.add(host) // 60s TTL, cap 10k entries
+        http.Error(w, "unknown host", http.StatusForbidden)
+        return
+    }
+    h.acmeBudget.RecordAttempt(sandboxID) // see §5b
+    h.status.MarkIssuing(host)            // pending_dns → issuing
     w.WriteHeader(http.StatusOK)
 }
 ```
 
-Listen address: `internal/config.Config.InternalIngressAddr` (already
-loopback-only — same address the wake proxy binds to). Add an
-`/internal/tls-ask` route on that listener; **must not** be on the public
-API listener.
+The handler reads from the cluster FSM (`internal/cluster/fsm.go`'s
+hostname → sandbox map — see §10), not from the local SQLite store. In
+single-node mode the in-process FSM still serves the same lookup
+(`cluster.Noop` exposes a degenerate hostname map backed by the store).
+Negative cache entries are evicted whenever `AddCustomDomain` succeeds for
+that hostname (so a legitimate add doesn't have to wait 60s).
+
+### 5b. ACME budget (OV5A)
+
+Let's Encrypt enforces a per-account `new-orders` limit (currently 300 /
+3hr). A misconfigured user with 100 custom domains can blow that for the
+whole cluster. v1 ships a daemon-wide token bucket:
+
+```go
+// internal/service/acme_budget.go
+//
+// One bucket per Caddy ACME account. Refills at the LE published rate.
+// On every TLSAsk that would trigger issuance (status != ready), Reserve
+// returns false if we're at >=80% of the burst capacity, and ask returns
+// 429 to Caddy. 80% leaves headroom for the cert renewals already in
+// flight.
+type ACMEBudget struct { ... }
+
+func (b *ACMEBudget) Reserve(sandboxID string) (ok bool)
+```
+
+The 80% threshold is configurable via `SB_ACME_DAEMON_BUDGET_FRACTION`
+(default `0.8`). Budget exhaustion is logged with `sandbox_id` so the
+operator can see which tenant burned the quota. Cluster-mode: each node
+maintains its own bucket; we deliberately do **not** synchronise via
+Raft (one bucket per ingress node is fine — LE limits are per-account,
+not per-IP, and serial issuance across nodes is rare given the s3
+distributed lock).
 
 ### 6. HTTP-01 challenge path
 
@@ -393,40 +491,108 @@ plan it also:
    DB set (e.g. caddy was wiped, or a node took over and didn't have
    the matcher).
 
+**Fan-out ceiling (P1A).** Reconcile walks all sandboxes; each
+custom-domain matcher write is O(1) in Caddy. At 10k sandboxes × 25
+custom domains the bounded matcher-string size is ~25k hostnames
+per cluster, well under Caddy's host-matcher scaling. We do not
+paginate reconcile in v1; if cluster size ever crosses 50k sandboxes
+we revisit. (Documented assumption, not a code gate.)
+
 ### 9. Cluster mode
 
-`internal/cluster/` carries no per-sandbox routing state — that lives
-in the owner's local store. Custom domains follow the same shape:
+Custom-domain routing piggybacks on the **delta-driven ingress
+convergence** mechanism in `internal/service/ingress_delta.go` (A1A) —
+the same path that already keeps non-owner ingress nodes in sync for
+per-port routes. We do **not** make direct `UpsertSandboxRouteToPeer`
+calls from `AddCustomDomain`.
 
-- **DB rows live on the owner.** `sandbox_custom_domains` is part of
-  the owner's SQLite. Failover replication (`recovery_replication.go`)
-  must include the new table — every place we currently replicate
-  `exposed_ports` for a sandbox, we replicate `sandbox_custom_domains`
-  alongside it.
-- **Ingress nodes need the matcher.** Today the ingress path for a non-
-  owned sandbox is `UpsertSandboxRouteToPeer` (`client.go:175`). That
-  function must learn the custom hostnames too. The owner pushes them
-  via the existing route-publish gossip path; ingress nodes apply.
-- **`ask` endpoint is per-node.** Each node's `ResolveCustomDomain` only
-  knows about sandboxes whose state it has — i.e. the owner and any
-  ingress node that has been told about the route. For v1 we accept
-  that the first request after a custom domain is added might hit a
-  cold ingress node that returns 403 to Caddy on the `ask`. The owner
-  push to ingress nodes happens on the same code path as the existing
-  per-port route push, so the window is small. If this is unacceptable
-  we add a cluster-wide hostname → sandbox lookup that any node can
-  serve (e.g. via the placement FSM); call this an open question for
-  the eng review.
+Flow:
+
+1. **Owner applies the change locally.** `AddCustomDomain` validates,
+   inserts the SQLite row, and submits an `ApplyAddCustomDomain` Raft
+   command (§10). The command writes the hostname → sandbox mapping into
+   the FSM and bumps the sandbox's `ingress_version`.
+2. **Ingress delta loop notices.** `ingress_delta.go` watches the FSM
+   for `ingress_version` changes on sandboxes whose routes this node
+   serves. On bump it computes the delta between
+   `cluster.SandboxRouteSpec.CustomHostnames` (now the union from the
+   FSM) and Caddy's currently-installed matcher set, and PATCHes
+   `UpsertSandboxRouteToPeer` once with the full set.
+3. **`cluster.ForwardHTTP` is unchanged.** Cross-node HTTP forwarding
+   keys off `sandbox_id`, not hostname; once Caddy on the ingress node
+   matches the custom hostname, the existing reverse-proxy path
+   transparently reaches the owner.
+4. **Failover.** `recovery_replication.go` already replicates
+   per-sandbox state to the failover replicas. Extend the replicated
+   blob with `custom_domains: []{hostname, status, last_error}` so the
+   new owner has the SQLite rows on takeover. The FSM hostname map is
+   already replicated by Raft itself.
 
 PR call-outs required (`CLAUDE.md` cluster hard-rule):
 
-- Replication tests: a custom domain set on the owner before failover
-  appears on the new owner.
-- Single-node regression: `EnableCluster=false` still works (the
-  `cluster.Noop` already returns nil; we just need to not call
-  cluster-specific paths in single-node).
-- Replay safety: re-applying an `AddCustomDomain` event after recovery
-  is a no-op (the `INSERT OR IGNORE` semantics already give us this).
+- **Replication test**: sandbox with two custom domains, kill the
+  owner, assert new owner answers `TLSAsk` for both hostnames and
+  Caddy still serves them.
+- **FSM replay test**: re-applying `ApplyAddCustomDomain` after Raft
+  snapshot restore is a no-op (idempotent on hostname PK in the map).
+- **Single-node regression**: `EnableCluster=false` uses a degenerate
+  `Noop` FSM that resolves hostnames from the local store; no Raft
+  commands submitted; same `TLSAsk` and route-install code paths.
+- **Cluster ingress on a non-owner node**: SNI for the custom hostname
+  arrives at node Z which is not the owner; FSM lookup resolves it;
+  Caddy matches the route; `cluster.ForwardHTTP` reaches the owner.
+
+### 10. FSM hostname uniqueness (A2A + OV7A)
+
+`internal/cluster/fsm.go` gains a hostname → sandbox map and two new
+Raft commands:
+
+```go
+// internal/cluster/fsm.go
+type FSMState struct {
+    // ... existing
+    CustomDomains map[string]string // hostname → sandboxID (lowercase)
+}
+
+type ApplyAddCustomDomain struct {
+    Hostname  string
+    SandboxID string
+    NodeID    string // owner node, for audit
+}
+
+type ApplyRemoveCustomDomain struct {
+    Hostname  string
+    SandboxID string // must match; cross-sandbox removal rejected
+}
+```
+
+`ApplyAddCustomDomain` is the **uniqueness gate**. On replay:
+
+- If `CustomDomains[hostname]` is unset → insert, bump
+  `sandboxes[id].IngressVersion`, return ok.
+- If it points to the same `SandboxID` → no-op (replay-safe), return ok.
+- Otherwise → return `models.ErrConflict`. The owner's `AddCustomDomain`
+  reverses the SQLite insert and returns 409 to the caller. This is the
+  cluster-wide collision-safe allocation guarantee — the same shape as
+  the `host_port` partial-unique-index pattern (`store.go:312`) but at
+  the Raft layer because SQLite-PK uniqueness is per-node.
+
+**Lifecycle tied to placement (OV7A).** Hostname entries are owned by
+the sandbox placement, not by the SQLite row. Wherever a placement is
+removed from the FSM (sandbox destroy, owner-drained-and-not-recovered,
+cluster shrink), the same Raft command path releases every hostname in
+`CustomDomains` whose `sandboxID` matches. There is no
+"orphan hostname" path — if the placement is gone the hostname is gone
+in the same Raft log entry. The matching `ApplyRemoveSandbox` (or
+whichever existing command tears placement down) is extended with the
+hostname-release sweep.
+
+Snapshot/restore: the hostname map serializes alongside the rest of
+`FSMState`. No new snapshot path; piggybacks on the existing one.
+
+`cluster.Noop` (single-node) implements the same interface against a
+local store-backed map; in single-node mode SQLite PK uniqueness is the
+backing guarantee. The single-node path is the regression test target.
 
 ---
 
@@ -444,13 +610,21 @@ PR call-outs required (`CLAUDE.md` cluster hard-rule):
 | `internal/service/custom_domains.go` *(new)* | `AddCustomDomain`, `RemoveCustomDomain`, `reinstallCustomDomainRoutes`. |
 | `internal/service/service.go` | `CreateSandbox` consumes `req.CustomDomains` after route install. `StartSandbox`/`RecreateSandbox` pass custom hostnames into `UpsertSandboxRoute`. |
 | `internal/service/reconcile.go` (or service.go if not yet split) | Apply custom hostnames in the re-install pass; zombie matcher GC. |
-| `internal/ingress/tls_ask.go` *(new)* | The `ask` handler. Bound to `InternalIngressAddr`. |
-| `cmd/sandboxd/main.go` | Wire the new internal route on the existing internal listener. |
-| `pkg/caddy/client.go` | `UpsertSandboxRoute` and `UpsertSandboxRouteToPeer` take `customHostnames []string`. Install-time config push adds the on-demand TLS policy. |
+| `pkg/api/ingressproxy/tls_ask.go` *(new)* | The `ask` handler + LRU negative cache. Sibling of `routes.go` on the existing `InternalIngressAddr` listener (A5A). |
+| `pkg/api/ingressproxy/routes.go` | Register `/internal/tls-ask` on the ingress mux. |
+| `pkg/caddy/client.go` | `UpsertSandboxRoute` and `UpsertSandboxRouteToPeer` take `customHostnames []string`. Install-time config push adds the on-demand TLS policy (after the wildcard policy). |
 | `pkg/caddy/client_test.go` | New: matcher PATCH includes custom hostnames; on-demand policy is present after install push; rate-limit shape matches. |
-| `internal/cluster/recovery_replication.go` | Replicate the new table. |
-| `internal/cluster/*_test.go` | Failover regression: custom domains survive owner change. |
-| `internal/config/config.go` | Read `SB_CUSTOM_DOMAINS_MAX_PER_SANDBOX` (default 25), `SB_TLS_ON_DEMAND_BURST` (default 5), `SB_TLS_ON_DEMAND_INTERVAL` (default `1m`). |
+| `internal/cluster/fsm.go` | Hostname → sandbox map; `ApplyAddCustomDomain` / `ApplyRemoveCustomDomain` Raft commands; hostname-release sweep in placement-teardown command (OV7A). |
+| `internal/cluster/fsm_test.go` | Conflict, replay safety, placement-teardown release, snapshot/restore. |
+| `internal/cluster/noop.go` | Degenerate hostname-map shim backed by the local store (single-node mode). |
+| `internal/cluster/recovery_replication.go` | Replicate the new table alongside `exposed_ports`. |
+| `internal/service/ingress_delta.go` | Extend the spec carried per sandbox to include `CustomHostnames`; bump `ingress_version` on add/remove. |
+| `internal/service/ingress_delta_test.go` | Delta-driven matcher propagation to ingress nodes. |
+| `internal/service/acme_budget.go` *(new)* | Daemon-wide ACME token bucket (OV5A). 80%-of-LE-account-limit gate. |
+| `internal/observability/metrics.go` | `acme_lock_held_seconds` gauge, `acme_lock_acquire_duration_seconds` histogram, `ask_requests_total{result}` counter (F3/F4). |
+| `setup/prometheus/alerts/sandboxd.yml` | Alert on `acme_lock_held_seconds > 300`; alert on `rate(ask_requests_total[2m]) == 0 while up == 1`. |
+| `setup/multi-node-cert-sharing.md` | Cross-link from §5: explicitly mention custom-hostname certs ride the same S3 bucket as the wildcard (A4-doc). |
+| `internal/config/config.go` | `SB_CUSTOM_DOMAINS_MAX_PER_SANDBOX` (default 25), `SB_TLS_ON_DEMAND_BURST` (default 5), `SB_TLS_ON_DEMAND_INTERVAL` (default `1m`), `SB_ENABLE_CUSTOM_DOMAINS` (gate, default false), `SB_ACME_DAEMON_BUDGET_FRACTION` (default 0.8). |
 | `sdk/typescript/src/Sandbox.ts` and the other 4 SDKs | `sandbox.customDomains` add/remove/list, `customDomains: string[]` on the create request. Use `/add-sdk-method` to keep lockstep. |
 | `docs/src/content/docs/custom-domains.mdx` *(new)* | Hard rule: 5-language tabs, no curl. Includes DNS setup steps (CNAME to ingress host) and the `ask` flow at a high level. |
 | `docs/src/content.config.ts` | Register the new page in the sidebar. |
@@ -461,31 +635,147 @@ PR call-outs required (`CLAUDE.md` cluster hard-rule):
 
 Required (per `CLAUDE.md` hard rules and `pr-review.md`):
 
-- `internal/store/store_test.go`
-  - `AddCustomDomain` returns ErrConflict on PK collision.
-  - `RemoveCustomDomain` is no-op + ErrNotFound on mismatched sandbox.
-  - `ResolveCustomDomain` returns ErrNotFound for unknown hosts (no panic).
+**Store** — `internal/store/store_test.go`
+  - `AddCustomDomain` returns `ErrConflict` on hostname PK collision
+    across sandboxes.
+  - `AddCustomDomain` is idempotent for same `(sandbox, hostname)`.
+  - `RemoveCustomDomain` returns `ErrNotFound` on mismatched sandbox.
+  - `ResolveCustomDomain` returns `ErrNotFound` for unknown hosts.
   - Cascade: deleting the sandbox row removes its custom domains.
-- `pkg/caddy/client_test.go`
+  - `attachCustomDomainsBulk` correctly groups by `sandbox_id` across
+    a mixed-result query.
+  - Status transitions: `MarkIssuing`, `MarkReady`, `MarkFailed` are
+    idempotent and update `updated_at`.
+
+**Models / validation** — `pkg/models/types_test.go`
+  - Case-folding (`API.ACME.COM` → `api.acme.com`).
+  - Trailing dot stripped.
+  - Base-domain rejection (`<id>.$DOMAIN`, `$DOMAIN` itself).
+  - IP literal rejection (v4 + v6).
+  - `localhost`, `*.local` rejected.
+  - Boundary: 63-char label accepted, 64-char rejected; 253-char total
+    accepted, 254 rejected.
+  - Per-request cap (5 on create) → validation error.
+
+**Caddy** — `pkg/caddy/client_test.go`
   - `UpsertSandboxRoute` writes `host: [...]` with the union of base
     name and custom hostnames; passing the same set twice is byte-
     identical (idempotent PATCH).
+  - `UpsertSandboxRouteToPeer` (cluster ingress path) includes the
+    custom-hostname set in its matcher.
   - Install config push contains exactly one on-demand policy with
-    `ask` pointing at the loopback address.
-- `internal/service/custom_domains_test.go`
-  - Add → Caddy failure → store row deleted.
-  - Remove → Caddy success → store row deleted.
-  - Add over the per-sandbox cap → 4xx with stable error.
-- `internal/ingress/tls_ask_test.go`
-  - Known host → 200, unknown → 403, malformed → 400, base-domain child
-    → 200.
-- `internal/cluster/recovery_replication_test.go`
-  - Sandbox has 2 custom domains, owner dies, new owner answers
-    `ask` for both.
-- `layer4_bootstrap_test.go` — unchanged, but cross-link: custom
-  domains must not interact with the L4 latch (TCP/TLS exposures
-  are explicitly rejected when custom_domains is set; the test
-  asserts the error path).
+    `ask` URL pointing at `InternalIngressAddr/internal/tls-ask`,
+    `rate_limit.interval=1m`, `rate_limit.burst=5`.
+
+**Service** — `internal/service/custom_domains_test.go`
+  - Add → store insert OK → Caddy PATCH fails → store row rolled back.
+  - Remove → Caddy PATCH OK → store delete; reconcile recovers if step 2
+    fails.
+  - Add over per-sandbox cap → stable error with cap name.
+  - **IRON RULE regression**: `protocol="tcp"` exposure + `custom_domains`
+    → rejected with explicit error (not silently accepted, not panic).
+  - **IRON RULE regression**: `protocol="tls"` exposure + `custom_domains`
+    → same.
+  - IP-mode deployment (`SB_DOMAIN=""`) + `custom_domains` →
+    412 Precondition Failed.
+  - `EnableCustomDomains=false` + `custom_domains` → 412.
+
+**ask handler** — `pkg/api/ingressproxy/tls_ask_test.go`
+  - Known host → 200; unknown → 403; malformed (empty / IP) → 400;
+    base-domain child → 200.
+  - Negative cache: 1000 successive lookups for an unknown host hit FSM
+    once, return 403 from cache subsequently; entries expire after 60s.
+  - `AddCustomDomain` evicts the host from negative cache (verified by
+    immediate ask returning 200 without 60s wait).
+  - ACME budget exhaustion → 429 with `Retry-After` header.
+
+**FSM** — `internal/cluster/fsm_test.go`
+  - `ApplyAddCustomDomain` rejects cross-sandbox hostname conflict.
+  - `ApplyAddCustomDomain` is replay-safe for same `(host, sandbox)`.
+  - Removing a sandbox releases all its hostnames in the same Raft
+    command.
+  - Snapshot + restore round-trips the hostname map intact.
+
+**Cluster ingress** — `internal/service/ingress_delta_test.go`
+  - Adding a custom domain bumps `ingress_version`; ingress nodes
+    pick up the new matcher within one delta cycle.
+  - SNI request for a custom hostname arrives at a non-owner node →
+    matched by Caddy → forwarded via `cluster.ForwardHTTP` to owner.
+
+**Failover** — `internal/cluster/recovery_replication_test.go`
+  - Sandbox has 2 custom domains; owner dies; new owner answers
+    `TLSAsk` 200 for both; Caddy still serves them via shared S3 cert
+    storage (no re-issuance triggered).
+
+**API contract** — `pkg/api/v1/handlers_test.go`
+  - `GET /v1/sandboxes/{id}` includes `custom_domains` with per-domain
+    `status` field.
+  - `POST /v1/sandboxes/{id}/custom-domains` idempotent for same host.
+  - `DELETE` returns 404 for unknown host, 204 for known.
+
+**E2E ACME** (T1A) — `internal/service/custom_domains_e2e_test.go`
+  - Stand up Pebble (LE staging stand-in) + localstack S3 + sandboxd.
+  - Add a custom domain with `/etc/hosts` override pointing at ingress.
+  - Hit `https://<host>/` → first request triggers issuance via Pebble,
+    second request serves cached cert from S3.
+  - Kill ingress node, bring up a second one against the same S3 — cert
+    reused, no second Pebble issuance.
+
+**Layer4 cross-link** — `layer4_bootstrap_test.go` unchanged; the
+IRON RULE regression above is the assertion that custom domains do not
+interact with the L4 latch.
+
+---
+
+## 11. Workload assumptions (OV1A)
+
+Designing for these workloads — scope decisions become wrong if reality
+drifts far from them:
+
+- **Long-lived sandboxes with stable hostnames.** Median sandbox lifetime
+  measured in days, custom hostname attached at create time and rarely
+  changed. We are **not** optimising for the "thousands of ephemeral
+  one-off hostnames per hour" case — that would warrant a different
+  cert-cache strategy (and is what TODO `Custom domains — cert blob GC
+  after removal` is for at scale, see `TODOS.md`).
+- **Bounded fan-out per sandbox.** Per-sandbox cap of 25 is intentional;
+  it lets us keep the host matcher as a single in-place PATCH and avoid
+  paginating reconcile.
+- **Operator-controlled DNS.** Users own the DNS record they point at the
+  cluster. We do not validate DNS pre-issuance; the `ask` endpoint is
+  the only gate. Misconfigured users get a 502 until they fix DNS, not
+  a silent failure.
+- **Multi-tenant cluster.** A misbehaving tenant burning ACME budget
+  must not starve other tenants. This is the OV5A motivation.
+- **Read-heavy `ask` path.** Caddy can hammer `ask` during SNI bursts
+  (scanners, mistuned clients). We size the negative cache for that.
+
+If any of these stop holding (e.g. we want hostname-per-port, or we
+expect 100k churning hostnames/day), revisit before extending v1.
+
+## 12. Observability
+
+Two failure modes from the eng review require monitoring before ship,
+not just tests:
+
+- **F3 — S3 lock held by a dead node during ACME.** certmagic-s3 takes
+  a distributed lock on the cert key for the duration of the ACME flow.
+  If a node dies mid-issuance the lock falls off via TTL; in pathological
+  cases (network partition that masks the death) it can stick.
+  Instrument: `acme_lock_acquire_duration_seconds` histogram +
+  `acme_lock_held_seconds` per-active-lock gauge in `expvar`;
+  Prometheus alert at >5m held.
+- **F4 — `ask` loopback listener crashes mid-process.** If
+  `ingressproxy.Server` exits but the rest of sandboxd keeps running,
+  every new HTTPS connection will fail TLS until the next restart and
+  Caddy's on-demand cache is cold. Instrument: `ask_requests_total{result}`
+  counter + a Prometheus alert on the absence of any successful `ask`
+  for >2m while the process is up.
+
+Implementation lives next to existing metrics in
+`internal/observability/`. Prometheus rules go in
+`setup/prometheus/alerts/` alongside existing alerts. Both metrics + rules
+ship in the v1 PR — not a follow-up.
 
 ---
 
@@ -515,27 +805,20 @@ The gate is a rollout switch, not a per-sandbox toggle — matches the
    Cloud DNS providers that don't support `ALIAS` (e.g. Route53 for
    non-AWS targets, raw bind) will be limited to subdomains. Document
    clearly; consider supporting per-domain DNS-01 in v2 to sidestep.
-2. **Cold ingress node returning 403 on `ask`.** Stated above. The
-   cleanest fix is a cluster-wide lookup via the placement FSM, but it
-   adds Raft load. Eng review should decide: accept the small window,
-   or add the FSM lookup.
-3. **ACME rate limits.** Let's Encrypt has per-domain and per-account
-   limits. A misconfigured user could ask for 100 custom domains and
-   burn issuance budget. Per-sandbox cap + on-demand `rate_limit` give
-   us two layers; consider also a daemon-wide budget counter for v2.
-4. **Cert revocation on remove.** When a user removes a custom domain
+2. **Cert revocation on remove.** When a user removes a custom domain
    we delete the matcher; Caddy keeps the cert in storage until expiry.
-   That's fine for correctness (the host no longer routes) but bloats
-   `data_dir`. A background sweep that prunes cached certs for unknown
-   hosts is a follow-up.
-5. **Cluster-wide hostname uniqueness.** The store PK is per-owner. If
-   sandbox A on node N1 and sandbox B on node N2 both claim
-   `api.acme.com`, both inserts succeed locally. Today no global lock
-   exists. Either route this through Raft (placement FSM gains a
-   hostname→sandbox map) or accept that the second one to hit ingress
-   wins. Open question.
-6. **Wildcard custom domain via DNS-01.** Out of scope; flagged for
+   Correctness intact, bloat only. Background sweep deferred to a
+   follow-up — see `TODOS.md`.
+3. **Wildcard custom domain via DNS-01.** Out of scope; flagged for
    the v2 plan.
+
+**Closed during eng review** (decisions captured in GSTACK REVIEW REPORT below):
+
+- Cluster-wide hostname uniqueness → resolved via FSM (A2A, §10).
+- Cold ingress node returning 403 on `ask` → collapsed into FSM
+  lookup (A3A).
+- ACME budget burn by a misconfigured tenant → promoted to v1 scope
+  via daemon-wide token bucket (OV5A, §5b).
 
 ---
 

--- a/sdk/go/internal/apiclient/client.go
+++ b/sdk/go/internal/apiclient/client.go
@@ -468,6 +468,42 @@ func (c *Client) UnexposePort(ctx context.Context, id string, port int) error {
 	return c.doJSON(ctx, http.MethodDelete, fmt.Sprintf(c.versionPrefix+"/sandboxes/%s/ports/%d", id, port), nil, nil)
 }
 
+// customDomainsEnvelope mirrors the {"custom_domains":[...]} shape used by
+// both the add and list responses, so a single decoder handles both routes.
+type customDomainsEnvelope struct {
+	CustomDomains []models.CustomDomain `json:"custom_domains"`
+}
+
+// AddCustomDomain attaches an operator-provided public hostname to a sandbox.
+// Returns the full per-hostname row list so callers don't need a follow-up
+// GET to read the canonical (lowercased, dot-trimmed) hostname or initial
+// status. The server normalizes hostname; passing it verbatim is correct.
+func (c *Client) AddCustomDomain(ctx context.Context, id, hostname string) ([]models.CustomDomain, error) {
+	body := models.AddCustomDomainRequest{Hostname: hostname}
+	var response customDomainsEnvelope
+	if err := c.doJSON(ctx, http.MethodPost, c.versionPrefix+"/sandboxes/"+id+"/custom-domains", body, &response); err != nil {
+		return nil, err
+	}
+	return response.CustomDomains, nil
+}
+
+// RemoveCustomDomain detaches a hostname. The hostname is URL-encoded so dots
+// and other DNS-legal characters survive the path round-trip; the server
+// re-normalizes (lowercase, trim trailing dot) before comparing.
+func (c *Client) RemoveCustomDomain(ctx context.Context, id, hostname string) error {
+	return c.doJSON(ctx, http.MethodDelete, c.versionPrefix+"/sandboxes/"+id+"/custom-domains/"+url.PathEscape(hostname), nil, nil)
+}
+
+// ListCustomDomains returns the per-hostname rows attached to a sandbox. Same
+// envelope shape as AddCustomDomain so one decoder serves both routes.
+func (c *Client) ListCustomDomains(ctx context.Context, id string) ([]models.CustomDomain, error) {
+	var response customDomainsEnvelope
+	if err := c.doJSON(ctx, http.MethodGet, c.versionPrefix+"/sandboxes/"+id+"/custom-domains", nil, &response); err != nil {
+		return nil, err
+	}
+	return response.CustomDomains, nil
+}
+
 func (c *Client) Health(ctx context.Context) (HealthStatus, error) {
 	var response HealthStatus
 	err := c.doJSON(ctx, http.MethodGet, "/health", nil, &response)
@@ -497,6 +533,18 @@ func (s *Sandbox) DownloadFile(ctx context.Context, targetPath string) ([]byte, 
 
 func (s *Sandbox) ExposePort(ctx context.Context, port int, protocol string) (ExposeResult, error) {
 	return s.client.ExposePort(ctx, s.ID, port, protocol)
+}
+
+func (s *Sandbox) AddCustomDomain(ctx context.Context, hostname string) ([]models.CustomDomain, error) {
+	return s.client.AddCustomDomain(ctx, s.ID, hostname)
+}
+
+func (s *Sandbox) RemoveCustomDomain(ctx context.Context, hostname string) error {
+	return s.client.RemoveCustomDomain(ctx, s.ID, hostname)
+}
+
+func (s *Sandbox) ListCustomDomains(ctx context.Context) ([]models.CustomDomain, error) {
+	return s.client.ListCustomDomains(ctx, s.ID)
 }
 
 func (s *Sandbox) Start(ctx context.Context) error {

--- a/sdk/go/internal/apiclient/custom_domains_test.go
+++ b/sdk/go/internal/apiclient/custom_domains_test.go
@@ -1,0 +1,162 @@
+package apiclient
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// TestAddCustomDomainSendsHostnameAndDecodesEnvelope pins the POST wire shape
+// {"hostname": "..."} and the response envelope {"custom_domains":[...]}.
+// Drift here (e.g. someone renaming the JSON key, or unwrapping the envelope)
+// silently breaks every caller because Go decoders skip unknown fields.
+func TestAddCustomDomainSendsHostnameAndDecodesEnvelope(t *testing.T) {
+	ctx := context.Background()
+	var seenBody models.AddCustomDomainRequest
+	var seenPath string
+	var seenMethod string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenMethod = r.Method
+		seenPath = r.URL.Path
+		if err := json.NewDecoder(r.Body).Decode(&seenBody); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"custom_domains": []models.CustomDomain{{
+				Hostname:  "api.acme.com",
+				Status:    models.CustomDomainPendingDNS,
+				CreatedAt: time.Now().UTC(),
+				UpdatedAt: time.Now().UTC(),
+			}},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, ClientOptions{PATToken: "pat", HTTPClient: server.Client()})
+	domains, err := client.AddCustomDomain(ctx, "sb-123", "api.acme.com")
+	if err != nil {
+		t.Fatalf("AddCustomDomain() error = %v", err)
+	}
+	if seenMethod != http.MethodPost {
+		t.Fatalf("method = %q, want POST", seenMethod)
+	}
+	if seenPath != "/v1/sandboxes/sb-123/custom-domains" {
+		t.Fatalf("path = %q, want /v1/sandboxes/sb-123/custom-domains", seenPath)
+	}
+	if seenBody.Hostname != "api.acme.com" {
+		t.Fatalf("Hostname = %q, want api.acme.com", seenBody.Hostname)
+	}
+	if len(domains) != 1 || domains[0].Hostname != "api.acme.com" || domains[0].Status != models.CustomDomainPendingDNS {
+		t.Fatalf("unexpected domains: %+v", domains)
+	}
+}
+
+// TestListCustomDomainsDecodesEnvelope mirrors the add-path decoder check on
+// the GET route — same shape, different verb.
+func TestListCustomDomainsDecodesEnvelope(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/sandboxes/sb-1/custom-domains" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"custom_domains": []models.CustomDomain{
+				{Hostname: "a.example.com", Status: models.CustomDomainReady},
+				{Hostname: "b.example.com", Status: models.CustomDomainIssuing},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, ClientOptions{PATToken: "pat", HTTPClient: server.Client()})
+	domains, err := client.ListCustomDomains(ctx, "sb-1")
+	if err != nil {
+		t.Fatalf("ListCustomDomains() error = %v", err)
+	}
+	if len(domains) != 2 {
+		t.Fatalf("len(domains) = %d, want 2", len(domains))
+	}
+	if domains[0].Status != models.CustomDomainReady || domains[1].Status != models.CustomDomainIssuing {
+		t.Fatalf("statuses out of order: %+v", domains)
+	}
+}
+
+// TestRemoveCustomDomainURLEncodesHostname guards the URL-escaping rule for
+// the path segment. Hostnames with dots are normal; this pins that a path
+// helper isn't double-escaping or, worse, smuggling a "/" through to confuse
+// the router.
+func TestRemoveCustomDomainURLEncodesHostname(t *testing.T) {
+	ctx := context.Background()
+	var seenPath string
+	var seenMethod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenMethod = r.Method
+		seenPath = r.URL.Path
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, ClientOptions{PATToken: "pat", HTTPClient: server.Client()})
+	if err := client.RemoveCustomDomain(ctx, "sb-x", "api.acme.com"); err != nil {
+		t.Fatalf("RemoveCustomDomain() error = %v", err)
+	}
+	if seenMethod != http.MethodDelete {
+		t.Fatalf("method = %q, want DELETE", seenMethod)
+	}
+	// Server decodes the path segment, so api.acme.com stays human-readable
+	// on the wire. The escape guard kicks in only for non-ASCII / reserved
+	// chars; this assertion pins the happy path so the helper is exercised.
+	if seenPath != "/v1/sandboxes/sb-x/custom-domains/api.acme.com" {
+		t.Fatalf("path = %q, want /v1/sandboxes/sb-x/custom-domains/api.acme.com", seenPath)
+	}
+}
+
+// TestCreateForwardsCustomDomains proves the create-time custom_domains
+// field rides on the wire under its snake_case JSON name. Without this, a
+// silent rename (e.g. someone retypes the tag) means CreateSandbox attaches
+// nothing and callers only discover the gap when their cert never issues.
+func TestCreateForwardsCustomDomains(t *testing.T) {
+	ctx := context.Background()
+	var seen models.CreateSandboxRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&seen); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(models.CreateSandboxResponse{
+			Sandbox: models.Sandbox{
+				ID:     "sb-cd",
+				Image:  "ubuntu:22.04",
+				Status: models.SandboxStatusStarted,
+				CustomDomains: []models.CustomDomain{{
+					Hostname: "api.acme.com",
+					Status:   models.CustomDomainPendingDNS,
+				}},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, ClientOptions{PATToken: "pat", HTTPClient: server.Client()})
+	sandbox, _, err := client.Create(ctx, CreateOptions{
+		Image:         "ubuntu:22.04",
+		CustomDomains: []string{"api.acme.com"},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if len(seen.CustomDomains) != 1 || seen.CustomDomains[0] != "api.acme.com" {
+		t.Fatalf("wire CustomDomains = %+v, want [api.acme.com]", seen.CustomDomains)
+	}
+	if len(sandbox.CustomDomains) != 1 || sandbox.CustomDomains[0].Hostname != "api.acme.com" {
+		t.Fatalf("response CustomDomains = %+v", sandbox.CustomDomains)
+	}
+}

--- a/sdk/go/pkg/microvm/client.go
+++ b/sdk/go/pkg/microvm/client.go
@@ -371,6 +371,34 @@ func (s *Sandbox) UnexposePort(ctx context.Context, port int) error {
 	return s.client.inner.UnexposePort(ctx, s.ID, port)
 }
 
+// AddCustomDomain attaches a public hostname (e.g. "api.acme.com") to this
+// sandbox. The server lowercases / trims and validates the hostname; the
+// returned slice is the full per-hostname row list, so callers can read the
+// canonical form and initial status without a follow-up GET.
+//
+// 412 Precondition Failed surfaces when the deployment is in IP mode or the
+// custom-domain feature is disabled. 409 Conflict surfaces when the hostname
+// is already attached to a different sandbox, or when the sandbox has any
+// tcp/tls-protocol exposed port (the IRON RULE: SNI cannot route per host on
+// a shared L4 listener).
+func (s *Sandbox) AddCustomDomain(ctx context.Context, hostname string) ([]sdktypes.CustomDomain, error) {
+	return s.client.inner.AddCustomDomain(ctx, s.ID, hostname)
+}
+
+// RemoveCustomDomain detaches a hostname previously attached via
+// AddCustomDomain or CreateSandboxOptions.CustomDomains. Case-insensitive;
+// the server normalizes before comparing.
+func (s *Sandbox) RemoveCustomDomain(ctx context.Context, hostname string) error {
+	return s.client.inner.RemoveCustomDomain(ctx, s.ID, hostname)
+}
+
+// ListCustomDomains returns the per-hostname rows currently attached to the
+// sandbox. Use this to poll Status (pending_dns → issuing → ready/failed)
+// after AddCustomDomain.
+func (s *Sandbox) ListCustomDomains(ctx context.Context) ([]sdktypes.CustomDomain, error) {
+	return s.client.inner.ListCustomDomains(ctx, s.ID)
+}
+
 func (s *Sandbox) CreateSnapshot(ctx context.Context, name string) (sdktypes.SandboxSnapshot, error) {
 	return s.client.CreateSnapshot(ctx, s.ID, name)
 }

--- a/sdk/go/pkg/types/types.go
+++ b/sdk/go/pkg/types/types.go
@@ -71,6 +71,22 @@ const (
 type NetworkUsage = models.NetworkUsage
 type SetNetworkLimitsOptions = models.UpdateNetworkLimitsRequest
 
+// CustomDomain is the per-hostname row attached to a sandbox. Status moves
+// pending_dns → issuing → ready (or failed), driven server-side by Caddy's
+// on-demand TLS asks; clients read but never write Status.
+type CustomDomain = models.CustomDomain
+
+// CustomDomainStatus enumerates the lifecycle states surfaced on
+// CustomDomain.Status.
+type CustomDomainStatus = models.CustomDomainStatus
+
+const (
+	CustomDomainPendingDNS = models.CustomDomainPendingDNS
+	CustomDomainIssuing    = models.CustomDomainIssuing
+	CustomDomainReady      = models.CustomDomainReady
+	CustomDomainFailed     = models.CustomDomainFailed
+)
+
 // BuildImagePushOptions describes the per-request push directive for
 // Client.BuildImageWithOptions. Credentials are forwarded to the daemon
 // as a one-shot X-Registry-Auth header on the push call and are never

--- a/sdk/java/src/main/java/ai/aerol/microvm/MicroVMClient.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/MicroVMClient.java
@@ -29,6 +29,7 @@ import ai.aerol.microvm.model.BuildImagePushOptions;
 import ai.aerol.microvm.model.BuildImageResult;
 import ai.aerol.microvm.model.CreateOptions;
 import ai.aerol.microvm.model.CreateSessionOptions;
+import ai.aerol.microvm.model.CustomDomain;
 import ai.aerol.microvm.model.ExecExitInfo;
 import ai.aerol.microvm.model.ExecRequest;
 import ai.aerol.microvm.model.ExecResult;
@@ -374,6 +375,61 @@ public class MicroVMClient {
         doNoContent("DELETE", sandboxPath(sandboxId) + "/ports/" + port, null);
     }
 
+    /**
+     * Attach an operator-supplied hostname to the sandbox's HTTP entrypoint.
+     * The server lowercases {@code hostname}, deduplicates against existing
+     * entries (so retries are safe), and returns the full attached-domain
+     * set. Newly added rows start in {@link ai.aerol.microvm.model.CustomDomainStatus#PENDING_DNS};
+     * Caddy advances them to {@code issuing} / {@code ready} once the
+     * operator's DNS resolves to the cluster.
+     */
+    public List<CustomDomain> addCustomDomain(String sandboxId, String hostname) {
+        CustomDomainListResponse response = doJson(
+            "POST",
+            sandboxPath(sandboxId) + "/custom-domains",
+            new AddCustomDomainRequest(hostname),
+            CustomDomainListResponse.class
+        );
+        if (response == null || response.customDomains == null) {
+            return Collections.emptyList();
+        }
+        return response.customDomains;
+    }
+
+    public List<CustomDomain> listCustomDomains(String sandboxId) {
+        CustomDomainListResponse response = doJson(
+            "GET",
+            sandboxPath(sandboxId) + "/custom-domains",
+            null,
+            CustomDomainListResponse.class
+        );
+        if (response == null || response.customDomains == null) {
+            return Collections.emptyList();
+        }
+        return response.customDomains;
+    }
+
+    public void removeCustomDomain(String sandboxId, String hostname) {
+        doNoContent(
+            "DELETE",
+            sandboxPath(sandboxId) + "/custom-domains/" + encodePathSegment(hostname),
+            null
+        );
+    }
+
+    static class AddCustomDomainRequest {
+        public final String hostname;
+
+        AddCustomDomainRequest(String hostname) {
+            this.hostname = hostname;
+        }
+    }
+
+    private static final class CustomDomainListResponse {
+        @com.fasterxml.jackson.annotation.JsonProperty("custom_domains")
+        public List<CustomDomain> customDomains;
+    }
+
     static class ExposePortRequest {
         public final String protocol;
 
@@ -633,6 +689,7 @@ public class MicroVMClient {
         copy.failover = source.failover;
         copy.runtime = source.runtime;
         copy.gpus = source.gpus;
+        copy.customDomains = source.customDomains;
         return copy;
     }
 

--- a/sdk/java/src/main/java/ai/aerol/microvm/Sandbox.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/Sandbox.java
@@ -3,6 +3,7 @@ package ai.aerol.microvm;
 import java.util.List;
 
 import ai.aerol.microvm.model.CreateSessionOptions;
+import ai.aerol.microvm.model.CustomDomain;
 import ai.aerol.microvm.model.ExecRequest;
 import ai.aerol.microvm.model.ExecResult;
 import ai.aerol.microvm.model.ExecStreamOptions;
@@ -107,6 +108,18 @@ public class Sandbox extends SandboxData {
 
     public void unexposePort(int port) {
         client.unexposePort(id, port);
+    }
+
+    public List<CustomDomain> addCustomDomain(String hostname) {
+        return client.addCustomDomain(id, hostname);
+    }
+
+    public List<CustomDomain> listCustomDomains() {
+        return client.listCustomDomains(id);
+    }
+
+    public void removeCustomDomain(String hostname) {
+        client.removeCustomDomain(id, hostname);
     }
 
     public Sandbox start() {

--- a/sdk/java/src/main/java/ai/aerol/microvm/model/CreateOptions.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/model/CreateOptions.java
@@ -29,6 +29,15 @@ public class CreateOptions {
     public String runtime;
     /** Attach GPU resources to the sandbox. Null means no GPU (CPU-only). */
     public GpuOptions gpus;
+    /**
+     * Operator-supplied hostnames to attach to the sandbox's HTTP entrypoint
+     * at creation time. Each entry travels through the same lifecycle as
+     * {@link ai.aerol.microvm.MicroVMClient#addCustomDomain(String, String)}
+     * (pending_dns → issuing → ready). The server lowercases each entry on
+     * write.
+     */
+    @JsonProperty("custom_domains")
+    public List<String> customDomains;
 
     public CreateOptions setImage(String image) {
         this.image = image;
@@ -107,6 +116,11 @@ public class CreateOptions {
 
     public CreateOptions setGpus(GpuOptions gpus) {
         this.gpus = gpus;
+        return this;
+    }
+
+    public CreateOptions setCustomDomains(List<String> customDomains) {
+        this.customDomains = customDomains;
         return this;
     }
 }

--- a/sdk/java/src/main/java/ai/aerol/microvm/model/CustomDomain.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/model/CustomDomain.java
@@ -1,0 +1,22 @@
+package ai.aerol.microvm.model;
+
+import java.time.Instant;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Operator-supplied hostname attached to a sandbox's HTTP entrypoint. The
+ * server lowercases {@link #hostname} on write, so the value returned here
+ * is the canonical form to render or compare against. {@link #lastError} is
+ * populated only when {@link #status} is {@link CustomDomainStatus#FAILED}.
+ */
+public class CustomDomain {
+    public String hostname;
+    public CustomDomainStatus status;
+    @JsonProperty("last_error")
+    public String lastError;
+    @JsonProperty("created_at")
+    public Instant createdAt;
+    @JsonProperty("updated_at")
+    public Instant updatedAt;
+}

--- a/sdk/java/src/main/java/ai/aerol/microvm/model/CustomDomainStatus.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/model/CustomDomainStatus.java
@@ -1,0 +1,49 @@
+package ai.aerol.microvm.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Lifecycle state of a custom domain attachment. The daemon advances a
+ * hostname through {@link #PENDING_DNS} (waiting for the operator to point
+ * an A/CNAME at the cluster) into {@link #ISSUING} (Caddy is fetching an
+ * ACME certificate on-demand) and finally {@link #READY} once a cert is in
+ * the on-demand cache. {@link #FAILED} is sticky and accompanied by a
+ * {@code last_error}.
+ */
+public enum CustomDomainStatus {
+    PENDING_DNS("pending_dns"),
+    ISSUING("issuing"),
+    READY("ready"),
+    FAILED("failed");
+
+    private final String wireValue;
+
+    CustomDomainStatus(String wireValue) {
+        this.wireValue = wireValue;
+    }
+
+    @JsonValue
+    public String getWireValue() {
+        return wireValue;
+    }
+
+    @JsonCreator
+    public static CustomDomainStatus fromWire(String value) {
+        if (value == null) {
+            return null;
+        }
+        switch (value) {
+            case "pending_dns":
+                return PENDING_DNS;
+            case "issuing":
+                return ISSUING;
+            case "ready":
+                return READY;
+            case "failed":
+                return FAILED;
+            default:
+                throw new IllegalArgumentException("unknown custom domain status: " + value);
+        }
+    }
+}

--- a/sdk/java/src/test/java/ai/aerol/microvm/MicroVMClientTest.java
+++ b/sdk/java/src/test/java/ai/aerol/microvm/MicroVMClientTest.java
@@ -29,6 +29,8 @@ import ai.aerol.microvm.internal.StreamingWebSocketListener;
 import ai.aerol.microvm.internal.WebSocketConnector;
 import ai.aerol.microvm.model.CreateOptions;
 import ai.aerol.microvm.model.CreateSessionOptions;
+import ai.aerol.microvm.model.CustomDomain;
+import ai.aerol.microvm.model.CustomDomainStatus;
 import ai.aerol.microvm.model.ExecExitInfo;
 import ai.aerol.microvm.model.ExecRequest;
 import ai.aerol.microvm.model.ExecResult;
@@ -914,6 +916,134 @@ class MicroVMClientTest {
             client.list(null);
             assertEquals(null, seenQuery.get());
             assertEquals(3, calls.get());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void customDomainsAddListAndRemoveMapApiShapes() throws Exception {
+        AtomicReference<Map<String, Object>> addBody = new AtomicReference<>();
+        AtomicReference<String> deletePath = new AtomicReference<>();
+        AtomicInteger deleteCalls = new AtomicInteger();
+        HttpServer server = startServer(exchange -> {
+            String path = exchange.getRequestURI().getPath();
+            String method = exchange.getRequestMethod();
+            if ("POST".equals(method) && "/v1/sandboxes/sb-1/custom-domains".equals(path)) {
+                addBody.set(castMap(JsonSupport.read(exchange.getRequestBody().readAllBytes(), Map.class)));
+                writeJson(exchange, 201, mapOf(
+                    "custom_domains", List.of(mapOf(
+                        "hostname", "api.acme.com",
+                        "status", "pending_dns",
+                        "created_at", "2026-05-24T10:00:00Z",
+                        "updated_at", "2026-05-24T10:00:00Z"
+                    ))
+                ));
+                return;
+            }
+            if ("GET".equals(method) && "/v1/sandboxes/sb-1/custom-domains".equals(path)) {
+                writeJson(exchange, 200, mapOf(
+                    "custom_domains", List.of(
+                        mapOf(
+                            "hostname", "api.acme.com",
+                            "status", "ready",
+                            "created_at", "2026-05-24T10:00:00Z",
+                            "updated_at", "2026-05-24T10:05:00Z"
+                        ),
+                        mapOf(
+                            "hostname", "app.acme.com",
+                            "status", "failed",
+                            "last_error", "no DNS",
+                            "created_at", "2026-05-24T10:00:00Z",
+                            "updated_at", "2026-05-24T10:05:00Z"
+                        )
+                    )
+                ));
+                return;
+            }
+            if ("DELETE".equals(method) && path.startsWith("/v1/sandboxes/sb-1/custom-domains/")) {
+                deletePath.set(path);
+                deleteCalls.incrementAndGet();
+                writeResponse(exchange, 204, "application/json", new byte[0]);
+                return;
+            }
+            throw new AssertionError("unexpected request: " + method + " " + path);
+        });
+
+        try {
+            MicroVMClient client = clientFor(server);
+            Sandbox sandbox = new Sandbox(client, new SandboxData());
+            sandbox.id = "sb-1";
+
+            List<CustomDomain> added = sandbox.addCustomDomain("api.acme.com");
+            assertEquals(1, added.size());
+            assertEquals("api.acme.com", added.get(0).hostname);
+            assertEquals(CustomDomainStatus.PENDING_DNS, added.get(0).status);
+            assertEquals("api.acme.com", addBody.get().get("hostname"));
+
+            List<CustomDomain> listed = sandbox.listCustomDomains();
+            assertEquals(2, listed.size());
+            assertEquals(CustomDomainStatus.READY, listed.get(0).status);
+            assertEquals(CustomDomainStatus.FAILED, listed.get(1).status);
+            assertEquals("no DNS", listed.get(1).lastError);
+
+            // Hostname with a space-y / colon-y character to prove URL-encoding.
+            sandbox.removeCustomDomain("API.acme.com");
+            assertEquals("/v1/sandboxes/sb-1/custom-domains/API.acme.com", deletePath.get());
+
+            sandbox.removeCustomDomain("a b.example.com");
+            assertEquals("/v1/sandboxes/sb-1/custom-domains/a%20b.example.com", deletePath.get());
+
+            assertEquals(2, deleteCalls.get());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void addCustomDomainSurfacesServerError() throws Exception {
+        HttpServer server = startServer(exchange -> {
+            writeJson(exchange, 409, mapOf("error", "hostname already attached to sandbox sb-other"));
+        });
+
+        try {
+            MicroVMClient client = clientFor(server);
+            MicroVMException error = assertThrows(MicroVMException.class, () -> client.addCustomDomain("sb-1", "api.acme.com"));
+            assertTrue(error.getMessage().contains("already attached"));
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void createIncludesCustomDomainsWhenSet() throws Exception {
+        AtomicReference<Map<String, Object>> requestBody = new AtomicReference<>();
+        HttpServer server = startServer(exchange -> {
+            requestBody.set(castMap(JsonSupport.read(exchange.getRequestBody().readAllBytes(), Map.class)));
+            writeJson(exchange, 200, mapOf(
+                "id", "sb-cd",
+                "image", "ubuntu:22.04",
+                "status", "started",
+                "public_url", "https://sb-cd.example.com",
+                "cpu", 1,
+                "memory_mb", 512,
+                "disk_gb", 10,
+                "os_user", "root",
+                "network_block_all", false,
+                "toolbox_enabled", true,
+                "exposed_ports", List.of(),
+                "created_at", "2026-05-24T10:00:00Z",
+                "updated_at", "2026-05-24T10:00:00Z",
+                "last_active_at", "2026-05-24T10:00:00Z"
+            ));
+        });
+
+        try {
+            MicroVMClient client = clientFor(server);
+            client.create(new CreateOptions()
+                .setImage("ubuntu:22.04")
+                .setCustomDomains(List.of("api.acme.com", "app.acme.com")));
+            assertEquals(List.of("api.acme.com", "app.acme.com"), requestBody.get().get("custom_domains"));
         } finally {
             server.stop(0);
         }

--- a/sdk/python/microvm/__init__.py
+++ b/sdk/python/microvm/__init__.py
@@ -3,6 +3,8 @@ from .image import Image
 from .types import (
     BuildImagePushOptions,
     BuildImageResult,
+    CustomDomain,
+    CustomDomainStatus,
     ExposeProtocol,
     ExposeResult,
     Failover,
@@ -13,6 +15,8 @@ from .types import (
 __all__ = [
     "BuildImagePushOptions",
     "BuildImageResult",
+    "CustomDomain",
+    "CustomDomainStatus",
     "Image",
     "MicroVM",
     "ExposeProtocol",

--- a/sdk/python/microvm/client.py
+++ b/sdk/python/microvm/client.py
@@ -19,6 +19,7 @@ from .types import (
     BuildImageResult,
     CreateOptions,
     CreateSessionOptions,
+    CustomDomain,
     ExecExitInfo,
     ExecRequest,
     ExecResult,
@@ -328,6 +329,15 @@ class Sandbox:
 
     def unexpose_port(self, port: int) -> None:
         self._client.unexpose_port(self.id, port)
+
+    def add_custom_domain(self, hostname: str) -> List[CustomDomain]:
+        return self._client.add_custom_domain(self.id, hostname)
+
+    def list_custom_domains(self) -> List[CustomDomain]:
+        return self._client.list_custom_domains(self.id)
+
+    def remove_custom_domain(self, hostname: str) -> None:
+        self._client.remove_custom_domain(self.id, hostname)
 
     def start(self) -> "Sandbox":
         updated = self._client.start(self.id)
@@ -658,6 +668,40 @@ class MicroVM:
     def unexpose_port(self, sandbox_id: str, port: int) -> None:
         self._do_json("DELETE", f"{self._version_prefix}/sandboxes/{sandbox_id}/ports/{port}", None)
 
+    def add_custom_domain(self, sandbox_id: str, hostname: str) -> List[CustomDomain]:
+        """Attach a public hostname to a sandbox.
+
+        Returns the post-attach list of :class:`CustomDomain` rows so callers
+        can read the initial ``status`` (typically ``"pending_dns"``) without
+        a follow-up GET. Server lowercases the hostname; case is preserved
+        as-passed.
+        """
+        response = self._do_json(
+            "POST",
+            self._versioned(f"/sandboxes/{sandbox_id}/custom-domains"),
+            {"hostname": hostname},
+        )
+        return _from_api_custom_domains_response(response)
+
+    def list_custom_domains(self, sandbox_id: str) -> List[CustomDomain]:
+        response = self._do_json(
+            "GET",
+            self._versioned(f"/sandboxes/{sandbox_id}/custom-domains"),
+            None,
+        )
+        return _from_api_custom_domains_response(response)
+
+    def remove_custom_domain(self, sandbox_id: str, hostname: str) -> None:
+        # URL-encode the hostname segment — DNS labels never need it in
+        # practice, but IDN/punycode hosts ("xn--…") and any operator-supplied
+        # garbage we still want to send must survive an exact round-trip.
+        encoded = urllib.parse.quote(hostname, safe="")
+        self._do_json(
+            "DELETE",
+            self._versioned(f"/sandboxes/{sandbox_id}/custom-domains/{encoded}"),
+            None,
+        )
+
     def _resolve_image(self, image: Any) -> str:
         if isinstance(image, Image):
             return self.build_image(image)
@@ -813,6 +857,7 @@ def _to_api_create_options(options: CreateOptions) -> Dict[str, Any]:
             "mounts": [_to_api_mount_spec(item) for item in (_first_of(options, "mounts") or [])],
             "lifecycle": _to_api_lifecycle(lifecycle) if isinstance(lifecycle, dict) else None,
             "failover": _to_api_failover(failover) if isinstance(failover, dict) else None,
+            "custom_domains": _first_of(options, "customDomains", "custom_domains"),
         }
     )
 
@@ -906,6 +951,28 @@ def _from_api_exec_result(result: Dict[str, Any]) -> ExecResult:
         "exitCode": int(_first_of(result, "exit_code", "exitCode") or 0),
         "durationMS": int(_first_of(result, "duration_ms", "durationMS") or 0),
     }
+
+
+def _from_api_custom_domain(domain: Dict[str, Any]) -> CustomDomain:
+    result: CustomDomain = {
+        "hostname": str(_first_of(domain, "hostname") or ""),
+        "status": str(_first_of(domain, "status") or "pending_dns"),  # type: ignore[typeddict-item]
+        "createdAt": str(_first_of(domain, "created_at", "createdAt") or ""),
+        "updatedAt": str(_first_of(domain, "updated_at", "updatedAt") or ""),
+    }
+    last_error = _first_of(domain, "last_error", "lastError")
+    if last_error not in (None, ""):
+        result["lastError"] = str(last_error)
+    return result
+
+
+def _from_api_custom_domains_response(response: Any) -> List[CustomDomain]:
+    if not isinstance(response, dict):
+        return []
+    domains = _first_of(response, "custom_domains", "customDomains") or []
+    if not isinstance(domains, list):
+        return []
+    return [_from_api_custom_domain(item) for item in domains if isinstance(item, dict)]
 
 
 def _from_api_exposed_port(port: Dict[str, Any]) -> Dict[str, Any]:
@@ -1095,6 +1162,9 @@ def _from_api_sandbox(sandbox: Dict[str, Any]) -> SandboxData:
     container_command = _first_of(sandbox, "container_command", "containerCommand")
     if isinstance(container_command, list) and len(container_command) > 0:
         result["containerCommand"] = [str(item) for item in container_command]
+    custom_domains = _first_of(sandbox, "custom_domains", "customDomains")
+    if isinstance(custom_domains, list) and len(custom_domains) > 0:
+        result["customDomains"] = [_from_api_custom_domain(item) for item in custom_domains if isinstance(item, dict)]
     return result
 
 

--- a/sdk/python/microvm/types.py
+++ b/sdk/python/microvm/types.py
@@ -145,6 +145,10 @@ class CreateOptions(TypedDict, total=False):
     # Attach GPU resources to the sandbox. Omit for CPU-only workloads.
     # Not compatible with runtime="gvisor".
     gpus: GPUOptions
+    # Operator-provided public hostnames to attach to this sandbox at create
+    # time. Server-side cap: ``MaxCustomDomainsPerCreateRequest`` (5). Each
+    # host is normalized + validated; the server lowercases for you.
+    customDomains: List[str]
 
 
 class ResizeOptions(TypedDict, total=False):
@@ -238,6 +242,29 @@ class ExposedPort(TypedDict, total=False):
     createdAt: str
 
 
+# Per-domain lifecycle state surfaced through the API. Mirrors
+# pkg/models/custom_domain.go::CustomDomainStatus on the server.
+# - "pending_dns": row exists, Caddy has not yet asked for the hostname.
+# - "issuing":     first ask hit, ACME flow started.
+# - "ready":       cert in shared storage, serving connections.
+# - "failed":      Caddy gave up on ACME for this host (see ``lastError``).
+CustomDomainStatus = Literal["pending_dns", "issuing", "ready", "failed"]
+
+
+class CustomDomain(TypedDict, total=False):
+    """Per-hostname row returned by the custom-domains endpoints.
+
+    Mirrors ``pkg/models.CustomDomain``. ``lastError`` is only present when
+    ``status == "failed"``.
+    """
+
+    hostname: str
+    status: CustomDomainStatus
+    lastError: str
+    createdAt: str
+    updatedAt: str
+
+
 class SandboxSnapshot(TypedDict, total=False):
     name: str
     image: str
@@ -290,6 +317,7 @@ class SandboxData(TypedDict, total=False):
     sshPublicKey: str
     sshPrivateKey: str
     exposedPorts: List[ExposedPort]
+    customDomains: List[CustomDomain]
     createdAt: str
     updatedAt: str
     lastActiveAt: str

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -865,5 +865,163 @@ class ListFilterTests(unittest.TestCase):
             self.assertEqual(path, "/v1/sandboxes")
 
 
+class CustomDomainsTests(unittest.TestCase):
+    """Mirrors the wire shape of the custom-domains endpoints
+    (POST/GET/DELETE /v1/sandboxes/{id}/custom-domains[...]).
+    """
+
+    def _client(self, *, post_status=201, post_body=None, get_body=None, delete_status=204):
+        captured = {"calls": []}
+
+        class FakeMicroVM(MicroVM):
+            def __init__(self) -> None:
+                super().__init__(api_url="https://sandbox.example.com", pat_token="pat-token")
+
+            def _do_json(self, method, path, payload):  # type: ignore[override]
+                captured["calls"].append((method, path, payload))
+                if method == "POST" and path.endswith("/custom-domains"):
+                    if post_status >= 400:
+                        raise client_module.MicroVMHTTPError(post_status, "boom")
+                    return post_body or {"custom_domains": []}
+                if method == "GET" and path.endswith("/custom-domains"):
+                    return get_body or {"custom_domains": []}
+                if method == "DELETE" and "/custom-domains/" in path:
+                    if delete_status >= 400:
+                        raise client_module.MicroVMHTTPError(delete_status, "boom")
+                    return {}
+                raise AssertionError(f"unexpected call: {method} {path}")
+
+        return FakeMicroVM(), captured
+
+    def test_add_custom_domain_returns_list_and_sends_body(self):
+        client, captured = self._client(
+            post_body={
+                "custom_domains": [
+                    {
+                        "hostname": "api.acme.com",
+                        "status": "pending_dns",
+                        "created_at": "2026-05-25T10:00:00Z",
+                        "updated_at": "2026-05-25T10:00:00Z",
+                    }
+                ]
+            },
+        )
+
+        domains = client.add_custom_domain("sb-1", "api.acme.com")
+
+        self.assertEqual(
+            captured["calls"][0],
+            ("POST", "/v1/sandboxes/sb-1/custom-domains", {"hostname": "api.acme.com"}),
+        )
+        self.assertEqual(len(domains), 1)
+        self.assertEqual(domains[0]["hostname"], "api.acme.com")
+        self.assertEqual(domains[0]["status"], "pending_dns")
+        self.assertEqual(domains[0]["createdAt"], "2026-05-25T10:00:00Z")
+        self.assertNotIn("lastError", domains[0])
+
+    def test_add_custom_domain_preserves_hostname_case(self):
+        # Case is forwarded as-passed; the server normalizes. The SDK must not
+        # lowercase locally or the wire payload diverges from caller intent.
+        client, captured = self._client(post_body={"custom_domains": []})
+        client.add_custom_domain("sb-1", "API.AcMe.COM")
+        self.assertEqual(captured["calls"][0][2], {"hostname": "API.AcMe.COM"})
+
+    def test_list_custom_domains_maps_response_shape(self):
+        client, captured = self._client(
+            get_body={
+                "custom_domains": [
+                    {
+                        "hostname": "a.acme.com",
+                        "status": "ready",
+                        "created_at": "2026-05-24T10:00:00Z",
+                        "updated_at": "2026-05-25T10:00:00Z",
+                    },
+                    {
+                        "hostname": "b.acme.com",
+                        "status": "failed",
+                        "last_error": "challenge timeout",
+                        "created_at": "2026-05-24T10:00:00Z",
+                        "updated_at": "2026-05-25T10:01:00Z",
+                    },
+                ]
+            },
+        )
+
+        domains = client.list_custom_domains("sb-1")
+
+        self.assertEqual(captured["calls"][0], ("GET", "/v1/sandboxes/sb-1/custom-domains", None))
+        self.assertEqual(len(domains), 2)
+        self.assertEqual(domains[0]["status"], "ready")
+        self.assertNotIn("lastError", domains[0])
+        self.assertEqual(domains[1]["status"], "failed")
+        self.assertEqual(domains[1]["lastError"], "challenge timeout")
+
+    def test_remove_custom_domain_returns_none_and_url_encodes_host(self):
+        client, captured = self._client()
+        # Hostname with characters that require percent-encoding to round-trip.
+        result = client.remove_custom_domain("sb-1", "weird host/.example.com")
+        self.assertIsNone(result)
+        method, path, payload = captured["calls"][0]
+        self.assertEqual(method, "DELETE")
+        self.assertEqual(payload, None)
+        self.assertEqual(
+            path,
+            "/v1/sandboxes/sb-1/custom-domains/weird%20host%2F.example.com",
+        )
+
+    def test_add_custom_domain_propagates_409_protocol_conflict(self):
+        client, _ = self._client(post_status=409)
+        with self.assertRaises(client_module.MicroVMHTTPError) as ctx:
+            client.add_custom_domain("sb-1", "api.acme.com")
+        self.assertEqual(ctx.exception.status_code, 409)
+
+    def test_add_custom_domain_propagates_412_not_supported(self):
+        client, _ = self._client(post_status=412)
+        with self.assertRaises(client_module.MicroVMHTTPError) as ctx:
+            client.add_custom_domain("sb-1", "api.acme.com")
+        self.assertEqual(ctx.exception.status_code, 412)
+
+    def test_sandbox_methods_delegate_to_client(self):
+        client, captured = self._client(
+            post_body={
+                "custom_domains": [
+                    {
+                        "hostname": "api.acme.com",
+                        "status": "pending_dns",
+                        "created_at": "2026-05-25T10:00:00Z",
+                        "updated_at": "2026-05-25T10:00:00Z",
+                    }
+                ]
+            },
+        )
+        # Construct a Sandbox without a create roundtrip.
+        sandbox = client_module.Sandbox(client, {"id": "sb-1"})
+
+        sandbox.add_custom_domain("api.acme.com")
+        sandbox.list_custom_domains()
+        sandbox.remove_custom_domain("api.acme.com")
+
+        self.assertEqual(
+            [(m, p) for (m, p, _) in captured["calls"]],
+            [
+                ("POST", "/v1/sandboxes/sb-1/custom-domains"),
+                ("GET", "/v1/sandboxes/sb-1/custom-domains"),
+                ("DELETE", "/v1/sandboxes/sb-1/custom-domains/api.acme.com"),
+            ],
+        )
+
+    def test_create_forwards_custom_domains_list(self):
+        client = RecordingMicroVM()
+        client.create(
+            {
+                "image": "ubuntu:22.04",
+                "customDomains": ["api.acme.com", "edge.acme.com"],
+            }
+        )
+        method, path, payload = client.calls[0]
+        self.assertEqual((method, path), ("POST", "/v1/sandboxes"))
+        self.assertEqual(payload["custom_domains"], ["api.acme.com", "edge.acme.com"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/sdk/rust/examples/create_sandbox.rs
+++ b/sdk/rust/examples/create_sandbox.rs
@@ -30,6 +30,7 @@ fn main() {
             failover: None,
             runtime: None,
             gpus: None,
+            custom_domains: None,
         })
         .expect("sandbox creation failed");
 

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -23,13 +23,13 @@ use tokio_tungstenite::tungstenite::{Error as WebSocketError, Message};
 
 pub use image::Image;
 pub use types::CreateSandboxResponse;
-use types::ExposePortResponseWire;
+use types::{CustomDomainListWire, ExposePortResponseWire};
 pub use types::{
-    BuildImageOptions, BuildImagePushOptions, BuildImageResult, CreateOptions,
-    CreateSessionOptions, ExecExitInfo, ExecRequest, ExecResult, ExposeOptions, ExposeProtocol,
-    ExposeResult, ExposedPort, Failover, HealthStatus, Lifecycle, MountSpec, MountSpecRedacted,
-    MountType, NetworkUsage, RegisterSnapshotOptions, RegistryAuth, ResizeOptions,
-    Sandbox as SandboxData, SandboxSnapshot, Session, SessionList, SessionStatus,
+    BuildImageOptions, BuildImagePushOptions, BuildImageResult, CreateOptions, CreateSessionOptions,
+    CustomDomain, CustomDomainStatus, ExecExitInfo, ExecRequest, ExecResult, ExposeOptions,
+    ExposeProtocol, ExposeResult, ExposedPort, Failover, HealthStatus, Lifecycle, MountSpec,
+    MountSpecRedacted, MountType, NetworkUsage, RegisterSnapshotOptions, RegistryAuth,
+    ResizeOptions, Sandbox as SandboxData, SandboxSnapshot, Session, SessionList, SessionStatus,
     SetNetworkLimitsOptions, UpdateLifecycleOptions,
 };
 
@@ -387,6 +387,24 @@ impl Sandbox {
 
     pub fn unexpose_port(&self, port: u16) -> Result<(), Error> {
         self.client.unexpose_port(&self.data.id, port)
+    }
+
+    /// Attach a custom hostname to this sandbox. Returns the post-add list
+    /// of bindings (sorted by hostname). Idempotent: calling with an
+    /// already-registered hostname returns the existing list.
+    pub fn add_custom_domain(&self, hostname: &str) -> Result<Vec<CustomDomain>, Error> {
+        self.client.add_custom_domain(&self.data.id, hostname)
+    }
+
+    /// List all custom hostnames currently bound to this sandbox.
+    pub fn list_custom_domains(&self) -> Result<Vec<CustomDomain>, Error> {
+        self.client.list_custom_domains(&self.data.id)
+    }
+
+    /// Detach a custom hostname from this sandbox. Idempotent: 204 on success
+    /// regardless of whether the hostname was registered.
+    pub fn remove_custom_domain(&self, hostname: &str) -> Result<(), Error> {
+        self.client.remove_custom_domain(&self.data.id, hostname)
     }
 
     pub fn start(&mut self) -> Result<&Self, Error> {
@@ -1109,6 +1127,48 @@ impl Client {
         )
     }
 
+    /// Register a custom hostname against `id`. Returns the post-add list of
+    /// bindings, sorted by hostname server-side. The hostname is forwarded
+    /// verbatim — the server lowercases and validates it.
+    pub fn add_custom_domain(
+        &self,
+        id: &str,
+        hostname: &str,
+    ) -> Result<Vec<CustomDomain>, Error> {
+        let body = serde_json::json!({ "hostname": hostname });
+        let wire = self.do_json::<Value, CustomDomainListWire>(
+            Method::POST,
+            &format!("{}/sandboxes/{}/custom-domains", self.version_prefix(), id),
+            Some(&body),
+        )?;
+        Ok(wire.custom_domains)
+    }
+
+    /// Fetch the current list of custom hostnames bound to `id`.
+    pub fn list_custom_domains(&self, id: &str) -> Result<Vec<CustomDomain>, Error> {
+        let wire = self.do_json::<(), CustomDomainListWire>(
+            Method::GET,
+            &format!("{}/sandboxes/{}/custom-domains", self.version_prefix(), id),
+            None,
+        )?;
+        Ok(wire.custom_domains)
+    }
+
+    /// Detach a custom hostname from `id`. The hostname is URL-encoded into
+    /// the path. Idempotent: returns Ok on 204 regardless of prior state.
+    pub fn remove_custom_domain(&self, id: &str, hostname: &str) -> Result<(), Error> {
+        self.do_json::<(), ()>(
+            Method::DELETE,
+            &format!(
+                "{}/sandboxes/{}/custom-domains/{}",
+                self.version_prefix(),
+                id,
+                urlencoding::encode(hostname),
+            ),
+            None,
+        )
+    }
+
     fn full_url(&self, path: &str) -> String {
         format!("{}{}", self.api_url, path)
     }
@@ -1655,6 +1715,7 @@ mod tests {
             failover: None,
             runtime: None,
             gpus: None,
+            custom_domains: None,
         }
     }
 
@@ -2720,6 +2781,170 @@ mod tests {
             request2.starts_with("GET /v1/sandboxes HTTP/1.1\r\n"),
             "unexpected request: {}",
             request2
+        );
+    }
+
+    // Custom-domains: POST returns 201 with the post-add list envelope, body
+    // is `{"hostname": "..."}`, hostname is forwarded verbatim (server
+    // lowercases). Mirrors the TS/Python/Go SDK tests for the same endpoint.
+    #[test]
+    fn add_custom_domain_posts_hostname_and_returns_list() {
+        let body = serde_json::json!({
+            "custom_domains": [
+                {
+                    "hostname": "api.acme.com",
+                    "status": "pending_dns",
+                    "created_at": "2026-05-24T10:00:00Z",
+                    "updated_at": "2026-05-24T10:00:00Z"
+                }
+            ]
+        })
+        .to_string();
+        let (url, request_rx) =
+            spawn_response_server("201 Created", "application/json", body.into_bytes());
+
+        let client = Client::new(Some(&url), Some("pat-token")).expect("client should build");
+        let domains = client
+            .add_custom_domain("sb-1", "api.acme.com")
+            .expect("add_custom_domain should succeed");
+        let request = request_rx.recv().expect("request should be captured");
+
+        assert!(
+            request.starts_with("POST /v1/sandboxes/sb-1/custom-domains HTTP/1.1\r\n"),
+            "unexpected request: {}",
+            request
+        );
+        assert_eq!(
+            request_json_body(&request),
+            serde_json::json!({"hostname": "api.acme.com"})
+        );
+        assert_eq!(domains.len(), 1);
+        assert_eq!(domains[0].hostname, "api.acme.com");
+        assert_eq!(domains[0].status, CustomDomainStatus::PendingDns);
+        assert!(domains[0].last_error.is_none());
+    }
+
+    #[test]
+    fn list_custom_domains_returns_envelope_contents() {
+        let body = serde_json::json!({
+            "custom_domains": [
+                {
+                    "hostname": "a.acme.com",
+                    "status": "ready",
+                    "created_at": "2026-05-24T10:00:00Z",
+                    "updated_at": "2026-05-24T10:00:00Z"
+                },
+                {
+                    "hostname": "b.acme.com",
+                    "status": "failed",
+                    "last_error": "no DNS",
+                    "created_at": "2026-05-24T10:00:00Z",
+                    "updated_at": "2026-05-24T10:00:00Z"
+                }
+            ]
+        })
+        .to_string();
+        let (url, request_rx) = spawn_json_server(body);
+
+        let client = Client::new(Some(&url), Some("pat-token")).expect("client should build");
+        let domains = client
+            .list_custom_domains("sb-1")
+            .expect("list_custom_domains should succeed");
+        let request = request_rx.recv().expect("request should be captured");
+
+        assert!(
+            request.starts_with("GET /v1/sandboxes/sb-1/custom-domains HTTP/1.1\r\n"),
+            "unexpected request: {}",
+            request
+        );
+        assert_eq!(domains.len(), 2);
+        assert_eq!(domains[0].status, CustomDomainStatus::Ready);
+        assert_eq!(domains[1].status, CustomDomainStatus::Failed);
+        assert_eq!(domains[1].last_error.as_deref(), Some("no DNS"));
+    }
+
+    // 204 No Content is the success path for DELETE — `do_json` already
+    // handles that case for `Result<(), Error>`. Hostname must be URL-encoded
+    // into the path so dots, hyphens, and uppercase survive intact.
+    #[test]
+    fn remove_custom_domain_url_encodes_and_accepts_no_content() {
+        let (url, request_rx) =
+            spawn_response_server("204 No Content", "application/json", Vec::new());
+
+        let client = Client::new(Some(&url), Some("pat-token")).expect("client should build");
+        client
+            .remove_custom_domain("sb-1", "API.Acme.com")
+            .expect("remove_custom_domain should succeed");
+        let request = request_rx.recv().expect("request should be captured");
+
+        // urlencoding::encode preserves unreserved chars (letters, digits,
+        // '-', '_', '.', '~') so this hostname round-trips verbatim. The
+        // assertion still pins the encoded path so a regression that drops
+        // the helper or swaps in a stricter encoder is caught.
+        assert!(
+            request.starts_with(
+                "DELETE /v1/sandboxes/sb-1/custom-domains/API.Acme.com HTTP/1.1\r\n"
+            ),
+            "unexpected request: {}",
+            request
+        );
+    }
+
+    // 409 Conflict is the documented response when the hostname is already
+    // bound to a different sandbox. We just need to confirm it surfaces as an
+    // Api error carrying the server-supplied JSON `error` field — that's the
+    // contract handle_response promises for any 4xx.
+    #[test]
+    fn add_custom_domain_surfaces_409_conflict() {
+        let body = serde_json::json!({ "error": "hostname already in use" })
+            .to_string()
+            .into_bytes();
+        let (url, _request_rx) = spawn_response_server("409 Conflict", "application/json", body);
+
+        let client = Client::new(Some(&url), Some("pat-token")).expect("client should build");
+        let err = client
+            .add_custom_domain("sb-1", "taken.acme.com")
+            .expect_err("add_custom_domain should fail on 409");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("409"),
+            "expected status in error: {}",
+            message
+        );
+        assert!(
+            message.contains("hostname already in use"),
+            "expected server message in error: {}",
+            message
+        );
+    }
+
+    // 412 Precondition Failed is what the server returns when the cluster
+    // hasn't finished bootstrapping TLS-on-demand yet. Same propagation path
+    // as 409 — we lock in the status code passes through.
+    #[test]
+    fn add_custom_domain_surfaces_412_precondition() {
+        let body = serde_json::json!({ "error": "tls-on-demand not ready" })
+            .to_string()
+            .into_bytes();
+        let (url, _request_rx) =
+            spawn_response_server("412 Precondition Failed", "application/json", body);
+
+        let client = Client::new(Some(&url), Some("pat-token")).expect("client should build");
+        let err = client
+            .add_custom_domain("sb-1", "api.acme.com")
+            .expect_err("add_custom_domain should fail on 412");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("412"),
+            "expected status in error: {}",
+            message
+        );
+        assert!(
+            message.contains("tls-on-demand not ready"),
+            "expected server message in error: {}",
+            message
         );
     }
 }

--- a/sdk/rust/src/types.rs
+++ b/sdk/rust/src/types.rs
@@ -183,6 +183,12 @@ pub struct CreateOptions {
     /// Not compatible with `runtime = "gvisor"`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gpus: Option<GPUOptions>,
+    /// Custom hostnames to attach to the sandbox at create time. Each entry
+    /// is server-normalized (lowercased, trailing dot stripped). Server-side
+    /// cap: `MaxCustomDomainsPerCreateRequest` (5). After create, manage the
+    /// list via [`Sandbox::add_custom_domain`] / [`Sandbox::remove_custom_domain`].
+    #[serde(rename = "custom_domains", skip_serializing_if = "Option::is_none")]
+    pub custom_domains: Option<Vec<String>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
@@ -245,6 +251,44 @@ pub struct ExposedPort {
     pub public_url: String,
     #[serde(rename = "created_at")]
     pub created_at: String,
+}
+
+/// Per-domain lifecycle state surfaced through the API. Mirrors
+/// `pkg/models/custom_domain.go::CustomDomainStatus` on the server.
+/// - `PendingDns`: row exists, Caddy has not yet asked for the hostname.
+/// - `Issuing`: first ask hit, ACME flow started.
+/// - `Ready`: cert in shared storage, serving connections.
+/// - `Failed`: Caddy gave up on ACME for this host (see `last_error`).
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CustomDomainStatus {
+    PendingDns,
+    Issuing,
+    Ready,
+    Failed,
+}
+
+/// Per-hostname row returned by the custom-domains endpoints. Mirrors
+/// `pkg/models.CustomDomain`. `last_error` is only populated when
+/// `status == CustomDomainStatus::Failed`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct CustomDomain {
+    pub hostname: String,
+    pub status: CustomDomainStatus,
+    #[serde(rename = "last_error", default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+    #[serde(rename = "created_at")]
+    pub created_at: String,
+    #[serde(rename = "updated_at")]
+    pub updated_at: String,
+}
+
+/// Wire envelope returned by the custom-domains endpoints — kept private;
+/// callers consume the public `Vec<CustomDomain>` instead.
+#[derive(Deserialize)]
+pub(crate) struct CustomDomainListWire {
+    #[serde(rename = "custom_domains", default)]
+    pub custom_domains: Vec<CustomDomain>,
 }
 
 /// Wire protocol an exposure publishes through.

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -9,6 +9,8 @@ export type {
   BuildImageResult,
   CreateOptions,
   CreateSessionOptions,
+  CustomDomain,
+  CustomDomainStatus,
   ExecRequest,
   ExecResult,
   ExecExitInfo,

--- a/sdk/typescript/src/internal/api/v1/paths.ts
+++ b/sdk/typescript/src/internal/api/v1/paths.ts
@@ -5,3 +5,24 @@
 //
 // Keep this in sync with pkg/api/v1/dto.go::PathPrefix on the server.
 export const PATH_PREFIX = "/v1";
+
+/**
+ * Collection URL for a sandbox's custom-domain bindings. Used for both POST
+ * (add) and GET (list). The DELETE variant lives at
+ * {@link sandboxCustomDomainPath}.
+ *
+ * `id` is interpolated verbatim — sandbox IDs are server-generated opaque
+ * tokens and already URL-safe.
+ */
+export function sandboxCustomDomainsPath(prefix: string, id: string): string {
+  return `${prefix}/sandboxes/${id}/custom-domains`;
+}
+
+/**
+ * URL for a single custom-domain binding. The hostname is percent-encoded so
+ * IDN punycode (`xn--...`) and wildcard labels round-trip safely through
+ * `DELETE /v1/sandboxes/{id}/custom-domains/{hostname}`.
+ */
+export function sandboxCustomDomainPath(prefix: string, id: string, hostname: string): string {
+  return `${prefix}/sandboxes/${id}/custom-domains/${encodeURIComponent(hostname)}`;
+}

--- a/sdk/typescript/src/internal/client.test.ts
+++ b/sdk/typescript/src/internal/client.test.ts
@@ -831,6 +831,199 @@ test("internal client create with bare image string skips build call", async () 
   assert.ok(seenURLs[0].endsWith("/v1/sandboxes"));
 });
 
+test("internal client addCustomDomain POSTs hostname and parses list", async () => {
+  let seenRequest: Request | undefined;
+  const client = new APIClient({
+    baseURL: "https://api.example.com",
+    patToken: "pat-token",
+    fetch: async (input, init) => {
+      seenRequest = new Request(input, init);
+      return jsonResponse(
+        {
+          custom_domains: [
+            {
+              hostname: "api.acme.com",
+              status: "pending_dns",
+              created_at: "2026-05-24T10:00:00Z",
+              updated_at: "2026-05-24T10:00:00Z",
+            },
+          ],
+        },
+        201,
+      );
+    },
+  });
+
+  const domains = await client.addCustomDomain("sb-cd", "api.acme.com");
+  assert.ok(seenRequest);
+  assert.equal(seenRequest.method, "POST");
+  assert.ok(seenRequest.url.endsWith("/v1/sandboxes/sb-cd/custom-domains"));
+  assert.deepEqual(await seenRequest.json(), { hostname: "api.acme.com" });
+  assert.equal(domains.length, 1);
+  assert.equal(domains[0].hostname, "api.acme.com");
+  assert.equal(domains[0].status, "pending_dns");
+  assert.equal(domains[0].lastError, undefined);
+});
+
+test("internal client addCustomDomain preserves hostname case sent by caller", async () => {
+  let sentBody: { hostname?: string } | undefined;
+  const client = new APIClient({
+    baseURL: "https://api.example.com",
+    patToken: "pat-token",
+    fetch: async (input, init) => {
+      const req = new Request(input, init);
+      sentBody = (await req.json()) as { hostname?: string };
+      return jsonResponse({ custom_domains: [] }, 201);
+    },
+  });
+
+  await client.addCustomDomain("sb-cd", "API.Acme.COM");
+  assert.equal(sentBody?.hostname, "API.Acme.COM");
+});
+
+test("internal client listCustomDomains GETs and maps response", async () => {
+  let seenRequest: Request | undefined;
+  const client = new APIClient({
+    baseURL: "https://api.example.com",
+    patToken: "pat-token",
+    fetch: async (input, init) => {
+      seenRequest = new Request(input, init);
+      return jsonResponse({
+        custom_domains: [
+          {
+            hostname: "a.example.com",
+            status: "ready",
+            created_at: "2026-05-24T10:00:00Z",
+            updated_at: "2026-05-24T10:05:00Z",
+          },
+          {
+            hostname: "b.example.com",
+            status: "failed",
+            last_error: "dns lookup failed",
+            created_at: "2026-05-24T10:01:00Z",
+            updated_at: "2026-05-24T10:06:00Z",
+          },
+        ],
+      });
+    },
+  });
+
+  const domains = await client.listCustomDomains("sb-cd");
+  assert.ok(seenRequest);
+  assert.equal(seenRequest.method, "GET");
+  assert.ok(seenRequest.url.endsWith("/v1/sandboxes/sb-cd/custom-domains"));
+  assert.equal(domains.length, 2);
+  assert.equal(domains[0].status, "ready");
+  assert.equal(domains[1].status, "failed");
+  assert.equal(domains[1].lastError, "dns lookup failed");
+});
+
+test("internal client removeCustomDomain DELETEs encoded hostname and resolves void", async () => {
+  let seenRequest: Request | undefined;
+  const client = new APIClient({
+    baseURL: "https://api.example.com",
+    patToken: "pat-token",
+    fetch: async (input, init) => {
+      seenRequest = new Request(input, init);
+      return new Response(null, { status: 204 });
+    },
+  });
+
+  const result = await client.removeCustomDomain("sb-cd", "weird host.example.com");
+  assert.equal(result, undefined);
+  assert.ok(seenRequest);
+  assert.equal(seenRequest.method, "DELETE");
+  assert.ok(seenRequest.url.endsWith("/v1/sandboxes/sb-cd/custom-domains/weird%20host.example.com"));
+});
+
+test("internal client addCustomDomain throws with server status on conflict", async () => {
+  const client = new APIClient({
+    baseURL: "https://api.example.com",
+    patToken: "pat-token",
+    fetch: async () => jsonResponse({ error: "hostname already bound to another sandbox" }, 409),
+  });
+
+  await assert.rejects(
+    () => client.addCustomDomain("sb-cd", "api.acme.com"),
+    /hostname already bound/,
+  );
+});
+
+test("internal client addCustomDomain surfaces 412 precondition errors", async () => {
+  const client = new APIClient({
+    baseURL: "https://api.example.com",
+    patToken: "pat-token",
+    fetch: async () => jsonResponse({ error: "custom domains require SB_PUBLIC_DOMAIN" }, 412),
+  });
+
+  await assert.rejects(
+    () => client.addCustomDomain("sb-cd", "api.acme.com"),
+    /SB_PUBLIC_DOMAIN/,
+  );
+});
+
+test("sandbox resource customDomains accessor delegates to client", async () => {
+  const calls: string[] = [];
+  const client = new APIClient({
+    baseURL: "https://api.example.com",
+    patToken: "pat-token",
+    fetch: async (input, init) => {
+      const req = new Request(input, init);
+      if (req.url.endsWith("/v1/sandboxes/sb-cd")) {
+        return jsonResponse(apiSandbox("sb-cd"));
+      }
+      if (req.method === "POST" && req.url.endsWith("/custom-domains")) {
+        calls.push("add");
+        return jsonResponse(
+          {
+            custom_domains: [
+              {
+                hostname: "staging.acme.com",
+                status: "pending_dns",
+                created_at: "2026-05-24T10:00:00Z",
+                updated_at: "2026-05-24T10:00:00Z",
+              },
+            ],
+          },
+          201,
+        );
+      }
+      if (req.method === "GET" && req.url.endsWith("/custom-domains")) {
+        calls.push("list");
+        return jsonResponse({ custom_domains: [] });
+      }
+      if (req.method === "DELETE" && req.url.includes("/custom-domains/")) {
+        calls.push("remove");
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`unexpected ${req.method} ${req.url}`);
+    },
+  });
+
+  const sandbox = await client.get("sb-cd");
+  const added = await sandbox.customDomains.add("staging.acme.com");
+  assert.equal(added[0].hostname, "staging.acme.com");
+  await sandbox.customDomains.list();
+  await sandbox.customDomains.remove("staging.acme.com");
+  assert.deepEqual(calls, ["add", "list", "remove"]);
+});
+
+test("internal client create forwards customDomains as snake_case", async () => {
+  let body: { custom_domains?: unknown } | undefined;
+  const client = new APIClient({
+    baseURL: "https://api.example.com",
+    patToken: "pat-token",
+    fetch: async (input, init) => {
+      const req = new Request(input, init);
+      body = (await req.json()) as { custom_domains?: unknown };
+      return jsonResponse(apiSandbox("sb-cd-create"));
+    },
+  });
+
+  await client.create({ image: "ubuntu:22.04", customDomains: ["api.acme.com", "www.acme.com"] });
+  assert.deepEqual(body?.custom_domains, ["api.acme.com", "www.acme.com"]);
+});
+
 function jsonResponse(value: unknown, status = 200): Response {
   return new Response(JSON.stringify(value), {
     status,

--- a/sdk/typescript/src/internal/client.ts
+++ b/sdk/typescript/src/internal/client.ts
@@ -1,6 +1,10 @@
 import { basename } from "node:path";
 
-import { PATH_PREFIX as V1_PATH_PREFIX } from "./api/v1/paths.js";
+import {
+  PATH_PREFIX as V1_PATH_PREFIX,
+  sandboxCustomDomainPath as v1SandboxCustomDomainPath,
+  sandboxCustomDomainsPath as v1SandboxCustomDomainsPath,
+} from "./api/v1/paths.js";
 import { Image } from "../Image.js";
 import type {
   BinaryLike,
@@ -8,6 +12,8 @@ import type {
   BuildImageResult,
   CreateOptions,
   CreateSessionOptions,
+  CustomDomain,
+  CustomDomainStatus,
   ExecExitInfo,
   ExecRequest,
   ExecResult,
@@ -82,6 +88,18 @@ interface ApiExposePortResponse {
   public_url: string;
   host?: string;
   host_port?: number;
+}
+
+interface ApiCustomDomain {
+  hostname: string;
+  status: CustomDomainStatus;
+  last_error?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface ApiCustomDomainList {
+  custom_domains: ApiCustomDomain[];
 }
 
 interface ApiLifecycle {
@@ -487,6 +505,36 @@ export class APIClient {
     await this.doJSON<void>("DELETE", `${this.versionPrefix}/sandboxes/${id}/ports/${port}`);
   }
 
+  /**
+   * Bind a custom hostname to a sandbox. The server lowercases the hostname
+   * and returns the post-add list of bindings (sorted by hostname). Calling
+   * with an already-registered hostname is idempotent and returns the
+   * existing list.
+   */
+  async addCustomDomain(id: string, hostname: string): Promise<CustomDomain[]> {
+    const response = await this.doJSON<ApiCustomDomainList>(
+      "POST",
+      v1SandboxCustomDomainsPath(this.versionPrefix, id),
+      { hostname },
+    );
+    return response.custom_domains.map(fromApiCustomDomain);
+  }
+
+  async listCustomDomains(id: string): Promise<CustomDomain[]> {
+    const response = await this.doJSON<ApiCustomDomainList>(
+      "GET",
+      v1SandboxCustomDomainsPath(this.versionPrefix, id),
+    );
+    return response.custom_domains.map(fromApiCustomDomain);
+  }
+
+  async removeCustomDomain(id: string, hostname: string): Promise<void> {
+    await this.doJSON<void>(
+      "DELETE",
+      v1SandboxCustomDomainPath(this.versionPrefix, id, hostname),
+    );
+  }
+
   async reconcile(): Promise<void> {
     await this.doJSON<unknown>("POST", this.versioned("/admin/reconcile"));
   }
@@ -658,6 +706,28 @@ export class SandboxResource implements Sandbox {
     await this.client.unexposePort(this.id, port);
   }
 
+  /**
+   * Per-sandbox custom-hostname bindings. Exposed as a namespaced accessor
+   * (rather than `addCustomDomain`/`removeCustomDomain`/`listCustomDomains`
+   * methods on the resource) so call sites read like
+   * `sandbox.customDomains.add("api.acme.com")`, mirroring the noun in the
+   * `/v1/.../custom-domains` URL space. A fresh object is returned per access
+   * so the closures always see the current `id` even after `refresh()`.
+   */
+  get customDomains(): {
+    add(hostname: string): Promise<CustomDomain[]>;
+    remove(hostname: string): Promise<void>;
+    list(): Promise<CustomDomain[]>;
+  } {
+    const client = this.client;
+    const id = this.id;
+    return {
+      add: (hostname: string) => client.addCustomDomain(id, hostname),
+      remove: (hostname: string) => client.removeCustomDomain(id, hostname),
+      list: () => client.listCustomDomains(id),
+    };
+  }
+
 	async createSnapshot(name: string): Promise<SandboxSnapshot> {
 		return this.client.createSnapshot(this.id, name);
 	}
@@ -724,6 +794,7 @@ function toApiCreateOptions(options: CreateOptions): Record<string, unknown> {
     lifecycle: options.lifecycle ? toApiLifecycle(options.lifecycle) : undefined,
     failover: options.failover ? toApiFailover(options.failover) : undefined,
     runtime: options.runtime,
+    custom_domains: options.customDomains,
   };
 }
 
@@ -865,6 +936,16 @@ function fromApiSession(session: ApiSession): Session {
     recording: session.recording,
     bytes: session.bytes,
     attached: session.attached,
+  };
+}
+
+function fromApiCustomDomain(domain: ApiCustomDomain): CustomDomain {
+  return {
+    hostname: domain.hostname,
+    status: domain.status,
+    lastError: domain.last_error,
+    createdAt: domain.created_at,
+    updatedAt: domain.updated_at,
   };
 }
 

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -186,6 +186,13 @@ export interface CreateOptions {
    * Not compatible with runtime="gvisor".
    */
   gpus?: GPUOptions;
+  /**
+   * Custom hostnames to bind to this sandbox at create-time. Each entry is
+   * lowercased server-side and progresses through the standard custom-domain
+   * lifecycle (pending_dns → issuing → ready). Equivalent to calling
+   * `sandbox.customDomains.add(host)` for each entry after create.
+   */
+  customDomains?: string[];
 }
 
 export interface ResizeOptions {
@@ -240,6 +247,23 @@ export interface ExposedPort {
   port: number;
   publicURL: string;
   createdAt: string;
+}
+
+/**
+ * Lifecycle states for a per-sandbox custom hostname.
+ *  - "pending_dns": hostname registered; awaiting DNS to point at the daemon.
+ *  - "issuing":     DNS resolves; Caddy is acquiring an ACME certificate.
+ *  - "ready":       certificate issued; traffic served end-to-end on the host.
+ *  - "failed":      ACME or DNS validation failed; see `lastError`.
+ */
+export type CustomDomainStatus = "pending_dns" | "issuing" | "ready" | "failed";
+
+export interface CustomDomain {
+  hostname: string;
+  status: CustomDomainStatus;
+  lastError?: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 /**

--- a/setup/multi-node-cert-sharing.md
+++ b/setup/multi-node-cert-sharing.md
@@ -267,6 +267,18 @@ encryption key, not the bucket itself.
 
 ---
 
+## End-to-end verification
+
+The shared-storage cert-reuse guarantee is exercised end-to-end by
+`internal/service/custom_domains_e2e_test.go` (build tag `e2e`, run via
+`make test-acme-e2e`). It boots Pebble + localstack + Caddy in containers,
+runs sandboxd in-process, and asserts that a fresh Caddy pointed at the same
+S3 bucket reuses the cert rather than triggering a second ACME order. Requires
+a local Docker daemon; the first run pulls ~500 MB of images and builds Caddy
+via xcaddy (~30 s). Not in CI.
+
+---
+
 ## Reference
 
 - Plugin: [`github.com/ss098/certmagic-s3`](https://github.com/ss098/certmagic-s3)

--- a/setup/multi-node-cert-sharing.md
+++ b/setup/multi-node-cert-sharing.md
@@ -26,6 +26,13 @@ When **not** to pick this:
 This feature does NOT change SDK behaviour, sandbox URL shape, or the wire
 protocol. End users see no difference.
 
+> **Required for custom domains in multi-node clusters.** The per-hostname
+> ACME flow described in [Custom Domains](../docs/src/content/docs/custom-domains.mdx)
+> issues one cert per user-supplied hostname. Without shared S3 storage,
+> each ingress node would race to issue the same cert and burn through
+> Let's Encrypt's `new-orders` per-account budget. Enable this before
+> turning on `SB_ENABLE_CUSTOM_DOMAINS` on any cluster larger than one node.
+
 ---
 
 ## How it works

--- a/setup/prometheus/sandboxd-alerts.yml
+++ b/setup/prometheus/sandboxd-alerts.yml
@@ -269,7 +269,7 @@ groups:
       # 429s are silent at the user layer (Caddy retries); the operator
       # needs the signal to intervene.
       - alert: SandboxdACMEBudgetThrottling
-        expr: sum(rate(aerolvm_ask_requests_total{key1="throttled"}[5m])) > 0
+        expr: sum(rate(aerolvm_ask_requests_total{key="throttled"}[5m])) > 0
         for: 5m
         labels:
           severity: warning

--- a/setup/prometheus/sandboxd-alerts.yml
+++ b/setup/prometheus/sandboxd-alerts.yml
@@ -230,3 +230,51 @@ groups:
           summary: "sandboxd secret decrypt errors are occurring"
           description: "Cluster recovery secret decrypts are failing. Verify credential encryption keys are identical on every node."
           runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/runbooks/slo-breach.md"
+
+  - name: sandboxd.custom-domains
+    interval: 30s
+    rules:
+      # F3 — certmagic-s3 distributed lock held abnormally long. The lock is
+      # taken for the duration of the ACME flow; if a node dies mid-issuance
+      # the TTL drops it, but a masked partition can leave it stuck. >5m
+      # held indicates either LE backoff trouble or a stuck peer.
+      - alert: SandboxdACMELockStuck
+        expr: max(aerolvm_acme_lock_held_seconds) > 300
+        for: 2m
+        labels:
+          severity: warning
+          component: custom-domains
+        annotations:
+          summary: "sandboxd ACME issuance lock held > 5 minutes"
+          description: "A custom-domain ACME flow has held the certmagic-s3 lock for over 5 minutes. Issuance for the affected hostname is stalled until the lock releases."
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/runbooks/slo-breach.md"
+
+      # F4 — the loopback ask listener can crash mid-process without taking
+      # the rest of sandboxd down. New HTTPS connections then fail TLS until
+      # restart. Absent asks while the process is up means the listener
+      # died. 2m gives the normal SNI traffic floor enough time to register.
+      - alert: SandboxdTLSAskListenerDown
+        expr: sum(rate(aerolvm_ask_requests_total[2m])) == 0 and on() up{job="sandboxd"} == 1
+        for: 2m
+        labels:
+          severity: critical
+          component: custom-domains
+        annotations:
+          summary: "sandboxd TLS-ask listener has no traffic but process is up"
+          description: "No on-demand TLS ask requests have arrived in 2 minutes while sandboxd reports healthy. The internal ask listener may have crashed; new HTTPS handshakes for custom domains will fail until restart."
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/runbooks/slo-breach.md"
+
+      # ACME budget burn — when the daemon-wide bucket throttles, a tenant
+      # is on track to exhaust the LE account limit for the whole cluster.
+      # 429s are silent at the user layer (Caddy retries); the operator
+      # needs the signal to intervene.
+      - alert: SandboxdACMEBudgetThrottling
+        expr: sum(rate(aerolvm_ask_requests_total{key1="throttled"}[5m])) > 0
+        for: 5m
+        labels:
+          severity: warning
+          component: custom-domains
+        annotations:
+          summary: "sandboxd is throttling ACME issuance"
+          description: "The daemon-wide ACME budget is refusing new orders. Check sandboxd logs for the offending sandbox_id and investigate the misconfigured tenant."
+          runbook_url: "https://github.com/aerol-ai/microvm/blob/main/setup/runbooks/slo-breach.md"


### PR DESCRIPTION
This pull request introduces first-class support for custom domains, allowing users to attach arbitrary public hostnames to sandboxes with automatic HTTPS via ACME. The implementation includes both backend and documentation changes, as well as new tests and Makefile targets. The most important changes are grouped below:

**Custom Domain Feature Implementation:**

* Added a cluster-aware domain resolver (`clusterAwareDomainResolver`) that first checks the in-memory cluster FSM for hostname-to-sandbox mappings, falling back to the SQLite store if not found. This ensures efficient handling of SNI floods and consistent behavior in both single-node and multi-node deployments. (`cmd/sandboxd/main.go`, [[1]](diffhunk://#diff-85cd4174384a81cdbf87370531855ae87bcbd19bf68f36b611d73cd5d96cb4daL381-R388) [[2]](diffhunk://#diff-85cd4174384a81cdbf87370531855ae87bcbd19bf68f36b611d73cd5d96cb4daR398-R470) [[3]](diffhunk://#diff-85cd4174384a81cdbf87370531855ae87bcbd19bf68f36b611d73cd5d96cb4daR734-R759)
* Updated the ingress proxy startup logic to enable the TLS-ask handler and ACME budget enforcement when custom domains are enabled, sharing the ingress listener with serverless if both are active. (`cmd/sandboxd/main.go`, [[1]](diffhunk://#diff-85cd4174384a81cdbf87370531855ae87bcbd19bf68f36b611d73cd5d96cb4daL381-R388) [[2]](diffhunk://#diff-85cd4174384a81cdbf87370531855ae87bcbd19bf68f36b611d73cd5d96cb4daR398-R470)
* Implemented cluster methods in `Agent` for adding, removing, and listing custom domains, ensuring cluster-wide uniqueness and correct synchronization during ownership assertions. (`internal/cluster/agent.go`, [[1]](diffhunk://#diff-5a2afffb171172fcd9d6ab79b11e15beb46e94ad948dc0eac5ab3889d72ec217R349-R391) [[2]](diffhunk://#diff-5a2afffb171172fcd9d6ab79b11e15beb46e94ad948dc0eac5ab3889d72ec217R479-R483) [[3]](diffhunk://#diff-5a2afffb171172fcd9d6ab79b11e15beb46e94ad948dc0eac5ab3889d72ec217R493-R497) [[4]](diffhunk://#diff-5a2afffb171172fcd9d6ab79b11e15beb46e94ad948dc0eac5ab3889d72ec217R509-R513)

**Testing and Developer Tooling:**

* Added comprehensive tests for the new cluster-aware domain resolver, covering cluster hits, store fallback, and not-found cases. (`cmd/sandboxd/cluster_resolver_test.go`, [cmd/sandboxd/cluster_resolver_test.goR1-R120](diffhunk://#diff-b20da5d56475daa429a793beee993a3bc1af2b562240bcacfa9f10d123a49a2dR1-R120))
* Introduced a new `test-acme-e2e` Makefile target for operator-runnable end-to-end ACME tests, facilitating local validation of the ACME flow. (`Makefile`, [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L4-R4) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R17-R22)

**Documentation:**

* Added a new "Custom Domains" documentation page detailing prerequisites, usage, API examples in multiple languages, status lifecycle, error codes, and cluster mode behavior. (`docs/src/content/docs/custom-domains.mdx`, [docs/src/content/docs/custom-domains.mdxR1-R203](diffhunk://#diff-8ef405063dfbbefd3ab4450c1fd6b1a1f0ee6817ebfa75133cbace706ddec27aR1-R203))
* Updated the documentation sidebar to include the new "Custom Domains" section for discoverability. (`docs/src/content.config.ts`, [docs/src/content.config.tsR213-R218](diffhunk://#diff-3c77bd19d81880d0f5739e83a4ae589c80940aedc6e4208018361c53ae761d56R213-R218))

---
- Introduced custom domain management features, including validation and status tracking.
- Added new API endpoints for adding, listing, and removing custom domains in the sandbox.
- Enhanced Caddy integration to support custom hostnames and on-demand TLS settings.
- Created tests and updated documentation for the new features.

