### PR TITLE
refactor: Refactor AOCR integration and observability configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ dist-test/
 *.db-wal
 Terraform/.terraform.lock.hcl
 *.log
+# Shared cluster secrets (read by both Terraform and Ansible). The committed
+# sibling is config/secrets.example.yml.
+config/secrets.yml
 node_modules/
 sdk/typescript/node_modules
 docs/.astro/

--- a/Ansible/README.md
+++ b/Ansible/README.md
@@ -113,10 +113,10 @@ ansible-playbook playbooks/tail-logs.yml -e lines=200
 ansible-playbook playbooks/prepare-role-change.yml --limit aerolvm-worker-17
 
 # Configure OTEL/image-pull hardening and deploy backup/recovery,
-# node lifecycle, Grafana, Prometheus, Alertmanager, and runbook artifacts:
+# node lifecycle, Grafana, Prometheus, Alertmanager, and runbook artifacts.
+# OTEL endpoints, image-pull/GC tuning, mirror host, and auto-import config
+# live in ../config/cluster.yml (shared with Terraform) — edit there.
 ansible-playbook playbooks/configure-ops.yml \
-  -e sandboxd_otel_metrics_endpoint=http://otel-collector:4318/v1/metrics \
-  -e sandboxd_otel_traces_endpoint=http://otel-collector:4318/v1/traces \
   -e sandboxd_backup_enabled=true
 ```
 
@@ -302,32 +302,37 @@ at whatever path that pipeline writes to.
 
 ### Step 3 — Fill in the vars
 
-Put these in your gitignored override file (e.g. `group_vars/all/local.yml`).
+Non-secret AOCR config (mirror host, auto-import toggle / hooks_url /
+cluster_id, retention/timeouts) lives in the shared `../config/cluster.yml`.
+Edit that file once; both Terraform (day-0) and Ansible (day-2) read it.
+
+```yaml
+# ../config/cluster.yml
+mirror:
+  host: "mirror.aocr.aerol.ai"
+  upstreams: "docker.io=docker,ghcr.io=ghcr,gcr.io=gcr,quay.io=quay,registry.k8s.io=k8s"
+
+auto_import:
+  enabled: true
+  hooks_url: "https://aocr.aerol.ai"
+  cluster_id: "prod-aerolvm-us-east-1"   # pick once, never change
+  retention_suffix: "--idle-7d"
+```
+
+Secrets stay in your gitignored override file (e.g. `group_vars/all/local.yml`)
+because cluster.yml is committable and they are not.
 
 **Option A — inline values (laptop):**
 
 ```yaml
-# Mirror rewrite — required
-sandboxd_mirror_host:                    "mirror.aocr.aerol.ai"
-sandboxd_upstream_wrap_key_value:        "tkKiFnTMJmA3AYkGyqZXWiU1kPFS14fGO9p5dCVQk/4="
-
-# Auto-import (F21) — optional; drop these four for cache-only mode
-sandboxd_auto_import_enabled:            true
-sandboxd_auto_import_hooks_url:          "https://aocr.aerol.ai"
-sandboxd_auto_import_cluster_id:         "prod-aerolvm-us-east-1"   # pick once, never change
+sandboxd_upstream_wrap_key_value:        "<paste upstream_wrap_key>"
 sandboxd_auto_import_cluster_pat_value:  "<paste internal_api_token>"
-# sandboxd_auto_import_retention_suffix: "--idle-90d"   # default
 ```
 
 **Option B — control-node file paths (fleet):**
 
 ```yaml
-sandboxd_mirror_host:                    "mirror.aocr.aerol.ai"
 sandboxd_upstream_wrap_key_src:          "/home/you/aerol-secrets/upstream_wrap_key"
-
-sandboxd_auto_import_enabled:            true
-sandboxd_auto_import_hooks_url:          "https://aocr.aerol.ai"
-sandboxd_auto_import_cluster_id:         "prod-aerolvm-us-east-1"
 sandboxd_auto_import_cluster_pat_src:    "/home/you/aerol-secrets/cluster_pat"
 ```
 
@@ -371,25 +376,35 @@ curl -sf -H "Authorization: Bearer $(cat aocr.sh/secrets/auth_pat_token)" \
   | grep "cluster/prod-aerolvm-us-east-1/_imported/"
 ```
 
-### What each `sandboxd_*` var means
+### What each var means
+
+The non-secret keys live in `../config/cluster.yml` (shared SoT). The two
+secret-delivery pairs are Ansible-side because they cannot be committed.
+
+**`../config/cluster.yml` — `mirror.*` / `auto_import.*`:**
+
+| Key | Purpose | Where the value comes from |
+|---|---|---|
+| `mirror.host` | Vhost sandboxd rewrites `ghcr.io` / `gcr.io` / `quay.io` / `registry.k8s.io` pulls onto. Empty disables rewrite entirely. Docker Hub is intentionally not rewritten. | AOCR side — derived from `aocr_global_domain` |
+| `mirror.push_host` | Optional. Push vhost (e.g. `aocr.aerol.ai`) so already-pushed refs aren't double-rewritten. Leave empty unless sandboxes also push. | AOCR side |
+| `mirror.upstreams` | Default `docker.io=docker,ghcr.io=ghcr,gcr.io=gcr,quay.io=quay,registry.k8s.io=k8s`. Override only if your AOCR exposes different upstream shortnames. | AOCR operator |
+| `auto_import.enabled` | Master switch for F21. When true, every successful private pull triggers a re-mount under `cluster/<id>/_imported/...`. | You |
+| `auto_import.hooks_url` | AOCR hooks service root, e.g. `https://aocr.aerol.ai`. Sandboxd appends `/v1/internal/imports`. | AOCR side — same as `aocr_global_domain` |
+| `auto_import.cluster_id` | **A label you choose**, not internal AOCR config. AOCR validates only the format (`^[A-Za-z0-9_-]{1,64}$`) and uses it as a namespace prefix for imported tags. Pick a meaningful per-cluster name like `prod-us-east-1`, `staging`, `dev-suman`. | You |
+| `auto_import.retention_suffix` | Suffix appended to imported tags. Drives the reaper's idle-eviction window (see [`aocr.sh/RETENTION.md`](https://github.com/aerolai/aocr/blob/main/RETENTION.md)). | Operator policy |
+
+`request_timeout`, `reconcile_interval`, and `max_in_flight` in the same
+file have sensible defaults — only tune if recovery storms or remote latency
+warrant it.
+
+**Ansible local override (gitignored) — secret delivery only:**
 
 | Var | Purpose | Where the value comes from |
 |---|---|---|
-| `sandboxd_mirror_host` | Vhost sandboxd rewrites `ghcr.io` / `gcr.io` / `quay.io` / `registry.k8s.io` pulls onto. Empty disables rewrite entirely. Docker Hub is intentionally not rewritten. | AOCR side — derived from `aocr_global_domain` |
-| `sandboxd_mirror_push_host` | Optional. Push vhost (e.g. `aocr.aerol.ai`) so already-pushed refs aren't double-rewritten. Leave empty unless sandboxes also push. | AOCR side |
-| `sandboxd_mirror_upstreams` | Default `ghcr.io=ghcr,gcr.io=gcr,quay.io=quay,registry.k8s.io=k8s`. Override only if your AOCR exposes different upstream shortnames. | AOCR operator |
 | `sandboxd_upstream_wrap_key_value` | **Inline** base64 32-byte AES-GCM key. Written to `/etc/sandboxd/secrets/upstream-wrap.key` via `copy: content:` (no_log). Use this OR `_src`, not both (inline wins). | AOCR side — `aocr_auth_upstream_wrap_key` from `secrets.yml`, or `cat secrets/upstream_wrap_key` |
 | `sandboxd_upstream_wrap_key_src` | Path on the **control node** to a file holding the key. The play copies it to `/etc/sandboxd/secrets/upstream-wrap.key` via `copy: src:`. Use this when Vault/SOPS/Secrets Manager renders the file. Sandboxd wraps per-pull upstream creds with this; only AOCR's mirror can unwrap. Without either var, private upstream pulls 401 at the mirror. | AOCR side — `secrets/upstream_wrap_key` (auto-generated on first AOCR deploy) |
-| `sandboxd_auto_import_enabled` | Master switch for F21. When true, every successful private pull triggers a re-mount under `cluster/<id>/_imported/...`. | You |
-| `sandboxd_auto_import_hooks_url` | AOCR hooks service root, e.g. `https://aocr.aerol.ai`. Sandboxd appends `/v1/internal/imports`. | AOCR side — same as `aocr_global_domain` |
-| `sandboxd_auto_import_cluster_id` | **A label you choose**, not internal AOCR config. AOCR validates only the format (`^[A-Za-z0-9_-]{1,64}$`) and uses it as a namespace prefix for imported tags. Pick a meaningful per-cluster name like `prod-us-east-1`, `staging`, `dev-suman`. | You |
 | `sandboxd_auto_import_cluster_pat_value` | **Inline** bearer token sandboxd presents on `POST /v1/internal/imports`. Written to `/etc/sandboxd/secrets/cluster-pat` via `copy: content:` (no_log). Use this OR `_src`, not both (inline wins). | AOCR side — `aocr_internal_api_token` or `cat secrets/internal_api_token` |
 | `sandboxd_auto_import_cluster_pat_src` | Path on the **control node** to a file holding the same token. Use this when Vault/SOPS/Secrets Manager renders the file. Despite the name, this is AOCR's `internal_api_token`, not the UUID-keyed cluster PAT used by `auth/src/clusterPat.ts` (different concept; see `aocr_aerol_stitch.md`). | AOCR side — `secrets/internal_api_token` |
-| `sandboxd_auto_import_retention_suffix` | Suffix appended to imported tags. Drives the reaper's idle-eviction window (see [`aocr.sh/RETENTION.md`](https://github.com/aerolai/aocr/blob/main/RETENTION.md)). | Operator policy |
-
-Everything else (`request_timeout`, `reconcile_interval`, `max_in_flight`)
-has a sensible default in `inventory/group_vars/all/defaults.yml` — only
-tune if recovery storms or remote latency warrant it.
 
 ### Rotating secrets
 
@@ -409,11 +424,12 @@ tune if recovery storms or remote latency warrant it.
 
 1. AOCR was deployed once; its secrets sit in `aocr.sh/secrets/` (or
    inline in `aocr.sh/ansible/inventory/group_vars/all/secrets.yml`).
-2. Pick one delivery mode per secret:
-   - **Inline** — set `sandboxd_*_value` in a gitignored override file.
+2. Set `mirror.host` and `auto_import.*` in `../config/cluster.yml` (shared
+   with Terraform — committable, no secrets).
+3. Pick one delivery mode per secret in your gitignored
+   `group_vars/all/local.yml`:
+   - **Inline** — set `sandboxd_*_value`.
    - **Control-node file** — set `sandboxd_*_src` to a path you stage.
-3. Set the `sandboxd_mirror_*` / `sandboxd_auto_import_*` vars in your
-   gitignored override (e.g. `group_vars/all/local.yml`).
 4. `ansible-playbook playbooks/configure-ops.yml`.
 5. Verify with `grep` / `ls` on a node and `curl /v1/images` on AOCR.
 

--- a/Ansible/README.md
+++ b/Ansible/README.md
@@ -296,15 +296,18 @@ chmod 0600 ~/aerol-secrets/*
 If your fleet renders these via Vault or another mechanism, point `_src`
 at whatever path that pipeline writes to.
 
-> If both `_value` and `_src` are set for the same secret, the inline
-> `_value` wins. Leaving both empty skips the copy entirely — sandboxd
-> boots without the secret and the corresponding feature is disabled.
+> If a `*_src` path is set AND the matching `aocr.*` key in
+> `config/secrets.yml` is non-empty, the `config/secrets.yml` value wins.
+> Leaving both empty skips the copy entirely — sandboxd boots without the
+> secret and the corresponding feature is disabled.
 
 ### Step 3 — Fill in the vars
 
 Non-secret AOCR config (mirror host, auto-import toggle / hooks_url /
 cluster_id, retention/timeouts) lives in the shared `../config/cluster.yml`.
-Edit that file once; both Terraform (day-0) and Ansible (day-2) read it.
+AOCR secret values live in the parallel shared `../config/secrets.yml`
+(gitignored — bootstrap with `cp ../config/secrets.example.yml ../config/secrets.yml`).
+Edit those two files once; both Terraform (day-0) and Ansible (day-2) read them.
 
 ```yaml
 # ../config/cluster.yml
@@ -319,17 +322,17 @@ auto_import:
   retention_suffix: "--idle-7d"
 ```
 
-Secrets stay in your gitignored override file (e.g. `group_vars/all/local.yml`)
-because cluster.yml is committable and they are not.
-
-**Option A — inline values (laptop):**
-
 ```yaml
-sandboxd_upstream_wrap_key_value:        "<paste upstream_wrap_key>"
-sandboxd_auto_import_cluster_pat_value:  "<paste internal_api_token>"
+# ../config/secrets.yml  (gitignored — copy from secrets.example.yml)
+aocr:
+  upstream_wrap_key: "<paste upstream_wrap_key>"
+  cluster_pat:       "<paste internal_api_token>"
 ```
 
-**Option B — control-node file paths (fleet):**
+**Optional — control-node file paths (Vault/SOPS workflow):** if your fleet
+renders the secrets to files instead, leave the matching keys in
+`config/secrets.yml` empty and point at the rendered files from
+`group_vars/all/local.yml`:
 
 ```yaml
 sandboxd_upstream_wrap_key_src:          "/home/you/aerol-secrets/upstream_wrap_key"
@@ -378,8 +381,11 @@ curl -sf -H "Authorization: Bearer $(cat aocr.sh/secrets/auth_pat_token)" \
 
 ### What each var means
 
-The non-secret keys live in `../config/cluster.yml` (shared SoT). The two
-secret-delivery pairs are Ansible-side because they cannot be committed.
+Non-secret keys live in `../config/cluster.yml` (shared SoT, committable).
+Secret values live in `../config/secrets.yml` (shared SoT, gitignored). The
+two `*_src` vars in `group_vars/all/local.yml` are an Ansible-only fallback
+for Vault/SOPS rendering — not needed if `config/secrets.yml` holds the
+values directly.
 
 **`../config/cluster.yml` — `mirror.*` / `auto_import.*`:**
 
@@ -397,28 +403,33 @@ secret-delivery pairs are Ansible-side because they cannot be committed.
 file have sensible defaults — only tune if recovery storms or remote latency
 warrant it.
 
-**Ansible local override (gitignored) — secret delivery only:**
+**`../config/secrets.yml` — `aocr.*` (gitignored):**
+
+| Key | Purpose | Where the value comes from |
+|---|---|---|
+| `aocr.upstream_wrap_key` | Base64 32-byte AES-GCM key. Written to `/etc/sandboxd/secrets/upstream-wrap.key` via `copy: content:` (no_log). Sandboxd wraps per-pull upstream creds with this; only AOCR's mirror can unwrap. Without it, private upstream pulls 401 at the mirror. | AOCR side — `aocr_auth_upstream_wrap_key` from `secrets.yml`, or `cat secrets/upstream_wrap_key` |
+| `aocr.cluster_pat` | Bearer token sandboxd presents on `POST /v1/internal/imports`. Written to `/etc/sandboxd/secrets/cluster-pat` via `copy: content:` (no_log). Despite the name, this is AOCR's `internal_api_token`, not the UUID-keyed cluster PAT used by `auth/src/clusterPat.ts` (different concept; see `aocr_aerol_stitch.md`). | AOCR side — `aocr_internal_api_token` or `cat secrets/internal_api_token` |
+
+**Ansible local override (gitignored) — Vault/SOPS fallback only:**
 
 | Var | Purpose | Where the value comes from |
 |---|---|---|
-| `sandboxd_upstream_wrap_key_value` | **Inline** base64 32-byte AES-GCM key. Written to `/etc/sandboxd/secrets/upstream-wrap.key` via `copy: content:` (no_log). Use this OR `_src`, not both (inline wins). | AOCR side — `aocr_auth_upstream_wrap_key` from `secrets.yml`, or `cat secrets/upstream_wrap_key` |
-| `sandboxd_upstream_wrap_key_src` | Path on the **control node** to a file holding the key. The play copies it to `/etc/sandboxd/secrets/upstream-wrap.key` via `copy: src:`. Use this when Vault/SOPS/Secrets Manager renders the file. Sandboxd wraps per-pull upstream creds with this; only AOCR's mirror can unwrap. Without either var, private upstream pulls 401 at the mirror. | AOCR side — `secrets/upstream_wrap_key` (auto-generated on first AOCR deploy) |
-| `sandboxd_auto_import_cluster_pat_value` | **Inline** bearer token sandboxd presents on `POST /v1/internal/imports`. Written to `/etc/sandboxd/secrets/cluster-pat` via `copy: content:` (no_log). Use this OR `_src`, not both (inline wins). | AOCR side — `aocr_internal_api_token` or `cat secrets/internal_api_token` |
-| `sandboxd_auto_import_cluster_pat_src` | Path on the **control node** to a file holding the same token. Use this when Vault/SOPS/Secrets Manager renders the file. Despite the name, this is AOCR's `internal_api_token`, not the UUID-keyed cluster PAT used by `auth/src/clusterPat.ts` (different concept; see `aocr_aerol_stitch.md`). | AOCR side — `secrets/internal_api_token` |
+| `sandboxd_upstream_wrap_key_src` | Path on the **control node** to a file holding the wrap key. The play copies it to `/etc/sandboxd/secrets/upstream-wrap.key` via `copy: src:`. Use when Vault/SOPS/Secrets Manager renders the file. If `aocr.upstream_wrap_key` in `config/secrets.yml` is also set, secrets.yml wins. | AOCR side — `secrets/upstream_wrap_key` (auto-generated on first AOCR deploy) |
+| `sandboxd_auto_import_cluster_pat_src` | Path on the **control node** to a file holding the cluster PAT. Same precedence rules as the wrap key. | AOCR side — `secrets/internal_api_token` |
 
 ### Rotating secrets
 
 - **Wrap key.** Add the new key alongside the old one in AOCR's
   `UPSTREAM_AUTH_WRAP_KEYS` (comma-separated), then update the cluster
-  side: either replace `sandboxd_upstream_wrap_key_value` in your override
-  file (inline mode) or overwrite the file at
-  `sandboxd_upstream_wrap_key_src` (file mode). Rerun `configure-ops.yml`.
-  After every node has rotated, drop the old key from AOCR.
+  side: replace `aocr.upstream_wrap_key` in `../config/secrets.yml`
+  (default) or overwrite the file at `sandboxd_upstream_wrap_key_src`
+  (Vault/SOPS mode). Rerun `configure-ops.yml`. After every node has
+  rotated, drop the old key from AOCR.
 - **Internal API token / cluster PAT.** Rotate AOCR's `INTERNAL_API_TOKEN`,
-  then update `sandboxd_auto_import_cluster_pat_value` (inline) or
-  overwrite the file at `sandboxd_auto_import_cluster_pat_src` (file), and
-  rerun `configure-ops.yml`. Auto-imports queued under the old token will
-  fail and the local reconciler will retry under the new one.
+  then update `aocr.cluster_pat` in `../config/secrets.yml` (default) or
+  overwrite the file at `sandboxd_auto_import_cluster_pat_src` (Vault/SOPS
+  mode), and rerun `configure-ops.yml`. Auto-imports queued under the old
+  token will fail and the local reconciler will retry under the new one.
 
 ### TL;DR
 
@@ -426,10 +437,10 @@ warrant it.
    inline in `aocr.sh/ansible/inventory/group_vars/all/secrets.yml`).
 2. Set `mirror.host` and `auto_import.*` in `../config/cluster.yml` (shared
    with Terraform — committable, no secrets).
-3. Pick one delivery mode per secret in your gitignored
-   `group_vars/all/local.yml`:
-   - **Inline** — set `sandboxd_*_value`.
-   - **Control-node file** — set `sandboxd_*_src` to a path you stage.
+3. Set `aocr.upstream_wrap_key` and `aocr.cluster_pat` in
+   `../config/secrets.yml` (copy from `secrets.example.yml`, gitignored,
+   shared with Terraform). For Vault/SOPS rendering, leave those empty and
+   point `sandboxd_*_src` at staged paths in `group_vars/all/local.yml`.
 4. `ansible-playbook playbooks/configure-ops.yml`.
 5. Verify with `grep` / `ls` on a node and `curl /v1/images` on AOCR.
 

--- a/Ansible/inventory/group_vars/all/defaults.yml
+++ b/Ansible/inventory/group_vars/all/defaults.yml
@@ -31,29 +31,10 @@ sandboxd_alertmanager_config_dir: /etc/sandboxd/alertmanager
 sandboxd_runbook_dir: /etc/sandboxd/runbooks
 sandboxd_restart_after_ops_config: true
 
-# --- Observability / pull-storm controls -----------------------------------
-# OFF by default. To enable, set the matching keys in local.yml.
-sandboxd_otel_metrics_enabled: false
-sandboxd_otel_metrics_endpoint: ""
-sandboxd_otel_metrics_interval: "30s"
-sandboxd_otel_traces_enabled: false
-sandboxd_otel_traces_endpoint: ""
-sandboxd_otel_traces_sample_ratio: 0.05
-sandboxd_otel_service_name: "sandboxd"
-sandboxd_image_pull_max_concurrent: 4
-sandboxd_image_pull_failure_backoff: "30s"
-# Image GC whitelist. Comma-joined list passed to SB_IMAGE_GC_WHITELIST.
-# Entries can be exact image refs ("nginx:1.27"), repos ("nginx",
-# "myorg/web"), or registry-org prefixes ending in "/" ("ghcr.io/myorg/").
-# Empty string (default) = no whitelist; the janitor's normal scope applies.
-sandboxd_image_gc_whitelist: ""
-# Image GC janitor cadence. Mirrors sandboxd's defaults. Both knobs apply
-# to BOTH sweeps (built-image + pending-destroy). Shorten the TTL when
-# disk pressure outweighs the cost of re-pulling on destroy/recreate
-# cycles inside the window.
-sandboxd_image_build_gc_enabled: true
-sandboxd_image_build_gc_interval: "10m"
-sandboxd_image_build_gc_ttl: "24h"
+# --- Observability / image controls / mirror / auto-import -----------------
+# These now live in ../../../../config/cluster.yml (shared with Terraform).
+# Edit that file; configure-ops.yml loads it via vars_files. Only Ansible-
+# specific secret-delivery vars remain in this file (below) and in local.yml.
 
 # --- Local backup schedule -------------------------------------------------
 # OFF by default. To enable, set sandboxd_backup_enabled: true in local.yml.
@@ -66,12 +47,13 @@ sandboxd_backup_retention_days: 7
 # --- Node lifecycle defaults (playbooks/prepare-role-change.yml) -----------
 sandboxd_role_change_drain_timeout_s: 3600
 
-# --- Phase 4: Authenticated Mirror + Auto-Import ---------------------------
-# OFF by default (empty SB_MIRROR_HOST disables the whole feature).
-# To opt in, set the relevant keys in local.yml. Full operator reference:
-# sandbox-library/AUTHENTICATED_MIRROR.md.
+# --- Phase 4: Authenticated Mirror + Auto-Import (secret delivery only) ----
+# Mirror host, upstreams, auto-import toggle / hooks_url / cluster_id, and
+# retention/timeouts live in ../../../../config/cluster.yml (shared with
+# Terraform). This block only carries the Ansible-specific plumbing needed
+# to land the upstream wrap key and cluster PAT on each host.
 #
-# These three are internal plumbing — the playbook templates them into
+# These two are internal plumbing — the playbook templates them into
 # SB_*_PATH env vars on each managed host. Do not override.
 sandboxd_secrets_dir: /etc/sandboxd/secrets
 sandboxd_upstream_wrap_key_path:       "{{ sandboxd_secrets_dir }}/upstream-wrap.key"
@@ -87,18 +69,3 @@ sandboxd_upstream_wrap_key_value: ""
 sandboxd_upstream_wrap_key_src: ""
 sandboxd_auto_import_cluster_pat_value: ""
 sandboxd_auto_import_cluster_pat_src: ""
-
-# Mirror rewrite — set sandboxd_mirror_host in local.yml to opt in.
-sandboxd_mirror_host: ""
-sandboxd_mirror_push_host: ""
-sandboxd_mirror_upstreams: "ghcr.io=ghcr,gcr.io=gcr,quay.io=quay,registry.k8s.io=k8s"
-
-# Auto-import — sandboxd refuses to boot with enabled=true unless
-# hooks_url, cluster_id, and a cluster-pat (value or src) are all set.
-sandboxd_auto_import_enabled: false
-sandboxd_auto_import_hooks_url: ""
-sandboxd_auto_import_cluster_id: ""
-sandboxd_auto_import_retention_suffix: "--idle-7d"
-sandboxd_auto_import_request_timeout: "15s"
-sandboxd_auto_import_reconcile_interval: "5m"
-sandboxd_auto_import_max_in_flight: 4

--- a/Ansible/inventory/group_vars/all/defaults.yml
+++ b/Ansible/inventory/group_vars/all/defaults.yml
@@ -50,8 +50,10 @@ sandboxd_role_change_drain_timeout_s: 3600
 # --- Phase 4: Authenticated Mirror + Auto-Import (secret delivery only) ----
 # Mirror host, upstreams, auto-import toggle / hooks_url / cluster_id, and
 # retention/timeouts live in ../../../../config/cluster.yml (shared with
-# Terraform). This block only carries the Ansible-specific plumbing needed
-# to land the upstream wrap key and cluster PAT on each host.
+# Terraform). The secret VALUES (upstream wrap key, cluster PAT) live in
+# ../../../../config/secrets.yml (also shared with Terraform; gitignored).
+# This block only carries the Ansible-specific plumbing for landing those
+# secrets on each host.
 #
 # These two are internal plumbing — the playbook templates them into
 # SB_*_PATH env vars on each managed host. Do not override.
@@ -59,13 +61,10 @@ sandboxd_secrets_dir: /etc/sandboxd/secrets
 sandboxd_upstream_wrap_key_path:       "{{ sandboxd_secrets_dir }}/upstream-wrap.key"
 sandboxd_auto_import_cluster_pat_path: "{{ sandboxd_secrets_dir }}/cluster-pat"
 
-# Secret delivery — pick ONE per secret, in local.yml:
-#   sandboxd_upstream_wrap_key_value: "<base64 wrap key>"        # inline (laptop)
-#   sandboxd_upstream_wrap_key_src:   "/path/on/control/node"    # file (Vault/SOPS)
-#   sandboxd_auto_import_cluster_pat_value: "<token>"
-#   sandboxd_auto_import_cluster_pat_src:   "/path/on/control/node"
-# If both _value and _src are set, _value wins. Both empty = feature off.
-sandboxd_upstream_wrap_key_value: ""
+# Optional Vault/SOPS workflow: deliver the secret from a file on the control
+# node instead of inlining it in config/secrets.yml. If a *_src path is set
+# AND the matching aocr.* key in config/secrets.yml is non-empty, the
+# config/secrets.yml value wins (it runs first). Both empty + secrets.yml
+# empty = feature off.
 sandboxd_upstream_wrap_key_src: ""
-sandboxd_auto_import_cluster_pat_value: ""
 sandboxd_auto_import_cluster_pat_src: ""

--- a/Ansible/inventory/group_vars/all/local.yml.example
+++ b/Ansible/inventory/group_vars/all/local.yml.example
@@ -1,18 +1,20 @@
 # Copy to local.yml (gitignored) and fill in your values.
-# Loaded automatically after main.yml; only set keys you want to override.
-
-# --- AOCR stitch (mirror + auto-import) ------------------------------------
-# sandboxd_mirror_host:                    "mirror.<your-aocr-domain>"
-# sandboxd_upstream_wrap_key_value:        "<base64 wrap key from aocr.sh>"
+# Loaded automatically after defaults.yml; only set keys you want to override.
 #
-# sandboxd_auto_import_enabled:            true
-# sandboxd_auto_import_hooks_url:          "https://<your-aocr-domain>"
-# sandboxd_auto_import_cluster_id:         "<label, e.g. prod-aerolvm-us-east-1>"
-# sandboxd_auto_import_cluster_pat_value:  "<internal_api_token from aocr.sh>"
+# Non-secret ops config (mirror host, auto-import toggle / hooks_url /
+# cluster_id, image_gc whitelist, OTEL endpoints, ...) lives in the shared
+# ../../../../config/cluster.yml and is read by both Ansible and Terraform.
+# Do NOT set those keys here — they belong in cluster.yml.
 
-# --- Observability ---------------------------------------------------------
-# sandboxd_otel_metrics_enabled:  true
-# sandboxd_otel_metrics_endpoint: "http://otel-collector:4318/v1/metrics"
+# --- AOCR secret delivery --------------------------------------------------
+# Required when cluster.yml has mirror.host set and/or auto_import.enabled.
+# Pick inline OR file-on-control-node for each secret; if both are set, the
+# inline value wins.
+#
+# sandboxd_upstream_wrap_key_value:        "<base64 wrap key from aocr.sh>"
+# sandboxd_upstream_wrap_key_src:          "/path/on/control/node/wrap.key"
+# sandboxd_auto_import_cluster_pat_value:  "<internal_api_token from aocr.sh>"
+# sandboxd_auto_import_cluster_pat_src:    "/path/on/control/node/cluster.pat"
 
 # --- Local backup ----------------------------------------------------------
 # sandboxd_backup_enabled: true

--- a/Ansible/inventory/group_vars/all/local.yml.example
+++ b/Ansible/inventory/group_vars/all/local.yml.example
@@ -4,16 +4,18 @@
 # Non-secret ops config (mirror host, auto-import toggle / hooks_url /
 # cluster_id, image_gc whitelist, OTEL endpoints, ...) lives in the shared
 # ../../../../config/cluster.yml and is read by both Ansible and Terraform.
-# Do NOT set those keys here — they belong in cluster.yml.
+# AOCR secret values (upstream_wrap_key, cluster_pat) live in the parallel
+# shared ../../../../config/secrets.yml (gitignored — copy from
+# secrets.example.yml). Do NOT set those keys here — they belong in their
+# respective shared files.
 
-# --- AOCR secret delivery --------------------------------------------------
-# Required when cluster.yml has mirror.host set and/or auto_import.enabled.
-# Pick inline OR file-on-control-node for each secret; if both are set, the
-# inline value wins.
+# --- AOCR secret delivery (Vault/SOPS workflow) ----------------------------
+# Optional: deliver the AOCR secrets from a file on the control node instead
+# of inlining them in config/secrets.yml. Useful for fleet rendering. If a
+# *_src path is set AND the matching aocr.* key in config/secrets.yml is
+# non-empty, the config/secrets.yml value wins.
 #
-# sandboxd_upstream_wrap_key_value:        "<base64 wrap key from aocr.sh>"
 # sandboxd_upstream_wrap_key_src:          "/path/on/control/node/wrap.key"
-# sandboxd_auto_import_cluster_pat_value:  "<internal_api_token from aocr.sh>"
 # sandboxd_auto_import_cluster_pat_src:    "/path/on/control/node/cluster.pat"
 
 # --- Local backup ----------------------------------------------------------

--- a/Ansible/playbooks/configure-ops.yml
+++ b/Ansible/playbooks/configure-ops.yml
@@ -1,15 +1,17 @@
 ---
 # Configure sandboxd operational hardening across the fleet.
 #
-# All non-secret ops env lives in ../../config/cluster.yml — the shared
-# source of truth Terraform also reads. Edit that file, then:
+# All non-secret ops env lives in ../../config/cluster.yml and AOCR secrets
+# in ../../config/secrets.yml — the shared sources of truth Terraform also
+# reads. Edit those files, then:
 #
 #   ansible-playbook playbooks/configure-ops.yml
 #
-# Secrets (wrap key, cluster PAT) still come from local.yml or -e overrides
-# because the shared file is intended to be committable and they are not.
+# For fleet / Vault / SOPS workflows the wrap key + cluster PAT can also come
+# from control-node files via the sandboxd_*_src vars in local.yml. If both a
+# secrets.yml value AND a *_src path are set, the secrets.yml value wins.
 #
-# Backup cron is also driven from inventory rather than the shared file:
+# Backup cron is driven from inventory rather than the shared files:
 #   ansible-playbook playbooks/configure-ops.yml -e sandboxd_backup_enabled=true
 
 - name: Configure sandboxd observability and operations
@@ -19,12 +21,15 @@
   any_errors_fatal: true
   gather_facts: false
 
-  # cluster_ops is the single source of truth, shared with Terraform
-  # (Terraform/locals.tf:cluster_ops). The path is relative to this playbook
-  # file; both tools point at the same on-disk file so day-0 and day-2
-  # rollouts render identical SB_* values into /etc/sandboxd/cluster.env.
+  # Shared SoT files Terraform also reads (Terraform/locals.tf: cluster_ops
+  # and cluster_secrets). Paths are relative to this playbook file; both
+  # tools point at the same on-disk files so day-0 and day-2 rollouts render
+  # identical SB_* values into /etc/sandboxd/cluster.env. cluster.yml is
+  # committed; secrets.yml is gitignored — bootstrap with
+  #   cp config/secrets.example.yml config/secrets.yml
   vars_files:
     - "../../config/cluster.yml"
+    - "../../config/secrets.yml"
 
   vars:
     sandboxd_ops_env:
@@ -46,14 +51,16 @@
       SB_MIRROR_HOST: "{{ mirror.host }}"
       SB_MIRROR_PUSH_HOST: "{{ mirror.push_host }}"
       SB_MIRROR_UPSTREAMS: "{{ mirror.upstreams }}"
-      # Secret path: keyed off whether the operator delivered a wrap key
-      # via local.yml (value/src), not the shared file. Empty path = no key.
-      SB_UPSTREAM_WRAP_KEY_PATH: "{{ sandboxd_upstream_wrap_key_path if ((sandboxd_upstream_wrap_key_src | length > 0) or (sandboxd_upstream_wrap_key_value | length > 0)) else '' }}"
+      # Secret path: keyed off whether the operator supplied a wrap key in
+      # config/secrets.yml (aocr.upstream_wrap_key) OR via a control-node
+      # file (sandboxd_upstream_wrap_key_src in local.yml). Empty path = no
+      # key, sandboxd skips wrap-key delivery.
+      SB_UPSTREAM_WRAP_KEY_PATH: "{{ sandboxd_upstream_wrap_key_path if ((sandboxd_upstream_wrap_key_src | length > 0) or (aocr.upstream_wrap_key | length > 0)) else '' }}"
       SB_AUTO_IMPORT_ENABLED: "{{ auto_import.enabled | bool | string | lower }}"
       SB_AUTO_IMPORT_HOOKS_URL: "{{ auto_import.hooks_url }}"
       SB_AUTO_IMPORT_CLUSTER_ID: "{{ auto_import.cluster_id }}"
-      # Same secret-vs-shared split as the wrap key.
-      SB_AUTO_IMPORT_CLUSTER_PAT_PATH: "{{ sandboxd_auto_import_cluster_pat_path if ((sandboxd_auto_import_cluster_pat_src | length > 0) or (sandboxd_auto_import_cluster_pat_value | length > 0)) else '' }}"
+      # Same secrets.yml-vs-src split as the wrap key.
+      SB_AUTO_IMPORT_CLUSTER_PAT_PATH: "{{ sandboxd_auto_import_cluster_pat_path if ((sandboxd_auto_import_cluster_pat_src | length > 0) or (aocr.cluster_pat | length > 0)) else '' }}"
       SB_AUTO_IMPORT_RETENTION_SUFFIX: "{{ auto_import.retention_suffix }}"
       SB_AUTO_IMPORT_REQUEST_TIMEOUT: "{{ auto_import.request_timeout }}"
       SB_AUTO_IMPORT_RECONCILE_INTERVAL: "{{ auto_import.reconcile_interval }}"
@@ -167,9 +174,9 @@
     - name: Ensure sandboxd secrets directory exists
       when: >-
         (sandboxd_upstream_wrap_key_src | length > 0)
-        or (sandboxd_upstream_wrap_key_value | length > 0)
+        or (aocr.upstream_wrap_key | length > 0)
         or (sandboxd_auto_import_cluster_pat_src | length > 0)
-        or (sandboxd_auto_import_cluster_pat_value | length > 0)
+        or (aocr.cluster_pat | length > 0)
       ansible.builtin.file:
         path: "{{ sandboxd_secrets_dir }}"
         state: directory
@@ -177,14 +184,14 @@
         owner: root
         group: root
 
-    # Upstream wrap key (Phase 4 F17). Two modes:
-    #   * inline value  -> sandboxd_upstream_wrap_key_value (single-operator / laptop)
+    # Upstream wrap key (Phase 4 F17). Two delivery modes:
+    #   * shared SoT      -> aocr.upstream_wrap_key in config/secrets.yml
     #   * control-node file -> sandboxd_upstream_wrap_key_src (fleet / Vault rendering)
-    # If both are set, the inline value wins (it runs first).
-    - name: Install upstream wrap key (from inline value)
-      when: sandboxd_upstream_wrap_key_value | length > 0
+    # If both are set, the secrets.yml value wins (it runs first).
+    - name: Install upstream wrap key (from config/secrets.yml)
+      when: aocr.upstream_wrap_key | length > 0
       ansible.builtin.copy:
-        content: "{{ sandboxd_upstream_wrap_key_value }}\n"
+        content: "{{ aocr.upstream_wrap_key }}\n"
         dest: "{{ sandboxd_upstream_wrap_key_path }}"
         mode: "0600"
         owner: root
@@ -195,7 +202,7 @@
     - name: Install upstream wrap key (from control-node file)
       when:
         - sandboxd_upstream_wrap_key_src | length > 0
-        - (sandboxd_upstream_wrap_key_value | length) == 0
+        - (aocr.upstream_wrap_key | length) == 0
       ansible.builtin.copy:
         src: "{{ sandboxd_upstream_wrap_key_src }}"
         dest: "{{ sandboxd_upstream_wrap_key_path }}"
@@ -205,10 +212,10 @@
       notify: Apply sandboxd ops config
 
     # Cluster PAT for auto-import (Phase 4 F21). Same two-mode pattern.
-    - name: Install cluster PAT for auto-import (from inline value)
-      when: sandboxd_auto_import_cluster_pat_value | length > 0
+    - name: Install cluster PAT for auto-import (from config/secrets.yml)
+      when: aocr.cluster_pat | length > 0
       ansible.builtin.copy:
-        content: "{{ sandboxd_auto_import_cluster_pat_value }}\n"
+        content: "{{ aocr.cluster_pat }}\n"
         dest: "{{ sandboxd_auto_import_cluster_pat_path }}"
         mode: "0600"
         owner: root
@@ -219,7 +226,7 @@
     - name: Install cluster PAT for auto-import (from control-node file)
       when:
         - sandboxd_auto_import_cluster_pat_src | length > 0
-        - (sandboxd_auto_import_cluster_pat_value | length) == 0
+        - (aocr.cluster_pat | length) == 0
       ansible.builtin.copy:
         src: "{{ sandboxd_auto_import_cluster_pat_src }}"
         dest: "{{ sandboxd_auto_import_cluster_pat_path }}"

--- a/Ansible/playbooks/configure-ops.yml
+++ b/Ansible/playbooks/configure-ops.yml
@@ -1,11 +1,16 @@
 ---
 # Configure sandboxd operational hardening across the fleet.
 #
-# Usage:
-#   ansible-playbook playbooks/configure-ops.yml \
-#     -e sandboxd_otel_metrics_endpoint=http://otel-collector:4318/v1/metrics \
-#     -e sandboxd_otel_traces_endpoint=http://otel-collector:4318/v1/traces \
-#     -e sandboxd_backup_enabled=true
+# All non-secret ops env lives in ../../config/cluster.yml — the shared
+# source of truth Terraform also reads. Edit that file, then:
+#
+#   ansible-playbook playbooks/configure-ops.yml
+#
+# Secrets (wrap key, cluster PAT) still come from local.yml or -e overrides
+# because the shared file is intended to be committable and they are not.
+#
+# Backup cron is also driven from inventory rather than the shared file:
+#   ansible-playbook playbooks/configure-ops.yml -e sandboxd_backup_enabled=true
 
 - name: Configure sandboxd observability and operations
   hosts: all
@@ -14,40 +19,45 @@
   any_errors_fatal: true
   gather_facts: false
 
+  # cluster_ops is the single source of truth, shared with Terraform
+  # (Terraform/locals.tf:cluster_ops). The path is relative to this playbook
+  # file; both tools point at the same on-disk file so day-0 and day-2
+  # rollouts render identical SB_* values into /etc/sandboxd/cluster.env.
+  vars_files:
+    - "../../config/cluster.yml"
+
   vars:
     sandboxd_ops_env:
-      SB_OTEL_METRICS_ENABLED: "{{ ((sandboxd_otel_metrics_enabled | bool) or (sandboxd_otel_metrics_endpoint | length > 0)) | string | lower }}"
-      SB_OTEL_METRICS_ENDPOINT: "{{ sandboxd_otel_metrics_endpoint }}"
-      SB_OTEL_METRICS_INTERVAL: "{{ sandboxd_otel_metrics_interval }}"
-      SB_OTEL_TRACES_ENABLED: "{{ ((sandboxd_otel_traces_enabled | bool) or (sandboxd_otel_traces_endpoint | length > 0)) | string | lower }}"
-      SB_OTEL_TRACES_ENDPOINT: "{{ sandboxd_otel_traces_endpoint }}"
-      SB_OTEL_TRACES_SAMPLE_RATIO: "{{ sandboxd_otel_traces_sample_ratio }}"
-      OTEL_SERVICE_NAME: "{{ sandboxd_otel_service_name }}"
-      SB_IMAGE_PULL_MAX_CONCURRENT: "{{ sandboxd_image_pull_max_concurrent }}"
-      SB_IMAGE_PULL_FAILURE_BACKOFF: "{{ sandboxd_image_pull_failure_backoff }}"
-      # Matches the SB_IMAGE_GC_WHITELIST line Terraform's bootstrap writes
-      # (Terraform/templates/bootstrap.sh.tftpl). Bootstrap only fires at
-      # node provisioning, so without this entry a tfvars change never
-      # reaches a running fleet — the playbook keeps the two in sync.
-      SB_IMAGE_GC_WHITELIST: "{{ sandboxd_image_gc_whitelist }}"
-      # Image GC master switch and cadence — same Terraform-vs-day-2 gap
-      # as the whitelist above. Bool is lowercased so it matches the
-      # "true"/"false" SB_IMAGE_BUILD_GC_ENABLED string config.go expects.
-      SB_IMAGE_BUILD_GC_ENABLED: "{{ sandboxd_image_build_gc_enabled | bool | string | lower }}"
-      SB_IMAGE_BUILD_GC_INTERVAL: "{{ sandboxd_image_build_gc_interval }}"
-      SB_IMAGE_BUILD_GC_TTL: "{{ sandboxd_image_build_gc_ttl }}"
-      SB_MIRROR_HOST: "{{ sandboxd_mirror_host }}"
-      SB_MIRROR_PUSH_HOST: "{{ sandboxd_mirror_push_host }}"
-      SB_MIRROR_UPSTREAMS: "{{ sandboxd_mirror_upstreams }}"
+      SB_OTEL_METRICS_ENABLED: "{{ ((otel.metrics_enabled | bool) or (otel.metrics_endpoint | length > 0)) | string | lower }}"
+      SB_OTEL_METRICS_ENDPOINT: "{{ otel.metrics_endpoint }}"
+      SB_OTEL_METRICS_INTERVAL: "{{ otel.metrics_interval }}"
+      SB_OTEL_TRACES_ENABLED: "{{ ((otel.traces_enabled | bool) or (otel.traces_endpoint | length > 0)) | string | lower }}"
+      SB_OTEL_TRACES_ENDPOINT: "{{ otel.traces_endpoint }}"
+      SB_OTEL_TRACES_SAMPLE_RATIO: "{{ otel.traces_sample_ratio }}"
+      OTEL_SERVICE_NAME: "{{ otel.service_name }}"
+      SB_IMAGE_PULL_MAX_CONCURRENT: "{{ image_pull.max_concurrent }}"
+      SB_IMAGE_PULL_FAILURE_BACKOFF: "{{ image_pull.failure_backoff }}"
+      SB_IMAGE_GC_WHITELIST: "{{ image_gc.whitelist | join(',') }}"
+      # Bool is lowercased so it matches the "true"/"false"
+      # SB_IMAGE_BUILD_GC_ENABLED string config.go expects.
+      SB_IMAGE_BUILD_GC_ENABLED: "{{ image_build_gc.enabled | bool | string | lower }}"
+      SB_IMAGE_BUILD_GC_INTERVAL: "{{ image_build_gc.interval }}"
+      SB_IMAGE_BUILD_GC_TTL: "{{ image_build_gc.ttl }}"
+      SB_MIRROR_HOST: "{{ mirror.host }}"
+      SB_MIRROR_PUSH_HOST: "{{ mirror.push_host }}"
+      SB_MIRROR_UPSTREAMS: "{{ mirror.upstreams }}"
+      # Secret path: keyed off whether the operator delivered a wrap key
+      # via local.yml (value/src), not the shared file. Empty path = no key.
       SB_UPSTREAM_WRAP_KEY_PATH: "{{ sandboxd_upstream_wrap_key_path if ((sandboxd_upstream_wrap_key_src | length > 0) or (sandboxd_upstream_wrap_key_value | length > 0)) else '' }}"
-      SB_AUTO_IMPORT_ENABLED: "{{ sandboxd_auto_import_enabled | bool | string | lower }}"
-      SB_AUTO_IMPORT_HOOKS_URL: "{{ sandboxd_auto_import_hooks_url }}"
-      SB_AUTO_IMPORT_CLUSTER_ID: "{{ sandboxd_auto_import_cluster_id }}"
+      SB_AUTO_IMPORT_ENABLED: "{{ auto_import.enabled | bool | string | lower }}"
+      SB_AUTO_IMPORT_HOOKS_URL: "{{ auto_import.hooks_url }}"
+      SB_AUTO_IMPORT_CLUSTER_ID: "{{ auto_import.cluster_id }}"
+      # Same secret-vs-shared split as the wrap key.
       SB_AUTO_IMPORT_CLUSTER_PAT_PATH: "{{ sandboxd_auto_import_cluster_pat_path if ((sandboxd_auto_import_cluster_pat_src | length > 0) or (sandboxd_auto_import_cluster_pat_value | length > 0)) else '' }}"
-      SB_AUTO_IMPORT_RETENTION_SUFFIX: "{{ sandboxd_auto_import_retention_suffix }}"
-      SB_AUTO_IMPORT_REQUEST_TIMEOUT: "{{ sandboxd_auto_import_request_timeout }}"
-      SB_AUTO_IMPORT_RECONCILE_INTERVAL: "{{ sandboxd_auto_import_reconcile_interval }}"
-      SB_AUTO_IMPORT_MAX_IN_FLIGHT: "{{ sandboxd_auto_import_max_in_flight }}"
+      SB_AUTO_IMPORT_RETENTION_SUFFIX: "{{ auto_import.retention_suffix }}"
+      SB_AUTO_IMPORT_REQUEST_TIMEOUT: "{{ auto_import.request_timeout }}"
+      SB_AUTO_IMPORT_RECONCILE_INTERVAL: "{{ auto_import.reconcile_interval }}"
+      SB_AUTO_IMPORT_MAX_IN_FLIGHT: "{{ auto_import.max_in_flight }}"
 
   pre_tasks:
     - name: Check base sandboxd env file
@@ -218,6 +228,10 @@
         group: root
       notify: Apply sandboxd ops config
 
+    # sandboxd_ops_env at the top of the play renders from cluster.yml plus
+    # the local-only secret paths. No skip-on-empty: both Ansible and
+    # Terraform project from the same SoT, so writing the full dict can't
+    # accidentally clobber a value the other tool set.
     - name: Write sandboxd operational env vars
       ansible.builtin.lineinfile:
         path: "{{ sandboxd_ops_env_file }}"

--- a/Terraform/dns.tf
+++ b/Terraform/dns.tf
@@ -7,11 +7,11 @@
 # A record at it instead.
 #
 # Zone resolution: var.cloudflare_zone_id wins if set. Otherwise we derive the
-# zone name from var.domain_name by stripping the first label
-# ("cluster.example.com" -> "example.com") and look it up via the Cloudflare
-# API. This requires Zone:Read on the API token in addition to Zone:DNS:Edit.
-# Multi-label TLDs (co.uk, com.au, ...) are not handled — pass
-# cloudflare_zone_id explicitly in that case.
+# zone name from cluster.yml's ingress.domain_name by stripping the first
+# label ("cluster.example.com" -> "example.com") and look it up via the
+# Cloudflare API. This requires Zone:Read on the API token in addition to
+# Zone:DNS:Edit. Multi-label TLDs (co.uk, com.au, ...) are not handled —
+# pass cloudflare_zone_id explicitly in that case.
 ###############################################################################
 
 locals {
@@ -22,8 +22,8 @@ locals {
 
   # Strip the leftmost label to get the zone for subdomain inputs.
   # "cluster.example.com" -> "example.com"; "example.com" -> "example.com".
-  domain_labels         = split(".", var.domain_name)
-  derived_zone_name     = length(local.domain_labels) > 2 ? join(".", slice(local.domain_labels, 1, length(local.domain_labels))) : var.domain_name
+  domain_labels         = split(".", local.domain_name)
+  derived_zone_name     = length(local.domain_labels) > 2 ? join(".", slice(local.domain_labels, 1, length(local.domain_labels))) : local.domain_name
   resolve_zone_from_api = var.cloudflare_zone_id == ""
 }
 
@@ -47,7 +47,7 @@ resource "cloudflare_record" "apex" {
   for_each = local.ingress_ip_by_node
 
   zone_id = local.effective_zone_id
-  name    = var.domain_name
+  name    = local.domain_name
   type    = "A"
   content = each.value
   ttl     = var.cloudflare_record_ttl
@@ -59,7 +59,7 @@ resource "cloudflare_record" "wildcard" {
   for_each = var.create_wildcard_record ? local.ingress_ip_by_node : {}
 
   zone_id = local.effective_zone_id
-  name    = "*.${var.domain_name}"
+  name    = "*.${local.domain_name}"
   type    = "A"
   content = each.value
   ttl     = var.cloudflare_record_ttl

--- a/Terraform/locals.tf
+++ b/Terraform/locals.tf
@@ -1,4 +1,11 @@
 locals {
+  # Operational env vars come from the shared SoT file that Ansible also
+  # reads (../config/cluster.yml). Both tools render identical SB_* values
+  # into /etc/sandboxd/cluster.env so day-0 (terraform apply) and day-2
+  # (ansible-playbook configure-ops.yml) can't drift. Tool-specific concerns
+  # — cluster topology, cloud creds, AOCR secrets — stay in terraform.tfvars.
+  cluster_ops = yamldecode(file("${path.module}/../config/cluster.yml"))
+
   # Normalise each node entry with its effective values (per-node overrides
   # win, then var.default_*). Doing this once here keeps nodes.tf / dns.tf
   # readable.
@@ -93,25 +100,97 @@ locals {
     )
   }
 
-  # AOCR (Phase 4 F17-F21) — resolved view for bootstrap.sh.tftpl. Same
-  # pattern as caddy_storage_s3: when enabled is false, every field
-  # collapses to its empty/default value so the template can splat the
-  # whole shape unconditionally and the `if aocr_enabled` block stays
-  # the only branch the renderer evaluates.
+  # AOCR (Phase 4 F17-F21) — resolved view for bootstrap.sh.tftpl. Non-secret
+  # config (mirror host, upstreams, auto-import toggle, cluster_id, ...)
+  # comes from the shared SoT in config/cluster.yml; secrets (wrap key,
+  # cluster PAT) stay in var.aocr_secrets because Terraform delivers them
+  # via cloud-init. enabled is derived: any non-empty mirror host OR
+  # auto-import on is enough to activate the AOCR template section.
+  aocr_enabled = (
+    local.cluster_ops.mirror.host != ""
+    || local.cluster_ops.auto_import.enabled
+  )
   aocr = {
-    enabled             = var.aocr.enabled
-    mirror_host         = var.aocr.enabled ? var.aocr.mirror_host : ""
-    mirror_push_host    = var.aocr.enabled ? var.aocr.mirror_push_host : ""
-    mirror_upstreams    = var.aocr.enabled ? var.aocr.mirror_upstreams : ""
-    upstream_wrap_key   = var.aocr.enabled ? var.aocr.upstream_wrap_key : ""
-    auto_import_enabled = var.aocr.enabled && var.aocr.auto_import_enabled
-    hooks_url           = var.aocr.enabled ? var.aocr.hooks_url : ""
-    cluster_id          = var.aocr.enabled ? var.aocr.cluster_id : ""
-    cluster_pat         = var.aocr.enabled ? var.aocr.cluster_pat : ""
-    retention_suffix    = var.aocr.enabled ? var.aocr.retention_suffix : "--idle-90d"
-    request_timeout     = var.aocr.enabled ? var.aocr.request_timeout : "15s"
-    reconcile_interval  = var.aocr.enabled ? var.aocr.reconcile_interval : "5m"
-    max_in_flight       = var.aocr.enabled ? var.aocr.max_in_flight : 4
+    enabled             = local.aocr_enabled
+    mirror_host         = local.aocr_enabled ? local.cluster_ops.mirror.host : ""
+    mirror_push_host    = local.aocr_enabled ? local.cluster_ops.mirror.push_host : ""
+    mirror_upstreams    = local.aocr_enabled ? local.cluster_ops.mirror.upstreams : ""
+    upstream_wrap_key   = local.aocr_enabled ? var.aocr_secrets.upstream_wrap_key : ""
+    auto_import_enabled = local.aocr_enabled && local.cluster_ops.auto_import.enabled
+    hooks_url           = local.aocr_enabled ? local.cluster_ops.auto_import.hooks_url : ""
+    cluster_id          = local.aocr_enabled ? local.cluster_ops.auto_import.cluster_id : ""
+    cluster_pat         = local.aocr_enabled ? var.aocr_secrets.cluster_pat : ""
+    retention_suffix    = local.aocr_enabled ? local.cluster_ops.auto_import.retention_suffix : "--idle-90d"
+    request_timeout     = local.aocr_enabled ? local.cluster_ops.auto_import.request_timeout : "15s"
+    reconcile_interval  = local.aocr_enabled ? local.cluster_ops.auto_import.reconcile_interval : "5m"
+    max_in_flight       = local.aocr_enabled ? local.cluster_ops.auto_import.max_in_flight : 4
+  }
+}
+
+# Plan-time validation of values that come from local.cluster_ops. Terraform
+# does not allow `validation {}` blocks on locals directly, so we hang the
+# preconditions off a free terraform_data resource (no apply-time side
+# effects). All four mirror what var.aocr's validation blocks did before
+# config/cluster.yml became the source of those fields.
+resource "terraform_data" "validate_cluster_ops" {
+  lifecycle {
+    precondition {
+      condition = (
+        !local.cluster_ops.auto_import.enabled
+        || (
+          local.cluster_ops.auto_import.hooks_url != ""
+          && local.cluster_ops.auto_import.cluster_id != ""
+          && var.aocr_secrets.cluster_pat != ""
+        )
+      )
+      error_message = "When auto_import.enabled = true in config/cluster.yml, auto_import.hooks_url, auto_import.cluster_id, and aocr_secrets.cluster_pat are all required (sandboxd refuses to boot otherwise)."
+    }
+
+    precondition {
+      condition = (
+        local.cluster_ops.auto_import.cluster_id == ""
+        || can(regex("^[A-Za-z0-9_-]{1,64}$", local.cluster_ops.auto_import.cluster_id))
+      )
+      error_message = "auto_import.cluster_id must match ^[A-Za-z0-9_-]{1,64}$ (matches AOCR ImportAPI validation)."
+    }
+
+    precondition {
+      condition = (
+        local.cluster_ops.auto_import.retention_suffix == ""
+        || can(regex("^--[a-z0-9]+(-[a-z0-9]+)*$", local.cluster_ops.auto_import.retention_suffix))
+      )
+      error_message = "auto_import.retention_suffix must start with '--' followed by lowercase alphanumerics, e.g. '--idle-90d'."
+    }
+
+    precondition {
+      condition = (
+        can(regex("^[0-9]+(ns|us|ms|s|m|h)$", local.cluster_ops.otel.metrics_interval))
+        && can(regex("^[0-9]+(ns|us|ms|s|m|h)$", local.cluster_ops.image_pull.failure_backoff))
+        && can(regex("^[0-9]+(ns|us|ms|s|m|h)$", local.cluster_ops.image_build_gc.interval))
+        && can(regex("^[0-9]+(ns|us|ms|s|m|h)$", local.cluster_ops.image_build_gc.ttl))
+        && can(regex("^[0-9]+(ns|us|ms|s|m|h)$", local.cluster_ops.auto_import.request_timeout))
+        && can(regex("^[0-9]+(ns|us|ms|s|m|h)$", local.cluster_ops.auto_import.reconcile_interval))
+      )
+      error_message = "Duration fields in config/cluster.yml must be Go durations such as 30s, 10m, 1h."
+    }
+
+    precondition {
+      condition = (
+        local.cluster_ops.otel.traces_sample_ratio >= 0
+        && local.cluster_ops.otel.traces_sample_ratio <= 1
+      )
+      error_message = "otel.traces_sample_ratio must be between 0 and 1."
+    }
+
+    precondition {
+      condition     = local.cluster_ops.image_pull.max_concurrent >= 0
+      error_message = "image_pull.max_concurrent must be >= 0."
+    }
+
+    precondition {
+      condition     = local.cluster_ops.auto_import.max_in_flight >= 1
+      error_message = "auto_import.max_in_flight must be >= 1."
+    }
   }
 }
 

--- a/Terraform/locals.tf
+++ b/Terraform/locals.tf
@@ -3,8 +3,23 @@ locals {
   # reads (../config/cluster.yml). Both tools render identical SB_* values
   # into /etc/sandboxd/cluster.env so day-0 (terraform apply) and day-2
   # (ansible-playbook configure-ops.yml) can't drift. Tool-specific concerns
-  # — cluster topology, cloud creds, AOCR secrets — stay in terraform.tfvars.
+  # — cluster topology, cloud creds — stay in terraform.tfvars.
   cluster_ops = yamldecode(file("${path.module}/../config/cluster.yml"))
+
+  # Cluster SECRETS (shared SB_PAT_TOKEN + AOCR wrap key + cluster PAT) live
+  # in the parallel SoT file ../config/secrets.yml. Gitignored; operators
+  # bootstrap with `cp config/secrets.example.yml config/secrets.yml`.
+  # sensitive() marks the whole decoded tree so values stay redacted in plan
+  # / apply output and propagate through any references into resource args.
+  cluster_secrets = sensitive(yamldecode(file("${path.module}/../config/secrets.yml")))
+
+  # Shared cluster-identity values that both Terraform (day-0 cloud-init +
+  # DNS records) and Ansible (day-2 rotation) read from the SoT. Lifted into
+  # named locals so the rest of the .tf files don't sprinkle
+  # local.cluster_ops.ingress.* / local.cluster_secrets.cluster.* everywhere.
+  domain_name = local.cluster_ops.ingress.domain_name
+  acme_email  = local.cluster_ops.ingress.acme_email
+  pat_token   = local.cluster_secrets.cluster.pat_token
 
   # Normalise each node entry with its effective values (per-node overrides
   # win, then var.default_*). Doing this once here keeps nodes.tf / dns.tf
@@ -103,9 +118,9 @@ locals {
   # AOCR (Phase 4 F17-F21) — resolved view for bootstrap.sh.tftpl. Non-secret
   # config (mirror host, upstreams, auto-import toggle, cluster_id, ...)
   # comes from the shared SoT in config/cluster.yml; secrets (wrap key,
-  # cluster PAT) stay in var.aocr_secrets because Terraform delivers them
-  # via cloud-init. enabled is derived: any non-empty mirror host OR
-  # auto-import on is enough to activate the AOCR template section.
+  # cluster PAT) come from the parallel SoT config/secrets.yml. Terraform
+  # delivers both via cloud-init. enabled is derived: any non-empty mirror
+  # host OR auto-import on is enough to activate the AOCR template section.
   aocr_enabled = (
     local.cluster_ops.mirror.host != ""
     || local.cluster_ops.auto_import.enabled
@@ -115,11 +130,11 @@ locals {
     mirror_host         = local.aocr_enabled ? local.cluster_ops.mirror.host : ""
     mirror_push_host    = local.aocr_enabled ? local.cluster_ops.mirror.push_host : ""
     mirror_upstreams    = local.aocr_enabled ? local.cluster_ops.mirror.upstreams : ""
-    upstream_wrap_key   = local.aocr_enabled ? var.aocr_secrets.upstream_wrap_key : ""
+    upstream_wrap_key   = local.aocr_enabled ? local.cluster_secrets.aocr.upstream_wrap_key : ""
     auto_import_enabled = local.aocr_enabled && local.cluster_ops.auto_import.enabled
     hooks_url           = local.aocr_enabled ? local.cluster_ops.auto_import.hooks_url : ""
     cluster_id          = local.aocr_enabled ? local.cluster_ops.auto_import.cluster_id : ""
-    cluster_pat         = local.aocr_enabled ? var.aocr_secrets.cluster_pat : ""
+    cluster_pat         = local.aocr_enabled ? local.cluster_secrets.aocr.cluster_pat : ""
     retention_suffix    = local.aocr_enabled ? local.cluster_ops.auto_import.retention_suffix : "--idle-90d"
     request_timeout     = local.aocr_enabled ? local.cluster_ops.auto_import.request_timeout : "15s"
     reconcile_interval  = local.aocr_enabled ? local.cluster_ops.auto_import.reconcile_interval : "5m"
@@ -140,10 +155,10 @@ resource "terraform_data" "validate_cluster_ops" {
         || (
           local.cluster_ops.auto_import.hooks_url != ""
           && local.cluster_ops.auto_import.cluster_id != ""
-          && var.aocr_secrets.cluster_pat != ""
+          && local.cluster_secrets.aocr.cluster_pat != ""
         )
       )
-      error_message = "When auto_import.enabled = true in config/cluster.yml, auto_import.hooks_url, auto_import.cluster_id, and aocr_secrets.cluster_pat are all required (sandboxd refuses to boot otherwise)."
+      error_message = "When auto_import.enabled = true in config/cluster.yml, auto_import.hooks_url, auto_import.cluster_id, and aocr.cluster_pat in config/secrets.yml are all required (sandboxd refuses to boot otherwise)."
     }
 
     precondition {
@@ -190,6 +205,11 @@ resource "terraform_data" "validate_cluster_ops" {
     precondition {
       condition     = local.cluster_ops.auto_import.max_in_flight >= 1
       error_message = "auto_import.max_in_flight must be >= 1."
+    }
+
+    precondition {
+      condition     = local.pat_token != ""
+      error_message = "cluster.pat_token in config/secrets.yml must be set (shared SB_PAT_TOKEN used by every node for operator/SDK API auth)."
     }
   }
 }

--- a/Terraform/nodes.tf
+++ b/Terraform/nodes.tf
@@ -42,10 +42,10 @@ resource "aws_instance" "seed" {
     node_name                  = "${var.cluster_name}-${local.seed_node.name}"
     role                       = local.seed_node.role
     is_seed                    = true
-    domain                     = var.domain_name
-    pat_token                  = var.pat_token
+    domain                     = local.domain_name
+    pat_token                  = local.pat_token
     cloudflare_api_token       = var.cloudflare_api_token
-    acme_email                 = var.acme_email
+    acme_email                 = local.acme_email
     with_gvisor                = local.seed_node.with_gvisor
     with_nvidia_gpu            = local.seed_node.with_nvidia_gpu
     with_amd_gpu               = local.seed_node.with_amd_gpu
@@ -143,10 +143,10 @@ resource "aws_instance" "joiner" {
     node_name                  = "${var.cluster_name}-${each.value.name}"
     role                       = each.value.role
     is_seed                    = false
-    domain                     = var.domain_name
-    pat_token                  = var.pat_token
+    domain                     = local.domain_name
+    pat_token                  = local.pat_token
     cloudflare_api_token       = var.cloudflare_api_token
-    acme_email                 = var.acme_email
+    acme_email                 = local.acme_email
     with_gvisor                = each.value.with_gvisor
     with_nvidia_gpu            = each.value.with_nvidia_gpu
     with_amd_gpu               = each.value.with_amd_gpu

--- a/Terraform/nodes.tf
+++ b/Terraform/nodes.tf
@@ -57,19 +57,19 @@ resource "aws_instance" "seed" {
     cluster_init_script_url    = var.cluster_init_script_url
     cluster_join_script_url    = var.cluster_join_script_url
     seed_wait_max_seconds      = var.seed_wait_max_seconds
-    otel_metrics_enabled       = var.otel_metrics_enabled || var.otel_metrics_endpoint != ""
-    otel_metrics_endpoint      = var.otel_metrics_endpoint
-    otel_metrics_interval      = var.otel_metrics_interval
-    otel_traces_enabled        = var.otel_traces_enabled || var.otel_traces_endpoint != ""
-    otel_traces_endpoint       = var.otel_traces_endpoint
-    otel_traces_sample_ratio   = var.otel_traces_sample_ratio
-    otel_service_name          = var.otel_service_name
-    image_pull_max_concurrent  = var.image_pull_max_concurrent
-    image_pull_failure_backoff = var.image_pull_failure_backoff
-    image_gc_whitelist         = join(",", var.image_gc_whitelist)
-    image_build_gc_enabled     = var.image_build_gc_enabled
-    image_build_gc_interval    = var.image_build_gc_interval
-    image_build_gc_ttl         = var.image_build_gc_ttl
+    otel_metrics_enabled       = local.cluster_ops.otel.metrics_enabled || local.cluster_ops.otel.metrics_endpoint != ""
+    otel_metrics_endpoint      = local.cluster_ops.otel.metrics_endpoint
+    otel_metrics_interval      = local.cluster_ops.otel.metrics_interval
+    otel_traces_enabled        = local.cluster_ops.otel.traces_enabled || local.cluster_ops.otel.traces_endpoint != ""
+    otel_traces_endpoint       = local.cluster_ops.otel.traces_endpoint
+    otel_traces_sample_ratio   = local.cluster_ops.otel.traces_sample_ratio
+    otel_service_name          = local.cluster_ops.otel.service_name
+    image_pull_max_concurrent  = local.cluster_ops.image_pull.max_concurrent
+    image_pull_failure_backoff = local.cluster_ops.image_pull.failure_backoff
+    image_gc_whitelist         = join(",", local.cluster_ops.image_gc.whitelist)
+    image_build_gc_enabled     = local.cluster_ops.image_build_gc.enabled
+    image_build_gc_interval    = local.cluster_ops.image_build_gc.interval
+    image_build_gc_ttl         = local.cluster_ops.image_build_gc.ttl
     extra_user_data            = local.seed_node.extra_user_data
     # Shared S3-backed Caddy cert storage — see local.caddy_storage_s3.
     caddy_storage_s3_enabled        = local.caddy_storage_s3.enabled
@@ -158,19 +158,19 @@ resource "aws_instance" "joiner" {
     cluster_init_script_url    = var.cluster_init_script_url
     cluster_join_script_url    = var.cluster_join_script_url
     seed_wait_max_seconds      = var.seed_wait_max_seconds
-    otel_metrics_enabled       = var.otel_metrics_enabled || var.otel_metrics_endpoint != ""
-    otel_metrics_endpoint      = var.otel_metrics_endpoint
-    otel_metrics_interval      = var.otel_metrics_interval
-    otel_traces_enabled        = var.otel_traces_enabled || var.otel_traces_endpoint != ""
-    otel_traces_endpoint       = var.otel_traces_endpoint
-    otel_traces_sample_ratio   = var.otel_traces_sample_ratio
-    otel_service_name          = var.otel_service_name
-    image_pull_max_concurrent  = var.image_pull_max_concurrent
-    image_pull_failure_backoff = var.image_pull_failure_backoff
-    image_gc_whitelist         = join(",", var.image_gc_whitelist)
-    image_build_gc_enabled     = var.image_build_gc_enabled
-    image_build_gc_interval    = var.image_build_gc_interval
-    image_build_gc_ttl         = var.image_build_gc_ttl
+    otel_metrics_enabled       = local.cluster_ops.otel.metrics_enabled || local.cluster_ops.otel.metrics_endpoint != ""
+    otel_metrics_endpoint      = local.cluster_ops.otel.metrics_endpoint
+    otel_metrics_interval      = local.cluster_ops.otel.metrics_interval
+    otel_traces_enabled        = local.cluster_ops.otel.traces_enabled || local.cluster_ops.otel.traces_endpoint != ""
+    otel_traces_endpoint       = local.cluster_ops.otel.traces_endpoint
+    otel_traces_sample_ratio   = local.cluster_ops.otel.traces_sample_ratio
+    otel_service_name          = local.cluster_ops.otel.service_name
+    image_pull_max_concurrent  = local.cluster_ops.image_pull.max_concurrent
+    image_pull_failure_backoff = local.cluster_ops.image_pull.failure_backoff
+    image_gc_whitelist         = join(",", local.cluster_ops.image_gc.whitelist)
+    image_build_gc_enabled     = local.cluster_ops.image_build_gc.enabled
+    image_build_gc_interval    = local.cluster_ops.image_build_gc.interval
+    image_build_gc_ttl         = local.cluster_ops.image_build_gc.ttl
     extra_user_data            = each.value.extra_user_data
     # Shared S3-backed Caddy cert storage — see local.caddy_storage_s3.
     caddy_storage_s3_enabled        = local.caddy_storage_s3.enabled

--- a/Terraform/outputs.tf
+++ b/Terraform/outputs.tf
@@ -27,7 +27,7 @@ output "ingress_public_ips" {
 }
 
 output "ingress_hostname" {
-  value = var.domain_name
+  value = local.domain_name
 }
 
 output "bundle_bucket" {

--- a/Terraform/terraform.tfvars.example
+++ b/Terraform/terraform.tfvars.example
@@ -4,11 +4,14 @@
 ###############################################################################
 
 # --- Required ---------------------------------------------------------------
+#
+# Cluster-wide values that both Terraform and Ansible read have moved out of
+# this file and into the shared SoT at ../config/:
+#   - pat_token              -> config/secrets.yml as cluster.pat_token
+#   - domain_name, acme_email -> config/cluster.yml under the ingress: section
+# Only the Terraform-provider credential (DNS API access) remains here.
 
-pat_token            = "REPLACE-with-shared-SB_PAT_TOKEN"
 cloudflare_api_token = "REPLACE-with-cloudflare-api-token" # Zone:DNS:Edit on the target zone; reused for Let's Encrypt DNS-01. Add Zone:Read if you want auto-zone-lookup below.
-domain_name          = "cluster.example.com"               # set empty to skip TLS and run in IP/path mode
-acme_email           = "ops@example.com"                   # Let's Encrypt contact email (expiry/revocation notices). Strongly recommended in domain mode; empty creates an anonymous ACME account with no notifications.
 
 # cloudflare_zone_id is optional. Leave it unset to auto-resolve the zone from
 # domain_name by stripping the first label ("cluster.example.com" -> "example.com").
@@ -50,9 +53,10 @@ default_volume_type       = "gp3"
 #
 # All non-secret sandboxd ops env (OTEL, image-pull controls, image-GC
 # whitelist + janitor cadence, mirror host, auto-import toggles, ...) lives
-# in ../config/cluster.yml. Edit that file; both `terraform apply` and
-# `ansible-playbook playbooks/configure-ops.yml` read from it, so day-0
-# and day-2 stay in sync. Only AOCR secrets remain in this file (below).
+# in ../config/cluster.yml. AOCR secrets (upstream_wrap_key, cluster_pat)
+# live in ../config/secrets.yml (copy from secrets.example.yml — gitignored).
+# Both files are read by `terraform apply` and `ansible-playbook
+# playbooks/configure-ops.yml` so day-0 and day-2 stay in sync.
 
 # --- Cloudflare DNS behavior ------------------------------------------------
 
@@ -149,16 +153,6 @@ nodes = {
 #   Owner = "platform-team"
 # }
 
-# --- AOCR secrets (authenticated mirror + auto-import) ----------------------
-#
-# Only credentials live here. The mirror host, upstreams, auto-import
-# toggle/hooks_url/cluster_id, retention/timeouts, etc. are in
-# ../config/cluster.yml (shared with Ansible). Setting the secrets without
-# flipping mirror.host / auto_import.enabled in cluster.yml is a no-op:
-# the bootstrap template only renders the AOCR section when one of those
-# is non-empty.
-#
-# aocr_secrets = {
-#   upstream_wrap_key = "REPLACE-with-base64-32-byte-key-from-aocr-secrets/upstream_wrap_key"
-#   cluster_pat       = "REPLACE-with-internal-api-token"
-# }
+# AOCR secrets (upstream_wrap_key, cluster_pat) live in ../config/secrets.yml
+# — the shared SoT Ansible also reads. There is no aocr_secrets variable in
+# this file anymore; populate config/secrets.yml instead.

--- a/Terraform/terraform.tfvars.example
+++ b/Terraform/terraform.tfvars.example
@@ -47,42 +47,12 @@ default_volume_type       = "gp3"
 # default_idle_timeout_min = 0       # sandbox auto-stop minutes; 0 disables
 
 # --- Observability / operational hardening ----------------------------------
-
-# Prometheus scrapes every node at /v1/metrics with the shared PAT. Terraform
-# outputs private-IP scrape targets after apply.
 #
-# Native OTEL export is optional. Setting an endpoint enables the matching
-# exporter and writes the SB_OTEL_* values into cluster.env.
-# otel_metrics_endpoint = "http://otel-collector.internal:4318/v1/metrics"
-# otel_metrics_interval = "30s"
-# otel_traces_endpoint = "http://otel-collector.internal:4318/v1/traces"
-# otel_traces_sample_ratio = 0.05
-# otel_service_name     = "sandboxd"
-
-# Docker image-pull storm controls. These are written into cluster.env on every
-# node; defaults match sandboxd's runtime defaults.
-# image_pull_max_concurrent  = 4
-# image_pull_failure_backoff = "30s"
-
-# Image-GC whitelist: repositories or refs the GC janitors must never remove.
-# Empty (default) means every image is eligible. Three match shapes:
-#   - exact ref                ("alpine:latest" — only that tag survives)
-#   - repo, tag/digest agnostic ("ubuntu" — every tag and digest of ubuntu)
-#   - registry/org prefix       (trailing "/" — "ghcr.io/myorg/" matches all)
-# Written into cluster.env as SB_IMAGE_GC_WHITELIST (comma-joined).
-# image_gc_whitelist = [
-#   "alpine",            # always keep alpine cached, any tag
-#   "ubuntu:22.04",      # only that specific tag
-#   "ghcr.io/myorg/",    # everything from this org
-# ]
-
-# Image GC janitors — master switch and cadence. Both knobs apply to BOTH
-# sweeps (built images + pending-destroy images). Defaults match sandboxd:
-# enabled, fire every 10m, 24h minimum age. Shorten the TTL when disk
-# pressure outweighs the cost of re-pulling on destroy/recreate cycles.
-# image_build_gc_enabled  = true
-# image_build_gc_interval = "10m"
-# image_build_gc_ttl      = "24h"
+# All non-secret sandboxd ops env (OTEL, image-pull controls, image-GC
+# whitelist + janitor cadence, mirror host, auto-import toggles, ...) lives
+# in ../config/cluster.yml. Edit that file; both `terraform apply` and
+# `ansible-playbook playbooks/configure-ops.yml` read from it, so day-0
+# and day-2 stay in sync. Only AOCR secrets remain in this file (below).
 
 # --- Cloudflare DNS behavior ------------------------------------------------
 
@@ -179,35 +149,16 @@ nodes = {
 #   Owner = "platform-team"
 # }
 
-# --- AOCR (authenticated mirror + auto-import) ------------------------------
+# --- AOCR secrets (authenticated mirror + auto-import) ----------------------
 #
-# Day-0 wiring against an already-deployed AOCR (Phase 4 F17-F21). Off by
-# default; flip enabled = true to template SB_MIRROR_* / SB_AUTO_IMPORT_*
-# into cluster.env and install wrap-key + cluster-PAT secrets under
-# /etc/sandboxd/secrets/ on every node. See sandbox-library/AUTHENTICATED_MIRROR.md.
+# Only credentials live here. The mirror host, upstreams, auto-import
+# toggle/hooks_url/cluster_id, retention/timeouts, etc. are in
+# ../config/cluster.yml (shared with Ansible). Setting the secrets without
+# flipping mirror.host / auto_import.enabled in cluster.yml is a no-op:
+# the bootstrap template only renders the AOCR section when one of those
+# is non-empty.
 #
-# Mirror-only mode (cache + credential wrapping, no Raft-coordinated
-# imports). Pulls flowing through SB_MIRROR_HOST get private upstream
-# credentials wrapped with upstream_wrap_key before they leave the node.
-# aocr = {
-#   enabled            = true
-#   mirror_host        = "mirror.aocr.aerol.ai"
-#   mirror_push_host   = "aocr.aerol.ai"
-#   upstream_wrap_key  = "REPLACE-with-base64-32-byte-key-from-aocr-secrets/upstream_wrap_key"
-# }
-#
-# Mirror + auto-import (full F21). hooks_url / cluster_id / cluster_pat are
-# required when auto_import_enabled = true (plan-time validation matches
-# sandboxd's startup guard). cluster_pat must equal the AOCR side's
-# INTERNAL_API_TOKEN (file aocr/secrets/internal_api_token).
-# aocr = {
-#   enabled             = true
-#   mirror_host         = "mirror.aocr.aerol.ai"
-#   mirror_push_host    = "aocr.aerol.ai"
-#   upstream_wrap_key   = "REPLACE-with-base64-32-byte-key"
-#   auto_import_enabled = true
-#   hooks_url           = "https://aocr.aerol.ai"
-#   cluster_id          = "prod-aerolvm-us-east-1"
-#   cluster_pat         = "REPLACE-with-internal-api-token"
-#   retention_suffix    = "--idle-90d"
+# aocr_secrets = {
+#   upstream_wrap_key = "REPLACE-with-base64-32-byte-key-from-aocr-secrets/upstream_wrap_key"
+#   cluster_pat       = "REPLACE-with-internal-api-token"
 # }

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -281,121 +281,11 @@ variable "default_idle_timeout_min" {
 # Observability and operational hardening
 ###############################################################################
 
-variable "otel_metrics_enabled" {
-  description = "Enable sandboxd's native OTLP/HTTP metrics exporter. Automatically true when otel_metrics_endpoint is non-empty."
-  type        = bool
-  default     = false
-}
-
-variable "otel_metrics_endpoint" {
-  description = "OTLP/HTTP metrics endpoint written as SB_OTEL_METRICS_ENDPOINT, for example http://otel-collector:4318/v1/metrics. Empty disables endpoint-specific config."
-  type        = string
-  default     = ""
-}
-
-variable "otel_metrics_interval" {
-  description = "sandboxd OTEL metrics export interval written as SB_OTEL_METRICS_INTERVAL."
-  type        = string
-  default     = "30s"
-
-  validation {
-    condition     = can(regex("^[0-9]+(ns|us|ms|s|m|h)$", var.otel_metrics_interval))
-    error_message = "otel_metrics_interval must be a Go duration such as 30s, 1m, or 500ms."
-  }
-}
-
-variable "otel_traces_enabled" {
-  description = "Enable sandboxd's native OTLP/HTTP trace exporter. Automatically true when otel_traces_endpoint is non-empty."
-  type        = bool
-  default     = false
-}
-
-variable "otel_traces_endpoint" {
-  description = "OTLP/HTTP traces endpoint written as SB_OTEL_TRACES_ENDPOINT, for example http://otel-collector:4318/v1/traces. Empty disables endpoint-specific config."
-  type        = string
-  default     = ""
-}
-
-variable "otel_traces_sample_ratio" {
-  description = "Parent-based trace sample ratio written as SB_OTEL_TRACES_SAMPLE_RATIO. 0 disables local sampling; 1 samples every root trace."
-  type        = number
-  default     = 0.05
-
-  validation {
-    condition     = var.otel_traces_sample_ratio >= 0 && var.otel_traces_sample_ratio <= 1
-    error_message = "otel_traces_sample_ratio must be between 0 and 1."
-  }
-}
-
-variable "otel_service_name" {
-  description = "OTEL_SERVICE_NAME written into sandboxd env."
-  type        = string
-  default     = "sandboxd"
-}
-
-variable "image_pull_max_concurrent" {
-  description = "Per-worker cap on concurrent Docker image pulls. 0 disables the cap."
-  type        = number
-  default     = 4
-
-  validation {
-    condition     = var.image_pull_max_concurrent >= 0
-    error_message = "image_pull_max_concurrent must be >= 0."
-  }
-}
-
-variable "image_pull_failure_backoff" {
-  description = "Per-image/auth retry suppression after a failed pull, written as SB_IMAGE_PULL_FAILURE_BACKOFF. Use 0s to disable."
-  type        = string
-  default     = "30s"
-
-  validation {
-    condition     = can(regex("^[0-9]+(ns|us|ms|s|m|h)$", var.image_pull_failure_backoff))
-    error_message = "image_pull_failure_backoff must be a Go duration such as 30s, 1m, or 0s."
-  }
-}
-
-variable "image_gc_whitelist" {
-  description = <<-EOT
-    Image repositories or refs the GC janitors must never remove. Three
-    match shapes:
-      - exact ref ("alpine:latest" — only that tag survives)
-      - repo, tag/digest agnostic ("ubuntu" — every tag/digest of ubuntu)
-      - registry/org prefix when the entry ends in "/" ("ghcr.io/myorg/")
-    Written as SB_IMAGE_GC_WHITELIST (comma-joined). Empty list (default)
-    preserves today's behavior — every image is eligible for GC.
-  EOT
-  type        = list(string)
-  default     = []
-}
-
-variable "image_build_gc_enabled" {
-  description = "Master switch for BOTH image janitors (built-image sweep + pending-image sweep). Written as SB_IMAGE_BUILD_GC_ENABLED. true (default) matches the sandboxd default; flip to false to disable both sweeps without unsetting the interval/TTL knobs."
-  type        = bool
-  default     = true
-}
-
-variable "image_build_gc_interval" {
-  description = "How often each image janitor ticker fires, written as SB_IMAGE_BUILD_GC_INTERVAL. Go duration."
-  type        = string
-  default     = "10m"
-
-  validation {
-    condition     = can(regex("^[0-9]+(ns|us|ms|s|m|h)$", var.image_build_gc_interval))
-    error_message = "image_build_gc_interval must be a Go duration such as 30s, 10m, or 1h."
-  }
-}
-
-variable "image_build_gc_ttl" {
-  description = "Minimum age before an image becomes eligible for GC removal (both built images and pending-destroy images). Written as SB_IMAGE_BUILD_GC_TTL. Go duration. Default 24h trades disk for warm-start latency: shorter values reclaim disk faster but re-pull on destroy/recreate cycles inside the window."
-  type        = string
-  default     = "24h"
-
-  validation {
-    condition     = can(regex("^[0-9]+(ns|us|ms|s|m|h)$", var.image_build_gc_ttl))
-    error_message = "image_build_gc_ttl must be a Go duration such as 1h, 24h, or 7d expressed as 168h."
-  }
-}
+# Observability, image-pull controls, image-GC, mirror/auto-import config —
+# everything except secrets — lives in ../config/cluster.yml. That file is
+# the single source of truth both Terraform and Ansible read from, so
+# day-0 (terraform apply) and day-2 (configure-ops.yml) cannot drift.
+# See locals.tf:cluster_ops and resource.terraform_data.validate_cluster_ops.
 
 ###############################################################################
 # Cloudflare DNS
@@ -550,107 +440,26 @@ variable "caddy_shared_cert_storage" {
 # keeps them out of plan/apply output.
 ###############################################################################
 
-variable "aocr" {
+variable "aocr_secrets" {
   description = <<-EOT
-    Connect this cluster to an already-deployed AOCR.
+    AOCR credentials Terraform delivers via cloud-init. Only secrets live
+    here; everything else (mirror host, upstreams, auto_import toggle,
+    cluster_id, hooks_url, retention/timeout knobs) is in
+    ../config/cluster.yml because Ansible reads the same file at day-2.
 
-    enabled              Master switch. When false, no AOCR env or secret
-                         files are templated.
-    mirror_host          Mirror vhost for cached pulls (e.g.
-                         "mirror.aocr.aerol.ai"). Empty disables rewrite
-                         even when enabled = true (auto-import can still
-                         run on its own).
-    mirror_push_host     Push vhost for the same AOCR cluster (e.g.
-                         "aocr.aerol.ai"). Refs already pointing here are
-                         left alone so they are not double-rewritten.
-    mirror_upstreams     Comma-separated host=short map of upstreams the
-                         mirror handles. Default covers ghcr/gcr/quay/k8s.
-    upstream_wrap_key    Base64-encoded 32-byte AES-GCM key. Must equal
-                         the active key in AOCR's UPSTREAM_AUTH_WRAP_KEYS
-                         (use the value from secrets/upstream_wrap_key
-                         emitted by the AOCR Ansible playbook). Empty
-                         disables credential wrapping; private pulls 401.
-    auto_import_enabled  Turn on post-pull auto-import (F21). When true,
-                         hooks_url + cluster_id + cluster_pat are required
-                         (plan-time validation mirrors sandboxd's startup
-                         guard).
-    hooks_url            AOCR hooks service root, no trailing slash, e.g.
-                         "https://aocr.aerol.ai".
-    cluster_id           This cluster's ID on the AOCR side.
-    cluster_pat          Bearer token AOCR validates against its
-                         INTERNAL_API_TOKEN. Same value as
-                         aocr_internal_api_token on the AOCR side
-                         (secrets/internal_api_token).
-    retention_suffix     Tag suffix imported tags get in the cluster
-                         namespace (e.g. "--idle-90d"); drives reaper
-                         eviction window.
-    request_timeout      Per-call timeout for the ImportAPI POST.
-    reconcile_interval   Ticker period for the local auto_import_pending
-                         reconciler.
-    max_in_flight        Fan-out cap for one reconciler sweep.
+    upstream_wrap_key  Base64-encoded 32-byte AES-GCM key. Must equal an
+                       entry in AOCR's UPSTREAM_AUTH_WRAP_KEYS or private
+                       upstream pulls 401. Empty = wrapping disabled.
+    cluster_pat        Bearer token AOCR validates against its
+                       INTERNAL_API_TOKEN (secrets/internal_api_token on
+                       the AOCR side). Required when
+                       auto_import.enabled = true in cluster.yml — the
+                       precondition in locals.tf enforces this.
   EOT
   type = object({
-    enabled             = bool
-    mirror_host         = optional(string, "")
-    mirror_push_host    = optional(string, "")
-    mirror_upstreams    = optional(string, "ghcr.io=ghcr,gcr.io=gcr,quay.io=quay,registry.k8s.io=k8s")
-    upstream_wrap_key   = optional(string, "")
-    auto_import_enabled = optional(bool, false)
-    hooks_url           = optional(string, "")
-    cluster_id          = optional(string, "")
-    cluster_pat         = optional(string, "")
-    retention_suffix    = optional(string, "--idle-90d")
-    request_timeout     = optional(string, "15s")
-    reconcile_interval  = optional(string, "5m")
-    max_in_flight       = optional(number, 4)
+    upstream_wrap_key = optional(string, "")
+    cluster_pat       = optional(string, "")
   })
   sensitive = true
-  default = {
-    enabled = false
-  }
-
-  validation {
-    condition = (
-      !var.aocr.enabled
-      || !var.aocr.auto_import_enabled
-      || (
-        var.aocr.hooks_url != ""
-        && var.aocr.cluster_id != ""
-        && var.aocr.cluster_pat != ""
-      )
-    )
-    error_message = "When aocr.auto_import_enabled = true, aocr.hooks_url, aocr.cluster_id, and aocr.cluster_pat are all required."
-  }
-
-  validation {
-    condition = (
-      !var.aocr.enabled
-      || var.aocr.cluster_id == ""
-      || can(regex("^[A-Za-z0-9_-]{1,64}$", var.aocr.cluster_id))
-    )
-    error_message = "aocr.cluster_id must match ^[A-Za-z0-9_-]{1,64}$ (matches AOCR ImportAPI validation)."
-  }
-
-  validation {
-    condition = (
-      var.aocr.retention_suffix == ""
-      || can(regex("^--[a-z0-9]+(-[a-z0-9]+)*$", var.aocr.retention_suffix))
-    )
-    error_message = "aocr.retention_suffix must start with '--' followed by lowercase alphanumerics, e.g. '--idle-90d'."
-  }
-
-  validation {
-    condition     = can(regex("^[0-9]+(ns|us|ms|s|m|h)$", var.aocr.request_timeout))
-    error_message = "aocr.request_timeout must be a Go duration such as 15s or 1m."
-  }
-
-  validation {
-    condition     = can(regex("^[0-9]+(ns|us|ms|s|m|h)$", var.aocr.reconcile_interval))
-    error_message = "aocr.reconcile_interval must be a Go duration such as 5m or 30s."
-  }
-
-  validation {
-    condition     = var.aocr.max_in_flight >= 1
-    error_message = "aocr.max_in_flight must be >= 1."
-  }
+  default   = {}
 }

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -8,11 +8,10 @@ variable "cluster_name" {
   default     = "aerolvm"
 }
 
-variable "pat_token" {
-  description = "Shared SB_PAT_TOKEN used by every node. Same value flows to install.sh and is consumed by cluster forwarding."
-  type        = string
-  sensitive   = true
-}
+# pat_token has moved to ../config/secrets.yml as cluster.pat_token. It's a
+# cluster-wide secret (every node uses the same value), so the shared SoT
+# pattern applies — Ansible can roll a rotated value into /etc/sandboxd at
+# day-2 from the same file. See locals.tf:pat_token.
 
 ###############################################################################
 # AWS credentials / region
@@ -303,16 +302,10 @@ variable "cloudflare_zone_id" {
   default     = ""
 }
 
-variable "domain_name" {
-  description = "Hostname advertised as the cluster ingress. Both an A record (this name) and a wildcard *.<name> are created and pointed at every ingress-bearing node's public IP."
-  type        = string
-}
-
-variable "acme_email" {
-  description = "Contact email registered with Let's Encrypt. Receives cert-expiry warnings and is the identity LE uses for rate-limit triage. Strongly recommended in domain mode; empty creates an anonymous ACME account with no notifications."
-  type        = string
-  default     = ""
-}
+# domain_name and acme_email have moved to ../config/cluster.yml under the
+# ingress: section. Both feed into Caddy / DNS / sandboxd at runtime, so
+# Ansible reading from the same source lets day-2 reconfig stay in sync with
+# day-0 provisioning. See locals.tf:domain_name and locals.tf:acme_email.
 
 variable "create_wildcard_record" {
   description = "Whether to create a wildcard *.<domain_name> A record alongside the apex."
@@ -429,37 +422,11 @@ variable "caddy_shared_cert_storage" {
 ###############################################################################
 # AOCR (Aerol OCI Registry) — Authenticated mirror + auto-import (Phase 4 F17-F21)
 #
-# Day-0 wiring against an already-deployed AOCR. When enabled = false (the
-# default), nothing AOCR-related is templated and the bootstrap is identical
-# to the pre-Phase-4 path. See sandbox-library/AUTHENTICATED_MIRROR.md for
-# the full operator reference.
-#
-# upstream_wrap_key and cluster_pat are real secrets and end up both in
-# Terraform state and in the EC2 instance user_data — same handling as
-# pat_token and cloudflare_api_token. Marking the whole object sensitive
-# keeps them out of plan/apply output.
+# All AOCR config has moved out of variables.tf:
+#   - Non-secret knobs (mirror host, upstreams, auto_import toggle, cluster_id,
+#     hooks_url, retention/timeout) live in ../config/cluster.yml.
+#   - Secrets (upstream_wrap_key, cluster_pat) live in ../config/secrets.yml.
+# Both files are read at the top of locals.tf and Ansible's configure-ops.yml,
+# so day-0 (terraform apply) and day-2 (ansible-playbook) cannot drift.
+# See sandbox-library/AUTHENTICATED_MIRROR.md for the full operator reference.
 ###############################################################################
-
-variable "aocr_secrets" {
-  description = <<-EOT
-    AOCR credentials Terraform delivers via cloud-init. Only secrets live
-    here; everything else (mirror host, upstreams, auto_import toggle,
-    cluster_id, hooks_url, retention/timeout knobs) is in
-    ../config/cluster.yml because Ansible reads the same file at day-2.
-
-    upstream_wrap_key  Base64-encoded 32-byte AES-GCM key. Must equal an
-                       entry in AOCR's UPSTREAM_AUTH_WRAP_KEYS or private
-                       upstream pulls 401. Empty = wrapping disabled.
-    cluster_pat        Bearer token AOCR validates against its
-                       INTERNAL_API_TOKEN (secrets/internal_api_token on
-                       the AOCR side). Required when
-                       auto_import.enabled = true in cluster.yml — the
-                       precondition in locals.tf enforces this.
-  EOT
-  type = object({
-    upstream_wrap_key = optional(string, "")
-    cluster_pat       = optional(string, "")
-  })
-  sensitive = true
-  default   = {}
-}

--- a/config/cluster.yml
+++ b/config/cluster.yml
@@ -1,0 +1,76 @@
+# Single source of truth for sandboxd operational env vars across the cluster.
+#
+# Both Terraform (./Terraform/) and Ansible (./Ansible/) read this file and
+# render its values into /etc/sandboxd/cluster.env on every node. Edit here,
+# then apply with EITHER tool — they produce the same env file contents:
+#
+#   - terraform apply                               # day-0 / re-provision
+#   - ansible-playbook playbooks/configure-ops.yml  # day-2 / live rollout
+#
+# DO NOT put values in terraform.tfvars or Ansible local.yml that this file
+# already controls — the two tools would disagree on which to write and the
+# last one to run would silently clobber the other.
+#
+# Secrets (PATs, wrap keys, cloud credentials) stay tool-specific:
+#   - Terraform/terraform.tfvars  : cloud creds, ACME, AOCR upstream wrap key,
+#                                   cluster PAT (delivered via cloud-init).
+#   - Ansible local.yml           : same secrets when applying day-2 (inline
+#                                   value or file path on the control node).
+# Those keys are intentionally NOT in this file.
+
+# --- OTEL exporter --------------------------------------------------------
+# Enable by setting metrics_endpoint and/or traces_endpoint. The *_enabled
+# flags are auto-promoted to true when the matching endpoint is set, so you
+# rarely need to flip them by hand.
+otel:
+  metrics_enabled: false
+  metrics_endpoint: ""
+  metrics_interval: "30s"
+  traces_enabled: false
+  traces_endpoint: ""
+  traces_sample_ratio: 0.05
+  service_name: "sandboxd"
+
+# --- Docker image pull storm controls -------------------------------------
+image_pull:
+  max_concurrent: 4
+  failure_backoff: "30s"
+
+# --- Image GC: whitelist of refs the janitors must never delete -----------
+# Three match shapes:
+#   - exact ref                ("alpine:latest" — only that tag survives)
+#   - repo, tag/digest agnostic ("ubuntu" — every tag and digest of ubuntu)
+#   - registry/org prefix      (trailing "/" — "ghcr.io/myorg/" matches all)
+# Joined with "," when rendered as SB_IMAGE_GC_WHITELIST.
+image_gc:
+  whitelist:
+    - "sumanrocs/"
+
+# --- Image GC: janitor cadence (built-image + pending-destroy sweeps) -----
+# Both sweeps share these knobs. Default TTL 24h trades disk for warm-start
+# latency: shorter values reclaim disk faster but re-pull on destroy/recreate
+# cycles inside the window.
+image_build_gc:
+  enabled: true
+  interval: "10m"
+  ttl: "24h"
+
+# --- AOCR mirror (Phase 4) ------------------------------------------------
+# Empty host disables mirror rewriting entirely. Upstreams maps upstream
+# hostnames to repository prefixes inside the mirror.
+mirror:
+  host: "mirror.aocr.aerol.ai"
+  push_host: ""
+  upstreams: "docker.io=docker,ghcr.io=ghcr,gcr.io=gcr,quay.io=quay,registry.k8s.io=k8s"
+
+# --- AOCR auto-import (Phase 4) -------------------------------------------
+# enabled=true requires hooks_url + cluster_id + a cluster PAT (delivered as
+# a secret separately — see header). Sandboxd refuses to boot otherwise.
+auto_import:
+  enabled: true
+  hooks_url: "https://aocr.aerol.ai"
+  cluster_id: "prod-aerolvm-us-east-1"
+  retention_suffix: "--idle-7d"
+  request_timeout: "15s"
+  reconcile_interval: "5m"
+  max_in_flight: 4

--- a/config/cluster.yml
+++ b/config/cluster.yml
@@ -11,12 +11,28 @@
 # already controls — the two tools would disagree on which to write and the
 # last one to run would silently clobber the other.
 #
-# Secrets (PATs, wrap keys, cloud credentials) stay tool-specific:
-#   - Terraform/terraform.tfvars  : cloud creds, ACME, AOCR upstream wrap key,
-#                                   cluster PAT (delivered via cloud-init).
-#   - Ansible local.yml           : same secrets when applying day-2 (inline
-#                                   value or file path on the control node).
+# Secrets split:
+#   - AOCR secrets (upstream wrap key, cluster PAT) live in ./secrets.yml,
+#     a parallel shared SoT also read by both Terraform and Ansible.
+#     Gitignored — bootstrap with `cp config/secrets.example.yml config/secrets.yml`.
+#   - Cloud creds (pat_token, cloudflare_api_token, ACME email, AWS profile)
+#     stay in Terraform/terraform.tfvars (Terraform-only — Ansible never
+#     re-provisions cloud infrastructure).
 # Those keys are intentionally NOT in this file.
+
+# --- Cluster identity / public ingress ------------------------------------
+# domain_name is the hostname advertised as the cluster ingress. Both an A
+# record (this name) and a wildcard *.<name> are created and pointed at every
+# ingress-bearing node's public IP. Set empty to skip TLS and run in IP/path
+# mode (Terraform-only; Ansible day-2 doesn't manage DNS).
+#
+# acme_email is the contact registered with Let's Encrypt — receives
+# cert-expiry warnings and is the identity LE uses for rate-limit triage.
+# Strongly recommended in domain mode; empty creates an anonymous ACME
+# account with no notifications.
+ingress:
+  domain_name: "vm.bareflux.co"
+  acme_email:  "sumansaurabh@aerol.ai"
 
 # --- OTEL exporter --------------------------------------------------------
 # Enable by setting metrics_endpoint and/or traces_endpoint. The *_enabled

--- a/config/cluster.yml
+++ b/config/cluster.yml
@@ -31,7 +31,7 @@
 # Strongly recommended in domain mode; empty creates an anonymous ACME
 # account with no notifications.
 ingress:
-  domain_name: "vm.bareflux.co"
+  domain_name: "vm.aerol.cloud"
   acme_email:  "sumansaurabh@aerol.ai"
 
 # --- OTEL exporter --------------------------------------------------------

--- a/config/secrets.example.yml
+++ b/config/secrets.example.yml
@@ -1,0 +1,27 @@
+# Template for config/secrets.yml — the shared SoT for cluster SECRETS that
+# Terraform and Ansible both read. Real-value sibling is gitignored.
+#
+# Bootstrap on a fresh checkout:
+#   cp config/secrets.example.yml config/secrets.yml
+#   # then fill in the values below.
+#
+# Keep keys empty if you are not using the matching feature in cluster.yml.
+# Setting these values without flipping mirror.host / auto_import.enabled in
+# cluster.yml is a no-op.
+
+# --- Cluster identity ------------------------------------------------------
+# pat_token is the shared SB_PAT_TOKEN every node uses for operator/SDK API
+# auth and cluster-internal forwarding. Generate one with
+#   openssl rand -hex 32 | sed 's/^/avm_/'
+# or whatever scheme you use for cluster secrets.
+cluster:
+  pat_token: ""
+
+# --- AOCR (authenticated mirror + auto-import) ------------------------------
+# upstream_wrap_key  Base64-encoded 32-byte AES-GCM key from aocr secrets/
+#                    upstream_wrap_key. Empty = wrapping disabled.
+# cluster_pat        Bearer token from aocr secrets/internal_api_token.
+#                    Required when cluster.yml has auto_import.enabled = true.
+aocr:
+  upstream_wrap_key: ""
+  cluster_pat:       ""

--- a/plans/aocr-vpc-private-routing-aws-checklist.md
+++ b/plans/aocr-vpc-private-routing-aws-checklist.md
@@ -1,0 +1,453 @@
+# AOCR Private VPC Routing AWS Checklist
+
+## Status
+
+Ready to execute.
+
+## Goal
+
+Make `aocr.aerol.ai` and `mirror.aocr.aerol.ai` resolve to the AOCR VM's private IP from inside the AerolVM VPC, without changing AerolVM code and without adding an AWS load balancer.
+
+This checklist assumes the cheap phase-1 design:
+
+- AOCR is on one EC2 VM
+- Traefik on that VM already terminates TLS for `aocr.aerol.ai` and `mirror.aocr.aerol.ai`
+- AerolVM should keep using the same hostnames it already has in `Terraform/terraform.tfvars`
+
+## What does not change
+
+Do not change the AerolVM AOCR config for phase 1:
+
+```hcl
+aocr = {
+  enabled             = true
+  mirror_host         = "mirror.aocr.aerol.ai"
+  auto_import_enabled = true
+  hooks_url           = "https://aocr.aerol.ai"
+}
+```
+
+The only change is AWS networking and private DNS.
+
+## Before you start
+
+You need:
+
+1. AWS CLI authenticated with permission to manage VPC, Route53, security groups, and VPC endpoints.
+2. The AOCR EC2 instance ID.
+3. The AerolVM VPC already deployed from this repo.
+4. Public AOCR DNS and TLS already working.
+
+Set this shell environment first:
+
+```bash
+set -euo pipefail
+
+export AWS_PROFILE="aerolvm-provisoner"
+export AWS_REGION="us-east-1"
+```
+
+## Step 1 - Gather live AerolVM values
+
+Run these from the `Terraform/` directory of this repo if the state is present locally:
+
+```bash
+cd /Users/sumansaurabh/Documents/startup-3/sandbox-library/Terraform
+
+terraform output nodes
+terraform output ssh_command_seed
+```
+
+Now gather the live AWS object IDs.
+
+### AerolVM VPC ID and CIDR
+
+```bash
+export AEROLVM_VPC_ID=$(aws ec2 describe-vpcs \
+  --region "$AWS_REGION" \
+  --filters Name=tag:Name,Values=aerolvm-vpc \
+  --query 'Vpcs[0].VpcId' \
+  --output text)
+
+export AEROLVM_VPC_CIDR=$(aws ec2 describe-vpcs \
+  --region "$AWS_REGION" \
+  --vpc-ids "$AEROLVM_VPC_ID" \
+  --query 'Vpcs[0].CidrBlock' \
+  --output text)
+
+echo "$AEROLVM_VPC_ID"
+echo "$AEROLVM_VPC_CIDR"
+```
+
+### AerolVM node security group
+
+```bash
+export AEROLVM_NODE_SG_ID=$(aws ec2 describe-security-groups \
+  --region "$AWS_REGION" \
+  --filters Name=group-name,Values=aerolvm-node \
+  --query 'SecurityGroups[0].GroupId' \
+  --output text)
+
+echo "$AEROLVM_NODE_SG_ID"
+```
+
+## Step 2 - Gather live AOCR values
+
+Set the AOCR instance ID manually, then resolve the rest from AWS.
+
+```bash
+export AOCR_INSTANCE_ID="i-REPLACE_ME"
+```
+
+```bash
+export AOCR_PRIVATE_IP=$(aws ec2 describe-instances \
+  --region "$AWS_REGION" \
+  --instance-ids "$AOCR_INSTANCE_ID" \
+  --query 'Reservations[0].Instances[0].PrivateIpAddress' \
+  --output text)
+
+export AOCR_VPC_ID=$(aws ec2 describe-instances \
+  --region "$AWS_REGION" \
+  --instance-ids "$AOCR_INSTANCE_ID" \
+  --query 'Reservations[0].Instances[0].VpcId' \
+  --output text)
+
+export AOCR_SUBNET_ID=$(aws ec2 describe-instances \
+  --region "$AWS_REGION" \
+  --instance-ids "$AOCR_INSTANCE_ID" \
+  --query 'Reservations[0].Instances[0].SubnetId' \
+  --output text)
+
+export AOCR_SG_ID=$(aws ec2 describe-instances \
+  --region "$AWS_REGION" \
+  --instance-ids "$AOCR_INSTANCE_ID" \
+  --query 'Reservations[0].Instances[0].SecurityGroups[0].GroupId' \
+  --output text)
+
+echo "$AOCR_PRIVATE_IP"
+echo "$AOCR_VPC_ID"
+echo "$AOCR_SUBNET_ID"
+echo "$AOCR_SG_ID"
+```
+
+## Step 3 - Check whether AOCR is in the same VPC
+
+```bash
+echo "AerolVM VPC: $AEROLVM_VPC_ID"
+echo "AOCR VPC:    $AOCR_VPC_ID"
+```
+
+If the VPC IDs match, continue to Step 4.
+
+If they do not match, do Step 3A first.
+
+## Step 3A - If AOCR is in a different VPC, add VPC peering first
+
+Gather the route table IDs you need on both sides.
+
+```bash
+export AEROLVM_ROUTE_TABLE_ID=$(aws ec2 describe-route-tables \
+  --region "$AWS_REGION" \
+  --filters Name=tag:Name,Values=aerolvm-public \
+  --query 'RouteTables[0].RouteTableId' \
+  --output text)
+
+export AOCR_ROUTE_TABLE_ID=$(aws ec2 describe-route-tables \
+  --region "$AWS_REGION" \
+  --filters Name=association.subnet-id,Values="$AOCR_SUBNET_ID" \
+  --query 'RouteTables[0].RouteTableId' \
+  --output text)
+
+echo "$AEROLVM_ROUTE_TABLE_ID"
+echo "$AOCR_ROUTE_TABLE_ID"
+```
+
+Create and accept peering:
+
+```bash
+export PEERING_ID=$(aws ec2 create-vpc-peering-connection \
+  --region "$AWS_REGION" \
+  --vpc-id "$AEROLVM_VPC_ID" \
+  --peer-vpc-id "$AOCR_VPC_ID" \
+  --tag-specifications 'ResourceType=vpc-peering-connection,Tags=[{Key=Name,Value=aerolvm-aocr-peering}]' \
+  --query 'VpcPeeringConnection.VpcPeeringConnectionId' \
+  --output text)
+
+aws ec2 accept-vpc-peering-connection \
+  --region "$AWS_REGION" \
+  --vpc-peering-connection-id "$PEERING_ID"
+
+echo "$PEERING_ID"
+```
+
+Add routes both ways:
+
+```bash
+export AOCR_VPC_CIDR=$(aws ec2 describe-vpcs \
+  --region "$AWS_REGION" \
+  --vpc-ids "$AOCR_VPC_ID" \
+  --query 'Vpcs[0].CidrBlock' \
+  --output text)
+
+aws ec2 create-route \
+  --region "$AWS_REGION" \
+  --route-table-id "$AEROLVM_ROUTE_TABLE_ID" \
+  --destination-cidr-block "$AOCR_VPC_CIDR" \
+  --vpc-peering-connection-id "$PEERING_ID"
+
+aws ec2 create-route \
+  --region "$AWS_REGION" \
+  --route-table-id "$AOCR_ROUTE_TABLE_ID" \
+  --destination-cidr-block "$AEROLVM_VPC_CIDR" \
+  --vpc-peering-connection-id "$PEERING_ID"
+```
+
+After this, continue to Step 4.
+
+## Step 4 - Verify current public AOCR still works
+
+Run this before introducing private DNS so you know the baseline is healthy.
+
+```bash
+curl -I https://aocr.aerol.ai/v2/
+curl -I https://mirror.aocr.aerol.ai/v2/
+```
+
+Expected:
+
+- both return `401 Unauthorized`
+
+That is a healthy registry challenge response.
+
+## Step 5 - Check certificate issuance mode on AOCR
+
+SSH to the AOCR VM and inspect the issuer.
+
+```bash
+ssh ubuntu@<AOCR_PUBLIC_IP_OR_BASTION_PATH> \
+  'sudo kubectl get clusterissuer letsencrypt-prod -o yaml'
+```
+
+Interpretation:
+
+- if you see `http01`, do not shut off public `80` yet
+- if you see `dns01`, public `80` is not needed for future cert issuance
+
+This step is only about future hardening. It does not block private DNS.
+
+## Step 6 - Create the Route53 private hosted zone
+
+Create a private zone only for `aocr.aerol.ai`. Do not create a private zone for the entire `aerol.ai` parent unless you intentionally want to shadow every record under that domain.
+
+```bash
+export AOCR_PRIVATE_ZONE_ID=$(aws route53 create-hosted-zone \
+  --profile "$AWS_PROFILE" \
+  --name aocr.aerol.ai \
+  --caller-reference "aocr-private-$(date +%s)" \
+  --hosted-zone-config Comment="Private AOCR routing for AerolVM",PrivateZone=true \
+  --vpc VPCRegion="$AWS_REGION",VPCId="$AEROLVM_VPC_ID" \
+  --query 'HostedZone.Id' \
+  --output text | awk -F/ '{print $NF}')
+
+echo "$AOCR_PRIVATE_ZONE_ID"
+```
+
+If the private zone already exists, use this instead:
+
+```bash
+export AOCR_PRIVATE_ZONE_ID=$(aws route53 list-hosted-zones-by-name \
+  --profile "$AWS_PROFILE" \
+  --dns-name aocr.aerol.ai \
+  --query 'HostedZones[?Config.PrivateZone==`true` && Name==`aocr.aerol.ai.`][0].Id' \
+  --output text | awk -F/ '{print $NF}')
+
+echo "$AOCR_PRIVATE_ZONE_ID"
+```
+
+## Step 7 - Add private Route53 records
+
+Create a temporary change batch:
+
+```bash
+cat > /tmp/aocr-private-records.json <<EOF
+{
+  "Comment": "Private AOCR records for AerolVM",
+  "Changes": [
+    {
+      "Action": "UPSERT",
+      "ResourceRecordSet": {
+        "Name": "aocr.aerol.ai.",
+        "Type": "A",
+        "TTL": 60,
+        "ResourceRecords": [{"Value": "$AOCR_PRIVATE_IP"}]
+      }
+    },
+    {
+      "Action": "UPSERT",
+      "ResourceRecordSet": {
+        "Name": "mirror.aocr.aerol.ai.",
+        "Type": "A",
+        "TTL": 60,
+        "ResourceRecords": [{"Value": "$AOCR_PRIVATE_IP"}]
+      }
+    }
+  ]
+}
+EOF
+```
+
+Apply it:
+
+```bash
+aws route53 change-resource-record-sets \
+  --profile "$AWS_PROFILE" \
+  --hosted-zone-id "$AOCR_PRIVATE_ZONE_ID" \
+  --change-batch file:///tmp/aocr-private-records.json
+```
+
+## Step 8 - Open AOCR inbound `443` for AerolVM private traffic
+
+If AOCR is in the same VPC, prefer a source security-group rule.
+
+### Same-VPC preferred rule
+
+```bash
+aws ec2 authorize-security-group-ingress \
+  --region "$AWS_REGION" \
+  --group-id "$AOCR_SG_ID" \
+  --ip-permissions "IpProtocol=tcp,FromPort=443,ToPort=443,UserIdGroupPairs=[{GroupId=$AEROLVM_NODE_SG_ID}]"
+```
+
+### Different-VPC or if SG referencing is not possible
+
+```bash
+aws ec2 authorize-security-group-ingress \
+  --region "$AWS_REGION" \
+  --group-id "$AOCR_SG_ID" \
+  --protocol tcp \
+  --port 443 \
+  --cidr "$AEROLVM_VPC_CIDR"
+```
+
+Do not revoke public `443` or public `80` yet. First prove the private path works.
+
+## Step 9 - Add an S3 Gateway Endpoint in the AOCR VPC
+
+Gather the AOCR subnet route table if you have not already:
+
+```bash
+export AOCR_ROUTE_TABLE_ID=$(aws ec2 describe-route-tables \
+  --region "$AWS_REGION" \
+  --filters Name=association.subnet-id,Values="$AOCR_SUBNET_ID" \
+  --query 'RouteTables[0].RouteTableId' \
+  --output text)
+
+echo "$AOCR_ROUTE_TABLE_ID"
+```
+
+Create the S3 Gateway Endpoint:
+
+```bash
+aws ec2 create-vpc-endpoint \
+  --region "$AWS_REGION" \
+  --vpc-id "$AOCR_VPC_ID" \
+  --service-name "com.amazonaws.$AWS_REGION.s3" \
+  --vpc-endpoint-type Gateway \
+  --route-table-ids "$AOCR_ROUTE_TABLE_ID" \
+  --tag-specifications 'ResourceType=vpc-endpoint,Tags=[{Key=Name,Value=aocr-s3-endpoint}]'
+```
+
+Verify it exists:
+
+```bash
+aws ec2 describe-vpc-endpoints \
+  --region "$AWS_REGION" \
+  --filters Name=vpc-id,Values="$AOCR_VPC_ID" Name=service-name,Values="com.amazonaws.$AWS_REGION.s3" \
+  --query 'VpcEndpoints[].{VpcEndpointId:VpcEndpointId,State:State,VpcId:VpcId}'
+```
+
+## Step 10 - Validate from an AerolVM node
+
+SSH to the seed or any worker node.
+
+If you have local Terraform state for the cluster, get the seed SSH command with:
+
+```bash
+cd /Users/sumansaurabh/Documents/startup-3/sandbox-library/Terraform
+terraform output -raw ssh_command_seed
+```
+
+On the AerolVM node, run:
+
+```bash
+getent hosts aocr.aerol.ai
+getent hosts mirror.aocr.aerol.ai
+
+curl -I https://aocr.aerol.ai/v2/
+curl -I https://mirror.aocr.aerol.ai/v2/
+
+sudo cat /etc/docker/daemon.json
+sudo grep -E '^SB_(MIRROR|AUTO_IMPORT)_' /etc/sandboxd/cluster.env
+
+docker pull alpine:3.20
+```
+
+Expected:
+
+1. `getent hosts` returns the AOCR private IP
+2. both `curl -I` calls return `401 Unauthorized`
+3. Docker daemon.json still points at `https://mirror.aocr.aerol.ai`
+4. the `alpine` pull succeeds
+
+## Step 11 - Validate a non-Docker-Hub pull and auto-import
+
+Trigger a pull that uses the AerolVM mirror rewrite path, for example via a sandbox using one of:
+
+- `ghcr.io/...`
+- `gcr.io/...`
+- `quay.io/...`
+- `registry.k8s.io/...`
+
+Then confirm AOCR still receives auto-import traffic for private pulls.
+
+At minimum, verify on the AerolVM node that:
+
+```bash
+sudo grep -E '^SB_AUTO_IMPORT_HOOKS_URL=' /etc/sandboxd/cluster.env
+```
+
+Expected:
+
+- it still points at `https://aocr.aerol.ai`
+- the name now resolves privately inside the VPC
+
+## Step 12 - Only after success, optionally reduce public exposure
+
+After all private-path validation passes, you can decide whether to tighten the public side.
+
+Safe sequence:
+
+1. narrow AOCR mirror ingress allow-lists from `0.0.0.0/0`
+2. keep public `80` if cert issuance still uses HTTP-01
+3. only remove public `443` if operator access has another path and cert issuance is not relying on public ingress
+
+## Rollback
+
+If anything fails, revert in this order:
+
+1. delete the two private Route53 records from the private hosted zone
+2. or disassociate/delete the private hosted zone entirely
+3. remove the new AOCR SG ingress rule if needed
+4. leave the AerolVM `aocr` block untouched
+
+Because AerolVM still points at the same public hostnames, removing the private DNS overlay returns it to the old public path.
+
+## End state
+
+When this checklist is complete:
+
+1. AerolVM nodes still use `mirror.aocr.aerol.ai` and `aocr.aerol.ai`
+2. inside the VPC, those names resolve to the AOCR private IP
+3. Docker and sandboxd continue to work without code changes
+4. AOCR-to-S3 traffic uses an AWS private path
+5. no AWS load balancer is involved

--- a/plans/aocr-vpc-private-routing-aws-implementation.md
+++ b/plans/aocr-vpc-private-routing-aws-implementation.md
@@ -4,6 +4,9 @@
 
 Draft - implementation-ready runbook.
 
+For an operator-focused step-by-step execution guide, see
+`plans/aocr-vpc-private-routing-aws-checklist.md`.
+
 ## Scope
 
 This file turns the higher-level design in `plans/aocr-vpc-private-routing.md` into an exact AWS implementation plan.

--- a/setup/aocr/README.md
+++ b/setup/aocr/README.md
@@ -42,76 +42,72 @@ The wrap key and the internal API token are real secrets. Treat them like
 
 ## Terraform setup
 
-Add an `aocr = { ... }` block to your `terraform.tfvars`. Everything else
-in the cluster's Terraform stays unchanged — when `enabled = false` (the
-default) no AOCR resources are templated.
+AOCR config is split across two shared SoT files at the repo root that
+both Terraform and Ansible read:
+
+- `config/cluster.yml` (committed) holds the non-secret knobs: mirror host,
+  upstreams, auto-import toggle / hooks_url / cluster_id, retention suffix,
+  timeouts, max-in-flight.
+- `config/secrets.yml` (gitignored — `cp config/secrets.example.yml config/secrets.yml`
+  on first checkout) holds the two AOCR secrets: `aocr.upstream_wrap_key`
+  and `aocr.cluster_pat`.
+
+Nothing AOCR-specific lives in `terraform.tfvars` anymore.
 
 ### Modes
 
-**Off (default).** Omit the block entirely, or:
+**Off (default).** Leave `mirror.host` empty and `auto_import.enabled = false`
+in `config/cluster.yml`. The bootstrap template skips the AOCR section.
 
-```hcl
-aocr = {
-  enabled = false
-}
+**Mirror-only — cached + wrapped private pulls.**
+
+```yaml
+# config/cluster.yml
+mirror:
+  host: "mirror.aocr.example.com"
+  upstreams: "docker.io=docker,ghcr.io=ghcr,gcr.io=gcr,quay.io=quay,registry.k8s.io=k8s"
 ```
 
-**Mirror-only — cached + wrapped private pulls.** Three fields:
-
-```hcl
-aocr = {
-  enabled           = true
-  mirror_host       = "mirror.aocr.example.com"
-  upstream_wrap_key = "BASE64_32_BYTES_FROM_aocr.sh/secrets/upstream_wrap_key"
-}
+```yaml
+# config/secrets.yml  (gitignored)
+aocr:
+  upstream_wrap_key: "BASE64_32_BYTES_FROM_aocr.sh/secrets/upstream_wrap_key"
+  cluster_pat:       ""
 ```
 
 Pulls of `ghcr.io/...`, `gcr.io/...`, `quay.io/...`, and `registry.k8s.io/...`
 flow through the mirror. Private pulls use wrapped credentials.
 
-**Mirror + auto-import (full F21).** Four more fields. Plan-time
-validation rejects `auto_import_enabled = true` without all three of
-`hooks_url`, `cluster_id`, and `cluster_pat`:
+**Mirror + auto-import (full F21).** Plan-time validation rejects
+`auto_import.enabled = true` without all three of `auto_import.hooks_url`,
+`auto_import.cluster_id`, and `aocr.cluster_pat`:
 
-```hcl
-aocr = {
-  enabled             = true
-  mirror_host         = "mirror.aocr.example.com"
-  upstream_wrap_key   = "BASE64_32_BYTES_FROM_aocr.sh/secrets/upstream_wrap_key"
-  auto_import_enabled = true
-  hooks_url           = "https://aocr.example.com"   # AOCR hooks service root, no trailing slash
-  cluster_id          = "prod-aerolvm-us-east-1"
-  cluster_pat         = "TOKEN_FROM_aocr.sh/secrets/internal_api_token"
-  retention_suffix    = "--idle-90d"                 # optional; default --idle-90d
-}
+```yaml
+# config/cluster.yml
+mirror:
+  host: "mirror.aocr.example.com"
+  upstreams: "docker.io=docker,ghcr.io=ghcr,gcr.io=gcr,quay.io=quay,registry.k8s.io=k8s"
+
+auto_import:
+  enabled: true
+  hooks_url: "https://aocr.example.com"     # AOCR hooks service root, no trailing slash
+  cluster_id: "prod-aerolvm-us-east-1"
+  retention_suffix: "--idle-90d"             # optional; default --idle-90d
+```
+
+```yaml
+# config/secrets.yml  (gitignored)
+aocr:
+  upstream_wrap_key: "BASE64_32_BYTES_FROM_aocr.sh/secrets/upstream_wrap_key"
+  cluster_pat:       "TOKEN_FROM_aocr.sh/secrets/internal_api_token"
 ```
 
 After this, each successful private pull triggers a re-mount under
 `cluster/prod-aerolvm-us-east-1/_imported/<host>/<repo>:<tag>--idle-90d`
 on the AOCR side, fully decoupled from the original upstream credential.
 
-### All available fields
-
-```hcl
-aocr = {
-  enabled             = bool          # required
-  mirror_host         = string        # default ""
-  mirror_push_host    = string        # default ""; leave empty unless AOCR exposes a separate push vhost
-  mirror_upstreams    = string        # default "ghcr.io=ghcr,gcr.io=gcr,quay.io=quay,registry.k8s.io=k8s"
-  upstream_wrap_key   = string        # default ""; base64 32-byte AES-GCM key
-  auto_import_enabled = bool          # default false
-  hooks_url           = string        # default ""
-  cluster_id          = string        # default ""; must match ^[A-Za-z0-9_-]{1,64}$
-  cluster_pat         = string        # default ""
-  retention_suffix    = string        # default "--idle-90d"
-  request_timeout     = string        # default "15s" (Go duration)
-  reconcile_interval  = string        # default "5m" (Go duration)
-  max_in_flight       = number        # default 4
-}
-```
-
-The whole variable is marked `sensitive = true`, so plan/apply output
-won't print the wrap key or PAT.
+`config/secrets.yml` is loaded via `sensitive(yamldecode(...))` so plan/apply
+output won't print the wrap key or PAT.
 
 ### Apply
 
@@ -135,31 +131,25 @@ in `systemctl show sandboxd` or process listings.
 
 ## Ansible setup
 
-If you provision with Ansible instead of (or alongside) Terraform, set
-the same values in `Ansible/inventory/group_vars/all/local.yml` (gitignored
-per-operator overrides, auto-loaded after the committed `defaults.yml`)
-and run `configure-ops.yml`.
+Ansible reads the **same** `config/cluster.yml` and `config/secrets.yml`
+files Terraform uses, so the YAML blocks under [Terraform setup](#terraform-setup)
+above are also the Ansible config — there is no separate inline-value var
+to set in `local.yml` anymore.
 
-Inline-value mode (single operator / laptop):
+For fleet / Vault-rendered workflows, leave `aocr.upstream_wrap_key` /
+`aocr.cluster_pat` empty in `config/secrets.yml` and point at staged file
+paths from `Ansible/inventory/group_vars/all/local.yml`:
 
 ```yaml
 # inventory/group_vars/all/local.yml — gitignored
-sandboxd_mirror_host:                    "mirror.aocr.example.com"
-sandboxd_upstream_wrap_key_value:        "<base64 wrap key>"
-
-sandboxd_auto_import_enabled:            true
-sandboxd_auto_import_hooks_url:          "https://aocr.example.com"
-sandboxd_auto_import_cluster_id:         "prod-aerolvm-us-east-1"
-sandboxd_auto_import_cluster_pat_value:  "<internal API token>"
-# sandboxd_auto_import_retention_suffix: "--idle-90d"   # default
+sandboxd_upstream_wrap_key_src:          "/home/you/aerol-secrets/upstream_wrap_key"
+sandboxd_auto_import_cluster_pat_src:    "/home/you/aerol-secrets/cluster_pat"
 ```
 
-Control-node file mode (fleet / Vault-rendered) — swap `_value` for `_src`
-and point at a file path on the Ansible control node. The playbook writes
-the bytes to `/etc/sandboxd/secrets/upstream-wrap.key` and
-`/etc/sandboxd/secrets/cluster-pat` on each managed host at `mode 0600`
+The playbook writes the bytes to `/etc/sandboxd/secrets/upstream-wrap.key`
+and `/etc/sandboxd/secrets/cluster-pat` on each managed host at `mode 0600`
 either way. See [`Ansible/README.md` § Step 2](../../Ansible/README.md#step-2--choose-how-to-hand-the-secrets-to-the-play)
-for the full file-layout pattern and both modes.
+for the full file-layout pattern.
 
 Then:
 
@@ -170,8 +160,8 @@ ansible-playbook Ansible/playbooks/configure-ops.yml
 Sandboxd restarts on each host as the env file changes (controlled by
 `sandboxd_restart_after_ops_config`).
 
-The full list of `sandboxd_mirror_*` / `sandboxd_auto_import_*` defaults
-lives in [`Ansible/inventory/group_vars/all/defaults.yml`](../../Ansible/inventory/group_vars/all/defaults.yml).
+The full list of plumbing defaults lives in
+[`Ansible/inventory/group_vars/all/defaults.yml`](../../Ansible/inventory/group_vars/all/defaults.yml).
 
 ---
 


### PR DESCRIPTION
This pull request refactors the Ansible sandboxd operational configuration to centralize all non-secret configuration and AOCR secrets into shared YAML files (`config/cluster.yml` and `config/secrets.yml`) that are also used by Terraform. The documentation and variable precedence are clarified, and most Ansible variable overrides for mirror/auto-import/observability are removed from group vars in favor of these shared sources of truth. Secret delivery via Vault/SOPS is now an explicit, optional fallback with clear precedence rules.

**Key changes:**

**Centralization of Configuration and Secrets:**
- All non-secret operational config (mirror host, auto-import, OTEL endpoints, image GC, etc.) is now stored in `config/cluster.yml`, and AOCR secrets (wrap key, cluster PAT) are in `config/secrets.yml`. Both files are shared with Terraform, reducing duplication and confusion. [[1]](diffhunk://#diff-ff585b83572a931664eeafa622e0a05cc634d7e552101eea98a74654401119ddL34-R37) [[2]](diffhunk://#diff-ff585b83572a931664eeafa622e0a05cc634d7e552101eea98a74654401119ddL69-L104) [[3]](diffhunk://#diff-5b6dd86734bb1d3a27311119412b520a959fa21911d270b0b395c4ff9fbb7e3eL2-R19) [[4]](diffhunk://#diff-6b40727b7ee1b6146e3019eb1e458c74b50ceac822f90d09052bc821ad605adcL4-R15) [[5]](diffhunk://#diff-eec29ea61b3a84f5b172310ea937d71fdaf686832f04018033f3ff72edc5f42cL299-L330) [[6]](diffhunk://#diff-eec29ea61b3a84f5b172310ea937d71fdaf686832f04018033f3ff72edc5f42cL116-L119) [[7]](diffhunk://#diff-eec29ea61b3a84f5b172310ea937d71fdaf686832f04018033f3ff72edc5f42cL374-R443)

**Simplified Ansible Variable Usage:**
- Most Ansible-specific variables for mirror/auto-import/observability are removed from `defaults.yml` and `local.yml.example`. Only secret delivery plumbing (for Vault/SOPS) remains in Ansible inventory. Operator-facing config is now edited in the shared YAML files. [[1]](diffhunk://#diff-ff585b83572a931664eeafa622e0a05cc634d7e552101eea98a74654401119ddL34-R37) [[2]](diffhunk://#diff-ff585b83572a931664eeafa622e0a05cc634d7e552101eea98a74654401119ddL69-L104) [[3]](diffhunk://#diff-5b6dd86734bb1d3a27311119412b520a959fa21911d270b0b395c4ff9fbb7e3eL2-R19)

**Secret Delivery Precedence and Workflow:**
- If both a secret is set in `config/secrets.yml` and a control-node file is specified via a `*_src` variable, the value from `config/secrets.yml` takes precedence. This is now clearly documented and reflected in example files and docs. [[1]](diffhunk://#diff-eec29ea61b3a84f5b172310ea937d71fdaf686832f04018033f3ff72edc5f42cL299-L330) [[2]](diffhunk://#diff-ff585b83572a931664eeafa622e0a05cc634d7e552101eea98a74654401119ddL69-L104) [[3]](diffhunk://#diff-5b6dd86734bb1d3a27311119412b520a959fa21911d270b0b395c4ff9fbb7e3eL2-R19)

**Documentation Overhaul:**
- The `Ansible/README.md` is extensively rewritten to explain the new config structure, secret delivery precedence, and operational workflows. Tables clarify the meaning and source of each key. Example YAML snippets are provided for the new shared config files. [[1]](diffhunk://#diff-eec29ea61b3a84f5b172310ea937d71fdaf686832f04018033f3ff72edc5f42cL299-L330) [[2]](diffhunk://#diff-eec29ea61b3a84f5b172310ea937d71fdaf686832f04018033f3ff72edc5f42cL116-L119) [[3]](diffhunk://#diff-eec29ea61b3a84f5b172310ea937d71fdaf686832f04018033f3ff72edc5f42cL374-R443)

**Playbook and Usage Updates:**
- The `configure-ops.yml` playbook and its usage instructions are updated to reflect the new config locations and workflows, including backup cron configuration. [[1]](diffhunk://#diff-6b40727b7ee1b6146e3019eb1e458c74b50ceac822f90d09052bc821ad605adcL4-R15) [[2]](diffhunk://#diff-eec29ea61b3a84f5b172310ea937d71fdaf686832f04018033f3ff72edc5f42cL116-L119)

These changes make the configuration more maintainable, reduce duplication between Ansible and Terraform, and clarify the operator workflow for both secrets and non-secrets.