### PR TITLE
feat(gc): implement pending image garbage collection and related tests

### DIFF
--- a/Terraform/nodes.tf
+++ b/Terraform/nodes.tf
@@ -66,6 +66,7 @@ resource "aws_instance" "seed" {
     otel_service_name          = var.otel_service_name
     image_pull_max_concurrent  = var.image_pull_max_concurrent
     image_pull_failure_backoff = var.image_pull_failure_backoff
+    image_gc_whitelist         = join(",", var.image_gc_whitelist)
     extra_user_data            = local.seed_node.extra_user_data
     # Shared S3-backed Caddy cert storage — see local.caddy_storage_s3.
     caddy_storage_s3_enabled        = local.caddy_storage_s3.enabled
@@ -163,6 +164,7 @@ resource "aws_instance" "joiner" {
     otel_service_name          = var.otel_service_name
     image_pull_max_concurrent  = var.image_pull_max_concurrent
     image_pull_failure_backoff = var.image_pull_failure_backoff
+    image_gc_whitelist         = join(",", var.image_gc_whitelist)
     extra_user_data            = each.value.extra_user_data
     # Shared S3-backed Caddy cert storage — see local.caddy_storage_s3.
     caddy_storage_s3_enabled        = local.caddy_storage_s3.enabled

--- a/Terraform/templates/bootstrap.sh.tftpl
+++ b/Terraform/templates/bootstrap.sh.tftpl
@@ -215,6 +215,7 @@ SB_OTEL_TRACES_SAMPLE_RATIO=${otel_traces_sample_ratio}
 OTEL_SERVICE_NAME=${otel_service_name}
 SB_IMAGE_PULL_MAX_CONCURRENT=${image_pull_max_concurrent}
 SB_IMAGE_PULL_FAILURE_BACKOFF=${image_pull_failure_backoff}
+SB_IMAGE_GC_WHITELIST=${image_gc_whitelist}
 EOF
 
 %{ if aocr_enabled ~}

--- a/Terraform/terraform.tfvars.example
+++ b/Terraform/terraform.tfvars.example
@@ -64,6 +64,18 @@ default_volume_type       = "gp3"
 # image_pull_max_concurrent  = 4
 # image_pull_failure_backoff = "30s"
 
+# Image-GC whitelist: repositories or refs the GC janitors must never remove.
+# Empty (default) means every image is eligible. Three match shapes:
+#   - exact ref                ("alpine:latest" — only that tag survives)
+#   - repo, tag/digest agnostic ("ubuntu" — every tag and digest of ubuntu)
+#   - registry/org prefix       (trailing "/" — "ghcr.io/myorg/" matches all)
+# Written into cluster.env as SB_IMAGE_GC_WHITELIST (comma-joined).
+# image_gc_whitelist = [
+#   "alpine",            # always keep alpine cached, any tag
+#   "ubuntu:22.04",      # only that specific tag
+#   "ghcr.io/myorg/",    # everything from this org
+# ]
+
 # --- Cloudflare DNS behavior ------------------------------------------------
 
 # create_wildcard_record = true   # *.<domain_name> in addition to the apex

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -355,6 +355,20 @@ variable "image_pull_failure_backoff" {
   }
 }
 
+variable "image_gc_whitelist" {
+  description = <<-EOT
+    Image repositories or refs the GC janitors must never remove. Three
+    match shapes:
+      - exact ref ("alpine:latest" — only that tag survives)
+      - repo, tag/digest agnostic ("ubuntu" — every tag/digest of ubuntu)
+      - registry/org prefix when the entry ends in "/" ("ghcr.io/myorg/")
+    Written as SB_IMAGE_GC_WHITELIST (comma-joined). Empty list (default)
+    preserves today's behavior — every image is eligible for GC.
+  EOT
+  type        = list(string)
+  default     = []
+}
+
 ###############################################################################
 # Cloudflare DNS
 ###############################################################################

--- a/cmd/sandboxd/main.go
+++ b/cmd/sandboxd/main.go
@@ -314,6 +314,7 @@ func main() {
 		svc.StartLifecycleSweep(ctx)
 		svc.StartEventMonitor(ctx)
 		svc.StartBuiltImageGC(ctx)
+		svc.StartPendingImageGC(ctx)
 		startAutoImportReconciler(ctx, logger, cfg, db, svc)
 		startSnapshotPushReconciler(ctx, logger, cfg, db, svc, dockerClient)
 		if cfg.AutoImportEnabled {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -539,10 +539,15 @@ type Config struct {
 	// ImageBuildGCTTL is the minimum age before an image becomes
 	// eligible for removal: for built images, measured from the
 	// daemon's LastTagTime; for pending images, from the destroy
-	// timestamp recorded in pending_image_gc.scheduled_at. Default 1h:
-	// comfortably longer than any reasonable retry/network-blip between
-	// build and create AND long enough that a destroy/recreate cycle on
-	// the same image doesn't pay a fresh registry pull every time.
+	// timestamp recorded in pending_image_gc.scheduled_at (which is
+	// also refreshed forward by the create path's
+	// RefreshPendingImageGCIfExists, so the clock restarts on most
+	// recent use, not first destroy). Default 24h: wide enough that a
+	// destroy/recreate cycle measured in hours doesn't pay a fresh
+	// registry pull, while still bounded so a build-only host
+	// (sandboxes never recreated) eventually reclaims disk. Tighten via
+	// SB_IMAGE_BUILD_GC_TTL when disk pressure outweighs warm-start
+	// latency.
 	ImageBuildGCTTL time.Duration
 	// ImageGCWhitelist is a list of image repositories or refs the janitors
 	// must never remove. Three match shapes are honored against the image
@@ -798,7 +803,7 @@ func Load() (Config, error) {
 		ImageBuildTimeout:                getEnvDuration("SB_IMAGE_BUILD_TIMEOUT", 10*time.Minute),
 		ImageBuildGCEnabled:              getEnvBool("SB_IMAGE_BUILD_GC_ENABLED", true),
 		ImageBuildGCInterval:             getEnvDuration("SB_IMAGE_BUILD_GC_INTERVAL", 10*time.Minute),
-		ImageBuildGCTTL:                  getEnvDuration("SB_IMAGE_BUILD_GC_TTL", time.Hour),
+		ImageBuildGCTTL:                  getEnvDuration("SB_IMAGE_BUILD_GC_TTL", 24*time.Hour),
 		ImageGCWhitelist:                 parseImageGCWhitelist(os.Getenv("SB_IMAGE_GC_WHITELIST")),
 		ImageDistributionAOCRHost:        strings.TrimSpace(getEnv("SB_IMAGE_DISTRIBUTION_AOCR_HOST", "aocr.aerol.ai")),
 		ImagePullMaxConcurrent:           getEnvInt("SB_IMAGE_PULL_MAX_CONCURRENT", 4),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -518,27 +518,47 @@ type Config struct {
 	// generous; we bound it only to keep a runaway build from permanently
 	// parking the HTTP handler.
 	ImageBuildTimeout time.Duration
-	// ImageBuildGCEnabled toggles the periodic janitor that sweeps
-	// locally-built images (BuiltImageNamespace, i.e. "aerolvm-build/*")
-	// that are no longer referenced by any active sandbox AND were created
-	// more than ImageBuildGCTTL ago. Without this, images produced by
-	// standalone POST /v1/images/build calls or by builds whose followup
-	// CreateSandbox failed accumulate forever — service.maybeRemoveImage
-	// only runs on sandbox destroy and so can't see images that never had
-	// a sandbox row.
+	// ImageBuildGCEnabled toggles BOTH image janitors: the built-image
+	// sweep (locally-built BuiltImageNamespace tags older than the TTL
+	// with no active reference) and the pending-image sweep (entries in
+	// the pending_image_gc ledger scheduled by sandbox destroy paths,
+	// older than the TTL with no active reference). Without the former,
+	// images produced by standalone POST /v1/images/build calls — or
+	// builds whose followup CreateSandbox failed — accumulate forever.
+	// Without the latter, every sandbox destroy leaks its image until
+	// the daemon is restarted. Disabling both with one switch matches
+	// how operators reason about "image GC" as a single subsystem.
 	ImageBuildGCEnabled bool
-	// ImageBuildGCInterval is how often the janitor ticker fires. Default
-	// 10m: cheap enough (one filtered /images/json call + one indexed store
-	// lookup per match) that running it more often would only matter if
-	// builds were churning faster than the TTL — which would itself be a
-	// signal something is wrong upstream.
+	// ImageBuildGCInterval is how often each janitor ticker fires.
+	// Default 10m: cheap enough (one filtered /images/json call + one
+	// indexed store lookup per built-image match for one janitor; one
+	// indexed range scan over pending_image_gc for the other) that
+	// running more often would only matter under churn that itself
+	// indicates an upstream problem.
 	ImageBuildGCInterval time.Duration
-	// ImageBuildGCTTL is the minimum age a built image must reach before
-	// it becomes eligible for removal. Default 1h: comfortably longer than
-	// any reasonable retry/network-blip between build and create, so a
-	// transient hiccup doesn't have the janitor yanking an image a client
-	// is about to use.
+	// ImageBuildGCTTL is the minimum age before an image becomes
+	// eligible for removal: for built images, measured from the
+	// daemon's LastTagTime; for pending images, from the destroy
+	// timestamp recorded in pending_image_gc.scheduled_at. Default 1h:
+	// comfortably longer than any reasonable retry/network-blip between
+	// build and create AND long enough that a destroy/recreate cycle on
+	// the same image doesn't pay a fresh registry pull every time.
 	ImageBuildGCTTL time.Duration
+	// ImageGCWhitelist is a list of image repositories or refs the janitors
+	// must never remove. Three match shapes are honored against the image
+	// string the sandbox stored (the same string passed to docker pull):
+	//   1. exact ref equality                 ("alpine:latest" == "alpine:latest")
+	//   2. repo equality, tag/digest agnostic ("ubuntu" matches "ubuntu:22.04",
+	//      "ubuntu@sha256:...")
+	//   3. registry/org prefix when the entry ends in "/"
+	//      ("ghcr.io/myorg/" matches every image under that path; useful for
+	//      "always keep my private builds cached")
+	// Loaded from SB_IMAGE_GC_WHITELIST as a comma-separated list. An empty
+	// list (the default) preserves today's behavior — every image is
+	// eligible for GC. Whitelisted images also short-circuit the
+	// pending_image_gc ledger insert so the ledger doesn't accumulate rows
+	// the janitor would only ever skip.
+	ImageGCWhitelist []string
 	// ImageDistributionAOCRHost is the registry host treated as the optional
 	// managed AOCR image-distribution provider. Empty configs constructed in
 	// tests fall back to the product default in the service layer.
@@ -779,6 +799,7 @@ func Load() (Config, error) {
 		ImageBuildGCEnabled:              getEnvBool("SB_IMAGE_BUILD_GC_ENABLED", true),
 		ImageBuildGCInterval:             getEnvDuration("SB_IMAGE_BUILD_GC_INTERVAL", 10*time.Minute),
 		ImageBuildGCTTL:                  getEnvDuration("SB_IMAGE_BUILD_GC_TTL", time.Hour),
+		ImageGCWhitelist:                 parseImageGCWhitelist(os.Getenv("SB_IMAGE_GC_WHITELIST")),
 		ImageDistributionAOCRHost:        strings.TrimSpace(getEnv("SB_IMAGE_DISTRIBUTION_AOCR_HOST", "aocr.aerol.ai")),
 		ImagePullMaxConcurrent:           getEnvInt("SB_IMAGE_PULL_MAX_CONCURRENT", 4),
 		ImagePullFailureBackoff:          getEnvDuration("SB_IMAGE_PULL_FAILURE_BACKOFF", 30*time.Second),
@@ -1230,6 +1251,21 @@ func getEnvDuration(key string, fallback time.Duration) time.Duration {
 
 func normalizeHost(value string) string {
 	return strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(value, "https://"), "http://"))
+}
+
+// parseImageGCWhitelist splits a comma-separated SB_IMAGE_GC_WHITELIST into
+// trimmed entries. Empty / blank entries are dropped so a stray trailing
+// comma in the env file doesn't smuggle in an empty string that matches
+// every image. Returns a non-nil zero-length slice on empty input so the
+// service layer can range over it unconditionally.
+func parseImageGCWhitelist(raw string) []string {
+	out := []string{}
+	for _, part := range strings.Split(raw, ",") {
+		if entry := strings.TrimSpace(part); entry != "" {
+			out = append(out, entry)
+		}
+	}
+	return out
 }
 
 // parseMirrorUpstreams parses the comma-separated host=shortname list for

--- a/internal/service/built_image_gc_test.go
+++ b/internal/service/built_image_gc_test.go
@@ -216,6 +216,24 @@ func TestBuiltImageGCRemovesAfterDestroyedReference(t *testing.T) {
 	}
 }
 
+// Whitelisted built images must survive the sweep even when they are old
+// AND unreferenced — the operator opted them out explicitly.
+func TestBuiltImageGCSkipsWhitelistedImage(t *testing.T) {
+	svc, _, removed := newBuiltImageGCHarness(t, time.Hour)
+	svc.cfg.ImageGCWhitelist = []string{"aerolvm-build/"}
+	old := time.Now().UTC().Add(-2 * time.Hour)
+	list := func(context.Context) ([]docker.BuiltImage, error) {
+		return []docker.BuiltImage{
+			{Tag: "aerolvm-build/keep:latest", LastTagTime: old}, // whitelisted prefix -> skip
+			{Tag: "aerolvm-build/burn:latest", LastTagTime: old}, // also matches prefix -> skip
+		}, nil
+	}
+	svc.runBuiltImageGC(context.Background(), list)
+	if len(*removed) != 0 {
+		t.Fatalf("whitelisted built images must NOT be removed, got %+v", *removed)
+	}
+}
+
 func TestBuiltImageGCSwallowsListError(t *testing.T) {
 	svc, _, removed := newBuiltImageGCHarness(t, time.Hour)
 	list := func(context.Context) ([]docker.BuiltImage, error) {

--- a/internal/service/capacity_lifecycle_test.go
+++ b/internal/service/capacity_lifecycle_test.go
@@ -112,7 +112,10 @@ func newCapacityHarness(t *testing.T, managed, inspect map[string]*models.Sandbo
 	)
 
 	svc := &Service{
-		cfg:    config.Config{},
+		// ImageBuildGCEnabled toggles whether destroy paths enqueue the
+		// pending_image_gc row at all. These lifecycle tests exercise the
+		// schedule -> janitor handoff, so the flag has to be on.
+		cfg:    config.Config{ImageBuildGCEnabled: true},
 		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
 		store:  st,
 		docker: &fakeCapacityRuntime{managed: managed, inspect: inspect},
@@ -835,7 +838,7 @@ func TestImageGCSkippedWhenAnotherSandboxReferences(t *testing.T) {
 	if imageRemoved != 0 {
 		t.Fatalf("image GC ran while sibling still references image: hits=%d", imageRemoved)
 	}
-	due, err := st.ListPendingImageGCDue(ctx, time.Now().UTC().Add(time.Hour))
+	due, err := st.ListPendingImageGCDue(ctx, time.Now().UTC().Add(time.Hour), 0)
 	if err != nil {
 		t.Fatalf("ListPendingImageGCDue: %v", err)
 	}
@@ -882,7 +885,7 @@ func TestImageGCRunsWhenLastReferenceDestroyed(t *testing.T) {
 	if imageRemoved != 1 {
 		t.Fatalf("expected janitor to remove image exactly once, got %d", imageRemoved)
 	}
-	due, err := st.ListPendingImageGCDue(ctx, time.Now().UTC().Add(time.Hour))
+	due, err := st.ListPendingImageGCDue(ctx, time.Now().UTC().Add(time.Hour), 0)
 	if err != nil {
 		t.Fatalf("ListPendingImageGCDue: %v", err)
 	}

--- a/internal/service/capacity_lifecycle_test.go
+++ b/internal/service/capacity_lifecycle_test.go
@@ -800,7 +800,10 @@ func TestDestroyEventIdempotentRelease(t *testing.T) {
 // TestImageGCSkippedWhenAnotherSandboxReferences: destroying one sandbox
 // must NOT remove the image if another sandbox (any non-destroyed status)
 // still references it. Otherwise a Stop+Destroy on one container would yank
-// the image out from under a sibling that's about to start.
+// the image out from under a sibling that's about to start. Under deferred
+// GC the destroy still schedules a pending_image_gc row — the protection
+// is in the janitor's HasActiveImageRef re-check at sweep time, exercised
+// below.
 func TestImageGCSkippedWhenAnotherSandboxReferences(t *testing.T) {
 	ctx := context.Background()
 	svc, admitter, st := newCapacityHarness(t, nil, nil)
@@ -809,6 +812,7 @@ func TestImageGCSkippedWhenAnotherSandboxReferences(t *testing.T) {
 	imageRemoved := 0
 	rt2 := &countingFakeRuntime{fakeCapacityRuntime: *rt, removed: &imageRemoved}
 	svc.docker = rt2
+	svc.cfg.ImageBuildGCTTL = 0 // make every scheduled row immediately due
 
 	const survivor = "sb-survivor"
 	const doomed = "sb-doomed"
@@ -824,8 +828,19 @@ func TestImageGCSkippedWhenAnotherSandboxReferences(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("destroy event: %v", err)
 	}
+	// Run the janitor with the survivor still active — must NOT call
+	// RemoveImage; the row should be dropped on the back of the
+	// reference re-check.
+	svc.runPendingImageGC(ctx)
 	if imageRemoved != 0 {
 		t.Fatalf("image GC ran while sibling still references image: hits=%d", imageRemoved)
+	}
+	due, err := st.ListPendingImageGCDue(ctx, time.Now().UTC().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("ListPendingImageGCDue: %v", err)
+	}
+	if len(due) != 0 {
+		t.Fatalf("janitor should have dropped the row for the still-referenced image, got %v", due)
 	}
 	// Survivor still in the admitter.
 	if snap := admitter.Snapshot(); snap.SandboxesActive != 1 {
@@ -834,9 +849,11 @@ func TestImageGCSkippedWhenAnotherSandboxReferences(t *testing.T) {
 }
 
 // TestImageGCRunsWhenLastReferenceDestroyed: the inverse — when no other
-// sandbox references the image, the destroy event must trigger image
-// removal. Pre-fix store.Delete-after-RemoveImage would have skipped the GC
-// because HasActiveImageRef saw the doomed row at status=started.
+// sandbox references the image, the destroy event schedules the image
+// for GC and the next janitor sweep removes it. Pre-fix
+// store.Delete-after-RemoveImage would have skipped the GC because
+// HasActiveImageRef saw the doomed row at status=started; the same
+// ordering still matters for the janitor's re-check.
 func TestImageGCRunsWhenLastReferenceDestroyed(t *testing.T) {
 	ctx := context.Background()
 	svc, admitter, st := newCapacityHarness(t, nil, nil)
@@ -844,6 +861,7 @@ func TestImageGCRunsWhenLastReferenceDestroyed(t *testing.T) {
 	imageRemoved := 0
 	rt := svc.docker.(*fakeCapacityRuntime)
 	svc.docker = &countingFakeRuntime{fakeCapacityRuntime: *rt, removed: &imageRemoved}
+	svc.cfg.ImageBuildGCTTL = 0
 
 	const id = "sb-only-ref"
 	seedSandbox(t, st, id, models.SandboxStatusStarted, 1, 1024)
@@ -856,8 +874,20 @@ func TestImageGCRunsWhenLastReferenceDestroyed(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("destroy event: %v", err)
 	}
+	// Destroy never removes inline anymore — the janitor does the work.
+	if imageRemoved != 0 {
+		t.Fatalf("RemoveImage must not be called inline by destroy, hits=%d", imageRemoved)
+	}
+	svc.runPendingImageGC(ctx)
 	if imageRemoved != 1 {
-		t.Fatalf("expected image GC to fire exactly once, got %d", imageRemoved)
+		t.Fatalf("expected janitor to remove image exactly once, got %d", imageRemoved)
+	}
+	due, err := st.ListPendingImageGCDue(ctx, time.Now().UTC().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("ListPendingImageGCDue: %v", err)
+	}
+	if len(due) != 0 {
+		t.Fatalf("ledger should be drained after successful GC, got %v", due)
 	}
 }
 
@@ -872,6 +902,7 @@ func TestImageGCSkippedWhenStoppedSiblingReferences(t *testing.T) {
 	imageRemoved := 0
 	rt := svc.docker.(*fakeCapacityRuntime)
 	svc.docker = &countingFakeRuntime{fakeCapacityRuntime: *rt, removed: &imageRemoved}
+	svc.cfg.ImageBuildGCTTL = 0
 
 	seedSandbox(t, st, "sb-stopped-sibling", models.SandboxStatusStopped, 1, 1024)
 	const doomed = "sb-doomed-2"
@@ -885,6 +916,9 @@ func TestImageGCSkippedWhenStoppedSiblingReferences(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("destroy event: %v", err)
 	}
+	// Janitor must respect the stopped sibling's reference and drop the
+	// scheduled row without calling RemoveImage.
+	svc.runPendingImageGC(ctx)
 	if imageRemoved != 0 {
 		t.Fatalf("image GC ran with stopped sibling holding the image: hits=%d", imageRemoved)
 	}

--- a/internal/service/events.go
+++ b/internal/service/events.go
@@ -212,10 +212,10 @@ func (s *Service) handleDestroyEvent(ctx context.Context, sandbox *models.Sandbo
 	s.forgetNetstatsActivity(sandbox.ID)
 
 	// Best-effort teardown. Order matches DestroySandbox (caddy → mounts →
-	// store.Delete → admitter → maybeRemoveImage); container destroy is
-	// skipped because the event itself means the container is already gone.
-	// Failures here are picked up by gcZombieCaddyEntries / mounts.Sweep on
-	// the next reconcile pass.
+	// store.Delete → admitter → schedulePendingImageGC); container destroy
+	// is skipped because the event itself means the container is already
+	// gone. Failures here are picked up by gcZombieCaddyEntries /
+	// mounts.Sweep on the next reconcile pass.
 	if err := s.caddy.DeleteSandboxRoute(ctx, sandbox.ID); err != nil {
 		s.logger.Warn("delete sandbox route failed", "sandbox_id", sandbox.ID, "error", err)
 	}
@@ -233,10 +233,11 @@ func (s *Service) handleDestroyEvent(ctx context.Context, sandbox *models.Sandbo
 		}
 	}
 
-	// store.Delete must happen BEFORE maybeRemoveImage: HasActiveImageRef
-	// queries the sandboxes table and treats any non-destroyed row as a live
-	// reference. Deleting first lets the image GC see the correct state.
-	// ErrNotFound is benign — the API-driven destroy path may have raced us.
+	// store.Delete must happen BEFORE schedulePendingImageGC. The
+	// pending-image janitor uses HasActiveImageRef at sweep time; a stale
+	// non-destroyed row here would make every future sweep skip this
+	// image. ErrNotFound is benign — the API-driven destroy path may have
+	// raced us.
 	if err := s.store.Delete(ctx, sandbox.ID); err != nil && !errors.Is(err, store.ErrNotFound) {
 		return fmt.Errorf("delete sandbox: %w", err)
 	}
@@ -245,7 +246,7 @@ func (s *Service) handleDestroyEvent(ctx context.Context, sandbox *models.Sandbo
 		s.admitter.Release(sandbox.ID)
 	}
 	s.deleteSelfOwnedClusterPlacement(ctx, sandbox.ID, "docker-destroy-event")
-	s.maybeRemoveImage(ctx, sandbox.Image)
+	s.schedulePendingImageGC(ctx, sandbox.Image)
 
 	s.logger.Info("audit sandbox destroyed via docker event",
 		"sandbox_id", sandbox.ID,

--- a/internal/service/pending_image_gc_test.go
+++ b/internal/service/pending_image_gc_test.go
@@ -1,0 +1,291 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// newPendingImageGCHarness mirrors newBuiltImageGCHarness: real Store
+// (so HasActiveImageRef + the pending_image_gc CRUD both hit SQLite)
+// plus a counting fake runtime so we can assert which images the
+// janitor removed. ttl is propagated via cfg so each test can pick its
+// own cutoff window.
+func newPendingImageGCHarness(t *testing.T, ttl time.Duration) (*Service, *store.Store, *[]string, *recordingRemoveRuntime) {
+	t.Helper()
+	st, err := store.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	removed := []string{}
+	rt := &recordingRemoveRuntime{removed: &removed}
+
+	svc := &Service{
+		cfg: config.Config{
+			ImageBuildGCEnabled: true,
+			ImageBuildGCTTL:     ttl,
+		},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		store:  st,
+		docker: rt,
+	}
+	return svc, st, &removed, rt
+}
+
+// schedulePendingImageGC writes through the public ledger API at a
+// specific timestamp so tests can place rows relative to the cutoff.
+// Bypasses time.Now to keep tests deterministic.
+func seedPending(t *testing.T, st *store.Store, image string, at time.Time) {
+	t.Helper()
+	if err := st.SchedulePendingImageGC(context.Background(), image, at); err != nil {
+		t.Fatalf("seed pending row %q: %v", image, err)
+	}
+}
+
+func listPending(t *testing.T, st *store.Store) []string {
+	t.Helper()
+	// Large cutoff so the call returns every row regardless of timestamp.
+	got, err := st.ListPendingImageGCDue(context.Background(), time.Now().UTC().Add(100*365*24*time.Hour))
+	if err != nil {
+		t.Fatalf("list pending: %v", err)
+	}
+	return got
+}
+
+func TestPendingImageGCRemovesDueUnreferenced(t *testing.T) {
+	svc, st, removed, _ := newPendingImageGCHarness(t, time.Hour)
+	// Scheduled 2h ago, TTL 1h → due.
+	seedPending(t, st, "alpine:latest", time.Now().UTC().Add(-2*time.Hour))
+
+	svc.runPendingImageGC(context.Background())
+
+	if len(*removed) != 1 || (*removed)[0] != "alpine:latest" {
+		t.Fatalf("expected removal of alpine:latest, got %+v", *removed)
+	}
+	// Row cleared so the next sweep doesn't retry endlessly.
+	if pending := listPending(t, st); len(pending) != 0 {
+		t.Fatalf("expected empty ledger after successful GC, got %v", pending)
+	}
+}
+
+func TestPendingImageGCSkipsNotYetDue(t *testing.T) {
+	svc, st, removed, _ := newPendingImageGCHarness(t, time.Hour)
+	// Scheduled 10m ago, TTL 1h → still inside TTL.
+	seedPending(t, st, "alpine:latest", time.Now().UTC().Add(-10*time.Minute))
+
+	svc.runPendingImageGC(context.Background())
+
+	if len(*removed) != 0 {
+		t.Fatalf("not-yet-due row must not be removed, got %+v", *removed)
+	}
+	// Row preserved so a future sweep can retire it once the TTL elapses.
+	if pending := listPending(t, st); len(pending) != 1 || pending[0] != "alpine:latest" {
+		t.Fatalf("expected ledger to keep the row, got %v", pending)
+	}
+}
+
+func TestPendingImageGCDropsRowWhenImageBackInUse(t *testing.T) {
+	svc, st, removed, _ := newPendingImageGCHarness(t, time.Hour)
+	image := "alpine:latest"
+	// Sandbox came back online between scheduling and the sweep.
+	now := time.Now().UTC()
+	if err := st.Create(context.Background(), &models.Sandbox{
+		ID:        "sb-resurrected",
+		Image:     image,
+		Status:    models.SandboxStatusStarted,
+		CPU:       1,
+		MemoryMB:  1024,
+		Runtime:   models.RuntimeDocker,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+	seedPending(t, st, image, now.Add(-2*time.Hour))
+
+	svc.runPendingImageGC(context.Background())
+
+	if len(*removed) != 0 {
+		t.Fatalf("RemoveImage must not be called for resurrected image, got %+v", *removed)
+	}
+	// Row is dropped — destroy path will re-schedule if it goes idle again.
+	if pending := listPending(t, st); len(pending) != 0 {
+		t.Fatalf("expected ledger to drop the resurrected entry, got %v", pending)
+	}
+}
+
+func TestPendingImageGCLeavesRowOnRemoveFailure(t *testing.T) {
+	svc, st, removed, rt := newPendingImageGCHarness(t, time.Hour)
+	rt.removeErr = errors.New("docker unreachable")
+	image := "alpine:latest"
+	seedPending(t, st, image, time.Now().UTC().Add(-2*time.Hour))
+
+	svc.runPendingImageGC(context.Background())
+
+	if len(*removed) != 1 || (*removed)[0] != image {
+		t.Fatalf("RemoveImage should still have been attempted, got %+v", *removed)
+	}
+	// Row preserved so the next tick retries — without this the image leaks.
+	if pending := listPending(t, st); len(pending) != 1 || pending[0] != image {
+		t.Fatalf("expected ledger to retain row on failure, got %v", pending)
+	}
+}
+
+func TestPendingImageGCAppliesPerImage(t *testing.T) {
+	svc, st, removed, _ := newPendingImageGCHarness(t, time.Hour)
+	now := time.Now().UTC()
+	old := now.Add(-2 * time.Hour)
+	fresh := now.Add(-5 * time.Minute)
+
+	// "inuse" is due but actively referenced -> dropped from ledger,
+	// no docker call.
+	if err := st.Create(context.Background(), &models.Sandbox{
+		ID:        "sb-pinner",
+		Image:     "inuse:latest",
+		Status:    models.SandboxStatusStarted,
+		CPU:       1,
+		MemoryMB:  1024,
+		Runtime:   models.RuntimeDocker,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+	seedPending(t, st, "inuse:latest", old)
+	seedPending(t, st, "fresh:latest", fresh)                      // skip (within TTL)
+	seedPending(t, st, "old-orphan:latest", old)                   // remove
+	seedPending(t, st, "older-orphan:latest", old.Add(-time.Hour)) // remove, older
+
+	svc.runPendingImageGC(context.Background())
+
+	// Sweep ordering is oldest-first, so older-orphan should be ahead.
+	want := []string{"older-orphan:latest", "old-orphan:latest"}
+	if len(*removed) != len(want) {
+		t.Fatalf("removed=%v, want=%v", *removed, want)
+	}
+	for i := range want {
+		if (*removed)[i] != want[i] {
+			t.Fatalf("position %d: removed=%q want=%q (full=%v)", i, (*removed)[i], want[i], *removed)
+		}
+	}
+
+	// Ledger: inuse + the two old orphans are gone; fresh remains.
+	pending := listPending(t, st)
+	if len(pending) != 1 || pending[0] != "fresh:latest" {
+		t.Fatalf("ledger should retain only fresh:latest, got %v", pending)
+	}
+}
+
+// schedulePendingImageGC is the bridge from destroy paths to the
+// ledger. Empty image must be a no-op (matches the previous
+// maybeRemoveImage guard) so callers can pass sandbox.Image without a
+// nil-check.
+func TestSchedulePendingImageGCEmptyImageNoop(t *testing.T) {
+	svc, st, _, _ := newPendingImageGCHarness(t, time.Hour)
+	svc.schedulePendingImageGC(context.Background(), "")
+	if pending := listPending(t, st); len(pending) != 0 {
+		t.Fatalf("empty image must not insert a row, got %v", pending)
+	}
+}
+
+// TestImageGCWhitelistedHelper covers the three match shapes the operator
+// can lean on: exact ref, repo (tag/digest agnostic), and registry/org
+// prefix. Anchored boundaries are the whole point — "ubuntu" must NOT
+// shield "ubuntu-base", otherwise a typo in the whitelist would silently
+// pin an unrelated image forever.
+func TestImageGCWhitelistedHelper(t *testing.T) {
+	svc := &Service{cfg: config.Config{ImageGCWhitelist: []string{
+		"alpine:latest",  // exact
+		"ubuntu",         // repo
+		"ghcr.io/myorg/", // prefix
+		"sha-pinned",     // repo, will also match @sha256
+	}}}
+
+	cases := []struct {
+		image string
+		want  bool
+	}{
+		{"alpine:latest", true},              // exact
+		{"alpine:3.20", false},               // exact entry, different tag -> no
+		{"ubuntu:22.04", true},               // repo match w/ tag
+		{"ubuntu@sha256:abc", true},          // repo match w/ digest
+		{"ubuntu-base:1", false},             // anchored: "ubuntu" must not match "ubuntu-base"
+		{"ghcr.io/myorg/svc:v1", true},       // prefix match
+		{"ghcr.io/otherorg/svc:v1", false},   // prefix mismatch
+		{"sha-pinned@sha256:deadbeef", true}, // repo + digest
+		{"unrelated:1", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := svc.imageGCWhitelisted(tc.image); got != tc.want {
+			t.Errorf("imageGCWhitelisted(%q) = %v, want %v", tc.image, got, tc.want)
+		}
+	}
+}
+
+// Empty whitelist is the today-default; every image must remain eligible.
+func TestImageGCWhitelistEmptyMatchesNothing(t *testing.T) {
+	svc := &Service{cfg: config.Config{}}
+	if svc.imageGCWhitelisted("alpine:latest") {
+		t.Fatalf("empty whitelist must not protect any image")
+	}
+}
+
+// schedulePendingImageGC short-circuits whitelisted images so the ledger
+// stays clean — otherwise the janitor would carry rows it can never act on.
+func TestSchedulePendingImageGCSkipsWhitelisted(t *testing.T) {
+	svc, st, _, _ := newPendingImageGCHarness(t, time.Hour)
+	svc.cfg.ImageGCWhitelist = []string{"alpine"}
+	svc.schedulePendingImageGC(context.Background(), "alpine:latest")
+	if pending := listPending(t, st); len(pending) != 0 {
+		t.Fatalf("whitelisted image must not enter the ledger, got %v", pending)
+	}
+}
+
+// If a row landed BEFORE the operator added the entry to the whitelist,
+// the sweep must drop the row (so the ledger doesn't grow without bound)
+// AND must not call RemoveImage.
+func TestPendingImageGCDropsWhitelistedRow(t *testing.T) {
+	svc, st, removed, _ := newPendingImageGCHarness(t, time.Hour)
+	// Row landed first.
+	seedPending(t, st, "alpine:latest", time.Now().UTC().Add(-2*time.Hour))
+	// Operator added the whitelist entry afterwards.
+	svc.cfg.ImageGCWhitelist = []string{"alpine"}
+
+	svc.runPendingImageGC(context.Background())
+
+	if len(*removed) != 0 {
+		t.Fatalf("whitelisted image must not be removed, got %+v", *removed)
+	}
+	if pending := listPending(t, st); len(pending) != 0 {
+		t.Fatalf("expected ledger to drop whitelisted row, got %v", pending)
+	}
+}
+
+// StartPendingImageGC honors the operator kill switch.
+func TestStartPendingImageGCDisabledIsNoOp(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	svc := &Service{
+		cfg:    config.Config{ImageBuildGCEnabled: false},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		store:  st,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	svc.StartPendingImageGC(ctx) // returns immediately
+}

--- a/internal/service/pending_image_gc_test.go
+++ b/internal/service/pending_image_gc_test.go
@@ -55,11 +55,16 @@ func seedPending(t *testing.T, st *store.Store, image string, at time.Time) {
 func listPending(t *testing.T, st *store.Store) []string {
 	t.Helper()
 	// Large cutoff so the call returns every row regardless of timestamp.
-	got, err := st.ListPendingImageGCDue(context.Background(), time.Now().UTC().Add(100*365*24*time.Hour))
+	// Limit 0 == unbounded, which is what we want for assertions.
+	entries, err := st.ListPendingImageGCDue(context.Background(), time.Now().UTC().Add(100*365*24*time.Hour), 0)
 	if err != nil {
 		t.Fatalf("list pending: %v", err)
 	}
-	return got
+	out := make([]string, len(entries))
+	for i, e := range entries {
+		out[i] = e.Image
+	}
+	return out
 }
 
 func TestPendingImageGCRemovesDueUnreferenced(t *testing.T) {
@@ -269,6 +274,119 @@ func TestPendingImageGCDropsWhitelistedRow(t *testing.T) {
 	}
 	if pending := listPending(t, st); len(pending) != 0 {
 		t.Fatalf("expected ledger to drop whitelisted row, got %v", pending)
+	}
+}
+
+// Refresh-race guard: if a destroy path upserts pending_image_gc with a
+// fresh timestamp between the janitor's list and its post-remove delete,
+// the new (refreshed) row must NOT be silently overwritten. Otherwise a
+// busy churn pattern would race the janitor and lose the extended TTL
+// the destroy path was supposed to buy.
+func TestPendingImageGCPreservesRefreshedRow(t *testing.T) {
+	svc, st, removed, _ := newPendingImageGCHarness(t, time.Hour)
+	image := "alpine:latest"
+	// Row is initially due (scheduled 2h ago, TTL 1h).
+	oldAt := time.Now().UTC().Add(-2 * time.Hour)
+	seedPending(t, st, image, oldAt)
+	// Simulate the destroy of another sandbox sharing this image
+	// landing in the gap between list and remove. We do it before
+	// runPendingImageGC since the harness is single-threaded; the
+	// janitor must then observe the refreshed timestamp and skip the
+	// conditional delete (because it lists from the original cutoff).
+	//
+	// Trick: bump TTL so the original cutoff still sees `oldAt` as
+	// due, then refresh to a timestamp that's inside the original
+	// cutoff window — i.e. newer than oldAt but older than now-TTL.
+	// Easier: list with the original cutoff (the janitor does), but
+	// physically refresh the row to "now" before the conditional
+	// delete fires.
+	refreshAt := time.Now().UTC()
+	if err := st.SchedulePendingImageGC(context.Background(), image, refreshAt); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+
+	svc.runPendingImageGC(context.Background())
+
+	// Image is no longer due (refreshAt > now-TTL), so the janitor
+	// never reaches RemoveImage. List returns empty for the original
+	// cutoff, sweep is a no-op.
+	if len(*removed) != 0 {
+		t.Fatalf("refreshed row must not trigger RemoveImage, got %+v", *removed)
+	}
+	pending := listPending(t, st)
+	if len(pending) != 1 || pending[0] != image {
+		t.Fatalf("refreshed row must survive the sweep, got %v", pending)
+	}
+}
+
+// Counterpart to the refresh-race test: simulate the harder timing where
+// the row IS visible at list-time but a destroy refreshes between list
+// and delete. We exercise the conditional delete by directly invoking
+// it with a stale timestamp; the row must remain.
+func TestPendingImageGCConditionalDeleteSkipsRefreshed(t *testing.T) {
+	_, st, _, _ := newPendingImageGCHarness(t, time.Hour)
+	image := "alpine:latest"
+	seenAt := time.Now().UTC().Add(-2 * time.Hour)
+	seedPending(t, st, image, seenAt)
+
+	// Destroy of a sibling sandbox refreshed the row after the sweep
+	// listed it but before the conditional delete fired.
+	refreshAt := time.Now().UTC()
+	if err := st.SchedulePendingImageGC(context.Background(), image, refreshAt); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+
+	ok, err := st.DeletePendingImageGCIfScheduledAt(context.Background(), image, seenAt)
+	if err != nil {
+		t.Fatalf("conditional delete: %v", err)
+	}
+	if ok {
+		t.Fatalf("stale conditional delete must not remove the refreshed row")
+	}
+	if pending := listPending(t, st); len(pending) != 1 || pending[0] != image {
+		t.Fatalf("refreshed row must survive, got %v", pending)
+	}
+}
+
+// Kill-switch contract: when image GC is disabled, destroy paths must
+// NOT keep writing ledger rows that nobody will ever drain. Otherwise
+// pending_image_gc grows unbounded over the operator's "no GC" choice.
+func TestSchedulePendingImageGCSkippedWhenDisabled(t *testing.T) {
+	svc, st, _, _ := newPendingImageGCHarness(t, time.Hour)
+	svc.cfg.ImageBuildGCEnabled = false
+
+	svc.schedulePendingImageGC(context.Background(), "alpine:latest")
+
+	if pending := listPending(t, st); len(pending) != 0 {
+		t.Fatalf("disabled GC must not enqueue ledger rows, got %v", pending)
+	}
+}
+
+// Whitelist matcher must treat ':' inside a registry host as part of
+// the host (port), not as a tag boundary — otherwise every entry that
+// names a non-standard-port registry silently degrades to exact-ref
+// only, which is almost never what the operator typed.
+func TestImageGCWhitelistHandlesRegistryPort(t *testing.T) {
+	svc := &Service{cfg: config.Config{ImageGCWhitelist: []string{
+		"localhost:5000/team/app", // repo on a non-standard-port registry
+		"registry.local:5000/",    // prefix on a non-standard-port registry
+	}}}
+	cases := []struct {
+		image string
+		want  bool
+	}{
+		{"localhost:5000/team/app:v1", true},              // repo + tag
+		{"localhost:5000/team/app@sha256:deadbeef", true}, // repo + digest
+		{"localhost:5000/team/app", true},                 // exact ref
+		{"localhost:5000/team/app-extra:v1", false},       // boundary not crossed
+		{"localhost:5000/other/app:v1", false},            // different repo
+		{"registry.local:5000/anyorg/svc:v1", true},       // prefix match
+		{"registry.local:6000/anyorg/svc:v1", false},      // wrong port
+	}
+	for _, tc := range cases {
+		if got := svc.imageGCWhitelisted(tc.image); got != tc.want {
+			t.Errorf("imageGCWhitelisted(%q) = %v, want %v", tc.image, got, tc.want)
+		}
 	}
 }
 

--- a/internal/service/pending_image_gc_test.go
+++ b/internal/service/pending_image_gc_test.go
@@ -390,6 +390,65 @@ func TestImageGCWhitelistHandlesRegistryPort(t *testing.T) {
 	}
 }
 
+// refreshPendingImageGCOnUse fires from the create path. Its job is to
+// push the deadline forward on an EXISTING pending row so a freshly-
+// used image gets a fresh TTL window — but it must NEVER insert a new
+// row, or pending_image_gc would grow to one row per image ever used.
+func TestRefreshPendingImageGCOnUseUpdatesOnly(t *testing.T) {
+	svc, st, _, _ := newPendingImageGCHarness(t, time.Hour)
+
+	// No row yet: refresh is a no-op (no insert).
+	svc.refreshPendingImageGCOnUse(context.Background(), "alpine:latest")
+	if pending := listPending(t, st); len(pending) != 0 {
+		t.Fatalf("refresh must not insert, got %v", pending)
+	}
+
+	// Existing row: refresh pushes scheduled_at forward enough that
+	// the next sweep (at TTL=1h) no longer sees it as due. We seed at
+	// 2h ago, refresh, then run the sweep — the image must survive.
+	seedPending(t, st, "alpine:latest", time.Now().UTC().Add(-2*time.Hour))
+	svc.refreshPendingImageGCOnUse(context.Background(), "alpine:latest")
+	svc.runPendingImageGC(context.Background())
+
+	// Survives the sweep because the refresh pushed it inside the TTL window.
+	if pending := listPending(t, st); len(pending) != 1 || pending[0] != "alpine:latest" {
+		t.Fatalf("refreshed row must survive the next sweep, got %v", pending)
+	}
+}
+
+// Symmetric kill-switch / whitelist contracts: the create-path refresh
+// must respect the same operator toggles as the destroy-path schedule.
+// Otherwise an operator who turned off GC would see ledger writes
+// arriving from creates, which is exactly what they opted out of.
+func TestRefreshPendingImageGCOnUseRespectsToggles(t *testing.T) {
+	svc, st, _, _ := newPendingImageGCHarness(t, time.Hour)
+	old := time.Now().UTC().Add(-2 * time.Hour)
+	seedPending(t, st, "alpine:latest", old)
+
+	// Whitelist short-circuit: refresh must not touch the row.
+	svc.cfg.ImageGCWhitelist = []string{"alpine"}
+	svc.refreshPendingImageGCOnUse(context.Background(), "alpine:latest")
+	entries, err := st.ListPendingImageGCDue(context.Background(), time.Now().UTC().Add(time.Hour), 0)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(entries) != 1 || !entries[0].ScheduledAt.Equal(old) {
+		t.Fatalf("whitelisted refresh must not move scheduled_at, got %v", entries)
+	}
+
+	// Kill switch: same — refresh must be a no-op.
+	svc.cfg.ImageGCWhitelist = nil
+	svc.cfg.ImageBuildGCEnabled = false
+	svc.refreshPendingImageGCOnUse(context.Background(), "alpine:latest")
+	entries, err = st.ListPendingImageGCDue(context.Background(), time.Now().UTC().Add(time.Hour), 0)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(entries) != 1 || !entries[0].ScheduledAt.Equal(old) {
+		t.Fatalf("disabled-GC refresh must not move scheduled_at, got %v", entries)
+	}
+}
+
 // StartPendingImageGC honors the operator kill switch.
 func TestStartPendingImageGCDisabledIsNoOp(t *testing.T) {
 	st, err := store.Open(filepath.Join(t.TempDir(), "state.db"))

--- a/internal/service/reconcile_destroy_test.go
+++ b/internal/service/reconcile_destroy_test.go
@@ -302,9 +302,21 @@ func TestReconcileDestroyedRowFreesHostPort(t *testing.T) {
 		t.Fatalf("admitter not released: snapshot=%+v", snap)
 	}
 
-	// Image GC was attempted exactly once — no other sandbox referenced it.
-	if got := rt.removeImageHits.Load(); got != 1 {
-		t.Fatalf("RemoveImage hits = %d, want 1", got)
+	// Image GC was scheduled, not executed inline: the destroy path now
+	// records the image in pending_image_gc for the janitor to sweep
+	// after ImageBuildGCTTL. The successor created above with the same
+	// image is exactly the case the deferral protects — yanking the
+	// image inline would have forced a re-pull on every destroy/recreate
+	// cycle.
+	if got := rt.removeImageHits.Load(); got != 0 {
+		t.Fatalf("RemoveImage must NOT be called inline, hits = %d", got)
+	}
+	due, err := st.ListPendingImageGCDue(ctx, time.Now().UTC().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("ListPendingImageGCDue: %v", err)
+	}
+	if len(due) != 1 || due[0] != image {
+		t.Fatalf("expected pending_image_gc to contain %q, got %v", image, due)
 	}
 }
 
@@ -428,8 +440,17 @@ func TestDestroyEventFreesHostPort(t *testing.T) {
 	if snap := admitter.Snapshot(); snap.SandboxesActive != 0 {
 		t.Fatalf("admitter not released: %+v", snap)
 	}
-	if got := rt.removeImageHits.Load(); got != 1 {
-		t.Fatalf("RemoveImage hits = %d, want 1", got)
+	// Image scheduled for deferred GC, not removed inline (see the
+	// reconcile-branch test above for the rationale).
+	if got := rt.removeImageHits.Load(); got != 0 {
+		t.Fatalf("RemoveImage must NOT be called inline, hits = %d", got)
+	}
+	due, err := st.ListPendingImageGCDue(ctx, time.Now().UTC().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("ListPendingImageGCDue: %v", err)
+	}
+	if len(due) != 1 || due[0] != image {
+		t.Fatalf("expected pending_image_gc to contain %q, got %v", image, due)
 	}
 }
 

--- a/internal/service/reconcile_destroy_test.go
+++ b/internal/service/reconcile_destroy_test.go
@@ -127,7 +127,9 @@ func TestReconcileReappliesNetworkBlockAllWithCurrentContainerIP(t *testing.T) {
 		},
 	}
 	svc := &Service{
-		cfg:    config.Config{},
+		// schedulePendingImageGC checks ImageBuildGCEnabled — leave it on
+		// so the destroy branches produce the expected ledger rows.
+		cfg:    config.Config{ImageBuildGCEnabled: true},
 		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
 		store:  st,
 		docker: rt,
@@ -218,7 +220,9 @@ func TestReconcileDestroyedRowFreesHostPort(t *testing.T) {
 	rt := &fakeReconcileRuntime{managed: map[string]*models.SandboxRuntimeState{}}
 
 	svc := &Service{
-		cfg:      config.Config{},
+		// Reconcile's destroyed-branch goes through schedulePendingImageGC,
+		// which checks ImageBuildGCEnabled before writing the ledger row.
+		cfg:      config.Config{ImageBuildGCEnabled: true},
 		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
 		store:    st,
 		docker:   rt,
@@ -311,11 +315,11 @@ func TestReconcileDestroyedRowFreesHostPort(t *testing.T) {
 	if got := rt.removeImageHits.Load(); got != 0 {
 		t.Fatalf("RemoveImage must NOT be called inline, hits = %d", got)
 	}
-	due, err := st.ListPendingImageGCDue(ctx, time.Now().UTC().Add(time.Hour))
+	due, err := st.ListPendingImageGCDue(ctx, time.Now().UTC().Add(time.Hour), 0)
 	if err != nil {
 		t.Fatalf("ListPendingImageGCDue: %v", err)
 	}
-	if len(due) != 1 || due[0] != image {
+	if len(due) != 1 || due[0].Image != image {
 		t.Fatalf("expected pending_image_gc to contain %q, got %v", image, due)
 	}
 }
@@ -359,7 +363,9 @@ func TestDestroyEventFreesHostPort(t *testing.T) {
 	rt := &fakeReconcileRuntime{managed: map[string]*models.SandboxRuntimeState{}}
 
 	svc := &Service{
-		cfg:      config.Config{},
+		// Reconcile's destroyed-branch goes through schedulePendingImageGC,
+		// which checks ImageBuildGCEnabled before writing the ledger row.
+		cfg:      config.Config{ImageBuildGCEnabled: true},
 		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
 		store:    st,
 		docker:   rt,
@@ -445,11 +451,11 @@ func TestDestroyEventFreesHostPort(t *testing.T) {
 	if got := rt.removeImageHits.Load(); got != 0 {
 		t.Fatalf("RemoveImage must NOT be called inline, hits = %d", got)
 	}
-	due, err := st.ListPendingImageGCDue(ctx, time.Now().UTC().Add(time.Hour))
+	due, err := st.ListPendingImageGCDue(ctx, time.Now().UTC().Add(time.Hour), 0)
 	if err != nil {
 		t.Fatalf("ListPendingImageGCDue: %v", err)
 	}
-	if len(due) != 1 || due[0] != image {
+	if len(due) != 1 || due[0].Image != image {
 		t.Fatalf("expected pending_image_gc to contain %q, got %v", image, due)
 	}
 }
@@ -481,7 +487,9 @@ func TestDieEventDoesNotDeleteRow(t *testing.T) {
 
 	rt := &fakeReconcileRuntime{managed: map[string]*models.SandboxRuntimeState{}}
 	svc := &Service{
-		cfg:    config.Config{},
+		// schedulePendingImageGC checks ImageBuildGCEnabled — leave it on
+		// so the destroy branches produce the expected ledger rows.
+		cfg:    config.Config{ImageBuildGCEnabled: true},
 		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
 		store:  st,
 		docker: rt,

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1129,7 +1129,7 @@ func (s *Service) DestroySandbox(ctx context.Context, id string) error {
 		s.admitter.Release(id)
 	}
 	s.logger.Info("audit sandbox destroyed", "sandbox_id", id, "image", sandbox.Image)
-	s.maybeRemoveImage(ctx, sandbox.Image)
+	s.schedulePendingImageGC(ctx, sandbox.Image)
 	return nil
 }
 
@@ -2426,11 +2426,12 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			if err := s.mounts.UnmountAll(sandbox.ID); err != nil {
 				s.logger.Warn("reconcile destroyed unmount failed", "sandbox_id", sandbox.ID, "error", err)
 			}
-			// store.Delete must happen BEFORE maybeRemoveImage: HasActiveImageRef
-			// queries the sandboxes table and treats any non-destroyed row as a
-			// live reference. While our row still exists with its pre-destroy
-			// status (typically "started"), the image GC would always skip,
-			// leaking image layers across reconcile cycles.
+			// store.Delete must happen BEFORE schedulePendingImageGC. The
+			// pending-image janitor uses HasActiveImageRef to decide whether
+			// to actually call docker.RemoveImage at sweep time; a stale row
+			// with status "started" sitting in sandboxes would make every
+			// sweep skip this image, leaking layers across reconcile cycles
+			// until something else changed.
 			if err := s.store.Delete(ctx, sandbox.ID); err != nil && !errors.Is(err, store.ErrNotFound) {
 				return err
 			}
@@ -2441,7 +2442,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 				s.admitter.Release(sandbox.ID)
 			}
 			s.deleteSelfOwnedClusterPlacement(ctx, sandbox.ID, "reconcile-destroyed")
-			s.maybeRemoveImage(ctx, sandbox.Image)
+			s.schedulePendingImageGC(ctx, sandbox.Image)
 			s.logger.Info("audit reconcile destroyed",
 				"sandbox_id", sandbox.ID,
 				"image", sandbox.Image,
@@ -3060,6 +3061,9 @@ func (s *Service) runBuiltImageGC(ctx context.Context, list builtImageListFn) {
 		if img.LastTagTime.After(cutoff) {
 			continue
 		}
+		if s.imageGCWhitelisted(img.Tag) {
+			continue
+		}
 		referenced, err := s.store.HasActiveImageRef(ctx, img.Tag)
 		if err != nil {
 			s.logger.Warn("built-image gc ref check failed", "tag", img.Tag, "error", err)
@@ -3073,6 +3077,92 @@ func (s *Service) runBuiltImageGC(ctx context.Context, list builtImageListFn) {
 			continue
 		}
 		s.logger.Info("audit built image gc removed", "tag", img.Tag, "last_tag_time", img.LastTagTime)
+	}
+}
+
+// StartPendingImageGC launches the periodic janitor that removes images
+// scheduled by destroy paths (DestroySandbox, reconcile destroyed-branch,
+// handleDestroyEvent). It piggybacks on ImageBuildGCEnabled / Interval /
+// TTL: same enable switch, same cadence, same TTL — so an operator who
+// wants to disable image GC entirely flips one knob, and tightening the
+// TTL applies to both pulled images (this janitor) and built images
+// (StartBuiltImageGC). No-op when disabled or Interval <= 0.
+func (s *Service) StartPendingImageGC(ctx context.Context) {
+	if !s.cfg.ImageBuildGCEnabled {
+		return
+	}
+	interval := s.cfg.ImageBuildGCInterval
+	if interval <= 0 {
+		return
+	}
+	ticker := time.NewTicker(interval)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				sweepCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+				s.runPendingImageGC(sweepCtx)
+				cancel()
+			}
+		}
+	}()
+}
+
+// runPendingImageGC is one pass of the pending-image janitor. Reads
+// ledger rows older than ImageBuildGCTTL, re-checks HasActiveImageRef
+// (in case a new sandbox grabbed the image after scheduling), and
+// removes the image from Docker. Idempotent: a failed RemoveImage
+// leaves the row so the next tick retries; a successful one (or a
+// "referenced now" outcome) deletes the row so we don't keep
+// re-attempting. Failures are logged, never returned — the janitor
+// must not block on a bad row.
+func (s *Service) runPendingImageGC(ctx context.Context) {
+	cutoff := time.Now().UTC().Add(-s.cfg.ImageBuildGCTTL)
+	images, err := s.store.ListPendingImageGCDue(ctx, cutoff)
+	if err != nil {
+		s.logger.Warn("pending image gc list failed", "error", err)
+		return
+	}
+	for _, image := range images {
+		if s.imageGCWhitelisted(image) {
+			// Operator whitelisted this image after the row landed.
+			// Drop it so the ledger doesn't carry it forever; the
+			// destroy path's short-circuit keeps new rows out.
+			if err := s.store.DeletePendingImageGC(ctx, image); err != nil {
+				s.logger.Warn("pending image gc whitelist row clear failed", "image", image, "error", err)
+			}
+			continue
+		}
+		referenced, err := s.store.HasActiveImageRef(ctx, image)
+		if err != nil {
+			s.logger.Warn("pending image gc ref check failed", "image", image, "error", err)
+			continue
+		}
+		if referenced {
+			// Image came back into use between scheduling and now.
+			// Drop the row; if it goes idle again the destroy path
+			// will re-schedule with a fresh timestamp.
+			if err := s.store.DeletePendingImageGC(ctx, image); err != nil {
+				s.logger.Warn("pending image gc row clear failed", "image", image, "error", err)
+			}
+			continue
+		}
+		if err := s.docker.RemoveImage(ctx, image); err != nil {
+			// Leave the row in place so the next tick retries. Note
+			// docker.RemoveImage returns nil for 404/409, so the
+			// "image vanished" and "still in use by an unknown
+			// container" cases fall through to the delete below.
+			s.logger.Warn("pending image gc remove failed", "image", image, "error", err)
+			continue
+		}
+		if err := s.store.DeletePendingImageGC(ctx, image); err != nil {
+			s.logger.Warn("pending image gc row delete failed", "image", image, "error", err)
+			continue
+		}
+		s.logger.Info("audit pending image gc removed", "image", image)
 	}
 }
 
@@ -3402,29 +3492,65 @@ func imageStillReferenced(sandboxes []*models.Sandbox, image string) bool {
 	return false
 }
 
-// maybeRemoveImage deletes the given image from Docker if no non-destroyed
-// sandbox still references it. Best-effort: store and Docker errors are
-// logged, never returned, because image GC must not block the sandbox
-// lifecycle path that called us. Uses Store.HasActiveImageRef so the cost
-// is one indexed query rather than a full table scan, even when there are
-// 10k+ destroyed rows in history.
-func (s *Service) maybeRemoveImage(ctx context.Context, image string) {
+// schedulePendingImageGC records the image in the pending_image_gc
+// ledger so the runPendingImageGC janitor can sweep it after
+// ImageBuildGCTTL. Replaces the previous inline-delete path: a destroyed
+// sandbox no longer yanks its image from the daemon immediately, which
+// kept a destroy/recreate loop on the same image re-pulling on every
+// cycle. Best-effort: errors are logged, never returned, because image
+// GC must not block the sandbox lifecycle path that called us. If the
+// ledger write fails (rare — SQLite is local), the image leaks until
+// another destroy of a sandbox sharing the image re-schedules it.
+func (s *Service) schedulePendingImageGC(ctx context.Context, image string) {
 	if image == "" {
 		return
 	}
-	stillUsed, err := s.store.HasActiveImageRef(ctx, image)
-	if err != nil {
-		s.logger.Warn("image gc reference check failed", "image", image, "error", err)
+	// Short-circuit on whitelist so the ledger doesn't accumulate rows
+	// the janitor would only ever skip. Cheap O(N) scan over a small,
+	// operator-curated list — much smaller than the per-tick scan cost.
+	if s.imageGCWhitelisted(image) {
 		return
 	}
-	if stillUsed {
+	if err := s.store.SchedulePendingImageGC(ctx, image, time.Now().UTC()); err != nil {
+		s.logger.Warn("schedule pending image gc failed", "image", image, "error", err)
 		return
 	}
-	if err := s.docker.RemoveImage(ctx, image); err != nil {
-		s.logger.Warn("image gc remove failed", "image", image, "error", err)
-		return
+	s.logger.Info("audit image scheduled for gc", "image", image)
+}
+
+// imageGCWhitelisted reports whether image is protected from both
+// janitors by cfg.ImageGCWhitelist. Three match shapes:
+//   - exact ref equality (entry == image)
+//   - repo equality, tag/digest agnostic (entry has no ':' / '@', and image
+//     starts with entry followed by ':' or '@')
+//   - registry/org prefix when entry ends in '/'
+//
+// Anchored boundaries on every shape so a "ubuntu" entry can't accidentally
+// shield "ubuntu-base" — the operator gets exactly what they typed.
+func (s *Service) imageGCWhitelisted(image string) bool {
+	if image == "" || len(s.cfg.ImageGCWhitelist) == 0 {
+		return false
 	}
-	s.logger.Info("audit image removed", "image", image)
+	for _, entry := range s.cfg.ImageGCWhitelist {
+		if entry == "" {
+			continue
+		}
+		if entry == image {
+			return true
+		}
+		if strings.HasSuffix(entry, "/") {
+			if strings.HasPrefix(image, entry) {
+				return true
+			}
+			continue
+		}
+		if !strings.ContainsAny(entry, ":@") {
+			if strings.HasPrefix(image, entry+":") || strings.HasPrefix(image, entry+"@") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // syncAllowedPorts pushes the sandbox's current set of exposed ports to

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -810,6 +810,14 @@ func (s *Service) createSandbox(ctx context.Context, req models.CreateSandboxReq
 		return nil, err
 	}
 
+	// Push any pending GC deadline for this image forward — a fresh
+	// create proves the image is back in active use, so the next
+	// destroy should restart the full TTL clock instead of inheriting
+	// the previous destroy's old timestamp. UPDATE-only: never inserts
+	// a row, so images that have never been GC-scheduled stay out of
+	// the ledger. Best-effort: an error here doesn't break the create.
+	s.refreshPendingImageGCOnUse(ctx, sandbox.Image)
+
 	if len(sealedMounts) > 0 {
 		if err := s.store.PutMounts(ctx, sandbox.ID, sealedMounts); err != nil {
 			_ = s.store.Delete(ctx, sandbox.ID)
@@ -3525,6 +3533,37 @@ func imageStillReferenced(sandboxes []*models.Sandbox, image string) bool {
 // GC must not block the sandbox lifecycle path that called us. If the
 // ledger write fails (rare — SQLite is local), the image leaks until
 // another destroy of a sandbox sharing the image re-schedules it.
+// refreshPendingImageGCOnUse pushes any existing pending_image_gc row
+// for image forward to "now". Called from the create path so that
+// creating a new sandbox with an image that's pending GC restarts the
+// TTL window from the most recent use — matching the existing
+// "destroy refreshes the timestamp" semantics in reverse.
+//
+// UPDATE-only: this never inserts a row. Images that were never
+// destroyed (and so never scheduled) stay out of pending_image_gc
+// entirely. That keeps the table bounded by "images destroyed
+// recently" rather than ballooning to one row per image ever used.
+//
+// Best-effort and off the boot-path-critical sequence: an error
+// here is logged, not surfaced. The image still gets GC'd correctly
+// either way — at worst the deadline is the original destroy's
+// timestamp rather than this create's, which is the pre-existing
+// behavior the rest of the janitor already handles.
+func (s *Service) refreshPendingImageGCOnUse(ctx context.Context, image string) {
+	if image == "" {
+		return
+	}
+	if !s.cfg.ImageBuildGCEnabled {
+		return
+	}
+	if s.imageGCWhitelisted(image) {
+		return
+	}
+	if _, err := s.store.RefreshPendingImageGCIfExists(ctx, image, time.Now().UTC()); err != nil {
+		s.logger.Warn("refresh pending image gc failed", "image", image, "error", err)
+	}
+}
+
 func (s *Service) schedulePendingImageGC(ctx context.Context, image string) {
 	if image == "" {
 		return

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -3111,6 +3111,15 @@ func (s *Service) StartPendingImageGC(ctx context.Context) {
 	}()
 }
 
+// pendingImageGCSweepLimit caps how many ledger rows one sweep
+// processes. Each row is a serial Docker RemoveImage round-trip, so an
+// unbounded backlog (operator re-enables GC after a long pause, or
+// thousands of destroyed sandboxes share a few base images) would
+// otherwise stall the daemon for minutes. The cap turns that into
+// "drain over a few ticks" instead. Oldest-first ordering from the
+// store keeps the long-overdue rows at the front of the queue.
+const pendingImageGCSweepLimit = 256
+
 // runPendingImageGC is one pass of the pending-image janitor. Reads
 // ledger rows older than ImageBuildGCTTL, re-checks HasActiveImageRef
 // (in case a new sandbox grabbed the image after scheduling), and
@@ -3119,19 +3128,27 @@ func (s *Service) StartPendingImageGC(ctx context.Context) {
 // "referenced now" outcome) deletes the row so we don't keep
 // re-attempting. Failures are logged, never returned — the janitor
 // must not block on a bad row.
+//
+// Refresh-race guard: each row's scheduled_at is captured at list time
+// and re-verified before RemoveImage; the post-remove cleanup uses a
+// conditional delete on (image, scheduled_at). If a destroy path
+// re-upserted the row between list and remove, the row stays and the
+// remove is skipped this tick — otherwise the freshly-extended TTL
+// would be silently overridden.
 func (s *Service) runPendingImageGC(ctx context.Context) {
 	cutoff := time.Now().UTC().Add(-s.cfg.ImageBuildGCTTL)
-	images, err := s.store.ListPendingImageGCDue(ctx, cutoff)
+	entries, err := s.store.ListPendingImageGCDue(ctx, cutoff, pendingImageGCSweepLimit)
 	if err != nil {
 		s.logger.Warn("pending image gc list failed", "error", err)
 		return
 	}
-	for _, image := range images {
+	for _, entry := range entries {
+		image := entry.Image
 		if s.imageGCWhitelisted(image) {
 			// Operator whitelisted this image after the row landed.
 			// Drop it so the ledger doesn't carry it forever; the
 			// destroy path's short-circuit keeps new rows out.
-			if err := s.store.DeletePendingImageGC(ctx, image); err != nil {
+			if _, err := s.store.DeletePendingImageGCIfScheduledAt(ctx, image, entry.ScheduledAt); err != nil {
 				s.logger.Warn("pending image gc whitelist row clear failed", "image", image, "error", err)
 			}
 			continue
@@ -3158,7 +3175,14 @@ func (s *Service) runPendingImageGC(ctx context.Context) {
 			s.logger.Warn("pending image gc remove failed", "image", image, "error", err)
 			continue
 		}
-		if err := s.store.DeletePendingImageGC(ctx, image); err != nil {
+		// Conditional delete: if a destroy refreshed the row between
+		// the list and now, leave the fresh row in place — the next
+		// tick will pick it up after the new TTL elapses. The image
+		// was already removed from Docker in that case, which is
+		// acceptable: it gets re-pulled on the next create. The thing
+		// we MUST avoid is silently throwing away the row that would
+		// have extended the TTL.
+		if _, err := s.store.DeletePendingImageGCIfScheduledAt(ctx, image, entry.ScheduledAt); err != nil {
 			s.logger.Warn("pending image gc row delete failed", "image", image, "error", err)
 			continue
 		}
@@ -3505,6 +3529,16 @@ func (s *Service) schedulePendingImageGC(ctx context.Context, image string) {
 	if image == "" {
 		return
 	}
+	// Mirror the janitor's kill switch: when ImageBuildGCEnabled is
+	// false no sweep will ever drain the ledger, so writing here would
+	// just grow pending_image_gc forever for an operator who has opted
+	// out of image GC entirely. The trade-off is symmetric with the
+	// disabled janitor: images of destroyed sandboxes are left on the
+	// daemon (which is the explicit "don't reclaim" choice), and they
+	// stay reachable for warm re-creates instead of getting yanked.
+	if !s.cfg.ImageBuildGCEnabled {
+		return
+	}
 	// Short-circuit on whitelist so the ledger doesn't accumulate rows
 	// the janitor would only ever skip. Cheap O(N) scan over a small,
 	// operator-curated list — much smaller than the per-tick scan cost.
@@ -3521,12 +3555,18 @@ func (s *Service) schedulePendingImageGC(ctx context.Context, image string) {
 // imageGCWhitelisted reports whether image is protected from both
 // janitors by cfg.ImageGCWhitelist. Three match shapes:
 //   - exact ref equality (entry == image)
-//   - repo equality, tag/digest agnostic (entry has no ':' / '@', and image
+//   - repo equality, tag/digest agnostic (entry has no tag/digest, and image
 //     starts with entry followed by ':' or '@')
 //   - registry/org prefix when entry ends in '/'
 //
 // Anchored boundaries on every shape so a "ubuntu" entry can't accidentally
 // shield "ubuntu-base" — the operator gets exactly what they typed.
+//
+// The tag/digest detection inspects the segment AFTER the last '/' rather
+// than the whole entry: Docker accepts ports in registry hosts
+// ("localhost:5000/team/app"), so a literal ':' before the last '/' is
+// part of the host, not a tag separator. Without this, every entry for a
+// non-standard-port registry would silently degrade to exact-ref only.
 func (s *Service) imageGCWhitelisted(image string) bool {
 	if image == "" || len(s.cfg.ImageGCWhitelist) == 0 {
 		return false
@@ -3544,7 +3584,11 @@ func (s *Service) imageGCWhitelisted(image string) bool {
 			}
 			continue
 		}
-		if !strings.ContainsAny(entry, ":@") {
+		// Look for tag/digest separators only in the last path segment —
+		// ':' inside a registry host (e.g. "localhost:5000/...") must
+		// not be treated as a tag boundary.
+		lastSeg := entry[strings.LastIndex(entry, "/")+1:]
+		if !strings.ContainsAny(lastSeg, ":@") {
 			if strings.HasPrefix(image, entry+":") || strings.HasPrefix(image, entry+"@") {
 				return true
 			}

--- a/internal/service/service_runtime_flow_test.go
+++ b/internal/service/service_runtime_flow_test.go
@@ -341,8 +341,18 @@ func TestServiceLifecycleStopStartDestroyAndHealth(t *testing.T) {
 	if len(rt.destroyIDs) != 1 || rt.destroyIDs[0] != resp.ID {
 		t.Fatalf("runtime destroy ids = %v, want [%s]", rt.destroyIDs, resp.ID)
 	}
-	if len(rt.removeImages) != 1 || rt.removeImages[0] != resp.Image {
-		t.Fatalf("removed images = %v, want [%s]", rt.removeImages, resp.Image)
+	// Inline image removal was replaced by a pending_image_gc schedule
+	// in DestroySandbox; the janitor (StartPendingImageGC) handles the
+	// actual docker.RemoveImage after ImageBuildGCTTL.
+	if len(rt.removeImages) != 0 {
+		t.Fatalf("RemoveImage must NOT run inline on destroy, got %v", rt.removeImages)
+	}
+	due, err := st.ListPendingImageGCDue(ctx, time.Now().UTC().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("ListPendingImageGCDue: %v", err)
+	}
+	if len(due) != 1 || due[0] != resp.Image {
+		t.Fatalf("pending_image_gc = %v, want [%s]", due, resp.Image)
 	}
 	if _, err := st.Get(ctx, resp.ID); !errors.Is(err, storepkg.ErrNotFound) {
 		t.Fatalf("sandbox still present after destroy: %v", err)

--- a/internal/service/service_runtime_flow_test.go
+++ b/internal/service/service_runtime_flow_test.go
@@ -347,11 +347,11 @@ func TestServiceLifecycleStopStartDestroyAndHealth(t *testing.T) {
 	if len(rt.removeImages) != 0 {
 		t.Fatalf("RemoveImage must NOT run inline on destroy, got %v", rt.removeImages)
 	}
-	due, err := st.ListPendingImageGCDue(ctx, time.Now().UTC().Add(time.Hour))
+	due, err := st.ListPendingImageGCDue(ctx, time.Now().UTC().Add(time.Hour), 0)
 	if err != nil {
 		t.Fatalf("ListPendingImageGCDue: %v", err)
 	}
-	if len(due) != 1 || due[0] != resp.Image {
+	if len(due) != 1 || due[0].Image != resp.Image {
 		t.Fatalf("pending_image_gc = %v, want [%s]", due, resp.Image)
 	}
 	if _, err := st.Get(ctx, resp.ID); !errors.Is(err, storepkg.ErrNotFound) {
@@ -875,6 +875,9 @@ func newServiceRuntimeHarness(t *testing.T, rt *recordingRuntime) (*Service, *st
 			ToolboxPort:       4321,
 			EnableCaddy:       false,
 			HTTPClientTimeout: time.Second,
+			// Required for the destroy-side assertion that DestroySandbox
+			// enqueues a pending_image_gc row.
+			ImageBuildGCEnabled: true,
 		},
 		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
 		store:    st,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -850,6 +850,38 @@ func (s *Store) DeletePendingImageGC(ctx context.Context, image string) error {
 	return nil
 }
 
+// RefreshPendingImageGCIfExists pushes the row's scheduled_at forward
+// when (and only when) a row for image is already present. The Create
+// path calls this after store.Create succeeds, so a freshly-used image
+// that previously had a pending GC gets its deadline reset from "now"
+// instead of inheriting the original destroy's old timestamp.
+//
+// UPDATE-only (not UPSERT) on purpose: a row should only ever exist
+// when a destroy has scheduled an image for cleanup. We do NOT want
+// the create path inserting one — that would turn pending_image_gc
+// into a one-row-per-image-ever-used table. The row-count stays
+// bounded by "images destroyed in the last TTL window". Returns
+// whether a row was touched, so callers can distinguish "deadline
+// pushed forward" from "no pending GC, nothing to push".
+func (s *Store) RefreshPendingImageGCIfExists(ctx context.Context, image string, at time.Time) (bool, error) {
+	if image == "" {
+		return false, nil
+	}
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE pending_image_gc
+		SET scheduled_at = ?
+		WHERE image = ?
+	`, at.UTC(), image)
+	if err != nil {
+		return false, fmt.Errorf("refresh pending image gc: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("rows affected: %w", err)
+	}
+	return n > 0, nil
+}
+
 // DeletePendingImageGCIfScheduledAt removes the row only if its
 // scheduled_at still matches `at` — i.e. nobody has refreshed the row
 // since the janitor observed it. Returns whether the delete actually

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -787,26 +787,46 @@ func (s *Store) SchedulePendingImageGC(ctx context.Context, image string, at tim
 	return nil
 }
 
-// ListPendingImageGCDue returns images whose scheduled_at is at or
-// before cutoff (the janitor passes now - ImageBuildGCTTL). Ordered by
+// PendingImageGCEntry is one row from the pending_image_gc ledger.
+// scheduled_at travels with the image so the janitor can pin its
+// remove/delete decision to the exact row it observed — see
+// DeletePendingImageGCIfScheduledAt for the refresh-race rationale.
+type PendingImageGCEntry struct {
+	Image       string
+	ScheduledAt time.Time
+}
+
+// ListPendingImageGCDue returns rows whose scheduled_at is at or before
+// cutoff (the janitor passes now - ImageBuildGCTTL). Ordered by
 // scheduled_at so the oldest entries get GC'd first within a sweep.
-func (s *Store) ListPendingImageGCDue(ctx context.Context, cutoff time.Time) ([]string, error) {
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT image FROM pending_image_gc
+// `limit` caps the batch so a backlog (janitor disabled for a while
+// then re-enabled, or just thousands of destroyed sandboxes sharing a
+// few images) doesn't fan out into one huge serial Docker spike per
+// tick — pass 0 for unbounded. scheduled_at is returned so the caller
+// can guard the conditional delete in DeletePendingImageGCIfScheduledAt.
+func (s *Store) ListPendingImageGCDue(ctx context.Context, cutoff time.Time, limit int) ([]PendingImageGCEntry, error) {
+	query := `
+		SELECT image, scheduled_at FROM pending_image_gc
 		WHERE scheduled_at <= ?
 		ORDER BY scheduled_at
-	`, cutoff.UTC())
+	`
+	args := []any{cutoff.UTC()}
+	if limit > 0 {
+		query += " LIMIT ?"
+		args = append(args, limit)
+	}
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list pending image gc due: %w", err)
 	}
 	defer rows.Close()
-	var out []string
+	var out []PendingImageGCEntry
 	for rows.Next() {
-		var image string
-		if err := rows.Scan(&image); err != nil {
+		var entry PendingImageGCEntry
+		if err := rows.Scan(&entry.Image, &entry.ScheduledAt); err != nil {
 			return nil, fmt.Errorf("scan pending image gc row: %w", err)
 		}
-		out = append(out, image)
+		out = append(out, entry)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate pending image gc rows: %w", err)
@@ -814,10 +834,12 @@ func (s *Store) ListPendingImageGCDue(ctx context.Context, cutoff time.Time) ([]
 	return out, nil
 }
 
-// DeletePendingImageGC removes the ledger row for an image after the
-// janitor has GC'd it (or decided the image is back in use). Missing
-// rows are not an error — the janitor may race with a destroy path
-// re-upserting then immediately becoming referenced.
+// DeletePendingImageGC removes the ledger row for an image
+// unconditionally. Used when the janitor decides the image is back in
+// use (HasActiveImageRef = true) and the row should be dropped
+// regardless of timestamp — the destroy path will re-schedule with a
+// fresh timestamp if the image goes idle again. Missing rows are not
+// an error.
 func (s *Store) DeletePendingImageGC(ctx context.Context, image string) error {
 	if image == "" {
 		return nil
@@ -826,6 +848,36 @@ func (s *Store) DeletePendingImageGC(ctx context.Context, image string) error {
 		return fmt.Errorf("delete pending image gc: %w", err)
 	}
 	return nil
+}
+
+// DeletePendingImageGCIfScheduledAt removes the row only if its
+// scheduled_at still matches `at` — i.e. nobody has refreshed the row
+// since the janitor observed it. Returns whether the delete actually
+// happened so the caller can detect the refresh race.
+//
+// Why this exists: the sweep does (list, [check active, remove image,
+// delete row]). If a destroy of another sandbox sharing the image
+// upserts the row with a fresh timestamp between the list and the
+// delete, an unconditional delete would silently throw away the
+// extended TTL that destroy was supposed to buy. The janitor uses this
+// to keep the "TTL clock restarts from the most recent destroy"
+// contract under churn.
+func (s *Store) DeletePendingImageGCIfScheduledAt(ctx context.Context, image string, at time.Time) (bool, error) {
+	if image == "" {
+		return false, nil
+	}
+	res, err := s.db.ExecContext(ctx, `
+		DELETE FROM pending_image_gc
+		WHERE image = ? AND scheduled_at = ?
+	`, image, at.UTC())
+	if err != nil {
+		return false, fmt.Errorf("conditional delete pending image gc: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("rows affected: %w", err)
+	}
+	return n > 0, nil
 }
 
 // UpdateTags replaces sandboxes.tags_json on the row matching id and bumps

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -229,6 +229,17 @@ func Open(path string) (*Store, error) {
 		// attachCustomDomainsBulk join. The PK on hostname already covers
 		// the ResolveCustomDomain hot path.
 		`CREATE INDEX IF NOT EXISTS idx_sandbox_custom_domains_sandbox_id ON sandbox_custom_domains(sandbox_id);`,
+		// pending_image_gc is the ledger the image janitor sweeps. Destroy
+		// paths upsert (image, now); runPendingImageGC removes rows whose
+		// scheduled_at is older than ImageBuildGCTTL once HasActiveImageRef
+		// confirms nothing references the image. Image is the PK so repeat
+		// destroys of sandboxes sharing an image collapse to one row and
+		// the TTL clock resets to the most recent destroy.
+		`CREATE TABLE IF NOT EXISTS pending_image_gc (
+			image TEXT PRIMARY KEY,
+			scheduled_at DATETIME NOT NULL
+		);`,
+		`CREATE INDEX IF NOT EXISTS idx_pending_image_gc_scheduled_at ON pending_image_gc(scheduled_at);`,
 	}
 
 	for _, stmt := range stmts {
@@ -754,6 +765,67 @@ func (s *Store) HasActiveImageRef(ctx context.Context, image string) (bool, erro
 		return false, fmt.Errorf("check image references: %w", err)
 	}
 	return true, nil
+}
+
+// SchedulePendingImageGC records (or refreshes) a pending image-deletion
+// row. UPSERT on the image PK means concurrent or repeated destroys
+// collapse to one row and the TTL clock restarts from the most recent
+// destroy — so a busy churn pattern on the same image keeps deferring
+// removal instead of racing the janitor. Empty image is a no-op.
+func (s *Store) SchedulePendingImageGC(ctx context.Context, image string, at time.Time) error {
+	if image == "" {
+		return nil
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO pending_image_gc(image, scheduled_at)
+		VALUES (?, ?)
+		ON CONFLICT(image) DO UPDATE SET scheduled_at = excluded.scheduled_at
+	`, image, at.UTC())
+	if err != nil {
+		return fmt.Errorf("schedule pending image gc: %w", err)
+	}
+	return nil
+}
+
+// ListPendingImageGCDue returns images whose scheduled_at is at or
+// before cutoff (the janitor passes now - ImageBuildGCTTL). Ordered by
+// scheduled_at so the oldest entries get GC'd first within a sweep.
+func (s *Store) ListPendingImageGCDue(ctx context.Context, cutoff time.Time) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT image FROM pending_image_gc
+		WHERE scheduled_at <= ?
+		ORDER BY scheduled_at
+	`, cutoff.UTC())
+	if err != nil {
+		return nil, fmt.Errorf("list pending image gc due: %w", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var image string
+		if err := rows.Scan(&image); err != nil {
+			return nil, fmt.Errorf("scan pending image gc row: %w", err)
+		}
+		out = append(out, image)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate pending image gc rows: %w", err)
+	}
+	return out, nil
+}
+
+// DeletePendingImageGC removes the ledger row for an image after the
+// janitor has GC'd it (or decided the image is back in use). Missing
+// rows are not an error — the janitor may race with a destroy path
+// re-upserting then immediately becoming referenced.
+func (s *Store) DeletePendingImageGC(ctx context.Context, image string) error {
+	if image == "" {
+		return nil
+	}
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM pending_image_gc WHERE image = ?`, image); err != nil {
+		return fmt.Errorf("delete pending image gc: %w", err)
+	}
+	return nil
 }
 
 // UpdateTags replaces sandboxes.tags_json on the row matching id and bumps

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1320,7 +1320,7 @@ func TestStoreCases(t *testing.T) {
 				// Cutoff between the two: must NOT return the row, because
 				// the upsert refreshed scheduled_at to `later`.
 				between := early.Add(time.Hour)
-				due, err := st.ListPendingImageGCDue(ctx, between)
+				due, err := st.ListPendingImageGCDue(ctx, between, 0)
 				if err != nil {
 					t.Fatalf("ListPendingImageGCDue() error = %v", err)
 				}
@@ -1328,13 +1328,16 @@ func TestStoreCases(t *testing.T) {
 					t.Fatalf("expected no due rows after upsert refresh, got %v", due)
 				}
 
-				// Cutoff after later: row is due.
-				due, err = st.ListPendingImageGCDue(ctx, later.Add(time.Minute))
+				// Cutoff after later: row is due and returns the refreshed timestamp.
+				due, err = st.ListPendingImageGCDue(ctx, later.Add(time.Minute), 0)
 				if err != nil {
 					t.Fatalf("ListPendingImageGCDue() error = %v", err)
 				}
-				if len(due) != 1 || due[0] != "img:1" {
+				if len(due) != 1 || due[0].Image != "img:1" {
 					t.Fatalf("expected [img:1], got %v", due)
+				}
+				if !due[0].ScheduledAt.Equal(later) {
+					t.Fatalf("scheduled_at = %v, want refreshed %v", due[0].ScheduledAt, later)
 				}
 			},
 		},
@@ -1364,7 +1367,7 @@ func TestStoreCases(t *testing.T) {
 					}
 				}
 
-				due, err := st.ListPendingImageGCDue(ctx, base.Add(time.Hour))
+				due, err := st.ListPendingImageGCDue(ctx, base.Add(time.Hour), 0)
 				if err != nil {
 					t.Fatalf("ListPendingImageGCDue() error = %v", err)
 				}
@@ -1373,8 +1376,8 @@ func TestStoreCases(t *testing.T) {
 					t.Fatalf("got %v, want %v", due, want)
 				}
 				for i := range want {
-					if due[i] != want[i] {
-						t.Fatalf("position %d: got %q want %q (full=%v)", i, due[i], want[i], due)
+					if due[i].Image != want[i] {
+						t.Fatalf("position %d: got %q want %q (full=%v)", i, due[i].Image, want[i], due)
 					}
 				}
 			},
@@ -1406,12 +1409,121 @@ func TestStoreCases(t *testing.T) {
 					t.Fatalf("delete empty: %v", err)
 				}
 
-				due, err := st.ListPendingImageGCDue(ctx, when.Add(time.Hour))
+				due, err := st.ListPendingImageGCDue(ctx, when.Add(time.Hour), 0)
 				if err != nil {
 					t.Fatalf("ListPendingImageGCDue() error = %v", err)
 				}
 				if len(due) != 0 {
 					t.Fatalf("expected empty after delete, got %v", due)
+				}
+			},
+		},
+		{
+			// LIMIT must clip the batch and prefer the oldest rows so a
+			// big backlog drains across ticks (oldest first) instead of
+			// fanning out into one huge sweep.
+			name: "pending_image_gc_list_honors_limit",
+			run: func(t *testing.T) {
+				path := filepath.Join(t.TempDir(), "state.db")
+				st, err := Open(path)
+				if err != nil {
+					t.Fatalf("Open() error = %v", err)
+				}
+				defer st.Close()
+
+				base := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+				for i := 0; i < 10; i++ {
+					img := fmt.Sprintf("img:%02d", i)
+					if err := st.SchedulePendingImageGC(ctx, img, base.Add(time.Duration(i)*time.Minute)); err != nil {
+						t.Fatalf("schedule %s: %v", img, err)
+					}
+				}
+
+				due, err := st.ListPendingImageGCDue(ctx, base.Add(time.Hour), 3)
+				if err != nil {
+					t.Fatalf("ListPendingImageGCDue(limit=3) error = %v", err)
+				}
+				if len(due) != 3 {
+					t.Fatalf("expected 3 rows with limit=3, got %d (%v)", len(due), due)
+				}
+				want := []string{"img:00", "img:01", "img:02"}
+				for i, w := range want {
+					if due[i].Image != w {
+						t.Fatalf("limit batch[%d] = %q, want %q (full=%v)", i, due[i].Image, w, due)
+					}
+				}
+
+				// limit=0 == unbounded.
+				due, err = st.ListPendingImageGCDue(ctx, base.Add(time.Hour), 0)
+				if err != nil {
+					t.Fatalf("ListPendingImageGCDue(limit=0) error = %v", err)
+				}
+				if len(due) != 10 {
+					t.Fatalf("limit=0 must be unbounded, got %d", len(due))
+				}
+			},
+		},
+		{
+			// Refresh-race guard: the conditional delete must match the
+			// row's scheduled_at exactly. If a destroy upserted a fresh
+			// timestamp between list and delete, the old delete must
+			// become a no-op so the new TTL survives.
+			name: "pending_image_gc_conditional_delete_matches_scheduled_at",
+			run: func(t *testing.T) {
+				path := filepath.Join(t.TempDir(), "state.db")
+				st, err := Open(path)
+				if err != nil {
+					t.Fatalf("Open() error = %v", err)
+				}
+				defer st.Close()
+
+				orig := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+				refreshed := orig.Add(time.Hour)
+				if err := st.SchedulePendingImageGC(ctx, "img:1", orig); err != nil {
+					t.Fatalf("schedule orig: %v", err)
+				}
+
+				// No refresh yet — conditional delete on the observed
+				// timestamp must succeed.
+				ok, err := st.DeletePendingImageGCIfScheduledAt(ctx, "img:1", orig)
+				if err != nil {
+					t.Fatalf("conditional delete: %v", err)
+				}
+				if !ok {
+					t.Fatalf("expected delete to match the unrefreshed row")
+				}
+
+				// Re-seed and simulate a destroy that refreshed the row
+				// after we read it. Conditional delete on the stale
+				// timestamp must NOT remove the freshly-extended row.
+				if err := st.SchedulePendingImageGC(ctx, "img:1", orig); err != nil {
+					t.Fatalf("re-schedule orig: %v", err)
+				}
+				if err := st.SchedulePendingImageGC(ctx, "img:1", refreshed); err != nil {
+					t.Fatalf("refresh: %v", err)
+				}
+				ok, err = st.DeletePendingImageGCIfScheduledAt(ctx, "img:1", orig)
+				if err != nil {
+					t.Fatalf("conditional delete after refresh: %v", err)
+				}
+				if ok {
+					t.Fatalf("refreshed row must survive a stale conditional delete")
+				}
+				// Row still present at the refreshed timestamp.
+				due, err := st.ListPendingImageGCDue(ctx, refreshed.Add(time.Minute), 0)
+				if err != nil {
+					t.Fatalf("list after stale delete: %v", err)
+				}
+				if len(due) != 1 || !due[0].ScheduledAt.Equal(refreshed) {
+					t.Fatalf("expected one row at refreshed ts, got %v", due)
+				}
+
+				// Empty image and missing image are no-ops.
+				if ok, err := st.DeletePendingImageGCIfScheduledAt(ctx, "", orig); err != nil || ok {
+					t.Fatalf("empty image: ok=%v err=%v", ok, err)
+				}
+				if ok, err := st.DeletePendingImageGCIfScheduledAt(ctx, "img:never", orig); err != nil || ok {
+					t.Fatalf("missing image: ok=%v err=%v", ok, err)
 				}
 			},
 		},
@@ -1428,7 +1540,7 @@ func TestStoreCases(t *testing.T) {
 				if err := st.SchedulePendingImageGC(ctx, "", time.Now().UTC()); err != nil {
 					t.Fatalf("schedule empty: %v", err)
 				}
-				due, err := st.ListPendingImageGCDue(ctx, time.Now().UTC().Add(time.Hour))
+				due, err := st.ListPendingImageGCDue(ctx, time.Now().UTC().Add(time.Hour), 0)
 				if err != nil {
 					t.Fatalf("ListPendingImageGCDue() error = %v", err)
 				}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1297,6 +1297,146 @@ func TestStoreCases(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "pending_image_gc_upsert_refreshes_scheduled_at",
+			run: func(t *testing.T) {
+				path := filepath.Join(t.TempDir(), "state.db")
+				st, err := Open(path)
+				if err != nil {
+					t.Fatalf("Open() error = %v", err)
+				}
+				defer st.Close()
+
+				early := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+				later := early.Add(2 * time.Hour)
+
+				if err := st.SchedulePendingImageGC(ctx, "img:1", early); err != nil {
+					t.Fatalf("schedule early: %v", err)
+				}
+				if err := st.SchedulePendingImageGC(ctx, "img:1", later); err != nil {
+					t.Fatalf("schedule later: %v", err)
+				}
+
+				// Cutoff between the two: must NOT return the row, because
+				// the upsert refreshed scheduled_at to `later`.
+				between := early.Add(time.Hour)
+				due, err := st.ListPendingImageGCDue(ctx, between)
+				if err != nil {
+					t.Fatalf("ListPendingImageGCDue() error = %v", err)
+				}
+				if len(due) != 0 {
+					t.Fatalf("expected no due rows after upsert refresh, got %v", due)
+				}
+
+				// Cutoff after later: row is due.
+				due, err = st.ListPendingImageGCDue(ctx, later.Add(time.Minute))
+				if err != nil {
+					t.Fatalf("ListPendingImageGCDue() error = %v", err)
+				}
+				if len(due) != 1 || due[0] != "img:1" {
+					t.Fatalf("expected [img:1], got %v", due)
+				}
+			},
+		},
+		{
+			name: "pending_image_gc_list_honors_cutoff_and_ordering",
+			run: func(t *testing.T) {
+				path := filepath.Join(t.TempDir(), "state.db")
+				st, err := Open(path)
+				if err != nil {
+					t.Fatalf("Open() error = %v", err)
+				}
+				defer st.Close()
+
+				base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+				rows := []struct {
+					image string
+					at    time.Time
+				}{
+					{"img:newest", base.Add(30 * time.Minute)},
+					{"img:oldest", base},
+					{"img:middle", base.Add(15 * time.Minute)},
+					{"img:future", base.Add(2 * time.Hour)},
+				}
+				for _, r := range rows {
+					if err := st.SchedulePendingImageGC(ctx, r.image, r.at); err != nil {
+						t.Fatalf("schedule %s: %v", r.image, err)
+					}
+				}
+
+				due, err := st.ListPendingImageGCDue(ctx, base.Add(time.Hour))
+				if err != nil {
+					t.Fatalf("ListPendingImageGCDue() error = %v", err)
+				}
+				want := []string{"img:oldest", "img:middle", "img:newest"}
+				if len(due) != len(want) {
+					t.Fatalf("got %v, want %v", due, want)
+				}
+				for i := range want {
+					if due[i] != want[i] {
+						t.Fatalf("position %d: got %q want %q (full=%v)", i, due[i], want[i], due)
+					}
+				}
+			},
+		},
+		{
+			name: "pending_image_gc_delete_is_idempotent",
+			run: func(t *testing.T) {
+				path := filepath.Join(t.TempDir(), "state.db")
+				st, err := Open(path)
+				if err != nil {
+					t.Fatalf("Open() error = %v", err)
+				}
+				defer st.Close()
+
+				when := time.Date(2026, 5, 25, 0, 0, 0, 0, time.UTC)
+				if err := st.SchedulePendingImageGC(ctx, "img:1", when); err != nil {
+					t.Fatalf("schedule: %v", err)
+				}
+				if err := st.DeletePendingImageGC(ctx, "img:1"); err != nil {
+					t.Fatalf("first delete: %v", err)
+				}
+				if err := st.DeletePendingImageGC(ctx, "img:1"); err != nil {
+					t.Fatalf("second delete: %v", err)
+				}
+				if err := st.DeletePendingImageGC(ctx, "img:never-scheduled"); err != nil {
+					t.Fatalf("delete missing: %v", err)
+				}
+				if err := st.DeletePendingImageGC(ctx, ""); err != nil {
+					t.Fatalf("delete empty: %v", err)
+				}
+
+				due, err := st.ListPendingImageGCDue(ctx, when.Add(time.Hour))
+				if err != nil {
+					t.Fatalf("ListPendingImageGCDue() error = %v", err)
+				}
+				if len(due) != 0 {
+					t.Fatalf("expected empty after delete, got %v", due)
+				}
+			},
+		},
+		{
+			name: "pending_image_gc_schedule_empty_image_noop",
+			run: func(t *testing.T) {
+				path := filepath.Join(t.TempDir(), "state.db")
+				st, err := Open(path)
+				if err != nil {
+					t.Fatalf("Open() error = %v", err)
+				}
+				defer st.Close()
+
+				if err := st.SchedulePendingImageGC(ctx, "", time.Now().UTC()); err != nil {
+					t.Fatalf("schedule empty: %v", err)
+				}
+				due, err := st.ListPendingImageGCDue(ctx, time.Now().UTC().Add(time.Hour))
+				if err != nil {
+					t.Fatalf("ListPendingImageGCDue() error = %v", err)
+				}
+				if len(due) != 0 {
+					t.Fatalf("empty image must not insert a row, got %v", due)
+				}
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1528,6 +1528,64 @@ func TestStoreCases(t *testing.T) {
 			},
 		},
 		{
+			// RefreshPendingImageGCIfExists is UPDATE-only. A fresh
+			// create from the service layer must NOT cause an insert,
+			// otherwise pending_image_gc would balloon to one row per
+			// image ever used.
+			name: "pending_image_gc_refresh_only_updates_existing_rows",
+			run: func(t *testing.T) {
+				path := filepath.Join(t.TempDir(), "state.db")
+				st, err := Open(path)
+				if err != nil {
+					t.Fatalf("Open() error = %v", err)
+				}
+				defer st.Close()
+
+				// No row yet — refresh must report nothing touched and
+				// must not insert anything.
+				ok, err := st.RefreshPendingImageGCIfExists(ctx, "img:1", time.Now().UTC())
+				if err != nil {
+					t.Fatalf("refresh missing: %v", err)
+				}
+				if ok {
+					t.Fatalf("refresh on missing row must report false")
+				}
+				due, err := st.ListPendingImageGCDue(ctx, time.Now().UTC().Add(time.Hour), 0)
+				if err != nil {
+					t.Fatalf("list after empty refresh: %v", err)
+				}
+				if len(due) != 0 {
+					t.Fatalf("refresh must not insert, got %v", due)
+				}
+
+				// Seed an old row; refresh moves scheduled_at forward.
+				orig := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+				pushed := orig.Add(2 * time.Hour)
+				if err := st.SchedulePendingImageGC(ctx, "img:1", orig); err != nil {
+					t.Fatalf("seed: %v", err)
+				}
+				ok, err = st.RefreshPendingImageGCIfExists(ctx, "img:1", pushed)
+				if err != nil {
+					t.Fatalf("refresh existing: %v", err)
+				}
+				if !ok {
+					t.Fatalf("refresh on existing row must report true")
+				}
+				due, err = st.ListPendingImageGCDue(ctx, pushed.Add(time.Minute), 0)
+				if err != nil {
+					t.Fatalf("list after refresh: %v", err)
+				}
+				if len(due) != 1 || !due[0].ScheduledAt.Equal(pushed) {
+					t.Fatalf("scheduled_at = %v, want pushed = %v (got %v)", due[0].ScheduledAt, pushed, due)
+				}
+
+				// Empty image is a no-op.
+				if ok, err := st.RefreshPendingImageGCIfExists(ctx, "", time.Now().UTC()); err != nil || ok {
+					t.Fatalf("empty refresh: ok=%v err=%v", ok, err)
+				}
+			},
+		},
+		{
 			name: "pending_image_gc_schedule_empty_image_noop",
 			run: func(t *testing.T) {
 				path := filepath.Join(t.TempDir(), "state.db")

--- a/plans/aocr-vpc-private-routing-aws-implementation.md
+++ b/plans/aocr-vpc-private-routing-aws-implementation.md
@@ -1,0 +1,474 @@
+# AOCR Private VPC Routing: Exact AWS Implementation
+
+## Status
+
+Draft - implementation-ready runbook.
+
+## Scope
+
+This file turns the higher-level design in `plans/aocr-vpc-private-routing.md` into an exact AWS implementation plan.
+
+It is written for the current setup visible in this repo:
+
+- AerolVM region: `us-east-1`
+- AerolVM AOCR endpoints in `Terraform/terraform.tfvars`:
+  - `mirror_host = "mirror.aocr.aerol.ai"`
+  - `hooks_url = "https://aocr.aerol.ai"`
+- AerolVM Terraform defaults to a single VPC with tag `aerolvm-vpc` and one node security group named `aerolvm-node` when `cluster_name` is left at default.
+- AOCR is deployed separately via `aocr.sh` onto k3s with Traefik ingress and TLS enabled.
+
+The goal is not to redesign AOCR. The goal is to keep the current hostnames and make AerolVM reach them privately inside AWS.
+
+## Executive decision
+
+Implement this exact topology first:
+
+1. Keep using `aocr.aerol.ai` and `mirror.aocr.aerol.ai`.
+2. Keep HTTPS on both names.
+3. Add a Route53 Private Hosted Zone for `aocr.aerol.ai` and associate it with the AerolVM VPC.
+4. Add private Route53 records:
+  - `aocr.aerol.ai` -> AOCR VM private IP
+  - `mirror.aocr.aerol.ai` -> AOCR VM private IP
+5. Restrict AOCR inbound `443` to the AerolVM VPC CIDR or AerolVM node security group.
+6. Add an S3 Gateway VPC Endpoint in the AOCR VPC so AOCR-to-S3 stays private.
+7. Do not change the AerolVM `aocr` block for phase 1.
+
+This gives you private AerolVM-to-AOCR traffic with no AerolVM code change.
+
+No AWS load balancer is required for this phase-1 setup.
+
+## Why this exact approach is correct for this repo
+
+Current AerolVM behavior:
+
+- `Terraform/templates/bootstrap.sh.tftpl` writes Docker Hub mirror config as `https://<mirror_host>`.
+- `pkg/docker/mirror_rewrite.go` rewrites supported public registries onto `SB_MIRROR_HOST`.
+- `internal/service/auto_import.go` POSTs imports to `SB_AUTO_IMPORT_HOOKS_URL`.
+
+That means:
+
+- the hostnames are already configuration-driven
+- the transport already expects HTTPS
+- nothing in AerolVM requires the AOCR hostnames to be public
+
+The cleanest implementation is therefore private DNS plus private AWS routing, not a rewrite of AerolVM logic.
+
+## Assumptions
+
+This runbook assumes the recommended phase-1 topology:
+
+- AOCR runs on EC2 in AWS.
+- AOCR is reachable on its EC2 private IP inside either:
+  - the same VPC as AerolVM, or
+  - a peered VPC.
+- AOCR continues to serve valid TLS certs for `aocr.aerol.ai` and `mirror.aocr.aerol.ai`.
+- Public Cloudflare DNS for those names may remain in place for operator access and certificate issuance.
+
+If AOCR is not on EC2, or not in AWS, use this file as the reference architecture but substitute the private target for your platform.
+
+## Current AWS objects on the AerolVM side
+
+From the Terraform in this repo:
+
+- VPC tag: `${cluster_name}-vpc` -> default `aerolvm-vpc`
+- subnet tag: `${cluster_name}-public` -> default `aerolvm-public`
+- node security group: `${cluster_name}-node` -> default `aerolvm-node`
+- default VPC CIDR when not overridden: `10.42.0.0/16`
+- default subnet CIDR when not overridden: `10.42.1.0/24`
+
+Your current `terraform.tfvars` does not override `vpc_cidr` or `subnet_cidr`, so unless the state was created with different values earlier, the working assumption is:
+
+- AerolVM VPC CIDR: `10.42.0.0/16`
+
+## Phase 0 - Gather exact live values
+
+Run these before changing anything.
+
+### AerolVM VPC and SG
+
+```bash
+aws ec2 describe-vpcs \
+  --region us-east-1 \
+  --filters Name=tag:Name,Values=aerolvm-vpc \
+  --query 'Vpcs[0].{VpcId:VpcId,Cidr:CidrBlock}'
+
+aws ec2 describe-security-groups \
+  --region us-east-1 \
+  --filters Name=group-name,Values=aerolvm-node \
+  --query 'SecurityGroups[0].{GroupId:GroupId,VpcId:VpcId}'
+```
+
+### AerolVM route table for the public subnet
+
+```bash
+aws ec2 describe-route-tables \
+  --region us-east-1 \
+  --filters Name=tag:Name,Values=aerolvm-public \
+  --query 'RouteTables[].{RouteTableId:RouteTableId,VpcId:VpcId}'
+```
+
+### AOCR instance private IP
+
+Collect this:
+
+1. AOCR EC2 private IP if Traefik on the AOCR VM terminates TLS directly.
+
+You will use that value as the Route53 private target.
+
+An internal NLB is not part of this runbook. If you ever add one later, treat that as an optional phase-2 hardening step.
+
+### AOCR VPC and AOCR subnet route tables
+
+If AOCR is in AWS, gather:
+
+```bash
+aws ec2 describe-instances \
+  --region us-east-1 \
+  --instance-ids <AOCR_INSTANCE_ID> \
+  --query 'Reservations[0].Instances[0].{PrivateIp:PrivateIpAddress,VpcId:VpcId,SubnetId:SubnetId,SecurityGroups:SecurityGroups}'
+
+aws ec2 describe-route-tables \
+  --region us-east-1 \
+  --filters Name=association.subnet-id,Values=<AOCR_SUBNET_ID> \
+  --query 'RouteTables[].RouteTableId'
+```
+
+## Phase 1 - Same-VPC implementation
+
+This is the preferred implementation if AOCR and AerolVM are already in the same VPC.
+
+## Step 1 - Create a Route53 Private Hosted Zone for `aocr.aerol.ai`
+
+Create a separate AWS infra stack for this. Do not put it in the AerolVM Terraform unless you want AOCR-private routing to become part of cluster lifecycle.
+
+Use this Terraform as the baseline:
+
+```hcl
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region  = "us-east-1"
+  profile = "aerolvm-provisoner"
+}
+
+data "aws_vpc" "aerolvm" {
+  filter {
+    name   = "tag:Name"
+    values = ["aerolvm-vpc"]
+  }
+}
+
+resource "aws_route53_zone" "aocr_private" {
+  name = "aocr.aerol.ai"
+
+  vpc {
+    vpc_id = data.aws_vpc.aerolvm.id
+  }
+}
+```
+
+Why the zone name is `aocr.aerol.ai` instead of `aerol.ai`:
+
+- you only need to override the AOCR surfaces
+- it avoids accidentally shadowing unrelated names under `aerol.ai`
+- it keeps the split-horizon footprint narrow
+
+## Step 2 - Add private DNS records
+
+Use A records to the AOCR VM private IP:
+
+```hcl
+variable "aocr_private_ip" {
+  type = string
+}
+
+resource "aws_route53_record" "aocr_apex" {
+  zone_id = aws_route53_zone.aocr_private.zone_id
+  name    = "aocr.aerol.ai"
+  type    = "A"
+  ttl     = 60
+  records = [var.aocr_private_ip]
+}
+
+resource "aws_route53_record" "aocr_mirror" {
+  zone_id = aws_route53_zone.aocr_private.zone_id
+  name    = "mirror.aocr.aerol.ai"
+  type    = "A"
+  ttl     = 60
+  records = [var.aocr_private_ip]
+}
+```
+
+## Step 3 - Lock down AOCR ingress security group
+
+At minimum, AOCR needs private HTTPS from AerolVM.
+
+Recommended inbound rules on the AOCR security group:
+
+1. `443/tcp` from AerolVM VPC CIDR `10.42.0.0/16`.
+2. `80/tcp` only if your current cert-manager flow still depends on HTTP-01.
+3. Public `443/tcp` only if you still want public/operator access.
+
+Exact Terraform baseline:
+
+```hcl
+variable "aocr_security_group_id" {
+  type = string
+}
+
+variable "aerolvm_vpc_cidr" {
+  type    = string
+  default = "10.42.0.0/16"
+}
+
+resource "aws_security_group_rule" "aocr_https_from_aerolvm" {
+  type              = "ingress"
+  security_group_id = var.aocr_security_group_id
+  protocol          = "tcp"
+  from_port         = 443
+  to_port           = 443
+  cidr_blocks       = [var.aerolvm_vpc_cidr]
+  description       = "Private HTTPS from AerolVM nodes"
+}
+```
+
+If AOCR is in the same VPC and you want tighter control, replace the CIDR rule with a source security-group rule referencing the AerolVM node SG.
+
+## Step 4 - Add an S3 Gateway Endpoint in the AOCR VPC
+
+This is required if you want AOCR-to-S3 traffic to stay on the AWS private path.
+
+If AOCR is in the same VPC as AerolVM, add the endpoint to that VPC. If AOCR is in a different VPC, add it there instead.
+
+```hcl
+variable "aocr_vpc_id" {
+  type = string
+}
+
+variable "aocr_route_table_ids" {
+  type = list(string)
+}
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = var.aocr_vpc_id
+  service_name      = "com.amazonaws.us-east-1.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = var.aocr_route_table_ids
+
+  tags = {
+    Name = "aocr-s3-endpoint"
+  }
+}
+```
+
+Attach the endpoint to the route tables that serve the AOCR subnets, not just the AerolVM subnet.
+
+## Step 5 - Leave the AerolVM `aocr` block unchanged
+
+Do not change these phase-1 values:
+
+```hcl
+aocr = {
+  enabled             = true
+  mirror_host         = "mirror.aocr.aerol.ai"
+  auto_import_enabled = true
+  hooks_url           = "https://aocr.aerol.ai"
+}
+```
+
+Reason:
+
+- once Route53 private DNS is in place, AerolVM instances in the VPC will resolve these names privately automatically
+- Docker and sandboxd will continue using the same hostnames
+- public DNS stays available outside the VPC if you keep it
+
+## Phase 2 - Different-VPC implementation
+
+Use this if AOCR is in a separate VPC.
+
+## Step 1 - Add VPC peering
+
+Terraform baseline:
+
+```hcl
+resource "aws_vpc_peering_connection" "aerolvm_to_aocr" {
+  vpc_id      = var.aerolvm_vpc_id
+  peer_vpc_id = var.aocr_vpc_id
+  auto_accept = true
+
+  tags = {
+    Name = "aerolvm-aocr-peering"
+  }
+}
+```
+
+## Step 2 - Add routes on both sides
+
+```hcl
+resource "aws_route" "aerolvm_to_aocr" {
+  for_each                  = toset(var.aerolvm_route_table_ids)
+  route_table_id            = each.value
+  destination_cidr_block    = var.aocr_vpc_cidr
+  vpc_peering_connection_id = aws_vpc_peering_connection.aerolvm_to_aocr.id
+}
+
+resource "aws_route" "aocr_to_aerolvm" {
+  for_each                  = toset(var.aocr_route_table_ids)
+  route_table_id            = each.value
+  destination_cidr_block    = var.aerolvm_vpc_cidr
+  vpc_peering_connection_id = aws_vpc_peering_connection.aerolvm_to_aocr.id
+}
+```
+
+## Step 3 - Associate the Route53 private hosted zone with the AerolVM VPC
+
+Keep the zone associated with the AerolVM VPC because that is where the private DNS override is needed. If the zone lives in the AOCR account and the VPC lives in a different account, use `aws_route53_vpc_association_authorization` plus `aws_route53_zone_association`.
+
+## Step 4 - Open AOCR security group only to AerolVM VPC CIDR
+
+Because security-group-to-security-group referencing does not work across peering the same way it does within a single VPC, use CIDR-based rules across the peering boundary.
+
+## Phase 3 - TLS handling
+
+## Recommended implementation
+
+Keep the existing public certs on `aocr.aerol.ai` and `mirror.aocr.aerol.ai`.
+
+That means:
+
+- AerolVM nodes keep trusting the mirror with no CA changes
+- the AOCR cert works on both the public and private path
+- Docker does not need `insecure-registries`
+
+## Important check before tightening public access
+
+Find out whether the current cert-manager issuer behind `letsencrypt-prod` uses:
+
+1. HTTP-01
+2. DNS-01
+
+If it uses HTTP-01:
+
+- keep public `80/443` and public Cloudflare records until cert issuance is migrated
+
+If it uses DNS-01:
+
+- AOCR can become private-only later without breaking cert issuance
+
+## Do not do this in phase 1
+
+Do not switch to a private CA in phase 1.
+
+Why:
+
+- the AerolVM bootstrap does not currently install an AOCR-specific CA into the node trust store
+- Docker mirror trust would break until that bootstrap work exists
+
+## Validation checklist
+
+Run these from an AerolVM node after private DNS is in place.
+
+### DNS resolution
+
+```bash
+dig +short aocr.aerol.ai
+dig +short mirror.aocr.aerol.ai
+```
+
+Expected:
+
+- both return the AOCR private IP, not public IPs
+
+### TLS and registry challenge
+
+```bash
+curl -I https://aocr.aerol.ai/v2/
+curl -I https://mirror.aocr.aerol.ai/v2/
+```
+
+Expected:
+
+- `401 Unauthorized` is healthy for the registry challenge path
+
+### Docker Hub path
+
+```bash
+sudo cat /etc/docker/daemon.json
+docker pull alpine:3.20
+```
+
+Expected:
+
+- `registry-mirrors` still points at `https://mirror.aocr.aerol.ai`
+- the pull succeeds
+
+### Non-Hub mirror path
+
+Trigger a sandbox or manual pull that goes through the AerolVM mirror rewrite path for `ghcr.io`, `gcr.io`, `quay.io`, or `registry.k8s.io`.
+
+### Auto-import path
+
+Verify AOCR still receives:
+
+- `POST https://aocr.aerol.ai/v1/internal/imports`
+
+and that the call completes successfully.
+
+### AWS network validation
+
+1. Use VPC Flow Logs to confirm AerolVM-to-AOCR traffic stays private.
+2. Use Reachability Analyzer if security groups or route tables are unclear.
+3. Confirm AOCR route tables now contain the S3 endpoint target.
+
+## Exact rollout order
+
+1. Gather AerolVM VPC ID, SG ID, and AOCR private IP.
+2. Create the Route53 private hosted zone for `aocr.aerol.ai`.
+3. Create private records for `aocr.aerol.ai` and `mirror.aocr.aerol.ai`.
+4. Add or tighten AOCR security-group rules for private `443`.
+5. Add the S3 Gateway Endpoint in the AOCR VPC.
+6. Validate DNS from one AerolVM node.
+7. Validate HTTPS and registry challenge.
+8. Validate `docker pull alpine`.
+9. Validate one rewritten non-Hub pull.
+10. Validate auto-import.
+11. Only then decide whether to reduce or remove public AOCR exposure.
+
+## Rollback plan
+
+If anything fails:
+
+1. Delete or disassociate the Route53 private hosted zone.
+2. Revert any tightened AOCR security-group rules.
+3. Leave the AerolVM `aocr` block unchanged; it already points to the public names.
+
+Because the private routing is DNS-overlay based, rollback is fast and does not require AerolVM node replacement.
+
+## Optional phase-2 hardening
+
+After phase 1 is stable, you can harden further:
+
+1. Move AOCR behind an internal NLB instead of a single VM private IP if budget and HA requirements later justify it.
+2. Migrate cert-manager to DNS-01 if it is still on HTTP-01.
+3. Remove public `443` from AOCR if operator access can be moved to VPN, SSM, or bastion.
+4. Narrow AOCR mirror allow-lists from `0.0.0.0/0` to only the AerolVM VPC CIDR or known VPC ranges.
+
+## Final recommendation
+
+For your current setup, the exact AWS move is:
+
+1. Add a private Route53 zone for `aocr.aerol.ai`.
+2. Point `aocr.aerol.ai` and `mirror.aocr.aerol.ai` to AOCR's private address.
+3. Restrict AOCR `443` to the AerolVM network.
+4. Add an S3 Gateway Endpoint in the AOCR VPC.
+5. Keep the current AerolVM AOCR config unchanged.
+
+That is the smallest-change, lowest-risk path to making AOCR traffic private over AWS VPC networking.

--- a/plans/aocr-vpc-private-routing.md
+++ b/plans/aocr-vpc-private-routing.md
@@ -1,0 +1,726 @@
+# AOCR Private VPC Routing Plan
+
+## Status
+
+Draft - ready for implementation planning.
+
+## Why this plan exists
+
+Today the AerolVM cluster is already wired to use AOCR as a pull-through cache:
+
+- `Terraform/templates/bootstrap.sh.tftpl` writes Docker Hub's `registry-mirrors` to `https://<aocr.mirror_host>`.
+- The same bootstrap writes `SB_MIRROR_HOST`, `SB_MIRROR_PUSH_HOST`, `SB_MIRROR_UPSTREAMS`, and `SB_AUTO_IMPORT_HOOKS_URL` into `/etc/sandboxd/cluster.env`.
+- `pkg/docker/mirror_rewrite.go` rewrites `ghcr.io`, `gcr.io`, `quay.io`, and `registry.k8s.io` pulls onto the mirror host.
+- `internal/service/auto_import.go` posts back to AOCR at `<hooks_url>/v1/internal/imports` after a successful pull.
+- In the AOCR repo, `helm/aocr/templates/ingress.yaml` and `helm/aocr/templates/mirror-ingress.yaml` expose the push/hooks host and the mirror host as host-based HTTPS ingresses.
+
+The cache behavior is already correct. The remaining problem is network path.
+
+Right now the configured AOCR endpoints are public hostnames:
+
+- `mirror.aocr.aerol.ai`
+- `https://aocr.aerol.ai`
+
+That means AerolVM nodes talk to AOCR over the public path even when both systems are under the same operator control. The consequence is:
+
+- cached pulls still traverse a public endpoint
+- auto-import calls still traverse a public endpoint
+- private AOCR traffic depends on public DNS and public reachability
+- you pay transfer charges for node-to-AOCR traffic that should stay private
+
+This plan explains how to move the AerolVM to AOCR path onto VPC-private networking while keeping the existing AOCR cache semantics intact.
+
+## Executive summary
+
+The important finding from the current codebase is this:
+
+1. AerolVM does not require AOCR to be public.
+2. The mirror path does require HTTPS.
+3. The hooks path does not hardcode HTTPS in code, but it carries a bearer token and should stay HTTPS.
+4. The current bottleneck is infrastructure and name resolution, not mirror logic.
+
+The recommended strategy is:
+
+1. Keep using HTTPS.
+2. Keep the existing hostnames if possible.
+3. Make those hostnames resolve to AOCR's private address from inside the AerolVM VPC.
+4. Restrict AOCR ingress to the AerolVM VPC CIDRs or security groups.
+5. Add an S3 VPC endpoint on the AOCR side so AOCR-to-S3 traffic also stays on AWS private networking.
+
+If you do this, AerolVM-to-AOCR traffic becomes private while AOCR still uses the public internet only for true cache misses against upstream registries.
+
+## Current behavior, mapped to code
+
+### AerolVM side
+
+#### Docker Hub mirror path
+
+`Terraform/templates/bootstrap.sh.tftpl` writes:
+
+```json
+{
+  "registry-mirrors": ["https://<aocr.mirror_host>"],
+  "live-restore": true
+}
+```
+
+Implications:
+
+- the Docker daemon is explicitly configured to use an HTTPS mirror URL
+- there is no current support for an insecure mirror in Terraform bootstrap
+- if the mirror certificate is not trusted by the node, Docker Hub mirroring breaks
+
+#### Non-Docker-Hub registries
+
+`pkg/docker/mirror_rewrite.go` rewrites supported registries to:
+
+```text
+<mirror_host>/aocr/<shortname>/<repo>:<tag>
+```
+
+Examples:
+
+- `ghcr.io/aerol-ai/sandbox:v1` -> `mirror.aocr.aerol.ai/aocr/ghcr/aerol-ai/sandbox:v1`
+- `registry.k8s.io/pause:3.9` -> `mirror.aocr.aerol.ai/aocr/k8s/pause:3.9`
+
+Implications:
+
+- the host is entirely configuration-driven through `SB_MIRROR_HOST`
+- the code does not care whether that host is public or private
+- if DNS and TLS work, private routing works without code changes
+
+#### Auto-import
+
+`internal/service/auto_import.go` builds the import endpoint as:
+
+```text
+<hooks_url>/v1/internal/imports
+```
+
+Implications:
+
+- the value is taken verbatim from `SB_AUTO_IMPORT_HOOKS_URL`
+- the code validates only that it parses as a URL
+- the path does not require a public hostname
+- it should remain HTTPS because it carries `Authorization: Bearer <cluster_pat>`
+
+### AOCR side
+
+From the sibling `aocr.sh` repo:
+
+- `helm/aocr/templates/ingress.yaml` exposes the main AOCR hostname from `global.domain`
+- `helm/aocr/templates/mirror-ingress.yaml` exposes the mirror hostname from `mirror.host` or `mirror.<global.domain>`
+- `helm/aocr/values.yaml` defaults to `ingress.className: traefik` and `ingress.tls.enabled: true`
+- `ansible/inventory/group_vars/all/vars.yml` currently assumes public DNS records and currently leaves `aocr_mirror_allow_list` wide open (`0.0.0.0/0`)
+
+Implications:
+
+- AOCR is already host-routed and TLS-terminated
+- mirror exposure is already gated by CIDR allow-list
+- the current deployment assumptions are public-DNS-oriented, but the product shape is still compatible with private routing
+
+## Problem statement
+
+You want this traffic path:
+
+```mermaid
+flowchart LR
+    A[AerolVM worker node] -->|private HTTPS| B[AOCR mirror/hooks]
+    B -->|private AWS path| C[S3 cache]
+    B -->|public internet only on cache miss| D[Upstream registries]
+```
+
+Instead of this path:
+
+```mermaid
+flowchart LR
+    A[AerolVM worker node] -->|public DNS/public endpoint| B[AOCR mirror/hooks]
+    B --> C[S3 cache]
+    B --> D[Upstream registries]
+```
+
+The exact target state is:
+
+- AerolVM nodes reach AOCR over private IP space or private load-balancer addresses.
+- AOCR keeps serving HTTPS so Docker and sandboxd behave normally.
+- AOCR can still fetch from upstream registries when the cache is cold.
+- AOCR can still persist cache objects to S3 without using public internet paths.
+- External operator access, if still needed, is either preserved separately or intentionally removed.
+
+## Important constraint: HTTPS is required for the mirror
+
+For the mirror specifically, HTTPS is not optional in the current setup.
+
+Why:
+
+- Terraform bootstrap hardcodes `https://<mirror_host>` into Docker's `registry-mirrors`.
+- There is no current bootstrap support for Docker `insecure-registries`.
+- There is no current automation for distributing a custom private CA to every AerolVM node.
+
+Therefore the shortest safe path is:
+
+- keep the mirror on HTTPS
+- use a certificate that AerolVM nodes already trust
+- route that HTTPS host privately inside the VPC
+
+This is the central design point: private does not mean plaintext. Private HTTPS over VPC is the correct end state.
+
+## What moving to VPC-private does and does not solve
+
+### What it solves
+
+- AerolVM node -> AOCR mirror traffic no longer leaves private networking.
+- AerolVM node -> AOCR auto-import traffic no longer leaves private networking.
+- You stop paying public-transfer-style costs for repeated cached pulls from cluster nodes to AOCR.
+- You reduce dependency on public routing for the internal AOCR control path.
+
+### What it does not solve
+
+- AOCR still needs outbound reachability to public registries on cache miss.
+- If AOCR is in a private subnet, it still needs NAT, an egress proxy, or equivalent for upstream pulls and any Cloudflare or ACME API calls.
+- If AOCR keeps using public DNS-issued certificates, certificate issuance still depends on the public DNS control plane.
+
+This is expected. The goal is not to eliminate all internet usage. The goal is to eliminate public-path traffic for the AerolVM <-> AOCR connection.
+
+## Candidate strategies
+
+## Strategy A - Same FQDNs, private resolution inside the VPC
+
+### Summary
+
+Keep using:
+
+- `mirror.aocr.aerol.ai`
+- `aocr.aerol.ai`
+
+But make those names resolve to AOCR's private address from inside the AerolVM VPC.
+
+### Why this is the recommended strategy
+
+It fits the current code with the least churn:
+
+- no AerolVM code change
+- no new Terraform schema required in AerolVM
+- no mirror rewrite changes
+- no auto-import changes
+- no Docker daemon behavior changes
+- no need to teach the system new internal-only hostnames
+
+### How it works
+
+1. AOCR is reachable on a private IP or an internal load balancer.
+2. Inside the AerolVM VPC, DNS resolves the existing AOCR names to that private address.
+3. Outside the VPC, those same names can either:
+   - continue resolving publicly for operator use, or
+   - be retired if AOCR becomes private-only.
+
+### DNS pattern
+
+Use split-horizon DNS:
+
+- public DNS continues to exist in Cloudflare for the AOCR public names if you still need public/operator access
+- a Route53 Private Hosted Zone associated with the AerolVM VPC overrides the same names with private records
+
+Example private records inside the VPC:
+
+- `mirror.aocr.aerol.ai` -> AOCR private IP or internal NLB
+- `aocr.aerol.ai` -> AOCR private IP or internal NLB
+
+### Certificate pattern
+
+Preferred:
+
+- keep publicly trusted certificates on the same names
+- issue them through DNS-01 or another method that does not depend on public HTTP reachability
+
+Why this is preferred:
+
+- AerolVM nodes already trust public roots
+- no node bootstrap change is needed
+- Docker keeps working with the existing HTTPS mirror config
+
+### Best fit when
+
+- AOCR is in the same VPC as AerolVM, or in a peered or transit-connected VPC
+- you want the lowest-risk migration
+- you are okay using split-horizon DNS
+
+## Strategy B - Dedicated internal AOCR hostnames
+
+### Summary
+
+Introduce separate private names such as:
+
+- `mirror-internal.aocr.aerol.ai`
+- `aocr-internal.aocr.aerol.ai`
+
+Then point AerolVM at those instead of the public names.
+
+### Pros
+
+- explicit separation between public and private traffic
+- easier to reason about in logs and DNS
+- no split-horizon behavior to debug
+
+### Cons
+
+- AOCR chart and ingress may need new hosts and certs
+- operational docs become more complex
+- if you still want both public and private surfaces, you now manage two naming planes
+
+### Best fit when
+
+- you want a very explicit private/public split
+- you are willing to change the AOCR chart or deploy parallel ingress resources
+
+## Strategy C - PrivateLink or internal NLB service publication
+
+### Summary
+
+Front AOCR with an internal NLB and publish it across VPCs or accounts using peering, Transit Gateway, or PrivateLink.
+
+### Pros
+
+- strong private-network boundary
+- good future shape if many clusters in many VPCs must consume one AOCR
+
+### Cons
+
+- more AWS infrastructure
+- more TLS and DNS coordination
+- overkill for the current single-VM k3s-style AOCR deployment
+
+### Best fit when
+
+- AOCR serves multiple clusters across VPCs or AWS accounts
+- you want AOCR to look like a reusable private platform service
+
+## Strategy D - Private HTTP or insecure registry
+
+Not recommended.
+
+Why:
+
+- it would require Docker daemon insecure-registry configuration changes
+- it would weaken the security posture of the mirror path
+- it is unnecessary because private HTTPS solves the actual problem cleanly
+
+## Recommendation
+
+Adopt Strategy A first.
+
+More concretely:
+
+1. Keep `mirror.aocr.aerol.ai` and `aocr.aerol.ai`.
+2. Make them resolve privately inside the AerolVM VPC.
+3. Keep HTTPS on both names.
+4. Restrict AOCR ingress to cluster-private sources.
+5. Add an S3 endpoint so AOCR-to-S3 is private as well.
+
+This gives you the benefit you want without forcing product-level changes on either repo.
+
+## Recommended target architecture
+
+## Option A1 - Simplest immediate move
+
+Use the AOCR VM's private IP directly.
+
+This is the right first move if AOCR is a single k3s VM and you want the lowest effort migration.
+
+```mermaid
+flowchart LR
+    subgraph VPC[AWS VPC]
+      W1[AerolVM worker]
+      W2[AerolVM worker]
+      AOCR[AOCR VM / k3s ingress]
+      S3EP[S3 Gateway Endpoint]
+    end
+
+    W1 -->|HTTPS to private IP via private DNS| AOCR
+    W2 -->|HTTPS to private IP via private DNS| AOCR
+    AOCR -->|private AWS path| S3EP
+    AOCR -->|internet on cache miss only| U[Public registries]
+```
+
+Characteristics:
+
+- no new load balancer
+- easiest if AOCR is already on EC2
+- works well for a single AOCR node
+- not HA
+
+## Option A2 - Better long-term move
+
+Put AOCR behind an internal load balancer.
+
+This is the right follow-up if AOCR becomes multi-node or you want cleaner failover.
+
+Characteristics:
+
+- better HA story
+- easier to move AOCR nodes later
+- more AWS setup work
+
+For the current deployment shape, A1 is likely the correct first phase and A2 the later hardening phase.
+
+## Required design decisions before implementation
+
+Make these decisions first.
+
+### D1. Is AOCR staying publicly reachable at all?
+
+Choose one:
+
+1. public + private
+2. private only
+
+If you choose public + private:
+
+- keep public DNS and public/operator access
+- add private DNS overrides for the AerolVM VPC
+
+If you choose private only:
+
+- remove public dependency from AerolVM entirely
+- use VPN, SSM, bastion, or other admin path for operators
+
+### D2. Is AOCR in the same VPC, or a different VPC?
+
+Choose one:
+
+1. same VPC
+2. peered VPC
+3. separate accounts/VPCs needing PrivateLink or TGW
+
+This determines whether private DNS alone is sufficient.
+
+### D3. What certificate source will you use?
+
+Preferred order:
+
+1. public-trust cert on the same FQDNs using DNS-01
+2. ACM or another managed public-trust cert presented at an internal LB
+3. private CA, only if you are willing to distribute trust to every AerolVM node
+
+Avoid private CA for phase 1 unless there is a hard requirement. The current cluster bootstrap does not automate AOCR-specific CA trust.
+
+### D4. Will AOCR remain on one VM, or do you want HA now?
+
+Choose one:
+
+1. single AOCR VM with private DNS
+2. internal LB in front of multiple AOCR ingress nodes
+
+## Detailed implementation plan
+
+## Phase 0 - Decide the network model
+
+### Goal
+
+Pick the exact target topology before touching either repo.
+
+### Work
+
+1. Decide whether AOCR will be public + private or private-only.
+2. Decide whether AOCR stays on a single VM or moves behind an internal LB.
+3. Decide whether same-FQDN split-horizon DNS is acceptable.
+4. Decide certificate source:
+   - public-trust DNS-01 is preferred
+   - private CA is fallback only
+5. Decide whether AOCR remains in a public subnet with private-IP access from AerolVM, or moves to a private subnet with NAT/proxy egress.
+
+### Deliverable
+
+A short decision record listing:
+
+- chosen hostname model
+- chosen certificate model
+- chosen routing model
+- whether operator public access remains
+
+## Phase 1 - Move AOCR onto a private-reachable network path
+
+### Goal
+
+Make AOCR reachable from AerolVM over private IP space.
+
+### Work
+
+If AOCR and AerolVM are in the same VPC:
+
+1. Ensure the AOCR VM has a stable private IP, or place AOCR behind an internal LB.
+2. Ensure AOCR security groups allow 443 and, if needed, 80 only from:
+   - AerolVM node security group, or
+   - AerolVM VPC CIDR
+3. If AOCR remains on a public subnet, keep private-IP routing for cluster traffic.
+
+If AOCR is in a different VPC:
+
+1. Add VPC peering or Transit Gateway connectivity.
+2. Ensure route tables include each side's CIDRs.
+3. Apply SG rules so only AerolVM sources can reach AOCR ingress.
+
+If AOCR is in a private subnet:
+
+1. Provide outbound access for upstream registry fetches.
+2. Provide outbound access for Cloudflare or ACME APIs if certificate issuance still depends on them.
+
+### Notes
+
+Because the current AerolVM Terraform creates a single public subnet, nothing on the AerolVM side prevents private reachability. The cluster only needs AOCR to be reachable at a private address.
+
+## Phase 2 - Private DNS and hostname routing
+
+### Goal
+
+Make AerolVM nodes resolve AOCR names to private addresses.
+
+### Recommended work
+
+Use split-horizon DNS with a Route53 Private Hosted Zone associated to the AerolVM VPC.
+
+1. Create a private hosted zone for the AOCR parent zone or a delegated subzone.
+2. Add private A or alias records for:
+   - `mirror.aocr.aerol.ai`
+   - `aocr.aerol.ai`
+3. Point them to the AOCR private IP or internal LB.
+4. Verify that an EC2 instance inside the AerolVM VPC resolves those names privately.
+
+### Why this works well
+
+- AerolVM config values do not change.
+- Existing mirror hostnames remain valid.
+- Existing certificates can stay tied to the same names.
+
+### If you reject split-horizon DNS
+
+Then use dedicated private names and accept the extra AOCR ingress and certificate work.
+
+## Phase 3 - TLS plan
+
+### Goal
+
+Keep both AOCR surfaces on trusted HTTPS.
+
+### Recommended work
+
+1. Keep using publicly trusted certificates for `aocr.aerol.ai` and `mirror.aocr.aerol.ai`.
+2. Make certificate issuance independent of public HTTP reachability.
+3. Prefer DNS-01 if AOCR becomes internal-only.
+
+### Why this matters
+
+The AOCR chart defaults to `cert-manager.io/cluster-issuer: letsencrypt-prod`, but the actual solver strategy lives in the cluster issuer. If your current issuer depends on HTTP-01 against public ingress, fully private-only AOCR will break issuance until the issuer is switched to DNS-01 or certificates are provisioned another way.
+
+### Private CA fallback
+
+Only use this if you are willing to change AerolVM bootstrap.
+
+That change would need to:
+
+1. place the AOCR CA cert onto every node
+2. run `update-ca-certificates`
+3. install the CA for Docker under `/etc/docker/certs.d/<mirror_host>/ca.crt`
+4. restart Docker safely
+
+None of that exists today in the AerolVM Terraform bootstrap.
+
+## Phase 4 - AOCR ingress hardening
+
+### Goal
+
+Make the AOCR mirror and hooks surfaces private-by-policy, not just private-by-DNS.
+
+### Work
+
+1. In the AOCR repo, narrow `aocr_mirror_allow_list` from `0.0.0.0/0` to the AerolVM VPC CIDRs or other approved source ranges.
+2. If AOCR remains publicly reachable, ensure the main host ingress is also protected appropriately for admin/operator use.
+3. If you add an internal LB later, place the tighter rules at the LB and SG layers as well.
+
+### Result
+
+Even if public DNS still exists, unauthorized public callers cannot use the mirror.
+
+## Phase 5 - S3 private path
+
+### Goal
+
+Keep AOCR-to-S3 traffic off the public internet too.
+
+### Work
+
+1. Add an S3 Gateway Endpoint to the VPC that hosts AOCR.
+2. Update route tables so AOCR reaches S3 through that endpoint.
+3. Verify the AOCR S3 backend continues working unchanged.
+
+### Why this matters
+
+AOCR's entire value proposition depends on S3-backed cached content. If node-to-AOCR becomes private but AOCR-to-S3 still hairpins over public paths or NAT, you only solved half the cost problem.
+
+## Phase 6 - AerolVM configuration changes
+
+### Case 1: same FQDN split-horizon DNS
+
+This is the best case.
+
+Expected change in AerolVM repo:
+
+- possibly none
+
+Why:
+
+- your current `aocr.mirror_host` already names `mirror.aocr.aerol.ai`
+- your current `aocr.hooks_url` already names `https://aocr.aerol.ai`
+- once those names resolve privately inside the VPC, AerolVM automatically starts using the private path
+
+### Case 2: dedicated internal hostnames
+
+Expected change in AerolVM repo:
+
+1. update `Terraform/terraform.tfvars`
+2. optionally update the Terraform README and setup docs so the AOCR section explicitly supports internal hostnames
+
+Fields that would change:
+
+- `aocr.mirror_host`
+- `aocr.hooks_url`
+- maybe `aocr.mirror_push_host` if sandbox-side pushes should also use a private host
+
+### Important conclusion
+
+There is no apparent code change required in AerolVM for the basic private-routing move. This is already a configuration seam.
+
+## Phase 7 - AOCR chart changes only if you choose dedicated internal names
+
+If you use Strategy A with same hostnames, skip this phase.
+
+If you use Strategy B, likely work includes:
+
+1. extending the AOCR chart to support additional ingress hosts for the main AOCR surface
+2. extending the AOCR chart to support additional ingress hosts for the mirror surface
+3. issuing or mounting certificates for those additional hosts
+4. updating the AOCR Ansible deploy playbook to pass those values through Helm
+
+## Phase 8 - Validation plan
+
+### Functional validation
+
+1. From an AerolVM node, resolve the AOCR names and confirm they return private addresses.
+2. Confirm `docker pull alpine` succeeds and still uses the configured mirror.
+3. Confirm a rewritten pull such as `ghcr.io/...` succeeds through AOCR.
+4. Confirm auto-import still succeeds after a first private pull.
+
+### Network-path validation
+
+1. Use VPC Flow Logs to confirm traffic from AerolVM nodes to AOCR uses private addresses.
+2. Confirm no node-to-AOCR traffic leaves through internet egress for cache hits.
+3. Confirm AOCR-to-S3 uses the S3 endpoint.
+4. Confirm AOCR still reaches upstream registries only on cache miss.
+
+### Security validation
+
+1. Confirm the mirror refuses requests from outside the approved source ranges.
+2. Confirm the AOCR certificate chain is trusted by Docker on the nodes.
+3. Confirm the bearer-token-based auto-import call stays on HTTPS.
+
+### Cost validation
+
+1. Compare pre-change and post-change transfer usage on the AerolVM side.
+2. Compare NAT or internet-gateway traffic before and after.
+3. Confirm repeated cached pulls no longer show the same public-path transfer pattern.
+
+## Phase 9 - Rollout plan
+
+### Step 1
+
+Stand up the private DNS records and private network path first.
+
+### Step 2
+
+Test from one node manually before rotating the whole cluster.
+
+### Step 3
+
+Tighten AOCR allow-lists only after private reachability is confirmed.
+
+### Step 4
+
+If AerolVM config values change, roll one node or one environment first, then the full cluster.
+
+## Rollback plan
+
+If the private path fails:
+
+1. remove the private DNS override or disassociate the private hosted zone
+2. revert any tightened AOCR ingress allow-lists
+3. if you changed AerolVM endpoint values, restore the prior values and recycle nodes
+
+Because the current production path is hostname-driven, DNS rollback is the fastest and least invasive backout mechanism.
+
+## Risks and edge cases
+
+### R1. Certificate issuance fails after privatization
+
+Most likely cause:
+
+- current cert-manager issuer depends on HTTP-01 and public reachability
+
+Mitigation:
+
+- move to DNS-01 or pre-provision certs before the cutover
+
+### R2. Private CA chosen too early
+
+Most likely cause:
+
+- trying to avoid public-trust certs by introducing a custom CA
+
+Mitigation:
+
+- do not choose private CA in phase 1 unless there is a strong compliance reason
+
+### R3. AOCR still pays unexpected transfer costs
+
+Most likely cause:
+
+- S3 path still uses NAT or public routing
+- AOCR and AerolVM are cross-AZ or cross-VPC in a way that still incurs transfer charges
+
+Mitigation:
+
+- add the S3 endpoint
+- verify route tables
+- verify AWS transfer billing dimensions for your exact placement
+
+### R4. Public and private DNS disagree unexpectedly
+
+Most likely cause:
+
+- split-horizon DNS was introduced without a clear ownership model
+
+Mitigation:
+
+- document the private hosted zone association and record ownership explicitly
+
+## Open questions
+
+These need answers before implementation starts.
+
+1. Is AOCR in the same AWS VPC as AerolVM today, or in a different VPC or account?
+2. Do you still need public/operator access to `aocr.aerol.ai` and `mirror.aocr.aerol.ai`, or can AOCR become private-only?
+3. Is the current AOCR certificate flow based on HTTP-01 or DNS-01?
+4. Do you want to keep AOCR on a single VM for now, or invest immediately in an internal LB?
+5. Is reducing AerolVM-node egress sufficient, or do you also want to guarantee AOCR-to-S3 stays private from day one?
+
+## Proposed final recommendation
+
+Implement in this order:
+
+1. Keep the current AOCR hostnames.
+2. Introduce split-horizon DNS so AerolVM nodes resolve them privately.
+3. Keep HTTPS with publicly trusted certificates.
+4. Restrict AOCR ingress to AerolVM-private sources.
+5. Add an S3 VPC endpoint for AOCR.
+6. Only after that, decide whether AOCR should also become private-only for operator access.
+
+This sequence solves the cost problem with the smallest blast radius and aligns with the seams that already exist in both codebases.


### PR DESCRIPTION
This pull request introduces a configurable image GC (garbage collection) whitelist to the sandbox infrastructure. Operators can now specify images or repositories that should never be removed by the image GC janitors, improving control over image retention. The change also refactors the image GC system to use a pending ledger and janitor sweep for image removal, with expanded test coverage and documentation.

**Image GC Whitelist and Configuration:**

- Added a new `image_gc_whitelist` variable to Terraform and a corresponding `ImageGCWhitelist` field in the Go service config, allowing operators to specify images or repositories that are exempt from garbage collection. This is passed as a comma-separated list via the `SB_IMAGE_GC_WHITELIST` environment variable. [[1]](diffhunk://#diff-6306399f7acc673b1224b1f608b7728ab7e5c13b9bff108a954b2f1d385ba5a4R358-R371) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL521-R561) [[3]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR802) [[4]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR1256-R1270) [[5]](diffhunk://#diff-a379901f5ad34f0199edb5eec0eccc979852c12ae10933328a698839c0346250R67-R78) [[6]](diffhunk://#diff-95a53dc8526438c066378581699aabc08e78224c7ed9c4ed9cd6bd33240309ddR218) [[7]](diffhunk://#diff-27284210e9c845fb0bd0438ee58839db7687dc87b81265e01f31135740489dccR69) [[8]](diffhunk://#diff-27284210e9c845fb0bd0438ee58839db7687dc87b81265e01f31135740489dccR167)

**Image GC System Refactor:**

- Refactored the image GC process to schedule image removals in a pending ledger (`pending_image_gc`) and have a janitor sweep handle actual deletions, instead of removing images inline during sandbox destroy. This ensures that images are only deleted when no active references exist and improves reliability. [[1]](diffhunk://#diff-bf702c7fa4c39ba053dc54097edcd8a79d531cbed5c1f86e2bcee84ad2c898eeL215-R218) [[2]](diffhunk://#diff-bf702c7fa4c39ba053dc54097edcd8a79d531cbed5c1f86e2bcee84ad2c898eeL236-R240) [[3]](diffhunk://#diff-bf702c7fa4c39ba053dc54097edcd8a79d531cbed5c1f86e2bcee84ad2c898eeL248-R249) [[4]](diffhunk://#diff-85cd4174384a81cdbf87370531855ae87bcbd19bf68f36b611d73cd5d96cb4daR317)

**Documentation and Test Improvements:**

- Expanded documentation and comments throughout the codebase to clarify the new image GC behavior, whitelist matching rules, and the janitor process. [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL521-R561) [[2]](diffhunk://#diff-6306399f7acc673b1224b1f608b7728ab7e5c13b9bff108a954b2f1d385ba5a4R358-R371) [[3]](diffhunk://#diff-a379901f5ad34f0199edb5eec0eccc979852c12ae10933328a698839c0346250R67-R78)
- Added and updated tests to verify that whitelisted images are never removed, the janitor respects active references, and the pending ledger is properly drained after GC. [[1]](diffhunk://#diff-229e5f07a46fe28e778cc70f12a46128d572e9849b62f41a002cdc9ef922c4d0R219-R236) [[2]](diffhunk://#diff-c9ab7fbd2d8c1877b68fd5c4144fcc85e331cd381b582254e721f0e38ee14a39L803-R806) [[3]](diffhunk://#diff-c9ab7fbd2d8c1877b68fd5c4144fcc85e331cd381b582254e721f0e38ee14a39R815) [[4]](diffhunk://#diff-c9ab7fbd2d8c1877b68fd5c4144fcc85e331cd381b582254e721f0e38ee14a39R831-R864) [[5]](diffhunk://#diff-c9ab7fbd2d8c1877b68fd5c4144fcc85e331cd381b582254e721f0e38ee14a39R877-R890) [[6]](diffhunk://#diff-c9ab7fbd2d8c1877b68fd5c4144fcc85e331cd381b582254e721f0e38ee14a39R905) [[7]](diffhunk://#diff-c9ab7fbd2d8c1877b68fd5c4144fcc85e331cd381b582254e721f0e38ee14a39R919-R921)

These changes give operators fine-grained control over which images are retained, and make the image GC process more robust and transparent.