### PR TITLE
refactor: reorganize Terraform configuration and enhance secret management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,9 @@ config/secrets.yml
 node_modules/
 sdk/typescript/node_modules
 docs/.astro/
-Terraform/terraform.tfvars
+# Shared Terraform tfvars (read by Terraform via scripts/terraform.sh).
+# The committed sibling is config/terraform.tfvars.example.
+config/terraform.tfvars
 # Python SDK artifacts
 sdk/python/__pycache__/
 sdk/python/.venv/
@@ -47,8 +49,8 @@ terraform.tfstate
 terraform.tfstate.backup
 terraform.rc
 .terraformrc
-# Auto-loaded var files often hold secrets. terraform.tfvars is already
-# ignored above; this catches *.auto.tfvars / *.auto.tfvars.json too.
+# Auto-loaded var files often hold secrets. config/terraform.tfvars is
+# already ignored above; this catches *.auto.tfvars / *.auto.tfvars.json too.
 *.auto.tfvars
 *.auto.tfvars.json
 .terraform.tfstate.lock.info

--- a/Terraform/README.md
+++ b/Terraform/README.md
@@ -1,6 +1,6 @@
 # AerolVM cluster on AWS - Terraform
 
-Spawns a complete AerolVM cluster on EC2 in one `terraform apply`:
+Spawns a complete AerolVM cluster on EC2 in one `scripts/terraform.sh apply`:
 
 - a VPC + public subnet + IGW + security group with the cluster-internal
   ports (`7000/TCP`, `7001/TCP+UDP`, `7002/TCP`) and public ingress
@@ -28,18 +28,38 @@ Spawns a complete AerolVM cluster on EC2 in one `terraform apply`:
 
 ## Quick start
 
+All cluster configuration lives under `config/` at the repo root. From the
+repo root:
+
 ```bash
-cp terraform.tfvars.example terraform.tfvars
-# edit Terraform/terraform.tfvars, config/cluster.yml, and config/secrets.yml
-terraform init
-terraform apply
+cp config/terraform.tfvars.example config/terraform.tfvars
+cp config/secrets.example.yml      config/secrets.yml
+# then edit:
+#   config/terraform.tfvars  -> AWS placement, instance sizing, node list
+#   config/cluster.yml       -> ingress.domain_name, ingress.acme_email, mirror/auto_import/...
+#   config/secrets.yml       -> cluster.pat_token, cloudflare.api_token, aocr.*, fleet.token
+scripts/terraform.sh init
+scripts/terraform.sh apply
 ```
 
-The split is intentional:
+> **Always invoke via `scripts/terraform.sh`**, not bare `terraform`. The
+> wrapper runs `terraform -chdir=Terraform` with
+> `-var-file=../config/terraform.tfvars`. Running `terraform` directly from
+> `Terraform/` will silently skip the tfvars file (which no longer sits on
+> Terraform's auto-load path) and produce an incomplete plan.
 
-- `Terraform/terraform.tfvars`: cloud and per-node Terraform inputs such as `cloudflare_api_token`, instance sizing, `nodes[*].with_firecracker`, and the optional `firecracker.*_url` artifact downloads.
-- `config/cluster.yml`: shared non-secret cluster config such as `ingress.domain_name` and `ingress.acme_email`.
-- `config/secrets.yml`: shared cluster secrets such as `cluster.pat_token`.
+### Where each value lives
+
+Three files, one rule: **non-secret day-0+day-2 SoT → `cluster.yml`,
+secrets → `secrets.yml`, Terraform-only inputs → `terraform.tfvars`**.
+
+| File | Contents | Tracked? |
+|---|---|---|
+| `config/terraform.tfvars` | Terraform-only inputs: `aws_region`, `aws_profile`, `ssh_key_name`, `default_*`, `nodes = {...}`, `firecracker = {...}`, `caddy_shared_cert_storage`, `cloudflare_zone_id`, `extra_tags`. | gitignored |
+| `config/terraform.tfvars.example` | Drop-in starter for the above. | committed |
+| `config/cluster.yml` | Shared non-secret cluster ops env both Terraform (day-0) and Ansible (day-2) read: `ingress.domain_name`, `ingress.acme_email`, `mirror.*`, `auto_import.*`, `fleet_control_plane.*`, `otel.*`, `image_pull.*`, `image_build_gc.*`. | committed |
+| `config/secrets.yml` | Shared cluster secrets both Terraform and Ansible read: `cluster.pat_token`, `cloudflare.api_token`, `aocr.upstream_wrap_key`, `aocr.cluster_pat`, `fleet.token`. | gitignored |
+| `config/secrets.example.yml` | Empty template for the above. | committed |
 
 Outputs include every node's public IP, the seed's SSH command, and the
 verify-cluster `curl`. They also include Prometheus scrape targets for
@@ -110,7 +130,7 @@ Each instance's `user_data` (rendered from
 phases:
 
 1. **`install.sh`** with `--pat-token <shared> --domain <domain_name>
-   --dns-provider cloudflare --dns-api-token <cloudflare_api_token>` so the
+   --dns-provider cloudflare --dns-api-token <cloudflare.api_token>` so the
    per-node Caddy gets a real wildcard cert via Let's Encrypt DNS-01. Optional
    `--with-gvisor` / `--with-nvidia-gpu` / `--with-amd-gpu` /
    `--idle-timeout-min` are appended from per-node flags. If `domain_name` is
@@ -149,7 +169,7 @@ making operators smuggle everything through `extra_user_data`.
 > **only** on node entries whose `instance_type` is a bare-metal SKU.
 
 1. Mark worker-capable nodes with `with_firecracker = true`.
-2. Fill the `firecracker` object in `terraform.tfvars`.
+2. Fill the `firecracker` object in `config/terraform.tfvars`.
 3. Choose one of two bootstrap modes:
 
 - **Artifact-download mode**: set `firecracker.binary_url`, `firecracker.jailer_url`, and `firecracker.kernel_url`. Terraform bootstrap installs `skopeo`, `umoci`, `e2fsprogs`, and `iproute2`, downloads those artifacts, writes the matching `SB_ENABLE_FIRECRACKER` / `SB_FIRECRACKER_*` env vars into `/etc/sandboxd/cluster.env`, and restarts `sandboxd`.
@@ -262,7 +282,10 @@ proxies HTTP(S); leave it `false` for raw TCP ingress.
 | `dns.tf`                    | Cloudflare A + wildcard records           |
 | `outputs.tf`                | Node summary, ingress IPs, SSH help       |
 | `templates/bootstrap.sh.tftpl` | Single user_data template (seed/joiner) |
-| `terraform.tfvars.example`  | Drop-in starter config                    |
+| `../config/terraform.tfvars.example` | Drop-in starter for `config/terraform.tfvars` (gitignored sibling) |
+| `../config/cluster.yml`     | Shared non-secret cluster ops env (Terraform + Ansible) |
+| `../config/secrets.example.yml` | Template for `config/secrets.yml` (gitignored sibling) |
+| `../scripts/terraform.sh`   | Wrapper — always invoke Terraform via this, not bare `terraform` |
 
 ## Connect this cluster to AOCR (mirror + auto-import)
 
@@ -332,7 +355,14 @@ group your imported tags under `cluster/<your-id>/_imported/...`. Pick once
 per cluster and never change it (changing it later orphans previously
 imported tags under the old namespace).
 
-### Step 2 - Add the `aocr` block to `terraform.tfvars`
+### Step 2 - Add the `aocr` block to `config/cluster.yml` + `config/secrets.yml`
+
+> **AOCR no longer lives in `terraform.tfvars`.** Non-secret AOCR config
+> (`mirror.host`, `auto_import.*`) sits in `config/cluster.yml` so both
+> Terraform and Ansible read it; AOCR secrets (`upstream_wrap_key`,
+> `cluster_pat`) sit in `config/secrets.yml`. The example block below shows
+> the shape — for the live keys see `config/cluster.yml` and
+> `config/secrets.example.yml`.
 
 ```hcl
 aocr = {
@@ -349,14 +379,14 @@ aocr = {
 }
 ```
 
-The whole variable is `sensitive = true`, so `terraform plan/apply` won't
-print the wrap key or PAT.
+`config/secrets.yml` is loaded through `sensitive(yamldecode(...))` in
+`locals.tf`, so `terraform plan/apply` won't print the wrap key or PAT.
 
 ### Step 3 - Apply
 
 ```bash
-terraform plan       # expect existing nodes to recycle; user_data changed
-terraform apply
+scripts/terraform.sh plan    # expect existing nodes to recycle; user_data changed
+scripts/terraform.sh apply
 ```
 
 `nodes.tf` sets `user_data_replace_on_change = true`, so existing EC2
@@ -415,16 +445,18 @@ warrant it. The full default set lives in `variables.tf`.
 ### TL;DR
 
 1. AOCR was deployed once; its secrets sit in `aocr.sh/secrets/`.
-2. Add the `aocr = { … }` block to `terraform.tfvars` with values copied
-   from those files plus a `cluster_id` you pick.
-3. `terraform apply` - nodes recycle, secrets land at `/etc/sandboxd/secrets/`,
-   sandboxd restarts wired to the mirror.
+2. Fill the `mirror.*` + `auto_import.*` blocks in `config/cluster.yml`, and
+   the `aocr.upstream_wrap_key` + `aocr.cluster_pat` keys in
+   `config/secrets.yml`, with values copied from those files plus an
+   `auto_import.cluster_id` you pick.
+3. `scripts/terraform.sh apply` - nodes recycle, secrets land at
+   `/etc/sandboxd/secrets/`, sandboxd restarts wired to the mirror.
 4. Verify with `grep` / `ls` on a node and `curl /v1/images` on AOCR.
 
 ## Tear-down
 
 ```bash
-terraform destroy
+scripts/terraform.sh destroy
 ```
 
 This deletes the VPC, instances, security group, IAM profiles, S3 bundle

--- a/Terraform/locals.tf
+++ b/Terraform/locals.tf
@@ -23,6 +23,13 @@ locals {
   custom_domain_txt_value_prefix = local.cluster_ops.ingress.custom_domain_txt_value_prefix
   pat_token                      = local.cluster_secrets.cluster.pat_token
 
+  # Cloudflare provider credential. Lives in config/secrets.yml under
+  # cloudflare.api_token (NOT in config/terraform.tfvars) so the rule
+  # "non-secret config in cluster.yml / terraform.tfvars, secrets in
+  # secrets.yml" holds uniformly. providers.tf reads this local; if the value
+  # is empty the precondition below fails at plan time.
+  cloudflare_api_token = local.cluster_secrets.cloudflare.api_token
+
   # Normalise each node entry with its effective values (per-node overrides
   # win, then var.default_*). Doing this once here keeps nodes.tf / dns.tf
   # readable.
@@ -228,6 +235,11 @@ resource "terraform_data" "validate_cluster_ops" {
     precondition {
       condition     = local.pat_token != ""
       error_message = "cluster.pat_token in config/secrets.yml must be set (shared SB_PAT_TOKEN used by every node for operator/SDK API auth)."
+    }
+
+    precondition {
+      condition     = local.cloudflare_api_token != ""
+      error_message = "cloudflare.api_token in config/secrets.yml must be set (Cloudflare token with Zone:DNS:Edit on the target zone; reused for Let's Encrypt DNS-01)."
     }
 
     precondition {

--- a/Terraform/nodes.tf
+++ b/Terraform/nodes.tf
@@ -46,7 +46,7 @@ resource "aws_instance" "seed" {
     custom_domain_txt_prefix                 = local.custom_domain_txt_prefix
     custom_domain_txt_value_prefix           = local.custom_domain_txt_value_prefix
     pat_token                                = local.pat_token
-    cloudflare_api_token                     = var.cloudflare_api_token
+    cloudflare_api_token                     = local.cloudflare_api_token
     acme_email                               = local.acme_email
     with_firecracker                         = local.seed_node.with_firecracker
     with_gvisor                              = local.seed_node.with_gvisor
@@ -193,7 +193,7 @@ resource "aws_instance" "joiner" {
     custom_domain_txt_prefix                 = local.custom_domain_txt_prefix
     custom_domain_txt_value_prefix           = local.custom_domain_txt_value_prefix
     pat_token                                = local.pat_token
-    cloudflare_api_token                     = var.cloudflare_api_token
+    cloudflare_api_token                     = local.cloudflare_api_token
     acme_email                               = local.acme_email
     with_firecracker                         = each.value.with_firecracker
     with_gvisor                              = each.value.with_gvisor

--- a/Terraform/providers.tf
+++ b/Terraform/providers.tf
@@ -15,5 +15,8 @@ provider "aws" {
 }
 
 provider "cloudflare" {
-  api_token = var.cloudflare_api_token
+  # Pulled from config/secrets.yml (cloudflare.api_token) via locals.tf —
+  # not from config/terraform.tfvars. Keeps every cluster secret in one
+  # gitignored file alongside cluster.pat_token, aocr.*, and fleet.token.
+  api_token = local.cloudflare_api_token
 }

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -375,18 +375,23 @@ variable "firecracker" {
 # Observability, image-pull controls, image-GC, mirror/auto-import config —
 # everything except secrets — lives in ../config/cluster.yml. That file is
 # the single source of truth both Terraform and Ansible read from, so
-# day-0 (terraform apply) and day-2 (configure-ops.yml) cannot drift.
-# See locals.tf:cluster_ops and resource.terraform_data.validate_cluster_ops.
+# day-0 (scripts/terraform.sh apply) and day-2 (configure-ops.yml) cannot
+# drift. See locals.tf:cluster_ops and
+# resource.terraform_data.validate_cluster_ops.
+#
+# Cluster SECRETS (pat_token, cloudflare api_token, aocr secrets, fleet
+# token) live in ../config/secrets.yml, also shared with Ansible. See
+# locals.tf:cluster_secrets.
 
 ###############################################################################
 # Cloudflare DNS
 ###############################################################################
 
-variable "cloudflare_api_token" {
-  description = "Cloudflare API token with Zone:DNS:Edit on the target zone."
-  type        = string
-  sensitive   = true
-}
+# cloudflare_api_token has moved to ../config/secrets.yml (cloudflare.api_token).
+# It's a real secret — the rest of secrets.yml holds cluster.pat_token,
+# aocr.*, and fleet.token, so the Cloudflare token belongs there too rather
+# than in the non-secret config/terraform.tfvars. providers.tf reads it via
+# local.cloudflare_api_token; locals.tf validates it is non-empty.
 
 variable "cloudflare_zone_id" {
   description = "Cloudflare zone ID for the apex domain (the 'region key' shown on the zone overview page). Leave empty to auto-resolve from domain_name (requires Zone:Read on the API token)."

--- a/config/cluster.yml
+++ b/config/cluster.yml
@@ -4,21 +4,23 @@
 # render its values into /etc/sandboxd/cluster.env on every node. Edit here,
 # then apply with EITHER tool — they produce the same env file contents:
 #
-#   - terraform apply                               # day-0 / re-provision
+#   - scripts/terraform.sh apply                    # day-0 / re-provision
 #   - ansible-playbook playbooks/configure-ops.yml  # day-2 / live rollout
 #
-# DO NOT put values in terraform.tfvars or Ansible local.yml that this file
-# already controls — the two tools would disagree on which to write and the
-# last one to run would silently clobber the other.
+# DO NOT put values in config/terraform.tfvars or Ansible local.yml that
+# this file already controls — the two tools would disagree on which to
+# write and the last one to run would silently clobber the other.
 #
 # Secrets split:
-#   - AOCR secrets (upstream wrap key, cluster PAT) live in ./secrets.yml,
-#     a parallel shared SoT also read by both Terraform and Ansible.
-#     Gitignored — bootstrap with `cp config/secrets.example.yml config/secrets.yml`.
-#   - Cloud creds (pat_token, cloudflare_api_token, ACME email, AWS profile)
-#     stay in Terraform/terraform.tfvars (Terraform-only — Ansible never
-#     re-provisions cloud infrastructure).
-# Those keys are intentionally NOT in this file.
+#   - All cluster secrets (cluster.pat_token, cloudflare.api_token, aocr.*,
+#     fleet.token) live in ./secrets.yml, a parallel shared SoT also read
+#     by both Terraform and Ansible. Gitignored — bootstrap with
+#     `cp config/secrets.example.yml config/secrets.yml`.
+#   - Terraform-only inputs that Ansible never sees (AWS placement,
+#     instance sizing, the node list, firecracker artifact URLs, the
+#     caddy shared-cert-storage block) live in ./terraform.tfvars
+#     (also gitignored; example in ./terraform.tfvars.example).
+# None of those keys belong in this file.
 
 # --- Cluster identity / public ingress ------------------------------------
 # domain_name is the hostname advertised as the cluster ingress. Both an A

--- a/config/secrets.example.yml
+++ b/config/secrets.example.yml
@@ -26,6 +26,19 @@ aocr:
   upstream_wrap_key: ""
   cluster_pat:       ""
 
+# --- Cloudflare DNS --------------------------------------------------------
+# api_token is the Cloudflare API token Terraform uses to manage DNS records
+# for the cluster (apex + optional wildcard) and that Caddy reuses for
+# Let's Encrypt DNS-01 challenges. Required: Zone:DNS:Edit on the target zone.
+# Add Zone:Read if you want auto-zone-lookup (leaving cloudflare_zone_id unset
+# in config/terraform.tfvars).
+#
+# This is a Terraform-provider credential, but it's a real secret — it must
+# never sit in config/terraform.tfvars (which is gitignored but still ends up
+# in plaintext on the operator's disk alongside non-secret topology values).
+cloudflare:
+  api_token: ""
+
 # --- Fleet control plane ---------------------------------------------------
 # token is the fleet credential (avm_<32hex>) sandboxd presents to the managed
 # control plane as a Bearer. Required when cluster.yml has

--- a/config/terraform.tfvars.example
+++ b/config/terraform.tfvars.example
@@ -1,17 +1,27 @@
 ###############################################################################
-# Copy to terraform.tfvars, fill in the four required values, then:
-#   terraform init && terraform apply
+# Copy to config/terraform.tfvars, then from the repo root:
+#   scripts/terraform.sh init
+#   scripts/terraform.sh apply
+#
+# scripts/terraform.sh runs `terraform -chdir=Terraform` and auto-loads this
+# file via -var-file=../config/terraform.tfvars. Don't run `terraform` directly
+# from Terraform/ — this file is no longer on Terraform's auto-load path.
 ###############################################################################
 
 # --- Required ---------------------------------------------------------------
 #
-# Cluster-wide values that both Terraform and Ansible read have moved out of
-# this file and into the shared SoT at ../config/:
-#   - pat_token              -> config/secrets.yml as cluster.pat_token
-#   - domain_name, acme_email -> config/cluster.yml under the ingress: section
-# Only the Terraform-provider credential (DNS API access) remains here.
-
-cloudflare_api_token = "REPLACE-with-cloudflare-api-token" # Zone:DNS:Edit on the target zone; reused for Let's Encrypt DNS-01. Add Zone:Read if you want auto-zone-lookup below.
+# All cluster-wide secrets live in the shared SoT at ../config/secrets.yml:
+#   - cluster.pat_token       (shared SB_PAT_TOKEN)
+#   - cloudflare.api_token    (Cloudflare DNS + Let's Encrypt DNS-01)
+#   - aocr.*                  (mirror auth + auto-import bearer)
+#   - fleet.token             (managed fleet control plane bearer)
+#
+# Non-secret cluster ops config (ingress.*, mirror.*, auto_import.*,
+# fleet_control_plane.*, otel.*, image_pull.*, image_build_gc.*) lives in the
+# shared SoT at ../config/cluster.yml.
+#
+# What remains in THIS file are Terraform-only inputs: AWS placement,
+# instance sizing, the node list, and a few tweakable Cloudflare DNS flags.
 
 # cloudflare_zone_id is optional. Leave it unset to auto-resolve the zone from
 # domain_name by stripping the first label ("cluster.example.com" -> "example.com").

--- a/scripts/terraform.sh
+++ b/scripts/terraform.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# terraform.sh — wrapper that runs Terraform with the right -chdir + var-file.
+#
+# Why this exists: the cluster's Terraform inputs (config/terraform.tfvars)
+# live OUTSIDE the Terraform/ module directory so all cluster config + secrets
+# sit in one place — alongside config/cluster.yml and config/secrets.yml.
+# Terraform only auto-loads terraform.tfvars from its working directory, so
+# every plan/apply needs an explicit -var-file. This wrapper injects it so
+# operators never have to remember the flag.
+#
+# Usage (from anywhere inside the repo):
+#   scripts/terraform.sh init
+#   scripts/terraform.sh plan
+#   scripts/terraform.sh apply
+#   scripts/terraform.sh destroy
+#   scripts/terraform.sh output -json
+#   scripts/terraform.sh state list
+#
+# Pass-through: every argument after the subcommand is forwarded verbatim.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TF_DIR="${REPO_ROOT}/Terraform"
+TFVARS="${REPO_ROOT}/config/terraform.tfvars"
+
+if ! command -v terraform >/dev/null 2>&1; then
+  echo "error: terraform not found on PATH" >&2
+  exit 127
+fi
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $(basename "$0") <terraform-subcommand> [args...]" >&2
+  echo "       wraps: terraform -chdir=${TF_DIR} <subcommand> [-var-file=${TFVARS}] [args...]" >&2
+  exit 2
+fi
+
+SUBCOMMAND="$1"
+shift
+
+# Subcommands that consume root-module variables. Everything else (init, fmt,
+# providers, version, output, state, workspace, ...) ignores -var-file and
+# Terraform refuses to accept it for those — so only inject when needed.
+needs_varfile=false
+case "$SUBCOMMAND" in
+  plan|apply|destroy|refresh|import|console|validate|taint|untaint|test)
+    needs_varfile=true
+    ;;
+esac
+
+# `terraform validate` does NOT need credentials/tfvars to typecheck the
+# module, and silently tolerates -var-file for parity with plan/apply. We pass
+# it through anyway so the same wrapper works for `validate -json` in CI.
+
+extra_args=()
+if $needs_varfile; then
+  if [[ ! -f "$TFVARS" ]]; then
+    cat >&2 <<EOF
+error: ${TFVARS} not found.
+
+Bootstrap with:
+  cp config/terraform.tfvars.example config/terraform.tfvars
+  # then edit it with your AWS placement, node list, etc.
+
+Cluster secrets (cluster.pat_token, cloudflare.api_token, aocr.*, fleet.token)
+live in config/secrets.yml — bootstrap from config/secrets.example.yml.
+EOF
+    exit 1
+  fi
+  extra_args+=("-var-file=${TFVARS}")
+fi
+
+exec terraform -chdir="$TF_DIR" "$SUBCOMMAND" "${extra_args[@]}" "$@"


### PR DESCRIPTION
This commit introduces several changes to improve the structure and security of the Terraform configuration:

- Updated `.gitignore` to include `config/terraform.tfvars` for better secret management.
- Moved `cloudflare_api_token` to `config/secrets.yml` to centralize sensitive information, ensuring it is not exposed in `terraform.tfvars`.
- Adjusted `locals.tf`, `providers.tf`, and `nodes.tf` to reference the new location of `cloudflare_api_token`.
- Enhanced the `README.md` and `variables.tf` to clarify the separation of secrets and non-secret configurations.
- Added a new `scripts/terraform.sh` wrapper to streamline Terraform commands and ensure proper loading of variable files.

These changes aim to improve security practices and maintainability of the Terraform setup.
