### PR TITLE
DNS: emit ANAME/ALIAS apex-flattening candidates for hostname ingress

### DIFF
--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -4,7 +4,7 @@ import LanguageSelect from './LanguageSelect.astro'
 import ThemeSelect from './ThemeSelect.astro'
 
 const currentPath = Astro.url.pathname
-const version = import.meta.env.VERSION || '0.4.1'
+const version = import.meta.env.VERSION || '0.5.1'
 const basePath = import.meta.env.BASE_URL
 
 const navLinks = [

--- a/docs/src/content/docs/cluster-glossary.mdx
+++ b/docs/src/content/docs/cluster-glossary.mdx
@@ -28,14 +28,14 @@ Each node in a cluster has a role that determines what it does.
 | Voting nodes | Can lose | Notes |
 |---|---|---|
 | 1 | 0 | Testing only |
-| 2 | 0 | Avoid — same fault tolerance as 1 voter, higher quorum cost |
+| 2 | 0 | Avoid - same fault tolerance as 1 voter, higher quorum cost |
 | 3 | 1 | Minimum for production |
 | 5 | 2 | Recommended when spanning availability zones |
 | 7 | 3 | Diminishing returns; replication overhead increases |
 
 Always use an **odd number** of voting nodes. Even numbers raise the quorum threshold without improving fault tolerance.
 
-`SB_CLUSTER_MAX_AUTO_VOTERS` caps how many nodes automatically become voters. Nodes beyond the cap join as **non-voters** — they receive the placement log and can run sandboxes, but don't count toward quorum. The default cap is `5`.
+`SB_CLUSTER_MAX_AUTO_VOTERS` caps how many nodes automatically become voters. Nodes beyond the cap join as **non-voters** - they receive the placement log and can run sandboxes, but don't count toward quorum. The default cap is `5`.
 
 ## Cluster environment variables
 
@@ -46,7 +46,7 @@ These variables are written to `/etc/sandboxd/cluster.env` on each node when you
 | Variable | Required | Description |
 |---|---|---|
 | `SB_ENABLE_CLUSTER` | Yes | Set to `true` to enable cluster mode. Default `false`. |
-| `SB_NODE_ID` | Yes | Stable name for this node (e.g. `node1`). Must not change across restarts — a changed ID leaves a ghost entry in the cluster configuration. |
+| `SB_NODE_ID` | Yes | Stable name for this node (e.g. `node1`). Must not change across restarts - a changed ID leaves a ghost entry in the cluster configuration. |
 | `SB_CLUSTER_BOOTSTRAP` | Yes | `true` only on the seed node; `false` on all others. |
 | `SB_CLUSTER_MAX_AUTO_VOTERS` | No | Maximum nodes auto-promoted to Raft voters. Default `5`. Nodes beyond this cap join as non-voters. |
 
@@ -54,7 +54,7 @@ These variables are written to `/etc/sandboxd/cluster.env` on each node when you
 
 | Variable | Required | Description |
 |---|---|---|
-| `SB_API_ADVERTISE_URL` | Yes | URL other nodes use to forward API requests to this node — e.g. `http://10.0.0.5:21212`. |
+| `SB_API_ADVERTISE_URL` | Yes | URL other nodes use to forward API requests to this node - e.g. `http://10.0.0.5:21212`. |
 | `SB_DATA_PLANE_ADVERTISE_HOST` | Yes | Host other nodes use to route sandbox traffic. Defaults to the host in `SB_API_ADVERTISE_URL`; set explicitly when the API address and sandbox traffic address differ. |
 | `SB_BOOTSTRAP_PEERS` | Joiners only | Comma-separated gossip addresses to connect to when joining the cluster. Empty on the seed. |
 
@@ -85,8 +85,8 @@ Gossip is how nodes discover each other and share capacity information.
 |---|---|---|
 | `SB_CLUSTER_TLS_DIR` | Recommended | Directory holding the cluster CA and this node's cert and key (`ca.crt`, `node.crt`, `node.key`). When set, internal cluster traffic uses mutual TLS so possession of a PAT alone isn't enough to forge forwarded writes. |
 | `SB_CLUSTER_INTERNAL_LISTEN` | No | Bind address for the cluster-internal mTLS listener. Default `0.0.0.0:7002`. |
-| `SB_CLUSTER_INTERNAL_ADVERTISE` | No | HTTPS URL peers use for the internal mTLS channel — e.g. `https://10.0.0.5:7002`. Auto-derived from the node's primary IP when empty. |
-| `SB_CREDENTIAL_ENCRYPTION_KEY` | Yes | Base64-encoded 32-byte key used to encrypt sandbox credentials (registry passwords, mount secrets) before replicating them across nodes. Every node must share the same value — if they differ, sandboxes that fail over to a new host will lose access to private registries and credentialed mounts. |
+| `SB_CLUSTER_INTERNAL_ADVERTISE` | No | HTTPS URL peers use for the internal mTLS channel - e.g. `https://10.0.0.5:7002`. Auto-derived from the node's primary IP when empty. |
+| `SB_CREDENTIAL_ENCRYPTION_KEY` | Yes | Base64-encoded 32-byte key used to encrypt sandbox credentials (registry passwords, mount secrets) before replicating them across nodes. Every node must share the same value - if they differ, sandboxes that fail over to a new host will lose access to private registries and credentialed mounts. |
 | `SB_CREDENTIAL_ENCRYPTION_KEY_PATH` | No | File path to load the credential key from. Default `/var/lib/sandboxd/credential_encryption.key`. |
 | `SB_CLUSTER_INSECURE_CREDENTIALS` | No | Skip the credential key requirement. **Recovered sandboxes lose access to private registries and credentialed mounts after failover** without this key. Only for test setups. Default `false`. |
 
@@ -98,11 +98,11 @@ GPU support is installed as a host capability when you set `with_nvidia_gpu = tr
 
 There is no additional environment variable to set. GPU capability is advertised through the gossip protocol alongside CPU and memory capacity.
 
-**NVIDIA** — installs NVIDIA Container Toolkit. Requires an EC2 instance with a physical NVIDIA GPU (`g4dn`, `g5`, `p3`, etc.).
+**NVIDIA** - installs NVIDIA Container Toolkit. Requires an EC2 instance with a physical NVIDIA GPU (`g4dn`, `g5`, `p3`, etc.).
 
-**AMD** — installs ROCm. Supported on `x86_64` instances only (`g4ad`, etc.).
+**AMD** - installs ROCm. Supported on `x86_64` instances only (`g4ad`, etc.).
 
-GPU passthrough is not compatible with gVisor — a sandbox can request one or the other, but not both.
+GPU passthrough is not compatible with gVisor - a sandbox can request one or the other, but not both.
 
 ## gVisor
 
@@ -123,7 +123,7 @@ These variables are written automatically when a node has `with_firecracker = tr
 | `SB_ENABLE_FIRECRACKER` | Set to `true` to enable the Firecracker runtime on this node. |
 | `SB_FIRECRACKER_BINARY` | Path to the `firecracker` binary. |
 | `SB_JAILER_BINARY` | Path to the `jailer` binary. The jailer wraps each microVM for extra isolation. |
-| `SB_FIRECRACKER_KERNEL` | Path to the Linux kernel image (`vmlinux`). Required — Firecracker cannot start without a kernel. |
+| `SB_FIRECRACKER_KERNEL` | Path to the Linux kernel image (`vmlinux`). Required - Firecracker cannot start without a kernel. |
 | `SB_FIRECRACKER_USE_JAILER` | `true` to run each microVM inside the jailer. Default `true`. |
 | `SB_FIRECRACKER_RUN_DIR` | Directory where Firecracker stores per-VM socket files and state. |
 | `SB_FIRECRACKER_TEMPLATES_DIR` | Directory where Firecracker rootfs templates are cached on disk. |

--- a/docs/src/content/docs/comparison.md
+++ b/docs/src/content/docs/comparison.md
@@ -16,7 +16,7 @@ A side-by-side look at how AerolVM compares to the two most common alternatives 
 | **Sandbox startup** | <70ms | ~200s | <90ms |
 | **Runtime isolation** | Docker, gVisor (kernel-level), Firecracker (microVM) | Kata | Docker |
 | **Serveless Sandbox(based on Lambda Arch)** | ✅ | ✗ | ✗ |
-| **Security** | gVisor (very secure) | Kata(Extremely secure) | ✗ |
+| **Security** | gVisor + FireCracker (Extremely secure) | FireCracker(Extremely secure) | ✗ |
 | **Port Isolation** | ✅ | ✗ | ✗ |
 | **Persistent** | ✅ | ✗ | ✅ |
 | **Sandbox Lifecycle** | Infinite | 1 day | Infinite |
@@ -69,7 +69,6 @@ The 16 GB disk allocation sits on top of this, but compute is the main cost driv
 **e2b** is a managed cloud service optimized for AI agent sandboxes. It is the fastest way to get started if you do not want to run any infrastructure yourself, but the trade-offs add up quickly:
 
 - **No self-hosting.** Your code, your customers' code, and your data all run on e2b's infrastructure. Regulated workloads, air-gapped deployments, and bring-your-own-cloud requirements are off the table.
-- **No kernel-level isolation.** e2b runs Docker containers. AerolVM ships with gVisor as a first-class runtime, so untrusted code from LLMs or end-users is isolated at the kernel boundary.
 - **Per-sandbox-hour pricing.** Costs scale linearly with usage. A team running 1,000+ sandboxes can pay $500+ per month on e2b vs. ~$20/month on a single host with AerolVM.
 - **Hard sandbox lifetime cap.** Sandboxes expire after 1 day. AerolVM sandboxes live indefinitely and support persistent stop/start.
 - **No GPU, no external storage, no SSH, no TCP ports, no per-sandbox egress control, no per-sandbox network quotas, no multi-tenant tagging.**

--- a/docs/src/content/docs/custom-domains.mdx
+++ b/docs/src/content/docs/custom-domains.mdx
@@ -14,7 +14,7 @@ Before a custom domain can go `ready`, three things must be true:
 
 1. **DNS points at the cluster ingress.** Issuance uses ACME HTTP-01, so Let's
    Encrypt must reach the hostname on port 80/443 at your ingress. Until DNS
-   resolves, the domain stays `pending_dns`. See the [record shapes](#dns-records) below.
+   resolves, the domain stays `pending_dns`. See [DNS records](#dns-records).
 2. **An ownership TXT record is published.** Without it, `attach` returns `403`.
    See [ownership verification](#ownership-verification).
 3. **The sandbox exposes HTTP/HTTPS only on a given PORT).** Custom domains bind to the sandbox
@@ -76,10 +76,130 @@ to built-in flattening.
   </TabItem>
 </Tabs>
 
-The SDK can also hand back ready-to-paste DNS rows for the cluster you're
-connected to - `dns.target()` (cluster-wide ingress target, for "point your DNS
-here first") and `sandbox.customDomains.dns()` (per-domain routing + TXT rows).
-Use them instead of re-deriving the tables above.
+## DNS records
+
+`sandbox.customDomains.dns()` returns, for each attached hostname, the routing
+record (`CNAME` / `A` / `AAAA`) and the ownership `TXT` record. Each record has
+`hostname`, `type`, `name`, `value`, and an optional `notes`. An **apex** domain
+on a hostname ingress instead returns three mutually-exclusive routing rows —
+`CNAME`, `ANAME`, and `ALIAS` — since a bare `CNAME` is invalid at a zone root
+and providers expose flattening under different types.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    const dns = await sandbox.customDomains.dns();
+
+    // dns.target  → { hostname: "ingress.example.com", source: "hostname" }
+    // dns.records → [
+    //   { hostname: "api.acme.com", type: "CNAME", name: "api",
+    //     value: "ingress.example.com",
+    //     notes: "Cloudflare/CDN: set the record to DNS only (gray cloud). …" },
+    //   { hostname: "api.acme.com", type: "TXT", name: "_aerol-verify.api",
+    //     value: "aerol-verify=api.acme.com",
+    //     notes: "Required for domain ownership verification." },
+    // ]
+
+    for (const r of dns.records) {
+      console.log(`${r.type}\t${r.name}\t→ ${r.value}`);
+    }
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    dns = sandbox.custom_domain_dns()
+
+    # dns["target"]  -> {"hostname": "ingress.example.com", "source": "hostname"}
+    # dns["records"] -> [
+    #   {"hostname": "api.acme.com", "type": "CNAME", "name": "api",
+    #    "value": "ingress.example.com",
+    #    "notes": "Cloudflare/CDN: set the record to DNS only (gray cloud). …"},
+    #   {"hostname": "api.acme.com", "type": "TXT", "name": "_aerol-verify.api",
+    #    "value": "aerol-verify=api.acme.com",
+    #    "notes": "Required for domain ownership verification."},
+    # ]
+
+    for r in dns["records"]:
+        print(r["type"], r["name"], "->", r["value"])
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    dns, err := sandbox.CustomDomainDNS(ctx)
+    if err != nil { log.Fatal(err) }
+
+    // dns.Target  = {Hostname: "ingress.example.com", Source: "hostname"}
+    // dns.Records = [
+    //   {Hostname: "api.acme.com", Type: "CNAME", Name: "api",
+    //    Value: "ingress.example.com", Notes: "Cloudflare/CDN: … (gray cloud). …"},
+    //   {Hostname: "api.acme.com", Type: "TXT", Name: "_aerol-verify.api",
+    //    Value: "aerol-verify=api.acme.com", Notes: "Required for domain ownership verification."},
+    // ]
+
+    for _, r := range dns.Records {
+        fmt.Printf("%s\t%s\t→ %s\n", r.Type, r.Name, r.Value)
+    }
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let dns = sandbox.custom_domain_dns()?;
+
+    // dns.target  = IngressTarget { hostname: Some("ingress.example.com"), source: "hostname", .. }
+    // dns.records = [
+    //   DnsRecord { hostname: "api.acme.com", record_type: "CNAME", name: "api",
+    //     value: "ingress.example.com", notes: Some("Cloudflare/CDN: … (gray cloud). …") },
+    //   DnsRecord { hostname: "api.acme.com", record_type: "TXT", name: "_aerol-verify.api",
+    //     value: "aerol-verify=api.acme.com", notes: Some("Required for domain ownership verification.") },
+    // ]
+
+    // NB: the JSON `type` field is exposed as `record_type` in Rust.
+    for r in &dns.records {
+        println!("{}\t{}\t→ {}", r.record_type, r.name, r.value);
+    }
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    CustomDomainDnsRecords dns = sandbox.customDomainDns();
+
+    // dns.target  = IngressTarget{hostname="ingress.example.com", source="hostname"}
+    // dns.records = [
+    //   DnsRecord{hostname="api.acme.com", type="CNAME", name="api",
+    //     value="ingress.example.com", notes="Cloudflare/CDN: … (gray cloud). …"},
+    //   DnsRecord{hostname="api.acme.com", type="TXT", name="_aerol-verify.api",
+    //     value="aerol-verify=api.acme.com", notes="Required for domain ownership verification."},
+    // ]
+
+    for (DnsRecord r : dns.records) {
+        System.out.println(r.type + "\t" + r.name + "\t→ " + r.value);
+    }
+    ```
+  </TabItem>
+</Tabs>
+
+For the example above (a subdomain against a hostname ingress), the routing row
+to add at your DNS provider is:
+
+| Type | Name | Value |
+|---|---|---|
+| `CNAME` | `api` | `ingress.example.com` |
+
+The type depends on `target`. A hostname against a raw-IP ingress returns one
+`A` / `AAAA` per IP instead of a `CNAME`. The same response also carries the
+ownership `TXT` record from [Ownership verification](#ownership-verification). In
+Cloudflare, set the `CNAME` to **DNS only (gray cloud)** — a proxied record
+terminates TLS at the CDN and blocks ACME issuance.
+
+For an **apex** domain (e.g. `acme.com`) on a hostname ingress, the response
+returns three rows at `@` with the same value. Add **only the one** your
+provider supports:
+
+| Type | Name | Value | Provider |
+|---|---|---|---|
+| `CNAME` | `@` | `ingress.example.com` | Cloudflare (CNAME flattening) |
+| `ANAME` | `@` | `ingress.example.com` | dnsmadeeasy, EasyDNS |
+| `ALIAS` | `@` | `ingress.example.com` | Route 53, DNSimple |
 
 ## Status lifecycle
 

--- a/docs/src/content/docs/custom-domains.mdx
+++ b/docs/src/content/docs/custom-domains.mdx
@@ -4,146 +4,49 @@ title: Custom Domains
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-Attach an arbitrary public hostname (`api.acme.com`, `acme.com`) to a sandbox so traffic to that host reaches the sandbox's root service over HTTPS. 
+Attach a public hostname (`api.acme.com`, `acme.com`) to a sandbox so traffic to
+that host reaches the sandbox over HTTPS. TLS is issued automatically via ACME
+HTTP-01.
 
 ## Prerequisites
 
-1. **DNS must point at the cluster's ingress** when the first HTTPS request arrives. AerolVM does not host DNS, and issuance uses ACME HTTP-01 - Let's Encrypt's validator must be able to reach the hostname over port 80/443 at the cluster. If DNS isn't pointing yet, the domain stays in `pending_dns` until you fix it.
-2. **HTTP / HTTPS only.** Custom domains attach to the sandbox root (the toolbox-proxied URL). Raw `tcp://` and `tls://` port exposures are out of scope - they reject with `409 Conflict` if a custom domain is configured.
+Before a custom domain can go `ready`, three things must be true:
 
-### DNS records to add
+1. **DNS points at the cluster ingress.** Issuance uses ACME HTTP-01, so Let's
+   Encrypt must reach the hostname on port 80/443 at your ingress. Until DNS
+   resolves, the domain stays `pending_dns`. See the [record shapes](#dns-records) below.
+2. **An ownership TXT record is published.** Without it, `attach` returns `403`.
+   See [ownership verification](#ownership-verification).
+3. **The sandbox exposes HTTP/HTTPS only on a given PORT).** Custom domains bind to the sandbox
+   root (or a target port). A sandbox with a raw `tcp://` / `tls://` exposure
+   rejects custom domains with `409` - the two can't coexist.
 
-The "target" below is whatever your default sandbox URLs already resolve to - `SB_INGRESS_ADVERTISE_HOST` in cluster mode (see [Cluster Ingress](/cluster-ingress/)) or `SB_PUBLIC_HOST` for single-node. The record type you create depends on the shape of the custom hostname and how your ingress is published.
 
-| Custom hostname | Ingress target is a hostname (e.g. `ingress.example.com`) | Ingress target is raw IPs |
+### Ownership verification
+
+Publish a TXT record proving you control the zone. It is keyed to the
+**hostname** (not the sandbox), so provision it once and reuse it across
+recreates.
+
+| Custom hostname | TXT name | TXT value |
 |---|---|---|
-| Subdomain (`api.acme.com`) | `CNAME api → ingress.example.com` | `A` (and `AAAA` if IPv6) on `api`, one record per ingress IP |
-| Apex (`acme.com`) | `CNAME @ → ingress.example.com` *(requires apex-CNAME support: Cloudflare CNAME flattening, Route 53 alias, DNSimple `ALIAS`, dnsmadeeasy `ANAME`, etc.)* | `A` (and `AAAA` if IPv6) on `@`, one record per ingress IP |
+| Subdomain (`api.acme.com`) | `_aerol-verify.api` | `aerol-verify=api.acme.com` |
+| Apex (`acme.com`) | `_aerol-verify` | `aerol-verify=acme.com` |
 
-If your DNS provider does not support a flattened apex CNAME and you only have an ingress hostname (not IPs), the workaround is per-host DNS-01 issuance - tracked for v2 in `plans/custom-domains-dns01.md`.
+Some provider UIs want the FQDN (`_aerol-verify.api.acme.com`) instead of the
+zone-relative name; the value is unchanged. 
 
-### Ownership verification (TXT record)
+Verify with `dig TXT _aerol-verify.<host>` before attaching. 
 
-In addition to the CNAME / A / AAAA above, you must publish a TXT record proving you control the zone. Without it, every `attach` call returns `403 Forbidden` with `custom domain TXT record verification failed`.
 
-The value is keyed to the **hostname**, not to a sandbox ID - one record per hostname, provisioned once, reusable across sandbox recreates and for any sandbox that wants to claim it. Cross-sandbox hijack of an already-attached hostname is still blocked by the cluster-wide uniqueness gate at attach time.
-
-| Custom hostname | TXT record name | TXT record value |
-|---|---|---|
-| Subdomain (`api.acme.com`) | `_aerol-verify.api` (zone `acme.com`) | `aerol-verify=api.acme.com` |
-| Apex (`acme.com`) | `_aerol-verify` (at zone root) | `aerol-verify=acme.com` |
-
-Most DNS provider UIs expect the Name relative to the managed zone (the left columns above); some expect the FQDN - in that case use `_aerol-verify.api.acme.com` or `_aerol-verify.acme.com` and the value is unchanged.
-
-Publish the TXT, wait for it to propagate (`dig TXT _aerol-verify.<your-host>`), then call `attach`. If you operate the cluster with non-default verification prefixes (`SB_CUSTOM_DOMAIN_VERIFY_PREFIX`, `SB_CUSTOM_DOMAIN_VERIFY_VALUE_PREFIX`), substitute those - `customDomains.dns()` always returns the correct row for the cluster you're talking to.
-
-### Cloudflare specifics
-
-1. **Set the record to DNS-only (gray cloud), not Proxied (orange cloud).** With the proxy on, Cloudflare terminates TLS with its own certificate and the cluster never sees the SNI - Caddy's `ask` handler is never invoked, ACME never runs, and the domain stays `pending_dns` forever. The same applies to any CDN or reverse proxy that intercepts TLS in front of the ingress.
-2. **Apex works as a plain `CNAME` in Cloudflare** thanks to built-in CNAME flattening - there is no separate `ALIAS` / `ANAME` record type to pick. Create the row with `Type = CNAME`, `Name = @`, `Target = <ingress hostname>`, and Cloudflare resolves it to A/AAAA at query time.
-
-## Attach at create time
-
-Pass `customDomains` on the create call. Up to 5 hostnames per request; the server validates each one and rejects the entire create with `400` if any is malformed or already taken.
-
-<Tabs syncKey="lang">
-  <TabItem label="TypeScript">
-    ```ts
-    const sb = await microvm.sandboxes.create({
-      image: "node:20",
-      customDomains: ["api.acme.com", "acme.com"],
-    });
-    for (const d of sb.customDomains ?? []) {
-      console.log(d.hostname, d.status); // "api.acme.com" "pending_dns"
-    }
-    ```
-  </TabItem>
-  <TabItem label="Python">
-    ```python
-    sb = microvm.create(CreateOptions(
-        image="node:20",
-        customDomains=["api.acme.com", "acme.com"],
-    ))
-    for d in sb.get("customDomains", []):
-        print(d["hostname"], d["status"])
-    ```
-  </TabItem>
-  <TabItem label="Go">
-    ```go
-    sb, err := client.CreateSandbox(ctx, &microvm.CreateOptions{
-        Image:         "node:20",
-        CustomDomains: []string{"api.acme.com", "acme.com"},
-    })
-    if err != nil { log.Fatal(err) }
-    for _, d := range sb.CustomDomains {
-        fmt.Println(d.Hostname, d.Status)
-    }
-    ```
-  </TabItem>
-  <TabItem label="Rust">
-    ```rust
-    let sb = client.create_sandbox(CreateOptions {
-        image: Some("node:20".into()),
-        custom_domains: Some(vec!["api.acme.com".into(), "acme.com".into()]),
-        ..Default::default()
-    })?;
-    for d in sb.custom_domains.unwrap_or_default() {
-        println!("{} {:?}", d.hostname, d.status);
-    }
-    ```
-  </TabItem>
-  <TabItem label="Java">
-    ```java
-    Sandbox sb = client.create(new CreateOptions()
-        .setImage("node:20")
-        .setCustomDomains(List.of("api.acme.com", "acme.com")));
-    for (CustomDomain d : sb.customDomains) {
-        System.out.println(d.hostname + " " + d.status);
-    }
-    ```
-  </TabItem>
-</Tabs>
+:::caution[Cloudflare and other TLS-terminating proxies]
+Set the record to **DNS-only (gray cloud)**, not Proxied. A proxy that
+terminates TLS hides the SNI from the cluster, so ACME never runs and the domain
+stays `pending_dns` forever. Apex works as a plain `CNAME` in Cloudflare thanks
+to built-in flattening.
+:::
 
 ## Attach to a running sandbox
-
-The add call returns the post-attach list with the new row's `status` so callers don't need a follow-up `list`.
-
-<Tabs syncKey="lang">
-  <TabItem label="TypeScript">
-    ```ts
-    const domains = await sandbox.customDomains.add("staging.acme.com");
-    console.log(domains.map(d => d.hostname));
-    ```
-  </TabItem>
-  <TabItem label="Python">
-    ```python
-    domains = sandbox.add_custom_domain("staging.acme.com")
-    print([d["hostname"] for d in domains])
-    ```
-  </TabItem>
-  <TabItem label="Go">
-    ```go
-    domains, err := sandbox.AddCustomDomain(ctx, "staging.acme.com")
-    if err != nil { log.Fatal(err) }
-    ```
-  </TabItem>
-  <TabItem label="Rust">
-    ```rust
-    let domains = sandbox.add_custom_domain("staging.acme.com", None)?;
-    ```
-  </TabItem>
-  <TabItem label="Java">
-    ```java
-    List<CustomDomain> domains = sandbox.addCustomDomain("staging.acme.com");
-    ```
-  </TabItem>
-</Tabs>
-
-### Target port
-
-By default traffic to a custom domain dials the sandbox's toolbox port - the same root URL `https://{id}.{cluster-domain}` serves. Pass a `port` to route the hostname at a specific application port inside the container instead (e.g. an app listening on `3333`). This is the same routing the default `sb-{id}-{port}.{cluster-domain}` URLs use, but bound to your custom hostname.
-
-`port` is fixed at attach time. To change it, detach and re-add - re-adding the same hostname with a different `port` returns `409 Conflict` rather than silently redirecting live traffic.
 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">
@@ -163,10 +66,7 @@ By default traffic to a custom domain dials the sandbox's toolbox port - the sam
   </TabItem>
   <TabItem label="Rust">
     ```rust
-    sandbox.add_custom_domain(
-        "api.acme.com",
-        Some(AddCustomDomainOptions::with_port(3333)),
-    )?;
+    sandbox.add_custom_domain("api.acme.com", Some(AddCustomDomainOptions::with_port(3333)))?;
     ```
   </TabItem>
   <TabItem label="Java">
@@ -176,186 +76,73 @@ By default traffic to a custom domain dials the sandbox's toolbox port - the sam
   </TabItem>
 </Tabs>
 
-Create-time `customDomains` always uses the toolbox-port default; to bind a custom port, attach after create.
+The SDK can also hand back ready-to-paste DNS rows for the cluster you're
+connected to - `dns.target()` (cluster-wide ingress target, for "point your DNS
+here first") and `sandbox.customDomains.dns()` (per-domain routing + TXT rows).
+Use them instead of re-deriving the tables above.
 
-## Discover DNS records from the SDK
+## Status lifecycle
 
-The static table in [DNS records to add](#dns-records-to-add) describes the
-shape of the records. The SDK can also return them already filled in for the
-cluster you're connected to, so a product built on top of AerolVM can advertise
-"add this exact row" without re-implementing the apex-vs-subdomain /
-CNAME-vs-A logic.
+Each hostname carries a `status`. Poll `list` (or re-read the sandbox) to observe
+transitions - there is no push notification.
 
-Two entry points:
-
-- `dns.target()` - cluster-wide. Returns the ingress target (hostname or
-  IP set) that custom-domain DNS must point at. Useful **before** attaching a
-  domain, when rendering "point your DNS here first" instructions. `source`
-  is `"hostname"`, `"ips"`, `"mixed"`, or `"unknown"` - branch on it instead
-  of guessing from which field is populated.
-- `customDomains.dns()` - per-sandbox. Returns the ready-to-paste DNS rows
-  for each attached domain - the routing record (CNAME / A / AAAA) **and**
-  the ownership-verification TXT - plus the same `target` embedded, so
-  callers don't need a follow-up `dns.target()` round trip.
-
-<Tabs syncKey="lang">
-  <TabItem label="TypeScript">
-    ```ts
-    const target = await microvm.dns.target();
-    // { hostname: "ingress.example.com", source: "hostname" }
-
-    const dns = await sandbox.customDomains.dns();
-    for (const r of dns.records) {
-      console.log(`${r.type} ${r.name} → ${r.value}`); // "CNAME api → ingress.example.com"
-      if (r.notes) console.log("  note:", r.notes);
-    }
-    ```
-  </TabItem>
-  <TabItem label="Python">
-    ```python
-    target = microvm.dns_target()
-    # {"hostname": "ingress.example.com", "source": "hostname"}
-
-    dns = sandbox.custom_domain_dns()
-    for r in dns["records"]:
-        print(f"{r['type']} {r['name']} → {r['value']}")
-        if r.get("notes"):
-            print("  note:", r["notes"])
-    ```
-  </TabItem>
-  <TabItem label="Go">
-    ```go
-    target, err := client.DNSTarget(ctx)
-    if err != nil { log.Fatal(err) }
-    // target.Hostname == "ingress.example.com", target.Source == "hostname"
-
-    dns, err := sandbox.CustomDomainDNS(ctx)
-    if err != nil { log.Fatal(err) }
-    for _, r := range dns.Records {
-        fmt.Printf("%s %s → %s\n", r.Type, r.Name, r.Value)
-        if r.Notes != "" {
-            fmt.Println("  note:", r.Notes)
-        }
-    }
-    ```
-  </TabItem>
-  <TabItem label="Rust">
-    ```rust
-    let target = client.dns_target()?;
-    // target.hostname == Some("ingress.example.com"), target.source == "hostname"
-
-    let dns = sandbox.custom_domain_dns()?;
-    for r in dns.records {
-        println!("{} {} → {}", r.record_type, r.name, r.value);
-        if let Some(note) = r.notes {
-            println!("  note: {}", note);
-        }
-    }
-    ```
-  </TabItem>
-  <TabItem label="Java">
-    ```java
-    IngressTarget target = client.dnsTarget();
-    // target.hostname == "ingress.example.com", target.source == "hostname"
-
-    CustomDomainDnsRecords dns = sandbox.customDomainDns();
-    for (DnsRecord r : dns.records) {
-        System.out.println(r.type + " " + r.name + " → " + r.value);
-        if (r.notes != null) {
-            System.out.println("  note: " + r.notes);
-        }
-    }
-    ```
-  </TabItem>
-</Tabs>
-
-When the cluster has no ingress address gossiped yet (boot, mis-configured
-deployment), `source` is `"unknown"` and `records` is empty - treat the
-target as unusable rather than guessing.
-
-## Detach
-
-Detach removes the Caddy route and deletes the row. The issued certificate stays in Caddy's storage and ages out on renewal. Returns `404` if the hostname is not attached to this sandbox.
-
-<Tabs syncKey="lang">
-  <TabItem label="TypeScript">
-    ```ts
-    await sandbox.customDomains.remove("acme.com");
-    ```
-  </TabItem>
-  <TabItem label="Python">
-    ```python
-    sandbox.remove_custom_domain("acme.com")
-    ```
-  </TabItem>
-  <TabItem label="Go">
-    ```go
-    err := sandbox.RemoveCustomDomain(ctx, "acme.com")
-    ```
-  </TabItem>
-  <TabItem label="Rust">
-    ```rust
-    sandbox.remove_custom_domain("acme.com")?;
-    ```
-  </TabItem>
-  <TabItem label="Java">
-    ```java
-    sandbox.removeCustomDomain("acme.com");
-    ```
-  </TabItem>
-</Tabs>
-
-## List
+| Status | Meaning |
+|---|---|
+| `pending_dns` | Row exists, no TLS handshake seen yet. DNS not pointed, or no client has connected. |
+| `issuing` | First HTTPS hit arrived; ACME HTTP-01 challenge in progress. |
+| `ready` | Certificate issued and serving traffic. |
+| `failed` | ACME gave up. `lastError` has the reason (usually wrong DNS or LE rate-limit). Detach + reattach to retry. |
 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">
     ```ts
     const domains = await sandbox.customDomains.list();
+    await sandbox.customDomains.remove("acme.com");
     ```
   </TabItem>
   <TabItem label="Python">
     ```python
     domains = sandbox.list_custom_domains()
+    sandbox.remove_custom_domain("acme.com")
     ```
   </TabItem>
   <TabItem label="Go">
     ```go
-    domains, err := sandbox.ListCustomDomains(ctx)
+    domains, _ := sandbox.ListCustomDomains(ctx)
+    err := sandbox.RemoveCustomDomain(ctx, "acme.com")
     ```
   </TabItem>
   <TabItem label="Rust">
     ```rust
     let domains = sandbox.list_custom_domains()?;
+    sandbox.remove_custom_domain("acme.com")?;
     ```
   </TabItem>
   <TabItem label="Java">
     ```java
     List<CustomDomain> domains = sandbox.listCustomDomains();
+    sandbox.removeCustomDomain("acme.com");
     ```
   </TabItem>
 </Tabs>
 
-## Status lifecycle
-
-Each attached hostname carries a `status` that reflects where Caddy is in the per-host ACME flow. Poll `list` (or re-read the sandbox) to observe transitions - there is no push notification.
-
-| Status | Meaning |
-|---|---|
-| `pending_dns` | Row exists, no TLS handshake seen for this host yet. Either DNS isn't pointed yet, or no client has connected. |
-| `issuing` | Caddy has started the ACME flow (first HTTPS hit arrived). HTTP-01 challenge in progress. |
-| `ready` | Certificate is in Caddy storage and serving traffic. |
-| `failed` | ACME gave up. `lastError` carries the reason - usually DNS still wrong, or LE rate-limited. Detach + reattach after fixing DNS to retry. |
+Detach removes the Caddy route and deletes the row (the cert ages out of storage
+on renewal). Removing a hostname not attached to this sandbox returns `404`.
 
 ## Errors
 
 | Status | When |
 |---|---|
-| `400 Bad Request` | Hostname is malformed or includes a port, or `target_port` is outside `1..65535`. |
-| `403 Forbidden` | Ownership verification TXT record is missing or has the wrong value at `_aerol-verify.<hostname>`. See [Ownership verification (TXT record)](#ownership-verification-txt-record). |
-| `409 Conflict` | The hostname is already attached to a different sandbox (hostnames are globally unique across the cluster), the sandbox already exposes a `tcp://` / `tls://` port (the IRON RULE - custom domains and L4 exposures can't coexist on one sandbox), the per-sandbox cap is reached, or the hostname is already attached to this sandbox with a different `target_port` (detach + re-add to change it). |
-| `412 Precondition Failed` | Custom domains are disabled (`SB_ENABLE_CUSTOM_DOMAINS=false`) or the server runs in IP mode (`SB_DOMAIN` unset). |
-| `429 Too Many Requests` | The daemon-wide ACME issuance budget is exhausted (LE `new-orders` per-account limit nearing 80% of 300/3h). Honour `Retry-After` and try again. |
+| `400 Bad Request` | Hostname malformed or includes a port, or `target_port` outside `1..65535`. |
+| `403 Forbidden` | Ownership TXT missing or wrong at `_aerol-verify.<hostname>`. See [ownership verification](#ownership-verification). |
+| `409 Conflict` | Hostname already attached elsewhere (globally unique), the sandbox has a `tcp://`/`tls://` exposure, the per-sandbox cap is reached, or it's re-added with a different `target_port`. |
+| `412 Precondition Failed` | Custom domains disabled (`SB_ENABLE_CUSTOM_DOMAINS=false`) or server in IP mode (`SB_DOMAIN` unset). |
+| `429 Too Many Requests` | Daemon-wide ACME issuance budget exhausted. Honour `Retry-After`. |
 
 ## Cluster mode
 
-In multi-node clusters the hostname-to-sandbox mapping is replicated through Raft, so any ingress node accepts traffic for a custom domain regardless of which node owns the sandbox. Non-owner ingress nodes pass TLS through to the owner over SNI. The shared `certmagic-s3` cert store means only one node performs the ACME flow per hostname - see [multi-node cert sharing](https://github.com/aerol-ai/microvm/blob/main/setup/multi-node-cert-sharing.md) for the storage / lock layout.
+The hostname-to-sandbox mapping replicates through Raft, so any ingress node
+accepts traffic for a custom domain regardless of which node owns the sandbox;
+non-owner nodes pass TLS through to the owner over SNI. A shared `certmagic-s3`
+cert store means only one node runs ACME per hostname - see
+[multi-node cert sharing](https://github.com/aerol-ai/microvm/blob/main/setup/multi-node-cert-sharing.md).

--- a/docs/src/content/docs/firecracker-sandbox.mdx
+++ b/docs/src/content/docs/firecracker-sandbox.mdx
@@ -5,7 +5,7 @@ description: Create sandboxes backed by Firecracker microVMs for full kernel iso
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-Firecracker sandboxes run inside lightweight virtual machines instead of containers. Each sandbox boots its own Linux kernel in under 100ms and is completely isolated from the host and from other sandboxes at the hardware level. There is no shared kernel — a vulnerability in one sandbox cannot affect another.
+Firecracker sandboxes run inside lightweight virtual machines instead of containers. Each sandbox boots its own Linux kernel in under 100ms and is completely isolated from the host and from other sandboxes at the hardware level. There is no shared kernel - a vulnerability in one sandbox cannot affect another.
 
 Use Firecracker when:
 - You are running untrusted or LLM-generated code that should not have any path to the host kernel
@@ -23,7 +23,7 @@ Firecracker sandboxes require worker nodes that have Firecracker installed. On a
 | **Ad-hoc** | Pass any OCI image (`ubuntu:22.04`). The daemon converts it to a Firecracker rootfs on demand. | 10–60 seconds per create |
 | **Template-backed** | Pre-build a rootfs once using the Templates API, then pass `template_id` in the create request. | Under 100ms |
 
-The examples below use the ad-hoc path — it works without any setup beyond having Firecracker enabled on the node. For the fast template-backed path, see [Firecracker Templates](/firecracker-templates).
+The examples below use the ad-hoc path - it works without any setup beyond having Firecracker enabled on the node. For the fast template-backed path, see [Firecracker Templates](/firecracker-templates).
 
 ## Create a Firecracker sandbox
 
@@ -228,7 +228,7 @@ Pass `runtime: "firecracker"` and an OCI image reference. The daemon pulls the i
 
 ## Notes
 
-- **Ad-hoc builds every time.** Without a pre-built template, each create runs the full OCI-to-rootfs pipeline — expect 10–60 seconds per create. For sub-100ms boots, pre-build a template with [Firecracker Templates](/firecracker-templates) and pass `template_id` in the create request (Go SDK exposes this as `TemplateID`; other SDKs use the direct API).
+- **Ad-hoc builds every time.** Without a pre-built template, each create runs the full OCI-to-rootfs pipeline - expect 10–60 seconds per create. For sub-100ms boots, pre-build a template with [Firecracker Templates](/firecracker-templates) and pass `template_id` in the create request (Go SDK exposes this as `TemplateID`; other SDKs use the direct API).
 - **Memory is reserved.** Unlike Docker, Firecracker allocates the full `memoryMB` value upfront for the VM. Size the request to what the workload actually needs.
 - **Not compatible with GPU passthrough.** Firecracker VMs do not support direct GPU access.
 - **Lifecycle operations** (stop, start, destroy, resize) work the same as Docker sandboxes. See [Docker Sandbox](/sandboxes) for those examples.

--- a/docs/src/content/docs/firecracker-templates.mdx
+++ b/docs/src/content/docs/firecracker-templates.mdx
@@ -5,10 +5,10 @@ description: Register OCI images as Firecracker rootfs templates for sub-100ms s
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-**Firecracker Templates are a Firecracker-only feature.** Without a template, every Firecracker sandbox runs the full OCI-to-rootfs pipeline on each create — expect 10–60 seconds per boot. A template pre-builds the `ext4` rootfs once and captures a paused VM memory state; subsequent sandbox creates clone that snapshot instead of cold-booting the kernel, bringing boot time under 100ms.
+**Firecracker Templates are a Firecracker-only feature.** Without a template, every Firecracker sandbox runs the full OCI-to-rootfs pipeline on each create - expect 10–60 seconds per boot. A template pre-builds the `ext4` rootfs once and captures a paused VM memory state; subsequent sandbox creates clone that snapshot instead of cold-booting the kernel, bringing boot time under 100ms.
 
 :::note[Using Docker sandboxes?]
-If you are not using `runtime: "firecracker"`, templates do not apply to you. For saving and reusing Docker container state, see [Snapshots](/snapshots) instead — snapshots let you commit a running sandbox into a named image and launch copies from it.
+If you are not using `runtime: "firecracker"`, templates do not apply to you. For saving and reusing Docker container state, see [Snapshots](/snapshots) instead - snapshots let you commit a running sandbox into a named image and launch copies from it.
 :::
 
 Firecracker templates let one OCI image power many sandboxes with sub-100ms cold starts. Register an image once; the daemon builds an `ext4` rootfs and captures a paused-VM snapshot. Subsequent `firecracker` sandbox creates against that template clone the snapshot instead of cold-booting the kernel.
@@ -316,7 +316,7 @@ Deleting a template removes the rootfs and snapshot artifacts. The daemon reject
 
 When the daemon runs in cluster mode with AOCR (Aerol OCI Registry) configured, the build node ships the template's `rootfs.ext4` + paused-VM snapshot to AOCR as a single OCI artifact under `cluster/<id>/templates/<tid>:latest`, and peer nodes lazily pull + extract it the first time a sandbox lands on them. Placement is template-aware: the scheduler prefers nodes that already hold a copy of the template's artifacts. See [Cluster Setup](/cluster-setup/) for the deployment knobs.
 
-This reuses the same push pipeline as Docker [Snapshots](/snapshots#snapshot-distribution-in-cluster-mode) — one switch turns on both, and both push to the same AOCR host with the same cluster credential:
+This reuses the same push pipeline as Docker [Snapshots](/snapshots#snapshot-distribution-in-cluster-mode) - one switch turns on both, and both push to the same AOCR host with the same cluster credential:
 
 | Env var | Purpose |
 |---|---|
@@ -326,7 +326,7 @@ This reuses the same push pipeline as Docker [Snapshots](/snapshots#snapshot-dis
 | `SB_AUTO_IMPORT_CLUSTER_ID` | Cluster label that namespaces the artifact (`cluster/<id>/templates/...`) and scopes the credential. |
 | `SB_AUTO_IMPORT_CLUSTER_PAT_PATH` | File holding the cluster PAT presented as the registry credential for push **and** pull. Re-read per call, so rotation is just a file write. |
 
-The pull side is authenticated with the same cluster PAT and does **not** require `SB_SNAPSHOT_PUSH_ENABLED` — a consume-only node fetches template artifacts from AOCR as long as the cluster ID and PAT file are set. Each template row carries a `pushState` you can read back to watch the lifecycle, mirroring snapshots. Unlike snapshots, a template has no "register an existing image" shortcut: it always carries the locally-built rootfs + snapshot, so its only distribution states are `pushState` + `registryRef`.
+The pull side is authenticated with the same cluster PAT and does **not** require `SB_SNAPSHOT_PUSH_ENABLED` - a consume-only node fetches template artifacts from AOCR as long as the cluster ID and PAT file are set. Each template row carries a `pushState` you can read back to watch the lifecycle, mirroring snapshots. Unlike snapshots, a template has no "register an existing image" shortcut: it always carries the locally-built rootfs + snapshot, so its only distribution states are `pushState` + `registryRef`.
 
 ## Optional rotation
 

--- a/docs/src/content/docs/gvisor-sandbox.mdx
+++ b/docs/src/content/docs/gvisor-sandbox.mdx
@@ -5,20 +5,20 @@ description: Create sandboxes backed by the gVisor user-space kernel for stronge
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-gVisor sandboxes run inside the standard Docker runtime but with an extra layer between the container and the host kernel. gVisor implements a user-space kernel (`runsc`) that intercepts every system call the container makes — so instead of talking directly to the Linux kernel, the process talks to gVisor, which then decides what to pass through.
+gVisor sandboxes run inside the standard Docker runtime but with an extra layer between the container and the host kernel. gVisor implements a user-space kernel (`runsc`) that intercepts every system call the container makes - so instead of talking directly to the Linux kernel, the process talks to gVisor, which then decides what to pass through.
 
 Use gVisor when:
 - You are running LLM-generated or otherwise untrusted code that should not have direct access to the host kernel
 - You need stronger isolation than standard Docker containers without the overhead of full VMs
 - Your workload is compatible with gVisor's Linux ABI coverage (most common workloads are)
 
-gVisor works on **any standard server** — there are no bare-metal or special hardware requirements.
+gVisor works on **any standard server** - there are no bare-metal or special hardware requirements.
 
 ## Limitations
 
 - Not compatible with GPU passthrough. A sandbox can use gVisor or a GPU, but not both.
 - Privileged containers (`--privileged`) are not supported under gVisor.
-- `disk_gb` limits are not enforced by gVisor — disk usage falls back to host limits.
+- `disk_gb` limits are not enforced by gVisor - disk usage falls back to host limits.
 - Requires cgroupv2 + systemd on the host (satisfied by default on Ubuntu 22.04+).
 
 ## Create a gVisor sandbox

--- a/docs/src/content/docs/quick-start.md
+++ b/docs/src/content/docs/quick-start.md
@@ -6,7 +6,7 @@ title: Quick Start
 
 The idea is to provide a seamless, secure sandbox experience that can start in under 50ms to 1s.
 
-Sandboxes are the core component of the [Aerol.ai](https://aerol.ai) platform, spinning up in under 90ms from code to execution and running any code in Python, TypeScript, and JavaScript. Built on OCI/Docker compatibility, massive parallelization, and unlimited persistence, sandboxes deliver consistent, predictable environments for agent workflows.
+Sandboxes are the core component of the [Aerol.ai](https://aerol.ai) platform, spinning up in under 70ms from code to execution and running any code in Python, TypeScript, and JavaScript. Built on OCI/Docker compatibility, massive parallelization, and unlimited persistence, sandboxes deliver consistent, predictable environments for agent workflows.
 
 Agents and developers interact with sandboxes programmatically using the AerolVM SDKs, API, and CLI. Operations span sandbox lifecycle management, filesystem operations, process and code execution, and runtime configuration. Our stateful environment snapshots enable persistent agent operations across sessions, making AerolVM the ideal foundation for AI agent architectures.
 

--- a/docs/src/content/docs/sandboxes.mdx
+++ b/docs/src/content/docs/sandboxes.mdx
@@ -12,8 +12,8 @@ A sandbox is an isolated compute environment. Each sandbox has its own filesyste
 | Type | Runtime value | Description |
 |---|---|---|
 | Docker | `docker` (default) | Standard runc-backed containers. Works on any node. |
-| gVisor | `gvisor` | User-space kernel — intercepts syscalls. Better isolation, same hardware requirements. See [gVisor Sandbox](/gvisor-sandbox). |
-| Firecracker | `firecracker` | Full microVM — each sandbox boots its own kernel in under 100ms. Requires bare-metal nodes. See [Firecracker Sandbox](/firecracker-sandbox). |
+| gVisor | `gvisor` | User-space kernel - intercepts syscalls. Better isolation, same hardware requirements. See [gVisor Sandbox](/gvisor-sandbox). |
+| Firecracker | `firecracker` | Full microVM - each sandbox boots its own kernel in under 100ms. Requires bare-metal nodes. See [Firecracker Sandbox](/firecracker-sandbox). |
 | GPU | `docker` + `gpus` field | Standard Docker with direct GPU passthrough. See [GPU Sandbox](/gpu-sandboxes). |
 
 ## Lifecycle states
@@ -229,7 +229,7 @@ Retrieve a running sandbox by ID to get a fully usable sandbox object.
 
 ## Start and stop
 
-Stopping persists all container-level filesystem state. Starting resumes from the persisted layer — running processes are not retained across a stop/start cycle.
+Stopping persists all container-level filesystem state. Starting resumes from the persisted layer - running processes are not retained across a stop/start cycle.
 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">

--- a/docs/src/content/docs/snapshots.mdx
+++ b/docs/src/content/docs/snapshots.mdx
@@ -4,10 +4,10 @@ title: Snapshots
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-**Snapshots are a Docker sandbox feature.** They let you save a Docker container's state as a named image and spin up new sandboxes from it. The sandbox you get back runs on the standard Docker runtime — same as `create({ image: 'ubuntu:22.04' })`, just with your pre-built image instead.
+**Snapshots are a Docker sandbox feature.** They let you save a Docker container's state as a named image and spin up new sandboxes from it. The sandbox you get back runs on the standard Docker runtime - same as `create({ image: 'ubuntu:22.04' })`, just with your pre-built image instead.
 
 :::note[Using Firecracker?]
-If you are creating sandboxes with `runtime: "firecracker"`, snapshots are not what you want. Firecracker uses [Firecracker Templates](/firecracker-templates) instead — a separate concept that pre-builds a microVM rootfs and captures a paused VM memory state to enable sub-100ms boots. The two features are for different runtimes and are not interchangeable.
+If you are creating sandboxes with `runtime: "firecracker"`, snapshots are not what you want. Firecracker uses [Firecracker Templates](/firecracker-templates) instead - a separate concept that pre-builds a microVM rootfs and captures a paused VM memory state to enable sub-100ms boots. The two features are for different runtimes and are not interchangeable.
 :::
 
 A snapshot is a named, reusable image you can launch sandboxes from. AerolVM gives you three ways to make one and a single way to use it.

--- a/pkg/models/dns_records.go
+++ b/pkg/models/dns_records.go
@@ -16,6 +16,12 @@ import (
 // so we phrase the note generically and call Cloudflare out explicitly.
 const cloudflareNote = "Cloudflare/CDN: set the record to DNS only (gray cloud). A proxied record terminates TLS at the CDN and blocks on-demand ACME issuance."
 
+// apexFlatteningNote is attached to every apex routing candidate. A bare CNAME
+// is illegal at a zone root (RFC 1034 §3.6.2); providers expose flattening
+// under different record types, so we emit CNAME/ANAME/ALIAS together and tell
+// the caller to add exactly one — the type their provider accepts.
+const apexFlatteningNote = "Apex domain: add only ONE of these, whichever your DNS provider supports — CNAME (Cloudflare flattening), ANAME (dnsmadeeasy/EasyDNS), or ALIAS (Route 53/DNSimple)."
+
 // ComposeDNSRecords expands every hostname against an IngressTarget into
 // the set of DNS records the user must create at their provider. Shape
 // rules:
@@ -26,8 +32,11 @@ const cloudflareNote = "Cloudflare/CDN: set the record to DNS only (gray cloud).
 //     per IP. Apex prefers IPs over CNAME because CNAME-at-apex requires
 //     provider-specific flattening (Cloudflare, Route 53 alias, DNSimple
 //     ALIAS, etc.) and many providers reject it.
-//   - Apex hostnames with only target.Hostname (no IPs) → one CNAME with a
-//     note that the provider must support apex CNAME flattening.
+//   - Apex hostnames with only target.Hostname (no IPs) → three mutually-
+//     exclusive flattening candidates (CNAME, ANAME, ALIAS), all at "@" with
+//     the same value. A bare CNAME is illegal at a zone root, and providers
+//     name their flattening record differently, so we emit all three and the
+//     note tells the caller to add the one their provider supports.
 //   - Subdomains with only target.IPs → one A/AAAA per IP.
 //   - target empty / Source=unknown → returns nil. Callers render an
 //     operator-must-configure-ingress error rather than fake records.
@@ -59,7 +68,36 @@ func ComposeDNSRecords(hostnames []string, target IngressTarget, txtNamePrefix, 
 		name := dnsRecordName(host)
 		isApex := name == "@"
 		useCNAME := target.Hostname != "" && (!isApex || len(target.IPs) == 0)
-		if useCNAME {
+		if useCNAME && isApex {
+			// Apex on a hostname ingress: a bare CNAME is illegal at the zone
+			// root, so emit the three flattening candidates and let the caller
+			// pick the one their provider supports. Fixed order keeps the
+			// output deterministic. The CNAME row also carries the Cloudflare
+			// gray-cloud warning since Cloudflare users add exactly that row.
+			out = append(out,
+				DNSRecord{
+					Hostname: host,
+					Type:     DNSRecordTypeCNAME,
+					Name:     name,
+					Value:    target.Hostname,
+					Notes:    cloudflareNote + " " + apexFlatteningNote,
+				},
+				DNSRecord{
+					Hostname: host,
+					Type:     DNSRecordTypeANAME,
+					Name:     name,
+					Value:    target.Hostname,
+					Notes:    apexFlatteningNote,
+				},
+				DNSRecord{
+					Hostname: host,
+					Type:     DNSRecordTypeALIAS,
+					Name:     name,
+					Value:    target.Hostname,
+					Notes:    apexFlatteningNote,
+				},
+			)
+		} else if useCNAME {
 			out = append(out, DNSRecord{
 				Hostname: host,
 				Type:     DNSRecordTypeCNAME,

--- a/pkg/models/dns_records_test.go
+++ b/pkg/models/dns_records_test.go
@@ -35,10 +35,47 @@ func TestComposeDNSRecords_SubdomainCNAME(t *testing.T) {
 }
 
 func TestComposeDNSRecords_ApexCNAME(t *testing.T) {
+	// Apex on a hostname ingress emits three flattening candidates
+	// (CNAME/ANAME/ALIAS) at "@", all pointing at the same ingress host.
 	target := IngressTarget{Hostname: "ingress.example.com", Source: IngressTargetSourceHostname}
 	got := nonTXT(ComposeDNSRecords([]string{"acme.com"}, target, "_aerol-verify", "aerol-verify="))
-	if len(got) != 1 || got[0].Name != "@" || got[0].Type != DNSRecordTypeCNAME {
-		t.Fatalf("apex should produce one CNAME with Name=@, got %+v", got)
+	wantTypes := []string{DNSRecordTypeCNAME, DNSRecordTypeANAME, DNSRecordTypeALIAS}
+	if len(got) != len(wantTypes) {
+		t.Fatalf("apex should produce %d flattening rows, got %d: %+v", len(wantTypes), len(got), got)
+	}
+	for i, r := range got {
+		if r.Type != wantTypes[i] || r.Name != "@" || r.Value != "ingress.example.com" {
+			t.Fatalf("row %d = %+v, want Type=%s Name=@ Value=ingress.example.com", i, r, wantTypes[i])
+		}
+	}
+}
+
+func TestComposeDNSRecords_ApexHostnameEmitsFlatteningAlternatives(t *testing.T) {
+	// Each apex candidate must carry the pick-one guidance; the CNAME row
+	// additionally keeps the Cloudflare gray-cloud warning.
+	target := IngressTarget{Hostname: "ingress.example.com", Source: IngressTargetSourceHostname}
+	got := nonTXT(ComposeDNSRecords([]string{"acme.com"}, target, "_aerol-verify", "aerol-verify="))
+
+	byType := make(map[string]DNSRecord, len(got))
+	for _, r := range got {
+		byType[r.Type] = r
+	}
+	for _, typ := range []string{DNSRecordTypeCNAME, DNSRecordTypeANAME, DNSRecordTypeALIAS} {
+		r, ok := byType[typ]
+		if !ok {
+			t.Fatalf("missing %s apex row, got %+v", typ, got)
+		}
+		if !strings.Contains(r.Notes, "add only ONE") {
+			t.Errorf("%s row missing pick-one note: %q", typ, r.Notes)
+		}
+	}
+	// Only the CNAME row carries the gray-cloud proxy warning (Cloudflare
+	// users add that row); ANAME/ALIAS rows must not.
+	if !strings.Contains(byType[DNSRecordTypeCNAME].Notes, "gray cloud") {
+		t.Errorf("apex CNAME row should keep the gray-cloud warning: %q", byType[DNSRecordTypeCNAME].Notes)
+	}
+	if strings.Contains(byType[DNSRecordTypeANAME].Notes, "gray cloud") {
+		t.Errorf("ANAME row should not carry the gray-cloud warning: %q", byType[DNSRecordTypeANAME].Notes)
 	}
 }
 
@@ -60,8 +97,13 @@ func TestComposeDNSRecords_PublicSuffixApex(t *testing.T) {
 	// label-count heuristic would mis-render this as Name="example".
 	target := IngressTarget{Hostname: "ingress.example.com", Source: IngressTargetSourceHostname}
 	got := nonTXT(ComposeDNSRecords([]string{"example.co.uk"}, target, "_aerol-verify", "aerol-verify="))
-	if len(got) != 1 || got[0].Name != "@" {
-		t.Fatalf("expected apex Name=@ for example.co.uk, got %+v", got)
+	if len(got) == 0 {
+		t.Fatal("expected apex flattening rows for example.co.uk, got none")
+	}
+	for _, r := range got {
+		if r.Name != "@" {
+			t.Fatalf("expected apex Name=@ for example.co.uk, got %+v", r)
+		}
 	}
 }
 
@@ -142,13 +184,19 @@ func TestComposeDNSRecords_MixedSourceApexPrefersIPs(t *testing.T) {
 }
 
 func TestComposeDNSRecords_MultipleHostnames(t *testing.T) {
+	// Subdomain → 1 CNAME (Name=api); apex → 3 flattening rows (Name=@).
 	target := IngressTarget{Hostname: "ingress.example.com", Source: IngressTargetSourceHostname}
 	got := nonTXT(ComposeDNSRecords([]string{"api.acme.com", "acme.com"}, target, "_aerol-verify", "aerol-verify="))
-	if len(got) != 2 {
-		t.Fatalf("want 2 records, got %d", len(got))
+	if len(got) != 4 {
+		t.Fatalf("want 4 records (1 subdomain + 3 apex), got %d: %+v", len(got), got)
 	}
-	if got[0].Name != "api" || got[1].Name != "@" {
-		t.Fatalf("expected [api, @], got [%s, %s]", got[0].Name, got[1].Name)
+	if got[0].Name != "api" || got[0].Type != DNSRecordTypeCNAME {
+		t.Fatalf("expected first row CNAME api, got %+v", got[0])
+	}
+	for _, r := range got[1:] {
+		if r.Name != "@" {
+			t.Fatalf("expected apex rows at @, got %+v", r)
+		}
 	}
 }
 

--- a/pkg/models/dns_target.go
+++ b/pkg/models/dns_target.go
@@ -51,12 +51,20 @@ type DNSRecord struct {
 	Notes    string `json:"notes,omitempty"`
 }
 
-// DNS record types we emit. Limited to the three that on-demand ACME +
-// HTTP-01 actually require — TXT / SRV / etc. are not in scope.
+// DNS record types we emit. CNAME / A / AAAA are the routing records
+// on-demand ACME + HTTP-01 require; TXT (composed inline) proves ownership.
+// ANAME / ALIAS are apex-flattening alternatives to CNAME: a bare CNAME is
+// illegal at a zone root (RFC 1034 §3.6.2), so providers expose flattening
+// under different record types (Cloudflare: CNAME, dnsmadeeasy/EasyDNS:
+// ANAME, Route 53/DNSimple: ALIAS). For an apex on a hostname ingress we emit
+// all three as mutually-exclusive candidates — the caller adds the one their
+// provider supports.
 const (
 	DNSRecordTypeCNAME = "CNAME"
 	DNSRecordTypeA     = "A"
 	DNSRecordTypeAAAA  = "AAAA"
+	DNSRecordTypeANAME = "ANAME"
+	DNSRecordTypeALIAS = "ALIAS"
 )
 
 // CustomDomainDNSRecords is the response body for

--- a/sdk/go/pkg/types/types.go
+++ b/sdk/go/pkg/types/types.go
@@ -132,11 +132,15 @@ const (
 // the target. Notes carries provider-specific gotchas the daemon pre-renders.
 type DNSRecord = models.DNSRecord
 
-// DNS record types emitted in CustomDomainDNSRecords.
+// DNS record types emitted in CustomDomainDNSRecords. ANAME and ALIAS are
+// apex-flattening alternatives to CNAME, emitted only for an apex domain on a
+// hostname ingress; add the one your provider supports (see DNSRecord.Notes).
 const (
 	DNSRecordTypeCNAME = models.DNSRecordTypeCNAME
 	DNSRecordTypeA     = models.DNSRecordTypeA
 	DNSRecordTypeAAAA  = models.DNSRecordTypeAAAA
+	DNSRecordTypeANAME = models.DNSRecordTypeANAME
+	DNSRecordTypeALIAS = models.DNSRecordTypeALIAS
 )
 
 // CustomDomainDNSRecords is the response body for the per-sandbox

--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>ai.aerol</groupId>
   <artifactId>aerolvm-sdk</artifactId>
-  <version>0.4.1</version>
+  <version>0.5.1</version>
   <name>Aerol.ai MicroVM Java SDK</name>
   <description>A Java client for the Aerol.ai MicroVM sandbox API.</description>
   <url>https://github.com/aerol-ai/microvm</url>

--- a/sdk/java/src/main/java/ai/aerol/microvm/model/DnsRecord.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/model/DnsRecord.java
@@ -4,9 +4,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * One DNS record an operator needs to publish to validate a custom domain.
- * {@link #type} carries the RR type (e.g. {@code CNAME}, {@code A}) and is
- * bound explicitly via {@link JsonProperty} for symmetry with the wire field,
- * even though Jackson would map a bare {@code type} field already.
+ * {@link #type} carries the RR type — one of {@code CNAME}, {@code A},
+ * {@code AAAA}, {@code ANAME}, or {@code ALIAS}. {@code ANAME}/{@code ALIAS}
+ * appear only for an apex domain on a hostname ingress, as mutually-exclusive
+ * flattening alternatives to {@code CNAME} (add the one your provider supports,
+ * see {@link #notes}). It is bound explicitly via {@link JsonProperty} for
+ * symmetry with the wire field, even though Jackson would map a bare
+ * {@code type} field already.
  */
 public class DnsRecord {
     public String hostname;

--- a/sdk/python/microvm/types.py
+++ b/sdk/python/microvm/types.py
@@ -295,6 +295,11 @@ class DNSRecord(TypedDict, total=False):
     Mirrors ``pkg/models.DNSRecord`` on the server. ``notes`` is optional and
     only set when the server has additional human-readable guidance to attach
     (TTL recommendations, CNAME vs A choice rationale, etc.).
+
+    ``type`` is one of ``CNAME``, ``A``, ``AAAA``, ``ANAME``, or ``ALIAS``. The
+    last two appear only for an apex domain on a hostname ingress, as
+    mutually-exclusive flattening alternatives to ``CNAME`` — add the one your
+    DNS provider supports (see ``notes``).
     """
 
     hostname: str

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aerolvm-sdk"
-version = "0.4.1"
+version = "0.5.1"
 description = "A Python client for the Aerol.ai MicroVM sandbox API."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aerolvm-sdk"
-version = "0.4.1"
+version = "0.5.1"
 edition = "2021"
 authors = ["Aerol AI"]
 description = "A Rust SDK for the Aerol.ai MicroVM sandbox API"

--- a/sdk/rust/src/types.rs
+++ b/sdk/rust/src/types.rs
@@ -339,7 +339,10 @@ pub struct IngressTarget {
 /// One DNS row a user must add at their provider to make a custom domain
 /// reach the cluster. Mirrors `pkg/models.DNSRecord`. `notes` carries
 /// provider-specific gotchas the server pre-renders (e.g. Cloudflare
-/// "DNS only, gray cloud" warning) when relevant.
+/// "DNS only, gray cloud" warning) when relevant. `record_type` is one of
+/// `CNAME`, `A`, `AAAA`, `ANAME`, or `ALIAS` — the last two appear only for
+/// an apex domain on a hostname ingress, as mutually-exclusive flattening
+/// alternatives to `CNAME` (add the one your provider supports, per `notes`).
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct DnsRecord {
     pub hostname: String,

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aerol-ai/aerolvm-sdk",
-  "version": "0.4.1",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aerol-ai/aerolvm-sdk",
-      "version": "0.4.1",
+      "version": "0.5.1",
       "devDependencies": {
         "@types/node": "^25.9.1",
         "tsx": "^4.22.4",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerol-ai/aerolvm-sdk",
-  "version": "0.4.1",
+  "version": "0.5.1",
   "private": false,
   "type": "module",
   "main": "./dist/index.js",

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -307,8 +307,13 @@ export interface IngressTarget {
   source: IngressTargetSource;
 }
 
-/** DNS record types the daemon emits for custom-domain wiring. */
-export type DNSRecordType = "CNAME" | "A" | "AAAA";
+/**
+ * DNS record types the daemon emits for custom-domain wiring. `ANAME` and
+ * `ALIAS` only appear for an apex domain on a hostname ingress, where they are
+ * mutually-exclusive flattening alternatives to `CNAME` (add the one your
+ * provider supports — see each record's `notes`).
+ */
+export type DNSRecordType = "CNAME" | "A" | "AAAA" | "ANAME" | "ALIAS";
 
 /**
  * One ready-to-paste DNS record a user adds at their DNS provider to make a


### PR DESCRIPTION
## Summary

- Apex custom domains on a hostname-only ingress now emit **three mutually-exclusive flattening candidates** (`CNAME`, `ANAME`, `ALIAS`) instead of a single CNAME. A bare CNAME is illegal at a zone root (RFC 1034 §3.6.2) and providers expose flattening under different record types (Cloudflare → CNAME, dnsmadeeasy/EasyDNS → ANAME, Route 53/DNSimple → ALIAS); the caller adds the one their provider supports.
- New `DNSRecordTypeANAME` / `DNSRecordTypeALIAS` constants in `pkg/models`, propagated to all five SDK type definitions (TS/Python/Go/Rust/Java) and the custom-domains docs page.
- Per-record `notes` now spell out the "add exactly one of these" guidance; the CNAME row keeps the Cloudflare gray-cloud warning.
- Routine SDK version bumps (package.json/lock, pyproject, Cargo.toml, pom.xml).

## Sandbox boot impact

N/A - no work added to sandbox boot path. Changes are confined to `ComposeDNSRecords` (DNS-record presentation for custom domains) and SDK/doc type definitions.

## Idempotency

N/A - no API surface changed. `ComposeDNSRecords` is a pure function over its inputs; output is deterministic (fixed CNAME/ANAME/ALIAS order) and unchanged for the non-apex and apex-with-IPs paths.

## Failure-path consistency

N/A - no multi-step write path changed. No caddy or store writes are touched.

## L4 / host-port-pool changes

N/A - neither touched.

## Test plan

- `go test ./pkg/models/...` — `dns_records_test.go` extended to assert apex-on-hostname emits CNAME+ANAME+ALIAS in order with matching values and the correct notes.
- SDK type additions are compile-checked by each SDK's build.
- Docs build (`make docs-build`) for the updated `custom-domains.mdx`.
