### PR TITLE
bug: Fix Firecracker runtime and domain port number in configuration

### DIFF
--- a/cmd/sandboxd/cluster_resolver_test.go
+++ b/cmd/sandboxd/cluster_resolver_test.go
@@ -78,7 +78,7 @@ func TestClusterAwareDomainResolver_NoopFallsBackToStore(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("store.Create: %v", err)
 	}
-	if err := st.AddCustomDomain(ctx, "sb-local", "api.local.example"); err != nil {
+	if err := st.AddCustomDomain(ctx, "sb-local", "api.local.example", 0); err != nil {
 		t.Fatalf("AddCustomDomain: %v", err)
 	}
 

--- a/config/cluster.yml
+++ b/config/cluster.yml
@@ -79,7 +79,7 @@ image_build_gc:
 # install the runtime binaries and provide a kernel image at the configured
 # path before sandboxd starts with SB_ENABLE_FIRECRACKER=true.
 firecracker:
-  enabled: true
+  enabled: false
   kernel_path: "/var/lib/sandboxd/firecracker/vmlinux"
 
 # --- AOCR mirror (Phase 4) ------------------------------------------------

--- a/docs/src/content/docs/custom-domains.mdx
+++ b/docs/src/content/docs/custom-domains.mdx
@@ -129,7 +129,7 @@ The add call returns the post-attach list with the new row's `status` so callers
   </TabItem>
   <TabItem label="Rust">
     ```rust
-    let domains = sandbox.add_custom_domain("staging.acme.com")?;
+    let domains = sandbox.add_custom_domain("staging.acme.com", None)?;
     ```
   </TabItem>
   <TabItem label="Java">
@@ -138,6 +138,45 @@ The add call returns the post-attach list with the new row's `status` so callers
     ```
   </TabItem>
 </Tabs>
+
+### Target port
+
+By default traffic to a custom domain dials the sandbox's toolbox port — the same root URL `https://{id}.{cluster-domain}` serves. Pass a `port` to route the hostname at a specific application port inside the container instead (e.g. an app listening on `3333`). This is the same routing the default `sb-{id}-{port}.{cluster-domain}` URLs use, but bound to your custom hostname.
+
+`port` is fixed at attach time. To change it, detach and re-add — re-adding the same hostname with a different `port` returns `409 Conflict` rather than silently redirecting live traffic.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    await sandbox.customDomains.add("api.acme.com", { port: 3333 });
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    sandbox.add_custom_domain("api.acme.com", port=3333)
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    _, err := sandbox.AddCustomDomain(ctx, "api.acme.com", microvm.WithTargetPort(3333))
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    sandbox.add_custom_domain(
+        "api.acme.com",
+        Some(AddCustomDomainOptions::with_port(3333)),
+    )?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    sandbox.addCustomDomain("api.acme.com", 3333);
+    ```
+  </TabItem>
+</Tabs>
+
+Create-time `customDomains` always uses the toolbox-port default; to bind a custom port, attach after create.
 
 ## Discover DNS records from the SDK
 
@@ -311,9 +350,9 @@ Each attached hostname carries a `status` that reflects where Caddy is in the pe
 
 | Status | When |
 |---|---|
-| `400 Bad Request` | Hostname is malformed or includes a port. |
+| `400 Bad Request` | Hostname is malformed or includes a port, or `target_port` is outside `1..65535`. |
 | `403 Forbidden` | Ownership verification TXT record is missing or has the wrong value at `_aerol-verify.<hostname>`. See [Ownership verification (TXT record)](#ownership-verification-txt-record). |
-| `409 Conflict` | The hostname is already attached to a different sandbox (hostnames are globally unique across the cluster), the sandbox already exposes a `tcp://` / `tls://` port (the IRON RULE — custom domains and L4 exposures can't coexist on one sandbox), or the per-sandbox cap is reached. |
+| `409 Conflict` | The hostname is already attached to a different sandbox (hostnames are globally unique across the cluster), the sandbox already exposes a `tcp://` / `tls://` port (the IRON RULE — custom domains and L4 exposures can't coexist on one sandbox), the per-sandbox cap is reached, or the hostname is already attached to this sandbox with a different `target_port` (detach + re-add to change it). |
 | `412 Precondition Failed` | Custom domains are disabled (`SB_ENABLE_CUSTOM_DOMAINS=false`) or the server runs in IP mode (`SB_DOMAIN` unset). |
 | `429 Too Many Requests` | The daemon-wide ACME issuance budget is exhausted (LE `new-orders` per-account limit nearing 80% of 300/3h). Honour `Retry-After` and try again. |
 

--- a/internal/service/cluster_ownership.go
+++ b/internal/service/cluster_ownership.go
@@ -106,7 +106,7 @@ func placementCanBeClaimedBySelf(p cluster.Placement, self string) bool {
 // failed to ship them. Force a replay so the failover-recreate target has
 // the user's TLS matchers.
 func placementMissingLocalCustomHostnames(p cluster.Placement, sb *models.Sandbox) bool {
-	local := sandboxCustomHostnames(sb)
+	local := sandboxCustomHostnamesList(sb)
 	if len(local) == 0 {
 		return false
 	}
@@ -163,7 +163,7 @@ func (s *Service) localSandboxStateForCluster(ctx context.Context, c cluster.Cli
 		Spec:            spec,
 		Secrets:         secrets,
 		ExposedPorts:    clusterPortsFromSandbox(sb),
-		CustomHostnames: sandboxCustomHostnames(sb),
+		CustomHostnames: sandboxCustomHostnamesList(sb),
 	}
 }
 

--- a/internal/service/custom_domains.go
+++ b/internal/service/custom_domains.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aerol-ai/microvm/internal/cluster"
 	"github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/caddy"
 	"github.com/aerol-ai/microvm/pkg/models"
 )
 
@@ -55,15 +56,39 @@ func evictCustomDomainNegativeCache(hostname string) {
 	}
 }
 
-// sandboxCustomHostnames extracts the operator-attached public hostnames from
-// a sandbox snapshot in the shape expected by pkg/caddy's matcher helpers.
-// Returns nil when the field is empty so the route shape stays byte-identical
-// to pre-custom-domains for sandboxes that never attached one.
-func sandboxCustomHostnames(sandbox *models.Sandbox) []string {
+// sandboxCustomHostnamesList returns just the operator-attached hostnames
+// (without per-domain ports) for cluster-FSM replay and similar consumers
+// that only care about the ownership binding, not the routing dial target.
+func sandboxCustomHostnamesList(sandbox *models.Sandbox) []string {
 	if sandbox == nil || len(sandbox.CustomDomains) == 0 {
 		return nil
 	}
 	out := make([]string, 0, len(sandbox.CustomDomains))
+	for _, cd := range sandbox.CustomDomains {
+		if cd.Hostname != "" {
+			out = append(out, cd.Hostname)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// sandboxCustomHostnames extracts the operator-attached public hostnames
+// plus their per-domain target ports from a sandbox snapshot, in the shape
+// expected by pkg/caddy.UpsertSandboxRoute. Returns nil when the field is
+// empty so the route shape stays byte-identical to pre-custom-domains for
+// sandboxes that never attached one.
+//
+// TargetPort=0 propagates as-is — pkg/caddy resolves that to the toolbox
+// port at install time, preserving the pre-target-port default behavior for
+// rows persisted before the feature shipped.
+func sandboxCustomHostnames(sandbox *models.Sandbox) []caddy.CustomHostnameRoute {
+	if sandbox == nil || len(sandbox.CustomDomains) == 0 {
+		return nil
+	}
+	out := make([]caddy.CustomHostnameRoute, 0, len(sandbox.CustomDomains))
 	for _, cd := range sandbox.CustomDomains {
 		// Defense in depth: only the validated, normalized hostname goes
 		// into the Caddy matcher. Status (pending_dns / issuing / ready /
@@ -71,9 +96,10 @@ func sandboxCustomHostnames(sandbox *models.Sandbox) []string {
 		// the cert lifecycle independently. A domain whose DNS hasn't
 		// propagated yet simply won't get traffic; once it does, the
 		// route is already in place.
-		if cd.Hostname != "" {
-			out = append(out, cd.Hostname)
+		if cd.Hostname == "" {
+			continue
 		}
+		out = append(out, caddy.CustomHostnameRoute{Hostname: cd.Hostname, TargetPort: cd.TargetPort})
 	}
 	if len(out) == 0 {
 		return nil
@@ -125,6 +151,11 @@ var ErrCustomDomainProtocolConflict = models.ErrCustomDomainProtocolConflict
 // ErrCustomDomainPerSandboxCap — see pkg/models comment.
 var ErrCustomDomainPerSandboxCap = models.ErrCustomDomainPerSandboxCap
 
+// ErrCustomDomainPortMismatch surfaces the store-layer port-mismatch sentinel
+// under the service-layer sentinel that the API handler already maps to 409.
+// See store.ErrCustomDomainPortMismatch for the underlying rule.
+var ErrCustomDomainPortMismatch = store.ErrCustomDomainPortMismatch
+
 // recordClusterCustomDomain replicates the (sandbox, hostname) binding into
 // the placement FSM so cluster-wide uniqueness, ingress-node TLS-ask lookup,
 // and failover replay all see it. Mirrors recordClusterExposedPort.
@@ -169,16 +200,26 @@ func (s *Service) removeClusterCustomDomain(ctx context.Context, sandboxID, host
 // the hostname is punched so the next ACME ask hits the resolver instead of
 // being refused for the cached 60s.
 //
+// targetPort selects the in-container port the hostname routes to. Zero is
+// the sentinel meaning "use the toolbox port" (the pre-target-port default,
+// preserving existing behavior). Set once at attach time; changing the port
+// requires detach + re-add so in-flight traffic can't silently redirect.
+//
 // Returns:
 //   - ErrCustomDomainNotSupported (412) when the deployment doesn't support custom domains.
 //   - ErrCustomDomainInvalid (400) when the hostname fails validation.
+//   - ErrCustomDomainInvalidTargetPort (400) when targetPort is outside [0, 65535].
 //   - ErrCustomDomainProtocolConflict (409) when the sandbox already exposes tcp/tls ports.
 //   - ErrCustomDomainPerSandboxCap (409) when the sandbox already holds the cap.
+//   - ErrCustomDomainPortMismatch (409) when re-adding an existing hostname with a different port.
 //   - store.ErrCustomDomainConflict (409) when the hostname is owned by a different sandbox.
 //   - store.ErrNotFound (404) when the sandbox does not exist.
-func (s *Service) AddCustomDomain(ctx context.Context, sandboxID, hostname string) error {
+func (s *Service) AddCustomDomain(ctx context.Context, sandboxID, hostname string, targetPort int) error {
 	if !s.cfg.EnableCustomDomains || strings.TrimSpace(s.cfg.Domain) == "" {
 		return ErrCustomDomainNotSupported
+	}
+	if err := models.ValidateCustomDomainTargetPort(targetPort); err != nil {
+		return err
 	}
 	canonical, err := models.NormalizeCustomDomain(hostname, s.cfg.Domain)
 	if err != nil {
@@ -224,7 +265,7 @@ func (s *Service) AddCustomDomain(ctx context.Context, sandboxID, hostname strin
 		return err
 	}
 
-	if err := s.store.AddCustomDomain(ctx, sandboxID, canonical); err != nil {
+	if err := s.store.AddCustomDomain(ctx, sandboxID, canonical, targetPort); err != nil {
 		return err
 	}
 
@@ -316,11 +357,17 @@ func (s *Service) RemoveCustomDomain(ctx context.Context, sandboxID, hostname st
 		return fmt.Errorf("reload sandbox after custom-domain delete: %w", err)
 	}
 	if err := s.caddy.UpsertSandboxRoute(ctx, refreshed.ID, refreshed.ContainerIP, s.cfg.ToolboxPort, sandboxCustomHostnames(refreshed)); err != nil {
-		// Caddy is the source of truth for routing; if we couldn't strip the
-		// host matcher entry, the row is gone from the store but Caddy still
-		// serves the hostname. The next ingress reconcile (or AddCustomDomain
+		// Caddy is the source of truth for routing; if we couldn't refresh the
+		// route set, the row is gone from the store but Caddy may still serve
+		// the hostname. The next ingress reconcile (or AddCustomDomain
 		// re-attaching the same hostname elsewhere) will converge it.
 		return fmt.Errorf("update caddy route after custom-domain delete %q: %w", canonical, err)
+	}
+	// UpsertSandboxRoute only writes; it does not GC the per-hostname route
+	// for the detached domain. Drop it explicitly so the dial target stops
+	// answering immediately rather than waiting on a reconcile sweep.
+	if err := s.caddy.DeleteCustomDomainHTTPRoute(ctx, refreshed.ID, canonical); err != nil {
+		return fmt.Errorf("delete caddy per-hostname route for %q: %w", canonical, err)
 	}
 	return nil
 }
@@ -372,6 +419,11 @@ func hasCustomDomains(sandbox *models.Sandbox) bool {
 // We deliberately do NOT re-PATCH caddy per hostname here — the initial
 // UpsertSandboxRoute already included sandboxCustomHostnames(sandbox) with
 // the full set, so the route matcher is in place before this runs.
+//
+// CreateSandbox does not (yet) accept per-domain target ports — the bulk
+// CustomDomains field on the request is still []string and every row is
+// persisted with target_port=0 (the toolbox-default sentinel). Callers that
+// need a per-domain port use AddCustomDomain post-create.
 func (s *Service) persistCustomDomainsOnCreate(ctx context.Context, sandboxID string, hostnames []string) error {
 	if len(hostnames) == 0 {
 		return nil
@@ -384,7 +436,7 @@ func (s *Service) persistCustomDomainsOnCreate(ctx context.Context, sandboxID st
 		}
 	}
 	for _, h := range hostnames {
-		if err := s.store.AddCustomDomain(ctx, sandboxID, h); err != nil {
+		if err := s.store.AddCustomDomain(ctx, sandboxID, h, 0); err != nil {
 			rollback()
 			if errors.Is(err, store.ErrCustomDomainConflict) {
 				return err

--- a/internal/service/custom_domains_e2e_test.go
+++ b/internal/service/custom_domains_e2e_test.go
@@ -102,7 +102,7 @@ func TestACME_FirstIssueAndS3Reuse(t *testing.T) {
 
 	h := startInProcessSandboxd(t, caddy1)
 	mustCreateE2ESandboxRow(t, h.store, e2eSandboxID)
-	if err := h.svc.AddCustomDomain(context.Background(), e2eSandboxID, e2eHostname); err != nil {
+	if err := h.svc.AddCustomDomain(context.Background(), e2eSandboxID, e2eHostname, 0); err != nil {
 		t.Fatalf("AddCustomDomain: %v", err)
 	}
 	patchPebbleACME(t, caddy1, pebbleRoots)

--- a/internal/service/custom_domains_test.go
+++ b/internal/service/custom_domains_test.go
@@ -178,7 +178,7 @@ func TestAddCustomDomain_DisabledRejects(t *testing.T) {
 		c.EnableCustomDomains = false
 	})
 	mustCreateSandboxRow(t, st, "sb-1")
-	err := svc.AddCustomDomain(context.Background(), "sb-1", "api.acme.com")
+	err := svc.AddCustomDomain(context.Background(), "sb-1", "api.acme.com", 0)
 	if !errors.Is(err, models.ErrCustomDomainNotSupported) {
 		t.Fatalf("got %v, want ErrCustomDomainNotSupported", err)
 	}
@@ -187,7 +187,7 @@ func TestAddCustomDomain_DisabledRejects(t *testing.T) {
 func TestAddCustomDomain_HappyPath(t *testing.T) {
 	svc, st := newCustomDomainsHarness(t, nil)
 	mustCreateSandboxRow(t, st, "sb-1")
-	if err := svc.AddCustomDomain(context.Background(), "sb-1", "API.Acme.com"); err != nil {
+	if err := svc.AddCustomDomain(context.Background(), "sb-1", "API.Acme.com", 0); err != nil {
 		t.Fatalf("AddCustomDomain: %v", err)
 	}
 	domains, err := svc.ListCustomDomains(context.Background(), "sb-1")
@@ -210,7 +210,7 @@ func TestAddCustomDomain_IronRuleRejectsTCPExposure(t *testing.T) {
 		Protocol:  models.ExposedPortProtocolTCP,
 		HostPort:  22001,
 	})
-	err := svc.AddCustomDomain(context.Background(), "sb-1", "api.acme.com")
+	err := svc.AddCustomDomain(context.Background(), "sb-1", "api.acme.com", 0)
 	if !errors.Is(err, models.ErrCustomDomainProtocolConflict) {
 		t.Fatalf("got %v, want ErrCustomDomainProtocolConflict", err)
 	}
@@ -220,10 +220,10 @@ func TestAddCustomDomain_IdempotentReadd(t *testing.T) {
 	svc, st := newCustomDomainsHarness(t, nil)
 	mustCreateSandboxRow(t, st, "sb-1")
 	ctx := context.Background()
-	if err := svc.AddCustomDomain(ctx, "sb-1", "api.acme.com"); err != nil {
+	if err := svc.AddCustomDomain(ctx, "sb-1", "api.acme.com", 0); err != nil {
 		t.Fatalf("first: %v", err)
 	}
-	if err := svc.AddCustomDomain(ctx, "sb-1", "API.Acme.com."); err != nil {
+	if err := svc.AddCustomDomain(ctx, "sb-1", "API.Acme.com.", 0); err != nil {
 		t.Fatalf("idempotent re-add: %v", err)
 	}
 	domains, _ := svc.ListCustomDomains(ctx, "sb-1")
@@ -237,10 +237,10 @@ func TestAddCustomDomain_CrossSandboxConflict(t *testing.T) {
 	mustCreateSandboxRow(t, st, "sb-a")
 	mustCreateSandboxRow(t, st, "sb-b")
 	ctx := context.Background()
-	if err := svc.AddCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
+	if err := svc.AddCustomDomain(ctx, "sb-a", "api.acme.com", 0); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	err := svc.AddCustomDomain(ctx, "sb-b", "api.acme.com")
+	err := svc.AddCustomDomain(ctx, "sb-b", "api.acme.com", 0)
 	if !errors.Is(err, store.ErrCustomDomainConflict) {
 		t.Fatalf("got %v, want ErrCustomDomainConflict", err)
 	}
@@ -255,11 +255,11 @@ func TestAddCustomDomain_PerSandboxCap(t *testing.T) {
 	ctx := context.Background()
 	for i := range perSandboxCap {
 		host := "h" + itoa(i) + ".acme.com"
-		if err := svc.AddCustomDomain(ctx, "sb-1", host); err != nil {
+		if err := svc.AddCustomDomain(ctx, "sb-1", host, 0); err != nil {
 			t.Fatalf("add %d (%s): %v", i, host, err)
 		}
 	}
-	err := svc.AddCustomDomain(ctx, "sb-1", "extra.acme.com")
+	err := svc.AddCustomDomain(ctx, "sb-1", "extra.acme.com", 0)
 	if !errors.Is(err, models.ErrCustomDomainPerSandboxCap) {
 		t.Fatalf("got %v, want ErrCustomDomainPerSandboxCap", err)
 	}
@@ -267,7 +267,7 @@ func TestAddCustomDomain_PerSandboxCap(t *testing.T) {
 
 func TestAddCustomDomain_MissingSandboxReturns404(t *testing.T) {
 	svc, _ := newCustomDomainsHarness(t, nil)
-	err := svc.AddCustomDomain(context.Background(), "nope", "api.acme.com")
+	err := svc.AddCustomDomain(context.Background(), "nope", "api.acme.com", 0)
 	if !errors.Is(err, store.ErrNotFound) {
 		t.Fatalf("got %v, want ErrNotFound", err)
 	}
@@ -277,7 +277,7 @@ func TestRemoveCustomDomain_HappyPath(t *testing.T) {
 	svc, st := newCustomDomainsHarness(t, nil)
 	mustCreateSandboxRow(t, st, "sb-1")
 	ctx := context.Background()
-	if err := svc.AddCustomDomain(ctx, "sb-1", "api.acme.com"); err != nil {
+	if err := svc.AddCustomDomain(ctx, "sb-1", "api.acme.com", 0); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 	if err := svc.RemoveCustomDomain(ctx, "sb-1", "API.Acme.com"); err != nil {
@@ -294,7 +294,7 @@ func TestRemoveCustomDomain_CrossSandboxReturns404(t *testing.T) {
 	mustCreateSandboxRow(t, st, "sb-a")
 	mustCreateSandboxRow(t, st, "sb-b")
 	ctx := context.Background()
-	if err := svc.AddCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
+	if err := svc.AddCustomDomain(ctx, "sb-a", "api.acme.com", 0); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 	err := svc.RemoveCustomDomain(ctx, "sb-b", "api.acme.com")
@@ -312,13 +312,19 @@ func TestSandboxCustomHostnames(t *testing.T) {
 		t.Fatalf("empty CustomDomains: got %v, want nil", got)
 	}
 	sb.CustomDomains = []models.CustomDomain{
-		{Hostname: "api.acme.com"},
+		{Hostname: "api.acme.com", TargetPort: 3333},
 		{Hostname: ""}, // tolerated but skipped
 		{Hostname: "admin.acme.com"},
 	}
 	got := sandboxCustomHostnames(sb)
-	if len(got) != 2 || got[0] != "api.acme.com" || got[1] != "admin.acme.com" {
-		t.Fatalf("got %v", got)
+	if len(got) != 2 {
+		t.Fatalf("len(got)=%d, want 2; got=%+v", len(got), got)
+	}
+	if got[0].Hostname != "api.acme.com" || got[0].TargetPort != 3333 {
+		t.Fatalf("got[0]=%+v, want {api.acme.com, 3333}", got[0])
+	}
+	if got[1].Hostname != "admin.acme.com" || got[1].TargetPort != 0 {
+		t.Fatalf("got[1]=%+v, want {admin.acme.com, 0}", got[1])
 	}
 }
 
@@ -357,7 +363,7 @@ func TestAddCustomDomain_EvictsNegativeCacheOnSuccess(t *testing.T) {
 	svc.AttachCustomDomainCacheEvicter(evict)
 	t.Cleanup(func() { svc.AttachCustomDomainCacheEvicter(nil) })
 
-	if err := svc.AddCustomDomain(context.Background(), "sb-1", "api.acme.com"); err != nil {
+	if err := svc.AddCustomDomain(context.Background(), "sb-1", "api.acme.com", 0); err != nil {
 		t.Fatalf("add: %v", err)
 	}
 	evict.mu.Lock()

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -3471,6 +3471,16 @@ func (s *Service) gcZombieCaddyEntries(ctx context.Context, sandboxes []*models.
 				expectedTLSRoutes[fmt.Sprintf("sandbox-%s-port-%d-tls", sb.ID, p.Port)] = struct{}{}
 			}
 		}
+		// Custom-domain per-hostname HTTP routes share the same Caddy server
+		// as the default sandbox route, so they have to be enumerated as
+		// expected or the GC sweep will drop them on the next pass. The route
+		// ID matches what pkg/caddy installs in upsertCustomDomainHTTPRoute.
+		for _, cd := range sb.CustomDomains {
+			if cd.Hostname == "" {
+				continue
+			}
+			expectedHTTP[caddy.IngressCustomDomainHTTPRouteID(sb.ID, cd.Hostname)] = struct{}{}
+		}
 	}
 	s.addClusterIngressExpectedRoutes(expectedHTTP, expectedTCPServers, expectedTLSRoutes)
 

--- a/internal/store/custom_domains_test.go
+++ b/internal/store/custom_domains_test.go
@@ -17,7 +17,7 @@ func TestAddCustomDomain(t *testing.T) {
 		if err := st.Create(ctx, sampleSandbox("sb-a")); err != nil {
 			t.Fatalf("Create: %v", err)
 		}
-		if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
+		if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com", 0); err != nil {
 			t.Fatalf("AddCustomDomain: %v", err)
 		}
 		got, err := st.ListCustomDomains(ctx, "sb-a")
@@ -40,14 +40,14 @@ func TestAddCustomDomain(t *testing.T) {
 		if err := st.Create(ctx, sampleSandbox("sb-a")); err != nil {
 			t.Fatalf("Create: %v", err)
 		}
-		if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
+		if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com", 0); err != nil {
 			t.Fatalf("first add: %v", err)
 		}
 		// Mutate status so we can prove the second add does not reset it.
 		if err := st.SetCustomDomainStatus(ctx, "api.acme.com", models.CustomDomainReady, ""); err != nil {
 			t.Fatalf("SetCustomDomainStatus: %v", err)
 		}
-		if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
+		if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com", 0); err != nil {
 			t.Fatalf("idempotent re-add: %v", err)
 		}
 		got, _ := st.ListCustomDomains(ctx, "sb-a")
@@ -64,10 +64,10 @@ func TestAddCustomDomain(t *testing.T) {
 		if err := st.Create(ctx, sampleSandbox("sb-b")); err != nil {
 			t.Fatalf("Create sb-b: %v", err)
 		}
-		if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
+		if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com", 0); err != nil {
 			t.Fatalf("first add: %v", err)
 		}
-		err := st.AddCustomDomain(ctx, "sb-b", "api.acme.com")
+		err := st.AddCustomDomain(ctx, "sb-b", "api.acme.com", 0)
 		if !errors.Is(err, ErrCustomDomainConflict) {
 			t.Fatalf("got %v, want ErrCustomDomainConflict", err)
 		}
@@ -83,10 +83,10 @@ func TestAddCustomDomain(t *testing.T) {
 
 	t.Run("rejects empty inputs", func(t *testing.T) {
 		st := newTestStore(t)
-		if err := st.AddCustomDomain(ctx, "", "api.acme.com"); err == nil {
+		if err := st.AddCustomDomain(ctx, "", "api.acme.com", 0); err == nil {
 			t.Fatalf("empty sandbox id accepted")
 		}
-		if err := st.AddCustomDomain(ctx, "sb-a", ""); err == nil {
+		if err := st.AddCustomDomain(ctx, "sb-a", "", 0); err == nil {
 			t.Fatalf("empty hostname accepted")
 		}
 	})
@@ -100,7 +100,7 @@ func TestRemoveCustomDomain(t *testing.T) {
 		if err := st.Create(ctx, sampleSandbox("sb-a")); err != nil {
 			t.Fatalf("Create: %v", err)
 		}
-		if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
+		if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com", 0); err != nil {
 			t.Fatalf("AddCustomDomain: %v", err)
 		}
 		if err := st.RemoveCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
@@ -119,7 +119,7 @@ func TestRemoveCustomDomain(t *testing.T) {
 		if err := st.Create(ctx, sampleSandbox("sb-b")); err != nil {
 			t.Fatalf("Create sb-b: %v", err)
 		}
-		if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
+		if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com", 0); err != nil {
 			t.Fatalf("AddCustomDomain: %v", err)
 		}
 		err := st.RemoveCustomDomain(ctx, "sb-b", "api.acme.com")
@@ -150,7 +150,7 @@ func TestResolveCustomDomain(t *testing.T) {
 	if err := st.Create(ctx, sampleSandbox("sb-a")); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
+	if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com", 0); err != nil {
 		t.Fatalf("AddCustomDomain: %v", err)
 	}
 
@@ -177,7 +177,7 @@ func TestCustomDomainsCascadeOnSandboxDelete(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 	for _, h := range []string{"api.acme.com", "acme.com"} {
-		if err := st.AddCustomDomain(ctx, "sb-a", h); err != nil {
+		if err := st.AddCustomDomain(ctx, "sb-a", h, 0); err != nil {
 			t.Fatalf("AddCustomDomain %s: %v", h, err)
 		}
 	}
@@ -200,7 +200,7 @@ func TestSetCustomDomainStatus(t *testing.T) {
 	if err := st.Create(ctx, sampleSandbox("sb-a")); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
+	if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com", 0); err != nil {
 		t.Fatalf("AddCustomDomain: %v", err)
 	}
 
@@ -251,7 +251,7 @@ func TestListAllCustomDomainsGroupsBySandbox(t *testing.T) {
 	}
 	for sb, hosts := range domains {
 		for _, h := range hosts {
-			if err := st.AddCustomDomain(ctx, sb, h); err != nil {
+			if err := st.AddCustomDomain(ctx, sb, h, 0); err != nil {
 				t.Fatalf("AddCustomDomain %s %s: %v", sb, h, err)
 			}
 		}
@@ -281,13 +281,13 @@ func TestAttachCustomDomainsBulkInList(t *testing.T) {
 			t.Fatalf("Create %s: %v", id, err)
 		}
 	}
-	if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
+	if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com", 0); err != nil {
 		t.Fatalf("AddCustomDomain a: %v", err)
 	}
-	if err := st.AddCustomDomain(ctx, "sb-a", "acme.com"); err != nil {
+	if err := st.AddCustomDomain(ctx, "sb-a", "acme.com", 0); err != nil {
 		t.Fatalf("AddCustomDomain a2: %v", err)
 	}
-	if err := st.AddCustomDomain(ctx, "sb-b", "foo.example.com"); err != nil {
+	if err := st.AddCustomDomain(ctx, "sb-b", "foo.example.com", 0); err != nil {
 		t.Fatalf("AddCustomDomain b: %v", err)
 	}
 
@@ -315,7 +315,7 @@ func TestGetIncludesCustomDomains(t *testing.T) {
 	if err := st.Create(ctx, sampleSandbox("sb-a")); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com"); err != nil {
+	if err := st.AddCustomDomain(ctx, "sb-a", "api.acme.com", 0); err != nil {
 		t.Fatalf("AddCustomDomain: %v", err)
 	}
 	got, err := st.Get(ctx, "sb-a")

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -119,11 +119,20 @@ func Open(path string) (*Store, error) {
 		// (pending_dns → issuing → ready / failed) surfaced through the API;
 		// last_error carries the surfaced reason on failed. FK CASCADE so
 		// destroying the sandbox releases every hostname in the same write.
+		// target_port is the in-container TCP port the ingress route dials
+		// for this hostname. 0 (the default) means "fall back to the
+		// daemon-wide toolbox port" — the legacy behavior from before
+		// per-domain target ports existed. Non-zero pins the route to a
+		// specific app port (e.g. 3333). Changing the value for an
+		// already-attached hostname is forbidden at the service layer
+		// (detach + re-add required) so live traffic cannot silently
+		// redirect.
 		`CREATE TABLE IF NOT EXISTS sandbox_custom_domains (
 			hostname TEXT PRIMARY KEY,
 			sandbox_id TEXT NOT NULL,
 			status TEXT NOT NULL DEFAULT 'pending_dns',
 			last_error TEXT NOT NULL DEFAULT '',
+			target_port INTEGER NOT NULL DEFAULT 0,
 			created_at DATETIME NOT NULL,
 			updated_at DATETIME NOT NULL,
 			FOREIGN KEY (sandbox_id) REFERENCES sandboxes(id) ON DELETE CASCADE
@@ -498,6 +507,10 @@ func Open(path string) (*Store, error) {
 		`ALTER TABLE firecracker_templates ADD COLUMN push_error TEXT NOT NULL DEFAULT '';`,
 		`ALTER TABLE firecracker_templates ADD COLUMN registry_ref TEXT NOT NULL DEFAULT '';`,
 		`ALTER TABLE firecracker_templates ADD COLUMN push_digest TEXT NOT NULL DEFAULT '';`,
+		// Per-custom-domain target port — 0 keeps the legacy toolbox-port
+		// behavior for rows attached before this column existed, so the
+		// upgrade is silent.
+		`ALTER TABLE sandbox_custom_domains ADD COLUMN target_port INTEGER NOT NULL DEFAULT 0;`,
 	}
 	for _, stmt := range migrations {
 		if _, err := db.Exec(stmt); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
@@ -2771,20 +2784,30 @@ var ErrCustomDomainConflict = errors.New("custom domain hostname already taken")
 // sandbox_custom_domains. ListAllCustomDomains returns these so the
 // reconcile loop and the cluster FSM hydration can walk the full set.
 type CustomDomainRow struct {
-	Hostname  string
-	SandboxID string
-	Status    models.CustomDomainStatus
-	LastError string
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	Hostname   string
+	SandboxID  string
+	Status     models.CustomDomainStatus
+	LastError  string
+	TargetPort int
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
 }
+
+// ErrCustomDomainPortMismatch surfaces an idempotent re-add of an
+// already-attached hostname that carries a different target_port than the
+// stored row. We never silently change the dial target — that would redirect
+// live traffic without the caller knowing. The service layer translates this
+// to HTTP 409 so the caller can detach + re-add deliberately.
+var ErrCustomDomainPortMismatch = errors.New("custom domain target_port mismatch on re-add")
 
 // AddCustomDomain inserts a hostname → sandbox mapping. Returns
 // ErrCustomDomainConflict when the hostname is already owned by a different
-// sandbox; returns nil when the same (hostname, sandbox) pair already exists
-// (idempotent — the caller may retry safely). New rows start in
-// CustomDomainPendingDNS; existing rows are left in whatever state they hold.
-func (s *Store) AddCustomDomain(ctx context.Context, sandboxID, hostname string) error {
+// sandbox; returns ErrCustomDomainPortMismatch when the row exists for the
+// same sandbox but with a different targetPort; returns nil when the same
+// (hostname, sandbox, targetPort) tuple already exists (idempotent — the
+// caller may retry safely). targetPort=0 is the toolbox-default sentinel.
+// New rows start in CustomDomainPendingDNS.
+func (s *Store) AddCustomDomain(ctx context.Context, sandboxID, hostname string, targetPort int) error {
 	if sandboxID == "" {
 		return errors.New("sandbox id is required")
 	}
@@ -2798,9 +2821,9 @@ func (s *Store) AddCustomDomain(ctx context.Context, sandboxID, hostname string)
 	// reservation path — see TryReserveHostPort for the canonical rationale.
 	res, err := s.db.ExecContext(ctx, `
 		INSERT OR IGNORE INTO sandbox_custom_domains (
-			hostname, sandbox_id, status, last_error, created_at, updated_at
-		) VALUES (?, ?, ?, '', ?, ?)
-	`, hostname, sandboxID, string(models.CustomDomainPendingDNS), now, now)
+			hostname, sandbox_id, status, last_error, target_port, created_at, updated_at
+		) VALUES (?, ?, ?, '', ?, ?, ?)
+	`, hostname, sandboxID, string(models.CustomDomainPendingDNS), targetPort, now, now)
 	if err != nil {
 		return fmt.Errorf("insert sandbox_custom_domains: %w", err)
 	}
@@ -2811,9 +2834,10 @@ func (s *Store) AddCustomDomain(ctx context.Context, sandboxID, hostname string)
 	// IGNORE swallowed a PK conflict. The existing row may belong to the same
 	// sandbox (idempotent re-add) or a different one (true conflict).
 	var owner string
+	var existingPort int
 	if err := s.db.QueryRowContext(ctx, `
-		SELECT sandbox_id FROM sandbox_custom_domains WHERE hostname = ?
-	`, hostname).Scan(&owner); err != nil {
+		SELECT sandbox_id, target_port FROM sandbox_custom_domains WHERE hostname = ?
+	`, hostname).Scan(&owner, &existingPort); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			// Row vanished between INSERT IGNORE and SELECT (cascade delete).
 			// Treat as conflict so the caller does not assume success.
@@ -2821,10 +2845,13 @@ func (s *Store) AddCustomDomain(ctx context.Context, sandboxID, hostname string)
 		}
 		return fmt.Errorf("disambiguate custom domain insert: %w", err)
 	}
-	if owner == sandboxID {
-		return nil
+	if owner != sandboxID {
+		return ErrCustomDomainConflict
 	}
-	return ErrCustomDomainConflict
+	if existingPort != targetPort {
+		return ErrCustomDomainPortMismatch
+	}
+	return nil
 }
 
 // RemoveCustomDomain deletes the (sandbox, hostname) row. Cross-sandbox
@@ -2851,7 +2878,7 @@ func (s *Store) RemoveCustomDomain(ctx context.Context, sandboxID, hostname stri
 // Empty slice (nil) when the sandbox has no custom domains.
 func (s *Store) ListCustomDomains(ctx context.Context, sandboxID string) ([]models.CustomDomain, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT hostname, status, last_error, created_at, updated_at
+		SELECT hostname, status, last_error, target_port, created_at, updated_at
 		FROM sandbox_custom_domains
 		WHERE sandbox_id = ?
 		ORDER BY hostname ASC
@@ -2865,7 +2892,7 @@ func (s *Store) ListCustomDomains(ctx context.Context, sandboxID string) ([]mode
 	for rows.Next() {
 		var cd models.CustomDomain
 		var status string
-		if err := rows.Scan(&cd.Hostname, &status, &cd.LastError, &cd.CreatedAt, &cd.UpdatedAt); err != nil {
+		if err := rows.Scan(&cd.Hostname, &status, &cd.LastError, &cd.TargetPort, &cd.CreatedAt, &cd.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan custom domain: %w", err)
 		}
 		cd.Status = models.CustomDomainStatus(status)
@@ -2882,7 +2909,7 @@ func (s *Store) ListCustomDomains(ctx context.Context, sandboxID string) ([]mode
 // Ordered by hostname so reconcile diffs are stable across calls.
 func (s *Store) ListAllCustomDomains(ctx context.Context) ([]CustomDomainRow, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT hostname, sandbox_id, status, last_error, created_at, updated_at
+		SELECT hostname, sandbox_id, status, last_error, target_port, created_at, updated_at
 		FROM sandbox_custom_domains
 		ORDER BY hostname ASC
 	`)
@@ -2895,7 +2922,7 @@ func (s *Store) ListAllCustomDomains(ctx context.Context) ([]CustomDomainRow, er
 	for rows.Next() {
 		var r CustomDomainRow
 		var status string
-		if err := rows.Scan(&r.Hostname, &r.SandboxID, &status, &r.LastError, &r.CreatedAt, &r.UpdatedAt); err != nil {
+		if err := rows.Scan(&r.Hostname, &r.SandboxID, &status, &r.LastError, &r.TargetPort, &r.CreatedAt, &r.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan custom domain row: %w", err)
 		}
 		r.Status = models.CustomDomainStatus(status)
@@ -2909,7 +2936,10 @@ func (s *Store) ListAllCustomDomains(ctx context.Context) ([]CustomDomainRow, er
 
 // ResolveCustomDomain is the hot path for the TLSAsk handler — single PK
 // lookup, no scan. Returns ErrNotFound for unknown hostnames so the handler
-// can fold it into a 403 without an error log on the success path.
+// can fold it into a 403 without an error log on the success path. We do not
+// surface target_port here because the routing dial target is already baked
+// into the per-domain Caddy route at install time (see
+// IngressCustomDomainHTTPRouteID); TLSAsk only needs the ownership signal.
 func (s *Store) ResolveCustomDomain(ctx context.Context, hostname string) (string, error) {
 	if hostname == "" {
 		return "", ErrNotFound
@@ -2966,7 +2996,7 @@ func (s *Store) loadCustomDomains(ctx context.Context, sandboxID string) ([]mode
 // ever crosses ~100k rows.
 func (s *Store) attachCustomDomainsBulk(ctx context.Context, byID map[string]*models.Sandbox) error {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT sandbox_id, hostname, status, last_error, created_at, updated_at
+		SELECT sandbox_id, hostname, status, last_error, target_port, created_at, updated_at
 		FROM sandbox_custom_domains
 		ORDER BY sandbox_id, hostname ASC
 	`)
@@ -2979,7 +3009,7 @@ func (s *Store) attachCustomDomainsBulk(ctx context.Context, byID map[string]*mo
 		var sandboxID string
 		var cd models.CustomDomain
 		var status string
-		if err := rows.Scan(&sandboxID, &cd.Hostname, &status, &cd.LastError, &cd.CreatedAt, &cd.UpdatedAt); err != nil {
+		if err := rows.Scan(&sandboxID, &cd.Hostname, &status, &cd.LastError, &cd.TargetPort, &cd.CreatedAt, &cd.UpdatedAt); err != nil {
 			return fmt.Errorf("scan custom domain: %w", err)
 		}
 		cd.Status = models.CustomDomainStatus(status)

--- a/pkg/api/apihttp/apihttp.go
+++ b/pkg/api/apihttp/apihttp.go
@@ -91,8 +91,13 @@ func WriteStoreAwareError(logger *slog.Logger, w http.ResponseWriter, err error)
 	}
 	if errors.Is(err, models.ErrCustomDomainProtocolConflict) ||
 		errors.Is(err, models.ErrCustomDomainPerSandboxCap) ||
-		errors.Is(err, store.ErrCustomDomainConflict) {
+		errors.Is(err, store.ErrCustomDomainConflict) ||
+		errors.Is(err, store.ErrCustomDomainPortMismatch) {
 		WriteError(w, http.StatusConflict, err.Error())
+		return
+	}
+	if errors.Is(err, models.ErrCustomDomainInvalidTargetPort) {
+		WriteError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	if errors.Is(err, models.ErrCustomDomainVerificationFailed) {

--- a/pkg/api/v1/dns_test.go
+++ b/pkg/api/v1/dns_test.go
@@ -57,10 +57,10 @@ func TestV1CustomDomainDNS_ReturnsRecordsAfterAttach(t *testing.T) {
 		c.PublicHost = "ingress.example.com"
 	})
 	seedSandboxRowV1(t, env.store, "sb-1")
-	if err := env.svc.AddCustomDomain(context.Background(), "sb-1", "api.acme.com"); err != nil {
+	if err := env.svc.AddCustomDomain(context.Background(), "sb-1", "api.acme.com", 0); err != nil {
 		t.Fatalf("AddCustomDomain: %v", err)
 	}
-	if err := env.svc.AddCustomDomain(context.Background(), "sb-1", "acme.com"); err != nil {
+	if err := env.svc.AddCustomDomain(context.Background(), "sb-1", "acme.com", 0); err != nil {
 		t.Fatalf("AddCustomDomain apex: %v", err)
 	}
 

--- a/pkg/api/v1/handlers.go
+++ b/pkg/api/v1/handlers.go
@@ -207,10 +207,13 @@ func (h *handlers) unexposePort(w http.ResponseWriter, r *http.Request) {
 }
 
 // addCustomDomain attaches a new operator-provided public hostname to a
-// sandbox. Body shape: {"hostname":"api.acme.com"}. Status codes follow the
+// sandbox. Body shape: {"hostname":"api.acme.com","target_port":3333}.
+// target_port is optional; omitting it (or sending 0) routes the hostname to
+// the toolbox agent, preserving pre-v2 behavior. Status codes follow the
 // custom-domain sentinels in pkg/api/apihttp.WriteStoreAwareError:
-// 412 = feature disabled / IP mode; 409 = hostname owned by another sandbox
-// or IRON RULE violation (tcp/tls coexistence); 400 = malformed hostname;
+// 412 = feature disabled / IP mode; 409 = hostname owned by another sandbox,
+// IRON RULE violation (tcp/tls coexistence), or target_port mismatch on
+// idempotent re-add; 400 = malformed hostname / invalid target_port;
 // 404 = sandbox not found.
 func (h *handlers) addCustomDomain(w http.ResponseWriter, r *http.Request) {
 	var req models.AddCustomDomainRequest
@@ -219,7 +222,7 @@ func (h *handlers) addCustomDomain(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	id := r.PathValue("id")
-	if err := h.deps.Service.AddCustomDomain(r.Context(), id, req.Hostname); err != nil {
+	if err := h.deps.Service.AddCustomDomain(r.Context(), id, req.Hostname, req.TargetPort); err != nil {
 		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
 		return
 	}

--- a/pkg/caddy/client.go
+++ b/pkg/caddy/client.go
@@ -144,14 +144,34 @@ func (c *Client) TLSPublicEndpoint(id string, port int, l4Listen string) string 
 	return fmt.Sprintf("tls://%s-%d.%s:%s", id, port, c.domain, listenPort)
 }
 
+// CustomHostnameRoute describes one operator-attached public hostname plus
+// the in-container TCP port traffic should dial. TargetPort=0 means "use the
+// toolbox port" (the pre-target-port default), so existing callers that only
+// know hostnames can pass a zero-valued entry and preserve old behavior.
+type CustomHostnameRoute struct {
+	Hostname   string
+	TargetPort int
+}
+
 // UpsertSandboxRoute installs the HTTP ingress route for a sandbox owned by
-// this node. customHostnames is the operator-attached set of public hostnames
-// added under the custom-domains feature; when non-empty (and domain mode is
-// active) the host matcher includes both the default `{id}.{domain}` and each
-// custom hostname so a single route serves traffic for all of them. Order in
-// the list is irrelevant — Caddy treats `host` as a set match. nil/empty is
-// the legacy single-hostname behaviour.
-func (c *Client) UpsertSandboxRoute(ctx context.Context, id, containerIP string, toolboxPort int, customHostnames []string) error {
+// this node, plus one route per attached custom hostname. The default
+// `sandbox-{id}` route matches ONLY `{id}.{domain}` (or the path-mode
+// equivalent in IP mode) and dials the toolbox port — the custom-hostname
+// routes are independent so each can dial a different in-container port
+// without affecting the toolbox-served default URL.
+//
+// customs is the operator-attached set of (hostname, target_port) pairs from
+// the custom-domains feature. Each entry is installed as a separate route
+// keyed by IngressCustomDomainHTTPRouteID(id, hostname), so the per-hostname
+// dial target can change independently. Passing nil/empty preserves the
+// legacy single-hostname behaviour. Custom-domain routes only take effect in
+// domain mode; in IP mode the field is ignored (custom domains are rejected
+// at the service layer in that deployment shape).
+//
+// NOTE: UpsertSandboxRoute does NOT garbage-collect stale per-hostname
+// routes — callers that detach a hostname must call
+// DeleteCustomDomainHTTPRoute (or the reconciler must converge it).
+func (c *Client) UpsertSandboxRoute(ctx context.Context, id, containerIP string, toolboxPort int, customs []CustomHostnameRoute) error {
 	if !c.enabled {
 		return nil
 	}
@@ -169,16 +189,64 @@ func (c *Client) UpsertSandboxRoute(ctx context.Context, id, containerIP string,
 	}
 
 	if c.domain != "" {
-		hosts := []string{fmt.Sprintf("%s.%s", id, c.domain)}
-		hosts = append(hosts, normalizeCustomHostnames(customHostnames)...)
-		route["match"] = []map[string]any{{"host": hosts}}
+		route["match"] = []map[string]any{{"host": []string{fmt.Sprintf("%s.%s", id, c.domain)}}}
 	} else {
-		// IP mode never serves a public hostname; custom domains are
-		// rejected at the service layer in that deployment shape.
 		route["match"] = []map[string]any{{"path": []string{fmt.Sprintf("/%s", id), fmt.Sprintf("/%s/*", id)}}}
 	}
 
+	if err := c.upsertRoute(ctx, routeID, route); err != nil {
+		return err
+	}
+
+	// Custom-hostname routes are only relevant in domain mode — IP-mode
+	// deployments reject custom domains at the service layer.
+	if c.domain == "" {
+		return nil
+	}
+	for _, cd := range customs {
+		host := strings.TrimSpace(strings.ToLower(cd.Hostname))
+		if host == "" {
+			continue
+		}
+		port := cd.TargetPort
+		if port <= 0 {
+			port = toolboxPort
+		}
+		if err := c.upsertCustomDomainHTTPRoute(ctx, id, host, containerIP, port); err != nil {
+			return fmt.Errorf("install custom-domain route %q: %w", host, err)
+		}
+	}
+	return nil
+}
+
+// upsertCustomDomainHTTPRoute installs (or replaces) the per-hostname HTTP
+// route for a single (sandbox, custom hostname). The route ID is stable
+// across calls (IngressCustomDomainHTTPRouteID) so a re-add with the same
+// port is a no-op PUT, and a port change replaces the leaf in place.
+func (c *Client) upsertCustomDomainHTTPRoute(ctx context.Context, sandboxID, hostname, containerIP string, port int) error {
+	routeID := IngressCustomDomainHTTPRouteID(sandboxID, hostname)
+	route := map[string]any{
+		"@id":   routeID,
+		"match": []map[string]any{{"host": []string{hostname}}},
+		"handle": []map[string]any{{
+			"handler": "reverse_proxy",
+			"upstreams": []map[string]string{{
+				"dial": fmt.Sprintf("%s:%d", containerIP, port),
+			}},
+		}},
+		"terminal": true,
+	}
 	return c.upsertRoute(ctx, routeID, route)
+}
+
+// DeleteCustomDomainHTTPRoute removes the per-hostname HTTP route. 404 is a
+// no-op so the detach path is safe to retry and reconcile-driven GC can call
+// it without first checking existence.
+func (c *Client) DeleteCustomDomainHTTPRoute(ctx context.Context, sandboxID, hostname string) error {
+	if !c.enabled || c.domain == "" {
+		return nil
+	}
+	return c.deleteRoute(ctx, IngressCustomDomainHTTPRouteID(sandboxID, hostname))
 }
 
 // UpsertSandboxRouteToPeer installs the IP/path-mode ingress route for a
@@ -210,26 +278,6 @@ func (c *Client) UpsertSandboxRouteToPeer(ctx context.Context, id, peerHost stri
 		"terminal": true,
 	}
 	return c.upsertRoute(ctx, routeID, route)
-}
-
-// normalizeCustomHostnames drops empty / whitespace-only entries and
-// lower-cases the rest. The service layer is expected to have already
-// validated the inputs via models.ValidateCustomDomainList; this is purely
-// belt-and-braces against accidentally pushing a junk matcher value to
-// Caddy (which would silently match nothing, hiding the upstream).
-func normalizeCustomHostnames(in []string) []string {
-	if len(in) == 0 {
-		return nil
-	}
-	out := make([]string, 0, len(in))
-	for _, h := range in {
-		h = strings.TrimSpace(strings.ToLower(h))
-		if h == "" {
-			continue
-		}
-		out = append(out, h)
-	}
-	return out
 }
 
 func (c *Client) DeleteSandboxRoute(ctx context.Context, id string) error {
@@ -658,6 +706,18 @@ func IngressCustomDomainSNIRouteID(sandboxID, hostname string) string {
 	h := fnv.New64a()
 	_, _ = h.Write([]byte(strings.ToLower(hostname)))
 	return fmt.Sprintf("sandbox-%s-custom-%016x-ingress-sni", sandboxID, h.Sum64())
+}
+
+// IngressCustomDomainHTTPRouteID is the stable @id for the per-custom-
+// hostname HTTP route installed on the owner node. Mirrors the SNI variant's
+// naming so reconcile / GC code can derive both from the same (sandboxID,
+// hostname) pair. The hostname is fnv64-hashed so very long hostnames stay
+// within Caddy's @id size budget and the slug avoids characters that would
+// have to be escaped.
+func IngressCustomDomainHTTPRouteID(sandboxID, hostname string) string {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(strings.ToLower(hostname)))
+	return fmt.Sprintf("sandbox-%s-custom-%016x-http", sandboxID, h.Sum64())
 }
 
 // EnsureOnDemandTLS idempotently installs the on-demand TLS automation

--- a/pkg/caddy/custom_domains_test.go
+++ b/pkg/caddy/custom_domains_test.go
@@ -12,10 +12,10 @@ import (
 	"time"
 )
 
-// upsertSandboxRouteWithCustomHostnames verifies that the custom-hostnames
-// slice flows into the route's host matcher alongside the default
-// {id}.{domain} hostname. Order in the matcher is the default first then
-// the customs — the test checks the set, not the order.
+// Custom hostnames now install their own per-hostname routes (one route per
+// hostname, keyed by IngressCustomDomainHTTPRouteID) so each can dial a
+// different in-container port. The default sandbox-{id} route's host matcher
+// stops carrying customs; this test pins both invariants.
 func TestUpsertSandboxRouteWithCustomHostnames(t *testing.T) {
 	fake := newFakeCaddy(t)
 	client := &Client{
@@ -26,42 +26,57 @@ func TestUpsertSandboxRouteWithCustomHostnames(t *testing.T) {
 		httpClient: fake.Client,
 	}
 
-	customs := []string{"api.acme.com", "ADMIN.Acme.com"}
+	customs := []CustomHostnameRoute{
+		{Hostname: "api.acme.com", TargetPort: 3333},
+		{Hostname: "ADMIN.Acme.com"}, // TargetPort=0 → falls back to toolbox port
+	}
 	if err := client.UpsertSandboxRoute(context.Background(), "abc", "10.0.0.2", 2280, customs); err != nil {
 		t.Fatalf("UpsertSandboxRoute() error = %v", err)
 	}
 
-	route, ok := fake.routes["sandbox-abc"]
+	// Default route matches ONLY abc.aerol.cloud — it must not carry the
+	// custom hostnames anymore, otherwise a port-targeted custom domain
+	// would race the default route for the same match.
+	defaultRoute, ok := fake.routes["sandbox-abc"]
 	if !ok {
-		t.Fatalf("route not inserted; routes=%+v", fake.routes)
+		t.Fatalf("default sandbox route not inserted; routes=%+v", fake.routes)
 	}
-	matches, ok := route["match"].([]any)
-	if !ok || len(matches) == 0 {
-		t.Fatalf("missing match: %#v", route)
-	}
+	matches, _ := defaultRoute["match"].([]any)
 	match, _ := matches[0].(map[string]any)
 	hostsRaw, _ := match["host"].([]any)
-	got := map[string]struct{}{}
-	for _, h := range hostsRaw {
-		s, _ := h.(string)
-		got[s] = struct{}{}
+	if len(hostsRaw) != 1 || hostsRaw[0].(string) != "abc.aerol.cloud" {
+		t.Fatalf("default route host matcher = %v, want [abc.aerol.cloud]", hostsRaw)
 	}
-	want := []string{"abc.aerol.cloud", "api.acme.com", "admin.acme.com"}
-	if len(got) != len(want) {
-		t.Fatalf("host matcher set %v, want %v", got, want)
+
+	// api.acme.com → its own route, dialing 10.0.0.2:3333.
+	apiID := IngressCustomDomainHTTPRouteID("abc", "api.acme.com")
+	apiRoute, ok := fake.routes[apiID]
+	if !ok {
+		t.Fatalf("per-hostname route %q missing; routes=%+v", apiID, fake.routes)
 	}
-	for _, w := range want {
-		if _, ok := got[w]; !ok {
-			t.Fatalf("expected host %q in matcher, got %v", w, got)
-		}
+	dial := mustDialFromRoute(t, apiRoute)
+	if dial != "10.0.0.2:3333" {
+		t.Fatalf("api.acme.com dial = %q, want 10.0.0.2:3333", dial)
+	}
+
+	// admin.acme.com (lowercased) → its own route, dialing the toolbox port
+	// because TargetPort=0 is the "use toolbox" sentinel.
+	adminID := IngressCustomDomainHTTPRouteID("abc", "admin.acme.com")
+	adminRoute, ok := fake.routes[adminID]
+	if !ok {
+		t.Fatalf("per-hostname route %q missing; routes=%+v", adminID, fake.routes)
+	}
+	if dial := mustDialFromRoute(t, adminRoute); dial != "10.0.0.2:2280" {
+		t.Fatalf("admin.acme.com dial = %q, want 10.0.0.2:2280", dial)
 	}
 }
 
-// In IP mode (no domain) the matcher must remain path-based even when
-// custom hostnames are passed — the service layer rejects custom domains
-// in IP-mode deployments via 412, but a defense-in-depth check inside the
-// Caddy helper keeps us from publishing a host matcher with no wildcard
-// fallback if a stray nil-base call slips through.
+// In IP mode (no domain) the matcher must remain path-based and the
+// per-hostname custom routes must NOT be installed — the service layer
+// rejects custom domains in IP-mode deployments via 412, but a
+// defense-in-depth check inside the Caddy helper keeps us from publishing
+// a host matcher with no wildcard fallback if a stray nil-base call slips
+// through.
 func TestUpsertSandboxRouteIPModeIgnoresCustomHostnames(t *testing.T) {
 	fake := newFakeCaddy(t)
 	client := &Client{
@@ -71,7 +86,8 @@ func TestUpsertSandboxRouteIPModeIgnoresCustomHostnames(t *testing.T) {
 		baseURL:    fake.URL,
 		httpClient: fake.Client,
 	}
-	if err := client.UpsertSandboxRoute(context.Background(), "abc", "10.0.0.2", 2280, []string{"api.acme.com"}); err != nil {
+	customs := []CustomHostnameRoute{{Hostname: "api.acme.com", TargetPort: 3333}}
+	if err := client.UpsertSandboxRoute(context.Background(), "abc", "10.0.0.2", 2280, customs); err != nil {
 		t.Fatalf("UpsertSandboxRoute() error = %v", err)
 	}
 	route := fake.routes["sandbox-abc"]
@@ -79,6 +95,47 @@ func TestUpsertSandboxRouteIPModeIgnoresCustomHostnames(t *testing.T) {
 	if match, _ := matches[0].(map[string]any); match["host"] != nil {
 		t.Fatalf("IP mode must not set host matcher: %#v", route)
 	}
+	// No per-hostname routes in IP mode either.
+	if _, ok := fake.routes[IngressCustomDomainHTTPRouteID("abc", "api.acme.com")]; ok {
+		t.Fatalf("per-hostname route must not be installed in IP mode")
+	}
+}
+
+func TestDeleteCustomDomainHTTPRoute(t *testing.T) {
+	fake := newFakeCaddy(t)
+	client := &Client{
+		enabled:    true,
+		domain:     "aerol.cloud",
+		serverID:   "srv0",
+		baseURL:    fake.URL,
+		httpClient: fake.Client,
+	}
+	customs := []CustomHostnameRoute{{Hostname: "api.acme.com", TargetPort: 3333}}
+	if err := client.UpsertSandboxRoute(context.Background(), "abc", "10.0.0.2", 2280, customs); err != nil {
+		t.Fatalf("UpsertSandboxRoute() error = %v", err)
+	}
+	if err := client.DeleteCustomDomainHTTPRoute(context.Background(), "abc", "api.acme.com"); err != nil {
+		t.Fatalf("DeleteCustomDomainHTTPRoute() error = %v", err)
+	}
+	if _, ok := fake.routes[IngressCustomDomainHTTPRouteID("abc", "api.acme.com")]; ok {
+		t.Fatalf("per-hostname route should be deleted")
+	}
+}
+
+func mustDialFromRoute(t *testing.T, route map[string]any) string {
+	t.Helper()
+	handlers, _ := route["handle"].([]any)
+	if len(handlers) == 0 {
+		t.Fatalf("route has no handlers: %#v", route)
+	}
+	rp, _ := handlers[0].(map[string]any)
+	upstreams, _ := rp["upstreams"].([]any)
+	if len(upstreams) == 0 {
+		t.Fatalf("route has no upstreams: %#v", route)
+	}
+	up, _ := upstreams[0].(map[string]any)
+	dial, _ := up["dial"].(string)
+	return dial
 }
 
 // EnsureOnDemandTLS — fresh Caddy, no apps/tls. PUT installs the on_demand

--- a/pkg/models/custom_domain.go
+++ b/pkg/models/custom_domain.go
@@ -32,16 +32,26 @@ const (
 
 // CustomDomain is the per-domain row returned in Sandbox.CustomDomains.
 type CustomDomain struct {
-	Hostname  string             `json:"hostname"`
-	Status    CustomDomainStatus `json:"status"`
-	LastError string             `json:"last_error,omitempty"`
-	CreatedAt time.Time          `json:"created_at"`
-	UpdatedAt time.Time          `json:"updated_at"`
+	Hostname string             `json:"hostname"`
+	Status   CustomDomainStatus `json:"status"`
+	// TargetPort is the in-container TCP port traffic for this hostname
+	// reverse-proxies to. Zero means "use the toolbox port" (the legacy
+	// behavior before per-domain target ports existed). Non-zero values
+	// dial straight to the user's app — e.g. an HTTP server on 3333.
+	// Set once at attach time; changing it requires detach + re-add so
+	// in-flight traffic can't silently redirect.
+	TargetPort int       `json:"target_port,omitempty"`
+	LastError  string    `json:"last_error,omitempty"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
 }
 
 // AddCustomDomainRequest is the body for POST /v1/sandboxes/{id}/custom-domains.
+// Omitting target_port (or sending 0) routes the hostname to the toolbox
+// agent, preserving pre-v2 behavior.
 type AddCustomDomainRequest struct {
-	Hostname string `json:"hostname"`
+	Hostname   string `json:"hostname"`
+	TargetPort int    `json:"target_port,omitempty"`
 }
 
 // Custom-domain caps. Exported so internal/config can read SB_ env overrides
@@ -82,7 +92,28 @@ var (
 	ErrCustomDomainPerSandboxCap = fmt.Errorf("at most %d custom domains per sandbox", MaxCustomDomainsPerSandbox)
 	// ErrCustomDomainVerificationFailed is returned when the DNS TXT record check fails.
 	ErrCustomDomainVerificationFailed = errors.New("custom domain TXT record verification failed")
+	// ErrCustomDomainInvalidTargetPort is returned when AddCustomDomainRequest
+	// carries a target_port outside [0, 65535]. Zero is the toolbox-default
+	// sentinel; anything else must be a real TCP port number. Surfaced as 400.
+	ErrCustomDomainInvalidTargetPort = errors.New("invalid custom domain target_port")
+	// ErrCustomDomainPortMismatch is returned when an idempotent re-add of
+	// an already-attached hostname carries a different target_port than the
+	// existing row. We do not silently change the dial target — that would
+	// redirect live traffic without the caller knowing. Surfaced as 409 so
+	// the caller can detach + re-add deliberately.
+	ErrCustomDomainPortMismatch = errors.New("custom domain target_port mismatch on re-add")
 )
+
+// ValidateCustomDomainTargetPort returns nil for 0 (the toolbox sentinel)
+// and any 1..65535. Anything else is ErrCustomDomainInvalidTargetPort. Kept
+// alongside the other custom-domain validators so the API + service layers
+// reference one canonical bound.
+func ValidateCustomDomainTargetPort(port int) error {
+	if port < 0 || port > 65535 {
+		return fmt.Errorf("%w: %d (must be 0 or 1..65535)", ErrCustomDomainInvalidTargetPort, port)
+	}
+	return nil
+}
 
 // NormalizeCustomDomain lowercases, strips a trailing dot, and validates the
 // shape of host. baseDomain is the operator's SB_DOMAIN — empty means the

--- a/sdk/go/internal/apiclient/client.go
+++ b/sdk/go/internal/apiclient/client.go
@@ -560,11 +560,15 @@ type customDomainsEnvelope struct {
 }
 
 // AddCustomDomain attaches an operator-provided public hostname to a sandbox.
-// Returns the full per-hostname row list so callers don't need a follow-up
-// GET to read the canonical (lowercased, dot-trimmed) hostname or initial
-// status. The server normalizes hostname; passing it verbatim is correct.
-func (c *Client) AddCustomDomain(ctx context.Context, id, hostname string) ([]models.CustomDomain, error) {
-	body := models.AddCustomDomainRequest{Hostname: hostname}
+// targetPort is the in-container TCP port traffic for the hostname should
+// dial; pass 0 to route to the toolbox agent (the pre-target-port default,
+// preserving existing behavior). The port is set once at attach time —
+// changing it requires detach + re-add. Returns the full per-hostname row
+// list so callers don't need a follow-up GET to read the canonical hostname
+// or initial status. The server normalizes hostname; passing it verbatim is
+// correct.
+func (c *Client) AddCustomDomain(ctx context.Context, id, hostname string, targetPort int) ([]models.CustomDomain, error) {
+	body := models.AddCustomDomainRequest{Hostname: hostname, TargetPort: targetPort}
 	var response customDomainsEnvelope
 	if err := c.doJSON(ctx, http.MethodPost, c.versionPrefix+"/sandboxes/"+id+"/custom-domains", body, &response); err != nil {
 		return nil, err
@@ -640,8 +644,8 @@ func (s *Sandbox) ExposePort(ctx context.Context, port int, protocol string) (Ex
 	return s.client.ExposePort(ctx, s.ID, port, protocol)
 }
 
-func (s *Sandbox) AddCustomDomain(ctx context.Context, hostname string) ([]models.CustomDomain, error) {
-	return s.client.AddCustomDomain(ctx, s.ID, hostname)
+func (s *Sandbox) AddCustomDomain(ctx context.Context, hostname string, targetPort int) ([]models.CustomDomain, error) {
+	return s.client.AddCustomDomain(ctx, s.ID, hostname, targetPort)
 }
 
 func (s *Sandbox) RemoveCustomDomain(ctx context.Context, hostname string) error {

--- a/sdk/go/internal/apiclient/custom_domains_test.go
+++ b/sdk/go/internal/apiclient/custom_domains_test.go
@@ -41,7 +41,7 @@ func TestAddCustomDomainSendsHostnameAndDecodesEnvelope(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.URL, ClientOptions{PATToken: "pat", HTTPClient: server.Client()})
-	domains, err := client.AddCustomDomain(ctx, "sb-123", "api.acme.com")
+	domains, err := client.AddCustomDomain(ctx, "sb-123", "api.acme.com", 0)
 	if err != nil {
 		t.Fatalf("AddCustomDomain() error = %v", err)
 	}

--- a/sdk/go/pkg/microvm/client.go
+++ b/sdk/go/pkg/microvm/client.go
@@ -429,6 +429,23 @@ func (s *Sandbox) UnexposePort(ctx context.Context, port int) error {
 	return s.client.inner.UnexposePort(ctx, s.ID, port)
 }
 
+// CustomDomainOption customizes an AddCustomDomain call. Build values with
+// WithTargetPort; the variadic shape leaves room for future expansion.
+type CustomDomainOption func(*customDomainOptions)
+
+type customDomainOptions struct {
+	targetPort int
+}
+
+// WithTargetPort routes the custom hostname to the given in-container TCP
+// port instead of the default toolbox agent. Set once at attach time;
+// changing the port for an already-attached hostname requires
+// RemoveCustomDomain + AddCustomDomain so in-flight traffic can't silently
+// redirect. Re-adding the same hostname with a different port returns 409.
+func WithTargetPort(port int) CustomDomainOption {
+	return func(o *customDomainOptions) { o.targetPort = port }
+}
+
 // AddCustomDomain attaches a public hostname (e.g. "api.acme.com") to this
 // sandbox. The server lowercases / trims and validates the hostname; the
 // returned slice is the full per-hostname row list, so callers can read the
@@ -436,11 +453,16 @@ func (s *Sandbox) UnexposePort(ctx context.Context, port int) error {
 //
 // 412 Precondition Failed surfaces when the deployment is in IP mode or the
 // custom-domain feature is disabled. 409 Conflict surfaces when the hostname
-// is already attached to a different sandbox, or when the sandbox has any
+// is already attached to a different sandbox, the sandbox has any
 // tcp/tls-protocol exposed port (the IRON RULE: SNI cannot route per host on
-// a shared L4 listener).
-func (s *Sandbox) AddCustomDomain(ctx context.Context, hostname string) ([]sdktypes.CustomDomain, error) {
-	return s.client.inner.AddCustomDomain(ctx, s.ID, hostname)
+// a shared L4 listener), or the re-add target_port differs from the stored
+// value. 400 Bad Request surfaces when target_port is outside [0, 65535].
+func (s *Sandbox) AddCustomDomain(ctx context.Context, hostname string, opts ...CustomDomainOption) ([]sdktypes.CustomDomain, error) {
+	cfg := customDomainOptions{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return s.client.inner.AddCustomDomain(ctx, s.ID, hostname, cfg.targetPort)
 }
 
 // RemoveCustomDomain detaches a hostname previously attached via

--- a/sdk/java/src/main/java/ai/aerol/microvm/MicroVMClient.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/MicroVMClient.java
@@ -445,10 +445,20 @@ public class MicroVMClient {
      * operator's DNS resolves to the cluster.
      */
     public List<CustomDomain> addCustomDomain(String sandboxId, String hostname) {
+        return addCustomDomain(sandboxId, hostname, 0);
+    }
+
+    /**
+     * Attach with a per-domain target port. {@code targetPort == 0} routes to
+     * the sandbox's toolbox port (the same default the single-arg overload
+     * uses). Re-adding the same hostname with a different port returns 409 —
+     * detach first if you need to change it.
+     */
+    public List<CustomDomain> addCustomDomain(String sandboxId, String hostname, int targetPort) {
         CustomDomainListResponse response = doJson(
             "POST",
             sandboxPath(sandboxId) + "/custom-domains",
-            new AddCustomDomainRequest(hostname),
+            new AddCustomDomainRequest(hostname, targetPort),
             CustomDomainListResponse.class
         );
         if (response == null || response.customDomains == null) {
@@ -514,8 +524,13 @@ public class MicroVMClient {
     static class AddCustomDomainRequest {
         public final String hostname;
 
-        AddCustomDomainRequest(String hostname) {
+        @com.fasterxml.jackson.annotation.JsonProperty("target_port")
+        @com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_DEFAULT)
+        public final int targetPort;
+
+        AddCustomDomainRequest(String hostname, int targetPort) {
             this.hostname = hostname;
+            this.targetPort = targetPort;
         }
     }
 

--- a/sdk/java/src/main/java/ai/aerol/microvm/Sandbox.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/Sandbox.java
@@ -115,6 +115,10 @@ public class Sandbox extends SandboxData {
         return client.addCustomDomain(id, hostname);
     }
 
+    public List<CustomDomain> addCustomDomain(String hostname, int targetPort) {
+        return client.addCustomDomain(id, hostname, targetPort);
+    }
+
     public List<CustomDomain> listCustomDomains() {
         return client.listCustomDomains(id);
     }

--- a/sdk/java/src/main/java/ai/aerol/microvm/model/CustomDomain.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/model/CustomDomain.java
@@ -19,4 +19,11 @@ public class CustomDomain {
     public Instant createdAt;
     @JsonProperty("updated_at")
     public Instant updatedAt;
+    /**
+     * Container port traffic to this hostname dials. {@code 0} (the default)
+     * means the sandbox's toolbox port — set once at attach time. To change
+     * the port, detach the binding and re-add it.
+     */
+    @JsonProperty("target_port")
+    public int targetPort;
 }

--- a/sdk/python/microvm/client.py
+++ b/sdk/python/microvm/client.py
@@ -339,8 +339,13 @@ class Sandbox:
     def unexpose_port(self, port: int) -> None:
         self._client.unexpose_port(self.id, port)
 
-    def add_custom_domain(self, hostname: str) -> List[CustomDomain]:
-        return self._client.add_custom_domain(self.id, hostname)
+    def add_custom_domain(
+        self,
+        hostname: str,
+        *,
+        port: Optional[int] = None,
+    ) -> List[CustomDomain]:
+        return self._client.add_custom_domain(self.id, hostname, port=port)
 
     def list_custom_domains(self) -> List[CustomDomain]:
         return self._client.list_custom_domains(self.id)
@@ -749,18 +754,32 @@ class MicroVM:
     def unexpose_port(self, sandbox_id: str, port: int) -> None:
         self._do_json("DELETE", f"{self._version_prefix}/sandboxes/{sandbox_id}/ports/{port}", None)
 
-    def add_custom_domain(self, sandbox_id: str, hostname: str) -> List[CustomDomain]:
+    def add_custom_domain(
+        self,
+        sandbox_id: str,
+        hostname: str,
+        *,
+        port: Optional[int] = None,
+    ) -> List[CustomDomain]:
         """Attach a public hostname to a sandbox.
 
         Returns the post-attach list of :class:`CustomDomain` rows so callers
         can read the initial ``status`` (typically ``"pending_dns"``) without
         a follow-up GET. Server lowercases the hostname; case is preserved
         as-passed.
+
+        ``port`` pins the container port traffic to this hostname dials. Omit
+        (or pass ``0``) to route to the sandbox's toolbox port (the default).
+        Re-adding the same hostname with a different ``port`` returns 409 —
+        detach first.
         """
+        body: Dict[str, Any] = {"hostname": hostname}
+        if port is not None and port != 0:
+            body["target_port"] = port
         response = self._do_json(
             "POST",
             self._versioned(f"/sandboxes/{sandbox_id}/custom-domains"),
-            {"hostname": hostname},
+            body,
         )
         return _from_api_custom_domains_response(response)
 
@@ -1098,6 +1117,9 @@ def _from_api_custom_domain(domain: Dict[str, Any]) -> CustomDomain:
     last_error = _first_of(domain, "last_error", "lastError")
     if last_error not in (None, ""):
         result["lastError"] = str(last_error)
+    target_port = _first_of(domain, "target_port", "targetPort")
+    if isinstance(target_port, int) and target_port > 0:
+        result["targetPort"] = target_port
     return result
 
 

--- a/sdk/python/microvm/types.py
+++ b/sdk/python/microvm/types.py
@@ -263,6 +263,9 @@ class CustomDomain(TypedDict, total=False):
     lastError: str
     createdAt: str
     updatedAt: str
+    # Container port traffic to this hostname dials. 0 (or absent) means the
+    # sandbox's toolbox port (the default). Set once at attach time.
+    targetPort: int
 
 
 class IngressTarget(TypedDict, total=False):

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -919,6 +919,33 @@ class CustomDomainsTests(unittest.TestCase):
         self.assertEqual(domains[0]["createdAt"], "2026-05-25T10:00:00Z")
         self.assertNotIn("lastError", domains[0])
 
+    def test_add_custom_domain_forwards_target_port_when_set(self):
+        client, captured = self._client(
+            post_body={
+                "custom_domains": [
+                    {
+                        "hostname": "api.acme.com",
+                        "status": "pending_dns",
+                        "target_port": 3333,
+                        "created_at": "2026-05-25T10:00:00Z",
+                        "updated_at": "2026-05-25T10:00:00Z",
+                    }
+                ]
+            },
+        )
+        domains = client.add_custom_domain("sb-1", "api.acme.com", port=3333)
+        self.assertEqual(
+            captured["calls"][0][2],
+            {"hostname": "api.acme.com", "target_port": 3333},
+        )
+        self.assertEqual(domains[0]["targetPort"], 3333)
+
+    def test_add_custom_domain_omits_target_port_when_unset_or_zero(self):
+        for port_arg in (None, 0):
+            client, captured = self._client(post_body={"custom_domains": []})
+            client.add_custom_domain("sb-1", "api.acme.com", port=port_arg)
+            self.assertEqual(captured["calls"][0][2], {"hostname": "api.acme.com"})
+
     def test_add_custom_domain_preserves_hostname_case(self):
         # Case is forwarded as-passed; the server normalizes. The SDK must not
         # lowercase locally or the wire payload diverges from caller intent.

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -25,8 +25,9 @@ pub use image::Image;
 pub use types::CreateSandboxResponse;
 use types::{CustomDomainListWire, ExposePortResponseWire};
 pub use types::{
-    BuildImageOptions, BuildImagePushOptions, BuildImageResult, ClientConfig, CreateOptions,
-    CreateSessionOptions, CreateTemplateOptions, CustomDomain, CustomDomainDnsRecords,
+    AddCustomDomainOptions, BuildImageOptions, BuildImagePushOptions, BuildImageResult,
+    ClientConfig, CreateOptions, CreateSessionOptions, CreateTemplateOptions, CustomDomain,
+    CustomDomainDnsRecords,
     CustomDomainStatus, DnsRecord, ExecExitInfo, ExecRequest, ExecResult, ExposeOptions,
     ExposeProtocol, ExposeResult, ExposedPort, Failover, HealthStatus, IngressTarget, Lifecycle,
     MountSpec, MountSpecRedacted, MountType, NetworkUsage, RegisterSnapshotOptions, RegistryAuth,
@@ -394,9 +395,15 @@ impl Sandbox {
 
     /// Attach a custom hostname to this sandbox. Returns the post-add list
     /// of bindings (sorted by hostname). Idempotent: calling with an
-    /// already-registered hostname returns the existing list.
-    pub fn add_custom_domain(&self, hostname: &str) -> Result<Vec<CustomDomain>, Error> {
-        self.client.add_custom_domain(&self.data.id, hostname)
+    /// already-registered hostname returns the existing list — but re-adding
+    /// with a different `port` returns 409 (detach first).
+    pub fn add_custom_domain(
+        &self,
+        hostname: &str,
+        options: Option<AddCustomDomainOptions>,
+    ) -> Result<Vec<CustomDomain>, Error> {
+        self.client
+            .add_custom_domain(&self.data.id, hostname, options)
     }
 
     /// List all custom hostnames currently bound to this sandbox.
@@ -1213,13 +1220,24 @@ impl Client {
 
     /// Register a custom hostname against `id`. Returns the post-add list of
     /// bindings, sorted by hostname server-side. The hostname is forwarded
-    /// verbatim — the server lowercases and validates it.
+    /// verbatim — the server lowercases and validates it. `options.port`, if
+    /// set to a non-zero value, pins the container port traffic dials.
     pub fn add_custom_domain(
         &self,
         id: &str,
         hostname: &str,
+        options: Option<AddCustomDomainOptions>,
     ) -> Result<Vec<CustomDomain>, Error> {
-        let body = serde_json::json!({ "hostname": hostname });
+        let mut body = serde_json::json!({ "hostname": hostname });
+        if let Some(opts) = options {
+            if let Some(port) = opts.port {
+                if port != 0 {
+                    body.as_object_mut()
+                        .expect("body is object")
+                        .insert("target_port".to_string(), Value::from(port));
+                }
+            }
+        }
         let wire = self.do_json::<Value, CustomDomainListWire>(
             Method::POST,
             &format!("{}/sandboxes/{}/custom-domains", self.version_prefix(), id),
@@ -2947,7 +2965,7 @@ mod tests {
 
         let client = Client::new(Some(&url), Some("pat-token")).expect("client should build");
         let domains = client
-            .add_custom_domain("sb-1", "api.acme.com")
+            .add_custom_domain("sb-1", "api.acme.com", None)
             .expect("add_custom_domain should succeed");
         let request = request_rx.recv().expect("request should be captured");
 
@@ -2964,6 +2982,65 @@ mod tests {
         assert_eq!(domains[0].hostname, "api.acme.com");
         assert_eq!(domains[0].status, CustomDomainStatus::PendingDns);
         assert!(domains[0].last_error.is_none());
+        assert_eq!(domains[0].target_port, 0);
+    }
+
+    #[test]
+    fn add_custom_domain_forwards_target_port() {
+        let body = serde_json::json!({
+            "custom_domains": [
+                {
+                    "hostname": "api.acme.com",
+                    "status": "pending_dns",
+                    "target_port": 3333,
+                    "created_at": "2026-05-24T10:00:00Z",
+                    "updated_at": "2026-05-24T10:00:00Z"
+                }
+            ]
+        })
+        .to_string();
+        let (url, request_rx) =
+            spawn_response_server("201 Created", "application/json", body.into_bytes());
+
+        let client = Client::new(Some(&url), Some("pat-token")).expect("client should build");
+        let domains = client
+            .add_custom_domain(
+                "sb-1",
+                "api.acme.com",
+                Some(AddCustomDomainOptions::with_port(3333)),
+            )
+            .expect("add_custom_domain should succeed");
+        let request = request_rx.recv().expect("request should be captured");
+
+        assert_eq!(
+            request_json_body(&request),
+            serde_json::json!({"hostname": "api.acme.com", "target_port": 3333})
+        );
+        assert_eq!(domains[0].target_port, 3333);
+    }
+
+    #[test]
+    fn add_custom_domain_omits_target_port_when_zero() {
+        let (url, request_rx) = spawn_response_server(
+            "201 Created",
+            "application/json",
+            br#"{"custom_domains":[]}"#.to_vec(),
+        );
+
+        let client = Client::new(Some(&url), Some("pat-token")).expect("client should build");
+        client
+            .add_custom_domain(
+                "sb-1",
+                "api.acme.com",
+                Some(AddCustomDomainOptions::with_port(0)),
+            )
+            .expect("add_custom_domain should succeed");
+        let request = request_rx.recv().expect("request should be captured");
+
+        assert_eq!(
+            request_json_body(&request),
+            serde_json::json!({"hostname": "api.acme.com"})
+        );
     }
 
     #[test]
@@ -3045,7 +3122,7 @@ mod tests {
 
         let client = Client::new(Some(&url), Some("pat-token")).expect("client should build");
         let err = client
-            .add_custom_domain("sb-1", "taken.acme.com")
+            .add_custom_domain("sb-1", "taken.acme.com", None)
             .expect_err("add_custom_domain should fail on 409");
 
         let message = err.to_string();
@@ -3074,7 +3151,7 @@ mod tests {
 
         let client = Client::new(Some(&url), Some("pat-token")).expect("client should build");
         let err = client
-            .add_custom_domain("sb-1", "api.acme.com")
+            .add_custom_domain("sb-1", "api.acme.com", None)
             .expect_err("add_custom_domain should fail on 412");
 
         let message = err.to_string();

--- a/sdk/rust/src/types.rs
+++ b/sdk/rust/src/types.rs
@@ -281,6 +281,30 @@ pub struct CustomDomain {
     pub created_at: String,
     #[serde(rename = "updated_at")]
     pub updated_at: String,
+    /// Container port traffic to this hostname dials. `0` (the default) means
+    /// the sandbox's toolbox port — preserves the pre-target-port behavior.
+    /// Set once at attach time via [`AddCustomDomainOptions::port`].
+    #[serde(rename = "target_port", default, skip_serializing_if = "is_zero_u16")]
+    pub target_port: u16,
+}
+
+fn is_zero_u16(v: &u16) -> bool {
+    *v == 0
+}
+
+/// Options for [`Sandbox::add_custom_domain`]. `port` pins the container port
+/// traffic to this hostname dials; leave `None` (or set to `0`) to route to the
+/// sandbox's toolbox port (the default). Re-adding the same hostname with a
+/// different port returns 409 — detach first.
+#[derive(Debug, Clone, Default)]
+pub struct AddCustomDomainOptions {
+    pub port: Option<u16>,
+}
+
+impl AddCustomDomainOptions {
+    pub fn with_port(port: u16) -> Self {
+        Self { port: Some(port) }
+    }
 }
 
 /// Wire envelope returned by the custom-domains endpoints — kept private;

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -4,6 +4,7 @@ export { Image } from "./Image.js";
 export type { MicroVMConfig } from "./MicroVM.js";
 export type { RetryConfig } from "./internal/client.js";
 export type {
+  AddCustomDomainOptions,
   BinaryLike,
   BuildImageOptions,
   BuildImagePushOptions,

--- a/sdk/typescript/src/internal/client.test.ts
+++ b/sdk/typescript/src/internal/client.test.ts
@@ -865,6 +865,57 @@ test("internal client addCustomDomain POSTs hostname and parses list", async () 
   assert.equal(domains[0].lastError, undefined);
 });
 
+test("internal client addCustomDomain forwards target_port when port option set", async () => {
+  let sentBody: { hostname?: string; target_port?: number } | undefined;
+  const client = new APIClient({
+    baseURL: "https://api.example.com",
+    patToken: "pat-token",
+    fetch: async (input, init) => {
+      const req = new Request(input, init);
+      sentBody = (await req.json()) as { hostname?: string; target_port?: number };
+      return jsonResponse(
+        {
+          custom_domains: [
+            {
+              hostname: "api.acme.com",
+              status: "pending_dns",
+              target_port: 3333,
+              created_at: "2026-05-24T10:00:00Z",
+              updated_at: "2026-05-24T10:00:00Z",
+            },
+          ],
+        },
+        201,
+      );
+    },
+  });
+
+  const domains = await client.addCustomDomain("sb-cd", "api.acme.com", { port: 3333 });
+  assert.equal(sentBody?.hostname, "api.acme.com");
+  assert.equal(sentBody?.target_port, 3333);
+  assert.equal(domains[0].targetPort, 3333);
+});
+
+test("internal client addCustomDomain omits target_port when port option absent or zero", async () => {
+  const seen: Array<Record<string, unknown>> = [];
+  const client = new APIClient({
+    baseURL: "https://api.example.com",
+    patToken: "pat-token",
+    fetch: async (input, init) => {
+      const req = new Request(input, init);
+      seen.push((await req.json()) as Record<string, unknown>);
+      return jsonResponse({ custom_domains: [] }, 201);
+    },
+  });
+
+  await client.addCustomDomain("sb-cd", "api.acme.com");
+  await client.addCustomDomain("sb-cd", "api.acme.com", {});
+  await client.addCustomDomain("sb-cd", "api.acme.com", { port: 0 });
+  for (const body of seen) {
+    assert.equal("target_port" in body, false);
+  }
+});
+
 test("internal client addCustomDomain preserves hostname case sent by caller", async () => {
   let sentBody: { hostname?: string } | undefined;
   const client = new APIClient({

--- a/sdk/typescript/src/internal/client.ts
+++ b/sdk/typescript/src/internal/client.ts
@@ -9,6 +9,7 @@ import {
 } from "./api/v1/paths.js";
 import { Image } from "../Image.js";
 import type {
+  AddCustomDomainOptions,
   BinaryLike,
   BuildImageOptions,
   BuildImageResult,
@@ -132,6 +133,7 @@ interface ApiCustomDomain {
   last_error?: string;
   created_at: string;
   updated_at: string;
+  target_port?: number;
 }
 
 interface ApiCustomDomainList {
@@ -619,11 +621,19 @@ export class APIClient {
    * with an already-registered hostname is idempotent and returns the
    * existing list.
    */
-  async addCustomDomain(id: string, hostname: string): Promise<CustomDomain[]> {
+  async addCustomDomain(
+    id: string,
+    hostname: string,
+    options?: AddCustomDomainOptions,
+  ): Promise<CustomDomain[]> {
+    const body: { hostname: string; target_port?: number } = { hostname };
+    if (options?.port !== undefined && options.port !== 0) {
+      body.target_port = options.port;
+    }
     const response = await this.doJSON<ApiCustomDomainList>(
       "POST",
       v1SandboxCustomDomainsPath(this.versionPrefix, id),
-      { hostname },
+      body,
     );
     return response.custom_domains.map(fromApiCustomDomain);
   }
@@ -912,7 +922,7 @@ export class SandboxResource implements Sandbox {
    * so the closures always see the current `id` even after `refresh()`.
    */
   get customDomains(): {
-    add(hostname: string): Promise<CustomDomain[]>;
+    add(hostname: string, options?: AddCustomDomainOptions): Promise<CustomDomain[]>;
     remove(hostname: string): Promise<void>;
     list(): Promise<CustomDomain[]>;
     dns(): Promise<CustomDomainDNSRecords>;
@@ -920,7 +930,8 @@ export class SandboxResource implements Sandbox {
     const client = this.client;
     const id = this.id;
     return {
-      add: (hostname: string) => client.addCustomDomain(id, hostname),
+      add: (hostname: string, options?: AddCustomDomainOptions) =>
+        client.addCustomDomain(id, hostname, options),
       remove: (hostname: string) => client.removeCustomDomain(id, hostname),
       list: () => client.listCustomDomains(id),
       dns: () => client.customDomainDNS(id),
@@ -1165,6 +1176,7 @@ function fromApiCustomDomain(domain: ApiCustomDomain): CustomDomain {
     lastError: domain.last_error,
     createdAt: domain.created_at,
     updatedAt: domain.updated_at,
+    targetPort: domain.target_port,
   };
 }
 

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -264,6 +264,23 @@ export interface CustomDomain {
   lastError?: string;
   createdAt: string;
   updatedAt: string;
+  /**
+   * Target container port traffic to this hostname dials. `0` (or omitted)
+   * means the sandbox's toolbox port — the default that preserves the
+   * pre-target-port behavior. Set once at attach time; to change it, remove
+   * the binding and re-add it with the new port.
+   */
+  targetPort?: number;
+}
+
+/**
+ * Options for `sandbox.customDomains.add()`. `port` pins the container port
+ * traffic to this hostname dials; omit it to route to the sandbox's toolbox
+ * port (the default). Re-adding the same hostname with a different `port`
+ * returns 409 — detach first.
+ */
+export interface AddCustomDomainOptions {
+  port?: number;
 }
 
 /**


### PR DESCRIPTION
This pull request adds support for routing custom domains to specific application ports inside a sandbox, instead of always defaulting to the toolbox port. It introduces a new `targetPort` parameter to the custom domain attach flow, updates documentation to describe this feature and its constraints, and refactors related service and test code to handle the new parameter. Additionally, it clarifies error handling and updates the domain removal logic to immediately drop per-hostname routes.

**Custom domain target port support:**

* Added a `targetPort` parameter to the `AddCustomDomain` method, allowing custom domains to route to a specified application port inside the container instead of always using the toolbox port. The parameter is validated and persisted, and callers must detach and re-add to change the port. [[1]](diffhunk://#diff-2ce1ab7496e788847086e20f4044c1f11371a6abf41246cfa79ec46adc0947b9R203-R223) [[2]](diffhunk://#diff-2ce1ab7496e788847086e20f4044c1f11371a6abf41246cfa79ec46adc0947b9L227-R268) [[3]](diffhunk://#diff-b20da5d56475daa429a793beee993a3bc1af2b562240bcacfa9f10d123a49a2dL81-R81) [[4]](diffhunk://#diff-8ef405063dfbbefd3ab4450c1fd6b1a1f0ee6817ebfa75133cbace706ddec27aL132-R132) [[5]](diffhunk://#diff-8ef405063dfbbefd3ab4450c1fd6b1a1f0ee6817ebfa75133cbace706ddec27aR142-R180) [[6]](diffhunk://#diff-8ef405063dfbbefd3ab4450c1fd6b1a1f0ee6817ebfa75133cbace706ddec27aL314-R355)
* Updated documentation to explain the new `port` option, usage examples in multiple languages, and clarified error conditions (e.g., `409 Conflict` if re-attaching a hostname with a different port, and `400 Bad Request` for invalid port ranges). [[1]](diffhunk://#diff-8ef405063dfbbefd3ab4450c1fd6b1a1f0ee6817ebfa75133cbace706ddec27aR142-R180) [[2]](diffhunk://#diff-8ef405063dfbbefd3ab4450c1fd6b1a1f0ee6817ebfa75133cbace706ddec27aL314-R355)

**Service and test refactoring:**

* Refactored service methods and tests to accept and propagate the new `targetPort` argument, ensuring all custom domain operations and test cases use the updated method signature. [[1]](diffhunk://#diff-0f95c39485004178298e98b63b41403f77e4113bb03f14ecfa32cd9783c799aaL181-R181) [[2]](diffhunk://#diff-0f95c39485004178298e98b63b41403f77e4113bb03f14ecfa32cd9783c799aaL190-R190) [[3]](diffhunk://#diff-0f95c39485004178298e98b63b41403f77e4113bb03f14ecfa32cd9783c799aaL213-R213) [[4]](diffhunk://#diff-0f95c39485004178298e98b63b41403f77e4113bb03f14ecfa32cd9783c799aaL223-R226) [[5]](diffhunk://#diff-0f95c39485004178298e98b63b41403f77e4113bb03f14ecfa32cd9783c799aaL240-R243) [[6]](diffhunk://#diff-0f95c39485004178298e98b63b41403f77e4113bb03f14ecfa32cd9783c799aaL258-R270) [[7]](diffhunk://#diff-0f95c39485004178298e98b63b41403f77e4113bb03f14ecfa32cd9783c799aaL280-R280) [[8]](diffhunk://#diff-4bd27ca55fe44e33fa7e554f9ef99ff918ed9a3f2ca702cc179d1e41d3c12facL105-R105) [[9]](diffhunk://#diff-2ce1ab7496e788847086e20f4044c1f11371a6abf41246cfa79ec46adc0947b9L387-R439)
* Added a new error sentinel for port mismatches (`ErrCustomDomainPortMismatch`) to distinguish this case and map it to a 409 response.

**Internal API and routing changes:**

* Updated internal helpers to distinguish between hostnames-only and hostname+port lists, used for cluster state and routing, and ensured correct propagation of target ports to the routing layer. [[1]](diffhunk://#diff-2ce1ab7496e788847086e20f4044c1f11371a6abf41246cfa79ec46adc0947b9L58-R102) [[2]](diffhunk://#diff-2ce1ab7496e788847086e20f4044c1f11371a6abf41246cfa79ec46adc0947b9R13) [[3]](diffhunk://#diff-e0db534a85d7e4d2d0dd6ea4b54c69cdb8abd8a42b6d3878be835bd6e2afa1ddL109-R109) [[4]](diffhunk://#diff-e0db534a85d7e4d2d0dd6ea4b54c69cdb8abd8a42b6d3878be835bd6e2afa1ddL166-R166)
* On domain removal, now explicitly deletes the per-hostname route from the router immediately, rather than waiting for a background reconcile, to stop traffic without delay.

**Other configuration and documentation updates:**

* Clarified that create-time bulk custom domain attachment does not yet support per-domain ports; only post-create attach supports this feature.
* Disabled Firecracker by default in the cluster config for unrelated reasons.