### PR TITLE
feat: Add Firecracker configuration options and custom domain verification

### DIFF
--- a/Ansible/README.md
+++ b/Ansible/README.md
@@ -444,6 +444,104 @@ warrant it.
 4. `ansible-playbook playbooks/configure-ops.yml`.
 5. Verify with `grep` / `ls` on a node and `curl /v1/images` on AOCR.
 
+## Install Firecracker on existing nodes
+
+`configure-ops.yml` installs the Firecracker binary, jailer, and a guest
+kernel image whenever `firecracker.enabled: true` in `../config/cluster.yml`.
+No per-host or per-arch configuration is required — the play detects
+`uname -m`, picks the matching upstream asset, verifies its SHA256, and
+installs to the paths sandboxd already reads from
+(`SB_FIRECRACKER_BINARY`, `SB_JAILER_BINARY`, `SB_FIRECRACKER_KERNEL`).
+
+### Host requirements (read this first)
+
+Firecracker is a **KVM-only VMM**. The host must expose `/dev/kvm`:
+
+- **AWS EC2:** only bare-metal instance types pass KVM through to the OS.
+  Use `*.metal` SKUs (`c5n.metal`, `m5zn.metal`, `c7g.metal`, `i3.metal`,
+  `m5.metal`, `c5.metal`, etc.). Standard `t3`/`m5`/`c5`/`c6i`/`m6i`/`r5`
+  instances are themselves Nitro guests — `/dev/kvm` does not exist and
+  Firecracker cannot run there.
+- **GCP:** N2/N1 with `--enable-nested-virtualization` on the image.
+- **Azure:** Dv3/Ev3+ with nested virtualization.
+- **Bare metal / on-prem:** Intel VT-x or AMD-V enabled in BIOS, then
+  `sudo modprobe kvm_intel` (or `kvm_amd`).
+
+The play **hard-fails** with a remediation message if `/dev/kvm` is missing.
+If you need to install `configure-ops.yml`'s other artifacts (OTEL,
+backup, runbooks) on a host that can't run Firecracker, set
+`firecracker.enabled: false` in `../config/cluster.yml` and re-run. To
+install Firecracker on a *subset* of capable hosts only, target the play
+with `--limit` at a group whose nodes all expose `/dev/kvm`.
+
+```yaml
+# ../config/cluster.yml
+firecracker:
+  enabled: true
+  kernel_path: "/var/lib/sandboxd/firecracker/vmlinux"
+```
+
+```bash
+ansible-playbook playbooks/configure-ops.yml
+```
+
+What the play actually does, per host:
+
+1. Runs `uname -m` and maps `x86_64|amd64 → x86_64`, `aarch64|arm64 → aarch64`.
+   Anything else fails fast — Firecracker upstream only publishes those two.
+2. Stats `/dev/kvm`. Missing? Fails fast (the host is a non-nested VM or virt
+   is off in BIOS — cheaper to fail here than at first `CreateSandbox`).
+3. Probes `firecracker --version`. If the installed binary already matches
+   `firecracker_version`, skips the download. Idempotent re-runs are cheap.
+4. Downloads `firecracker-<ver>-<arch>.tgz` + its `.sha256.txt` sidecar
+   from `github.com/firecracker-microvm/firecracker/releases`, verifies with
+   `sha256sum -c`, extracts, installs binary + jailer.
+5. Downloads the guest kernel from `s3.amazonaws.com/spec.ccfc.min`
+   (the upstream-blessed CI bucket) to `firecracker.kernel_path`. The
+   defaults are pinned to a known-good combination (see below).
+6. Creates `firecracker.run_dir`, `templates_dir`, and `jailer_chroot_base`.
+
+### Pins and overrides
+
+Defaults in `inventory/group_vars/all/defaults.yml`:
+
+| Var | Default | What it controls |
+|---|---|---|
+| `firecracker_version` | `v1.15.1` | GitHub release tag; binary + jailer come from `firecracker-microvm/firecracker/releases/download/<ver>/` |
+| `firecracker_kernel_ci_version` | `v1.15` | CI bucket directory; usually `v<major>.<minor>` of the release |
+| `firecracker_kernel_version` | `5.10.245` | Guest kernel patch level; the bucket also ships 6.1 if you need a newer guest |
+| `firecracker_binary_url` | `""` | Set in `local.yml` to pull binary from a private mirror; bypasses upstream + checksum |
+| `firecracker_jailer_url` | `""` | Same for the jailer |
+| `firecracker_kernel_url` | `""` | Same for the kernel; useful if you ship a hand-built `vmlinux` |
+
+Bump the version pins together: when Firecracker releases `v1.16.0`, set
+`firecracker_version: "v1.16.0"` and `firecracker_kernel_ci_version: "v1.16"`,
+then list the bucket to pick the latest patch:
+
+```bash
+curl -s 'https://s3.amazonaws.com/spec.ccfc.min/?prefix=firecracker-ci/v1.16/x86_64/vmlinux-5.10&list-type=2' \
+  | grep -oE '<Key>[^<]+</Key>' | sort -V | tail -3
+```
+
+Both `x86_64` and `aarch64` ship the same kernel patch in lockstep, so one
+`firecracker_kernel_version` value covers a mixed fleet.
+
+### Limit to specific hosts
+
+`firecracker.enabled` is a cluster-wide switch. To install on a subset of
+hosts without flipping the cluster default, target the play with `--limit`:
+
+```bash
+ansible-playbook playbooks/configure-ops.yml --limit aerolvm_role_worker
+```
+
+### Why this differs from `scripts/install.sh`
+
+`scripts/install.sh` is day-0 bootstrap and only handles binaries that ship
+with sandboxd itself (sandboxd, toolboxd, runsc, the NVIDIA toolkit). The
+Firecracker runtime is opt-in and large enough to want its own day-2
+lifecycle, so it lives here instead.
+
 ## When to use this vs. Terraform
 
 | You want to...                                  | Use         |
@@ -456,6 +554,7 @@ warrant it.
 | Deploy backup/recovery helpers or backup cron   | Ansible     |
 | Deploy Grafana/Prometheus/Alertmanager artifacts | Ansible     |
 | Deploy operational runbooks                     | Ansible     |
+| Install / upgrade Firecracker binary + kernel   | Ansible     |
 | Restart a service, rotate a PAT, tail logs      | Ansible     |
 | Run one-off shell commands across many nodes    | Ansible     |
 

--- a/Ansible/inventory/group_vars/all/defaults.yml
+++ b/Ansible/inventory/group_vars/all/defaults.yml
@@ -68,3 +68,22 @@ sandboxd_auto_import_cluster_pat_path: "{{ sandboxd_secrets_dir }}/cluster-pat"
 # empty = feature off.
 sandboxd_upstream_wrap_key_src: ""
 sandboxd_auto_import_cluster_pat_src: ""
+
+# Firecracker host-side artifact install. When firecracker.enabled is true
+# in config/cluster.yml, configure-ops.yml auto-detects host arch (uname -m)
+# and installs:
+#   - firecracker + jailer from the upstream GitHub release pinned to
+#     firecracker_version, SHA256-verified against the release's published
+#     .sha256.txt sidecar (same trust model install.sh uses for runsc).
+#   - a guest kernel image from the AWS spec.ccfc.min bucket pinned to
+#     firecracker_kernel_ci_version / firecracker_kernel_version. Both
+#     x86_64 and aarch64 paths exist there; unsupported arches fail fast.
+# Only x86_64 / aarch64 hosts are supported (Firecracker upstream constraint).
+# Override any of the *_url vars in local.yml to pull from a private mirror
+# instead — the override skips the upstream URL construction entirely.
+firecracker_version: "v1.15.1"
+firecracker_kernel_ci_version: "v1.15"
+firecracker_kernel_version: "5.10.245"
+firecracker_binary_url: ""
+firecracker_jailer_url: ""
+firecracker_kernel_url: ""

--- a/Ansible/playbooks/configure-ops.yml
+++ b/Ansible/playbooks/configure-ops.yml
@@ -198,6 +198,236 @@
         owner: root
         group: root
 
+    # Firecracker host-side install. Runs only when firecracker.enabled is
+    # true in config/cluster.yml. Arch is detected from uname -m so operators
+    # don't have to hand-craft per-arch URLs (mirrors the runsc pattern in
+    # scripts/install.sh:install_runsc_binary). Unsupported arches fail
+    # immediately rather than producing a sandboxd that fails to start hours
+    # later when a Firecracker sandbox is first requested.
+    - name: Detect host architecture for Firecracker
+      when: firecracker.enabled | default(false) | bool
+      ansible.builtin.command: uname -m
+      register: firecracker_uname_m
+      changed_when: false
+
+    - name: Map host arch → Firecracker release arch
+      when: firecracker.enabled | default(false) | bool
+      ansible.builtin.set_fact:
+        # Firecracker upstream + spec.ccfc.min both publish only x86_64 and
+        # aarch64. Map common uname -m outputs to those two; anything else
+        # trips the assert below.
+        firecracker_arch: >-
+          {{
+            {
+              'x86_64': 'x86_64',
+              'amd64':  'x86_64',
+              'aarch64': 'aarch64',
+              'arm64':   'aarch64',
+            }.get(firecracker_uname_m.stdout | trim, '')
+          }}
+
+    - name: Refuse when host arch is not supported by Firecracker
+      when: firecracker.enabled | default(false) | bool
+      ansible.builtin.assert:
+        that:
+          - firecracker_arch | length > 0
+        fail_msg: >-
+          Firecracker only ships x86_64 and aarch64 binaries; this host
+          reports uname -m={{ firecracker_uname_m.stdout | trim }}.
+          Either disable firecracker.enabled in config/cluster.yml or
+          exclude this host from the run.
+
+    - name: Check for /dev/kvm on host
+      when: firecracker.enabled | default(false) | bool
+      ansible.builtin.stat:
+        path: /dev/kvm
+      register: firecracker_kvm
+
+    - name: Refuse when host has no /dev/kvm
+      # Firecracker is a KVM-only VMM. Without /dev/kvm there is nothing to
+      # install onto — sandboxd would fail at first CreateSandbox(runtime=
+      # firecracker). Catch it here with a paste-able remediation instead of
+      # the default "failed_when_result: true" stack trace.
+      when: firecracker.enabled | default(false) | bool
+      ansible.builtin.assert:
+        that:
+          - firecracker_kvm.stat.exists
+        fail_msg: |
+          /dev/kvm is missing on {{ inventory_hostname }} ({{ firecracker_uname_m.stdout | trim }}).
+          Firecracker is KVM-only and CANNOT run on this host.
+
+          Most likely cause: this host does not expose hardware virtualization.
+            * AWS EC2: only bare-metal instance types pass KVM through. Use
+              *.metal (c5n.metal, m5zn.metal, c7g.metal, i3.metal, m5.metal,
+              c5.metal, etc.). Standard t3/m5/c5/c6i/m6i/r5 instances are
+              themselves Nitro guests and do not have /dev/kvm.
+            * GCP: enable nested virtualization on the image (only N2/N1
+              with --enable-nested-virtualization).
+            * Azure: only Dv3/Ev3 and later with nested virt support.
+            * Bare metal / on-prem: enable Intel VT-x / AMD-V in BIOS, then
+              `sudo modprobe kvm_intel` (or kvm_amd).
+
+          To proceed WITHOUT Firecracker on this host:
+            1. Edit ../config/cluster.yml and set:
+                 firecracker:
+                   enabled: false
+            2. Re-run: ansible-playbook playbooks/configure-ops.yml
+
+          To install Firecracker only on capable hosts, keep
+          firecracker.enabled: true in config/cluster.yml and target the
+          play with --limit at a group that excludes non-KVM hosts.
+
+    - name: Compute Firecracker upstream download URLs
+      when: firecracker.enabled | default(false) | bool
+      ansible.builtin.set_fact:
+        # Tarball layout: release-<ver>-<arch>/firecracker-<ver>-<arch>
+        #                 release-<ver>-<arch>/jailer-<ver>-<arch>
+        # Sidecar checksum: <tarball>.sha256.txt (single-line "<hash>  <file>").
+        firecracker_release_base: >-
+          https://github.com/firecracker-microvm/firecracker/releases/download/{{ firecracker_version }}
+        firecracker_release_tarball: "firecracker-{{ firecracker_version }}-{{ firecracker_arch }}.tgz"
+        # Kernel: spec.ccfc.min is the upstream-blessed kernel bucket. Path
+        # layout is firecracker-ci/<ci_version>/<arch>/vmlinux-<kernel_version>.
+        firecracker_kernel_default_url: >-
+          https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/{{ firecracker_kernel_ci_version }}/{{ firecracker_arch }}/vmlinux-{{ firecracker_kernel_version }}
+
+    - name: Ensure Firecracker install directories exist
+      when: firecracker.enabled | default(false) | bool
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: "0755"
+        owner: root
+        group: root
+      loop:
+        - "{{ firecracker.binary_path | default('/usr/local/bin/firecracker') | dirname }}"
+        - "{{ firecracker.jailer_path | default('/usr/local/bin/jailer') | dirname }}"
+        - "{{ firecracker.kernel_path | default('/var/lib/sandboxd/firecracker/vmlinux') | dirname }}"
+        - "{{ firecracker.run_dir | default('/run/sandboxd/firecracker') }}"
+        - "{{ firecracker.templates_dir | default('/var/lib/sandboxd/firecracker/templates') }}"
+        - "{{ firecracker.jailer_chroot_base | default('/srv/jailer') }}"
+
+    - name: Stat installed Firecracker binary
+      when: firecracker.enabled | default(false) | bool
+      ansible.builtin.stat:
+        path: "{{ firecracker.binary_path | default('/usr/local/bin/firecracker') }}"
+      register: firecracker_installed_bin
+
+    - name: Probe installed Firecracker version
+      when:
+        - firecracker.enabled | default(false) | bool
+        - firecracker_installed_bin.stat.exists
+      ansible.builtin.command: "{{ firecracker.binary_path | default('/usr/local/bin/firecracker') }} --version"
+      register: firecracker_installed_version
+      changed_when: false
+      failed_when: false
+
+    # Skip the download/extract dance when the installed binary already
+    # reports the requested version. `firecracker --version` prints e.g.
+    # "Firecracker v1.10.1". Re-runs of configure-ops.yml stay fast.
+    - name: Install Firecracker + jailer from upstream release
+      when:
+        - firecracker.enabled | default(false) | bool
+        - firecracker_binary_url | length == 0
+        - (not firecracker_installed_bin.stat.exists) or (firecracker_version not in (firecracker_installed_version.stdout | default('')))
+      block:
+        - name: Create temp workspace for Firecracker release
+          ansible.builtin.tempfile:
+            state: directory
+            suffix: firecracker
+          register: firecracker_tmp
+
+        - name: Download Firecracker release tarball
+          ansible.builtin.get_url:
+            url: "{{ firecracker_release_base }}/{{ firecracker_release_tarball }}"
+            dest: "{{ firecracker_tmp.path }}/{{ firecracker_release_tarball }}"
+            mode: "0644"
+
+        - name: Download Firecracker release SHA256 sidecar
+          ansible.builtin.get_url:
+            url: "{{ firecracker_release_base }}/{{ firecracker_release_tarball }}.sha256.txt"
+            dest: "{{ firecracker_tmp.path }}/{{ firecracker_release_tarball }}.sha256.txt"
+            mode: "0644"
+
+        - name: Verify Firecracker release tarball SHA256
+          # sha256sum -c reads "<hash>  <file>" and exits non-zero on mismatch.
+          # Run from the tmp dir so the relative <file> in the sidecar resolves.
+          ansible.builtin.command:
+            cmd: "sha256sum -c {{ firecracker_release_tarball }}.sha256.txt"
+            chdir: "{{ firecracker_tmp.path }}"
+          changed_when: false
+
+        - name: Extract Firecracker release tarball
+          ansible.builtin.unarchive:
+            src: "{{ firecracker_tmp.path }}/{{ firecracker_release_tarball }}"
+            dest: "{{ firecracker_tmp.path }}"
+            remote_src: true
+
+        - name: Install Firecracker binary
+          ansible.builtin.copy:
+            src: "{{ firecracker_tmp.path }}/release-{{ firecracker_version }}-{{ firecracker_arch }}/firecracker-{{ firecracker_version }}-{{ firecracker_arch }}"
+            dest: "{{ firecracker.binary_path | default('/usr/local/bin/firecracker') }}"
+            mode: "0755"
+            owner: root
+            group: root
+            remote_src: true
+
+        - name: Install jailer binary
+          ansible.builtin.copy:
+            src: "{{ firecracker_tmp.path }}/release-{{ firecracker_version }}-{{ firecracker_arch }}/jailer-{{ firecracker_version }}-{{ firecracker_arch }}"
+            dest: "{{ firecracker.jailer_path | default('/usr/local/bin/jailer') }}"
+            mode: "0755"
+            owner: root
+            group: root
+            remote_src: true
+      always:
+        - name: Remove Firecracker release workspace
+          ansible.builtin.file:
+            path: "{{ firecracker_tmp.path }}"
+            state: absent
+          when: firecracker_tmp.path is defined
+
+    # Operator override path: a private mirror URL bypasses the upstream
+    # GitHub fetch entirely. Binary and jailer overrides are independent so
+    # operators can mix-and-match (e.g. host the binary internally, take
+    # jailer from upstream).
+    - name: Download Firecracker binary from operator-supplied URL
+      when:
+        - firecracker.enabled | default(false) | bool
+        - firecracker_binary_url | length > 0
+      ansible.builtin.get_url:
+        url: "{{ firecracker_binary_url }}"
+        dest: "{{ firecracker.binary_path | default('/usr/local/bin/firecracker') }}"
+        mode: "0755"
+        owner: root
+        group: root
+        force: no
+
+    - name: Download jailer from operator-supplied URL
+      when:
+        - firecracker.enabled | default(false) | bool
+        - firecracker_jailer_url | length > 0
+      ansible.builtin.get_url:
+        url: "{{ firecracker_jailer_url }}"
+        dest: "{{ firecracker.jailer_path | default('/usr/local/bin/jailer') }}"
+        mode: "0755"
+        owner: root
+        group: root
+        force: no
+
+    - name: Download Firecracker guest kernel image
+      # Operator URL wins when set; otherwise pull the arch-matched vmlinux
+      # from the upstream spec.ccfc.min bucket. force: no preserves any
+      # locally-built kernel an operator dropped in by hand.
+      when: firecracker.enabled | default(false) | bool
+      ansible.builtin.get_url:
+        url: "{{ firecracker_kernel_url if (firecracker_kernel_url | length > 0) else firecracker_kernel_default_url }}"
+        dest: "{{ firecracker.kernel_path | default('/var/lib/sandboxd/firecracker/vmlinux') }}"
+        mode: "0644"
+        owner: root
+        group: root
+        force: no
+
     # Upstream wrap key (Phase 4 F17). Two delivery modes:
     #   * shared SoT      -> aocr.upstream_wrap_key in config/secrets.yml
     #   * control-node file -> sandboxd_upstream_wrap_key_src (fleet / Vault rendering)

--- a/Ansible/playbooks/configure-ops.yml
+++ b/Ansible/playbooks/configure-ops.yml
@@ -55,6 +55,16 @@
       SB_ENABLE_CUSTOM_DOMAINS: "{{ ingress.enable_custom_domains | bool | string | lower }}"
       SB_CUSTOM_DOMAIN_VERIFY_PREFIX: "{{ ingress.custom_domain_txt_prefix }}"
       SB_CUSTOM_DOMAIN_VERIFY_VALUE_PREFIX: "{{ ingress.custom_domain_txt_value_prefix }}"
+      SB_ENABLE_FIRECRACKER: "{{ firecracker.enabled | default(false) | bool | string | lower }}"
+      SB_FIRECRACKER_BINARY: "{{ firecracker.binary_path | default('/usr/local/bin/firecracker') }}"
+      SB_JAILER_BINARY: "{{ firecracker.jailer_path | default('/usr/local/bin/jailer') }}"
+      SB_FIRECRACKER_KERNEL: "{{ firecracker.kernel_path | default('/var/lib/sandboxd/firecracker/vmlinux') }}"
+      SB_FIRECRACKER_RUN_DIR: "{{ firecracker.run_dir | default('/run/sandboxd/firecracker') }}"
+      SB_FIRECRACKER_TEMPLATES_DIR: "{{ firecracker.templates_dir | default('/var/lib/sandboxd/firecracker/templates') }}"
+      SB_FIRECRACKER_USE_JAILER: "{{ firecracker.use_jailer | default(true) | bool | string | lower }}"
+      SB_JAILER_CHROOT_BASE: "{{ firecracker.jailer_chroot_base | default('/srv/jailer') }}"
+      SB_FIRECRACKER_TAP_BASE_CIDR: "{{ firecracker.tap_base_cidr | default('172.16.0.0/20') }}"
+      SB_FIRECRACKER_TAP_POOL_SIZE: "{{ firecracker.tap_pool_size | default(256) }}"
       # Secret path: keyed off whether the operator supplied a wrap key in
       # config/secrets.yml (aocr.upstream_wrap_key) OR via a control-node
       # file (sandboxd_upstream_wrap_key_src in local.yml). Empty path = no

--- a/Terraform/README.md
+++ b/Terraform/README.md
@@ -134,6 +134,20 @@ phases:
 Terraform now exposes Firecracker directly in the node schema instead of
 making operators smuggle everything through `extra_user_data`.
 
+> **Host requirements (read this first).** Firecracker is a KVM-only VMM
+> and needs `/dev/kvm` on the host. **On AWS that means a bare-metal
+> instance type only.** Use `*.metal` SKUs (`c5n.metal`, `m5zn.metal`,
+> `c7g.metal`, `i3.metal`, `m5.metal`, `c5.metal`, …). Standard
+> `t3`/`m5`/`c5`/`c6i`/`m6i`/`r5` instances are themselves Nitro guests,
+> have no `/dev/kvm`, and will fail user-data with a clear remediation
+> message at first boot. On GCP, use N1/N2 with
+> `--enable-nested-virtualization`. On Azure, Dv3/Ev3+ with nested
+> virtualization. Bare metal: enable VT-x / AMD-V in BIOS.
+>
+> To proceed without Firecracker on incapable hosts, leave
+> `default_with_firecracker = false` and set `with_firecracker = true`
+> **only** on node entries whose `instance_type` is a bare-metal SKU.
+
 1. Mark worker-capable nodes with `with_firecracker = true`.
 2. Fill the `firecracker` object in `terraform.tfvars`.
 3. Choose one of two bootstrap modes:
@@ -164,8 +178,11 @@ firecracker = {
 
 nodes = {
   srv1 = { role = "server", seed = true, instance_type = "t3.small" }
-  wrk1 = { role = "worker", with_firecracker = true, instance_type = "c6i.xlarge" }
-  wrk2 = { role = "worker", with_firecracker = true, instance_type = "c6i.xlarge" }
+  # Firecracker nodes MUST be bare-metal (*.metal) — standard Nitro types
+  # (c6i, m6i, c5, m5, t3, ...) do not expose /dev/kvm and bootstrap will
+  # hard-fail with a remediation message.
+  wrk1 = { role = "worker", with_firecracker = true, instance_type = "c5.metal" }
+  wrk2 = { role = "worker", with_firecracker = true, instance_type = "c5.metal" }
 }
 ```
 

--- a/Terraform/templates/bootstrap.sh.tftpl
+++ b/Terraform/templates/bootstrap.sh.tftpl
@@ -223,6 +223,39 @@ sudo /tmp/cluster-join.sh \
 # in. URLs are optional: when omitted we assume the AMI already carries the
 # artifact at the configured path.
 ###############################################################################
+
+# KVM precondition. Firecracker is a KVM-only VMM — without /dev/kvm there
+# is nothing to install onto. Fail user-data with a paste-able remediation
+# instead of letting sandboxd hit it at first CreateSandbox(runtime=
+# firecracker). The check fires from user-data so the EC2 instance still
+# launches, but cloud-init reports failed and the node never joins the
+# cluster — exactly the signal an operator needs to fix the instance type.
+if [ ! -e /dev/kvm ]; then
+  cat >&2 <<EOF
+[bootstrap] /dev/kvm is missing on this host (uname -m: $(uname -m)).
+Firecracker is KVM-only and CANNOT run on this instance.
+
+Most likely cause on AWS: the instance type does not pass KVM through.
+  * Use a bare-metal type: *.metal (c5n.metal, m5zn.metal, c7g.metal,
+    i3.metal, m5.metal, c5.metal, etc.). Standard t3/m5/c5/c6i/m6i/r5
+    instances are themselves Nitro guests and do not expose /dev/kvm.
+  * GCP: enable nested virtualization on the image (N2/N1 only,
+    --enable-nested-virtualization). Azure: Dv3/Ev3+ with nested virt.
+  * Bare metal: enable Intel VT-x / AMD-V in BIOS, then
+    sudo modprobe kvm_intel (or kvm_amd).
+
+To proceed WITHOUT Firecracker, in your terraform.tfvars set:
+  default_with_firecracker = false
+and remove the per-node override (with_firecracker = true) from any
+node entry in the nodes list. Then: terraform apply.
+
+To enable Firecracker only on capable nodes, leave
+default_with_firecracker = false and set with_firecracker = true only on
+node entries whose instance_type is a bare-metal SKU.
+EOF
+  exit 1
+fi
+
 apt-get install -y skopeo umoci e2fsprogs iproute2
 
 install -d -m 0755 \

--- a/config/cluster.yml
+++ b/config/cluster.yml
@@ -74,6 +74,14 @@ image_build_gc:
   interval: "10m"
   ttl: "24h"
 
+# --- Firecracker runtime bootstrap ---------------------------------------
+# Host-level Firecracker enablement is opt-in. The bootstrap path must
+# install the runtime binaries and provide a kernel image at the configured
+# path before sandboxd starts with SB_ENABLE_FIRECRACKER=true.
+firecracker:
+  enabled: true
+  kernel_path: "/var/lib/sandboxd/firecracker/vmlinux"
+
 # --- AOCR mirror (Phase 4) ------------------------------------------------
 # Empty host disables mirror rewriting entirely. Upstreams maps upstream
 # hostnames to repository prefixes inside the mirror.

--- a/docs/src/content/docs/custom-domains.mdx
+++ b/docs/src/content/docs/custom-domains.mdx
@@ -22,6 +22,21 @@ The "target" below is whatever your default sandbox URLs already resolve to — 
 
 If your DNS provider does not support a flattened apex CNAME and you only have an ingress hostname (not IPs), the workaround is per-host DNS-01 issuance — tracked for v2 in `plans/custom-domains-dns01.md`.
 
+### Ownership verification (TXT record)
+
+In addition to the CNAME / A / AAAA above, you must publish a TXT record proving you control the zone. Without it, every `attach` call returns `403 Forbidden` with `custom domain TXT record verification failed`.
+
+The value is keyed to the **hostname**, not to a sandbox ID — one record per hostname, provisioned once, reusable across sandbox recreates and for any sandbox that wants to claim it. Cross-sandbox hijack of an already-attached hostname is still blocked by the cluster-wide uniqueness gate at attach time.
+
+| Custom hostname | TXT record name | TXT record value |
+|---|---|---|
+| Subdomain (`api.acme.com`) | `_aerol-verify.api` (zone `acme.com`) | `aerol-verify=api.acme.com` |
+| Apex (`acme.com`) | `_aerol-verify` (at zone root) | `aerol-verify=acme.com` |
+
+Most DNS provider UIs expect the Name relative to the managed zone (the left columns above); some expect the FQDN — in that case use `_aerol-verify.api.acme.com` or `_aerol-verify.acme.com` and the value is unchanged.
+
+Publish the TXT, wait for it to propagate (`dig TXT _aerol-verify.<your-host>`), then call `attach`. If you operate the cluster with non-default verification prefixes (`SB_CUSTOM_DOMAIN_VERIFY_PREFIX`, `SB_CUSTOM_DOMAIN_VERIFY_VALUE_PREFIX`), substitute those — `customDomains.dns()` always returns the correct row for the cluster you're talking to.
+
 ### Cloudflare specifics
 
 1. **Set the record to DNS-only (gray cloud), not Proxied (orange cloud).** With the proxy on, Cloudflare terminates TLS with its own certificate and the cluster never sees the SNI — Caddy's `ask` handler is never invoked, ACME never runs, and the domain stays `pending_dns` forever. The same applies to any CDN or reverse proxy that intercepts TLS in front of the ingress.
@@ -139,9 +154,10 @@ Two entry points:
   domain, when rendering "point your DNS here first" instructions. `source`
   is `"hostname"`, `"ips"`, `"mixed"`, or `"unknown"` — branch on it instead
   of guessing from which field is populated.
-- `customDomains.dns()` — per-sandbox. Returns one ready-to-paste DNS row per
-  attached domain plus the same `target` embedded, so callers don't need a
-  follow-up `dns.target()` round trip.
+- `customDomains.dns()` — per-sandbox. Returns the ready-to-paste DNS rows
+  for each attached domain — the routing record (CNAME / A / AAAA) **and**
+  the ownership-verification TXT — plus the same `target` embedded, so
+  callers don't need a follow-up `dns.target()` round trip.
 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">
@@ -296,6 +312,7 @@ Each attached hostname carries a `status` that reflects where Caddy is in the pe
 | Status | When |
 |---|---|
 | `400 Bad Request` | Hostname is malformed or includes a port. |
+| `403 Forbidden` | Ownership verification TXT record is missing or has the wrong value at `_aerol-verify.<hostname>`. See [Ownership verification (TXT record)](#ownership-verification-txt-record). |
 | `409 Conflict` | The hostname is already attached to a different sandbox (hostnames are globally unique across the cluster), the sandbox already exposes a `tcp://` / `tls://` port (the IRON RULE — custom domains and L4 exposures can't coexist on one sandbox), or the per-sandbox cap is reached. |
 | `412 Precondition Failed` | Custom domains are disabled (`SB_ENABLE_CUSTOM_DOMAINS=false`) or the server runs in IP mode (`SB_DOMAIN` unset). |
 | `429 Too Many Requests` | The daemon-wide ACME issuance budget is exhausted (LE `new-orders` per-account limit nearing 80% of 300/3h). Honour `Retry-After` and try again. |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1083,7 +1083,7 @@ func Load() (Config, error) {
 		EnableFirecracker:       getEnvBool("SB_ENABLE_FIRECRACKER", false),
 		FirecrackerBinary:       getEnv("SB_FIRECRACKER_BINARY", "/usr/local/bin/firecracker"),
 		JailerBinary:            getEnv("SB_JAILER_BINARY", "/usr/local/bin/jailer"),
-		FirecrackerKernelImage:  strings.TrimSpace(os.Getenv("SB_FIRECRACKER_KERNEL")),
+		FirecrackerKernelImage:  getEnv("SB_FIRECRACKER_KERNEL", "/var/lib/sandboxd/firecracker/vmlinux"),
 		FirecrackerRunDir:       getEnv("SB_FIRECRACKER_RUN_DIR", "/run/sandboxd/firecracker"),
 		FirecrackerTemplatesDir: getEnv("SB_FIRECRACKER_TEMPLATES_DIR", "/var/lib/sandboxd/firecracker/templates"),
 		UseJailer:               getEnvBool("SB_FIRECRACKER_USE_JAILER", true),

--- a/internal/service/custom_domains.go
+++ b/internal/service/custom_domains.go
@@ -216,8 +216,11 @@ func (s *Service) AddCustomDomain(ctx context.Context, sandboxID, hostname strin
 		}
 	}
 
-	// Verify DNS ownership (TXT record)
-	if err := verifyCustomDomainOwnership(ctx, s.dnsResolver, canonical, sandboxID, s.cfg.CustomDomainVerifyPrefix, s.cfg.CustomDomainVerifyValuePrefix); err != nil {
+	// Verify DNS ownership (TXT record). The TXT proves zone control and is
+	// keyed to the hostname, not the sandbox ID, so users can provision it
+	// once and attach the hostname to any sandbox (including a recreated
+	// one with a new ID).
+	if err := verifyCustomDomainOwnership(ctx, s.dnsResolver, canonical, s.cfg.CustomDomainVerifyPrefix, s.cfg.CustomDomainVerifyValuePrefix); err != nil {
 		return err
 	}
 

--- a/internal/service/custom_domains_test.go
+++ b/internal/service/custom_domains_test.go
@@ -69,12 +69,13 @@ func newCustomDomainsHarness(t *testing.T, cfgOverride func(*config.Config)) (*S
 			HTTPClientTimeout: time.Second,
 		}),
 		dnsResolver: &mockDNSResolver{
+			// TXT value is the hostname itself (proves zone control,
+			// reusable across sandbox recreates) — not the sandbox ID.
 			records: map[string][]string{
-				// Match whatever tests need
-				"_aerol-verify.api.acme.com":   {"aerol-verify=sb-1", "aerol-verify=sb-a", "aerol-verify=sb-b"},
-				"_aerol-verify.h0.acme.com":    {"aerol-verify=sb-1"},
-				"_aerol-verify.h1.acme.com":    {"aerol-verify=sb-1"},
-				"_aerol-verify.extra.acme.com": {"aerol-verify=sb-1"},
+				"_aerol-verify.api.acme.com":   {"aerol-verify=api.acme.com"},
+				"_aerol-verify.h0.acme.com":    {"aerol-verify=h0.acme.com"},
+				"_aerol-verify.h1.acme.com":    {"aerol-verify=h1.acme.com"},
+				"_aerol-verify.extra.acme.com": {"aerol-verify=extra.acme.com"},
 			},
 		},
 	}

--- a/internal/service/dns_verify.go
+++ b/internal/service/dns_verify.go
@@ -29,10 +29,14 @@ func (s *Service) SetDNSResolver(resolver DNSResolver) {
 }
 
 // verifyCustomDomainOwnership checks if the operator has proven ownership of
-// the custom domain by placing a specific TXT record.
-func verifyCustomDomainOwnership(ctx context.Context, resolver DNSResolver, hostname, sandboxID, txtNamePrefix, txtValuePrefix string) error {
+// the custom domain by placing a specific TXT record. The expected value is
+// derived from the hostname itself (not a sandbox ID), so the TXT can be
+// provisioned once per zone and reused across sandbox recreates. Cross-
+// sandbox hijack of an already-attached hostname is prevented by the
+// cluster-wide uniqueness gate on insert, not by this check.
+func verifyCustomDomainOwnership(ctx context.Context, resolver DNSResolver, hostname, txtNamePrefix, txtValuePrefix string) error {
 	verifyDomain := fmt.Sprintf("%s.%s", txtNamePrefix, hostname)
-	expectedValue := fmt.Sprintf("%s%s", txtValuePrefix, sandboxID)
+	expectedValue := fmt.Sprintf("%s%s", txtValuePrefix, hostname)
 
 	txts, err := resolver.LookupTXT(ctx, verifyDomain)
 	if err != nil {

--- a/internal/service/dns_verify_test.go
+++ b/internal/service/dns_verify_test.go
@@ -11,11 +11,11 @@ import (
 func TestVerifyCustomDomainOwnership_Success(t *testing.T) {
 	resolver := &mockDNSResolver{
 		records: map[string][]string{
-			"_aerol-verify.api.acme.com": {"aerol-verify=sb-1"},
+			"_aerol-verify.api.acme.com": {"aerol-verify=api.acme.com"},
 		},
 	}
 
-	err := verifyCustomDomainOwnership(context.Background(), resolver, "api.acme.com", "sb-1", "_aerol-verify", "aerol-verify=")
+	err := verifyCustomDomainOwnership(context.Background(), resolver, "api.acme.com", "_aerol-verify", "aerol-verify=")
 	if err != nil {
 		t.Fatalf("expected nil, got %v", err)
 	}
@@ -26,20 +26,22 @@ func TestVerifyCustomDomainOwnership_NotFound(t *testing.T) {
 		records: map[string][]string{},
 	}
 
-	err := verifyCustomDomainOwnership(context.Background(), resolver, "api.acme.com", "sb-1", "_aerol-verify", "aerol-verify=")
+	err := verifyCustomDomainOwnership(context.Background(), resolver, "api.acme.com", "_aerol-verify", "aerol-verify=")
 	if !errors.Is(err, models.ErrCustomDomainVerificationFailed) {
 		t.Fatalf("expected ErrCustomDomainVerificationFailed, got %v", err)
 	}
 }
 
 func TestVerifyCustomDomainOwnership_Mismatch(t *testing.T) {
+	// Record present but bound to a different hostname (e.g. left over
+	// from a previous tenant) — must not satisfy verification.
 	resolver := &mockDNSResolver{
 		records: map[string][]string{
-			"_aerol-verify.api.acme.com": {"aerol-verify=different"},
+			"_aerol-verify.api.acme.com": {"aerol-verify=other.acme.com"},
 		},
 	}
 
-	err := verifyCustomDomainOwnership(context.Background(), resolver, "api.acme.com", "sb-1", "_aerol-verify", "aerol-verify=")
+	err := verifyCustomDomainOwnership(context.Background(), resolver, "api.acme.com", "_aerol-verify", "aerol-verify=")
 	if !errors.Is(err, models.ErrCustomDomainVerificationFailed) {
 		t.Fatalf("expected ErrCustomDomainVerificationFailed, got %v", err)
 	}
@@ -48,11 +50,11 @@ func TestVerifyCustomDomainOwnership_Mismatch(t *testing.T) {
 func TestVerifyCustomDomainOwnership_MultipleRecords(t *testing.T) {
 	resolver := &mockDNSResolver{
 		records: map[string][]string{
-			"_aerol-verify.api.acme.com": {"other=123", "aerol-verify=sb-1", "foo=bar"},
+			"_aerol-verify.api.acme.com": {"other=123", "aerol-verify=api.acme.com", "foo=bar"},
 		},
 	}
 
-	err := verifyCustomDomainOwnership(context.Background(), resolver, "api.acme.com", "sb-1", "_aerol-verify", "aerol-verify=")
+	err := verifyCustomDomainOwnership(context.Background(), resolver, "api.acme.com", "_aerol-verify", "aerol-verify=")
 	if err != nil {
 		t.Fatalf("expected nil, got %v", err)
 	}

--- a/internal/service/ingress.go
+++ b/internal/service/ingress.go
@@ -47,7 +47,7 @@ func (s *Service) CustomDomainDNS(ctx context.Context, sandboxID string) (models
 	// usable target. Normalise to an empty slice so the JSON shape is a
 	// stable `[]` — SDKs that type Records as `DNSRecord[]` would choke
 	// on `null` (TypeScript .map, Rust serde Vec, etc.).
-	records := models.ComposeDNSRecords(hostnames, target, sandboxID, s.cfg.CustomDomainVerifyPrefix, s.cfg.CustomDomainVerifyValuePrefix)
+	records := models.ComposeDNSRecords(hostnames, target, s.cfg.CustomDomainVerifyPrefix, s.cfg.CustomDomainVerifyValuePrefix)
 	if records == nil {
 		records = []models.DNSRecord{}
 	}

--- a/pkg/api/v1/custom_domains_test.go
+++ b/pkg/api/v1/custom_domains_test.go
@@ -52,9 +52,11 @@ func newCustomDomainsV1Env(t *testing.T, cfgOverride func(*config.Config)) *cust
 	caddyClient := caddy.New(config.Config{EnableCaddy: false, HTTPClientTimeout: time.Second})
 	svc := service.New(cfg, logger, st, &noopRuntime{}, nil, caddyClient, nil, nil, nil)
 	svc.SetDNSResolver(&mockDNSResolver{
+		// TXT value is the hostname itself, not the sandbox ID, so a
+		// single record can serve every sandbox that claims the host.
 		records: map[string][]string{
-			"_aerol-verify.api.acme.com": {"aerol-verify=sb-1", "aerol-verify=sb-a", "aerol-verify=sb-b"},
-			"_aerol-verify.acme.com":     {"aerol-verify=sb-1"},
+			"_aerol-verify.api.acme.com": {"aerol-verify=api.acme.com"},
+			"_aerol-verify.acme.com":     {"aerol-verify=acme.com"},
 		},
 	})
 

--- a/pkg/api/v1/dns_test.go
+++ b/pkg/api/v1/dns_test.go
@@ -82,17 +82,21 @@ func TestV1CustomDomainDNS_ReturnsRecordsAfterAttach(t *testing.T) {
 	cnames := 0
 	txts := 0
 	for _, r := range got.Records {
-		if r.Type == models.DNSRecordTypeCNAME {
+		switch r.Type {
+		case models.DNSRecordTypeCNAME:
 			cnames++
 			if r.Value != "ingress.example.com" {
 				t.Fatalf("unexpected CNAME record %+v", r)
 			}
-		} else if r.Type == "TXT" {
+		case "TXT":
 			txts++
-			if r.Value != "aerol-verify=sb-1" {
-				t.Fatalf("unexpected TXT record %+v", r)
+			// Value is keyed to the hostname, not the sandbox ID — same
+			// record works across sandbox recreates.
+			wantValue := "aerol-verify=" + r.Hostname
+			if r.Value != wantValue {
+				t.Fatalf("TXT Value=%q, want %q (record=%+v)", r.Value, wantValue, r)
 			}
-		} else {
+		default:
 			t.Fatalf("unexpected record %+v", r)
 		}
 	}

--- a/pkg/models/dns_records.go
+++ b/pkg/models/dns_records.go
@@ -36,9 +36,14 @@ const cloudflareNote = "Cloudflare/CDN: set the record to DNS only (gray cloud).
 // with A/AAAA records at the same name (RFC 1034 §3.6.2). DNS providers
 // reject the second row, so emitting both as "ready-to-paste" would just
 // trip the user up.
-// `sandboxID` is provided to generate ownership verification records.
+//
+// The TXT verification record proves zone control, not sandbox binding:
+// value is `<txtValuePrefix><hostname>`, so the same record stays valid
+// across sandbox recreates and can be provisioned BEFORE a sandbox exists.
+// Cross-sandbox hijack is still blocked by the cluster-wide uniqueness gate
+// on hostname insert.
 // `txtNamePrefix` and `txtValuePrefix` allow customizing the verification TXT records.
-func ComposeDNSRecords(hostnames []string, target IngressTarget, sandboxID, txtNamePrefix, txtValuePrefix string) []DNSRecord {
+func ComposeDNSRecords(hostnames []string, target IngressTarget, txtNamePrefix, txtValuePrefix string) []DNSRecord {
 	if len(hostnames) == 0 {
 		return nil
 	}
@@ -78,16 +83,17 @@ func ComposeDNSRecords(hostnames []string, target IngressTarget, sandboxID, txtN
 			}
 		}
 
-		// Add TXT verification record
-		if sandboxID != "" {
-			out = append(out, DNSRecord{
-				Hostname: host,
-				Type:     "TXT",
-				Name:     fmt.Sprintf("%s.%s", txtNamePrefix, name),
-				Value:    fmt.Sprintf("%s%s", txtValuePrefix, sandboxID),
-				Notes:    "Required for domain ownership verification.",
-			})
-		}
+		// Add TXT verification record. Value is the hostname itself so the
+		// record proves zone control (one-time setup per hostname) instead
+		// of binding to a specific sandbox ID — that lets the TXT be added
+		// BEFORE any sandbox exists and survive sandbox recreates.
+		out = append(out, DNSRecord{
+			Hostname: host,
+			Type:     "TXT",
+			Name:     fmt.Sprintf("%s.%s", txtNamePrefix, name),
+			Value:    fmt.Sprintf("%s%s", txtValuePrefix, host),
+			Notes:    "Required for domain ownership verification.",
+		})
 	}
 	return out
 }

--- a/pkg/models/dns_records_test.go
+++ b/pkg/models/dns_records_test.go
@@ -5,9 +5,23 @@ import (
 	"testing"
 )
 
+// nonTXT filters out the always-emitted TXT verification record so tests
+// focused on the CNAME/A/AAAA strategy don't have to re-count records every
+// time the verification rule changes shape.
+func nonTXT(recs []DNSRecord) []DNSRecord {
+	out := make([]DNSRecord, 0, len(recs))
+	for _, r := range recs {
+		if r.Type == "TXT" {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
 func TestComposeDNSRecords_SubdomainCNAME(t *testing.T) {
 	target := IngressTarget{Hostname: "ingress.example.com", Source: IngressTargetSourceHostname}
-	got := ComposeDNSRecords([]string{"api.acme.com"}, target, "", "_aerol-verify", "aerol-verify=")
+	got := nonTXT(ComposeDNSRecords([]string{"api.acme.com"}, target, "_aerol-verify", "aerol-verify="))
 	if len(got) != 1 {
 		t.Fatalf("want 1 record, got %d", len(got))
 	}
@@ -22,7 +36,7 @@ func TestComposeDNSRecords_SubdomainCNAME(t *testing.T) {
 
 func TestComposeDNSRecords_ApexCNAME(t *testing.T) {
 	target := IngressTarget{Hostname: "ingress.example.com", Source: IngressTargetSourceHostname}
-	got := ComposeDNSRecords([]string{"acme.com"}, target, "", "_aerol-verify", "aerol-verify=")
+	got := nonTXT(ComposeDNSRecords([]string{"acme.com"}, target, "_aerol-verify", "aerol-verify="))
 	if len(got) != 1 || got[0].Name != "@" || got[0].Type != DNSRecordTypeCNAME {
 		t.Fatalf("apex should produce one CNAME with Name=@, got %+v", got)
 	}
@@ -34,7 +48,7 @@ func TestComposeDNSRecords_DeepSubdomainUsesFullPrefix(t *testing.T) {
 	// "acme.com", the correct Name is "a.b.c" — using just "a" would
 	// create the wrong row.
 	target := IngressTarget{Hostname: "ingress.example.com", Source: IngressTargetSourceHostname}
-	got := ComposeDNSRecords([]string{"a.b.c.acme.com"}, target, "", "_aerol-verify", "aerol-verify=")
+	got := nonTXT(ComposeDNSRecords([]string{"a.b.c.acme.com"}, target, "_aerol-verify", "aerol-verify="))
 	if len(got) != 1 || got[0].Name != "a.b.c" {
 		t.Fatalf("expected Name=a.b.c for deep subdomain, got %+v", got)
 	}
@@ -45,7 +59,7 @@ func TestComposeDNSRecords_PublicSuffixApex(t *testing.T) {
 	// the leftmost label "example" is NOT a subdomain. A naive
 	// label-count heuristic would mis-render this as Name="example".
 	target := IngressTarget{Hostname: "ingress.example.com", Source: IngressTargetSourceHostname}
-	got := ComposeDNSRecords([]string{"example.co.uk"}, target, "", "_aerol-verify", "aerol-verify=")
+	got := nonTXT(ComposeDNSRecords([]string{"example.co.uk"}, target, "_aerol-verify", "aerol-verify="))
 	if len(got) != 1 || got[0].Name != "@" {
 		t.Fatalf("expected apex Name=@ for example.co.uk, got %+v", got)
 	}
@@ -53,7 +67,7 @@ func TestComposeDNSRecords_PublicSuffixApex(t *testing.T) {
 
 func TestComposeDNSRecords_PublicSuffixSubdomain(t *testing.T) {
 	target := IngressTarget{Hostname: "ingress.example.com", Source: IngressTargetSourceHostname}
-	got := ComposeDNSRecords([]string{"api.example.co.uk"}, target, "", "_aerol-verify", "aerol-verify=")
+	got := nonTXT(ComposeDNSRecords([]string{"api.example.co.uk"}, target, "_aerol-verify", "aerol-verify="))
 	if len(got) != 1 || got[0].Name != "api" {
 		t.Fatalf("expected Name=api for api.example.co.uk, got %+v", got)
 	}
@@ -61,7 +75,7 @@ func TestComposeDNSRecords_PublicSuffixSubdomain(t *testing.T) {
 
 func TestComposeDNSRecords_IPv4ProducesA(t *testing.T) {
 	target := IngressTarget{IPs: []string{"203.0.113.10"}, Source: IngressTargetSourceIPs}
-	got := ComposeDNSRecords([]string{"api.acme.com"}, target, "", "_aerol-verify", "aerol-verify=")
+	got := nonTXT(ComposeDNSRecords([]string{"api.acme.com"}, target, "_aerol-verify", "aerol-verify="))
 	if len(got) != 1 || got[0].Type != DNSRecordTypeA || got[0].Value != "203.0.113.10" {
 		t.Fatalf("expected single A record, got %+v", got)
 	}
@@ -69,7 +83,7 @@ func TestComposeDNSRecords_IPv4ProducesA(t *testing.T) {
 
 func TestComposeDNSRecords_IPv6ProducesAAAA(t *testing.T) {
 	target := IngressTarget{IPs: []string{"2001:db8::1"}, Source: IngressTargetSourceIPs}
-	got := ComposeDNSRecords([]string{"api.acme.com"}, target, "", "_aerol-verify", "aerol-verify=")
+	got := nonTXT(ComposeDNSRecords([]string{"api.acme.com"}, target, "_aerol-verify", "aerol-verify="))
 	if len(got) != 1 || got[0].Type != DNSRecordTypeAAAA {
 		t.Fatalf("expected AAAA for IPv6, got %+v", got)
 	}
@@ -77,7 +91,7 @@ func TestComposeDNSRecords_IPv6ProducesAAAA(t *testing.T) {
 
 func TestComposeDNSRecords_MixedIPv4AndIPv6(t *testing.T) {
 	target := IngressTarget{IPs: []string{"203.0.113.10", "2001:db8::1"}, Source: IngressTargetSourceIPs}
-	got := ComposeDNSRecords([]string{"acme.com"}, target, "", "_aerol-verify", "aerol-verify=")
+	got := nonTXT(ComposeDNSRecords([]string{"acme.com"}, target, "_aerol-verify", "aerol-verify="))
 	if len(got) != 2 {
 		t.Fatalf("want 2 records, got %d", len(got))
 	}
@@ -95,7 +109,7 @@ func TestComposeDNSRecords_MixedSourceSubdomainPrefersCNAME(t *testing.T) {
 		IPs:      []string{"203.0.113.10"},
 		Source:   IngressTargetSourceMixed,
 	}
-	got := ComposeDNSRecords([]string{"api.acme.com"}, target, "", "_aerol-verify", "aerol-verify=")
+	got := nonTXT(ComposeDNSRecords([]string{"api.acme.com"}, target, "_aerol-verify", "aerol-verify="))
 	if len(got) != 1 {
 		t.Fatalf("expected single record, got %d: %+v", len(got), got)
 	}
@@ -113,7 +127,7 @@ func TestComposeDNSRecords_MixedSourceApexPrefersIPs(t *testing.T) {
 		IPs:      []string{"203.0.113.10", "2001:db8::1"},
 		Source:   IngressTargetSourceMixed,
 	}
-	got := ComposeDNSRecords([]string{"acme.com"}, target, "", "_aerol-verify", "aerol-verify=")
+	got := nonTXT(ComposeDNSRecords([]string{"acme.com"}, target, "_aerol-verify", "aerol-verify="))
 	if len(got) != 2 {
 		t.Fatalf("expected A + AAAA at apex, got %d records: %+v", len(got), got)
 	}
@@ -129,7 +143,7 @@ func TestComposeDNSRecords_MixedSourceApexPrefersIPs(t *testing.T) {
 
 func TestComposeDNSRecords_MultipleHostnames(t *testing.T) {
 	target := IngressTarget{Hostname: "ingress.example.com", Source: IngressTargetSourceHostname}
-	got := ComposeDNSRecords([]string{"api.acme.com", "acme.com"}, target, "", "_aerol-verify", "aerol-verify=")
+	got := nonTXT(ComposeDNSRecords([]string{"api.acme.com", "acme.com"}, target, "_aerol-verify", "aerol-verify="))
 	if len(got) != 2 {
 		t.Fatalf("want 2 records, got %d", len(got))
 	}
@@ -139,17 +153,17 @@ func TestComposeDNSRecords_MultipleHostnames(t *testing.T) {
 }
 
 func TestComposeDNSRecords_EmptyInputReturnsNil(t *testing.T) {
-	if got := ComposeDNSRecords(nil, IngressTarget{Hostname: "x.example.com"}, "", "_aerol-verify", "aerol-verify="); got != nil {
+	if got := ComposeDNSRecords(nil, IngressTarget{Hostname: "x.example.com"}, "_aerol-verify", "aerol-verify="); got != nil {
 		t.Fatalf("expected nil for empty hostnames, got %+v", got)
 	}
-	if got := ComposeDNSRecords([]string{"api.acme.com"}, IngressTarget{Source: IngressTargetSourceUnknown}, "", "_aerol-verify", "aerol-verify="); got != nil {
+	if got := ComposeDNSRecords([]string{"api.acme.com"}, IngressTarget{Source: IngressTargetSourceUnknown}, "_aerol-verify", "aerol-verify="); got != nil {
 		t.Fatalf("expected nil for empty target, got %+v", got)
 	}
 }
 
 func TestComposeDNSRecords_NormalizesHostname(t *testing.T) {
 	target := IngressTarget{Hostname: "ingress.example.com", Source: IngressTargetSourceHostname}
-	got := ComposeDNSRecords([]string{"  API.Acme.COM.  "}, target, "", "_aerol-verify", "aerol-verify=")
+	got := nonTXT(ComposeDNSRecords([]string{"  API.Acme.COM.  "}, target, "_aerol-verify", "aerol-verify="))
 	if len(got) != 1 {
 		t.Fatalf("want 1 record, got %d", len(got))
 	}
@@ -159,8 +173,11 @@ func TestComposeDNSRecords_NormalizesHostname(t *testing.T) {
 }
 
 func TestComposeDNSRecords_IncludesTXTRecord(t *testing.T) {
+	// TXT value is the hostname itself (not a sandbox ID) so the record
+	// proves zone control, can be provisioned before any sandbox exists,
+	// and survives sandbox recreates.
 	target := IngressTarget{Hostname: "ingress.example.com", Source: IngressTargetSourceHostname}
-	got := ComposeDNSRecords([]string{"api.acme.com"}, target, "sb-123", "_aerol-verify", "aerol-verify=")
+	got := ComposeDNSRecords([]string{"api.acme.com"}, target, "_aerol-verify", "aerol-verify=")
 
 	txtFound := false
 	for _, r := range got {
@@ -169,8 +186,8 @@ func TestComposeDNSRecords_IncludesTXTRecord(t *testing.T) {
 			if r.Name != "_aerol-verify.api" {
 				t.Errorf("TXT Name = %q, want _aerol-verify.api", r.Name)
 			}
-			if r.Value != "aerol-verify=sb-123" {
-				t.Errorf("TXT Value = %q, want aerol-verify=sb-123", r.Value)
+			if r.Value != "aerol-verify=api.acme.com" {
+				t.Errorf("TXT Value = %q, want aerol-verify=api.acme.com", r.Value)
 			}
 		}
 	}


### PR DESCRIPTION
This pull request adds robust, automated support for installing the Firecracker microVM runtime via Ansible and improves related documentation and configuration. It ensures Firecracker is only installed on compatible hosts (with KVM support), provides clear remediation guidance when requirements aren't met, and allows for flexible operator overrides. The changes also update Terraform and bootstrap scripts to enforce these requirements and provide clear instructions for users.

**Firecracker Installation and Host Validation**

* Added an automated Ansible role in `configure-ops.yml` to install Firecracker, jailer, and a guest kernel image only on hosts with `firecracker.enabled: true` in `config/cluster.yml`. The playbook detects the host architecture, validates `/dev/kvm` presence, and fails early with actionable error messages if requirements are not met. [[1]](diffhunk://#diff-6b40727b7ee1b6146e3019eb1e458c74b50ceac822f90d09052bc821ad605adcR201-R430) [[2]](diffhunk://#diff-eec29ea61b3a84f5b172310ea937d71fdaf686832f04018033f3ff72edc5f42cR447-R544)
* Updated bootstrap scripts (`Terraform/templates/bootstrap.sh.tftpl`) and Terraform documentation to check for `/dev/kvm` and fail fast with clear remediation steps if the host is not suitable for Firecracker. [[1]](diffhunk://#diff-95a53dc8526438c066378581699aabc08e78224c7ed9c4ed9cd6bd33240309ddR226-R258) [[2]](diffhunk://#diff-e236e2d863f30a3543aa94a911c05a4b0ac38c2d4cd81d8b12f9b195693fbf23R137-R150) [[3]](diffhunk://#diff-e236e2d863f30a3543aa94a911c05a4b0ac38c2d4cd81d8b12f9b195693fbf23L167-R185)

**Configuration and Defaults**

* Introduced new Firecracker-related configuration options and version pins in `inventory/group_vars/all/defaults.yml`, allowing for operator overrides and private mirrors for binaries and kernels.
* Added a Firecracker configuration section to `config/cluster.yml` to enable/disable Firecracker and set the kernel path.

**Documentation Updates**

* Expanded the Ansible and Terraform `README.md` files with detailed instructions, host requirements, and operational guidance for installing and managing Firecracker in various environments (AWS, GCP, Azure, bare metal). [[1]](diffhunk://#diff-eec29ea61b3a84f5b172310ea937d71fdaf686832f04018033f3ff72edc5f42cR447-R544) [[2]](diffhunk://#diff-e236e2d863f30a3543aa94a911c05a4b0ac38c2d4cd81d8b12f9b195693fbf23R137-R150) [[3]](diffhunk://#diff-e236e2d863f30a3543aa94a911c05a4b0ac38c2d4cd81d8b12f9b195693fbf23L167-R185)
* Clarified in the Ansible documentation that installing or upgrading Firecracker artifacts should be done via Ansible.

**Environment Variable Support**

* Added support for Firecracker-related environment variables in the Ansible playbook to configure paths, enablement, and network settings for sandboxd integration.<!--
GitHub auto-fills new PR descriptions with this template. Fill in EVERY
section below. "N/A — <one-line reason>" is a valid answer; an empty answer
is not. See pr-review.md at the repo root for what each section is asking.
-->

## Summary

<!-- 1-3 bullets: what changed and why. -->

## Sandbox boot impact

<!--
Did this PR add ANY work — DB query, HTTP round-trip, file I/O, lock
acquisition — to CreateSandbox or anything it calls?

If yes: state what was added, expected added latency, when it fires, and
whether it's bounded. "Only on the first call" is still impact and must be
called out.

If no: write "N/A — no work added to sandbox boot path."
-->

## Idempotency

<!--
For every API surface this PR touches, describe behavior under retry and
under concurrent calls with the same inputs. Sandbox APIs MUST be
idempotent (see pr-review.md §1).

If no API surface changed: write "N/A — no API surface changed."
-->

## Failure-path consistency

<!--
For any multi-step write that touches BOTH caddy and the store: what is the
rollback rule on partial failure? Who cleans up if step 2 of 3 fails?

If no multi-step write path was changed: write "N/A — no multi-step write
path changed."
-->

## L4 / host-port-pool changes

<!--
Did this PR touch TryReserveHostPort, the partial unique index on
host_port, allocateHostPort, EnsureLayer4, EnsureLayer4Ready, or the
l4Ready latch? If yes, link the regression test that covers the change.

If no: write "N/A — neither touched."
-->

## Test plan

<!-- Bulleted checklist of how this was verified. -->
