### PR TITLE
test: add unit tests for image pull error classification and device retrieval

### DIFF
--- a/internal/observability/expvar_test.go
+++ b/internal/observability/expvar_test.go
@@ -3,6 +3,7 @@ package observability
 import (
 	"expvar"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 )
@@ -46,4 +47,96 @@ func hasIntSample(samples []ExpvarSample, name, labelName, labelValue string, wa
 		}
 	}
 	return false
+}
+
+// rawVar is a minimal expvar.Var whose String() returns its value verbatim.
+// expvar.String quotes its output (JSON), so we use this to exercise the
+// default branch in sampleFromExpvar that parses bare numeric strings.
+type rawVar string
+
+func (r rawVar) String() string { return string(r) }
+
+func TestSampleFromExpvar(t *testing.T) {
+	t.Run("expvar_int", func(t *testing.T) {
+		v := new(expvar.Int)
+		v.Set(42)
+		s, ok := sampleFromExpvar("m", nil, v)
+		if !ok || s.Int64 == nil || *s.Int64 != 42 {
+			t.Fatalf("expected Int64=42, got ok=%v sample=%+v", ok, s)
+		}
+		if s.Float != nil {
+			t.Fatal("expected Float nil for Int var")
+		}
+	})
+
+	t.Run("expvar_float_valid", func(t *testing.T) {
+		v := new(expvar.Float)
+		v.Set(3.14)
+		s, ok := sampleFromExpvar("m", nil, v)
+		if !ok || s.Float == nil {
+			t.Fatalf("expected Float sample, got ok=%v sample=%+v", ok, s)
+		}
+		if math.Abs(*s.Float-3.14) > 1e-9 {
+			t.Fatalf("Float = %v, want 3.14", *s.Float)
+		}
+	})
+
+	t.Run("expvar_float_nan_filtered", func(t *testing.T) {
+		v := new(expvar.Float)
+		v.Set(math.NaN())
+		_, ok := sampleFromExpvar("m", nil, v)
+		if ok {
+			t.Fatal("NaN float should be filtered (ok=false)")
+		}
+	})
+
+	t.Run("expvar_float_inf_filtered", func(t *testing.T) {
+		v := new(expvar.Float)
+		v.Set(math.Inf(1))
+		_, ok := sampleFromExpvar("m", nil, v)
+		if ok {
+			t.Fatal("+Inf float should be filtered (ok=false)")
+		}
+	})
+
+	t.Run("string_backed_int", func(t *testing.T) {
+		// A custom expvar.Var whose String() returns a bare integer (no JSON quotes).
+		// This exercises the default branch that falls through to ParseInt.
+		s, ok := sampleFromExpvar("m", nil, rawVar("99"))
+		if !ok || s.Int64 == nil || *s.Int64 != 99 {
+			t.Fatalf("expected Int64=99, got ok=%v sample=%+v", ok, s)
+		}
+	})
+
+	t.Run("string_backed_float", func(t *testing.T) {
+		s, ok := sampleFromExpvar("m", nil, rawVar("2.718"))
+		if !ok || s.Float == nil {
+			t.Fatalf("expected Float sample, got ok=%v sample=%+v", ok, s)
+		}
+		if math.Abs(*s.Float-2.718) > 1e-9 {
+			t.Fatalf("Float = %v, want 2.718", *s.Float)
+		}
+	})
+
+	t.Run("string_unparseable_filtered", func(t *testing.T) {
+		_, ok := sampleFromExpvar("m", nil, rawVar("not-a-number"))
+		if ok {
+			t.Fatal("unparseable string should be filtered (ok=false)")
+		}
+	})
+
+	t.Run("labels_copied", func(t *testing.T) {
+		v := new(expvar.Int)
+		v.Set(1)
+		labels := []ExpvarLabel{{Name: "k", Value: "v"}}
+		s, ok := sampleFromExpvar("m", labels, v)
+		if !ok || len(s.Labels) != 1 || s.Labels[0].Name != "k" {
+			t.Fatalf("labels not propagated: ok=%v sample=%+v", ok, s)
+		}
+		// mutating original labels must not affect the stored copy
+		labels[0].Value = "changed"
+		if s.Labels[0].Value != "v" {
+			t.Fatal("labels were not deep-copied")
+		}
+	})
 }

--- a/pkg/docker/metrics_test.go
+++ b/pkg/docker/metrics_test.go
@@ -1,0 +1,44 @@
+package docker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestClassifyImagePullError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "nil", err: nil, want: ""},
+		{name: "context_canceled_sentinel", err: context.Canceled, want: "canceled"},
+		{name: "context_deadline_exceeded_sentinel", err: context.DeadlineExceeded, want: "timeout"},
+		{name: "wrapped_context_canceled", err: fmt.Errorf("op failed: %w", context.Canceled), want: "canceled"},
+		{name: "string_context_canceled", err: errors.New("context canceled"), want: "canceled"},
+		{name: "string_deadline_exceeded", err: errors.New("deadline exceeded"), want: "timeout"},
+		{name: "string_timeout", err: errors.New("i/o timeout"), want: "timeout"},
+		{name: "string_timed_out", err: errors.New("connection timed out"), want: "timeout"},
+		{name: "string_unauthorized", err: errors.New("unauthorized"), want: "auth"},
+		{name: "string_authentication_required", err: errors.New("authentication required"), want: "auth"},
+		{name: "string_denied", err: errors.New("access denied"), want: "auth"},
+		{name: "string_manifest_unknown", err: errors.New("manifest unknown"), want: "not_found"},
+		{name: "string_not_found", err: errors.New("image not found"), want: "not_found"},
+		{name: "string_no_such_image", err: errors.New("no such image"), want: "not_found"},
+		{name: "string_too_many_requests", err: errors.New("too many requests"), want: "rate_limited"},
+		{name: "string_rate_limit", err: errors.New("rate limit exceeded"), want: "rate_limited"},
+		{name: "string_backoff", err: errors.New("pull backoff"), want: "backoff"},
+		{name: "unknown_error", err: errors.New("some unexpected failure"), want: "error"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyImagePullError(tc.err)
+			if got != tc.want {
+				t.Fatalf("classifyImagePullError(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/docker/netrules/manager_test.go
+++ b/pkg/docker/netrules/manager_test.go
@@ -1,6 +1,9 @@
 package netrules
 
-import "testing"
+import (
+	"runtime"
+	"testing"
+)
 
 func TestManagerDisabledAndNilGuards(t *testing.T) {
 	var nilMgr *Manager
@@ -52,5 +55,18 @@ func TestNew_DisabledReturnsDisabledManager(t *testing.T) {
 	}
 	if m == nil || m.Enabled() {
 		t.Fatalf("New(false) = %+v, want non-nil disabled manager", m)
+	}
+}
+
+func TestNew_EnabledOnNonLinux(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("this test covers the non-Linux branch only")
+	}
+	m, err := New(true)
+	if err != nil {
+		t.Fatalf("New(true) on non-Linux err = %v", err)
+	}
+	if m == nil || m.Enabled() {
+		t.Fatalf("New(true) on non-Linux = %+v, want non-nil disabled manager", m)
 	}
 }

--- a/pkg/mounts/sweep.go
+++ b/pkg/mounts/sweep.go
@@ -16,9 +16,13 @@ import (
 // because mount tools (mountpoint-s3, sshfs, rclone) don't all show up under
 // a single name and we want to match by argv path.
 func killFUSEProcessesFor(logger *slog.Logger, dir string) {
-	entries, err := os.ReadDir("/proc")
+	killFUSEProcessesInRoot(logger, dir, "/proc")
+}
+
+func killFUSEProcessesInRoot(logger *slog.Logger, dir, procRoot string) {
+	entries, err := os.ReadDir(procRoot)
 	if err != nil {
-		// /proc not available (non-Linux test, container without /proc, etc.).
+		// procRoot not available (non-Linux test, container without /proc, etc.).
 		return
 	}
 	dirSlash := dir
@@ -35,7 +39,7 @@ func killFUSEProcessesFor(logger *slog.Logger, dir string) {
 		if err != nil {
 			continue
 		}
-		raw, err := os.ReadFile(filepath.Join("/proc", name, "cmdline"))
+		raw, err := os.ReadFile(filepath.Join(procRoot, name, "cmdline"))
 		if err != nil {
 			continue
 		}

--- a/pkg/mounts/sweep_test.go
+++ b/pkg/mounts/sweep_test.go
@@ -1,0 +1,39 @@
+package mounts
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+)
+
+func TestDevOf(t *testing.T) {
+	t.Run("existing_dir_nonzero", func(t *testing.T) {
+		dir := t.TempDir()
+		dev := devOf(dir)
+		if dev == 0 {
+			t.Fatalf("devOf(%q) = 0, want non-zero", dir)
+		}
+	})
+
+	t.Run("nonexistent_path_zero", func(t *testing.T) {
+		dev := devOf("/nonexistent/path/that/does/not/exist")
+		if dev != 0 {
+			t.Fatalf("devOf non-existent = %d, want 0", dev)
+		}
+	})
+}
+
+func TestKillFUSEProcessesFor_NoPanic(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// On non-Linux hosts /proc doesn't exist; function must return without panic.
+	if _, err := os.Stat("/proc"); os.IsNotExist(err) {
+		killFUSEProcessesFor(logger, t.TempDir())
+		return
+	}
+
+	// On Linux /proc exists. Passing a dir that no process references should
+	// still complete without error or panic.
+	killFUSEProcessesFor(logger, t.TempDir())
+}

--- a/pkg/mounts/sweep_test.go
+++ b/pkg/mounts/sweep_test.go
@@ -4,6 +4,10 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"syscall"
 	"testing"
 )
 
@@ -24,16 +28,121 @@ func TestDevOf(t *testing.T) {
 	})
 }
 
-func TestKillFUSEProcessesFor_NoPanic(t *testing.T) {
+func TestKillFUSEProcessesInRoot(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	targetDir := "/some/fuse/mountpoint"
 
-	// On non-Linux hosts /proc doesn't exist; function must return without panic.
-	if _, err := os.Stat("/proc"); os.IsNotExist(err) {
-		killFUSEProcessesFor(logger, t.TempDir())
-		return
-	}
+	t.Run("missing_proc_root", func(t *testing.T) {
+		// ReadDir fails → early return, no panic.
+		killFUSEProcessesInRoot(logger, targetDir, "/nonexistent/proc/root")
+	})
 
-	// On Linux /proc exists. Passing a dir that no process references should
-	// still complete without error or panic.
-	killFUSEProcessesFor(logger, t.TempDir())
+	t.Run("skips_non_dir_entry", func(t *testing.T) {
+		procRoot := t.TempDir()
+		// A regular file named like a PID should be skipped.
+		if err := os.WriteFile(filepath.Join(procRoot, "123"), []byte("data"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		killFUSEProcessesInRoot(logger, targetDir, procRoot)
+	})
+
+	t.Run("skips_non_numeric_dir", func(t *testing.T) {
+		procRoot := t.TempDir()
+		if err := os.Mkdir(filepath.Join(procRoot, "notapid"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		killFUSEProcessesInRoot(logger, targetDir, procRoot)
+	})
+
+	t.Run("skips_pid_dir_without_cmdline", func(t *testing.T) {
+		procRoot := t.TempDir()
+		if err := os.Mkdir(filepath.Join(procRoot, "999"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// No cmdline file → ReadFile fails → skipped.
+		killFUSEProcessesInRoot(logger, targetDir, procRoot)
+	})
+
+	t.Run("skips_non_matching_cmdline", func(t *testing.T) {
+		procRoot := t.TempDir()
+		pidDir := filepath.Join(procRoot, "998")
+		if err := os.Mkdir(pidDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pidDir, "cmdline"), []byte("/other/path\x00arg"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		killFUSEProcessesInRoot(logger, targetDir, procRoot)
+	})
+
+	t.Run("dir_already_has_trailing_slash", func(t *testing.T) {
+		// Exercises the !strings.HasSuffix branch (condition is false, no "/" appended).
+		procRoot := t.TempDir()
+		dirWithSlash := targetDir + "/"
+		pidDir := filepath.Join(procRoot, "997")
+		if err := os.Mkdir(pidDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// cmdline matches via bytes.Contains
+		if err := os.WriteFile(filepath.Join(pidDir, "cmdline"), []byte(dirWithSlash+"sub\x00"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		// Use a non-existent PID so Kill is a no-op (ESRCH ignored).
+		killFUSEProcessesInRoot(logger, dirWithSlash, procRoot)
+	})
+
+	t.Run("matches_contains_nonexistent_pid", func(t *testing.T) {
+		// cmdline contains dirSlash → match via bytes.Contains.
+		// Non-existent PID → Getpgid fails → Kill(pid, SIGKILL) called (ESRCH silently ignored).
+		procRoot := t.TempDir()
+		const fakePID = "4194305" // above Linux pid_max; Getpgid returns ESRCH
+		pidDir := filepath.Join(procRoot, fakePID)
+		if err := os.Mkdir(pidDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pidDir, "cmdline"), []byte(targetDir+"/subdir\x00"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		killFUSEProcessesInRoot(logger, targetDir, procRoot)
+	})
+
+	t.Run("matches_has_suffix_nonexistent_pid", func(t *testing.T) {
+		// cmdline ends with dir (no trailing slash) → match only via bytes.HasSuffix.
+		procRoot := t.TempDir()
+		const fakePID = "4194306"
+		pidDir := filepath.Join(procRoot, fakePID)
+		if err := os.Mkdir(pidDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// Does NOT contain dirSlash ("/some/fuse/mountpoint/"), but HasSuffix of dir matches.
+		if err := os.WriteFile(filepath.Join(pidDir, "cmdline"), []byte("rclone mount"+targetDir), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		killFUSEProcessesInRoot(logger, targetDir, procRoot)
+	})
+
+	t.Run("kills_real_subprocess_pgid_path", func(t *testing.T) {
+		// Start a subprocess in its own process group so Kill(-pgid, SIGKILL)
+		// only affects it, not the test runner. Exercises the Getpgid-success branch.
+		cmd := exec.Command("sleep", "100")
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		if err := cmd.Start(); err != nil {
+			t.Skip("cannot start subprocess:", err)
+		}
+
+		procRoot := t.TempDir()
+		pid := cmd.Process.Pid
+		pidDir := filepath.Join(procRoot, strconv.Itoa(pid))
+		if err := os.Mkdir(pidDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pidDir, "cmdline"), []byte(targetDir+"/\x00"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		killFUSEProcessesInRoot(logger, targetDir, procRoot)
+
+		// Wait confirms the process was killed (not still running).
+		_ = cmd.Wait()
+	})
 }


### PR DESCRIPTION
This pull request adds comprehensive new unit tests across several packages to improve test coverage and ensure correct behavior for error classification, OS-specific logic, and filesystem utilities. The changes introduce targeted tests for edge cases and platform differences, as well as some minor test utility code improvements.

**New and improved test coverage:**

*Docker package:*
- Added `TestClassifyImagePullError` to verify that the `classifyImagePullError` function correctly categorizes a wide range of error messages and sentinel errors, improving reliability of error handling logic.

*Mounts package:*
- Introduced tests for `devOf` to check correct device number extraction for existing and non-existent paths.
- Added a test for `killFUSEProcessesFor` to ensure it does not panic on non-Linux systems or when given unused directories, increasing robustness across platforms.

*Net rules manager:*
- Added `TestNew_EnabledOnNonLinux` to confirm that enabling the manager on non-Linux systems returns a disabled manager, guarding against platform-specific bugs.
- Minor import improvements for OS detection in tests.

*Observability package:*
- Significantly expanded tests for `sampleFromExpvar` to cover integer, float, NaN, Inf, string-backed numeric, unparseable, and label-copying cases, ensuring correct parsing and filtering of expvar metrics.
- Added import of `math` for numeric edge case testing.