### PR TITLE
feat: authenticated AOCR pull for cluster snapshots + Firecracker templates

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -875,8 +875,13 @@ func configureMirror(logger *slog.Logger, cfg config.Config, c *docker.Client) {
 // never produces artifacts but must pull snapshots/templates on failover or
 // cross-node placement) still needs the pull credential. ConfigureAOCRPullAuth
 // is a no-op when cluster_id or the PAT path is unset, so a node with no AOCR
-// wiring keeps pulling anonymously exactly as before. This adds no per-create
-// latency — it sets node-local config once at boot.
+// wiring keeps pulling anonymously exactly as before.
+//
+// This call itself runs once at boot and adds nothing to the create path. The
+// only per-create cost it introduces lands later, in resolveAOCRPullAuth: a
+// single node-local PAT file read, and only on a cache-miss pull of an AOCR
+// `cluster/...` ref (warm pulls, non-AOCR refs, and caller-supplied creds all
+// skip it). The fresh read is deliberate — it makes PAT rotation a file write.
 func configureAOCRPullAuth(logger *slog.Logger, cfg config.Config, c *docker.Client) {
 	clusterID := strings.TrimSpace(cfg.AutoImportClusterID)
 	patPath := strings.TrimSpace(cfg.AutoImportClusterPATPath)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -155,6 +155,7 @@ func Run(ctx context.Context, logger *slog.Logger, makeProvider ProviderFactory)
 		return fmt.Errorf("create docker client: %w", err)
 	}
 	configureMirror(logger, cfg, dockerClient)
+	configureAOCRPullAuth(logger, cfg, dockerClient)
 
 	caddyClient := caddy.New(cfg)
 
@@ -862,6 +863,48 @@ func configureMirror(logger *slog.Logger, cfg config.Config, c *docker.Client) {
 		"upstreams", len(mcfg.Upstreams),
 		"wrap_key_loaded", ring != nil,
 	)
+}
+
+// configureAOCRPullAuth installs the cluster-PAT credential the docker client
+// uses to pull cluster-owned artifacts (snapshots + Firecracker templates) from
+// AOCR's `cluster/<id>/*` namespace. It reuses the same host/cluster/PAT config
+// as the producer-side snapshot and template pushers, so one credential covers
+// push and pull symmetrically.
+//
+// Deliberately independent of SnapshotPushEnabled: a consume-only node (one that
+// never produces artifacts but must pull snapshots/templates on failover or
+// cross-node placement) still needs the pull credential. ConfigureAOCRPullAuth
+// is a no-op when cluster_id or the PAT path is unset, so a node with no AOCR
+// wiring keeps pulling anonymously exactly as before. This adds no per-create
+// latency — it sets node-local config once at boot.
+func configureAOCRPullAuth(logger *slog.Logger, cfg config.Config, c *docker.Client) {
+	clusterID := strings.TrimSpace(cfg.AutoImportClusterID)
+	patPath := strings.TrimSpace(cfg.AutoImportClusterPATPath)
+	if clusterID == "" || patPath == "" {
+		return
+	}
+	// Cluster artifact refs target the AOCR push vhost (MirrorPushHost), with
+	// ImageDistributionAOCRHost as the fallback both pushers also use. Pass both
+	// so a ref under either host is recognized; ConfigureAOCRPullAuth dedups and
+	// drops empties.
+	hosts := []string{cfg.MirrorPushHost, cfg.ImageDistributionAOCRHost}
+	c.ConfigureAOCRPullAuth(hosts, clusterID, patPath)
+	logger.Info("aocr pull auth configured",
+		"cluster_id", clusterID,
+		"hosts", strings.Join(nonEmptyHosts(hosts), ","),
+	)
+}
+
+// nonEmptyHosts is a tiny log helper: it filters blank host entries so the
+// boot log line shows only the hosts actually in play.
+func nonEmptyHosts(hosts []string) []string {
+	out := make([]string, 0, len(hosts))
+	for _, h := range hosts {
+		if strings.TrimSpace(h) != "" {
+			out = append(out, h)
+		}
+	}
+	return out
 }
 
 // startAutoImportReconciler builds the F21 auto-import importer + reconciler

--- a/pkg/daemon/daemon_adapters_test.go
+++ b/pkg/daemon/daemon_adapters_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -15,6 +16,7 @@ import (
 	fcruntime "github.com/aerol-ai/microvm/internal/runtime/firecracker"
 	"github.com/aerol-ai/microvm/internal/service"
 	"github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/docker"
 	"github.com/aerol-ai/microvm/pkg/models"
 )
 
@@ -55,6 +57,27 @@ func TestDaemonReconcilerGuards_NoPanic(t *testing.T) {
 	attachTemplateArtifactPuller(logger, config.Config{EnableFirecracker: true, FirecrackerTemplatesDir: ""}, nil, nil)
 	startTemplateArtifactPushReconciler(ctx, logger, config.Config{EnableFirecracker: false, SnapshotPushEnabled: true}, nil, nil, nil)
 	startTemplateArtifactPushReconciler(ctx, logger, config.Config{EnableFirecracker: true, SnapshotPushEnabled: false}, nil, nil, nil)
+}
+
+func TestConfigureAOCRPullAuthGuard_NoPanic(t *testing.T) {
+	logger := testLogger()
+
+	// Empty config: must short-circuit before touching the client.
+	configureAOCRPullAuth(logger, config.Config{}, &docker.Client{})
+
+	// Fully configured: writes node-local pull auth onto the client. The
+	// behavior of the resolver itself is covered in pkg/docker; here we only
+	// assert the daemon wiring path runs cleanly.
+	patPath := filepath.Join(t.TempDir(), "cluster-pat")
+	if err := os.WriteFile(patPath, []byte("tok"), 0o600); err != nil {
+		t.Fatalf("write pat: %v", err)
+	}
+	configureAOCRPullAuth(logger, config.Config{
+		AutoImportClusterID:       "prod-aerolvm-us-east-1",
+		AutoImportClusterPATPath:  patPath,
+		MirrorPushHost:            "aocr.aerol.ai",
+		ImageDistributionAOCRHost: "aocr.aerol.ai",
+	}, &docker.Client{})
 }
 
 func TestAdaptTapSlot(t *testing.T) {

--- a/pkg/docker/aocr_pull_auth.go
+++ b/pkg/docker/aocr_pull_auth.go
@@ -54,7 +54,7 @@ func (c *Client) ConfigureAOCRPullAuth(hosts []string, clusterID, patPath string
 	normalized := make([]string, 0, len(hosts))
 	seen := make(map[string]struct{}, len(hosts))
 	for _, h := range hosts {
-		h = strings.ToLower(strings.TrimRight(strings.TrimSpace(h), "/"))
+		h = normalizeAOCRHost(h)
 		if h == "" {
 			continue
 		}
@@ -98,7 +98,7 @@ func (c *Client) resolveAOCRPullAuth(imageRef string) *models.RegistryAuth {
 	if host == "" {
 		return nil
 	}
-	if !slices.Contains(c.aocrPullAuth.hosts, strings.ToLower(host)) {
+	if !slices.Contains(c.aocrPullAuth.hosts, normalizeAOCRHost(host)) {
 		return nil
 	}
 	// Only the cluster-owned namespace is in scope for this credential; a
@@ -121,6 +121,28 @@ func (c *Client) resolveAOCRPullAuth(imageRef string) *models.RegistryAuth {
 		Username: c.aocrPullAuth.clusterID,
 		Password: pat,
 	}
+}
+
+// normalizeAOCRHost canonicalizes a registry host for comparison: trims space
+// and trailing slashes, lowercases, and drops an explicit default registry port
+// (`:443`/`:80`) so a configured `aocr.aerol.ai` still matches a ref written as
+// `aocr.aerol.ai:443/cluster/...`. A non-default port (e.g. `:5000`) is
+// significant and kept. IPv6 literals are bracketed (`[::1]:443`), so only the
+// final `:port` is treated as a port — `strings.LastIndex` after the last `]`.
+func normalizeAOCRHost(h string) string {
+	h = strings.ToLower(strings.TrimRight(strings.TrimSpace(h), "/"))
+	if h == "" {
+		return ""
+	}
+	// Find a port colon that isn't part of an IPv6 literal.
+	portColon := strings.LastIndexByte(h, ':')
+	if portColon > strings.LastIndexByte(h, ']') {
+		switch h[portColon+1:] {
+		case "443", "80":
+			h = h[:portColon]
+		}
+	}
+	return h
 }
 
 // readAOCRPATFile reads the bearer token from disk, trimming trailing

--- a/pkg/docker/aocr_pull_auth.go
+++ b/pkg/docker/aocr_pull_auth.go
@@ -1,0 +1,140 @@
+package docker
+
+import (
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// aocrClusterPullAuth is the node-local credential the daemon presents when
+// pulling cluster-owned artifacts (snapshots + Firecracker templates) from
+// AOCR. It mirrors the producer-side SnapshotPushConfig: the same cluster PAT
+// authorizes both push (snapshot_push.go / template_push.go) and pull, scoped
+// to the `cluster/<id>/*` namespace by AOCR's auth/src/clusterPat.ts.
+//
+// Why this lives on the Client rather than being threaded through every
+// caller: the two consumer paths that need it — the create-path pull of an
+// AOCR-distributed snapshot (client.go Create → pullImageDedup) and the
+// Firecracker template puller (export.go PullImage → pullImageDedup) — both
+// funnel through pullImageDedup with a nil RegistryAuth. Back-filling there in
+// one place keeps the credential out of the per-sandbox sealed-registry path
+// (it is node config, not user data, so it is never sealed or forwarded
+// cross-node) and reads the PAT fresh on every pull so rotation is a file
+// write — the exact contract the pushers already follow.
+type aocrClusterPullAuth struct {
+	// hosts are the registry vhosts whose `cluster/...` repos this credential
+	// applies to (typically the AOCR push host). Lowercased, trailing slash
+	// stripped. A ref whose host is not in this set is left untouched so the
+	// cluster PAT never leaks to an unrelated registry.
+	hosts []string
+	// clusterID is presented as the registry username. AOCR validates the PAT
+	// (the password), not the username, but the convention keeps logs and the
+	// `cluster/<id>/` path segment aligned.
+	clusterID string
+	// patPath is the file holding the bearer token presented as the registry
+	// password. Re-read on every resolve so rotation needs no restart; never
+	// logged.
+	patPath string
+}
+
+// ConfigureAOCRPullAuth installs the cluster-PAT pull credential onto an
+// existing Client. A no-op (leaves the feature off, pulls stay anonymous) when
+// clusterID or patPath is empty, or when no non-empty host is supplied —
+// matching the "consume-only node without AOCR creds" case where a public
+// registry needs no auth. Called once from main() after config load, alongside
+// ConfigureMirror.
+func (c *Client) ConfigureAOCRPullAuth(hosts []string, clusterID, patPath string) {
+	clusterID = strings.TrimSpace(clusterID)
+	patPath = strings.TrimSpace(patPath)
+	if clusterID == "" || patPath == "" {
+		return
+	}
+	normalized := make([]string, 0, len(hosts))
+	seen := make(map[string]struct{}, len(hosts))
+	for _, h := range hosts {
+		h = strings.ToLower(strings.TrimRight(strings.TrimSpace(h), "/"))
+		if h == "" {
+			continue
+		}
+		if _, dup := seen[h]; dup {
+			continue
+		}
+		seen[h] = struct{}{}
+		normalized = append(normalized, h)
+	}
+	if len(normalized) == 0 {
+		return
+	}
+	c.aocrPullAuth = &aocrClusterPullAuth{
+		hosts:     normalized,
+		clusterID: clusterID,
+		patPath:   patPath,
+	}
+}
+
+// resolveAOCRPullAuth returns the cluster-PAT credential for imageRef when the
+// ref targets a configured AOCR host under the `cluster/` namespace, and nil
+// otherwise. Returning nil leaves the pull anonymous — correct for public
+// images and for nodes that never configured AOCR pull auth.
+//
+// The PAT is read fresh from disk on each call; a read failure resolves to nil
+// (and a warning) rather than blocking the pull — an anonymous attempt that
+// 401s surfaces a clearer registry error than a half-applied credential.
+func (c *Client) resolveAOCRPullAuth(imageRef string) *models.RegistryAuth {
+	if c.aocrPullAuth == nil {
+		return nil
+	}
+	ref := strings.TrimSpace(imageRef)
+	if ref == "" {
+		return nil
+	}
+	// Strip any transport prefix (docker://, oci:, etc.) before splitting host.
+	if _, after, ok := strings.Cut(ref, "://"); ok {
+		ref = after
+	}
+	host, rest := splitHostRepo(ref)
+	if host == "" {
+		return nil
+	}
+	if !slices.Contains(c.aocrPullAuth.hosts, strings.ToLower(host)) {
+		return nil
+	}
+	// Only the cluster-owned namespace is in scope for this credential; a
+	// non-cluster repo on the same host (e.g. a user push) must not silently
+	// borrow the cluster PAT.
+	if rest != "cluster" && !strings.HasPrefix(rest, "cluster/") {
+		return nil
+	}
+
+	pat, err := readAOCRPATFile(c.aocrPullAuth.patPath)
+	if err != nil {
+		if c.logger != nil {
+			c.logger.Warn("aocr pull auth: read PAT failed; pulling anonymously",
+				"path", c.aocrPullAuth.patPath, "error", err)
+		}
+		return nil
+	}
+	return &models.RegistryAuth{
+		Server:   host,
+		Username: c.aocrPullAuth.clusterID,
+		Password: pat,
+	}
+}
+
+// readAOCRPATFile reads the bearer token from disk, trimming trailing
+// whitespace (newlines from `echo "..." > pat`) so an editor-written token is
+// not rejected by the registry. Mirrors service.readPATFile; duplicated here
+// to keep pkg/docker free of an internal/service import.
+func readAOCRPATFile(path string) (string, error) {
+	raw, err := os.ReadFile(strings.TrimSpace(path))
+	if err != nil {
+		return "", err
+	}
+	token := strings.TrimSpace(string(raw))
+	if token == "" {
+		return "", os.ErrInvalid
+	}
+	return token, nil
+}

--- a/pkg/docker/aocr_pull_auth_test.go
+++ b/pkg/docker/aocr_pull_auth_test.go
@@ -1,0 +1,128 @@
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writePAT writes a PAT file under a temp dir and returns its path.
+func writePAT(t *testing.T, token string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "cluster-pat")
+	if err := os.WriteFile(p, []byte(token), 0o600); err != nil {
+		t.Fatalf("write pat: %v", err)
+	}
+	return p
+}
+
+func TestResolveAOCRPullAuth_NilWhenUnconfigured(t *testing.T) {
+	c := &Client{}
+	if got := c.resolveAOCRPullAuth("aocr.aerol.ai/cluster/c1/templates/py311:latest"); got != nil {
+		t.Fatalf("expected nil auth when unconfigured, got %+v", got)
+	}
+}
+
+func TestResolveAOCRPullAuth_TemplatesAndSnapshots(t *testing.T) {
+	patPath := writePAT(t, "tok-123\n") // trailing newline must be trimmed
+	c := &Client{}
+	c.ConfigureAOCRPullAuth([]string{"aocr.aerol.ai", ""}, "prod-aerolvm-us-east-1", patPath)
+
+	for _, ref := range []string{
+		"aocr.aerol.ai/cluster/prod-aerolvm-us-east-1/templates/py311:latest",
+		"aocr.aerol.ai/cluster/prod-aerolvm-us-east-1/snapshots/py-ready:latest",
+	} {
+		got := c.resolveAOCRPullAuth(ref)
+		if got == nil {
+			t.Fatalf("expected auth for %q, got nil", ref)
+		}
+		if got.Server != "aocr.aerol.ai" {
+			t.Errorf("ref %q: Server = %q, want aocr.aerol.ai", ref, got.Server)
+		}
+		if got.Username != "prod-aerolvm-us-east-1" {
+			t.Errorf("ref %q: Username = %q, want cluster id", ref, got.Username)
+		}
+		if got.Password != "tok-123" {
+			t.Errorf("ref %q: Password = %q, want trimmed token", ref, got.Password)
+		}
+	}
+}
+
+func TestResolveAOCRPullAuth_ScopingRules(t *testing.T) {
+	patPath := writePAT(t, "tok")
+	c := &Client{}
+	c.ConfigureAOCRPullAuth([]string{"aocr.aerol.ai"}, "c1", patPath)
+
+	cases := []struct {
+		name string
+		ref  string
+		want bool
+	}{
+		{"other host cluster path", "ghcr.io/cluster/c1/templates/py311:latest", false},
+		{"configured host non-cluster repo", "aocr.aerol.ai/acme/my-image:latest", false},
+		{"configured host mirror namespace", "aocr.aerol.ai/mirror/aocr/ghcr/foo:latest", false},
+		{"docker hub short ref (no host)", "ubuntu:22.04", false},
+		{"cluster prefix collision", "aocr.aerol.ai/clusterfoo/bar:latest", false},
+		{"configured host cluster path", "aocr.aerol.ai/cluster/c1/templates/py311:latest", true},
+		{"transport prefix stripped", "docker://aocr.aerol.ai/cluster/c1/snapshots/s:latest", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := c.resolveAOCRPullAuth(tc.ref) != nil
+			if got != tc.want {
+				t.Fatalf("resolveAOCRPullAuth(%q) matched=%v, want %v", tc.ref, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveAOCRPullAuth_PATReadFreshEachCall(t *testing.T) {
+	patPath := writePAT(t, "first")
+	c := &Client{}
+	c.ConfigureAOCRPullAuth([]string{"aocr.aerol.ai"}, "c1", patPath)
+
+	ref := "aocr.aerol.ai/cluster/c1/templates/py311:latest"
+	if got := c.resolveAOCRPullAuth(ref); got == nil || got.Password != "first" {
+		t.Fatalf("first resolve: got %+v, want password=first", got)
+	}
+	// Rotate the PAT on disk; the next resolve must reflect it without any
+	// restart or reconfigure — the rotation contract.
+	if err := os.WriteFile(patPath, []byte("second"), 0o600); err != nil {
+		t.Fatalf("rotate pat: %v", err)
+	}
+	if got := c.resolveAOCRPullAuth(ref); got == nil || got.Password != "second" {
+		t.Fatalf("after rotation: got %+v, want password=second", got)
+	}
+}
+
+func TestResolveAOCRPullAuth_NilWhenPATMissing(t *testing.T) {
+	c := &Client{}
+	c.ConfigureAOCRPullAuth([]string{"aocr.aerol.ai"}, "c1", filepath.Join(t.TempDir(), "does-not-exist"))
+	if got := c.resolveAOCRPullAuth("aocr.aerol.ai/cluster/c1/templates/py311:latest"); got != nil {
+		t.Fatalf("expected nil auth when PAT file missing, got %+v", got)
+	}
+}
+
+func TestConfigureAOCRPullAuth_NoOpWhenIncomplete(t *testing.T) {
+	patPath := writePAT(t, "tok")
+	cases := []struct {
+		name      string
+		hosts     []string
+		clusterID string
+		patPath   string
+	}{
+		{"empty cluster id", []string{"aocr.aerol.ai"}, "", patPath},
+		{"empty pat path", []string{"aocr.aerol.ai"}, "c1", ""},
+		{"no non-empty hosts", []string{"", "  "}, "c1", patPath},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Client{}
+			c.ConfigureAOCRPullAuth(tc.hosts, tc.clusterID, tc.patPath)
+			if c.aocrPullAuth != nil {
+				t.Fatalf("expected aocrPullAuth to stay nil for incomplete config")
+			}
+		})
+	}
+}

--- a/pkg/docker/aocr_pull_auth_test.go
+++ b/pkg/docker/aocr_pull_auth_test.go
@@ -1,8 +1,15 @@
 package docker
 
 import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -66,6 +73,8 @@ func TestResolveAOCRPullAuth_ScopingRules(t *testing.T) {
 		{"cluster prefix collision", "aocr.aerol.ai/clusterfoo/bar:latest", false},
 		{"configured host cluster path", "aocr.aerol.ai/cluster/c1/templates/py311:latest", true},
 		{"transport prefix stripped", "docker://aocr.aerol.ai/cluster/c1/snapshots/s:latest", true},
+		{"default https port stripped", "aocr.aerol.ai:443/cluster/c1/templates/py311:latest", true},
+		{"non-default port is significant", "aocr.aerol.ai:5000/cluster/c1/templates/py311:latest", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -101,6 +110,76 @@ func TestResolveAOCRPullAuth_NilWhenPATMissing(t *testing.T) {
 	c.ConfigureAOCRPullAuth([]string{"aocr.aerol.ai"}, "c1", filepath.Join(t.TempDir(), "does-not-exist"))
 	if got := c.resolveAOCRPullAuth("aocr.aerol.ai/cluster/c1/templates/py311:latest"); got != nil {
 		t.Fatalf("expected nil auth when PAT file missing, got %+v", got)
+	}
+}
+
+// newAOCRCaptureClient builds a Client whose pull transport records the
+// X-Registry-Auth header and the fromImage query of the /images/create call,
+// with pulls initialized so pullImageDedup is safe to drive directly.
+func newAOCRCaptureClient(gotAuthB64, gotFrom *string) *Client {
+	transport := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		*gotAuthB64 = r.Header.Get("X-Registry-Auth")
+		*gotFrom = r.URL.Query().Get("fromImage")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"status":"done"}`)),
+			Header:     make(http.Header),
+		}, nil
+	})
+	return &Client{
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		streamClient: &http.Client{Transport: transport},
+		httpClient:   &http.Client{Transport: transport},
+		pulls:        make(map[string]*imagePull),
+	}
+}
+
+// TestPullImageDedup_SetsClusterPATForClusterRef is the end-to-end assertion
+// that the back-fill actually reaches the daemon request: a nil-auth pull of an
+// AOCR cluster ref (the template-puller's exact call shape) must carry the
+// cluster PAT in X-Registry-Auth, and the ref must not be mirror-rewritten.
+func TestPullImageDedup_SetsClusterPATForClusterRef(t *testing.T) {
+	patPath := writePAT(t, "tok-xyz")
+	var gotAuthB64, gotFrom string
+	c := newAOCRCaptureClient(&gotAuthB64, &gotFrom)
+	c.ConfigureAOCRPullAuth([]string{"aocr.aerol.ai"}, "prod-aerolvm-us-east-1", patPath)
+
+	ref := "aocr.aerol.ai/cluster/prod-aerolvm-us-east-1/templates/py311:latest"
+	if err := c.PullImage(context.Background(), ref, nil); err != nil {
+		t.Fatalf("PullImage: %v", err)
+	}
+	if gotFrom != ref {
+		t.Fatalf("fromImage = %q, want %q (no mirror rewrite expected)", gotFrom, ref)
+	}
+	if gotAuthB64 == "" {
+		t.Fatal("X-Registry-Auth missing; cluster PAT was not applied to the pull")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(gotAuthB64)
+	if err != nil {
+		t.Fatalf("decode X-Registry-Auth: %v", err)
+	}
+	var a map[string]string
+	if err := json.Unmarshal(decoded, &a); err != nil {
+		t.Fatalf("unmarshal auth: %v", err)
+	}
+	if a["username"] != "prod-aerolvm-us-east-1" || a["password"] != "tok-xyz" || a["serveraddress"] != "aocr.aerol.ai" {
+		t.Fatalf("auth payload mismatch: %+v", a)
+	}
+}
+
+// TestPullImageDedup_NoAuthForNonClusterRef confirms the back-fill stays scoped:
+// a non-cluster repo on the same AOCR host must not borrow the cluster PAT.
+func TestPullImageDedup_NoAuthForNonClusterRef(t *testing.T) {
+	patPath := writePAT(t, "tok-xyz")
+	var gotAuthB64, gotFrom string
+	c := newAOCRCaptureClient(&gotAuthB64, &gotFrom)
+	c.ConfigureAOCRPullAuth([]string{"aocr.aerol.ai"}, "c1", patPath)
+
+	if err := c.PullImage(context.Background(), "aocr.aerol.ai/acme/my-image:latest", nil); err != nil {
+		t.Fatalf("PullImage: %v", err)
+	}
+	if gotAuthB64 != "" {
+		t.Fatalf("unexpected X-Registry-Auth for non-cluster ref: %q", gotAuthB64)
 	}
 }
 

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -72,6 +72,11 @@ type Client struct {
 	mirrorCfg    MirrorConfig
 	wrapKeyRing  *secrets.UpstreamWrapKeyRing
 	pullObserver PullObserver
+	// aocrPullAuth is the node-local cluster PAT used to pull cluster-owned
+	// artifacts (snapshots + Firecracker templates) from AOCR. nil disables it
+	// (anonymous pulls). Set via ConfigureAOCRPullAuth after construction. See
+	// aocr_pull_auth.go.
+	aocrPullAuth *aocrClusterPullAuth
 }
 
 type imagePull struct {
@@ -829,6 +834,18 @@ func (c *Client) pullImageDedup(ctx context.Context, imageRef string, auth *mode
 	finishMetric := beginImagePullMetric()
 	var resultErr error
 	defer func() { finishMetric(resultErr) }()
+
+	// Back-fill the cluster PAT for AOCR `cluster/...` refs when the caller
+	// supplied no credentials. This is the single chokepoint for both consumer
+	// paths that pull cluster-owned artifacts anonymously today: the create-path
+	// snapshot pull (Create) and the Firecracker template puller (PullImage).
+	// Resolving here — before the dedup key is computed — keeps the key,
+	// backoff, and pull all keyed off the credential that will actually be used.
+	// No-op (returns nil) for non-AOCR hosts, non-cluster repos, or when AOCR
+	// pull auth was never configured.
+	if auth == nil {
+		auth = c.resolveAOCRPullAuth(imageRef)
+	}
 
 	key := imagePullKey(imageRef, auth)
 	c.pullMu.Lock()

--- a/pkg/docker/export.go
+++ b/pkg/docker/export.go
@@ -50,9 +50,11 @@ func (c *Client) ExportImageTar(ctx context.Context, ref string) (io.ReadCloser,
 // PullImage is the exported single-call pull wrapper the template puller
 // uses. Goes through pullImageDedup so concurrent first-callers for the
 // same ref collapse to one daemon request — the same dedup that protects
-// the create-sandbox pull path. Auth is optional; nil means anonymous,
-// which is fine for AOCR refs that the daemon already has credentials
-// configured for at the daemon level.
+// the create-sandbox pull path. Auth is optional: nil means anonymous,
+// except that pullImageDedup back-fills the cluster PAT for AOCR
+// `cluster/...` refs when ConfigureAOCRPullAuth has been called (see
+// aocr_pull_auth.go), so the template puller can pass nil and still
+// authenticate against a private AOCR.
 func (c *Client) PullImage(ctx context.Context, ref string, auth *models.RegistryAuth) error {
 	if strings.TrimSpace(ref) == "" {
 		return errors.New("pull image: ref is required")


### PR DESCRIPTION
## Summary

- Wires an authenticated AOCR pull path for **cluster-owned artifacts** (Docker snapshots + Firecracker templates). Previously the Firecracker template puller and the create-path snapshot pull passed `nil` registry credentials, so they only worked if the daemon happened to have an ambient `docker login` to AOCR — against an authenticated registry they 401.
- Adds `Client.ConfigureAOCRPullAuth` + `resolveAOCRPullAuth` (new `pkg/docker/aocr_pull_auth.go`) which back-fills the cluster PAT — scoped to a configured AOCR host **and** the `cluster/...` namespace — at the single `pullImageDedup` chokepoint both consumer paths funnel through. PAT is read fresh per pull (rotation-safe), reusing the same host/cluster/PAT config as the snapshot + template pushers, so one credential covers push and pull symmetrically.
- Wired in `pkg/daemon/daemon.go` next to `configureMirror`, independent of `SB_SNAPSHOT_PUSH_ENABLED` so consume-only nodes (failover / cross-node placement) can still pull.

> Companion change in the AOCR repo (separate PR): `clusterPat.ts` now accepts label-format cluster IDs (`^[A-Za-z0-9_-]{1,64}$`, UUIDs still a subset) and the Ansible/Helm deploy path plumbs `aocr_auth_cluster_pat_tokens`. Operators must register `AUTH_CLUSTER_PAT_TOKENS=<cluster_id>=<token>` for push/pull to authenticate. Docs (firecracker-templates.mdx cluster-mode section) already landed on `main`.

## Sandbox boot impact

Yes — small, bounded, and only on a cache-miss pull. When `CreateSandbox` pulls an image that is **not already present locally** AND the ref targets a configured AOCR host under `cluster/...` AND the caller supplied no registry auth, `resolveAOCRPullAuth` performs one node-local file read of the PAT before the pull. It does **not** fire when: the image is already local (the common warm path), the ref is not an AOCR `cluster/...` ref, the caller already passed creds, or AOCR pull auth was never configured (resolver returns `nil` immediately on a nil config). No DB query, no network round-trip, no lock. The fresh-read-per-pull is deliberate (PAT rotation is a file write, matching the pushers' contract).

## Idempotency

No API surface changed. The pull path remains idempotent: `resolveAOCRPullAuth` is a pure function of the image ref + node config, and resolving before the dedup key is computed means concurrent first-callers for the same ref still collapse to one in-flight pull (the resolved auth is part of `imagePullKey`). Re-pulling an already-present artifact is the existing fast no-op.

## Failure-path consistency

N/A - no multi-step write path changed. A PAT read failure resolves to `nil` (logged) and the pull proceeds anonymously rather than half-applying a credential — an anonymous 401 surfaces a clearer registry error.

## L4 / host-port-pool changes

N/A - neither touched.

## Test plan

- `go test ./pkg/docker/...` — new `aocr_pull_auth_test.go`: scoping rules (other host, non-cluster repo, mirror namespace, docker-hub short ref, `clusterfoo` prefix collision, transport-prefix stripping), fresh-PAT-per-call rotation, nil on missing PAT, no-op `ConfigureAOCRPullAuth` for incomplete config.
- `go test ./pkg/daemon/...` — `TestConfigureAOCRPullAuthGuard_NoPanic` covers the daemon wiring (empty config + fully configured).
- `go build ./...` clean; `go test ./pkg/docker/... ./pkg/daemon/... ./internal/service/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
