### PR TITLE
Add comprehensive tests for Docker client functionality

### DIFF
--- a/cmd/toolboxd/sessions/coverage_extra_test.go
+++ b/cmd/toolboxd/sessions/coverage_extra_test.go
@@ -1,0 +1,129 @@
+package sessions
+
+import (
+	"context"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func TestSessionAccessorsAndPipeWrite(t *testing.T) {
+	mgr := newTestManager(t)
+	ctx := context.Background()
+
+	// `cat` echoes stdin back — lets us exercise Write/CloseStdin on a pipe.
+	sess, err := mgr.Create(ctx, models.CreateSessionRequest{Name: "cat-session", Command: "cat"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if sess.Name() != "cat-session" {
+		t.Fatalf("Name = %q", sess.Name())
+	}
+	if sess.ID() == "" {
+		t.Fatal("ID empty")
+	}
+	if sess.IsPTY() {
+		t.Fatal("pipe session should not be PTY")
+	}
+	if sess.PID() <= 0 {
+		t.Fatalf("PID = %d, want > 0", sess.PID())
+	}
+
+	// Resize is a no-op in pipe mode (no error).
+	if err := sess.Resize(80, 24); err != nil {
+		t.Fatalf("Resize(pipe) = %v", err)
+	}
+
+	if _, err := sess.Write([]byte("ping\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := sess.CloseStdin(); err != nil {
+		t.Fatalf("CloseStdin: %v", err)
+	}
+
+	select {
+	case <-sess.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("cat session did not exit after stdin close")
+	}
+
+	// Writing after exit must error.
+	if _, err := sess.Write([]byte("late")); err == nil {
+		t.Fatal("Write after exit should error")
+	}
+}
+
+func TestSessionPTYResizeAndWrite(t *testing.T) {
+	mgr := newTestManager(t)
+	ctx := context.Background()
+
+	sess, err := mgr.Create(ctx, models.CreateSessionRequest{
+		Name:    "pty-session",
+		Command: "cat",
+		PTY:     true,
+		Cols:    80,
+		Rows:    24,
+	})
+	if err != nil {
+		t.Fatalf("Create PTY: %v", err)
+	}
+	if !sess.IsPTY() {
+		t.Fatal("expected PTY session")
+	}
+	// Valid resize.
+	if err := sess.Resize(120, 40); err != nil {
+		t.Fatalf("Resize: %v", err)
+	}
+	// Invalid window size → error.
+	if err := sess.Resize(0, 0); err == nil {
+		t.Fatal("Resize(0,0) should error in PTY mode")
+	}
+	if _, err := sess.Write([]byte("hi\n")); err != nil {
+		t.Fatalf("Write PTY: %v", err)
+	}
+	_ = mgr.Delete(sess.ID())
+}
+
+func TestBuildArgvAndDetectShell(t *testing.T) {
+	// Explicit argv passes through verbatim.
+	argv, err := buildArgv(models.CreateSessionRequest{Argv: []string{"/bin/echo", "x"}})
+	if err != nil || len(argv) != 2 || argv[0] != "/bin/echo" {
+		t.Fatalf("buildArgv(argv) = %v, %v", argv, err)
+	}
+	// Command wraps in shell -c.
+	argv, err = buildArgv(models.CreateSessionRequest{Command: "echo hi"})
+	if err != nil || len(argv) != 3 || argv[1] != "-c" {
+		t.Fatalf("buildArgv(command) = %v, %v", argv, err)
+	}
+	// Default login shell.
+	argv, err = buildArgv(models.CreateSessionRequest{})
+	if err != nil || len(argv) == 0 {
+		t.Fatalf("buildArgv(default) = %v, %v", argv, err)
+	}
+
+	if detectShell() == "" {
+		t.Fatal("detectShell returned empty")
+	}
+}
+
+func TestMapSignal(t *testing.T) {
+	cases := map[string]syscall.Signal{
+		"INT":     syscall.SIGINT,
+		"sigterm": syscall.SIGTERM,
+		"KILL":    syscall.SIGKILL,
+		"HUP":     syscall.SIGHUP,
+		"QUIT":    syscall.SIGQUIT,
+	}
+	for name, want := range cases {
+		got := mapSignal(name)
+		if got != want {
+			t.Fatalf("mapSignal(%q) = %v, want %v", name, got, want)
+		}
+	}
+	if mapSignal("BOGUS") != nil {
+		t.Fatal("mapSignal(unknown) should be nil")
+	}
+}

--- a/internal/config/load_coverage_test.go
+++ b/internal/config/load_coverage_test.go
@@ -1,0 +1,124 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Exercises the validation branches of Load that the happy-path tests skip.
+// Each case sets the minimum env to reach one error return.
+
+func TestLoad_HappyPathMinimal(t *testing.T) {
+	t.Setenv("SB_PAT_TOKEN", "operator-pat")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.PATToken != "operator-pat" {
+		t.Fatalf("PATToken = %q", cfg.PATToken)
+	}
+	// Defaults should be populated.
+	if cfg.APIPort == 0 || cfg.DBPath == "" {
+		t.Fatalf("expected defaults populated, got %+v", cfg)
+	}
+}
+
+func TestLoad_MissingPATToken(t *testing.T) {
+	// Ensure no inherited token.
+	t.Setenv("SB_PAT_TOKEN", "")
+	_, err := Load()
+	if err == nil || !strings.Contains(err.Error(), "SB_PAT_TOKEN is required") {
+		t.Fatalf("err = %v, want SB_PAT_TOKEN required", err)
+	}
+}
+
+func TestLoad_ValidationErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]string
+		want string
+	}{
+		{
+			name: "otel metrics interval",
+			env:  map[string]string{"SB_OTEL_METRICS_ENABLED": "true", "SB_OTEL_METRICS_INTERVAL": "0s"},
+			want: "SB_OTEL_METRICS_INTERVAL",
+		},
+		{
+			name: "otel traces sample ratio",
+			env:  map[string]string{"SB_OTEL_TRACES_ENABLED": "true", "SB_OTEL_TRACES_SAMPLE_RATIO": "2"},
+			want: "SB_OTEL_TRACES_SAMPLE_RATIO",
+		},
+		{
+			name: "image pull max concurrent negative",
+			env:  map[string]string{"SB_IMAGE_PULL_MAX_CONCURRENT": "-1"},
+			want: "SB_IMAGE_PULL_MAX_CONCURRENT",
+		},
+		{
+			name: "auto import without hooks url",
+			env:  map[string]string{"SB_AUTO_IMPORT_ENABLED": "true"},
+			want: "SB_AUTO_IMPORT_HOOKS_URL",
+		},
+		{
+			name: "snapshot push without cluster id",
+			env:  map[string]string{"SB_SNAPSHOT_PUSH_ENABLED": "true"},
+			want: "SB_AUTO_IMPORT_CLUSTER_ID",
+		},
+		{
+			name: "toolbox mount path relative",
+			env:  map[string]string{"SB_TOOLBOX_MOUNT_PATH": "relative/path"},
+			want: "SB_TOOLBOX_MOUNT_PATH",
+		},
+		{
+			name: "invalid runtime",
+			env:  map[string]string{"SB_CONTAINER_RUNTIME": "bogus"},
+			want: "invalid SB_CONTAINER_RUNTIME",
+		},
+		{
+			name: "firecracker as host default rejected",
+			env:  map[string]string{"SB_CONTAINER_RUNTIME": "firecracker"},
+			want: "not allowed as the host default",
+		},
+		{
+			name: "enable firecracker with bad tap pool size",
+			env:  map[string]string{"SB_ENABLE_FIRECRACKER": "true", "SB_FIRECRACKER_TAP_POOL_SIZE": "0"},
+			want: "SB_FIRECRACKER_TAP_POOL_SIZE must be > 0",
+		},
+		{
+			name: "auto import bad retention suffix",
+			env: map[string]string{
+				"SB_AUTO_IMPORT_ENABLED":          "true",
+				"SB_AUTO_IMPORT_HOOKS_URL":        "https://hooks.example.com",
+				"SB_AUTO_IMPORT_CLUSTER_ID":       "cluster-1",
+				"SB_AUTO_IMPORT_CLUSTER_PAT_PATH": "/tmp/pat",
+				"SB_AUTO_IMPORT_RETENTION_SUFFIX": "nodashes",
+			},
+			want: "SB_AUTO_IMPORT_RETENTION_SUFFIX must start with",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SB_PAT_TOKEN", "operator-pat")
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+			_, err := Load()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoad_OTELEndpointEnablesExporters(t *testing.T) {
+	t.Setenv("SB_PAT_TOKEN", "operator-pat")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4317")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.OTELMetricsEnabled || !cfg.OTELTracesEnabled {
+		t.Fatalf("expected OTEL exporters enabled by generic endpoint, got metrics=%v traces=%v",
+			cfg.OTELMetricsEnabled, cfg.OTELTracesEnabled)
+	}
+}

--- a/internal/runtime/firecracker/helpers_coverage_test.go
+++ b/internal/runtime/firecracker/helpers_coverage_test.go
@@ -1,0 +1,75 @@
+package firecracker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func TestFromDaemonConfig(t *testing.T) {
+	c := config.Config{
+		FirecrackerBinary:               "/usr/local/bin/firecracker",
+		JailerBinary:                    "/usr/local/bin/jailer",
+		FirecrackerKernelImage:          "/var/lib/vmlinux",
+		FirecrackerRunDir:               "/run/fc",
+		FirecrackerTemplatesDir:         "/var/lib/templates",
+		UseJailer:                       true,
+		JailerChrootBase:                "/srv/jailer",
+		JailerUID:                       1000,
+		JailerGID:                       1001,
+		FirecrackerSnapshotVerifyOnLoad: true,
+		FirecrackerOverlayEnabled:       true,
+		FirecrackerMkfs4Bin:             "/sbin/mkfs.ext4",
+	}
+	got := FromDaemonConfig(c)
+	if got.FirecrackerBinary != c.FirecrackerBinary ||
+		got.KernelImage != c.FirecrackerKernelImage ||
+		got.RunDir != c.FirecrackerRunDir ||
+		got.TemplatesDir != c.FirecrackerTemplatesDir ||
+		!got.UseJailer ||
+		got.JailerUID != 1000 || got.JailerGID != 1001 ||
+		!got.SnapshotVerifyOnLoad || !got.OverlayEnabled {
+		t.Fatalf("FromDaemonConfig mismatch: %+v", got)
+	}
+}
+
+func TestStatusFromInstanceState(t *testing.T) {
+	cases := map[string]models.SandboxStatus{
+		"Running":     models.SandboxStatusStarted,
+		"Paused":      models.SandboxStatusStopped,
+		"Not started": models.SandboxStatusStopped,
+		"weird":       models.SandboxStatusStarted, // default
+	}
+	for state, want := range cases {
+		if got := statusFromInstanceState(state); got != want {
+			t.Fatalf("statusFromInstanceState(%q) = %q, want %q", state, got, want)
+		}
+	}
+}
+
+func TestLinkOrCopyRootfs(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.ext4")
+	if err := os.WriteFile(src, []byte("rootfs-bytes"), 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	// Same-filesystem link succeeds.
+	dst := filepath.Join(dir, "dst.ext4")
+	if err := linkOrCopyRootfs(src, dst); err != nil {
+		t.Fatalf("linkOrCopyRootfs: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil || string(got) != "rootfs-bytes" {
+		t.Fatalf("dst contents = %q, %v", got, err)
+	}
+
+	// Missing source surfaces a real error (link target already exists OR
+	// source missing — either way a non-EXDEV failure).
+	if err := linkOrCopyRootfs(filepath.Join(dir, "nope.ext4"), filepath.Join(dir, "dst2.ext4")); err == nil {
+		t.Fatal("expected error linking a missing source")
+	}
+}

--- a/internal/service/accessors_coverage_test.go
+++ b/internal/service/accessors_coverage_test.go
@@ -1,0 +1,138 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/cluster"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func TestTemplateReadPaths(t *testing.T) {
+	ctx := context.Background()
+	svc, st, _ := newServiceRuntimeHarness(t, &recordingRuntime{})
+
+	// Empty store: ListTemplates returns no rows; GetTemplate not found.
+	list, err := svc.ListTemplates(ctx)
+	if err != nil {
+		t.Fatalf("ListTemplates: %v", err)
+	}
+	if len(list) != 0 {
+		t.Fatalf("expected no templates, got %d", len(list))
+	}
+	if _, err := svc.GetTemplate(ctx, "tpl-missing"); err == nil {
+		t.Fatal("GetTemplate(missing) should error")
+	}
+
+	// Seed a template row via the store and read it back through the service.
+	now := time.Now().UTC().Round(time.Second)
+	if err := st.CreateTemplate(ctx, &models.Template{
+		ID:        "tpl-cov",
+		Image:     "ubuntu:22.04",
+		Status:    models.TemplateStatusPending,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("CreateTemplate: %v", err)
+	}
+	got, err := svc.GetTemplate(ctx, "tpl-cov")
+	if err != nil {
+		t.Fatalf("GetTemplate: %v", err)
+	}
+	if got.ID != "tpl-cov" {
+		t.Fatalf("GetTemplate = %+v", got)
+	}
+	list, err = svc.ListTemplates(ctx)
+	if err != nil || len(list) != 1 {
+		t.Fatalf("ListTemplates = %v, %v", list, err)
+	}
+}
+
+func TestPusherAccessors(t *testing.T) {
+	svc, _, _ := newServiceRuntimeHarness(t, &recordingRuntime{})
+
+	// Nil reconcilers initially.
+	if svc.SnapshotPushReconciler() != nil {
+		t.Fatal("SnapshotPushReconciler should be nil before attach")
+	}
+	if svc.TemplateArtifactPushReconciler() != nil {
+		t.Fatal("TemplateArtifactPushReconciler should be nil before attach")
+	}
+
+	// Nil pusher is ignored (no panic, stays nil).
+	svc.AttachSnapshotPusher(nil, nil)
+	svc.AttachTemplateArtifactPusher(nil, nil)
+	if svc.SnapshotPushReconciler() != nil || svc.TemplateArtifactPushReconciler() != nil {
+		t.Fatal("nil attach should leave reconcilers nil")
+	}
+}
+
+func TestIngressAndCustomDomainDNS(t *testing.T) {
+	ctx := context.Background()
+	svc, st, _ := newServiceRuntimeHarness(t, &recordingRuntime{})
+	svc.AttachCluster(cluster.NewNoop("n1", "http://127.0.0.1:1", "sandbox.example.com"))
+
+	// IngressDNSTarget surfaces the configured public host via the Noop.
+	target := svc.IngressDNSTarget()
+	_ = target // value shape varies; the call itself is what we cover.
+
+	// Custom domains disabled in this config → ErrCustomDomainNotSupported.
+	if _, err := svc.CustomDomainDNS(ctx, "whatever"); !errors.Is(err, ErrCustomDomainNotSupported) {
+		t.Fatalf("CustomDomainDNS(disabled) = %v, want ErrCustomDomainNotSupported", err)
+	}
+
+	// Enable custom domains + a domain so the read path runs end to end.
+	svc.cfg.EnableCustomDomains = true
+	svc.cfg.Domain = "sandbox.example.com"
+
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{
+		ID:           "sb-dns",
+		Image:        "alpine:3.20",
+		Status:       models.SandboxStatusStarted,
+		Runtime:      models.RuntimeDocker,
+		CPU:          1,
+		MemoryMB:     512,
+		DiskGB:       5,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		LastActiveAt: now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+
+	// No attached domains → empty Records, no error.
+	recs, err := svc.CustomDomainDNS(ctx, "sb-dns")
+	if err != nil {
+		t.Fatalf("CustomDomainDNS: %v", err)
+	}
+	if recs.Records == nil {
+		t.Fatal("Records should be non-nil (stable [] JSON shape)")
+	}
+
+	// Missing sandbox → not found.
+	if _, err := svc.CustomDomainDNS(ctx, "sb-missing"); err == nil {
+		t.Fatal("CustomDomainDNS(missing) should error")
+	}
+}
+
+func TestIngressInstalledVersion(t *testing.T) {
+	// Package-level expvar-backed read; just ensure it returns without panic.
+	_ = IngressInstalledVersion()
+}
+
+func TestCaddyCoalescerToggle(t *testing.T) {
+	svc, _, _ := newServiceRuntimeHarness(t, &recordingRuntime{})
+
+	// Stop without start is a safe no-op.
+	svc.StopCaddyCoalescer()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	svc.StartCaddyCoalescer(ctx)
+	// Second start is idempotent.
+	svc.StartCaddyCoalescer(ctx)
+	svc.StopCaddyCoalescer()
+}

--- a/internal/service/custom_domains_coverage_test.go
+++ b/internal/service/custom_domains_coverage_test.go
@@ -1,0 +1,111 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/cluster"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// matchingDNSResolver returns a TXT value that always satisfies
+// verifyCustomDomainOwnership for the empty verify-value prefix used in the
+// test config: the looked-up name is "<prefix>.<hostname>", and with an empty
+// prefix the expected value is exactly the hostname, which is the looked-up
+// name minus the leading dot.
+type matchingDNSResolver struct{}
+
+func (matchingDNSResolver) LookupTXT(_ context.Context, name string) ([]string, error) {
+	return []string{strings.TrimPrefix(name, ".")}, nil
+}
+
+func TestCustomDomainLifecycle(t *testing.T) {
+	ctx := context.Background()
+	svc, st, _ := newServiceRuntimeHarness(t, &recordingRuntime{})
+	svc.AttachCluster(cluster.NewNoop("n1", "http://127.0.0.1:1", "sandbox.example.com"))
+	svc.SetDNSResolver(matchingDNSResolver{})
+	svc.cfg.EnableCustomDomains = true
+	svc.cfg.Domain = "sandbox.example.com"
+	svc.cfg.CustomDomainsMaxPerSandbox = 5
+
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{
+		ID:           "sb-cd",
+		Image:        "alpine:3.20",
+		Status:       models.SandboxStatusStarted,
+		Runtime:      models.RuntimeDocker,
+		ContainerIP:  "10.0.0.50",
+		CPU:          1,
+		MemoryMB:     512,
+		DiskGB:       5,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		LastActiveAt: now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+
+	// Add a custom domain.
+	if err := svc.AddCustomDomain(ctx, "sb-cd", "api.acme.com", 0); err != nil {
+		t.Fatalf("AddCustomDomain: %v", err)
+	}
+	// Idempotent re-add.
+	if err := svc.AddCustomDomain(ctx, "sb-cd", "api.acme.com", 0); err != nil {
+		t.Fatalf("AddCustomDomain (re-add): %v", err)
+	}
+
+	// List should reflect the attached hostname.
+	domains, err := svc.ListCustomDomains(ctx, "sb-cd")
+	if err != nil {
+		t.Fatalf("ListCustomDomains: %v", err)
+	}
+	if len(domains) != 1 || domains[0].Hostname != "api.acme.com" {
+		t.Fatalf("ListCustomDomains = %+v", domains)
+	}
+
+	// Remove it.
+	if err := svc.RemoveCustomDomain(ctx, "sb-cd", "API.acme.com"); err != nil {
+		t.Fatalf("RemoveCustomDomain: %v", err)
+	}
+	domains, err = svc.ListCustomDomains(ctx, "sb-cd")
+	if err != nil {
+		t.Fatalf("ListCustomDomains after remove: %v", err)
+	}
+	if len(domains) != 0 {
+		t.Fatalf("expected no domains after remove, got %+v", domains)
+	}
+}
+
+func TestCustomDomainDisabledAndValidation(t *testing.T) {
+	ctx := context.Background()
+	svc, st, _ := newServiceRuntimeHarness(t, &recordingRuntime{})
+	svc.AttachCluster(cluster.NewNoop("n1", "http://127.0.0.1:1", ""))
+
+	// Feature disabled in this config → ErrCustomDomainNotSupported.
+	if err := svc.AddCustomDomain(ctx, "sb-x", "api.acme.com", 0); !errors.Is(err, ErrCustomDomainNotSupported) {
+		t.Fatalf("AddCustomDomain(disabled) = %v, want ErrCustomDomainNotSupported", err)
+	}
+	if _, err := svc.ListCustomDomains(ctx, "sb-x"); !errors.Is(err, ErrCustomDomainNotSupported) {
+		t.Fatalf("ListCustomDomains(disabled) = %v, want ErrCustomDomainNotSupported", err)
+	}
+
+	// Enable but feed a bad target port to hit the validation branch.
+	svc.SetDNSResolver(matchingDNSResolver{})
+	svc.cfg.EnableCustomDomains = true
+	svc.cfg.Domain = "sandbox.example.com"
+
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{
+		ID: "sb-y", Image: "alpine:3.20", Status: models.SandboxStatusStarted,
+		Runtime: models.RuntimeDocker, CPU: 1, MemoryMB: 512, DiskGB: 5,
+		CreatedAt: now, UpdatedAt: now, LastActiveAt: now,
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := svc.AddCustomDomain(ctx, "sb-y", "api.acme.com", -1); err == nil {
+		t.Fatal("expected validation error for negative target port")
+	}
+}

--- a/internal/service/feature_paths_coverage_test.go
+++ b/internal/service/feature_paths_coverage_test.go
@@ -1,0 +1,199 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func seedStartedSandbox(t *testing.T, st interface {
+	Create(context.Context, *models.Sandbox) error
+}, id string) {
+	t.Helper()
+	now := time.Now().UTC()
+	if err := st.Create(context.Background(), &models.Sandbox{
+		ID:           id,
+		Image:        "alpine:3.20",
+		Status:       models.SandboxStatusStarted,
+		Runtime:      models.RuntimeDocker,
+		ContainerID:  "ctr-" + id,
+		ContainerIP:  "10.0.0.77",
+		CPU:          2,
+		MemoryMB:     1024,
+		DiskGB:       10,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		LastActiveAt: now,
+	}); err != nil {
+		t.Fatalf("seed %s: %v", id, err)
+	}
+}
+
+func TestNetworkUsageAndLimits(t *testing.T) {
+	ctx := context.Background()
+	svc, st, _ := newServiceRuntimeHarness(t, &recordingRuntime{})
+	seedStartedSandbox(t, st, "sb-net")
+
+	usage, err := svc.GetNetworkUsage(ctx, "sb-net")
+	if err != nil {
+		t.Fatalf("GetNetworkUsage: %v", err)
+	}
+	if usage == nil {
+		t.Fatal("nil usage")
+	}
+
+	updated, err := svc.SetNetworkLimits(ctx, "sb-net", 1_000_000, 2_000_000)
+	if err != nil {
+		t.Fatalf("SetNetworkLimits: %v", err)
+	}
+	if updated.BytesInLimit != 1_000_000 || updated.BytesOutLimit != 2_000_000 {
+		t.Fatalf("limits = %+v", updated)
+	}
+
+	// Not-found paths.
+	if _, err := svc.GetNetworkUsage(ctx, "missing"); err == nil {
+		t.Fatal("GetNetworkUsage(missing) should error")
+	}
+	if _, err := svc.SetNetworkLimits(ctx, "missing", 1, 1); err == nil {
+		t.Fatal("SetNetworkLimits(missing) should error")
+	}
+}
+
+func TestServiceUpdateTags(t *testing.T) {
+	ctx := context.Background()
+	svc, st, _ := newServiceRuntimeHarness(t, &recordingRuntime{})
+	seedStartedSandbox(t, st, "sb-tags")
+
+	if err := svc.UpdateTags(ctx, "sb-tags", map[string]string{"team": "blue"}); err != nil {
+		t.Fatalf("UpdateTags: %v", err)
+	}
+	got, err := svc.GetSandbox(ctx, "sb-tags")
+	if err != nil {
+		t.Fatalf("GetSandbox: %v", err)
+	}
+	if got.Tags["team"] != "blue" {
+		t.Fatalf("tags = %+v", got.Tags)
+	}
+}
+
+// resizeSnapRuntime supports Resize/CreateSnapshot (the bare recordingRuntime
+// panics on both) so the service-level resize/snapshot paths can run.
+type resizeSnapRuntime struct {
+	*recordingRuntime
+}
+
+func (resizeSnapRuntime) Resize(context.Context, string, models.ResizeSandboxRequest) error {
+	return nil
+}
+
+func (resizeSnapRuntime) CreateSnapshot(context.Context, string, string) (string, error) {
+	return "img-snapshot", nil
+}
+
+func TestResizeAndLifecycle(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+	svc.docker = resizeSnapRuntime{rt}
+	seedStartedSandbox(t, st, "sb-rz")
+
+	resized, err := svc.ResizeSandbox(ctx, "sb-rz", models.ResizeSandboxRequest{CPU: 4, MemoryMB: 2048, DiskGB: 20})
+	if err != nil {
+		t.Fatalf("ResizeSandbox: %v", err)
+	}
+	if resized.CPU != 4 || resized.MemoryMB != 2048 {
+		t.Fatalf("resized = cpu=%v mem=%d", resized.CPU, resized.MemoryMB)
+	}
+
+	updated, err := svc.UpdateLifecycle(ctx, "sb-rz", models.Lifecycle{StopIfIdleFor: 5 * time.Minute})
+	if err != nil {
+		t.Fatalf("UpdateLifecycle: %v", err)
+	}
+	if updated.Lifecycle.StopIfIdleFor != 5*time.Minute {
+		t.Fatalf("lifecycle = %+v", updated.Lifecycle)
+	}
+}
+
+func TestExposeUnexposeHTTPPort(t *testing.T) {
+	ctx := context.Background()
+	svc, st, _ := newServiceRuntimeHarness(t, &recordingRuntime{})
+	seedStartedSandbox(t, st, "sb-port")
+
+	// Caddy is disabled in the harness, so HTTP exposure is a store-only op.
+	resp, err := svc.ExposePort(ctx, "sb-port", 8080, "")
+	if err != nil {
+		t.Fatalf("ExposePort: %v", err)
+	}
+	if resp.Protocol != models.ExposedPortProtocolHTTP {
+		t.Fatalf("expose resp = %+v", resp)
+	}
+	// Idempotent re-expose returns the same exposure.
+	if _, err := svc.ExposePort(ctx, "sb-port", 8080, ""); err != nil {
+		t.Fatalf("ExposePort (re-expose): %v", err)
+	}
+
+	if err := svc.UnexposePort(ctx, "sb-port", 8080); err != nil {
+		t.Fatalf("UnexposePort: %v", err)
+	}
+}
+
+func TestStopStartDestroyLifecycle(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+	seedStartedSandbox(t, st, "sb-life")
+
+	stopped, err := svc.StopSandbox(ctx, "sb-life")
+	if err != nil {
+		t.Fatalf("StopSandbox: %v", err)
+	}
+	if stopped.Status != models.SandboxStatusStopped {
+		t.Fatalf("status after stop = %q", stopped.Status)
+	}
+
+	started, err := svc.StartSandbox(ctx, "sb-life")
+	if err != nil {
+		t.Fatalf("StartSandbox: %v", err)
+	}
+	if started.Status != models.SandboxStatusStarted {
+		t.Fatalf("status after start = %q", started.Status)
+	}
+
+	// List with and without a tag filter.
+	all, err := svc.ListSandboxes(ctx, nil)
+	if err != nil || len(all) != 1 {
+		t.Fatalf("ListSandboxes = %v, %v", all, err)
+	}
+	none, err := svc.ListSandboxes(ctx, map[string]string{"team": "nope"})
+	if err != nil {
+		t.Fatalf("ListSandboxes(filter): %v", err)
+	}
+	if len(none) != 0 {
+		t.Fatalf("expected no sandboxes for non-matching tag, got %d", len(none))
+	}
+
+	if err := svc.DestroySandbox(ctx, "sb-life"); err != nil {
+		t.Fatalf("DestroySandbox: %v", err)
+	}
+	if _, err := svc.GetSandbox(ctx, "sb-life"); err == nil {
+		t.Fatal("GetSandbox after destroy should error")
+	}
+}
+
+func TestCreateSnapshotService(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+	svc.docker = resizeSnapRuntime{rt}
+	seedStartedSandbox(t, st, "sb-snap")
+
+	snap, err := svc.CreateSnapshot(ctx, "sb-snap", models.CreateSandboxSnapshotRequest{Name: "snap-svc"})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+	if snap.Name != "snap-svc" {
+		t.Fatalf("snapshot = %+v", snap)
+	}
+}

--- a/internal/service/pure_helpers_coverage_test.go
+++ b/internal/service/pure_helpers_coverage_test.go
@@ -1,0 +1,182 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	storepkg "github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// Covers small pure helpers that carry rationale comments but had no
+// direct unit coverage: ID generation shape, audit-field shaping, the
+// stopMode String mapping, and the coalescer debug stringer.
+
+func TestGenerateTemplateIDShape(t *testing.T) {
+	id, err := generateTemplateID()
+	if err != nil {
+		t.Fatalf("generateTemplateID: %v", err)
+	}
+	if !strings.HasPrefix(id, "tpl-") {
+		t.Fatalf("want tpl- prefix, got %q", id)
+	}
+	// "tpl-" + 16 hex chars (8 bytes).
+	if len(id) != len("tpl-")+16 {
+		t.Fatalf("want length %d, got %d (%q)", len("tpl-")+16, len(id), id)
+	}
+	// Two calls must not collide.
+	id2, err := generateTemplateID()
+	if err != nil {
+		t.Fatalf("generateTemplateID 2: %v", err)
+	}
+	if id == id2 {
+		t.Fatalf("expected distinct IDs, both %q", id)
+	}
+}
+
+func TestFormatStopAuditFields(t *testing.T) {
+	fields := formatStopAuditFields("sbx-1", stopModeLifecycle, true)
+	// slog field slices are flat key/value pairs.
+	if len(fields)%2 != 0 {
+		t.Fatalf("expected even number of fields, got %d", len(fields))
+	}
+	got := map[string]any{}
+	for i := 0; i < len(fields); i += 2 {
+		key, ok := fields[i].(string)
+		if !ok {
+			t.Fatalf("field key %d not a string: %v", i, fields[i])
+		}
+		got[key] = fields[i+1]
+	}
+	if got["sandbox_id"] != "sbx-1" {
+		t.Fatalf("sandbox_id = %v", got["sandbox_id"])
+	}
+	if got["stop_mode"] != "lifecycle" {
+		t.Fatalf("stop_mode = %v", got["stop_mode"])
+	}
+	if got["wake_armed"] != true {
+		t.Fatalf("wake_armed = %v", got["wake_armed"])
+	}
+}
+
+func TestStopModeString(t *testing.T) {
+	cases := map[stopMode]string{
+		stopModeManual:      "manual",
+		stopModeLifecycle:   "lifecycle",
+		stopModeInvoluntary: "involuntary",
+	}
+	for mode, want := range cases {
+		if got := mode.String(); got != want {
+			t.Fatalf("stopMode(%d).String() = %q, want %q", int(mode), got, want)
+		}
+	}
+	// Unknown value falls through to the formatted default.
+	if got := stopMode(99).String(); !strings.Contains(got, "99") {
+		t.Fatalf("unknown stopMode String() = %q, want it to contain 99", got)
+	}
+}
+
+func TestIsSandboxStartedStatesAndCache(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+
+	now := time.Now().UTC()
+	seed := func(id string, status models.SandboxStatus) {
+		if err := st.Create(ctx, &models.Sandbox{
+			ID:           id,
+			Image:        "alpine:3.20",
+			Status:       status,
+			Runtime:      models.RuntimeDocker,
+			CPU:          1,
+			MemoryMB:     512,
+			DiskGB:       5,
+			CreatedAt:    now,
+			UpdatedAt:    now,
+			LastActiveAt: now,
+		}); err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+
+	seed("sb-started", models.SandboxStatusStarted)
+	seed("sb-stopped", models.SandboxStatusStopped)
+
+	started, err := svc.IsSandboxStarted(ctx, "sb-started")
+	if err != nil || !started {
+		t.Fatalf("IsSandboxStarted(started) = %v, %v; want true, nil", started, err)
+	}
+	// Second call should hit the warm-cache positive path.
+	started2, err := svc.IsSandboxStarted(ctx, "sb-started")
+	if err != nil || !started2 {
+		t.Fatalf("IsSandboxStarted(started, cached) = %v, %v; want true, nil", started2, err)
+	}
+
+	stopped, err := svc.IsSandboxStarted(ctx, "sb-stopped")
+	if err != nil || stopped {
+		t.Fatalf("IsSandboxStarted(stopped) = %v, %v; want false, nil", stopped, err)
+	}
+
+	_, err = svc.IsSandboxStarted(ctx, "sb-missing")
+	if !errors.Is(err, storepkg.ErrNotFound) {
+		t.Fatalf("IsSandboxStarted(missing) err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestWakeAwarePortTarget(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{
+		ID:           "sb-port",
+		Image:        "alpine:3.20",
+		Status:       models.SandboxStatusStarted,
+		Runtime:      models.RuntimeDocker,
+		ContainerIP:  "10.0.0.42",
+		CPU:          1,
+		MemoryMB:     512,
+		DiskGB:       5,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		LastActiveAt: now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+	if err := st.UpsertPort(ctx, models.ExposedPort{
+		SandboxID: "sb-port",
+		Port:      8080,
+		Protocol:  models.ExposedPortProtocolHTTP,
+		CreatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed exposed port: %v", err)
+	}
+
+	ep, err := svc.WakeAwarePortTarget(ctx, "sb-port", 8080)
+	if err != nil {
+		t.Fatalf("WakeAwarePortTarget: %v", err)
+	}
+	if ep.URL != "http://10.0.0.42:8080" {
+		t.Fatalf("URL = %q, want http://10.0.0.42:8080", ep.URL)
+	}
+
+	// Port that is not exposed → error.
+	if _, err := svc.WakeAwarePortTarget(ctx, "sb-port", 9090); err == nil {
+		t.Fatalf("expected error for unexposed port 9090")
+	}
+}
+
+func TestCaddyCoalescerString(t *testing.T) {
+	c := newCaddyCoalescer(nil, 100*time.Millisecond)
+	s := c.String()
+	if !strings.Contains(s, "caddyCoalescer{") {
+		t.Fatalf("String() = %q", s)
+	}
+	if !strings.Contains(s, "pending=0") {
+		t.Fatalf("fresh coalescer should report pending=0, got %q", s)
+	}
+}

--- a/internal/store/store_extra_coverage_test.go
+++ b/internal/store/store_extra_coverage_test.go
@@ -1,0 +1,275 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// Covers per-row mutators and small read paths that had no direct unit
+// coverage. All are plain SQLite CRUD; the focus is the ErrNotFound and
+// success branches.
+
+func TestUpdateTagsAndLifecycleMutators(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+
+	if err := st.Create(ctx, sampleSandbox("sb-mut")); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := st.UpdateTags(ctx, "sb-mut", map[string]string{"team": "a"}); err != nil {
+		t.Fatalf("UpdateTags: %v", err)
+	}
+	if err := st.UpdateTags(ctx, "missing", map[string]string{"x": "y"}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("UpdateTags(missing) = %v, want ErrNotFound", err)
+	}
+
+	got, err := st.Get(ctx, "sb-mut")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Tags["team"] != "a" {
+		t.Fatalf("tags = %v", got.Tags)
+	}
+}
+
+func TestNetworkCountersAndLimits(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	if err := st.Create(ctx, sampleSandbox("sb-net")); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Negative deltas rejected.
+	if err := st.UpdateSandboxNetCounters(ctx, "sb-net", -1, 0); err == nil {
+		t.Fatalf("expected error for negative delta")
+	}
+	// No-op when both zero.
+	if err := st.UpdateSandboxNetCounters(ctx, "sb-net", 0, 0); err != nil {
+		t.Fatalf("zero delta: %v", err)
+	}
+	if err := st.UpdateSandboxNetCounters(ctx, "sb-net", 100, 200); err != nil {
+		t.Fatalf("UpdateSandboxNetCounters: %v", err)
+	}
+	if err := st.UpdateSandboxNetCounters(ctx, "missing", 1, 1); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("UpdateSandboxNetCounters(missing) = %v", err)
+	}
+
+	if err := st.SetNetworkLimits(ctx, "sb-net", 1000, 2000); err != nil {
+		t.Fatalf("SetNetworkLimits: %v", err)
+	}
+	if err := st.SetNetworkLimits(ctx, "missing", 1, 1); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("SetNetworkLimits(missing) = %v", err)
+	}
+
+	now := time.Now().UTC()
+	if err := st.MarkNetworkQuotaExceeded(ctx, "sb-net", now); err != nil {
+		t.Fatalf("MarkNetworkQuotaExceeded: %v", err)
+	}
+	// Re-mark preserves original detection timestamp (just must not error).
+	if err := st.MarkNetworkQuotaExceeded(ctx, "sb-net", now.Add(time.Hour)); err != nil {
+		t.Fatalf("MarkNetworkQuotaExceeded re-mark: %v", err)
+	}
+	if err := st.MarkNetworkQuotaExceeded(ctx, "missing", now); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("MarkNetworkQuotaExceeded(missing) = %v", err)
+	}
+	if err := st.ClearNetworkQuotaExceeded(ctx, "sb-net"); err != nil {
+		t.Fatalf("ClearNetworkQuotaExceeded: %v", err)
+	}
+	if err := st.ClearNetworkQuotaExceeded(ctx, "missing"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("ClearNetworkQuotaExceeded(missing) = %v", err)
+	}
+}
+
+func TestAutoImportPendingRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	if err := st.Create(ctx, sampleSandbox("sb-imp")); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	ids, err := st.ListAutoImportPendingIDs(ctx)
+	if err != nil {
+		t.Fatalf("ListAutoImportPendingIDs: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("expected no pending, got %v", ids)
+	}
+
+	if err := st.SetAutoImportPending(ctx, "sb-imp", true); err != nil {
+		t.Fatalf("SetAutoImportPending: %v", err)
+	}
+	if err := st.SetAutoImportPending(ctx, "missing", true); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("SetAutoImportPending(missing) = %v", err)
+	}
+
+	ids, err = st.ListAutoImportPendingIDs(ctx)
+	if err != nil {
+		t.Fatalf("ListAutoImportPendingIDs: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "sb-imp" {
+		t.Fatalf("pending ids = %v, want [sb-imp]", ids)
+	}
+
+	if err := st.SetAutoImportPending(ctx, "sb-imp", false); err != nil {
+		t.Fatalf("SetAutoImportPending(false): %v", err)
+	}
+}
+
+func TestExposedPortReads(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	if err := st.Create(ctx, sampleSandbox("sb-port")); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	now := time.Now().UTC()
+	if err := st.UpsertPort(ctx, models.ExposedPort{
+		SandboxID: "sb-port",
+		Port:      8080,
+		Protocol:  models.ExposedPortProtocolTCP,
+		HostPort:  31000,
+		CreatedAt: now,
+	}); err != nil {
+		t.Fatalf("UpsertPort: %v", err)
+	}
+
+	// By host port — hit.
+	ep, err := st.GetPortByHostPort(ctx, 31000)
+	if err != nil {
+		t.Fatalf("GetPortByHostPort: %v", err)
+	}
+	if ep == nil || ep.SandboxID != "sb-port" || ep.Port != 8080 {
+		t.Fatalf("GetPortByHostPort = %+v", ep)
+	}
+	// By host port — miss returns (nil, nil).
+	ep, err = st.GetPortByHostPort(ctx, 9999)
+	if err != nil || ep != nil {
+		t.Fatalf("GetPortByHostPort(miss) = %+v, %v", ep, err)
+	}
+
+	all, err := st.ListAllExposedPorts(ctx)
+	if err != nil {
+		t.Fatalf("ListAllExposedPorts: %v", err)
+	}
+	if len(all) != 1 || all[0].HostPort != 31000 {
+		t.Fatalf("ListAllExposedPorts = %+v", all)
+	}
+}
+
+func TestSnapshotPushLifecycle(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+
+	now := time.Now().UTC().Round(0)
+	if err := st.CreateSnapshot(ctx, &models.SandboxSnapshot{
+		Name:      "snap-1",
+		Image:     "img:1",
+		CreatedAt: now,
+		PushState: models.SnapshotPushStatePending,
+	}); err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+
+	pending, err := st.ListSnapshotsPendingPush(ctx)
+	if err != nil {
+		t.Fatalf("ListSnapshotsPendingPush: %v", err)
+	}
+	if len(pending) != 1 || pending[0].Name != "snap-1" {
+		t.Fatalf("pending = %+v", pending)
+	}
+
+	if err := st.UpdateSnapshotImageDistribution(ctx, "snap-1", "aocr", "reg/ref", "sha256:abc"); err != nil {
+		t.Fatalf("UpdateSnapshotImageDistribution: %v", err)
+	}
+	if err := st.UpdateSnapshotImageDistribution(ctx, "missing", "aocr", "r", "d"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("UpdateSnapshotImageDistribution(missing) = %v", err)
+	}
+
+	if err := st.SetSnapshotPushState(ctx, "snap-1", "active", ""); err != nil {
+		t.Fatalf("SetSnapshotPushState: %v", err)
+	}
+	if err := st.SetSnapshotPushState(ctx, "missing", "active", ""); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("SetSnapshotPushState(missing) = %v", err)
+	}
+
+	// snap-1 is now active so no longer pending.
+	pending, err = st.ListSnapshotsPendingPush(ctx)
+	if err != nil {
+		t.Fatalf("ListSnapshotsPendingPush 2: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("expected no pending after active, got %+v", pending)
+	}
+}
+
+func TestReleaseOrphanedFirecrackerVMMSlots(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	now := time.Now().UTC()
+
+	// Two spawning slots with no owning sandbox — both orphaned.
+	for _, id := range []string{"vmms-1", "vmms-2"} {
+		if err := st.InsertFirecrackerVMMSlot(ctx, FirecrackerVMMSlot{
+			ID:         id,
+			TemplateID: "tpl-a",
+		}, now); err != nil {
+			t.Fatalf("InsertFirecrackerVMMSlot %s: %v", id, err)
+		}
+	}
+
+	n, err := st.ReleaseOrphanedFirecrackerVMMSlots(ctx, now)
+	if err != nil {
+		t.Fatalf("ReleaseOrphanedFirecrackerVMMSlots: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("released = %d, want 2", n)
+	}
+	// Idempotent: a second sweep releases nothing (rows already released).
+	n, err = st.ReleaseOrphanedFirecrackerVMMSlots(ctx, now)
+	if err != nil {
+		t.Fatalf("ReleaseOrphanedFirecrackerVMMSlots 2: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("second sweep released = %d, want 0", n)
+	}
+}
+
+func TestMountsBlobRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	if err := st.Create(ctx, sampleSandbox("sb-mnt")); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if _, err := st.GetMounts(ctx, "sb-mnt"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetMounts(absent) = %v, want ErrNotFound", err)
+	}
+
+	blob := []byte("sealed-bytes")
+	if err := st.PutMounts(ctx, "sb-mnt", blob); err != nil {
+		t.Fatalf("PutMounts: %v", err)
+	}
+	// Upsert path: overwrite.
+	if err := st.PutMounts(ctx, "sb-mnt", []byte("sealed-bytes-2")); err != nil {
+		t.Fatalf("PutMounts overwrite: %v", err)
+	}
+
+	got, err := st.GetMounts(ctx, "sb-mnt")
+	if err != nil {
+		t.Fatalf("GetMounts: %v", err)
+	}
+	if string(got) != "sealed-bytes-2" {
+		t.Fatalf("GetMounts = %q", got)
+	}
+
+	if err := st.DeleteMounts(ctx, "sb-mnt"); err != nil {
+		t.Fatalf("DeleteMounts: %v", err)
+	}
+	if _, err := st.GetMounts(ctx, "sb-mnt"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetMounts after delete = %v, want ErrNotFound", err)
+	}
+}

--- a/pkg/api/daytona/toolbox_exec_coverage_test.go
+++ b/pkg/api/daytona/toolbox_exec_coverage_test.go
@@ -1,0 +1,387 @@
+package daytona
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"mime"
+	"mime/multipart"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/internal/service"
+	"github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/models"
+	"github.com/aerol-ai/microvm/pkg/mounts"
+)
+
+// newToolboxExecEnv wires a fake toolbox daemon that answers the
+// execute/download endpoints so the JSON-RPC-style helpers (runToolboxCommand,
+// runToolboxString, sendToolboxJSON) and the bulk-download multipart path get
+// real coverage. Mirrors newToolboxProxyTestEnv but with exec-oriented routes.
+func newToolboxExecEnv(t *testing.T) (facadeURL, sandboxID string) {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/process/execute", func(w http.ResponseWriter, r *http.Request) {
+		// Echo a deterministic result. userHomeDir/workDir run shell strings
+		// through here too, so just return a fixed stdout.
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"stdout":"/root\n","stderr":"","exit_code":0,"duration_ms":1}`)
+	})
+	mux.HandleFunc("/files/download", func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Query().Get("path")
+		if path == "/missing.txt" {
+			http.Error(w, `{"error":"no such file"}`, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = io.WriteString(w, "contents-of-"+filepath.Base(path))
+	})
+	mux.HandleFunc("/files/upload", func(w http.ResponseWriter, r *http.Request) {
+		// Drain the uploaded multipart body and ack.
+		_ = r.ParseMultipartForm(1 << 20)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	toolboxServer := httptest.NewServer(mux)
+	t.Cleanup(toolboxServer.Close)
+
+	host, portText, err := net.SplitHostPort(mustParseURL(t, toolboxServer.URL).Host)
+	if err != nil {
+		t.Fatalf("split toolbox host: %v", err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatalf("parse toolbox port: %v", err)
+	}
+
+	dir := t.TempDir()
+	st, err := store.Open(filepath.Join(dir, "state.db"))
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	mountManager, err := mounts.New(logger, mounts.Config{
+		RootDir:     filepath.Join(dir, "mounts"),
+		CredDir:     filepath.Join(dir, "cred"),
+		WaitTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("mounts.New: %v", err)
+	}
+	t.Cleanup(mountManager.Close)
+
+	cfg := config.Config{
+		DBPath:            filepath.Join(dir, "state.db"),
+		PublicHost:        "sandbox.test",
+		ToolboxPort:       port,
+		Runtime:           models.RuntimeDocker,
+		EnableCaddy:       false,
+		HTTPClientTimeout: 5 * time.Second,
+	}
+	svc := service.New(cfg, logger, st, fakeToolboxRouteRuntime{}, nil, nil, nil, mountManager, nil)
+
+	sandboxID = "sb-exec"
+	now := time.Now().UTC().Round(time.Second)
+	if err := st.Upsert(context.Background(), &models.Sandbox{
+		ID:             sandboxID,
+		Name:           sandboxID,
+		Image:          "ubuntu:22.04",
+		Status:         models.SandboxStatusStarted,
+		ContainerID:    "ctr-" + sandboxID,
+		ContainerIP:    host,
+		ToolboxEnabled: true,
+		ToolboxToken:   "tok-exec",
+		Runtime:        models.RuntimeDocker,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		LastActiveAt:   now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+
+	mux2 := http.NewServeMux()
+	RegisterRoutes(mux2, Deps{
+		Service: svc,
+		Logger:  logger,
+		Auth:    func(next http.Handler) http.Handler { return next },
+	})
+	facadeServer := httptest.NewServer(mux2)
+	t.Cleanup(facadeServer.Close)
+	return facadeServer.URL, sandboxID
+}
+
+func TestToolboxExecuteCommand(t *testing.T) {
+	facadeURL, id := newToolboxExecEnv(t)
+
+	resp, err := http.Post(
+		facadeURL+ToolboxPrefix+"/"+id+"/process/execute",
+		"application/json",
+		strings.NewReader(`{"command":"echo hi"}`),
+	)
+	if err != nil {
+		t.Fatalf("POST process/execute: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body=%s", resp.StatusCode, body)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "/root") {
+		t.Fatalf("execute response = %s", body)
+	}
+}
+
+func TestToolboxExecuteCommand_BadJSON(t *testing.T) {
+	facadeURL, id := newToolboxExecEnv(t)
+	resp, err := http.Post(
+		facadeURL+ToolboxPrefix+"/"+id+"/process/execute",
+		"application/json",
+		strings.NewReader(`{bad`),
+	)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestToolboxUserHomeDirAndWorkDir(t *testing.T) {
+	facadeURL, id := newToolboxExecEnv(t)
+
+	for _, path := range []string{"user-home-dir", "work-dir"} {
+		resp, err := http.Get(facadeURL + ToolboxPrefix + "/" + id + "/" + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("%s status = %d, body=%s", path, resp.StatusCode, body)
+		}
+		if !strings.Contains(string(body), "/root") {
+			t.Fatalf("%s body = %s", path, body)
+		}
+	}
+}
+
+func TestToolboxBulkDownload(t *testing.T) {
+	facadeURL, id := newToolboxExecEnv(t)
+
+	resp, err := http.Post(
+		facadeURL+ToolboxPrefix+"/"+id+"/files/bulk-download",
+		"application/json",
+		strings.NewReader(`{"paths":["/a.txt","/missing.txt"]}`),
+	)
+	if err != nil {
+		t.Fatalf("POST bulk-download: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+
+	mediaType, params, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	if err != nil || !strings.HasPrefix(mediaType, "multipart/") {
+		t.Fatalf("Content-Type = %q (%v)", resp.Header.Get("Content-Type"), err)
+	}
+	mr := multipart.NewReader(resp.Body, params["boundary"])
+	var fileParts, errorParts int
+	for {
+		part, err := mr.NextPart()
+		if err != nil {
+			break
+		}
+		if part.FormName() == "error" {
+			errorParts++
+		} else {
+			fileParts++
+		}
+		_, _ = io.Copy(io.Discard, part)
+	}
+	// One good file + one error part (the missing path).
+	if fileParts != 1 || errorParts != 1 {
+		t.Fatalf("parts: file=%d error=%d, want 1/1", fileParts, errorParts)
+	}
+}
+
+func TestToolboxBulkDownload_BadRequests(t *testing.T) {
+	facadeURL, id := newToolboxExecEnv(t)
+
+	// Bad JSON.
+	resp, _ := http.Post(facadeURL+ToolboxPrefix+"/"+id+"/files/bulk-download",
+		"application/json", strings.NewReader(`{bad`))
+	if resp != nil {
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("bad json status = %d, want 400", resp.StatusCode)
+		}
+	}
+
+	// Empty paths.
+	resp2, _ := http.Post(facadeURL+ToolboxPrefix+"/"+id+"/files/bulk-download",
+		"application/json", strings.NewReader(`{"paths":[]}`))
+	if resp2 != nil {
+		resp2.Body.Close()
+		if resp2.StatusCode != http.StatusBadRequest {
+			t.Fatalf("empty paths status = %d, want 400", resp2.StatusCode)
+		}
+	}
+}
+
+func TestToolboxBulkUpload(t *testing.T) {
+	facadeURL, id := newToolboxExecEnv(t)
+
+	var buf strings.Builder
+	mw := multipart.NewWriter(&buf)
+	_ = mw.WriteField("files[0].path", "/dest/a.txt")
+	part, err := mw.CreateFormFile("files[0].file", "a.txt")
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	_, _ = io.WriteString(part, "hello")
+	_ = mw.Close()
+
+	req, _ := http.NewRequest(http.MethodPost,
+		facadeURL+ToolboxPrefix+"/"+id+"/files/bulk-upload", strings.NewReader(buf.String()))
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("bulk-upload: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body=%s", resp.StatusCode, body)
+	}
+}
+
+func TestToolboxBulkUpload_NoFiles(t *testing.T) {
+	facadeURL, id := newToolboxExecEnv(t)
+	var buf strings.Builder
+	mw := multipart.NewWriter(&buf)
+	_ = mw.WriteField("unrelated", "x")
+	_ = mw.Close()
+
+	req, _ := http.NewRequest(http.MethodPost,
+		facadeURL+ToolboxPrefix+"/"+id+"/files/bulk-upload", strings.NewReader(buf.String()))
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("bulk-upload: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestParseListFilters(t *testing.T) {
+	mk := func(rawQuery string) *http.Request {
+		return httptest.NewRequest(http.MethodGet, "/daytona/sandbox?"+rawQuery, nil)
+	}
+
+	f, err := parseListFilters(mk(`id=abc&name=foo&labels=%7B%22team%22%3A%22a%22%7D&states=started&states=stopped`))
+	if err != nil {
+		t.Fatalf("parseListFilters: %v", err)
+	}
+	if f.ID != "abc" || f.Name != "foo" {
+		t.Fatalf("filters = %+v", f)
+	}
+	if f.Labels["team"] != "a" {
+		t.Fatalf("labels = %+v", f.Labels)
+	}
+	if _, ok := f.States["started"]; !ok {
+		t.Fatalf("states = %+v", f.States)
+	}
+
+	// Malformed labels JSON → error.
+	if _, err := parseListFilters(mk(`labels=notjson`)); err == nil {
+		t.Fatal("expected error for malformed labels")
+	}
+}
+
+func TestToolbox_SandboxNotFound(t *testing.T) {
+	facadeURL, _ := newToolboxExecEnv(t)
+	resp, err := http.Get(facadeURL + ToolboxPrefix + "/sb-does-not-exist/user-home-dir")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestToolboxErrorHelpers(t *testing.T) {
+	// toolboxHTTPError.Error
+	var nilErr *toolboxHTTPError
+	if nilErr.Error() != "" {
+		t.Fatalf("nil error string = %q", nilErr.Error())
+	}
+	if (&toolboxHTTPError{StatusCode: 404, Message: "nope"}).Error() != "nope" {
+		t.Fatal("message error string")
+	}
+	if got := (&toolboxHTTPError{StatusCode: http.StatusTeapot}).Error(); got != http.StatusText(http.StatusTeapot) {
+		t.Fatalf("status-only error = %q", got)
+	}
+
+	// errorPayload
+	if got := string(errorPayload(&toolboxHTTPError{StatusCode: 502, Message: "boom"})); !strings.Contains(got, "boom") {
+		t.Fatalf("errorPayload(httpErr) = %s", got)
+	}
+	if got := string(errorPayload(nil)); !strings.Contains(got, "toolbox unavailable") {
+		t.Fatalf("errorPayload(nil) = %s", got)
+	}
+
+	// responseErrorPayload — extracts error field from JSON body.
+	if got := string(responseErrorPayload(500, []byte(`{"error":"upstream"}`))); !strings.Contains(got, "upstream") {
+		t.Fatalf("responseErrorPayload(json) = %s", got)
+	}
+	if got := string(responseErrorPayload(500, nil)); !strings.Contains(got, http.StatusText(500)) {
+		t.Fatalf("responseErrorPayload(empty) = %s", got)
+	}
+
+	// readToolboxHTTPError
+	if err := readToolboxHTTPError(nil); err == nil {
+		t.Fatal("readToolboxHTTPError(nil) should return error")
+	}
+	resp := &http.Response{StatusCode: 503, Body: io.NopCloser(strings.NewReader(`{"error":"down"}`))}
+	terr := readToolboxHTTPError(resp)
+	var he *toolboxHTTPError
+	if !errors.As(terr, &he) || he.Message != "down" {
+		t.Fatalf("readToolboxHTTPError = %v", terr)
+	}
+}
+
+func TestWriteToolboxError(t *testing.T) {
+	h := newHandlers(Deps{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))})
+
+	// Typed toolbox error maps to its own status.
+	rr := httptest.NewRecorder()
+	h.writeToolboxError(rr, &toolboxHTTPError{StatusCode: http.StatusNotFound, Message: "missing"})
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("typed err status = %d, want 404", rr.Code)
+	}
+
+	// Generic error maps to 502 bad gateway.
+	rr2 := httptest.NewRecorder()
+	h.writeToolboxError(rr2, io.EOF)
+	if rr2.Code != http.StatusBadGateway {
+		t.Fatalf("generic err status = %d, want 502", rr2.Code)
+	}
+}

--- a/pkg/api/e2b/handlers_extra_coverage_test.go
+++ b/pkg/api/e2b/handlers_extra_coverage_test.go
@@ -1,0 +1,289 @@
+package e2b
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// createE2BSandbox drives a real create through the facade and returns its ID.
+func createE2BSandbox(t *testing.T, handler http.Handler) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/e2b/sandboxes",
+		strings.NewReader(`{"templateID":"base","timeout":120}`))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create status = %d, body=%s", rr.Code, rr.Body.String())
+	}
+	var created sandboxResponse
+	if err := json.NewDecoder(rr.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	if created.SandboxID == "" {
+		t.Fatal("create response missing sandboxID")
+	}
+	return created.SandboxID
+}
+
+func TestE2BDeleteSandbox(t *testing.T) {
+	_, _, handler := newE2BHandlerTestEnv(t)
+	id := createE2BSandbox(t, handler)
+
+	// Delete an existing sandbox → 204.
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodDelete, "/e2b/sandboxes/"+id, nil))
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("delete status = %d, want 204; body=%s", rr.Code, rr.Body.String())
+	}
+
+	// Deleting again → 404.
+	rr2 := httptest.NewRecorder()
+	handler.ServeHTTP(rr2, httptest.NewRequest(http.MethodDelete, "/e2b/sandboxes/"+id, nil))
+	if rr2.Code != http.StatusNotFound {
+		t.Fatalf("re-delete status = %d, want 404", rr2.Code)
+	}
+}
+
+func TestE2BHandlerNotFoundPaths(t *testing.T) {
+	_, _, handler := newE2BHandlerTestEnv(t)
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{"get", http.MethodGet, "/e2b/sandboxes/missing", ""},
+		{"delete", http.MethodDelete, "/e2b/sandboxes/missing", ""},
+		{"pause", http.MethodPost, "/e2b/sandboxes/missing/pause", ""},
+		{"connect", http.MethodPost, "/e2b/sandboxes/missing/connect", `{"timeout":90}`},
+		{"timeout", http.MethodPost, "/e2b/sandboxes/missing/timeout", `{"timeout":30}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var body *strings.Reader
+			if tc.body != "" {
+				body = strings.NewReader(tc.body)
+			} else {
+				body = strings.NewReader("")
+			}
+			req := httptest.NewRequest(tc.method, tc.path, body)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			if rr.Code != http.StatusNotFound {
+				t.Fatalf("%s status = %d, want 404; body=%s", tc.name, rr.Code, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestE2BConnectValidation(t *testing.T) {
+	_, _, handler := newE2BHandlerTestEnv(t)
+	id := createE2BSandbox(t, handler)
+
+	// Bad JSON → 400.
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/e2b/sandboxes/"+id+"/connect",
+		strings.NewReader(`{bad`)))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("bad json status = %d, want 400", rr.Code)
+	}
+
+	// timeout <= 0 → 400.
+	rr2 := httptest.NewRecorder()
+	handler.ServeHTTP(rr2, httptest.NewRequest(http.MethodPost, "/e2b/sandboxes/"+id+"/connect",
+		strings.NewReader(`{"timeout":0}`)))
+	if rr2.Code != http.StatusBadRequest {
+		t.Fatalf("zero timeout status = %d, want 400", rr2.Code)
+	}
+}
+
+func TestE2BPauseRunningSandbox(t *testing.T) {
+	_, _, handler := newE2BHandlerTestEnv(t)
+	id := createE2BSandbox(t, handler)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/e2b/sandboxes/"+id+"/pause", nil))
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("pause status = %d, want 204; body=%s", rr.Code, rr.Body.String())
+	}
+	// Pausing an already-stopped sandbox is idempotent → 204.
+	rr2 := httptest.NewRecorder()
+	handler.ServeHTTP(rr2, httptest.NewRequest(http.MethodPost, "/e2b/sandboxes/"+id+"/pause", nil))
+	if rr2.Code != http.StatusNoContent {
+		t.Fatalf("re-pause status = %d, want 204", rr2.Code)
+	}
+}
+
+func TestE2BCreateIdempotentReplay(t *testing.T) {
+	_, _, handler := newE2BHandlerTestEnv(t)
+	body := `{"templateID":"base","timeout":120,"metadata":{"k":"v"}}`
+
+	do := func() sandboxResponse {
+		req := httptest.NewRequest(http.MethodPost, "/e2b/sandboxes", strings.NewReader(body))
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("create status = %d; body=%s", rr.Code, rr.Body.String())
+		}
+		var resp sandboxResponse
+		if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return resp
+	}
+
+	first := do()
+	// Identical request → replay of the same deterministic sandbox.
+	second := do()
+	if first.SandboxID != second.SandboxID {
+		t.Fatalf("idempotent replay returned different IDs: %s vs %s", first.SandboxID, second.SandboxID)
+	}
+}
+
+func TestE2BCreateMissingTemplate(t *testing.T) {
+	_, _, handler := newE2BHandlerTestEnv(t)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/e2b/sandboxes",
+		strings.NewReader(`{"timeout":120}`)))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestE2BCreateBadJSON(t *testing.T) {
+	_, _, handler := newE2BHandlerTestEnv(t)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/e2b/sandboxes", strings.NewReader(`{bad`)))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rr.Code)
+	}
+}
+
+func TestE2BSnapshotCreateListDelete(t *testing.T) {
+	_, _, handler := newE2BHandlerTestEnv(t)
+	id := createE2BSandbox(t, handler)
+
+	// Create a snapshot.
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/e2b/sandboxes/"+id+"/snapshots",
+		strings.NewReader(`{"name":"snap-cov"}`)))
+	if rr.Code != http.StatusCreated && rr.Code != http.StatusOK {
+		t.Fatalf("create snapshot status = %d; body=%s", rr.Code, rr.Body.String())
+	}
+	var snap snapshotInfoResponse
+	if err := json.NewDecoder(rr.Body).Decode(&snap); err != nil {
+		t.Fatalf("decode snapshot: %v", err)
+	}
+	if snap.SnapshotID == "" {
+		t.Fatalf("snapshot response missing snapshotID: %s", rr.Body.String())
+	}
+
+	// List snapshots.
+	rrList := httptest.NewRecorder()
+	handler.ServeHTTP(rrList, httptest.NewRequest(http.MethodGet, "/e2b/snapshots", nil))
+	if rrList.Code != http.StatusOK {
+		t.Fatalf("list snapshots status = %d", rrList.Code)
+	}
+
+	// Delete the snapshot by its returned ID.
+	rrDel := httptest.NewRecorder()
+	handler.ServeHTTP(rrDel, httptest.NewRequest(http.MethodDelete, "/e2b/templates/"+snap.SnapshotID, nil))
+	if rrDel.Code != http.StatusNoContent {
+		t.Fatalf("delete snapshot status = %d; body=%s", rrDel.Code, rrDel.Body.String())
+	}
+
+	// Deleting again → 404 (resolveSnapshotDeleteTarget exhausts every lookup).
+	rrDel2 := httptest.NewRecorder()
+	handler.ServeHTTP(rrDel2, httptest.NewRequest(http.MethodDelete, "/e2b/templates/"+snap.SnapshotID, nil))
+	if rrDel2.Code != http.StatusNotFound {
+		t.Fatalf("re-delete snapshot status = %d, want 404", rrDel2.Code)
+	}
+}
+
+// --- pure helpers ---
+
+func TestTimeoutDeadlineAndEndAt(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// nil sandbox → not ok.
+	if _, ok := timeoutDeadline(nil, sandboxMeta{}); ok {
+		t.Fatal("nil sandbox should not yield a deadline")
+	}
+
+	// OnTimeout=pause uses StopAtAge.
+	sb := &models.Sandbox{CreatedAt: base, Lifecycle: models.Lifecycle{StopAtAge: time.Hour}}
+	d, ok := timeoutDeadline(sb, sandboxMeta{OnTimeout: "pause"})
+	if !ok || !d.Equal(base.Add(time.Hour)) {
+		t.Fatalf("pause deadline = %v ok=%v", d, ok)
+	}
+
+	// OnTimeout=kill uses DestroyAtAge.
+	sb2 := &models.Sandbox{CreatedAt: base, Lifecycle: models.Lifecycle{DestroyAtAge: 2 * time.Hour}}
+	d, ok = timeoutDeadline(sb2, sandboxMeta{OnTimeout: "kill"})
+	if !ok || !d.Equal(base.Add(2*time.Hour)) {
+		t.Fatalf("kill deadline = %v ok=%v", d, ok)
+	}
+
+	// endAt falls back to TimeoutSeconds when no lifecycle age set.
+	sb3 := &models.Sandbox{CreatedAt: base}
+	if got := timeoutEndAt(sb3, sandboxMeta{TimeoutSeconds: 60}); !got.Equal(base.Add(time.Minute)) {
+		t.Fatalf("endAt timeoutSeconds = %v", got)
+	}
+	// endAt falls back to CreatedAt when nothing else applies.
+	if got := timeoutEndAt(sb3, sandboxMeta{}); !got.Equal(base) {
+		t.Fatalf("endAt fallback = %v", got)
+	}
+}
+
+func TestParsePagination(t *testing.T) {
+	mk := func(q string) *http.Request {
+		return httptest.NewRequest(http.MethodGet, "/e2b/sandboxes?"+q, nil)
+	}
+
+	limit, offset, err := parsePagination(mk("limit=10&nextToken=5"), 100)
+	if err != nil || limit != 10 || offset != 5 {
+		t.Fatalf("parsePagination = %d,%d,%v", limit, offset, err)
+	}
+	// Defaults when absent.
+	limit, offset, err = parsePagination(mk(""), 50)
+	if err != nil || limit != 50 || offset != 0 {
+		t.Fatalf("parsePagination defaults = %d,%d,%v", limit, offset, err)
+	}
+	// Invalid limit / nextToken → error.
+	if _, _, err := parsePagination(mk("limit=0"), 50); err == nil {
+		t.Fatal("expected error for limit=0")
+	}
+	if _, _, err := parsePagination(mk("nextToken=-1"), 50); err == nil {
+		t.Fatal("expected error for negative nextToken")
+	}
+}
+
+func TestSnapshotNameFromID(t *testing.T) {
+	// Not prefixed → false.
+	if _, ok := snapshotNameFromID("plainstring"); ok {
+		t.Fatal("non-prefixed ID should not decode")
+	}
+	// Round trip a known name through the encoder used by the facade.
+	id := snapshotIDFromName("my-snap")
+	name, ok := snapshotNameFromID(id)
+	if !ok || !strings.Contains(name, "my-snap") {
+		t.Fatalf("snapshotNameFromID(%q) = %q,%v", id, name, ok)
+	}
+}
+
+func TestDefaultSandboxMeta(t *testing.T) {
+	meta := defaultSandboxMeta(&models.Sandbox{ID: "sb"})
+	if !meta.Secure {
+		t.Fatal("default meta should be secure")
+	}
+	if meta.OnTimeout != "kill" {
+		t.Fatalf("default OnTimeout = %q, want kill", meta.OnTimeout)
+	}
+}

--- a/pkg/caddy/client_extra_coverage_test.go
+++ b/pkg/caddy/client_extra_coverage_test.go
@@ -1,0 +1,130 @@
+package caddy
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// Covers the pure accessors / ID generators and the delete helpers that the
+// existing table tests skipped.
+
+func TestClientAccessors(t *testing.T) {
+	c := &Client{
+		domain:        "sandbox.example.com",
+		publicHost:    "203.0.113.10",
+		l4TLSListen:   ":443",
+		l4TLSFallback: "127.0.0.1:8443",
+	}
+	if c.L4TLSListen() != ":443" {
+		t.Fatalf("L4TLSListen = %q", c.L4TLSListen())
+	}
+	if c.L4TLSFallback() != "127.0.0.1:8443" {
+		t.Fatalf("L4TLSFallback = %q", c.L4TLSFallback())
+	}
+	if got := c.SNIHost("abc", 3000); got != "abc-3000.sandbox.example.com" {
+		t.Fatalf("SNIHost = %q", got)
+	}
+	// Domain mode: PublicHost returns the base domain.
+	if got := c.PublicHost(); got != "sandbox.example.com" {
+		t.Fatalf("PublicHost(domain mode) = %q", got)
+	}
+
+	// IP mode: SNIHost empty, PublicHost falls back to the IP.
+	ip := &Client{publicHost: "203.0.113.10"}
+	if got := ip.SNIHost("abc", 3000); got != "" {
+		t.Fatalf("SNIHost(ip mode) = %q, want empty", got)
+	}
+	if got := ip.PublicHost(); got != "203.0.113.10" {
+		t.Fatalf("PublicHost(ip mode) = %q", got)
+	}
+}
+
+func TestExportedRouteIDs(t *testing.T) {
+	if SandboxRouteID("abc") == "" {
+		t.Fatal("SandboxRouteID empty")
+	}
+	if !strings.Contains(PortRouteID("abc", 3000), "3000") {
+		t.Fatalf("PortRouteID = %q", PortRouteID("abc", 3000))
+	}
+	if !strings.Contains(WakePortRouteID("abc", 3000), "wake") {
+		t.Fatalf("WakePortRouteID = %q", WakePortRouteID("abc", 3000))
+	}
+	if !strings.Contains(InFluxSandboxRouteID("abc"), "abc") {
+		t.Fatalf("InFluxSandboxRouteID = %q", InFluxSandboxRouteID("abc"))
+	}
+	if !strings.Contains(InFluxPortRouteID("abc", 3000), "3000") {
+		t.Fatalf("InFluxPortRouteID = %q", InFluxPortRouteID("abc", 3000))
+	}
+	if !strings.Contains(IngressSandboxSNIRouteID("abc"), "ingress-sni") {
+		t.Fatalf("IngressSandboxSNIRouteID = %q", IngressSandboxSNIRouteID("abc"))
+	}
+	if !strings.Contains(IngressPortSNIRouteID("abc", 3000), "ingress-sni") {
+		t.Fatalf("IngressPortSNIRouteID = %q", IngressPortSNIRouteID("abc", 3000))
+	}
+	// Hostname is hashed: same input → same ID, different host → different ID.
+	a := IngressCustomDomainSNIRouteID("abc", "API.acme.com")
+	b := IngressCustomDomainSNIRouteID("abc", "api.acme.com")
+	if a != b {
+		t.Fatalf("case-insensitive hostname should hash equal: %q vs %q", a, b)
+	}
+	if a == IngressCustomDomainSNIRouteID("abc", "other.acme.com") {
+		t.Fatal("distinct hostnames must yield distinct IDs")
+	}
+}
+
+func TestDeleteHelpers_Disabled(t *testing.T) {
+	// Disabled client short-circuits every delete to nil with no admin call.
+	c := &Client{enabled: false}
+	ctx := context.Background()
+	if err := c.DeleteRouteByID(ctx, "rt"); err != nil {
+		t.Fatalf("DeleteRouteByID(disabled) = %v", err)
+	}
+	if err := c.DeleteTCPServer(ctx, "tcp-port-1"); err != nil {
+		t.Fatalf("DeleteTCPServer(disabled) = %v", err)
+	}
+	if err := c.DeleteInFluxPortRoute(ctx, "abc", 3000); err != nil {
+		t.Fatalf("DeleteInFluxPortRoute(disabled) = %v", err)
+	}
+	// Empty IDs are also no-ops even when enabled.
+	c.enabled = true
+	if err := c.DeleteRouteByID(ctx, ""); err != nil {
+		t.Fatalf("DeleteRouteByID(empty) = %v", err)
+	}
+	if err := c.DeleteTCPServer(ctx, ""); err != nil {
+		t.Fatalf("DeleteTCPServer(empty) = %v", err)
+	}
+}
+
+func TestDeleteHelpers_AgainstFakeCaddy(t *testing.T) {
+	ctx := context.Background()
+	fake := newFakeCaddy(t)
+	client := &Client{enabled: true, serverID: "srv0", baseURL: fake.URL, httpClient: fake.Client}
+
+	// DeleteRouteByID against an existing route.
+	fake.routes["rt-1"] = map[string]any{"@id": "rt-1"}
+	if err := client.DeleteRouteByID(ctx, "rt-1"); err != nil {
+		t.Fatalf("DeleteRouteByID: %v", err)
+	}
+	if _, ok := fake.routes["rt-1"]; ok {
+		t.Fatal("route rt-1 should be deleted")
+	}
+
+	// DeleteInFluxPortRoute issues a DELETE (not-found tolerated).
+	if err := client.DeleteInFluxPortRoute(ctx, "abc", 3000); err != nil {
+		t.Fatalf("DeleteInFluxPortRoute: %v", err)
+	}
+
+	// DeleteTCPServer against an existing l4 server.
+	fake.l4Servers["tcp-port-31000"] = map[string]any{}
+	if err := client.DeleteTCPServer(ctx, "tcp-port-31000"); err != nil {
+		t.Fatalf("DeleteTCPServer: %v", err)
+	}
+	if _, ok := fake.l4Servers["tcp-port-31000"]; ok {
+		t.Fatal("l4 server should be deleted")
+	}
+	// DeleteTCPServer on a missing server tolerates 404.
+	if err := client.DeleteTCPServer(ctx, "tcp-port-99999"); err != nil {
+		t.Fatalf("DeleteTCPServer(missing): %v", err)
+	}
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -60,9 +60,13 @@ type ProviderFactory func(ctx context.Context, fc FleetConfig) (controlplane.Pro
 
 // Run loads configuration and executes the full daemon boot sequence, blocking
 // until ctx is cancelled (SIGINT/SIGTERM in the standard wrapper), then performs
-// graceful shutdown. Fatal boot failures call os.Exit(1) exactly as the
-// historical main() did; the returned error covers the pre-boot phases (config
-// load, provider construction) and is nil at graceful shutdown.
+// graceful shutdown. Every fatal boot failure is returned as a wrapped error
+// rather than calling os.Exit; the thin main() wrapper turns a non-nil return
+// into the exit(1) the historical main() did, so observable behavior is
+// unchanged (process dies on boot failure) while the boot-failure paths stay
+// testable. Returning also lets the deferred cleanup (store/mount/otel
+// shutdown) run on failure, which os.Exit skipped. The returned error covers
+// every boot phase; it is nil at graceful shutdown.
 //
 // makeProvider supplies the control-plane capabilities. nil (the open-source
 // default) means controlplane.Noop(): every non-PAT token rejected, every usage
@@ -137,21 +141,18 @@ func Run(ctx context.Context, logger *slog.Logger, makeProvider ProviderFactory)
 
 	db, err := store.Open(cfg.DBPath)
 	if err != nil {
-		logger.Error("failed to open store", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("open store: %w", err)
 	}
 	defer db.Close()
 
 	rules, err := netrules.New(cfg.EnableNetworkRules)
 	if err != nil {
-		logger.Error("failed to create netrules manager", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("create netrules manager: %w", err)
 	}
 
 	dockerClient, err := docker.New(logger, cfg, rules)
 	if err != nil {
-		logger.Error("failed to create docker client", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("create docker client: %w", err)
 	}
 	configureMirror(logger, cfg, dockerClient)
 
@@ -159,8 +160,7 @@ func Run(ctx context.Context, logger *slog.Logger, makeProvider ProviderFactory)
 
 	cipher, err := secrets.NewCipher(cfg.CredentialEncryptionKey, cfg.CredentialEncryptionKeyPath)
 	if err != nil {
-		logger.Error("failed to initialize credential cipher", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("initialize credential cipher: %w", err)
 	}
 
 	mountManager, err := mounts.New(logger, mounts.Config{
@@ -169,8 +169,7 @@ func Run(ctx context.Context, logger *slog.Logger, makeProvider ProviderFactory)
 		WaitTimeout: cfg.MountWaitTimeout,
 	})
 	if err != nil {
-		logger.Error("failed to initialize mount manager", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("initialize mount manager: %w", err)
 	}
 	defer mountManager.Close()
 
@@ -290,8 +289,7 @@ func Run(ctx context.Context, logger *slog.Logger, makeProvider ProviderFactory)
 			BaseCIDR: cfg.FirecrackerTapBaseCIDR,
 			PoolSize: cfg.FirecrackerTapPoolSize,
 		}, time.Now()); err != nil {
-			logger.Error("firecracker tap pool seed failed", "error", err)
-			os.Exit(1)
+			return fmt.Errorf("firecracker tap pool seed: %w", err)
 		}
 		// OCI rootfs builder: depends on skopeo, umoci, mkfs.ext4 being
 		// installed and on $PATH. The validator already required these
@@ -305,8 +303,7 @@ func Run(ctx context.Context, logger *slog.Logger, makeProvider ProviderFactory)
 			WorkDir:   filepath.Join(cfg.FirecrackerRunDir, "oci-work"),
 		})
 		if err != nil {
-			logger.Error("firecracker oci builder init failed", "error", err)
-			os.Exit(1)
+			return fmt.Errorf("firecracker oci builder init: %w", err)
 		}
 		// Phase 5: start the per-VMM RSS sampler now that we know
 		// firecracker is on. Run is a blocking ticker loop, so it goes in
@@ -432,8 +429,7 @@ func Run(ctx context.Context, logger *slog.Logger, makeProvider ProviderFactory)
 			clusterClient, err = cluster.NewAgent(cfg, logger, admitter)
 		}
 		if err != nil {
-			logger.Error("failed to start cluster mode", "error", err)
-			os.Exit(1)
+			return fmt.Errorf("start cluster mode: %w", err)
 		}
 		defer func() {
 			if err := clusterClient.Close(); err != nil {
@@ -641,8 +637,7 @@ func Run(ctx context.Context, logger *slog.Logger, makeProvider ProviderFactory)
 			ToolboxPort: cfg.ToolboxPort,
 		}, svc, dockerClient)
 		if err != nil {
-			logger.Error("failed to create ssh gateway", "error", err)
-			os.Exit(1)
+			return fmt.Errorf("create ssh gateway: %w", err)
 		}
 		go func() {
 			if err := gw.Start(ctx); err != nil {

--- a/pkg/daemon/daemon_coverage_test.go
+++ b/pkg/daemon/daemon_coverage_test.go
@@ -147,37 +147,32 @@ func TestReplayClusterOwnership_StoreError(t *testing.T) {
 
 // TestStartClusterOwnershipReplayRetry_StopsOnCtxCancel: the retry goroutine
 // must return when its context is cancelled rather than ticking forever.
+// t.Context() is cancelled at test cleanup, which is what unblocks the
+// goroutine's <-ctx.Done() case.
 func TestStartClusterOwnershipReplayRetry_StopsOnCtxCancel(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
 	st := openTestStore(t)
 	svc := service.New(config.Config{}, testLogger(), st, nil, nil, nil, nil, nil, nil)
-	startClusterOwnershipReplayRetry(ctx, svc, testLogger())
-	cancel()
-	// Give the goroutine a moment to observe the cancellation. There's no
-	// observable signal, so this is a best-effort no-leak check; the test
-	// passing means the call didn't block or panic.
-	time.Sleep(20 * time.Millisecond)
+	startClusterOwnershipReplayRetry(t.Context(), svc, testLogger())
+	// No observable signal; the test passing means the call didn't block
+	// or panic, and cleanup-time ctx cancellation stops the goroutine.
 }
 
 // TestStartAutoImportReconciler_PATUnreadable: enabled but the PAT file is
 // missing — the feature logs and stays off without scheduling a goroutine.
 func TestStartAutoImportReconciler_PATUnreadable(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	st := openTestStore(t)
 	svc := service.New(config.Config{}, testLogger(), st, nil, nil, nil, nil, nil, nil)
-	startAutoImportReconciler(ctx, testLogger(), config.Config{
+	startAutoImportReconciler(t.Context(), testLogger(), config.Config{
 		AutoImportEnabled:        true,
 		AutoImportClusterPATPath: filepath.Join(t.TempDir(), "missing-pat"),
 	}, st, svc)
 }
 
 // TestStartAutoImportReconciler_Enabled: a readable PAT plus a valid config
-// builds the importer + reconciler and starts the ticker goroutine, which we
-// stop via ctx cancellation.
+// builds the importer + reconciler and starts the ticker goroutine. The
+// interval is shrunk so one empty sweep fires (Scanned == 0 → continue)
+// before t.Context() cancellation stops the loop at cleanup.
 func TestStartAutoImportReconciler_Enabled(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	st := openTestStore(t)
 	svc := service.New(config.Config{}, testLogger(), st, nil, nil, nil, nil, nil, nil)
 
@@ -186,45 +181,43 @@ func TestStartAutoImportReconciler_Enabled(t *testing.T) {
 		t.Fatalf("write pat: %v", err)
 	}
 
-	startAutoImportReconciler(ctx, testLogger(), config.Config{
+	startAutoImportReconciler(t.Context(), testLogger(), config.Config{
 		AutoImportEnabled:           true,
 		AutoImportClusterPATPath:    patPath,
 		AutoImportHooksBaseURL:      "https://hooks.example",
 		AutoImportClusterID:         "cluster-1",
-		AutoImportReconcileInterval: time.Hour,
+		AutoImportReconcileInterval: 5 * time.Millisecond,
 		AutoImportMaxInFlight:       2,
 	}, st, svc)
+	time.Sleep(40 * time.Millisecond)
 }
 
 // TestStartSnapshotPushReconciler_Enabled: a valid push config builds the
-// pusher + reconciler and schedules the sweep goroutine.
+// pusher + reconciler and drives one empty sweep through the goroutine.
 func TestStartSnapshotPushReconciler_Enabled(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	st := openTestStore(t)
 	svc := service.New(config.Config{}, testLogger(), st, nil, nil, nil, nil, nil, nil)
 	dc := newTestDockerClient(t)
 
-	startSnapshotPushReconciler(ctx, testLogger(), config.Config{
+	startSnapshotPushReconciler(t.Context(), testLogger(), config.Config{
 		SnapshotPushEnabled:           true,
 		MirrorPushHost:                "push.example",
 		AutoImportClusterID:           "cluster-1",
 		AutoImportClusterPATPath:      filepath.Join(t.TempDir(), "pat"),
-		SnapshotPushReconcileInterval: time.Hour,
+		SnapshotPushReconcileInterval: 5 * time.Millisecond,
 		SnapshotPushMaxInFlight:       1,
 	}, st, svc, dc)
+	time.Sleep(40 * time.Millisecond)
 }
 
 // TestStartSnapshotPushReconciler_HostFallback: with MirrorPushHost unset the
 // reconciler falls back to ImageDistributionAOCRHost.
 func TestStartSnapshotPushReconciler_HostFallback(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	st := openTestStore(t)
 	svc := service.New(config.Config{}, testLogger(), st, nil, nil, nil, nil, nil, nil)
 	dc := newTestDockerClient(t)
 
-	startSnapshotPushReconciler(ctx, testLogger(), config.Config{
+	startSnapshotPushReconciler(t.Context(), testLogger(), config.Config{
 		SnapshotPushEnabled:           true,
 		MirrorPushHost:                "",
 		ImageDistributionAOCRHost:     "aocr.example",
@@ -239,16 +232,15 @@ func TestStartSnapshotPushReconciler_HostFallback(t *testing.T) {
 // rotation interval and a max-age builds the reconciler and starts its
 // ticker.
 func TestStartTemplateRotationReconciler_Enabled(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	st := openTestStore(t)
 	svc := service.New(config.Config{}, testLogger(), st, nil, nil, nil, nil, nil, nil)
 
-	startTemplateRotationReconciler(ctx, testLogger(), config.Config{
+	startTemplateRotationReconciler(t.Context(), testLogger(), config.Config{
 		EnableFirecracker:                   true,
-		FirecrackerTemplateRotationInterval: time.Hour,
+		FirecrackerTemplateRotationInterval: 5 * time.Millisecond,
 		FirecrackerTemplateMaxAge:           24 * time.Hour,
 	}, st, svc)
+	time.Sleep(40 * time.Millisecond)
 }
 
 // TestAttachTemplateArtifactPuller_Enabled: firecracker on with a templates
@@ -267,34 +259,31 @@ func TestAttachTemplateArtifactPuller_Enabled(t *testing.T) {
 // TestStartTemplateArtifactPushReconciler_Enabled: firecracker + snapshot
 // push on builds the template-artifact pusher and schedules its sweep.
 func TestStartTemplateArtifactPushReconciler_Enabled(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	st := openTestStore(t)
 	svc := service.New(config.Config{}, testLogger(), st, nil, nil, nil, nil, nil, nil)
 	dc := newTestDockerClient(t)
 
-	startTemplateArtifactPushReconciler(ctx, testLogger(), config.Config{
+	startTemplateArtifactPushReconciler(t.Context(), testLogger(), config.Config{
 		EnableFirecracker:             true,
 		SnapshotPushEnabled:           true,
 		MirrorPushHost:                "push.example",
 		AutoImportClusterID:           "cluster-1",
 		AutoImportClusterPATPath:      filepath.Join(t.TempDir(), "pat"),
 		FirecrackerTemplatesDir:       t.TempDir(),
-		SnapshotPushReconcileInterval: time.Hour,
+		SnapshotPushReconcileInterval: 5 * time.Millisecond,
 		SnapshotPushMaxInFlight:       1,
 	}, st, svc, dc)
+	time.Sleep(40 * time.Millisecond)
 }
 
 // TestStartTemplateArtifactPushReconciler_HostFallback: MirrorPushHost unset
 // falls back to ImageDistributionAOCRHost on the template push side too.
 func TestStartTemplateArtifactPushReconciler_HostFallback(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	st := openTestStore(t)
 	svc := service.New(config.Config{}, testLogger(), st, nil, nil, nil, nil, nil, nil)
 	dc := newTestDockerClient(t)
 
-	startTemplateArtifactPushReconciler(ctx, testLogger(), config.Config{
+	startTemplateArtifactPushReconciler(t.Context(), testLogger(), config.Config{
 		EnableFirecracker:             true,
 		SnapshotPushEnabled:           true,
 		MirrorPushHost:                "",

--- a/pkg/daemon/daemon_coverage_test.go
+++ b/pkg/daemon/daemon_coverage_test.go
@@ -3,8 +3,10 @@ package daemon
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,6 +16,7 @@ import (
 	fcruntime "github.com/aerol-ai/microvm/internal/runtime/firecracker"
 	"github.com/aerol-ai/microvm/internal/service"
 	"github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/controlplane"
 	"github.com/aerol-ai/microvm/pkg/docker"
 	"github.com/aerol-ai/microvm/pkg/docker/netrules"
 	"github.com/aerol-ai/microvm/pkg/models"
@@ -46,6 +49,63 @@ func writeWrapKeyFile(t *testing.T) string {
 		t.Fatalf("write wrap key: %v", err)
 	}
 	return path
+}
+
+// TestRun_ConfigLoadFailureReturnsError: a missing SB_PAT_TOKEN makes
+// config.Load fail, and Run must surface that as a wrapped error rather than
+// exiting the process. This is the boot-failure path that os.Exit previously
+// made impossible to assert.
+func TestRun_ConfigLoadFailureReturnsError(t *testing.T) {
+	t.Setenv("SB_PAT_TOKEN", "") // config.Load rejects an empty PAT first.
+	err := Run(context.Background(), testLogger(), nil)
+	if err == nil {
+		t.Fatalf("Run with empty SB_PAT_TOKEN = nil error, want failure")
+	}
+	if !strings.Contains(err.Error(), "load config") {
+		t.Fatalf("Run error = %v, want it to wrap \"load config\"", err)
+	}
+}
+
+// TestRun_StoreOpenFailureReturnsError: with a loadable config but an
+// unopenable DB path (parent is a regular file, so store.Open's MkdirAll
+// fails), Run must return the wrapped error. This exercises the store.Open
+// boot-failure branch that previously called os.Exit(1).
+func TestRun_StoreOpenFailureReturnsError(t *testing.T) {
+	// A regular file standing where store.Open expects the DB's parent dir.
+	parentAsFile := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(parentAsFile, []byte("x"), 0o600); err != nil {
+		t.Fatalf("seed parent file: %v", err)
+	}
+	t.Setenv("SB_PAT_TOKEN", "test-token")
+	t.Setenv("SB_PUBLIC_HOST", "localhost") // required when SB_DOMAIN is empty
+	t.Setenv("SB_DB_PATH", filepath.Join(parentAsFile, "state.db"))
+
+	err := Run(context.Background(), testLogger(), nil)
+	if err == nil {
+		t.Fatalf("Run with unopenable DB path = nil error, want failure")
+	}
+	if !strings.Contains(err.Error(), "open store") {
+		t.Fatalf("Run error = %v, want it to wrap \"open store\"", err)
+	}
+}
+
+// TestRun_ProviderFactoryErrorReturnsError: a makeProvider that fails must
+// abort boot with a wrapped error before any infrastructure is opened.
+func TestRun_ProviderFactoryErrorReturnsError(t *testing.T) {
+	t.Setenv("SB_PAT_TOKEN", "test-token")
+	t.Setenv("SB_PUBLIC_HOST", "localhost")
+	t.Setenv("SB_DB_PATH", filepath.Join(t.TempDir(), "state.db"))
+
+	boom := func(context.Context, FleetConfig) (controlplane.Provider, error) {
+		return controlplane.Provider{}, errors.New("provider boom")
+	}
+	err := Run(context.Background(), testLogger(), boom)
+	if err == nil {
+		t.Fatalf("Run with failing provider factory = nil error, want failure")
+	}
+	if !strings.Contains(err.Error(), "control plane provider") {
+		t.Fatalf("Run error = %v, want it to wrap \"control plane provider\"", err)
+	}
 }
 
 // TestConfigureMirror walks every branch: the disabled early-return, the

--- a/pkg/docker/coverage_full_test.go
+++ b/pkg/docker/coverage_full_test.go
@@ -1,0 +1,561 @@
+package docker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/pkg/docker/netrules"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// ---------------------------------------------------------------------------
+// Shared test plumbing
+// ---------------------------------------------------------------------------
+
+// jsonResponse builds a 200/whatever response carrying a JSON body.
+func jsonResponse(status int, v any) *http.Response {
+	data, _ := json.Marshal(v)
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(string(data))),
+		Header:     make(http.Header),
+	}
+}
+
+// textResponse builds a response carrying a raw (non-JSON) body.
+func textResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+// inspectBody is a literal helper producing the JSON the daemon returns for
+// GET /containers/{id}/json. Marshalling a containerInspect value directly is
+// awkward because of its anonymous nested structs, so we build the wire JSON.
+func inspectBody(id, name, ip string, running bool, status string, pid int) string {
+	return fmt.Sprintf(`{"Id":%q,"Name":%q,"State":{"Running":%t,"Status":%q,"Pid":%d},"NetworkSettings":{"Networks":{"bridge":{"IPAddress":%q}}}}`,
+		id, name, running, status, pid, ip)
+}
+
+// disabledRules returns a no-op netrules manager (BlockAll/Clear all return
+// nil). On non-linux hosts netrules.New always yields a disabled manager, but
+// passing false makes the intent explicit and host-independent.
+func disabledRules(t *testing.T) *netrules.Manager {
+	t.Helper()
+	rules, err := netrules.New(false)
+	if err != nil {
+		t.Fatalf("netrules.New: %v", err)
+	}
+	return rules
+}
+
+// ---------------------------------------------------------------------------
+// Ping
+// ---------------------------------------------------------------------------
+
+func TestPing(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if r.URL.Path != "/_ping" {
+				t.Fatalf("unexpected path %s", r.URL.Path)
+			}
+			return textResponse(http.StatusOK, "OK"), nil
+		})}}
+		if err := c.Ping(context.Background()); err != nil {
+			t.Fatalf("Ping() = %v", err)
+		}
+	})
+
+	t.Run("error_status", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusInternalServerError, "boom"), nil
+		})}}
+		if err := c.Ping(context.Background()); err == nil {
+			t.Fatal("Ping() expected error on 500")
+		}
+	})
+
+	t.Run("transport_error", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, fmt.Errorf("dial fail")
+		})}}
+		if err := c.Ping(context.Background()); err == nil {
+			t.Fatal("Ping() expected transport error")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Network rule wrappers + ContainerPID
+// ---------------------------------------------------------------------------
+
+func TestNetworkRuleWrappers(t *testing.T) {
+	c := &Client{networkRules: disabledRules(t)}
+
+	// Empty IP short-circuits before touching the manager.
+	if err := c.ClearNetworkRules(""); err != nil {
+		t.Fatalf("ClearNetworkRules(\"\") = %v", err)
+	}
+	if err := c.ApplyNetworkBlockAll(""); err != nil {
+		t.Fatalf("ApplyNetworkBlockAll(\"\") = %v", err)
+	}
+	if err := c.ApplyNetworkBlockIngress(""); err != nil {
+		t.Fatalf("ApplyNetworkBlockIngress(\"\") = %v", err)
+	}
+	if err := c.ClearNetworkBlockIngress(""); err != nil {
+		t.Fatalf("ClearNetworkBlockIngress(\"\") = %v", err)
+	}
+	if err := c.ClearNetworkBlockEgress(""); err != nil {
+		t.Fatalf("ClearNetworkBlockEgress(\"\") = %v", err)
+	}
+
+	// Non-empty IP drives into the (disabled, no-op) manager.
+	const ip = "172.17.0.9"
+	if err := c.ClearNetworkRules(ip); err != nil {
+		t.Fatalf("ClearNetworkRules(ip) = %v", err)
+	}
+	if err := c.ApplyNetworkBlockAll(ip); err != nil {
+		t.Fatalf("ApplyNetworkBlockAll(ip) = %v", err)
+	}
+	if err := c.ApplyNetworkBlockIngress(ip); err != nil {
+		t.Fatalf("ApplyNetworkBlockIngress(ip) = %v", err)
+	}
+	if err := c.ClearNetworkBlockIngress(ip); err != nil {
+		t.Fatalf("ClearNetworkBlockIngress(ip) = %v", err)
+	}
+	if err := c.ClearNetworkBlockEgress(ip); err != nil {
+		t.Fatalf("ClearNetworkBlockEgress(ip) = %v", err)
+	}
+}
+
+func TestContainerPID(t *testing.T) {
+	t.Run("running_pid", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusOK, inspectBody("cid", "/sb", "172.17.0.2", true, "running", 4321)), nil
+		})}}
+		pid, err := c.ContainerPID(context.Background(), "sb")
+		if err != nil || pid != 4321 {
+			t.Fatalf("ContainerPID() = %d, %v", pid, err)
+		}
+	})
+
+	t.Run("nil_state_zero", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusOK, `{"Id":"cid","Name":"/sb"}`), nil
+		})}}
+		pid, err := c.ContainerPID(context.Background(), "sb")
+		if err != nil || pid != 0 {
+			t.Fatalf("ContainerPID() = %d, %v", pid, err)
+		}
+	})
+
+	t.Run("inspect_error", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusNotFound, "nope"), nil
+		})}}
+		if _, err := c.ContainerPID(context.Background(), "sb"); err == nil {
+			t.Fatal("ContainerPID() expected inspect error")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Stop / Destroy / CreateSnapshot / Resize / Inspect / ListManaged / RemoveImage
+// ---------------------------------------------------------------------------
+
+func TestStop(t *testing.T) {
+	c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if !strings.HasSuffix(r.URL.Path, "/stop") {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		return textResponse(http.StatusNoContent, ""), nil
+	})}}
+	if err := c.Stop(context.Background(), "sb"); err != nil {
+		t.Fatalf("Stop() = %v", err)
+	}
+}
+
+func TestDestroy(t *testing.T) {
+	t.Run("nil_sandbox", func(t *testing.T) {
+		c := &Client{networkRules: disabledRules(t)}
+		if err := c.Destroy(context.Background(), nil); err != nil {
+			t.Fatalf("Destroy(nil) = %v", err)
+		}
+	})
+
+	t.Run("missing_container_id", func(t *testing.T) {
+		c := &Client{networkRules: disabledRules(t)}
+		if err := c.Destroy(context.Background(), &models.Sandbox{ContainerIP: "172.17.0.2"}); err == nil {
+			t.Fatal("Destroy() expected error for empty container ID")
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		c := &Client{
+			networkRules: disabledRules(t),
+			httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				if r.Method != http.MethodDelete {
+					t.Fatalf("unexpected method %s", r.Method)
+				}
+				return textResponse(http.StatusNoContent, ""), nil
+			})},
+		}
+		sb := &models.Sandbox{ContainerID: "cid", ContainerIP: "172.17.0.2"}
+		if err := c.Destroy(context.Background(), sb); err != nil {
+			t.Fatalf("Destroy() = %v", err)
+		}
+	})
+}
+
+func TestCreateSnapshot(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if r.URL.Path != "/commit" {
+				t.Fatalf("unexpected path %s", r.URL.Path)
+			}
+			if got := r.URL.Query().Get("tag"); got != "v1" {
+				t.Fatalf("tag query = %q", got)
+			}
+			return jsonResponse(http.StatusCreated, map[string]string{"Id": "img-sha"}), nil
+		})}}
+		id, err := c.CreateSnapshot(context.Background(), "cid", "snap-alpha:v1")
+		if err != nil || id != "img-sha" {
+			t.Fatalf("CreateSnapshot() = %q, %v", id, err)
+		}
+	})
+
+	t.Run("invalid_ref", func(t *testing.T) {
+		c := &Client{}
+		if _, err := c.CreateSnapshot(context.Background(), "cid", "bad@sha256:x"); err == nil {
+			t.Fatal("CreateSnapshot() expected ref error")
+		}
+	})
+
+	t.Run("commit_error", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusInternalServerError, "boom"), nil
+		})}}
+		if _, err := c.CreateSnapshot(context.Background(), "cid", "snap-alpha"); err == nil {
+			t.Fatal("CreateSnapshot() expected commit error")
+		}
+	})
+}
+
+func TestResize(t *testing.T) {
+	t.Run("limits_off_noop", func(t *testing.T) {
+		c := &Client{resourceLimitsOff: true}
+		if err := c.Resize(context.Background(), "cid", models.ResizeSandboxRequest{CPU: 2}); err != nil {
+			t.Fatalf("Resize() = %v", err)
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if !strings.HasSuffix(r.URL.Path, "/update") {
+				t.Fatalf("unexpected path %s", r.URL.Path)
+			}
+			return textResponse(http.StatusOK, "{}"), nil
+		})}}
+		if err := c.Resize(context.Background(), "cid", models.ResizeSandboxRequest{CPU: 2, MemoryMB: 512}); err != nil {
+			t.Fatalf("Resize() = %v", err)
+		}
+	})
+
+	t.Run("update_error", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusInternalServerError, "boom"), nil
+		})}}
+		if err := c.Resize(context.Background(), "cid", models.ResizeSandboxRequest{CPU: 1}); err == nil {
+			t.Fatal("Resize() expected update error")
+		}
+	})
+}
+
+func TestInspect(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusOK, inspectBody("cid", "/sb-7", "172.17.0.5", true, "running", 9)), nil
+		})}}
+		rt, err := c.Inspect(context.Background(), "sb-7")
+		if err != nil {
+			t.Fatalf("Inspect() = %v", err)
+		}
+		if rt.SandboxID != "sb-7" || rt.ContainerID != "cid" || rt.ContainerIP != "172.17.0.5" {
+			t.Fatalf("Inspect() runtime = %+v", rt)
+		}
+		if rt.Status != models.SandboxStatusStarted {
+			t.Fatalf("Inspect() status = %q", rt.Status)
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusNotFound, "missing"), nil
+		})}}
+		if _, err := c.Inspect(context.Background(), "sb"); err == nil {
+			t.Fatal("Inspect() expected error")
+		}
+	})
+}
+
+func TestListManaged(t *testing.T) {
+	t.Run("filters_and_inspects", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			switch {
+			case r.URL.Path == "/containers/json":
+				return jsonResponse(http.StatusOK, []map[string]any{
+					{"Id": "managed", "Labels": map[string]string{managedLabelKey: "true"}},
+					{"Id": "unmanaged", "Labels": map[string]string{}},
+					{"Id": "inspect-fails", "Labels": map[string]string{managedLabelKey: "true"}},
+				}), nil
+			case r.URL.Path == "/containers/managed/json":
+				return textResponse(http.StatusOK, inspectBody("managed", "/sb-managed", "172.17.0.2", true, "running", 1)), nil
+			case r.URL.Path == "/containers/inspect-fails/json":
+				return textResponse(http.StatusInternalServerError, "boom"), nil
+			default:
+				t.Fatalf("unexpected path %s", r.URL.Path)
+				return nil, nil
+			}
+		})}}
+		result, err := c.ListManaged(context.Background())
+		if err != nil {
+			t.Fatalf("ListManaged() = %v", err)
+		}
+		if len(result) != 1 {
+			t.Fatalf("ListManaged() returned %d entries, want 1", len(result))
+		}
+		if _, ok := result["sb-managed"]; !ok {
+			t.Fatalf("ListManaged() missing sb-managed: %+v", result)
+		}
+	})
+
+	t.Run("list_error", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusInternalServerError, "boom"), nil
+		})}}
+		if _, err := c.ListManaged(context.Background()); err == nil {
+			t.Fatal("ListManaged() expected list error")
+		}
+	})
+}
+
+func TestRemoveImage(t *testing.T) {
+	t.Run("empty_noop", func(t *testing.T) {
+		c := &Client{}
+		if err := c.RemoveImage(context.Background(), "  "); err != nil {
+			t.Fatalf("RemoveImage(empty) = %v", err)
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if r.Method != http.MethodDelete {
+				t.Fatalf("unexpected method %s", r.Method)
+			}
+			return jsonResponse(http.StatusOK, []map[string]string{{"Deleted": "sha"}}), nil
+		})}}
+		if err := c.RemoveImage(context.Background(), "repo/img:latest"); err != nil {
+			t.Fatalf("RemoveImage() = %v", err)
+		}
+	})
+
+	t.Run("benign_409", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusConflict, "image is in use"), nil
+		})}}
+		if err := c.RemoveImage(context.Background(), "repo/img:latest"); err != nil {
+			t.Fatalf("RemoveImage() 409 should be benign, got %v", err)
+		}
+	})
+
+	t.Run("real_error", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusInternalServerError, "boom"), nil
+		})}}
+		if err := c.RemoveImage(context.Background(), "repo/img:latest"); err == nil {
+			t.Fatal("RemoveImage() expected 500 to propagate")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// PushAllowedPorts (toolbox client)
+// ---------------------------------------------------------------------------
+
+func TestPushAllowedPorts(t *testing.T) {
+	t.Run("empty_ip", func(t *testing.T) {
+		c := &Client{}
+		if err := c.PushAllowedPorts(context.Background(), "", "tok", []int{1}); err == nil {
+			t.Fatal("PushAllowedPorts() expected empty-IP error")
+		}
+	})
+
+	t.Run("success_and_nil_ports", func(t *testing.T) {
+		ip, port, closeFn := toolboxServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/admin/allowed-ports" {
+				t.Errorf("unexpected path %s", r.URL.Path)
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer tok" {
+				t.Errorf("auth header = %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+		})
+		defer closeFn()
+		c := &Client{toolboxClient: &http.Client{}, toolboxPort: port}
+		if err := c.PushAllowedPorts(context.Background(), ip, "tok", nil); err != nil {
+			t.Fatalf("PushAllowedPorts(nil ports) = %v", err)
+		}
+		if err := c.PushAllowedPorts(context.Background(), ip, "tok", []int{8080}); err != nil {
+			t.Fatalf("PushAllowedPorts() = %v", err)
+		}
+	})
+
+	t.Run("non_200", func(t *testing.T) {
+		ip, port, closeFn := toolboxServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		})
+		defer closeFn()
+		c := &Client{toolboxClient: &http.Client{}, toolboxPort: port}
+		if err := c.PushAllowedPorts(context.Background(), ip, "", []int{1}); err == nil {
+			t.Fatal("PushAllowedPorts() expected non-200 error")
+		}
+	})
+
+	t.Run("transport_error", func(t *testing.T) {
+		// Port 1 on 127.0.0.1 refuses connections → Do() returns an error.
+		c := &Client{toolboxClient: &http.Client{Timeout: time.Second}, toolboxPort: 1}
+		if err := c.PushAllowedPorts(context.Background(), "127.0.0.1", "tok", []int{1}); err == nil {
+			t.Fatal("PushAllowedPorts() expected transport error")
+		}
+	})
+}
+
+// toolboxServer spins up an httptest server and returns the loopback IP + port
+// the toolbox client should dial.
+func toolboxServer(t *testing.T, handler http.HandlerFunc) (ip string, port int, closeFn func()) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	hostPort := strings.TrimPrefix(server.URL, "http://")
+	host, portStr, err := net.SplitHostPort(hostPort)
+	if err != nil {
+		server.Close()
+		t.Fatalf("split host port: %v", err)
+	}
+	p, err := strconv.Atoi(portStr)
+	if err != nil {
+		server.Close()
+		t.Fatalf("parse port: %v", err)
+	}
+	return host, p, server.Close
+}
+
+// ---------------------------------------------------------------------------
+// New + ensureToolboxBinary
+// ---------------------------------------------------------------------------
+
+func TestNew(t *testing.T) {
+	t.Run("requires_toolbox_binary", func(t *testing.T) {
+		if _, err := New(slog.Default(), config.Config{}, nil); err == nil {
+			t.Fatal("New() expected error for empty toolbox binary path")
+		}
+	})
+
+	t.Run("success_with_docker_host_and_pull_cap", func(t *testing.T) {
+		t.Setenv("DOCKER_HOST", "unix:///tmp/custom-docker.sock")
+		cfg := config.Config{
+			ToolboxBinaryPath:      "/usr/local/bin/toolboxd",
+			ImagePullMaxConcurrent: 2,
+		}
+		c, err := New(slog.Default(), cfg, disabledRules(t))
+		if err != nil {
+			t.Fatalf("New() = %v", err)
+		}
+		if c.socketPath != "/tmp/custom-docker.sock" {
+			t.Fatalf("socketPath = %q", c.socketPath)
+		}
+		if c.pullSlots == nil || cap(c.pullSlots) != 2 {
+			t.Fatalf("pullSlots cap = %v", c.pullSlots)
+		}
+	})
+}
+
+func TestEnsureToolboxBinary(t *testing.T) {
+	t.Run("missing", func(t *testing.T) {
+		c := &Client{toolboxBinaryPath: "/nonexistent/toolboxd-xyz"}
+		if err := c.ensureToolboxBinary(); err == nil {
+			t.Fatal("ensureToolboxBinary() expected not-found error")
+		}
+	})
+
+	t.Run("is_directory", func(t *testing.T) {
+		c := &Client{toolboxBinaryPath: t.TempDir()}
+		if err := c.ensureToolboxBinary(); err == nil {
+			t.Fatal("ensureToolboxBinary() expected directory error")
+		}
+	})
+
+	t.Run("relative_path", func(t *testing.T) {
+		// A relative path that exists (created under the temp working dir).
+		dir := t.TempDir()
+		rel := "toolboxd-rel"
+		if err := os.WriteFile(filepath.Join(dir, rel), []byte("x"), 0o755); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		t.Chdir(dir)
+		c := &Client{toolboxBinaryPath: rel}
+		if err := c.ensureToolboxBinary(); err == nil {
+			t.Fatal("ensureToolboxBinary() expected absolute-path error")
+		}
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		dir := t.TempDir()
+		bin := filepath.Join(dir, "toolboxd")
+		if err := os.WriteFile(bin, []byte("x"), 0o755); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		c := &Client{toolboxBinaryPath: bin}
+		if err := c.ensureToolboxBinary(); err != nil {
+			t.Fatalf("ensureToolboxBinary() = %v", err)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// doRequest white-box error branches
+// ---------------------------------------------------------------------------
+
+func TestDoRequestErrorBranches(t *testing.T) {
+	t.Run("marshal_error", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{}}
+		// channels are not JSON-marshalable → json.Marshal fails before any I/O.
+		_, err := c.doRequest(context.Background(), http.MethodPost, "/x", nil, map[string]any{"bad": make(chan int)}, nil)
+		if err == nil {
+			t.Fatal("doRequest() expected marshal error")
+		}
+	})
+
+	t.Run("bad_method", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{}}
+		// A method string with a space is rejected by http.NewRequestWithContext.
+		_, err := c.doRequest(context.Background(), "BAD METHOD", "/x", nil, nil, nil)
+		if err == nil {
+			t.Fatal("doRequest() expected request-construction error")
+		}
+	})
+}

--- a/pkg/docker/create_coverage_test.go
+++ b/pkg/docker/create_coverage_test.go
@@ -1,0 +1,434 @@
+package docker
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+	"github.com/aerol-ai/microvm/pkg/mounts"
+)
+
+// fakeDaemon is a configurable Docker-API stub. Each field, when set, handles
+// the matching endpoint; unset endpoints fall through to a 404 so a test only
+// wires the routes its path exercises.
+type fakeDaemon struct {
+	t            *testing.T
+	imageInspect func() *http.Response // GET /images/{ref}/json
+	pull         func() *http.Response // POST /images/create
+	create       func() *http.Response // POST /containers/create
+	start        func() *http.Response // POST /containers/{id}/start
+	containerGet func() *http.Response // GET /containers/{id}/json (waitForRuntime / inspect)
+	remove       func() *http.Response // DELETE /containers/{id}
+	removeCalls  int
+}
+
+func (d *fakeDaemon) transport() roundTripFunc {
+	return func(r *http.Request) (*http.Response, error) {
+		p := r.URL.Path
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(p, "/images/") && strings.HasSuffix(p, "/json"):
+			if d.imageInspect != nil {
+				return d.imageInspect(), nil
+			}
+		case r.Method == http.MethodPost && p == "/images/create":
+			if d.pull != nil {
+				return d.pull(), nil
+			}
+		case r.Method == http.MethodPost && p == "/containers/create":
+			if d.create != nil {
+				return d.create(), nil
+			}
+		case r.Method == http.MethodPost && strings.HasSuffix(p, "/start"):
+			if d.start != nil {
+				return d.start(), nil
+			}
+		case r.Method == http.MethodGet && strings.HasPrefix(p, "/containers/") && strings.HasSuffix(p, "/json"):
+			if d.containerGet != nil {
+				return d.containerGet(), nil
+			}
+		case r.Method == http.MethodDelete && strings.HasPrefix(p, "/containers/"):
+			d.removeCalls++
+			if d.remove != nil {
+				return d.remove(), nil
+			}
+			return textResponse(http.StatusNoContent, ""), nil
+		}
+		return textResponse(http.StatusNotFound, "no such endpoint: "+r.Method+" "+p), nil
+	}
+}
+
+// newCreateClient wires a Client around a fake daemon + a real toolbox health
+// server so the waitForRuntime → waitForToolbox handshake completes.
+func newCreateClient(t *testing.T, d *fakeDaemon, toolboxOK bool, mutate func(*Client)) *Client {
+	t.Helper()
+	ip, port, closeFn := toolboxServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if toolboxOK {
+			w.WriteHeader(http.StatusOK)
+		} else {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+	})
+	t.Cleanup(closeFn)
+
+	// Default container inspect returns the loopback IP so waitForToolbox dials
+	// the real httptest server above.
+	if d.containerGet == nil {
+		d.containerGet = func() *http.Response {
+			return textResponse(http.StatusOK, inspectBody("cid", "/sb", ip, true, "running", 7))
+		}
+	}
+
+	c := &Client{
+		logger:             slog.Default(),
+		toolboxBinaryPath:  writableToolbox(t),
+		toolboxMountPath:   "/usr/local/bin/toolboxd",
+		toolboxPort:        port,
+		networkRules:       disabledRules(t),
+		httpClient:         &http.Client{Transport: d.transport()},
+		streamClient:       &http.Client{Transport: d.transport()},
+		toolboxClient:      &http.Client{Timeout: 2 * time.Second},
+		waitTimeout:        2 * time.Second,
+		toolboxWaitTimeout: 2 * time.Second,
+		pulls:              map[string]*imagePull{},
+		pullFailures:       map[string]imagePullFailure{},
+	}
+	if mutate != nil {
+		mutate(c)
+	}
+	return c
+}
+
+func writableToolbox(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "toolboxd")
+	if err := os.WriteFile(path, []byte("binary"), 0o755); err != nil {
+		t.Fatalf("write toolbox: %v", err)
+	}
+	return path
+}
+
+func TestCreate_Validation(t *testing.T) {
+	t.Run("empty_sandbox_id", func(t *testing.T) {
+		c := &Client{}
+		if _, err := c.Create(context.Background(), models.CreateSandboxRequest{}, "  ", "tok", nil); err == nil {
+			t.Fatal("Create() expected empty sandbox ID error")
+		}
+	})
+
+	t.Run("toolbox_binary_missing", func(t *testing.T) {
+		c := &Client{toolboxBinaryPath: "/nonexistent/toolboxd-xyz"}
+		if _, err := c.Create(context.Background(), models.CreateSandboxRequest{}, "sb", "tok", nil); err == nil {
+			t.Fatal("Create() expected toolbox-binary error")
+		}
+	})
+
+	t.Run("gvisor_privileged_conflict", func(t *testing.T) {
+		c := newCreateClient(t, &fakeDaemon{t: t}, true, func(c *Client) { c.privileged = true })
+		req := models.CreateSandboxRequest{Image: "img", Runtime: models.RuntimeGvisor}
+		if _, err := c.Create(context.Background(), req, "sb", "tok", nil); err == nil ||
+			!strings.Contains(err.Error(), "incompatible with privileged") {
+			t.Fatalf("Create() gvisor+privileged err = %v", err)
+		}
+	})
+
+	t.Run("gvisor_gpu_conflict", func(t *testing.T) {
+		c := newCreateClient(t, &fakeDaemon{t: t}, true, nil)
+		req := models.CreateSandboxRequest{
+			Image:   "img",
+			Runtime: models.RuntimeGvisor,
+			GPUs:    &models.GPURequest{Vendor: models.GPUVendorNVIDIA},
+		}
+		if _, err := c.Create(context.Background(), req, "sb", "tok", nil); err == nil ||
+			!strings.Contains(err.Error(), "GPU access is not supported") {
+			t.Fatalf("Create() gvisor+gpu err = %v", err)
+		}
+	})
+
+	t.Run("kata_runtime_rejected", func(t *testing.T) {
+		c := newCreateClient(t, &fakeDaemon{t: t}, true, nil)
+		req := models.CreateSandboxRequest{Image: "img", Runtime: models.RuntimeKata}
+		if _, err := c.Create(context.Background(), req, "sb", "tok", nil); err == nil {
+			t.Fatal("Create() expected kata runtime rejection")
+		}
+	})
+
+	t.Run("local_only_image_missing", func(t *testing.T) {
+		d := &fakeDaemon{t: t, imageInspect: func() *http.Response { return textResponse(http.StatusNotFound, "no such image") }}
+		c := newCreateClient(t, d, true, nil)
+		req := models.CreateSandboxRequest{Image: BuiltImageNamespace + "/abc:latest"}
+		if _, err := c.Create(context.Background(), req, "sb", "tok", nil); err == nil ||
+			!strings.Contains(err.Error(), "local-only") {
+			t.Fatalf("Create() local-only err = %v", err)
+		}
+	})
+
+	t.Run("local_only_distribution_mode_missing", func(t *testing.T) {
+		d := &fakeDaemon{t: t, imageInspect: func() *http.Response { return textResponse(http.StatusNotFound, "no such image") }}
+		c := newCreateClient(t, d, true, nil)
+		req := models.CreateSandboxRequest{Image: "registry.example/app:v1", ImageDistributionMode: models.ImageDistributionLocalOnly}
+		if _, err := c.Create(context.Background(), req, "sb", "tok", nil); err == nil ||
+			!strings.Contains(err.Error(), "local-only") {
+			t.Fatalf("Create() local-only mode err = %v", err)
+		}
+	})
+}
+
+func TestCreate_PullThenSuccess(t *testing.T) {
+	inspectCalls := 0
+	d := &fakeDaemon{
+		t: t,
+		imageInspect: func() *http.Response {
+			inspectCalls++
+			if inspectCalls == 1 {
+				// First inspect misses → triggers a pull.
+				return textResponse(http.StatusNotFound, "no such image")
+			}
+			return jsonResponse(http.StatusOK, map[string]any{
+				"Config": map[string]any{"WorkingDir": "", "Entrypoint": []string{"/bin/sh"}, "Cmd": []string{"-c", "sleep"}},
+			})
+		},
+		pull: func() *http.Response {
+			return textResponse(http.StatusOK, `{"status":"Pulling"}`+"\n"+`{"status":"done"}`)
+		},
+		create: func() *http.Response { return jsonResponse(http.StatusCreated, map[string]string{"Id": "cid"}) },
+		start:  func() *http.Response { return textResponse(http.StatusNoContent, "") },
+	}
+	c := newCreateClient(t, d, true, nil)
+
+	req := models.CreateSandboxRequest{Image: "registry.example/app:v1"}
+	rt, err := c.Create(context.Background(), req, "sb", "tok", nil)
+	if err != nil {
+		t.Fatalf("Create() = %v", err)
+	}
+	if rt.SandboxID != "sb" || rt.ContainerID != "cid" {
+		t.Fatalf("Create() runtime = %+v", rt)
+	}
+}
+
+func TestCreate_ImagePresentFullSuccess(t *testing.T) {
+	d := &fakeDaemon{
+		t: t,
+		imageInspect: func() *http.Response {
+			return jsonResponse(http.StatusOK, map[string]any{
+				"Config": map[string]any{"WorkingDir": "/app", "Entrypoint": []string{}, "Cmd": []string{}},
+			})
+		},
+		create: func() *http.Response { return jsonResponse(http.StatusCreated, map[string]string{"Id": "cid"}) },
+		start:  func() *http.Response { return textResponse(http.StatusNoContent, "") },
+	}
+	c := newCreateClient(t, d, true, func(c *Client) {
+		c.network = "custom-net" // exercises the NetworkMode branch
+	})
+
+	req := models.CreateSandboxRequest{
+		Image:            "registry.example/app:v1",
+		CPU:              2,
+		MemoryMB:         512,
+		DiskGB:           5,
+		Env:              map[string]string{"FOO": "bar"},
+		ContainerCommand: []string{"/bin/run"},
+		NetworkBlockAll:  true,
+		GPUs:             &models.GPURequest{Vendor: models.GPUVendorNVIDIA, Count: 2, DeviceIDs: []string{"0", "1"}},
+	}
+	// containerGet must report an IP on the "custom-net" network so getContainerIP
+	// (preferred network) resolves; the default helper uses "bridge", so override.
+	ip, port, closeFn := toolboxServer(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	defer closeFn()
+	c.toolboxPort = port
+	d.containerGet = func() *http.Response {
+		return textResponse(http.StatusOK,
+			`{"Id":"cid","Name":"/sb","State":{"Running":true,"Status":"running","Pid":7},"NetworkSettings":{"Networks":{"custom-net":{"IPAddress":"`+ip+`"}}}}`)
+	}
+
+	rt, err := c.Create(context.Background(), req, "sb", "tok", []mounts.ContainerBind{
+		{HostPath: "/h", ContainerPath: "/c", ReadOnly: true},
+		{HostPath: "/h2", ContainerPath: "/c2"},
+	})
+	if err != nil {
+		t.Fatalf("Create() = %v", err)
+	}
+	if rt.SandboxID != "sb" {
+		t.Fatalf("Create() runtime = %+v", rt)
+	}
+}
+
+func TestCreate_GPUVariants(t *testing.T) {
+	cases := []struct {
+		name    string
+		vendor  models.GPUVendor
+		runtime string
+		diskGB  int
+	}{
+		{name: "amd", vendor: models.GPUVendorAMD},
+		{name: "apple", vendor: models.GPUVendorApple},
+		{name: "gvisor_disk_warn", vendor: "", runtime: models.RuntimeGvisor, diskGB: 5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := &fakeDaemon{
+				t: t,
+				imageInspect: func() *http.Response {
+					return jsonResponse(http.StatusOK, map[string]any{
+						"Config": map[string]any{"WorkingDir": "/", "Entrypoint": []string{"/e"}, "Cmd": []string{}},
+					})
+				},
+				create: func() *http.Response { return jsonResponse(http.StatusCreated, map[string]string{"Id": "cid"}) },
+				start:  func() *http.Response { return textResponse(http.StatusNoContent, "") },
+			}
+			c := newCreateClient(t, d, true, nil)
+			req := models.CreateSandboxRequest{Image: "img", Runtime: tc.runtime, DiskGB: tc.diskGB}
+			if tc.vendor != "" {
+				req.GPUs = &models.GPURequest{Vendor: tc.vendor}
+			}
+			if _, err := c.Create(context.Background(), req, "sb", "tok", nil); err != nil {
+				t.Fatalf("Create() = %v", err)
+			}
+		})
+	}
+}
+
+func TestCreate_FailurePaths(t *testing.T) {
+	imagePresent := func() *http.Response {
+		return jsonResponse(http.StatusOK, map[string]any{
+			"Config": map[string]any{"WorkingDir": "/", "Entrypoint": []string{"/e"}, "Cmd": []string{}},
+		})
+	}
+
+	t.Run("pull_error", func(t *testing.T) {
+		d := &fakeDaemon{
+			t:            t,
+			imageInspect: func() *http.Response { return textResponse(http.StatusNotFound, "no such image") },
+			pull: func() *http.Response {
+				return textResponse(http.StatusOK, `{"errorDetail":{"message":"manifest unknown"}}`)
+			},
+		}
+		c := newCreateClient(t, d, true, nil)
+		if _, err := c.Create(context.Background(), models.CreateSandboxRequest{Image: "registry.example/x:v1"}, "sb", "tok", nil); err == nil {
+			t.Fatal("Create() expected pull error")
+		}
+	})
+
+	t.Run("inspect_after_pull_error", func(t *testing.T) {
+		first := true
+		d := &fakeDaemon{
+			t: t,
+			imageInspect: func() *http.Response {
+				if first {
+					first = false
+					return textResponse(http.StatusNotFound, "no such image")
+				}
+				return textResponse(http.StatusInternalServerError, "boom")
+			},
+			pull: func() *http.Response { return textResponse(http.StatusOK, `{"status":"done"}`) },
+		}
+		c := newCreateClient(t, d, true, nil)
+		if _, err := c.Create(context.Background(), models.CreateSandboxRequest{Image: "registry.example/x:v1"}, "sb", "tok", nil); err == nil {
+			t.Fatal("Create() expected post-pull inspect error")
+		}
+	})
+
+	t.Run("create_container_error", func(t *testing.T) {
+		d := &fakeDaemon{
+			t:            t,
+			imageInspect: imagePresent,
+			create:       func() *http.Response { return textResponse(http.StatusInternalServerError, "boom") },
+		}
+		c := newCreateClient(t, d, true, nil)
+		if _, err := c.Create(context.Background(), models.CreateSandboxRequest{Image: "img"}, "sb", "tok", nil); err == nil {
+			t.Fatal("Create() expected create error")
+		}
+	})
+
+	t.Run("start_error_rolls_back", func(t *testing.T) {
+		d := &fakeDaemon{
+			t:            t,
+			imageInspect: imagePresent,
+			create:       func() *http.Response { return jsonResponse(http.StatusCreated, map[string]string{"Id": "cid"}) },
+			start:        func() *http.Response { return textResponse(http.StatusInternalServerError, "boom") },
+		}
+		c := newCreateClient(t, d, true, nil)
+		if _, err := c.Create(context.Background(), models.CreateSandboxRequest{Image: "img"}, "sb", "tok", nil); err == nil {
+			t.Fatal("Create() expected start error")
+		}
+		if d.removeCalls == 0 {
+			t.Fatal("Create() should roll back the container on start failure")
+		}
+	})
+
+	t.Run("wait_runtime_inspect_error_rolls_back", func(t *testing.T) {
+		d := &fakeDaemon{
+			t:            t,
+			imageInspect: imagePresent,
+			create:       func() *http.Response { return jsonResponse(http.StatusCreated, map[string]string{"Id": "cid"}) },
+			start:        func() *http.Response { return textResponse(http.StatusNoContent, "") },
+			containerGet: func() *http.Response { return textResponse(http.StatusInternalServerError, "boom") },
+		}
+		c := newCreateClient(t, d, true, nil)
+		if _, err := c.Create(context.Background(), models.CreateSandboxRequest{Image: "img"}, "sb", "tok", nil); err == nil {
+			t.Fatal("Create() expected waitForRuntime inspect error")
+		}
+		if d.removeCalls == 0 {
+			t.Fatal("Create() should roll back on waitForRuntime failure")
+		}
+	})
+}
+
+func TestStartAndWaitForRuntime(t *testing.T) {
+	t.Run("start_success", func(t *testing.T) {
+		ip, port, closeFn := toolboxServer(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+		defer closeFn()
+		d := &fakeDaemon{
+			t:     t,
+			start: func() *http.Response { return textResponse(http.StatusNoContent, "") },
+			containerGet: func() *http.Response {
+				return textResponse(http.StatusOK, inspectBody("cid", "/sb", ip, true, "running", 7))
+			},
+		}
+		c := &Client{
+			httpClient:         &http.Client{Transport: d.transport()},
+			toolboxClient:      &http.Client{Timeout: 2 * time.Second},
+			toolboxPort:        port,
+			waitTimeout:        2 * time.Second,
+			toolboxWaitTimeout: 2 * time.Second,
+		}
+		rt, err := c.Start(context.Background(), "sb")
+		if err != nil {
+			t.Fatalf("Start() = %v", err)
+		}
+		if rt.ContainerIP != ip {
+			t.Fatalf("Start() ip = %q", rt.ContainerIP)
+		}
+	})
+
+	t.Run("start_error", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusInternalServerError, "boom"), nil
+		})}}
+		if _, err := c.Start(context.Background(), "sb"); err == nil {
+			t.Fatal("Start() expected error")
+		}
+	})
+
+	t.Run("wait_timeout_not_running", func(t *testing.T) {
+		d := &fakeDaemon{
+			t: t,
+			containerGet: func() *http.Response {
+				return textResponse(http.StatusOK, inspectBody("cid", "/sb", "", false, "created", 0))
+			},
+		}
+		c := &Client{
+			httpClient:  &http.Client{Transport: d.transport()},
+			waitTimeout: 5 * time.Millisecond,
+		}
+		if _, err := c.waitForRuntime(context.Background(), "cid"); err == nil {
+			t.Fatal("waitForRuntime() expected timeout")
+		}
+	})
+}

--- a/pkg/docker/exec.go
+++ b/pkg/docker/exec.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -94,7 +95,12 @@ func (c *Client) ExecStart(ctx context.Context, execID string, tty bool) (*ExecS
 		return nil, err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, "http://docker/exec/"+url.PathEscape(execID)+"/start", nil)
+	// The payload rides as the request body so req.Write emits headers and
+	// body in one well-formed write. Setting req.ContentLength on a nil-Body
+	// request and writing the body separately is rejected by net/http's
+	// transfer writer ("ContentLength=N with nil Body") before a single byte
+	// reaches the socket, which would break every exec start.
+	req, err := http.NewRequest(http.MethodPost, "http://docker/exec/"+url.PathEscape(execID)+"/start", bytes.NewReader(payload))
 	if err != nil {
 		conn.Close()
 		return nil, err
@@ -102,15 +108,10 @@ func (c *Client) ExecStart(ctx context.Context, execID string, tty bool) (*ExecS
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Connection", "Upgrade")
 	req.Header.Set("Upgrade", "tcp")
-	req.ContentLength = int64(len(payload))
 
 	if err := req.Write(conn); err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("write exec start request: %w", err)
-	}
-	if _, err := conn.Write(payload); err != nil {
-		conn.Close()
-		return nil, fmt.Errorf("write exec start body: %w", err)
 	}
 
 	reader := bufio.NewReader(conn)

--- a/pkg/docker/exec_events_build_coverage_test.go
+++ b/pkg/docker/exec_events_build_coverage_test.go
@@ -1,0 +1,583 @@
+package docker
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// ---------------------------------------------------------------------------
+// exec.go
+// ---------------------------------------------------------------------------
+
+func TestExecCreate(t *testing.T) {
+	t.Run("empty_container", func(t *testing.T) {
+		c := &Client{}
+		if _, err := c.ExecCreate(context.Background(), "", []string{"sh"}, nil, "", false); err == nil {
+			t.Fatal("ExecCreate() expected empty-container error")
+		}
+	})
+	t.Run("empty_cmd", func(t *testing.T) {
+		c := &Client{}
+		if _, err := c.ExecCreate(context.Background(), "cid", nil, nil, "", false); err == nil {
+			t.Fatal("ExecCreate() expected empty-cmd error")
+		}
+	})
+	t.Run("success_with_env_and_workdir", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if !strings.HasSuffix(r.URL.Path, "/exec") {
+				t.Fatalf("unexpected path %s", r.URL.Path)
+			}
+			return jsonResponse(http.StatusCreated, map[string]string{"Id": "exec-1"}), nil
+		})}}
+		id, err := c.ExecCreate(context.Background(), "cid", []string{"sh", "-c", "ls"}, []string{"A=B"}, "/work", true)
+		if err != nil || id != "exec-1" {
+			t.Fatalf("ExecCreate() = %q, %v", id, err)
+		}
+	})
+	t.Run("empty_exec_id_returned", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return jsonResponse(http.StatusCreated, map[string]string{"Id": ""}), nil
+		})}}
+		if _, err := c.ExecCreate(context.Background(), "cid", []string{"sh"}, nil, "", false); err == nil {
+			t.Fatal("ExecCreate() expected empty-ID error")
+		}
+	})
+	t.Run("api_error", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusInternalServerError, "boom"), nil
+		})}}
+		if _, err := c.ExecCreate(context.Background(), "cid", []string{"sh"}, nil, "", false); err == nil {
+			t.Fatal("ExecCreate() expected API error")
+		}
+	})
+}
+
+func TestExecResize(t *testing.T) {
+	t.Run("empty_exec_id", func(t *testing.T) {
+		c := &Client{}
+		if err := c.ExecResize(context.Background(), "", 24, 80); err == nil {
+			t.Fatal("ExecResize() expected empty-ID error")
+		}
+	})
+	t.Run("non_positive_dims_noop", func(t *testing.T) {
+		c := &Client{}
+		if err := c.ExecResize(context.Background(), "exec-1", 0, 80); err != nil {
+			t.Fatalf("ExecResize() noop = %v", err)
+		}
+	})
+	t.Run("success", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if !strings.HasSuffix(r.URL.Path, "/resize") {
+				t.Fatalf("unexpected path %s", r.URL.Path)
+			}
+			return textResponse(http.StatusOK, "{}"), nil
+		})}}
+		if err := c.ExecResize(context.Background(), "exec-1", 24, 80); err != nil {
+			t.Fatalf("ExecResize() = %v", err)
+		}
+	})
+	t.Run("api_error", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusInternalServerError, "boom"), nil
+		})}}
+		if err := c.ExecResize(context.Background(), "exec-1", 24, 80); err == nil {
+			t.Fatal("ExecResize() expected API error")
+		}
+	})
+}
+
+func TestExecInspect(t *testing.T) {
+	t.Run("empty_exec_id", func(t *testing.T) {
+		c := &Client{}
+		if _, _, err := c.ExecInspect(context.Background(), ""); err == nil {
+			t.Fatal("ExecInspect() expected empty-ID error")
+		}
+	})
+	t.Run("success", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return jsonResponse(http.StatusOK, map[string]any{"ExitCode": 3, "Running": false}), nil
+		})}}
+		code, running, err := c.ExecInspect(context.Background(), "exec-1")
+		if err != nil || code != 3 || running {
+			t.Fatalf("ExecInspect() = %d, %v, %v", code, running, err)
+		}
+	})
+	t.Run("api_error", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusInternalServerError, "boom"), nil
+		})}}
+		if _, _, err := c.ExecInspect(context.Background(), "exec-1"); err == nil {
+			t.Fatal("ExecInspect() expected API error")
+		}
+	})
+}
+
+func TestExecSessionClose(t *testing.T) {
+	// nil receiver and nil conn are both no-ops.
+	var nilSession *ExecSession
+	if err := nilSession.Close(); err != nil {
+		t.Fatalf("nil session Close() = %v", err)
+	}
+	if err := (&ExecSession{}).Close(); err != nil {
+		t.Fatalf("nil conn Close() = %v", err)
+	}
+
+	// A real (piped) conn is closed.
+	server, client := net.Pipe()
+	defer server.Close()
+	s := &ExecSession{Conn: client}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close() = %v", err)
+	}
+}
+
+func TestExecStart(t *testing.T) {
+	t.Run("empty_exec_id", func(t *testing.T) {
+		c := &Client{}
+		if _, err := c.ExecStart(context.Background(), "", false); err == nil {
+			t.Fatal("ExecStart() expected empty-ID error")
+		}
+	})
+
+	t.Run("dial_failure", func(t *testing.T) {
+		c := &Client{socketPath: filepath.Join(t.TempDir(), "nonexistent.sock")}
+		if _, err := c.ExecStart(context.Background(), "exec-1", false); err == nil {
+			t.Fatal("ExecStart() expected dial error")
+		}
+	})
+
+	t.Run("success_101", func(t *testing.T) {
+		sock := execSocketServer(t, "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: tcp\r\n\r\n")
+		c := &Client{socketPath: sock}
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(2*time.Second))
+		defer cancel()
+		sess, err := c.ExecStart(ctx, "exec-1", true)
+		if err != nil {
+			t.Fatalf("ExecStart() = %v", err)
+		}
+		if sess.ID != "exec-1" {
+			t.Fatalf("ExecStart() session ID = %q", sess.ID)
+		}
+		sess.Close()
+	})
+
+	t.Run("non_101_status", func(t *testing.T) {
+		sock := execSocketServer(t, "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 4\r\n\r\nboom")
+		c := &Client{socketPath: sock}
+		if _, err := c.ExecStart(context.Background(), "exec-1", false); err == nil {
+			t.Fatal("ExecStart() expected non-101 error")
+		}
+	})
+}
+
+// execSocketServer listens on a unix socket, reads one HTTP request, and writes
+// the canned response back. Returns the socket path.
+func execSocketServer(t *testing.T, response string) string {
+	t.Helper()
+	sock := filepath.Join(t.TempDir(), "exec.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		// Drain the request line + headers so the client's write doesn't block.
+		reader := bufio.NewReader(conn)
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil || line == "\r\n" {
+				break
+			}
+		}
+		// The exec start body follows; we don't need to read it to respond.
+		_, _ = conn.Write([]byte(response))
+		// Give the client time to read before the deferred Close tears down.
+		time.Sleep(200 * time.Millisecond)
+	}()
+	return sock
+}
+
+// ---------------------------------------------------------------------------
+// events.go: StreamEvents
+// ---------------------------------------------------------------------------
+
+func TestStreamEvents(t *testing.T) {
+	t.Run("subscribe_error", func(t *testing.T) {
+		c := &Client{streamClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, io.ErrUnexpectedEOF
+		})}}
+		out := make(chan DockerEvent, 1)
+		if err := c.StreamEvents(context.Background(), out); err == nil {
+			t.Fatal("StreamEvents() expected subscribe error")
+		}
+	})
+
+	t.Run("non_200", func(t *testing.T) {
+		c := &Client{streamClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusInternalServerError, "boom"), nil
+		})}}
+		out := make(chan DockerEvent, 1)
+		if err := c.StreamEvents(context.Background(), out); err == nil {
+			t.Fatal("StreamEvents() expected non-200 error")
+		}
+	})
+
+	t.Run("streams_events_then_eof", func(t *testing.T) {
+		// One event that normalizes (has name+action), one that doesn't (no id).
+		body := `{"Action":"die","id":"cid","time":1700000000,"Actor":{"Attributes":{"name":"/sb-1","exitCode":"0"}}}` +
+			`{"Action":"start","id":"","Actor":{"Attributes":{}}}`
+		c := &Client{streamClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusOK, body), nil
+		})}}
+		out := make(chan DockerEvent, 4)
+		if err := c.StreamEvents(context.Background(), out); err != nil {
+			t.Fatalf("StreamEvents() = %v", err)
+		}
+		select {
+		case ev := <-out:
+			if ev.SandboxID != "sb-1" || ev.Action != "die" {
+				t.Fatalf("unexpected event %+v", ev)
+			}
+		default:
+			t.Fatal("expected at least one event")
+		}
+	})
+
+	t.Run("decode_error", func(t *testing.T) {
+		c := &Client{streamClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusOK, `{not json`), nil
+		})}}
+		out := make(chan DockerEvent, 1)
+		if err := c.StreamEvents(context.Background(), out); err == nil {
+			t.Fatal("StreamEvents() expected decode error")
+		}
+	})
+
+	t.Run("ctx_done_on_send", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // already cancelled → the send select hits <-ctx.Done()
+		body := `{"Action":"die","id":"cid","time":1700000000,"Actor":{"Attributes":{"name":"/sb-1"}}}`
+		c := &Client{streamClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusOK, body), nil
+		})}}
+		out := make(chan DockerEvent) // unbuffered → send would block, forcing ctx branch
+		if err := c.StreamEvents(ctx, out); err != nil {
+			t.Fatalf("StreamEvents() = %v", err)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// build.go: BuildImage, PushImage, ImageExists, ListBuiltImages, RefreshTag
+// ---------------------------------------------------------------------------
+
+func TestBuildImage(t *testing.T) {
+	t.Run("empty_tag", func(t *testing.T) {
+		c := &Client{}
+		if err := c.BuildImage(context.Background(), BuildImageRequest{}); err == nil {
+			t.Fatal("BuildImage() expected empty-tag error")
+		}
+	})
+
+	t.Run("empty_dockerfile", func(t *testing.T) {
+		c := &Client{}
+		if err := c.BuildImage(context.Background(), BuildImageRequest{Tag: "t:1", DockerfileContent: "   "}); err == nil {
+			t.Fatal("BuildImage() expected empty-dockerfile error")
+		}
+	})
+
+	t.Run("success_with_context_and_logs", func(t *testing.T) {
+		var logs []string
+		c := &Client{streamClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if r.URL.Path != "/build" {
+				t.Fatalf("unexpected path %s", r.URL.Path)
+			}
+			return textResponse(http.StatusOK, `{"stream":"Step 1/2\nStep 2/2\n"}`), nil
+		})}}
+		req := BuildImageRequest{
+			Tag:               "aerolvm-build/x:latest",
+			DockerfileContent: "FROM scratch",
+			ContextTar:        makeTar(t, map[string]string{"a.txt": "hi"}),
+			OnLog:             func(line string) { logs = append(logs, line) },
+		}
+		if err := c.BuildImage(context.Background(), req); err != nil {
+			t.Fatalf("BuildImage() = %v", err)
+		}
+		if len(logs) == 0 {
+			t.Fatal("BuildImage() expected forwarded log lines")
+		}
+	})
+
+	t.Run("http_error", func(t *testing.T) {
+		c := &Client{streamClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusBadRequest, "bad dockerfile"), nil
+		})}}
+		req := BuildImageRequest{Tag: "t:1", DockerfileContent: "FROM scratch"}
+		if err := c.BuildImage(context.Background(), req); err == nil {
+			t.Fatal("BuildImage() expected HTTP error")
+		}
+	})
+
+	t.Run("stream_error", func(t *testing.T) {
+		c := &Client{streamClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusOK, `{"error":"build failed"}`), nil
+		})}}
+		req := BuildImageRequest{Tag: "t:2", DockerfileContent: "FROM scratch"}
+		if err := c.BuildImage(context.Background(), req); err == nil {
+			t.Fatal("BuildImage() expected stream error")
+		}
+	})
+
+	t.Run("transport_error", func(t *testing.T) {
+		c := &Client{streamClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, io.ErrUnexpectedEOF
+		})}}
+		req := BuildImageRequest{Tag: "t:3", DockerfileContent: "FROM scratch"}
+		if err := c.BuildImage(context.Background(), req); err == nil {
+			t.Fatal("BuildImage() expected transport error")
+		}
+	})
+}
+
+func TestPushImage(t *testing.T) {
+	validAuth := models.RegistryAuth{Username: "u", Password: "p", Server: "ghcr.io"}
+
+	t.Run("validations", func(t *testing.T) {
+		c := &Client{}
+		cases := []PushImageRequest{
+			{SourceTag: "", DestRef: "d"},
+			{SourceTag: "s", DestRef: ""},
+			{SourceTag: "s", DestRef: "d", Auth: models.RegistryAuth{}},
+		}
+		for i, req := range cases {
+			if _, err := c.PushImage(context.Background(), req); err == nil {
+				t.Fatalf("PushImage() case %d expected validation error", i)
+			}
+		}
+	})
+
+	t.Run("tag_error", func(t *testing.T) {
+		c := &Client{
+			logger: slog.Default(),
+			httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return textResponse(http.StatusInternalServerError, "boom"), nil
+			})},
+		}
+		req := PushImageRequest{SourceTag: "src:latest", DestRef: "ghcr.io/org/img:v1", Auth: validAuth}
+		if _, err := c.PushImage(context.Background(), req); err == nil {
+			t.Fatal("PushImage() expected tag error")
+		}
+	})
+
+	t.Run("success_with_log_and_digest", func(t *testing.T) {
+		var gotLog, gotDigest string
+		c := &Client{
+			logger: slog.Default(),
+			httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				// tag + untag (DELETE) both go through httpClient.
+				return textResponse(http.StatusOK, "{}"), nil
+			})},
+			streamClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				if !strings.Contains(r.URL.Path, "/push") {
+					t.Fatalf("unexpected stream path %s", r.URL.Path)
+				}
+				return textResponse(http.StatusOK, `{"status":"Pushing"}`+"\n"+`{"aux":{"Digest":"sha256:abc"}}`), nil
+			})},
+		}
+		req := PushImageRequest{
+			SourceTag: "src:latest",
+			DestRef:   "ghcr.io/org/img:v1",
+			Auth:      validAuth,
+			OnLog:     func(line string) { gotLog = line },
+			OnDigest:  func(d string) { gotDigest = d },
+		}
+		pushed, err := c.PushImage(context.Background(), req)
+		if err != nil {
+			t.Fatalf("PushImage() = %v", err)
+		}
+		if pushed != "ghcr.io/org/img:v1" {
+			t.Fatalf("PushImage() returned %q", pushed)
+		}
+		if gotLog == "" || gotDigest != "sha256:abc" {
+			t.Fatalf("PushImage() log=%q digest=%q", gotLog, gotDigest)
+		}
+	})
+
+	t.Run("push_http_error", func(t *testing.T) {
+		c := &Client{
+			logger:     slog.Default(),
+			httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) { return textResponse(http.StatusOK, "{}"), nil })},
+			streamClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return textResponse(http.StatusUnauthorized, "denied"), nil
+			})},
+		}
+		req := PushImageRequest{SourceTag: "src:latest", DestRef: "ghcr.io/org/img:v1", Auth: validAuth}
+		if _, err := c.PushImage(context.Background(), req); err == nil {
+			t.Fatal("PushImage() expected push HTTP error")
+		}
+	})
+
+	t.Run("push_stream_error", func(t *testing.T) {
+		c := &Client{
+			logger:     slog.Default(),
+			httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) { return textResponse(http.StatusOK, "{}"), nil })},
+			streamClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return textResponse(http.StatusOK, `{"errorDetail":{"message":"quota exceeded"}}`), nil
+			})},
+		}
+		req := PushImageRequest{SourceTag: "src:latest", DestRef: "ghcr.io/org/img:v1", Auth: validAuth}
+		if _, err := c.PushImage(context.Background(), req); err == nil {
+			t.Fatal("PushImage() expected push stream error")
+		}
+	})
+}
+
+func TestImageExists(t *testing.T) {
+	t.Run("exists", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusOK, "{}"), nil
+		})}}
+		ok, err := c.ImageExists(context.Background(), "img")
+		if err != nil || !ok {
+			t.Fatalf("ImageExists() = %v, %v", ok, err)
+		}
+	})
+	t.Run("not_found_no_such_image", func(t *testing.T) {
+		// The "no such image" substring branch (distinct from the bare 404 path).
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusInternalServerError, "no such image: img"), nil
+		})}}
+		ok, err := c.ImageExists(context.Background(), "img")
+		if err != nil || ok {
+			t.Fatalf("ImageExists() = %v, %v", ok, err)
+		}
+	})
+	t.Run("not_found_404", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusNotFound, "boom"), nil
+		})}}
+		ok, err := c.ImageExists(context.Background(), "img")
+		if err != nil || ok {
+			t.Fatalf("ImageExists() = %v, %v", ok, err)
+		}
+	})
+	t.Run("other_error", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, io.ErrUnexpectedEOF
+		})}}
+		if _, err := c.ImageExists(context.Background(), "img"); err == nil {
+			t.Fatal("ImageExists() expected transport error")
+		}
+	})
+}
+
+func TestListBuiltImages(t *testing.T) {
+	t.Run("filters_and_inspects", func(t *testing.T) {
+		c := &Client{
+			logger: slog.Default(),
+			httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				switch {
+				case r.URL.Path == "/images/json":
+					return jsonResponse(http.StatusOK, []map[string]any{
+						{"RepoTags": []string{BuiltImageNamespace + "/keep:latest", "other/img:latest"}},
+						{"RepoTags": []string{BuiltImageNamespace + "/inspect-fails:latest"}},
+					}), nil
+				case strings.Contains(r.URL.Path, "inspect-fails"):
+					return textResponse(http.StatusInternalServerError, "boom"), nil
+				case strings.HasPrefix(r.URL.Path, "/images/") && strings.HasSuffix(r.URL.Path, "/json"):
+					return jsonResponse(http.StatusOK, map[string]any{
+						"Metadata": map[string]any{"LastTagTime": "2024-01-01T00:00:00Z"},
+					}), nil
+				default:
+					t.Fatalf("unexpected path %s", r.URL.Path)
+					return nil, nil
+				}
+			})},
+		}
+		images, err := c.ListBuiltImages(context.Background())
+		if err != nil {
+			t.Fatalf("ListBuiltImages() = %v", err)
+		}
+		if len(images) != 1 || images[0].Tag != BuiltImageNamespace+"/keep:latest" {
+			t.Fatalf("ListBuiltImages() = %+v", images)
+		}
+	})
+
+	t.Run("list_error", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusInternalServerError, "boom"), nil
+		})}}
+		if _, err := c.ListBuiltImages(context.Background()); err == nil {
+			t.Fatal("ListBuiltImages() expected list error")
+		}
+	})
+}
+
+func TestRefreshTag(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if !strings.HasSuffix(r.URL.Path, "/tag") {
+				t.Fatalf("unexpected path %s", r.URL.Path)
+			}
+			return textResponse(http.StatusCreated, ""), nil
+		})}}
+		if err := c.RefreshTag(context.Background(), "aerolvm-build/x:latest"); err != nil {
+			t.Fatalf("RefreshTag() = %v", err)
+		}
+	})
+
+	t.Run("tag_error", func(t *testing.T) {
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusInternalServerError, "boom"), nil
+		})}}
+		if err := c.RefreshTag(context.Background(), "aerolvm-build/x:latest"); err == nil {
+			t.Fatal("RefreshTag() expected tag error")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// export.go: PullImage
+// ---------------------------------------------------------------------------
+
+func TestPullImageWrapper(t *testing.T) {
+	t.Run("empty_ref", func(t *testing.T) {
+		c := &Client{}
+		if err := c.PullImage(context.Background(), "  ", nil); err == nil {
+			t.Fatal("PullImage() expected empty-ref error")
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		c := &Client{
+			logger: slog.Default(),
+			streamClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return textResponse(http.StatusOK, `{"status":"done"}`), nil
+			})},
+			pulls:        map[string]*imagePull{},
+			pullFailures: map[string]imagePullFailure{},
+		}
+		if err := c.PullImage(context.Background(), "busybox:latest", &models.RegistryAuth{}); err != nil {
+			t.Fatalf("PullImage() = %v", err)
+		}
+	})
+}
+
+// keep os import used even if all other refs change.
+var _ = os.WriteFile

--- a/pkg/docker/internals_coverage_test.go
+++ b/pkg/docker/internals_coverage_test.go
@@ -1,0 +1,563 @@
+package docker
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/pkg/models"
+	"github.com/aerol-ai/microvm/pkg/secrets"
+)
+
+// ---------------------------------------------------------------------------
+// Small pure helpers
+// ---------------------------------------------------------------------------
+
+func TestQueryValuesEmpty(t *testing.T) {
+	if got := queryValues(nil); got != nil {
+		t.Fatalf("queryValues(nil) = %v, want nil", got)
+	}
+	if got := queryValues(map[string]string{}); got != nil {
+		t.Fatalf("queryValues(empty) = %v, want nil", got)
+	}
+}
+
+func TestContainerStatusUnknownIsError(t *testing.T) {
+	in := containerInspect{}
+	in.State = &struct {
+		Running bool   `json:"Running"`
+		Status  string `json:"Status"`
+		Pid     int    `json:"Pid"`
+	}{Running: false, Status: "restarting"}
+	if got := containerStatus(in); got != models.SandboxStatusError {
+		t.Fatalf("containerStatus(restarting) = %q, want error", got)
+	}
+}
+
+func TestRefreshTagMissingRepo(t *testing.T) {
+	c := &Client{}
+	if err := c.RefreshTag(context.Background(), ""); err == nil {
+		t.Fatal("RefreshTag(\"\") expected missing-repo error")
+	}
+}
+
+func TestNewDefaultSocketNoPullCap(t *testing.T) {
+	// No DOCKER_HOST → default socket path; ImagePullMaxConcurrent=0 → nil slots.
+	t.Setenv("DOCKER_HOST", "")
+	c, err := New(slog.Default(), config.Config{ToolboxBinaryPath: "/usr/local/bin/toolboxd"}, disabledRules(t))
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+	if c.socketPath != "/var/run/docker.sock" {
+		t.Fatalf("socketPath = %q", c.socketPath)
+	}
+	if c.pullSlots != nil {
+		t.Fatalf("pullSlots should be nil when no concurrency cap set")
+	}
+}
+
+func TestNewDialsConfiguredSocket(t *testing.T) {
+	// Point New at a real unix socket so the transport's DialContext closure
+	// runs on the first request, exercising the wiring end-to-end.
+	sock := filepath.Join(t.TempDir(), "docker.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})}
+	go srv.Serve(ln)
+	t.Cleanup(func() { _ = srv.Close() })
+
+	t.Setenv("DOCKER_HOST", "unix://"+sock)
+	c, err := New(slog.Default(), config.Config{ToolboxBinaryPath: "/usr/local/bin/toolboxd", HTTPClientTimeout: 2 * time.Second}, disabledRules(t))
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+	if err := c.Ping(context.Background()); err != nil {
+		t.Fatalf("Ping() over configured socket = %v", err)
+	}
+}
+
+func TestDoRequestSetsCustomHeaders(t *testing.T) {
+	var gotHeader string
+	c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		gotHeader = r.Header.Get("X-Test")
+		return textResponse(http.StatusOK, "{}"), nil
+	})}}
+	resp, err := c.doRequest(context.Background(), http.MethodGet, "/x", nil, nil, map[string]string{"X-Test": "yes"})
+	if err != nil {
+		t.Fatalf("doRequest() = %v", err)
+	}
+	resp.Body.Close()
+	if gotHeader != "yes" {
+		t.Fatalf("custom header not set, got %q", gotHeader)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// waitForRuntime → waitForToolbox error path
+// ---------------------------------------------------------------------------
+
+func TestWaitForRuntimeToolboxUnhealthy(t *testing.T) {
+	ip, port, closeFn := toolboxServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	defer closeFn()
+	c := &Client{
+		httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusOK, inspectBody("cid", "/sb", ip, true, "running", 1)), nil
+		})},
+		toolboxClient:      &http.Client{Timeout: time.Second},
+		toolboxPort:        port,
+		waitTimeout:        time.Second,
+		toolboxWaitTimeout: 250 * time.Millisecond,
+	}
+	if _, err := c.waitForRuntime(context.Background(), "cid"); err == nil {
+		t.Fatal("waitForRuntime() expected toolbox-unhealthy error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// pullImage error branches (transport / status / decode)
+// ---------------------------------------------------------------------------
+
+func newPullClient(rt roundTripFunc) *Client {
+	return &Client{
+		logger:       slog.Default(),
+		streamClient: &http.Client{Transport: rt},
+		httpClient:   &http.Client{Transport: rt},
+		pulls:        map[string]*imagePull{},
+		pullFailures: map[string]imagePullFailure{},
+	}
+}
+
+func TestPullImageErrorBranches(t *testing.T) {
+	t.Run("transport_error", func(t *testing.T) {
+		c := newPullClient(func(*http.Request) (*http.Response, error) { return nil, io.ErrUnexpectedEOF })
+		if err := c.pullImage(context.Background(), "busybox:latest", nil); err == nil {
+			t.Fatal("pullImage() expected transport error")
+		}
+	})
+	t.Run("status_error", func(t *testing.T) {
+		c := newPullClient(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusUnauthorized, "denied"), nil
+		})
+		if err := c.pullImage(context.Background(), "busybox:latest", nil); err == nil {
+			t.Fatal("pullImage() expected status error")
+		}
+	})
+	t.Run("decode_error", func(t *testing.T) {
+		c := newPullClient(func(*http.Request) (*http.Response, error) { return textResponse(http.StatusOK, `{bad json`), nil })
+		if err := c.pullImage(context.Background(), "busybox:latest", nil); err == nil {
+			t.Fatal("pullImage() expected decode error")
+		}
+	})
+	t.Run("stream_reports_error_field", func(t *testing.T) {
+		c := newPullClient(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusOK, `{"error":"nope"}`), nil
+		})
+		if err := c.pullImage(context.Background(), "busybox:latest", nil); err == nil {
+			t.Fatal("pullImage() expected stream error field")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// aliasMirrorPull: tag failure surfaces; digest ref is skipped
+// ---------------------------------------------------------------------------
+
+func TestAliasMirrorPull(t *testing.T) {
+	t.Run("tag_failure_propagates", func(t *testing.T) {
+		// Mirror rewrite fires for ghcr.io; pull succeeds (EOF) then the alias
+		// retag (/tag) fails with 500 → pullImage returns that error.
+		c := newPullClient(func(r *http.Request) (*http.Response, error) {
+			if strings.HasSuffix(r.URL.Path, "/tag") {
+				return textResponse(http.StatusInternalServerError, "boom"), nil
+			}
+			return textResponse(http.StatusOK, `{"status":"done"}`), nil
+		})
+		c.ConfigureMirror(defaultMirrorCfg(), nil)
+		if err := c.pullImage(context.Background(), "ghcr.io/aerol-ai/sandbox:v1", nil); err == nil {
+			t.Fatal("pullImage() expected alias retag error")
+		}
+	})
+
+	t.Run("digest_ref_skips_alias", func(t *testing.T) {
+		rewrite := MirrorRewrite{Rewritten: true, OriginalRef: "ghcr.io/x@sha256:abc"}
+		c := &Client{}
+		if err := c.aliasMirrorPull(context.Background(), rewrite); err != nil {
+			t.Fatalf("aliasMirrorPull(digest) = %v", err)
+		}
+	})
+
+	t.Run("not_rewritten_noop", func(t *testing.T) {
+		c := &Client{}
+		if err := c.aliasMirrorPull(context.Background(), MirrorRewrite{Rewritten: false}); err != nil {
+			t.Fatalf("aliasMirrorPull(noop) = %v", err)
+		}
+	})
+
+	t.Run("empty_repo_skips_alias", func(t *testing.T) {
+		// An OriginalRef that splitDestRef resolves to an empty repo (":v1")
+		// short-circuits before any /tag call.
+		c := &Client{}
+		if err := c.aliasMirrorPull(context.Background(), MirrorRewrite{Rewritten: true, OriginalRef: ":v1"}); err != nil {
+			t.Fatalf("aliasMirrorPull(empty repo) = %v", err)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// pullImageDedup: ctx-done on wait, slot acquire error, slot release
+// ---------------------------------------------------------------------------
+
+func TestPullImageDedupContextDoneWhileWaiting(t *testing.T) {
+	release := make(chan struct{})
+	c := newPullClient(func(*http.Request) (*http.Response, error) {
+		<-release
+		return textResponse(http.StatusOK, `{"status":"done"}`), nil
+	})
+	c.pullBackoff = time.Minute
+
+	// First caller occupies the in-flight slot and blocks on release.
+	go func() { _ = c.pullImageDedup(context.Background(), "busybox:latest", nil) }()
+	for deadline := time.Now().Add(time.Second); ; {
+		c.pullMu.Lock()
+		n := len(c.pulls)
+		c.pullMu.Unlock()
+		if n > 0 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Second caller waits on the same in-flight pull but its ctx is cancelled.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := c.pullImageDedup(ctx, "busybox:latest", nil); err == nil {
+		t.Fatal("pullImageDedup() expected ctx cancellation while waiting")
+	}
+	close(release)
+}
+
+func TestPullImageDedupSlotAcquireError(t *testing.T) {
+	c := newPullClient(func(*http.Request) (*http.Response, error) {
+		return textResponse(http.StatusOK, `{"status":"done"}`), nil
+	})
+	c.pullSlots = make(chan struct{}, 1)
+	c.pullSlots <- struct{}{} // saturate so acquire blocks
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := c.pullImageDedup(ctx, "busybox:latest", nil); err == nil {
+		t.Fatal("pullImageDedup() expected slot-acquire ctx error")
+	}
+}
+
+func TestPullImageDedupAcquiresAndReleasesSlot(t *testing.T) {
+	c := newPullClient(func(*http.Request) (*http.Response, error) {
+		return textResponse(http.StatusOK, `{"status":"done"}`), nil
+	})
+	c.pullSlots = make(chan struct{}, 1) // empty → acquire succeeds, then releases
+	if err := c.pullImageDedup(context.Background(), "busybox:latest", nil); err != nil {
+		t.Fatalf("pullImageDedup() = %v", err)
+	}
+	if len(c.pullSlots) != 0 {
+		t.Fatalf("slot not released, len = %d", len(c.pullSlots))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Backoff bookkeeping internals
+// ---------------------------------------------------------------------------
+
+func TestPullBackoffFailureLockedExpiry(t *testing.T) {
+	c := &Client{pullBackoff: time.Minute, pullFailures: map[string]imagePullFailure{}}
+	key := "k"
+	c.pullFailures[key] = imagePullFailure{err: io.EOF, retryAt: time.Now().Add(-time.Minute)}
+	failure, blocked := c.pullBackoffFailureLocked(key, time.Now())
+	if blocked {
+		t.Fatalf("expired entry should not block: %+v", failure)
+	}
+	if _, ok := c.pullFailures[key]; ok {
+		t.Fatal("expired entry should be deleted")
+	}
+}
+
+func TestRecordPullFailureLocked(t *testing.T) {
+	t.Run("nil_map_init_and_store", func(t *testing.T) {
+		c := &Client{pullBackoff: time.Minute} // pullFailures nil
+		c.recordPullFailureLocked("k", io.ErrUnexpectedEOF)
+		if _, ok := c.pullFailures["k"]; !ok {
+			t.Fatal("expected failure recorded after nil-map init")
+		}
+	})
+	t.Run("context_canceled_deletes", func(t *testing.T) {
+		c := &Client{pullBackoff: time.Minute, pullFailures: map[string]imagePullFailure{"k": {}}}
+		c.recordPullFailureLocked("k", context.Canceled)
+		if _, ok := c.pullFailures["k"]; ok {
+			t.Fatal("context.Canceled should not be recorded as a failure")
+		}
+	})
+	t.Run("nil_err_clears", func(t *testing.T) {
+		c := &Client{pullBackoff: time.Minute, pullFailures: map[string]imagePullFailure{"k": {}}}
+		c.recordPullFailureLocked("k", nil)
+		if _, ok := c.pullFailures["k"]; ok {
+			t.Fatal("nil error should clear prior failure")
+		}
+	})
+}
+
+func TestPruneExpiredPullFailuresLocked(t *testing.T) {
+	now := time.Now()
+	t.Run("zero_budget_noop", func(t *testing.T) {
+		failures := map[string]imagePullFailure{"k": {retryAt: now.Add(-time.Hour)}}
+		pruneExpiredPullFailuresLocked(failures, now, 0)
+		if len(failures) != 1 {
+			t.Fatal("zero budget must not prune")
+		}
+	})
+	t.Run("budget_caps_deletions", func(t *testing.T) {
+		failures := map[string]imagePullFailure{
+			"a": {retryAt: now.Add(-time.Hour)},
+			"b": {retryAt: now.Add(-time.Hour)},
+			"c": {retryAt: now.Add(time.Hour)}, // not expired
+		}
+		pruneExpiredPullFailuresLocked(failures, now, 1)
+		// Exactly one expired entry removed; the future one stays.
+		if len(failures) != 2 {
+			t.Fatalf("expected one deletion under budget=1, len=%d", len(failures))
+		}
+		if _, ok := failures["c"]; !ok {
+			t.Fatal("non-expired entry must survive")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Pull-slot acquire/release edge cases
+// ---------------------------------------------------------------------------
+
+func TestAcquirePullSlotQueuedThenAcquires(t *testing.T) {
+	c := &Client{pullSlots: make(chan struct{}, 1)}
+	c.pullSlots <- struct{}{} // full → first select default, fall into queued select
+
+	acquired := make(chan bool, 1)
+	go func() {
+		ok, err := c.acquirePullSlot(context.Background())
+		if err == nil && ok {
+			c.releasePullSlot()
+		}
+		acquired <- ok
+	}()
+
+	// Let the goroutine reach the blocking queued select, then free a slot.
+	time.Sleep(50 * time.Millisecond)
+	<-c.pullSlots
+	select {
+	case ok := <-acquired:
+		if !ok {
+			t.Fatal("expected queued acquire to succeed")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("queued acquire did not complete")
+	}
+}
+
+func TestReleasePullSlotVariants(t *testing.T) {
+	// nil slots → no-op.
+	(&Client{}).releasePullSlot()
+	// empty (non-nil) slots → default branch, no panic.
+	(&Client{pullSlots: make(chan struct{}, 1)}).releasePullSlot()
+	// held slot → received.
+	c := &Client{pullSlots: make(chan struct{}, 1)}
+	c.pullSlots <- struct{}{}
+	c.releasePullSlot()
+	if len(c.pullSlots) != 0 {
+		t.Fatal("held slot should have been released")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// decodePushStream: decode error + plain error field
+// ---------------------------------------------------------------------------
+
+func TestDecodePushStreamErrors(t *testing.T) {
+	if err := decodePushStream(strings.NewReader(`{bad json`), nil, nil); err == nil {
+		t.Fatal("decodePushStream() expected decode error")
+	}
+	if err := decodePushStream(strings.NewReader(`{"error":"denied"}`), nil, nil); err == nil {
+		t.Fatal("decodePushStream() expected error field")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PushImage extra branches: missing repo, untag warn, transport error
+// ---------------------------------------------------------------------------
+
+func TestPushImageExtraBranches(t *testing.T) {
+	auth := models.RegistryAuth{Username: "u", Password: "p"}
+
+	t.Run("dest_missing_repository", func(t *testing.T) {
+		c := &Client{logger: slog.Default()}
+		// ":v1" → splitDestRef yields an empty repo.
+		if _, err := c.PushImage(context.Background(), PushImageRequest{SourceTag: "s", DestRef: ":v1", Auth: auth}); err == nil {
+			t.Fatal("PushImage() expected missing-repository error")
+		}
+	})
+
+	t.Run("untag_warn_on_remove_failure", func(t *testing.T) {
+		// tag (POST) succeeds, push succeeds, untag (DELETE) fails → warn branch.
+		c := &Client{
+			logger: slog.Default(),
+			httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				if r.Method == http.MethodDelete {
+					return textResponse(http.StatusInternalServerError, "boom"), nil
+				}
+				return textResponse(http.StatusOK, "{}"), nil
+			})},
+			streamClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return textResponse(http.StatusOK, `{"status":"Pushed"}`), nil
+			})},
+		}
+		if _, err := c.PushImage(context.Background(), PushImageRequest{SourceTag: "s:latest", DestRef: "ghcr.io/o/i:v1", Auth: auth}); err != nil {
+			t.Fatalf("PushImage() = %v (warn path should not fail the push)", err)
+		}
+	})
+
+	t.Run("push_transport_error", func(t *testing.T) {
+		c := &Client{
+			logger:     slog.Default(),
+			httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) { return textResponse(http.StatusOK, "{}"), nil })},
+			streamClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return nil, io.ErrUnexpectedEOF
+			})},
+		}
+		if _, err := c.PushImage(context.Background(), PushImageRequest{SourceTag: "s:latest", DestRef: "ghcr.io/o/i:v1", Auth: auth}); err == nil {
+			t.Fatal("PushImage() expected push transport error")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// assembleBuildContext: non-zero tar trailer (not stripped)
+// ---------------------------------------------------------------------------
+
+func TestAssembleBuildContextNonZeroTrailer(t *testing.T) {
+	// 1024 trailing bytes that are NOT all zero → the strip is skipped, the
+	// extra is concatenated verbatim, and our Dockerfile is appended.
+	extra := make([]byte, 1100)
+	for i := range extra {
+		extra[i] = 0x41 // 'A'
+	}
+	out, err := assembleBuildContext("FROM scratch\n", extra)
+	if err != nil {
+		t.Fatalf("assembleBuildContext() = %v", err)
+	}
+	if len(out) <= len(extra) {
+		t.Fatalf("expected Dockerfile appended after extra, len=%d", len(out))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ExportImageTar transport error
+// ---------------------------------------------------------------------------
+
+func TestExportImageTarTransportError(t *testing.T) {
+	c := &Client{logger: slog.Default(), streamClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, io.ErrUnexpectedEOF
+	})}}
+	if _, err := c.ExportImageTar(context.Background(), "img:v1"); err == nil {
+		t.Fatal("ExportImageTar() expected transport error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ImportImage extra branches: missing repo, transport error, stream errors
+// ---------------------------------------------------------------------------
+
+func TestImportImageExtraBranches(t *testing.T) {
+	t.Run("dest_missing_repository", func(t *testing.T) {
+		c := &Client{}
+		if err := c.ImportImage(context.Background(), ImportImageRequest{DestTag: ":v1", Tar: strings.NewReader("x")}); err == nil {
+			t.Fatal("ImportImage() expected missing-repository error")
+		}
+	})
+	t.Run("transport_error", func(t *testing.T) {
+		c := &Client{streamClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, io.ErrUnexpectedEOF
+		})}}
+		if err := c.ImportImage(context.Background(), ImportImageRequest{DestTag: "repo/img:v1", Tar: strings.NewReader("x")}); err == nil {
+			t.Fatal("ImportImage() expected transport error")
+		}
+	})
+	t.Run("decode_error", func(t *testing.T) {
+		c := &Client{streamClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusOK, `{bad json`), nil
+		})}}
+		if err := c.ImportImage(context.Background(), ImportImageRequest{DestTag: "repo/img:v1", Tar: strings.NewReader("x")}); err == nil {
+			t.Fatal("ImportImage() expected decode error")
+		}
+	})
+	t.Run("stream_error_field", func(t *testing.T) {
+		c := &Client{streamClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return textResponse(http.StatusOK, `{"error":"import failed"}`), nil
+		})}}
+		if err := c.ImportImage(context.Background(), ImportImageRequest{DestTag: "repo/img:v1", Tar: strings.NewReader("x")}); err == nil {
+			t.Fatal("ImportImage() expected stream error field")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ContainerStats error branch
+// ---------------------------------------------------------------------------
+
+func TestContainerStatsError(t *testing.T) {
+	c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return textResponse(http.StatusInternalServerError, "boom"), nil
+	})}}
+	if _, err := c.ContainerStats(context.Background(), "cid"); err == nil {
+		t.Fatal("ContainerStats() expected error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ExecStart: response read failure (server closes after reading request)
+// ---------------------------------------------------------------------------
+
+func TestExecStartReadResponseError(t *testing.T) {
+	sock := execSocketServer(t, "") // server reads then closes without responding
+	c := &Client{socketPath: sock}
+	if _, err := c.ExecStart(context.Background(), "exec-1", false); err == nil {
+		t.Fatal("ExecStart() expected read-response error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// mirror_rewrite: empty repo after host → passthrough
+// ---------------------------------------------------------------------------
+
+func TestRewriteImageRefForMirrorEmptyRepo(t *testing.T) {
+	cfg := defaultMirrorCfg()
+	for _, ref := range []string{"ghcr.io/", "ghcr.io/:tag"} {
+		got := RewriteImageRefForMirror(ref, cfg)
+		if got.Rewritten {
+			t.Fatalf("RewriteImageRefForMirror(%q) should pass through, got %+v", ref, got)
+		}
+	}
+}
+
+// keep imports referenced regardless of branch edits.
+var (
+	_ = net.Dial
+	_ = secrets.IdentityTokenPrefix
+)

--- a/pkg/docker/netstats/poller_extra_coverage_test.go
+++ b/pkg/docker/netstats/poller_extra_coverage_test.go
@@ -1,0 +1,65 @@
+package netstats
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"testing/fstest"
+	"time"
+)
+
+func TestNewReader(t *testing.T) {
+	if NewReader() == nil {
+		t.Fatal("NewReader returned nil")
+	}
+}
+
+func TestNonNegative(t *testing.T) {
+	if nonNegative(-5) != 0 {
+		t.Fatal("negative should clamp to 0")
+	}
+	if nonNegative(7) != 7 {
+		t.Fatal("positive should pass through")
+	}
+}
+
+func TestPollerStartRejectsNonPositiveInterval(t *testing.T) {
+	p := NewPoller(slog.Default(), NewReaderFS(fstest.MapFS{}), &fakeLookup{}, &fakeLister{}, &fakeSink{}, 0)
+	if err := p.Start(context.Background()); err == nil {
+		t.Fatal("Start should reject interval <= 0")
+	}
+}
+
+func TestPollerStartRunsAndStops(t *testing.T) {
+	mfs := fstest.MapFS{
+		"100/net/dev": &fstest.MapFile{Data: []byte(sampleProcNetDev)},
+	}
+	reader := NewReaderFS(mfs)
+	lookup := &fakeLookup{pids: map[string]int{"sb-1": 100}}
+	lister := &fakeLister{targets: []Target{{SandboxID: "sb-1", ContainerRef: "sb-1"}}}
+	sink := &fakeSink{}
+
+	p := NewPoller(slog.Default(), reader, lookup, lister, sink, 5*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := p.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Give the run loop time to fire at least one tick.
+	deadline := time.After(2 * time.Second)
+	for {
+		sink.mu.Lock()
+		n := len(sink.batches)
+		sink.mu.Unlock()
+		if n > 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			cancel()
+			t.Fatal("poll loop never produced a sample")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	cancel()
+}

--- a/pkg/mounts/manager_helpers_coverage_test.go
+++ b/pkg/mounts/manager_helpers_coverage_test.go
@@ -1,0 +1,49 @@
+package mounts
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/mounts/adapters"
+)
+
+func TestWriteCredFileAndCleanup(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "cred.json")
+
+	if err := writeCredFile(path, []byte("secret")); err != nil {
+		t.Fatalf("writeCredFile: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat cred: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("cred mode = %v, want 0600", info.Mode().Perm())
+	}
+
+	// cleanupCred removes the file; second call is a no-op.
+	m := &Manager{}
+	m.cleanupCred(adapters.Plan{CredFile: path})
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("cred file should be removed, stat err = %v", err)
+	}
+	m.cleanupCred(adapters.Plan{CredFile: path}) // no panic on missing file
+	m.cleanupCred(adapters.Plan{})               // empty CredFile is a no-op
+}
+
+func TestWaitForMountTimesOut(t *testing.T) {
+	dir := t.TempDir()
+	// A path that never becomes a distinct mount point times out quickly.
+	if err := waitForMount(filepath.Join(dir, "never"), 250*time.Millisecond); err == nil {
+		t.Fatal("waitForMount should time out for a non-mount path")
+	}
+}
+
+func TestKillMountNil(t *testing.T) {
+	if err := killMount(nil); err != nil {
+		t.Fatalf("killMount(nil) = %v, want nil", err)
+	}
+}

--- a/scripts/load/ingress_churn_coverage_test.go
+++ b/scripts/load/ingress_churn_coverage_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// configureFlags points the package-level flag vars at a test server.
+func configureFlags(t *testing.T, baseURL string) {
+	t.Helper()
+	*apiURL = baseURL
+	*patToken = "test-pat"
+	*imageRef = "alpine:3.19"
+	*probeTimeout = time.Second
+}
+
+func TestCreateAndDestroySandbox(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/sandboxes":
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(createResponse{ID: "sb-load", PublicURL: "http://" + r.Host + "/ingress"})
+		case r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+	configureFlags(t, srv.URL)
+
+	id, _, status, err := createSandbox()
+	if err != nil || id != "sb-load" || status != http.StatusCreated {
+		t.Fatalf("createSandbox = %q, %d, %v", id, status, err)
+	}
+
+	dstatus, err := destroySandbox(id)
+	if err != nil || dstatus != http.StatusNoContent {
+		t.Fatalf("destroySandbox = %d, %v", dstatus, err)
+	}
+}
+
+func TestCreateSandboxErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	configureFlags(t, srv.URL)
+
+	_, _, status, err := createSandbox()
+	if err == nil || status != http.StatusInternalServerError {
+		t.Fatalf("expected 500 error, got status=%d err=%v", status, err)
+	}
+}
+
+func TestProbeIngress(t *testing.T) {
+	// Empty URL short-circuits.
+	if status, lag := probeIngress(""); status != 0 || lag != 0 {
+		t.Fatalf("probeIngress(empty) = %d, %v", status, lag)
+	}
+
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		if hits < 2 {
+			w.WriteHeader(http.StatusServiceUnavailable) // in-flux
+			return
+		}
+		w.WriteHeader(http.StatusOK) // converged
+	}))
+	defer srv.Close()
+	configureFlags(t, srv.URL)
+
+	status, lag := probeIngress(srv.URL)
+	if status != http.StatusOK {
+		t.Fatalf("probeIngress status = %d, want 200", status)
+	}
+	if lag <= 0 {
+		t.Fatalf("expected positive convergence lag, got %v", lag)
+	}
+}
+
+func TestRunOnce(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(createResponse{ID: "sb-run", PublicURL: "http://" + r.Host + "/x"})
+		case r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+	configureFlags(t, srv.URL)
+
+	samples := make(chan sample, 8)
+	runOnce(samples)
+	close(samples)
+
+	ops := map[string]bool{}
+	for s := range samples {
+		ops[s.op] = true
+	}
+	for _, want := range []string{"create", "probe", "destroy"} {
+		if !ops[want] {
+			t.Fatalf("runOnce missing %q sample; got %v", want, ops)
+		}
+	}
+}

--- a/sdk/go/internal/apiclient/coverage_extra_test.go
+++ b/sdk/go/internal/apiclient/coverage_extra_test.go
@@ -1,0 +1,106 @@
+package apiclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func TestSandboxCustomDomainWrappers(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost, http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"custom_domains": []models.CustomDomain{{
+					Hostname:  "api.acme.com",
+					Status:    models.CustomDomainPendingDNS,
+					CreatedAt: time.Now().UTC(),
+					UpdatedAt: time.Now().UTC(),
+				}},
+			})
+		case http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, ClientOptions{PATToken: "pat", HTTPClient: server.Client()})
+	sb := &Sandbox{Sandbox: models.Sandbox{ID: "sb1"}, client: client}
+
+	domains, err := sb.AddCustomDomain(ctx, "api.acme.com", 0)
+	if err != nil || len(domains) != 1 {
+		t.Fatalf("AddCustomDomain = %v, %v", domains, err)
+	}
+	listed, err := sb.ListCustomDomains(ctx)
+	if err != nil || len(listed) != 1 {
+		t.Fatalf("ListCustomDomains = %v, %v", listed, err)
+	}
+	if err := sb.RemoveCustomDomain(ctx, "api.acme.com"); err != nil {
+		t.Fatalf("RemoveCustomDomain = %v", err)
+	}
+}
+
+func TestIsTransientTransportError(t *testing.T) {
+	if isTransientTransportError(nil) {
+		t.Fatal("nil should not be transient")
+	}
+	if isTransientTransportError(context.Canceled) {
+		t.Fatal("context.Canceled should not be transient")
+	}
+	if !isTransientTransportError(context.DeadlineExceeded) {
+		t.Fatal("DeadlineExceeded should be transient")
+	}
+	for _, msg := range []string{"connection refused", "connection reset by peer", "unexpected EOF", "broken pipe", "i/o timeout"} {
+		if !isTransientTransportError(errors.New(msg)) {
+			t.Fatalf("%q should be transient", msg)
+		}
+	}
+	if isTransientTransportError(errors.New("some unrelated error")) {
+		t.Fatal("unrelated error should not be transient")
+	}
+}
+
+func TestIsRetryableStatusCode(t *testing.T) {
+	for _, code := range []int{http.StatusTooManyRequests, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout} {
+		if !isRetryableStatusCode(code) {
+			t.Fatalf("%d should be retryable", code)
+		}
+	}
+	for _, code := range []int{http.StatusOK, http.StatusBadRequest, http.StatusNotFound, http.StatusInternalServerError} {
+		if isRetryableStatusCode(code) {
+			t.Fatalf("%d should not be retryable", code)
+		}
+	}
+}
+
+func TestDoWithRetryRecoversAfter503(t *testing.T) {
+	ctx := context.Background()
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(models.Sandbox{ID: "sb1", Status: models.SandboxStatusStarted})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, ClientOptions{PATToken: "pat", HTTPClient: server.Client()})
+	// GetSandbox flows through doWithRetry; the first 503 should be retried.
+	if _, err := client.Get(ctx, "sb1"); err != nil {
+		t.Fatalf("GetSandbox after retry: %v", err)
+	}
+	if calls < 2 {
+		t.Fatalf("expected a retry, got %d calls", calls)
+	}
+}


### PR DESCRIPTION
- Implement tests for query values handling, container status evaluation, and tag refreshing.
- Validate socket configuration and HTTP request header settings.
- Test error handling for toolbox health checks and image pulling processes.
- Cover edge cases for pull image deduplication and backoff mechanisms.
- Ensure proper handling of transport errors during image export and import operations.
- Add tests for container statistics retrieval and exec command execution.
- Include tests for mirror rewriting logic and Dockerfile assembly with non-zero trailers.

<!--
GitHub auto-fills new PR descriptions with this template. Fill in EVERY
section below. "N/A — <one-line reason>" is a valid answer; an empty answer
is not. See pr-review.md at the repo root for what each section is asking.
-->

## Summary

<!-- 1-3 bullets: what changed and why. -->

## Sandbox boot impact

<!--
Did this PR add ANY work — DB query, HTTP round-trip, file I/O, lock
acquisition — to CreateSandbox or anything it calls?

If yes: state what was added, expected added latency, when it fires, and
whether it's bounded. "Only on the first call" is still impact and must be
called out.

If no: write "N/A — no work added to sandbox boot path."
-->

## Idempotency

<!--
For every API surface this PR touches, describe behavior under retry and
under concurrent calls with the same inputs. Sandbox APIs MUST be
idempotent (see pr-review.md §1).

If no API surface changed: write "N/A — no API surface changed."
-->

## Failure-path consistency

<!--
For any multi-step write that touches BOTH caddy and the store: what is the
rollback rule on partial failure? Who cleans up if step 2 of 3 fails?

If no multi-step write path was changed: write "N/A — no multi-step write
path changed."
-->

## L4 / host-port-pool changes

<!--
Did this PR touch TryReserveHostPort, the partial unique index on
host_port, allocateHostPort, EnsureLayer4, EnsureLayer4Ready, or the
l4Ready latch? If yes, link the regression test that covers the change.

If no: write "N/A — neither touched."
-->

## Test plan

<!-- Bulleted checklist of how this was verified. -->
