### PR TITLE
Snapshot-clone RNG correctness: kernel force-reseed + clone-generation signal + vmgenid docs

### DIFF
--- a/cmd/toolboxd/clonegen.go
+++ b/cmd/toolboxd/clonegen.go
@@ -1,0 +1,114 @@
+package main
+
+// clonegen.go publishes a "clone generation" token the guest can read to
+// detect that it was resumed from a snapshot — i.e. that it is a clone.
+//
+// Why this exists: a Firecracker snapshot-clone duplicates the whole VM
+// memory image, including the seed state of every userspace PRNG inside a
+// long-lived process (a preloaded `python` with `numpy`/`random` already
+// imported is the canonical case). Two clones of the same template would
+// then draw identical "random" streams. The kernel CSPRNG is force-reseeded
+// on resume (see quiesce_linux.go), which covers every freshly-spawned
+// process — but toolboxd is a *separate* process and cannot reach into a
+// foreign heap to reseed an already-running interpreter's PRNG.
+//
+// The fix is cooperative: toolboxd changes this token on every post_resume,
+// and a long-lived in-guest process reads it (via the well-known file or the
+// GET /clone-generation endpoint) and reseeds its own PRNGs when the token
+// changes. The token only needs to *change* on clone — it need not be
+// globally unique, because the reseed itself pulls fresh entropy from the
+// (already-reseeded) kernel, which is clone-distinct.
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// defaultCloneGenPath is the well-known file in-guest readers poll. It lives
+// on tmpfs (/run) so reads are cheap and the value never outlives a boot.
+const defaultCloneGenPath = "/run/aerolvm/clone-generation"
+
+// cloneGeneration holds the current generation token. Safe for concurrent
+// use: the post_resume handler bumps it while HTTP readers and in-guest
+// pollers read it.
+type cloneGeneration struct {
+	mu        sync.RWMutex
+	token     string
+	resumedAt int64 // host wall-clock unix-ns of the last resume; 0 = never
+	path      string
+	logger    *slog.Logger
+}
+
+// newCloneGeneration seeds an initial token and writes it to path. The
+// initial token is the baseline an in-guest process records at startup; it
+// stays put until a post_resume bumps it, so a sandbox that is never cloned
+// correctly reports "no clone." The file write is best-effort — a guest
+// without a writable /run still serves the token over HTTP.
+func newCloneGeneration(path string, logger *slog.Logger) *cloneGeneration {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if path == "" {
+		path = defaultCloneGenPath
+	}
+	c := &cloneGeneration{
+		token:  randomToken(),
+		path:   path,
+		logger: logger,
+	}
+	c.writeFile()
+	return c
+}
+
+// bump rotates the token and records the resume time. Called from the vsock
+// post_resume handler after the kernel RNG reseed. Last-writer-wins under
+// the mutex; concurrent post_resume calls (the host sends at most one per
+// resume) would simply leave the most recent token.
+func (c *cloneGeneration) bump(resumedAtUnixNs int64) {
+	c.mu.Lock()
+	c.token = randomToken()
+	c.resumedAt = resumedAtUnixNs
+	c.mu.Unlock()
+	c.writeFile()
+}
+
+// current returns the token and the last resume time for HTTP responses.
+func (c *cloneGeneration) current() (token string, resumedAt int64) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.token, c.resumedAt
+}
+
+// writeFile persists the current token to the well-known path. Best-effort:
+// failures are logged at Debug and swallowed so a read-only/missing /run
+// never breaks the sandbox — the HTTP endpoint remains the source of truth.
+func (c *cloneGeneration) writeFile() {
+	token, _ := c.current()
+	if err := os.MkdirAll(filepath.Dir(c.path), 0o755); err != nil {
+		c.logger.Debug("clone-generation: mkdir failed", "path", c.path, "error", err)
+		return
+	}
+	// Trailing newline so `cat` / shell `$(<file)` reads are clean.
+	if err := os.WriteFile(c.path, []byte(token+"\n"), 0o644); err != nil {
+		c.logger.Debug("clone-generation: write failed", "path", c.path, "error", err)
+	}
+}
+
+// randomToken returns 16 bytes of crypto entropy as hex. crypto/rand reads
+// the OS CSPRNG, which the resume path reseeds before bump() is ever called,
+// so successive clones get distinct tokens.
+func randomToken() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand.Read effectively never fails on a booted Linux guest;
+		// if it somehow does, fall back to an empty-but-distinct marker so
+		// callers still see *a* value. The kernel reseed is the real
+		// guarantee; this token is only a change signal.
+		return "0000000000000000"
+	}
+	return hex.EncodeToString(b[:])
+}

--- a/cmd/toolboxd/clonegen.go
+++ b/cmd/toolboxd/clonegen.go
@@ -22,10 +22,13 @@ package main
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
+	"time"
 )
 
 // defaultCloneGenPath is the well-known file in-guest readers poll. It lives
@@ -67,8 +70,12 @@ func newCloneGeneration(path string, logger *slog.Logger) *cloneGeneration {
 // bump rotates the token and records the resume time. Called from the vsock
 // post_resume handler after the kernel RNG reseed. Last-writer-wins under
 // the mutex; concurrent post_resume calls (the host sends at most one per
-// resume) would simply leave the most recent token.
+// resume) would simply leave the most recent token. Nil-safe so a future
+// caller that skipped init no-ops instead of panicking.
 func (c *cloneGeneration) bump(resumedAtUnixNs int64) {
+	if c == nil {
+		return
+	}
 	c.mu.Lock()
 	c.token = randomToken()
 	c.resumedAt = resumedAtUnixNs
@@ -77,7 +84,14 @@ func (c *cloneGeneration) bump(resumedAtUnixNs int64) {
 }
 
 // current returns the token and the last resume time for HTTP responses.
+// Nil-safe: a nil receiver (a partially-constructed server in a test, or a
+// future code path that skips newCloneGeneration) reports the baseline
+// "never cloned" state instead of panicking. Production always wires a real
+// instance, so this guard only protects against misconstruction.
 func (c *cloneGeneration) current() (token string, resumedAt int64) {
+	if c == nil {
+		return "", 0
+	}
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.token, c.resumedAt
@@ -98,17 +112,26 @@ func (c *cloneGeneration) writeFile() {
 	}
 }
 
+// fallbackCounter guarantees randomToken's fallback path varies between
+// calls even if crypto/rand is somehow unavailable. See randomToken.
+var fallbackCounter atomic.Uint64
+
 // randomToken returns 16 bytes of crypto entropy as hex. crypto/rand reads
 // the OS CSPRNG, which the resume path reseeds before bump() is ever called,
 // so successive clones get distinct tokens.
 func randomToken() string {
 	var b [16]byte
 	if _, err := rand.Read(b[:]); err != nil {
-		// crypto/rand.Read effectively never fails on a booted Linux guest;
-		// if it somehow does, fall back to an empty-but-distinct marker so
-		// callers still see *a* value. The kernel reseed is the real
-		// guarantee; this token is only a change signal.
-		return "0000000000000000"
+		// crypto/rand.Read effectively never fails on a booted Linux guest.
+		// If it somehow does we must STILL return a value that *changes*
+		// between calls: the token's entire job is to differ on each resume,
+		// and a constant fallback would make a second bump a silent no-op,
+		// hiding a clone from in-guest pollers. Mix a process-lifetime
+		// monotonic counter with the wall-clock nanosecond so successive
+		// fallbacks are distinct. (The kernel reseed is the real entropy
+		// guarantee; this token is only a change signal, so non-crypto
+		// uniqueness here is fine.)
+		return fmt.Sprintf("fallback-%d-%d", time.Now().UnixNano(), fallbackCounter.Add(1))
 	}
 	return hex.EncodeToString(b[:])
 }

--- a/cmd/toolboxd/clonegen_test.go
+++ b/cmd/toolboxd/clonegen_test.go
@@ -151,3 +151,19 @@ func TestQuiesceHandler_PostResume_BumpsCloneGeneration(t *testing.T) {
 		t.Errorf("resumedAt = %d, want 1700000000000000000", resumedAt)
 	}
 }
+
+// TestCloneGeneration_NilReceiverIsSafe pins the cheap hardening that the
+// /clone-generation route relies on: a nil *cloneGeneration (a partial
+// server in a test, or future code that skips newCloneGeneration) must
+// report the baseline "never cloned" state instead of panicking. bump on a
+// nil receiver is likewise a no-op.
+func TestCloneGeneration_NilReceiverIsSafe(t *testing.T) {
+	var cg *cloneGeneration // nil
+
+	token, resumedAt := cg.current()
+	if token != "" || resumedAt != 0 {
+		t.Errorf("nil current() = (%q, %d), want (\"\", 0)", token, resumedAt)
+	}
+	// Must not panic.
+	cg.bump(123)
+}

--- a/cmd/toolboxd/clonegen_test.go
+++ b/cmd/toolboxd/clonegen_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestCloneGeneration_InitWritesStableToken asserts the constructor seeds a
+// token and persists it, and that current() matches the file — the baseline
+// an in-guest reader records before any clone.
+func TestCloneGeneration_InitWritesStableToken(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sub", "clone-generation")
+	c := newCloneGeneration(path, nil)
+
+	token, resumedAt := c.current()
+	if token == "" {
+		t.Fatal("initial token is empty")
+	}
+	if resumedAt != 0 {
+		t.Errorf("initial resumedAt = %d, want 0 (never resumed)", resumedAt)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read clone-generation file: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != token {
+		t.Errorf("file token = %q, want %q", strings.TrimSpace(string(got)), token)
+	}
+}
+
+// TestCloneGeneration_BumpChangesTokenAndPersists asserts bump rotates the
+// token, records the resume time, and rewrites the file — the signal an
+// in-guest process keys off to reseed.
+func TestCloneGeneration_BumpChangesTokenAndPersists(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "clone-generation")
+	c := newCloneGeneration(path, nil)
+	before, _ := c.current()
+
+	c.bump(1700000000000000000)
+
+	after, resumedAt := c.current()
+	if after == before {
+		t.Errorf("token unchanged after bump: %q", after)
+	}
+	if resumedAt != 1700000000000000000 {
+		t.Errorf("resumedAt = %d, want 1700000000000000000", resumedAt)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read clone-generation file: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != after {
+		t.Errorf("file token = %q, want %q", strings.TrimSpace(string(got)), after)
+	}
+}
+
+// TestCloneGeneration_MissingDirIsNonFatal asserts an unwritable path never
+// panics or blocks — the HTTP endpoint stays the source of truth even when
+// /run is read-only. The token is still served from memory.
+func TestCloneGeneration_MissingDirIsNonFatal(t *testing.T) {
+	// A path under a file (not a dir) makes MkdirAll fail.
+	file := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c := newCloneGeneration(filepath.Join(file, "clone-generation"), nil)
+	if token, _ := c.current(); token == "" {
+		t.Error("token should still be served from memory when file write fails")
+	}
+	c.bump(1) // must not panic
+}
+
+// TestCloneGeneration_ConcurrentReadWrite is a race-detector smoke test:
+// concurrent bumps and reads must not data-race.
+func TestCloneGeneration_ConcurrentReadWrite(t *testing.T) {
+	c := newCloneGeneration(filepath.Join(t.TempDir(), "clone-generation"), nil)
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(2)
+		go func(n int) { defer wg.Done(); c.bump(int64(n)) }(i)
+		go func() { defer wg.Done(); _, _ = c.current() }()
+	}
+	wg.Wait()
+}
+
+// TestCloneGenerationRoute_ReturnsToken asserts GET /clone-generation is
+// unauthenticated (like /health) and returns the current token + resume time.
+func TestCloneGenerationRoute_ReturnsToken(t *testing.T) {
+	cg := newCloneGeneration(filepath.Join(t.TempDir(), "clone-generation"), nil)
+	cg.bump(1700000000000000000)
+	s := &server{
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		sandboxID:    "sb-test",
+		authToken:    "token-123",
+		allowedPorts: map[int]struct{}{},
+		cloneGen:     cg,
+	}
+
+	rr := httptest.NewRecorder()
+	s.routes().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/clone-generation", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (unauthenticated)", rr.Code)
+	}
+
+	var body struct {
+		Generation string `json:"generation"`
+		ResumedAt  int64  `json:"resumed_at"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	wantToken, wantResumedAt := cg.current()
+	if body.Generation != wantToken {
+		t.Errorf("generation = %q, want %q", body.Generation, wantToken)
+	}
+	if body.ResumedAt != wantResumedAt {
+		t.Errorf("resumed_at = %d, want %d", body.ResumedAt, wantResumedAt)
+	}
+}
+
+// TestQuiesceHandler_PostResume_BumpsCloneGeneration asserts the post_resume
+// handler rotates the clone-generation token — the wiring that lets an
+// in-guest process detect the clone and reseed its userspace PRNGs.
+func TestQuiesceHandler_PostResume_BumpsCloneGeneration(t *testing.T) {
+	cg := newCloneGeneration(filepath.Join(t.TempDir(), "clone-generation"), nil)
+	before, _ := cg.current()
+
+	h := newQuiesceHandler(nil, nil, cg)
+	h.quiesce = &fakeQuiesceOps{}
+
+	if err := h.OnPostResume(context.Background(),
+		json.RawMessage(`{"wallclock_unix_ns":1700000000000000000}`)); err != nil {
+		t.Fatalf("OnPostResume: %v", err)
+	}
+
+	after, resumedAt := cg.current()
+	if after == before {
+		t.Error("clone generation token was not bumped on post_resume")
+	}
+	if resumedAt != 1700000000000000000 {
+		t.Errorf("resumedAt = %d, want 1700000000000000000", resumedAt)
+	}
+}

--- a/cmd/toolboxd/coverage_boost4_test.go
+++ b/cmd/toolboxd/coverage_boost4_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestQuiesceHandlerOnPing(t *testing.T) {
-	h := newQuiesceHandler(slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	h := newQuiesceHandler(slog.New(slog.NewTextHandler(io.Discard, nil)), nil, nil)
 	if err := h.OnPing(t.Context()); err != nil {
 		t.Fatalf("OnPing: %v", err)
 	}

--- a/cmd/toolboxd/main.go
+++ b/cmd/toolboxd/main.go
@@ -40,6 +40,7 @@ type server struct {
 	sessions *sessions.Manager
 	daytona  *daytonaCompat
 	envd     *envdCompat
+	cloneGen *cloneGeneration
 }
 
 func (s *server) setAllowedPorts(ports []int) {
@@ -87,6 +88,7 @@ func main() {
 		allowedPorts: map[int]struct{}{},
 		daytona:      newDaytonaCompat(),
 		envd:         newEnvdCompat(),
+		cloneGen:     newCloneGeneration(envString("SB_CLONE_GEN_PATH", defaultCloneGenPath), logger),
 	}
 	// Evict the token from the process env table so child processes spawned
 	// for the user command and /exec endpoints don't inherit it via os.Environ().
@@ -131,7 +133,7 @@ func main() {
 	// Pass srv.sessions (may be nil if the manager failed to init above)
 	// so the handler's pre_snapshot can fsync session recordings; nil
 	// is treated as "no sessions to flush" by the handler.
-	vsockHandler := newQuiesceHandler(logger, newSessionFlusher(srv.sessions))
+	vsockHandler := newQuiesceHandler(logger, newSessionFlusher(srv.sessions), srv.cloneGen)
 	if vs, err := newVsockServer(defaultVsockPort, vsockHandler, logger); err != nil {
 		logger.Warn("vsock listener disabled", "error", err)
 	} else {
@@ -260,6 +262,13 @@ func (s *server) routes() http.Handler {
 			writeJSON(w, http.StatusOK, map[string]any{"status": "ok", "version": version.Version})
 		case r.Method == http.MethodGet && r.URL.Path == "/version":
 			writeJSON(w, http.StatusOK, map[string]any{"version": version.Version})
+		case r.Method == http.MethodGet && r.URL.Path == "/clone-generation":
+			// Unauthenticated like /health: the token is a non-sensitive
+			// change-detector for snapshot clones, and external access is
+			// gated by the auth'd v1 toolbox proxy. In-guest readers can use
+			// this or the well-known file written by cloneGeneration.
+			token, resumedAt := s.cloneGen.current()
+			writeJSON(w, http.StatusOK, map[string]any{"generation": token, "resumed_at": resumedAt})
 		case strings.HasPrefix(r.URL.Path, "/proxy/"):
 			s.handleProxy(w, r)
 		case strings.HasPrefix(r.URL.Path, "/envd/"):
@@ -432,6 +441,8 @@ func isKnownToolboxPath(path string) bool {
 	case path == "/health":
 		return true
 	case path == "/version":
+		return true
+	case path == "/clone-generation":
 		return true
 	case strings.HasPrefix(path, "/process/"):
 		return true

--- a/cmd/toolboxd/quiesce_linux.go
+++ b/cmd/toolboxd/quiesce_linux.go
@@ -14,10 +14,11 @@ package main
 //   - ReseedRandom: every snapshot clone resumes with the template's
 //     /dev/urandom entropy pool. Two clones of the same template
 //     would draw identical bytes from getrandom(0), a real crypto
-//     bug. RNDADDENTROPY forces the kernel to bump its entropy
-//     estimate AND mix the supplied bytes into the input pool, so
-//     the next getrandom reseeds the CSPRNG. Fresh entropy comes
-//     from the host-attached virtio-rng device via /dev/random.
+//     bug. RNDADDENTROPY credits the kernel input pool with fresh
+//     bytes; RNDRESEEDCRNG then forces the CRNG to consume them
+//     immediately so the next getrandom returns a clone-distinct
+//     stream. Fresh entropy comes from the host-attached virtio-rng
+//     device via /dev/random.
 
 import (
 	"crypto/rand"
@@ -29,15 +30,25 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// ioctlPtr is the syscall seam ReseedRandom uses for both the
+// RNDADDENTROPY and RNDRESEEDCRNG ioctls. A package var so the linux
+// unit test (quiesce_linux_test.go) can assert both fire — in order —
+// without a real kernel or CAP_SYS_ADMIN. Production wires the real
+// SYS_IOCTL.
+var ioctlPtr = func(fd, request, arg uintptr) syscall.Errno {
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, fd, request, arg)
+	return errno
+}
+
 // linuxQuiesceOps is the concrete quiesceOps used inside the sandbox.
 // Holds no state — all ops are syscalls against the running kernel.
 type linuxQuiesceOps struct{}
 
 // ReseedRandom mixes 32 fresh bytes of entropy into the kernel input
-// pool and credits them as 256 bits. Forces the next getrandom call to
-// reseed the CSPRNG so two clones drawing entropy after resume see
-// distinct streams. Errors are returned but the caller logs and
-// continues — a sandbox without fresh entropy is degraded, not broken.
+// pool and then forces the CRNG to reseed from it, so two clones drawing
+// entropy after resume see distinct streams. Errors are returned but the
+// caller logs and continues — a sandbox without fresh entropy is
+// degraded, not broken.
 func (linuxQuiesceOps) ReseedRandom() error {
 	const entropyBytes = 32
 	var buf [entropyBytes]byte
@@ -59,13 +70,28 @@ func (linuxQuiesceOps) ReseedRandom() error {
 		return fmt.Errorf("open /dev/random: %w", err)
 	}
 	defer f.Close()
-	if _, _, errno := syscall.Syscall(
-		syscall.SYS_IOCTL,
+
+	// Step 1: credit the input pool. This is the load-bearing op — if it
+	// fails the clone has no fresh entropy, so surface the error.
+	if errno := ioctlPtr(
 		f.Fd(),
 		uintptr(unix.RNDADDENTROPY),
 		uintptr(unsafe.Pointer(&payload[0])),
 	); errno != 0 {
 		return fmt.Errorf("ioctl RNDADDENTROPY: %w", errno)
+	}
+
+	// Step 2: force an immediate CRNG reseed. RNDADDENTROPY only credits
+	// the pool; on kernels < 5.18 the CRNG may not reseed from it until
+	// its own interval elapses, leaving a window where two clones'
+	// getrandom() still return the pre-snapshot stream. RNDRESEEDCRNG
+	// (Linux >= 5.10) closes that window. The request arg is ignored.
+	// Older kernels lack the ioctl and answer ENOTTY/EINVAL — tolerate
+	// that: the entropy is already credited and the CRNG will reseed on
+	// schedule, so it's a soft degrade, not a failure.
+	if errno := ioctlPtr(f.Fd(), uintptr(unix.RNDRESEEDCRNG), 0); errno != 0 &&
+		errno != syscall.ENOTTY && errno != syscall.EINVAL {
+		return fmt.Errorf("ioctl RNDRESEEDCRNG: %w", errno)
 	}
 	return nil
 }

--- a/cmd/toolboxd/quiesce_linux_test.go
+++ b/cmd/toolboxd/quiesce_linux_test.go
@@ -1,0 +1,77 @@
+//go:build linux
+
+package main
+
+import (
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestReseedRandomForcesCRNGReseed verifies ReseedRandom credits the pool
+// (RNDADDENTROPY) AND forces an immediate reseed (RNDRESEEDCRNG), in that
+// order. The ordering matters: crediting after the forced reseed would
+// leave the CRNG one interval behind. The ioctl seam is stubbed so the
+// test needs neither a real kernel nor CAP_SYS_ADMIN.
+func TestReseedRandomForcesCRNGReseed(t *testing.T) {
+	orig := ioctlPtr
+	t.Cleanup(func() { ioctlPtr = orig })
+
+	var requests []uintptr
+	ioctlPtr = func(_, request, _ uintptr) syscall.Errno {
+		requests = append(requests, request)
+		return 0
+	}
+
+	if err := (linuxQuiesceOps{}).ReseedRandom(); err != nil {
+		t.Fatalf("ReseedRandom: %v", err)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("ioctl call count = %d, want 2 (RNDADDENTROPY, RNDRESEEDCRNG)", len(requests))
+	}
+	if requests[0] != uintptr(unix.RNDADDENTROPY) {
+		t.Errorf("first ioctl = %#x, want RNDADDENTROPY %#x", requests[0], uintptr(unix.RNDADDENTROPY))
+	}
+	if requests[1] != uintptr(unix.RNDRESEEDCRNG) {
+		t.Errorf("second ioctl = %#x, want RNDRESEEDCRNG %#x", requests[1], uintptr(unix.RNDRESEEDCRNG))
+	}
+}
+
+// TestReseedRandomToleratesOldKernel asserts a missing RNDRESEEDCRNG
+// (kernels < 5.10 answer ENOTTY) is a soft degrade, not a failure: the
+// entropy was already credited by RNDADDENTROPY.
+func TestReseedRandomToleratesOldKernel(t *testing.T) {
+	orig := ioctlPtr
+	t.Cleanup(func() { ioctlPtr = orig })
+
+	ioctlPtr = func(_, request, _ uintptr) syscall.Errno {
+		if request == uintptr(unix.RNDRESEEDCRNG) {
+			return syscall.ENOTTY
+		}
+		return 0
+	}
+
+	if err := (linuxQuiesceOps{}).ReseedRandom(); err != nil {
+		t.Fatalf("ReseedRandom should tolerate missing RNDRESEEDCRNG: %v", err)
+	}
+}
+
+// TestReseedRandomSurfacesAddEntropyFailure asserts the load-bearing op
+// (RNDADDENTROPY) failing is surfaced — a clone with no fresh entropy is
+// the bug we are guarding against.
+func TestReseedRandomSurfacesAddEntropyFailure(t *testing.T) {
+	orig := ioctlPtr
+	t.Cleanup(func() { ioctlPtr = orig })
+
+	ioctlPtr = func(_, request, _ uintptr) syscall.Errno {
+		if request == uintptr(unix.RNDADDENTROPY) {
+			return syscall.EPERM
+		}
+		return 0
+	}
+
+	if err := (linuxQuiesceOps{}).ReseedRandom(); err == nil {
+		t.Fatal("ReseedRandom should surface RNDADDENTROPY failure, got nil")
+	}
+}

--- a/cmd/toolboxd/vsock.go
+++ b/cmd/toolboxd/vsock.go
@@ -249,9 +249,17 @@ func (h *quiesceHandler) OnPostResume(ctx context.Context, raw json.RawMessage) 
 	if err := h.quiesce.ReseedRandom(); err != nil {
 		h.logger.Warn("vsock post_resume: rng reseed failed", "error", err)
 	}
-	// Bump the clone-generation token AFTER the kernel reseed so an in-guest
-	// process that observes the new token can immediately reseed its own
-	// userspace PRNGs from a kernel that already has fresh entropy.
+	// Bump the clone-generation token on every resume, regardless of the
+	// reseed result above. The token is first a clone/migration *detector*
+	// (the SDK cloneGeneration() reader and in-guest pollers), so it must
+	// change even if the reseed failed — otherwise a clone goes undetected.
+	// Ordered after ReseedRandom so that on the happy path an in-guest poller
+	// reseeds its userspace PRNG from a kernel that already holds fresh
+	// entropy. On the rare reseed failure the kernel may still hold the
+	// snapshot's stale entropy, but reseeding userspace from it is no worse
+	// than leaving the frozen seed in place — both duplicate across clones —
+	// and that failure is logged loudly just above; vmgenid is the real
+	// backstop. See TestQuiesceHandler_PostResume_BumpsGenerationEvenOnReseedFailure.
 	if h.cloneGen != nil {
 		h.cloneGen.bump(data.WallclockUnixNs)
 	}

--- a/cmd/toolboxd/vsock.go
+++ b/cmd/toolboxd/vsock.go
@@ -200,9 +200,10 @@ type quiesceHandler struct {
 	logger   *slog.Logger
 	sessions sessionFlusher
 	quiesce  quiesceOps
+	cloneGen *cloneGeneration
 }
 
-func newQuiesceHandler(logger *slog.Logger, sessions sessionFlusher) *quiesceHandler {
+func newQuiesceHandler(logger *slog.Logger, sessions sessionFlusher, cloneGen *cloneGeneration) *quiesceHandler {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -210,6 +211,7 @@ func newQuiesceHandler(logger *slog.Logger, sessions sessionFlusher) *quiesceHan
 		logger:   logger,
 		sessions: sessions,
 		quiesce:  newQuiesceOps(),
+		cloneGen: cloneGen,
 	}
 }
 
@@ -246,6 +248,12 @@ func (h *quiesceHandler) OnPostResume(ctx context.Context, raw json.RawMessage) 
 	}
 	if err := h.quiesce.ReseedRandom(); err != nil {
 		h.logger.Warn("vsock post_resume: rng reseed failed", "error", err)
+	}
+	// Bump the clone-generation token AFTER the kernel reseed so an in-guest
+	// process that observes the new token can immediately reseed its own
+	// userspace PRNGs from a kernel that already has fresh entropy.
+	if h.cloneGen != nil {
+		h.cloneGen.bump(data.WallclockUnixNs)
 	}
 	h.logger.Info("vsock: post_resume complete",
 		"wallclock_set", data.WallclockUnixNs > 0)

--- a/cmd/toolboxd/vsock_test.go
+++ b/cmd/toolboxd/vsock_test.go
@@ -392,3 +392,35 @@ func TestQuiesceHandler_PostResume_QuiesceErrorIsNonFatal(t *testing.T) {
 		t.Errorf("OnPostResume returned %v; want nil despite quiesce errors", err)
 	}
 }
+
+// TestQuiesceHandler_PostResume_BumpsGenerationEvenOnReseedFailure pins the
+// deliberate coupling between the kernel reseed and the clone-generation
+// bump: the token MUST still change when ReseedRandom fails. The token is a
+// clone/migration detector first (SDK cloneGeneration() + in-guest pollers),
+// so a resume that failed to reseed must not also silently fail to register
+// as a clone. On that rare failure an in-guest poller reseeding userspace
+// from the (possibly stale) kernel is no worse than leaving its frozen seed
+// in place; the reseed failure is logged loudly and vmgenid is the backstop.
+// If you intend to gate the bump on reseed success, this test should fail
+// and force that decision to be explicit.
+func TestQuiesceHandler_PostResume_BumpsGenerationEvenOnReseedFailure(t *testing.T) {
+	cg := newCloneGeneration(t.TempDir()+"/clone-generation", nil)
+	initialToken, _ := cg.current()
+
+	q := &fakeQuiesceOps{reseedErr: errors.New("entropy pool unavailable")}
+	h := newQuiesceHandler(nil, nil, cg)
+	h.quiesce = q
+
+	if err := h.OnPostResume(context.Background(),
+		json.RawMessage(`{"wallclock_unix_ns":777}`)); err != nil {
+		t.Fatalf("OnPostResume returned %v; want nil", err)
+	}
+
+	gotToken, gotResumedAt := cg.current()
+	if gotToken == initialToken {
+		t.Errorf("clone-generation token unchanged after reseed failure (%q); bump must fire regardless of reseed result", gotToken)
+	}
+	if gotResumedAt != 777 {
+		t.Errorf("resumedAt = %d, want 777 (bump records resume time even on reseed failure)", gotResumedAt)
+	}
+}

--- a/cmd/toolboxd/vsock_test.go
+++ b/cmd/toolboxd/vsock_test.go
@@ -157,7 +157,7 @@ func TestVsock_UnknownOpReturnsError(t *testing.T) {
 
 func TestVsock_MissingOp(t *testing.T) {
 	host, guest := newPipePair()
-	done := runHandlerInBackground(t, guest, newQuiesceHandler(nil, nil))
+	done := runHandlerInBackground(t, guest, newQuiesceHandler(nil, nil, nil))
 
 	_, _ = host.Write([]byte(`{}` + "\n"))
 	var resp VsockResponse
@@ -209,7 +209,7 @@ func TestVsock_HandlerErrorDoesNotCloseConn(t *testing.T) {
 // newline). The host should reconnect.
 func TestVsock_DecodeErrorClosesConn(t *testing.T) {
 	host, guest := newPipePair()
-	done := runHandlerInBackground(t, guest, newQuiesceHandler(nil, nil))
+	done := runHandlerInBackground(t, guest, newQuiesceHandler(nil, nil, nil))
 
 	_, _ = host.Write([]byte("not json\n"))
 	var resp VsockResponse
@@ -298,7 +298,7 @@ func TestQuiesceHandler_PreSnapshot_FlushesEverySession(t *testing.T) {
 		ids:       []string{"s1", "s2", "s3"},
 		flushErrs: map[string]error{"s2": errors.New("disk full")},
 	}
-	h := newQuiesceHandler(nil, flusher)
+	h := newQuiesceHandler(nil, flusher, nil)
 	h.quiesce = &fakeQuiesceOps{} // unused for pre_snapshot but avoids nil deref
 
 	if err := h.OnPreSnapshot(context.Background(), nil); err != nil {
@@ -325,7 +325,7 @@ func TestQuiesceHandler_PreSnapshot_FlushesEverySession(t *testing.T) {
 // not gated on the wallclock field's presence.
 func TestQuiesceHandler_PostResume_ResyncsClockAndRNG(t *testing.T) {
 	q := &fakeQuiesceOps{}
-	h := newQuiesceHandler(nil, nil)
+	h := newQuiesceHandler(nil, nil, nil)
 	h.quiesce = q
 
 	raw := json.RawMessage(`{"wallclock_unix_ns":1700000000000000000}`)
@@ -359,7 +359,7 @@ func TestQuiesceHandler_PostResume_RNGReseedAlwaysFires(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			q := &fakeQuiesceOps{}
-			h := newQuiesceHandler(nil, nil)
+			h := newQuiesceHandler(nil, nil, nil)
 			h.quiesce = q
 			if err := h.OnPostResume(context.Background(), tc.raw); err != nil {
 				t.Fatalf("OnPostResume: %v", err)
@@ -385,7 +385,7 @@ func TestQuiesceHandler_PostResume_QuiesceErrorIsNonFatal(t *testing.T) {
 		reseedErr:    errors.New("entropy pool unavailable"),
 		wallclockErr: errors.New("CAP_SYS_TIME denied"),
 	}
-	h := newQuiesceHandler(nil, nil)
+	h := newQuiesceHandler(nil, nil, nil)
 	h.quiesce = q
 	if err := h.OnPostResume(context.Background(),
 		json.RawMessage(`{"wallclock_unix_ns":12345}`)); err != nil {

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -350,6 +350,12 @@ const getDocsSidebarConfig = (): NavigationGroup[] => [
     entries: [
       {
         type: 'link',
+        href: '/engineering-distributed-sandbox-runtime',
+        label: 'The Sandbox Runtime Nobody Built',
+        description: 'Every self-hostable sandbox is single-node. Every multi-node sandbox is managed. AerolVM is one Go binary that runs as both, with raw TCP ingress and HA stateful sandboxes that survive host death.',
+      },
+      {
+        type: 'link',
         href: '/engineering-idempotency',
         label: 'Idempotency on a Single Writer',
         description: 'Partial unique indexes + request_idempotency replay + a one-writer SQLite core. Making concurrent-duplicate races structurally unrepresentable.',

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -173,6 +173,12 @@ const getDocsSidebarConfig = (): NavigationGroup[] => [
             label: 'Firecracker Templates',
             description: 'Register OCI images as Firecracker rootfs templates for sub-100ms cold starts; rebuild on demand.',
           },
+          {
+            type: 'link',
+            href: '/randomness-in-cloned-sandboxes',
+            label: 'Randomness in Clones',
+            description: 'Why snapshot clones can share random-number state, what AerolVM reseeds automatically, and how to reseed your own long-lived processes.',
+          },
         ]
       },
       {

--- a/docs/src/content/docs/engineering-distributed-sandbox-runtime.mdx
+++ b/docs/src/content/docs/engineering-distributed-sandbox-runtime.mdx
@@ -1,0 +1,506 @@
+---
+title: The Sandbox Runtime Nobody Built
+description: Every self-hostable sandbox is single-node. Every multi-node sandbox is a managed service. AerolVM is one Go binary that runs as both — distributed control plane, raw TCP/TLS ingress, and stateful sandboxes that survive host death. This is the architecture, the competitive landscape, and why this gap existed in the first place.
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+I spent six months looking for an open-source, self-hostable sandbox runtime
+that could span more than one machine. It does not exist. Not E2B, not
+Daytona, not Microsandbox, not moru, not Era, not Cognitora, not Beam, not
+Northflank's self-host story. Every project in the agent-sandbox category is
+exactly one of two things: **a managed cloud you cannot self-host**, or **a
+single-node runtime you can self-host but cannot scale past one machine**.
+
+The category has a hole shaped like Kubernetes. I built the thing that fills
+it. This page is the architecture, the four differentiators that fall out of
+it, and an honest comparison with every adjacent project I could find.
+
+## The gap, stated precisely
+
+Sandbox runtimes for AI agents and untrusted code have converged on a shape.
+You boot a microVM or container, expose a public URL, run code via an SDK,
+tear it down. The thirty-plus projects in this category disagree on the
+isolation primitive (Firecracker, gVisor, Kata, libkrun, V8 isolates, raw
+runc) and on the SDK surface (Python-first, TypeScript-first, code-execution
+vs. dev-environment). They agree on one thing: **the orchestration story is
+either "ours, managed" or "yours, single-box."**
+
+That is not a small gap. It is the gap that defines whether you can run
+sandboxes on hardware you own at a scale that matters. Three concrete things
+fall out of the missing distributed control plane:
+
+1. **You cannot survive a host going down.** A managed service does this for
+   you, opaquely. A single-node runtime cannot, by definition. A self-hosted
+   multi-node runtime is the only shape that lets *you* own the failure
+   domain while *also* not losing sandboxes when a machine dies.
+2. **You cannot publish raw TCP/TLS from a sandbox to the internet.** The
+   reason is mundane: nobody built an open-source ingress layer for
+   sandbox-shaped workloads. Managed services have it (Fly Machines does);
+   self-hosted runtimes don't. So if you want to give a sandbox a real
+   Postgres port, you're stuck wiring it yourself or moving to a managed VM
+   platform that isn't pitched as a sandbox.
+3. **You cannot run stateful workloads with any kind of availability
+   guarantee.** Postgres, Redis, MinIO, a Jupyter kernel holding hours of
+   work — all of these become "if the host dies, the work is gone." For
+   ephemeral agent execution this is fine. For everything else, it's a
+   ceiling.
+
+I will defend each of those claims with code below, and with a comparison
+table against every project I evaluated. First, the architecture, because
+the claims are only meaningful if the architecture supports them.
+
+## The architecture, in one paragraph
+
+AerolVM is one Go binary, `sandboxd`. It runs in two modes from the same
+build: **standalone**, where it is the entire sandbox runtime on one host,
+and **cluster**, where N copies of it form a distributed control plane using
+[hashicorp/raft](https://github.com/hashicorp/raft) for placement consensus,
+[hashicorp/memberlist](https://github.com/hashicorp/memberlist) (SWIM) for
+membership, and HTTP reverse-proxy forwarding for mutating calls that need
+to land on the sandbox's current owner. There is no separate scheduler. No
+etcd. No Kubernetes. No control-plane / data-plane split — every node is
+both. The cluster package is a no-op when `EnableCluster=false`, so the
+standalone path costs nothing.
+
+Ingress is [Caddy](https://caddyserver.com/), embedded as a library, with
+[caddy-l4](https://github.com/mholt/caddy-l4) handling raw TCP/TLS routes
+in addition to standard HTTPS. The same daemon that runs sandboxes runs the
+ingress; routes are added and removed as sandboxes come and go, with
+zero-downtime config patches via the Caddy admin API.
+
+Storage is SQLite per node, single-writer (`MaxOpenConns=1`, WAL). Cluster
+state lives in the Raft FSM in memory and is replicated through Raft.
+
+That is the whole shape. The differentiators below all derive from it.
+
+## Differentiator 1: one binary holds the whole distributed control plane
+
+> **Video placeholder:** *Three-node cluster from zero in under two minutes.
+> Single binary on each box, `sandboxd cluster init` on the first, join on
+> the others, sandbox lands and is reachable.*
+
+Other "distributed" things in this space require:
+
+- A separate scheduler binary (Nomad-style).
+- An external KV store (etcd, Consul).
+- An orchestrator (Kubernetes) with a sandbox runtime layered on top
+  (KubeVirt + custom controllers, or one of the failed "sandbox operator"
+  projects).
+- A control-plane / data-plane split that means at minimum two binaries to
+  deploy.
+
+AerolVM has none of those. The same binary running your sandboxes is also
+the Raft member, the SWIM member, the ingress controller, the API server,
+and the SDK transport target. `internal/cluster/` is ~5000 lines of Go;
+when the cluster is disabled it returns the `Noop` implementation and the
+rest of the daemon never branches on cluster mode.
+
+The shape this enables for operators:
+
+```bash
+# Standalone, day zero
+systemctl start sandboxd
+
+# Cluster, same binary, three nodes
+sandboxd cluster init      # node A
+sandboxd cluster join A    # node B
+sandboxd cluster join A    # node C
+```
+
+That's it. No external dependencies. No companion services. No Helm charts.
+
+**Why nobody else did this.** Two reasons, and both are honest:
+
+- The agent-sandbox category is young (most projects launched 2024–2026).
+  Building a distributed control plane is a year of work that doesn't
+  visibly differentiate from "we have a fast cold start" in early demos.
+- The companies in the space are venture-funded, and shipping a multi-node
+  open-source story is a *direct subtraction* from their managed-service
+  revenue. The incentives point the other way.
+
+I'm not venture-funded and I had the year. So here we are.
+
+## Differentiator 2: raw TCP/TLS exposure, not just HTTP
+
+> **Video placeholder:** *Spin up a Postgres sandbox. Connect from `psql` on
+> a laptop over raw TCP via the cluster's public endpoint. Run a query.*
+
+Every sandbox vendor in the agent-sandbox category exposes HTTP. None of
+the open-source self-hostable ones publish raw TCP/TLS. The reason is that
+HTTP ingress is solved (nginx, Caddy, Envoy, Traefik) and TCP ingress for
+arbitrary multi-tenant workloads is not — it requires either SNI-based
+multiplexing on shared ports or per-sandbox host-port allocation, and both
+have ugly edge cases.
+
+AerolVM uses [caddy-l4](https://github.com/mholt/caddy-l4) for L4
+multiplexing on shared ports, plus the host-port pool described in
+[Idempotency on a Single Writer](/engineering-idempotency) for the cases
+where SNI doesn't apply (raw TCP without TLS, or protocols where the
+server expects to own the port). The same daemon that runs the sandbox
+patches the Caddy config to add and remove L4 routes as sandboxes come
+and go.
+
+The practical effect: a sandbox can publish a real Postgres port, a real
+Redis port, a real MongoDB port, a real MySQL port, a real Mosquitto MQTT
+port, a real anything-with-TCP, to the public internet, with optional TLS
+termination, behind a public hostname your DNS already points at the
+cluster. **No other open-source sandbox runtime does this.** Managed VM
+platforms that aren't pitched as sandboxes (Fly Machines, in particular)
+do. The gap in the sandbox category is real.
+
+See [TCP & TLS Ports](/tcp-ports) for the operator-facing docs and
+[Deploy your own Supabase](/use-cases/customer-facing-product-experiences/spawn-postgres)
+for the worked Postgres example.
+
+## Differentiator 3: stateful sandboxes that survive host death
+
+> **Video placeholder:** *Three-node cluster. Postgres sandbox running on
+> node B with data in S3-backed mount. `kill -9` sandboxd on B (or
+> `poweroff`). Watch placement re-elect, the sandbox respawn on node C
+> with the same mount reattached, `psql` reconnect, data intact.*
+
+This is the strongest claim in the document and I will defend it the
+hardest, because the database people in the HN thread will press on it.
+
+The mechanism, in order:
+
+1. **External persistent storage.** A sandbox can declare a mount backed
+   by S3, NFS, SSHFS, or any [rclone](https://rclone.org) remote (see
+   [Attach Volumes](/external-storage)). The mount tooling executes on
+   the host — see [Host-Mediated Trust Boundary](/engineering-trust-boundary) —
+   so credentials never enter the sandbox and the mount's lifetime is
+   not tied to the container's lifetime.
+2. **Cluster-wide placement state in Raft.** The sandbox's identity
+   (name, hostname binding, declared mounts, declared exposed ports) is
+   in the Raft FSM. When the owner node dies, that state is not lost; the
+   surviving leader has it.
+3. **Owner-death detection via SWIM.** `memberlist` declares a node
+   `Failed` after the configured suspect-to-confirm window (sub-second
+   to a few seconds depending on cluster size and probe interval).
+4. **Re-placement.** The placement code (`internal/cluster/placement.go`)
+   picks a new owner by power-of-two-choices over the remaining healthy
+   nodes weighted by capacity. The recovery path
+   (`internal/cluster/recovery_replication.go`,
+   `recovery_store.go`) re-instantiates the sandbox identity on the new
+   owner.
+5. **Mount reattachment.** The new owner's mount manager attaches the
+   same external volume. Because the storage is external (S3/NFS), the
+   bytes never moved. The new container sees the same filesystem the
+   old one wrote to.
+6. **Ingress cutover.** The Caddy route is updated to point at the new
+   owner. Clients hitting the public hostname (HTTP or raw TCP) are
+   routed to the new sandbox transparently. Long-lived TCP connections
+   are dropped at the cutover; clients reconnect.
+
+The honest caveats, because HN will ask:
+
+- **The cutover is not zero-RPO for in-flight writes that hadn't
+  reached the external store yet.** If you ran `psql` against a sandbox
+  whose Postgres had a transaction in shared buffers but not yet flushed
+  to the S3 mount when the host died, that transaction is lost. This is
+  the same property real Postgres has against a `kill -9` of the
+  process; we don't add durability the database doesn't have.
+- **The cutover is not zero-downtime.** Detection + re-placement +
+  mount + container start is on the order of a few seconds in normal
+  operation. Long-lived TCP connections drop and reconnect. HTTP
+  clients with retries handle it transparently; bespoke TCP clients
+  need a reconnect loop.
+- **The mount adapter must support concurrent-access semantics that
+  match your workload.** S3 with a single writer at a time is fine.
+  S3 with two writers concurrently is not, ever — and the cutover
+  window is technically a moment where the dying owner might still be
+  writing while the new owner is starting. We force-detach on the old
+  owner before the new one mounts; tested for the common cases but the
+  durability of your data is a function of the storage backend's
+  consistency model.
+- **You need at least one healthy node with capacity** for the
+  failed sandbox to land on. If the whole cluster is at capacity, the
+  sandbox stays unplaced until capacity frees up.
+
+With those caveats stated: **yes, kill the host, the sandbox respawns
+on a healthy node with its data, and the public hostname routes to the
+new sandbox.** Run your own Postgres, your own Redis, your own
+single-tenant MinIO inside a sandbox, and it survives node loss.
+
+I am not aware of another open-source sandbox runtime that does this.
+The closest comparable is running a Kubernetes StatefulSet with a PVC,
+which works but requires you to operate Kubernetes, find a CSI driver
+that maps to your storage, and accept that the workload is a pod, not a
+sandbox-with-an-SDK. See [Durability & Failover](/durability) for the
+operator-facing reference.
+
+## Differentiator 4: five SDKs in lockstep, plus drop-in E2B and Daytona facades
+
+Five SDKs (TypeScript, Python, Go, Rust, Java) ship from the same repo and
+the same release. They are not generated wrappers — each is hand-written to
+be idiomatic in its language, with matching method names and matching test
+coverage. Every new server feature is a five-package PR.
+
+On top of the native SDKs, AerolVM exposes two compatibility facades:
+
+- **`/daytona`** — speaks the Daytona SDK protocol. Point the official
+  Daytona SDK at this endpoint and your existing code runs unchanged.
+- **`/e2b`** — speaks the E2B SDK protocol, including the duplicate-body
+  retry dedupe described in
+  [Idempotency on a Single Writer](/engineering-idempotency).
+
+This is not a differentiator in the same league as "HA stateful
+sandboxes." It is a migration story. If you're already on E2B or Daytona
+and want to move to self-hosted, you change one URL.
+
+See [Using Daytona SDK](/using-daytona-sdk) and
+[Using E2B SDK](/using-e2b-sdk).
+
+## The competitive landscape, honestly
+
+I evaluated every project I could find in the adjacent space. Honest
+table, my best read as of writing — if I have any of this wrong, please
+correct me in the HN thread or via PR.
+
+| Project | Self-hostable | Multi-node | Raw TCP | HA stateful | SDKs | Notes |
+|---|---|---|---|---|---|---|
+| **AerolVM** | yes | yes | yes | yes | TS/Py/Go/Rust/Java + E2B + Daytona facades | This project. |
+| **E2B** | partial (lags cloud) | no (managed only) | no | no | TS/Py | Strongest cloud product. Self-host is an afterthought. |
+| **Daytona** | yes (AGPL) | unclear in OSS | no | no | TS/Py | Pivoted from dev-environment to agent runtime; managed-first. |
+| **Northflank** | no (BYOC) | yes (managed) | partial (managed addons) | yes (managed addons) | platform, not SDK | Strong product, not an OSS self-host story. |
+| **Modal** | no | no | no | no | Py | GPU-first, managed-only. |
+| **Beam** | yes | unclear | no | no | Py | runc/gVisor based, OSS, GPU-friendly. |
+| **Microsandbox** | yes | no | no | no | Rust core + bindings | Single-node, marked experimental. |
+| **Era** | yes | no | no | no | local CLI | Local dev sandboxes, microVM. |
+| **moru** | yes | no | no | no | TS | Agent runtime, single-node. |
+| **Cognitora** | yes (advertised) | unclear | no | no | TS/Py | Kata + Firecracker/Cloud HV. |
+| **Cloudflare Sandboxes** | no | no | no | no | TS (Workers) | V8 isolates, managed-only. |
+| **Vercel Sandbox** | no | no | no | no | TS | Beta, managed. |
+| **Fly Machines** | no | no (managed) | yes | yes (with volumes) | TS/Py/Go | Not pitched as a sandbox, but architecturally closest. |
+| **Kubernetes + KubeVirt** | yes | yes | yes (with work) | yes (with work) | n/a | Power user. Hundreds of moving parts. Not a sandbox runtime. |
+
+The row that matters: **AerolVM is the only project where every column is
+"yes."** Fly Machines comes closest but is a managed VM platform, not a
+self-hostable sandbox runtime. Kubernetes can be assembled into something
+similar, but assembling it is a small SRE team's quarter.
+
+## How this maps to actual workloads
+
+> **Video placeholder:** *Three workloads in one cluster — a coding agent
+> sandbox (ephemeral, agent SDK), a Postgres sandbox (HA stateful, raw
+> TCP), and a customer-facing live-preview sandbox (HTTP public URL).
+> Same binary, same cluster, same SDK shape.*
+
+This isn't theoretical. The use-cases section walks through real
+workloads, each of which leans on one or more of the differentiators
+above:
+
+- [Deploy your own Supabase](/use-cases/customer-facing-product-experiences/spawn-postgres) —
+  HA stateful + raw TCP.
+- [Impossible to Trace Burner VPN](/use-cases/customer-facing-product-experiences/secure-burner-vpn) —
+  raw TCP, per-sandbox network identity.
+- [Create your own Upstash Redis](/use-cases/customer-facing-product-experiences/create-upstash-redis) —
+  HA stateful + raw TCP.
+- [Live preview URLs for Web apps](/use-cases/customer-facing-product-experiences/ai-app-hosting) —
+  HTTP public URL with custom domain.
+- [Zero-shot code execution agent](/use-cases/coding-agents/large-scale-refactor-migration-agent) —
+  ephemeral agent execution.
+
+The same binary serves all of them.
+
+## What it looks like from a five-SDK perspective
+
+The shape that's interesting here is not the create call — every SDK has
+one. It's that the *same SDK* talks to a single-node `sandboxd` on a
+laptop and to a 50-node cluster, with no API surface change. The cluster
+is an operator concern. The SDK is unaware.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    import { MicroVM } from '@aerol-ai/aerolvm-sdk'
+
+    const client = new MicroVM({
+      apiUrl: process.env.SB_API_URL,   // single LB endpoint for the cluster
+      patToken: process.env.SB_PAT_TOKEN,
+    })
+
+    // Cluster picks an owner via power-of-two-choices. The SDK doesn't
+    // know or care which node ran this.
+    const pg = await client.create({
+      name: 'shared-postgres',           // cluster-wide unique
+      image: 'postgres:16',
+      cpu: 2,
+      memoryMB: 2048,
+      mounts: [{ source: 's3://my-bucket/pg-data', target: '/var/lib/postgresql/data' }],
+      env: { POSTGRES_PASSWORD: 'changeme' },
+    })
+
+    // Raw TCP, not HTTP. Caddy-l4 publishes 5432.
+    const port = await pg.exposeTcpPort(5432, { hostname: 'pg.example.com' })
+    console.log(`psql -h ${port.hostname} -p ${port.port}`)
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    from microvm import MicroVM
+
+    client = MicroVM(
+        api_url='https://cluster.example.com',
+        pat_token='your-token',
+    )
+
+    pg = client.create({
+        'name': 'shared-postgres',
+        'image': 'postgres:16',
+        'cpu': 2.0,
+        'memoryMB': 2048,
+        'mounts': [{'source': 's3://my-bucket/pg-data', 'target': '/var/lib/postgresql/data'}],
+        'env': {'POSTGRES_PASSWORD': 'changeme'},
+    })
+
+    port = pg.expose_tcp_port(5432, hostname='pg.example.com')
+    print(f"psql -h {port['hostname']} -p {port['port']}")
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    import (
+        "context"
+        "fmt"
+        "log"
+        "os"
+
+        microvm  "github.com/aerol-ai/microvm/sdk/go/pkg/microvm"
+        sdktypes "github.com/aerol-ai/microvm/sdk/go/pkg/types"
+    )
+
+    client, err := microvm.NewClientWithConfig(&sdktypes.MicroVMConfig{
+        APIUrl:   os.Getenv("SB_API_URL"),
+        PATToken: os.Getenv("SB_PAT_TOKEN"),
+    })
+    if err != nil { log.Fatal(err) }
+
+    pg, err := client.Create(context.Background(), sdktypes.CreateSandboxOptions{
+        Name:     "shared-postgres",
+        Image:    "postgres:16",
+        CPU:      2,
+        MemoryMB: 2048,
+        Mounts:   []sdktypes.Mount{{Source: "s3://my-bucket/pg-data", Target: "/var/lib/postgresql/data"}},
+        Env:      map[string]string{"POSTGRES_PASSWORD": "changeme"},
+    })
+    if err != nil { log.Fatal(err) }
+
+    port, err := pg.ExposeTCPPort(context.Background(), 5432, &sdktypes.ExposeTCPOptions{Hostname: "pg.example.com"})
+    if err != nil { log.Fatal(err) }
+    fmt.Printf("psql -h %s -p %d\n", port.Hostname, port.Port)
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use aerolvm_sdk::{Client, CreateOptions, Mount, ExposeTcpOptions};
+
+    let client = Client::new(
+        Some("https://cluster.example.com"),
+        Some("your-token"),
+    )?;
+
+    let pg = client.create(CreateOptions {
+        name:      Some("shared-postgres".to_string()),
+        image:     "postgres:16".to_string(),
+        cpu:       Some(2),
+        memory_mb: Some(2048),
+        mounts:    vec![Mount { source: "s3://my-bucket/pg-data".into(),
+                                target: "/var/lib/postgresql/data".into() }],
+        env:       [("POSTGRES_PASSWORD".to_string(), "changeme".to_string())].into(),
+        ..Default::default()
+    })?;
+
+    let port = pg.expose_tcp_port(5432, ExposeTcpOptions { hostname: Some("pg.example.com".into()) })?;
+    println!("psql -h {} -p {}", port.hostname, port.port);
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    import ai.aerol.microvm.MicroVMClient;
+    import ai.aerol.microvm.MicroVMConfig;
+    import ai.aerol.microvm.Sandbox;
+    import ai.aerol.microvm.model.CreateOptions;
+    import ai.aerol.microvm.model.Mount;
+    import ai.aerol.microvm.model.ExposeTcpResult;
+    import java.util.List;
+    import java.util.Map;
+
+    MicroVMClient client = new MicroVMClient(
+        new MicroVMConfig()
+            .setApiUrl("https://cluster.example.com")
+            .setPatToken(System.getenv("SB_PAT_TOKEN"))
+    );
+
+    Sandbox pg = client.create(
+        new CreateOptions()
+            .setName("shared-postgres")
+            .setImage("postgres:16")
+            .setCpu(2.0)
+            .setMemoryMb(2048)
+            .setMounts(List.of(new Mount("s3://my-bucket/pg-data", "/var/lib/postgresql/data")))
+            .setEnv(Map.of("POSTGRES_PASSWORD", "changeme"))
+    );
+
+    ExposeTcpResult port = pg.exposeTcpPort(5432, "pg.example.com");
+    System.out.println("psql -h " + port.hostname + " -p " + port.port);
+    ```
+  </TabItem>
+</Tabs>
+
+The same call shape works against `localhost` standalone and against a
+cluster. If the cluster's owner of `shared-postgres` dies, the next
+`psql` connect lands on the new owner with the data intact.
+
+## What I'm not claiming
+
+In the spirit of the rest of these engineering docs, the honest list of
+things AerolVM is *not*:
+
+- **Not a replacement for Kubernetes.** It does sandboxes well. Pods,
+  services, ingress for arbitrary container workloads, CRDs, operators
+  — Kubernetes does all of that, AerolVM does none of it. If you have
+  microservices, run them on Kubernetes.
+- **Not a replacement for managed databases.** HA Postgres in a sandbox
+  is honest single-writer Postgres on a host that might fail. If you
+  need streaming replication, point-in-time recovery, and read replicas,
+  you need a real database product. AerolVM gives you "Postgres that
+  comes back" — that is genuinely useful and not the same as "Postgres
+  that never goes down."
+- **Not feature-parity with E2B or Daytona on every endpoint.** The
+  facades cover the common paths (create, exec, file ops, lifecycle)
+  and we add coverage as needed. If you depend on a specific endpoint,
+  check before assuming.
+- **Not battle-hardened at hundreds-of-nodes scale.** Cluster mode is
+  tested at small-cluster sizes. There is no public benchmark of a
+  fifty-node deployment yet.
+
+If those caveats kill the use case for you, AerolVM is the wrong tool.
+If they don't, it's the only tool I'm aware of in its category.
+
+## What I want feedback on
+
+Three honest asks for the comment thread:
+
+1. **The "k8s-shaped, sandbox-sized" framing.** Is it the right
+   metaphor? It captures the shape (control plane + workers + ingress
+   + reconciliation) but invites unfair comparisons. What lands better?
+2. **The HA stateful claim.** I've stated the mechanism and the
+   caveats. Is there a failure mode I haven't surfaced that I should
+   document upfront? Database operators in particular — please press
+   on this.
+3. **The compatibility facades vs. a clean-sheet API.** Is
+   "drop-in for E2B and Daytona" a real migration path, or is it
+   technical debt I'll regret? The argument for the facades is that
+   nobody wants to rewrite their sandbox code. The argument against
+   is that I'm two version-skew bugs away from a perpetual chore.
+
+Repo, docs, and links to the other engineering deep-dives at the top
+of the page. The other three deep-dives — [Idempotency on a Single
+Writer](/engineering-idempotency), [Placement &
+Failover](/engineering-placement-failover), [Host-Mediated Trust
+Boundary](/engineering-trust-boundary), and the snapshot pair
+([Snapshot Clone Correctness](/engineering-snapshot-correctness),
+[The Frozen-Kernel Problem](/engineering-frozen-kernel-problem)) —
+cover the invariants this architecture leans on.

--- a/docs/src/content/docs/engineering-snapshot-correctness.mdx
+++ b/docs/src/content/docs/engineering-snapshot-correctness.mdx
@@ -159,6 +159,49 @@ indefinitely.
 > reseed failure does not destroy the sandbox. The warning log is load-bearing;
 > an operator watching for entropy-divergence regressions greps that signal.
 
+### Closing the entropy window: vmgenid
+
+`post_resume` is **reactive**: it runs after `Action(Resume)`, so the guest is
+already executing with template entropy for the few hundred milliseconds until
+the reseed lands. The robust complement is **synchronous, in-kernel, and needs
+no host round-trip**: Firecracker's **VM Generation ID** (vmgenid).
+
+vmgenid is a 128-bit value Firecracker regenerates on every snapshot restore and
+exposes to the guest through an ACPI device. A guest kernel built with
+`CONFIG_VMGENID` watches that device and, the instant it observes the value
+change on resume, reseeds the kernel CSPRNG from inside the resume path —
+*before* userspace is scheduled again. Code that runs in the window
+`post_resume` cannot reach (early init, systemd units, toolboxd's own startup)
+therefore still draws post-clone entropy. The two mechanisms compose as
+defense-in-depth: vmgenid covers the kernel CSPRNG with zero window, and
+`post_resume` still does the work vmgenid does *not* — it resyncs
+`CLOCK_REALTIME` (vmgenid is entropy-only) and credits additional host entropy
+via `RNDADDENTROPY` + `RNDRESEEDCRNG`.
+
+This only fires when the deployment supplies the pieces, and AerolVM controls
+only one of them in code:
+
+- **Kernel command line (in code).** vmgenid is surfaced over ACPI, so ACPI must
+  stay enabled. `baseBootArgs`
+  (`internal/runtime/firecracker/driver.go`) deliberately omits `acpi=off`;
+  `pci=off` is unrelated and safe. A regression test
+  (`bootargs_test.go`) fails the build if a future edit reintroduces
+  `acpi=off` and silently disables the pre-userspace reseed.
+- **Guest kernel (operator artifact).** The kernel image
+  (`SB_FIRECRACKER_KERNEL`) must be built with `CONFIG_VMGENID=y`. The repo does
+  not build the kernel; verify this at template-build / deploy time.
+- **Firecracker binary (operator artifact).** vmgenid support landed in
+  Firecracker v1.8; `SB_FIRECRACKER_BINARY` must be at least that. On a binary
+  that predates it, the guest never sees a generation-ID change and silently
+  falls back to `post_resume`-only behavior — correct on the happy path, but
+  with the window restored.
+
+vmgenid reseeds the **kernel** CSPRNG. A userspace PRNG already seeded inside a
+long-lived process baked into the template (a preloaded `python` that did
+`import numpy`) is in that process's own heap and is not reached by either
+mechanism; closing that gap needs the clone-generation signal documented in
+[Randomness in Cloned Sandboxes](/randomness-in-cloned-sandboxes).
+
 ## Hazard 3: dial the guest's CID, not the slot's
 
 The vsock handshake hinges on dialing the right CID, and the snapshot path makes
@@ -312,7 +355,11 @@ workload.
 - **Entropy window.** Between `Action(Resume)` and the `post_resume` ack, the
   guest is running with template entropy. Code that runs in that window
   (early init, systemd units, the toolboxd's own startup) draws stale
-  entropy. Quantified in Hazard 2.
+  entropy. Quantified in Hazard 2. **Closed when the deployment supports
+  vmgenid** (Firecracker ≥ v1.8 + a guest kernel with `CONFIG_VMGENID`), which
+  reseeds the kernel CSPRNG in-kernel before userspace runs — see "Closing the
+  entropy window" in Hazard 2. Without that kernel/binary support the window
+  stands.
 - **In-flight guest TCP.** `pre_snapshot` does not quiesce guest-side outbound
   sockets; connections that were open at capture resume broken.
 - **KASLR is not re-randomized across restore.** Every clone has the same

--- a/docs/src/content/docs/randomness-in-cloned-sandboxes.mdx
+++ b/docs/src/content/docs/randomness-in-cloned-sandboxes.mdx
@@ -19,12 +19,14 @@ A running Linux VM has random state at two layers, and they are reseeded differe
 
 ## What AerolVM does automatically
 
-On every resume-from-snapshot, the in-guest agent force-reseeds the **kernel** CSPRNG from fresh host entropy before your code runs again. This means:
+On every resume-from-snapshot, the in-guest agent force-reseeds the **kernel** CSPRNG from fresh host entropy. The reseed completes before any process you newly start through the SDK runs, which means:
 
 - Any process you start **after** the clone resumes (for example, each `exec` or code-run invocation spawns a fresh interpreter) seeds from the freshly-reseeded kernel and is already clone-distinct.
 - Anything that reads the OS CSPRNG per call — `crypto/rand`, Python's `secrets`, Node's `crypto`/WebCrypto, Java's `SecureRandom` — is safe with no action on your part.
 
 In short: **fresh processes and crypto RNGs are handled for you.**
+
+The one timing caveat is for a process *already running inside the template* when the clone resumes: it can be scheduled in the brief window before the agent's reseed lands. The engineering deep-dive covers that window and how Firecracker's vmgenid closes it where available — see [Snapshot Clone Correctness](/engineering-snapshot-correctness). It is the same long-lived-process case described next.
 
 ## The remaining gap: long-lived userspace PRNGs
 

--- a/docs/src/content/docs/randomness-in-cloned-sandboxes.mdx
+++ b/docs/src/content/docs/randomness-in-cloned-sandboxes.mdx
@@ -1,0 +1,230 @@
+---
+title: Randomness in Cloned Sandboxes
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+When a Firecracker sandbox boots from a snapshot template, AerolVM clones the **entire memory image** of the template VM. That is what makes clones start in milliseconds — but it also means every clone begins life with an identical copy of the template's random-number generator state. Two clones that draw "random" bytes after resuming can produce the **same** values: duplicate UUIDs, duplicate session tokens, duplicate cryptographic nonces or keys.
+
+This page explains what AerolVM handles for you automatically, where a gap remains, and how to close it for your own long-lived processes.
+
+## Two layers of randomness
+
+A running Linux VM has random state at two layers, and they are reseeded differently:
+
+| Layer | Example | Frozen into the snapshot? | Reseeded by AerolVM? |
+|---|---|---|---|
+| **Kernel CSPRNG** | `getrandom()`, `/dev/urandom`, `crypto/rand`, OpenSSL, `secrets`, `SecureRandom` | Yes | **Yes — automatically on every resume** |
+| **Userspace PRNG** | Python `random`/`numpy`, Go `math/rand`, `java.util.Random` inside a long-lived process | Yes | No — your process must reseed itself |
+
+## What AerolVM does automatically
+
+On every resume-from-snapshot, the in-guest agent force-reseeds the **kernel** CSPRNG from fresh host entropy before your code runs again. This means:
+
+- Any process you start **after** the clone resumes (for example, each `exec` or code-run invocation spawns a fresh interpreter) seeds from the freshly-reseeded kernel and is already clone-distinct.
+- Anything that reads the OS CSPRNG per call — `crypto/rand`, Python's `secrets`, Node's `crypto`/WebCrypto, Java's `SecureRandom` — is safe with no action on your part.
+
+In short: **fresh processes and crypto RNGs are handled for you.**
+
+## The remaining gap: long-lived userspace PRNGs
+
+The one case AerolVM cannot fix from outside is a **long-lived process baked into the template snapshot** that holds a userspace PRNG in its own memory — for example, a preloaded Python interpreter that already did `import numpy`. The interpreter's `random`/`numpy` seed is frozen into the snapshot, and the kernel reseed does not reach into another process's heap. Every clone of that template would then draw the same `random`/`numpy` sequence.
+
+The agent publishes a **clone-generation token** so such a process can detect the clone and reseed itself. The token changes on every resume. Read it either from the well-known file `/run/aerolvm/clone-generation` (fast, local, no auth) or via the SDK.
+
+## Detect a clone from the SDK
+
+`cloneGeneration()` returns the current token and the time of the last resume. Poll it to detect that a sandbox has been cloned or migrated — for example, to re-run setup. (This is a read-only signal; it does not reseed a process inside the guest.)
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+
+```ts
+const gen = await vm.cloneGeneration(sandboxID);
+console.log(gen.generation, gen.resumedAt);
+// or, from a Sandbox handle:
+const g = await sandbox.cloneGeneration();
+```
+
+  </TabItem>
+  <TabItem label="Python">
+
+```python
+gen = client.clone_generation(sandbox_id)
+print(gen.generation, gen.resumedAt)
+# or, from a Sandbox handle:
+g = sandbox.clone_generation()
+```
+
+  </TabItem>
+  <TabItem label="Go">
+
+```go
+gen, err := client.CloneGeneration(ctx, sandboxID)
+if err != nil {
+    return err
+}
+fmt.Println(gen.Generation, gen.ResumedAt)
+// or, from a *Sandbox handle:
+g, err := sandbox.CloneGeneration(ctx)
+```
+
+  </TabItem>
+  <TabItem label="Rust">
+
+```rust
+let gen = client.clone_generation(&sandbox_id)?;
+println!("{} {}", gen.generation, gen.resumed_at);
+// or, from a Sandbox handle:
+let g = sandbox.clone_generation()?;
+```
+
+  </TabItem>
+  <TabItem label="Java">
+
+```java
+CloneGeneration gen = client.cloneGeneration(sandboxId);
+System.out.println(gen.generation + " " + gen.resumedAt);
+// or, from a Sandbox handle:
+CloneGeneration g = sandbox.cloneGeneration();
+```
+
+  </TabItem>
+</Tabs>
+
+## Reseed your own process inside the guest
+
+If your template keeps a long-lived process alive across the snapshot, have **that process** read the clone-generation token and reseed its userspace PRNG when the token changes. The snippets below run *inside* the sandbox, in the language of your workload. Crypto RNGs are already safe (see above) — reseed only the userspace, non-crypto generators you control.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+
+```ts
+import { readFileSync } from "node:fs";
+
+// Node's Math.random() cannot be reseeded (V8 internal), and crypto /
+// WebCrypto read the OS CSPRNG directly — already safe after the kernel
+// reseed. Use this hook to reseed any third-party seeded PRNG you hold.
+let lastGen: string | undefined;
+
+export function reseedIfCloned(reseed: () => void): void {
+  let gen: string;
+  try {
+    gen = readFileSync("/run/aerolvm/clone-generation", "utf8").trim();
+  } catch {
+    return; // file absent: nothing to do
+  }
+  if (gen === lastGen) return;
+  lastGen = gen;
+  reseed(); // e.g. seedrandom(crypto.randomBytes(16).toString("hex"))
+}
+```
+
+  </TabItem>
+  <TabItem label="Python">
+
+```python
+import os
+import random
+
+_GEN_FILE = "/run/aerolvm/clone-generation"
+_last_gen = None
+
+def reseed_if_cloned() -> None:
+    global _last_gen
+    try:
+        gen = open(_GEN_FILE).read().strip()
+    except OSError:
+        return  # file absent: nothing to do
+    if gen == _last_gen:
+        return
+    _last_gen = gen
+    random.seed(os.urandom(2500))  # reseed the stdlib Mersenne Twister
+    try:
+        import numpy as np
+        np.random.seed(int.from_bytes(os.urandom(4), "little"))
+    except ImportError:
+        pass
+```
+
+  </TabItem>
+  <TabItem label="Go">
+
+```go
+// math/rand's global source is seeded once at startup and frozen into the
+// snapshot. Re-seed it from crypto/rand on clone. (math/rand/v2 and
+// crypto/rand read the OS and need no reseed.)
+var lastGen string
+
+func reseedIfCloned() {
+	b, err := os.ReadFile("/run/aerolvm/clone-generation")
+	if err != nil {
+		return // file absent: nothing to do
+	}
+	gen := strings.TrimSpace(string(b))
+	if gen == lastGen {
+		return
+	}
+	lastGen = gen
+	var seed [8]byte
+	_, _ = cryptorand.Read(seed[:])
+	mathrand.Seed(int64(binary.LittleEndian.Uint64(seed[:])))
+}
+```
+
+  </TabItem>
+  <TabItem label="Rust">
+
+```rust
+// rand::thread_rng() reseeds from the OS periodically, but a StdRng/SmallRng
+// you hold across the snapshot is frozen. Re-create it from entropy on clone.
+use rand::SeedableRng;
+use std::fs;
+
+fn reseed_if_cloned(last_gen: &mut String, rng: &mut rand::rngs::StdRng) {
+    let gen = match fs::read_to_string("/run/aerolvm/clone-generation") {
+        Ok(s) => s.trim().to_string(),
+        Err(_) => return, // file absent: nothing to do
+    };
+    if &gen == last_gen {
+        return;
+    }
+    *last_gen = gen;
+    *rng = rand::rngs::StdRng::from_entropy();
+}
+```
+
+  </TabItem>
+  <TabItem label="Java">
+
+```java
+// java.util.Random is seeded once and frozen into the snapshot. Re-seed it
+// from SecureRandom on clone. SecureRandom itself reads the OS and is safe.
+private String lastGen = null;
+
+void reseedIfCloned(java.util.Random rng) {
+    String gen;
+    try {
+        gen = java.nio.file.Files.readString(
+            java.nio.file.Path.of("/run/aerolvm/clone-generation")).trim();
+    } catch (java.io.IOException e) {
+        return; // file absent: nothing to do
+    }
+    if (gen.equals(lastGen)) {
+        return;
+    }
+    lastGen = gen;
+    rng.setSeed(new java.security.SecureRandom().nextLong());
+}
+```
+
+  </TabItem>
+</Tabs>
+
+:::tip
+The simplest way to avoid this entirely is to **not** bake a started, RNG-stateful interpreter into a template snapshot. If each request starts a fresh process (the default for `exec` and code-run), the kernel reseed covers you and no in-guest reseeding is needed.
+:::
+
+## Further reading
+
+For how the kernel reseed and clock resync are implemented on the resume path, see [Snapshot Clone Correctness](/engineering-snapshot-correctness).

--- a/internal/runtime/firecracker/bootargs_test.go
+++ b/internal/runtime/firecracker/bootargs_test.go
@@ -1,0 +1,30 @@
+package firecracker
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBootArgsKeepACPI is a security-relevant regression guard, not a
+// formatting check. Firecracker exposes its VM Generation ID (vmgenid) via
+// ACPI; a guest kernel with CONFIG_VMGENID reseeds the CRNG from it on
+// snapshot restore *before userspace runs*, which is the only mechanism that
+// closes the entropy window the post_resume reseed cannot (the guest is live
+// between Action(Resume) and the post_resume ack — see Hazard 2 /
+// "Entropy window" in the Snapshot Clone Correctness doc). Passing acpi=off
+// on the kernel command line would silently kill that pre-userspace reseed
+// and reintroduce duplicate-entropy-across-clones with no error. This test
+// fails loudly if a future edit to baseBootArgs adds it.
+func TestBootArgsKeepACPI(t *testing.T) {
+	args := defaultBootArgs()
+
+	if strings.Contains(args, "acpi=off") {
+		t.Fatalf("boot args must not disable ACPI (vmgenid CRNG reseed depends on it): %q", args)
+	}
+	// off=acpi / acpi = off style variants aren't valid kernel cmdline, but
+	// guard the obvious near-miss of a stray "acpi" key set to a disabling
+	// value so the intent ("ACPI stays available for vmgenid") is explicit.
+	if strings.Contains(args, "acpi=0") || strings.Contains(args, "noacpi") {
+		t.Fatalf("boot args must keep ACPI available for vmgenid: %q", args)
+	}
+}

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -1038,6 +1038,17 @@ func vcpuFromRequest(cpu float64) int {
 //     leaving it on costs boot time for no benefit.
 //   - nomodules: rootfs has no /lib/modules tree.
 //   - quiet: suppresses the spammy kernel boot lines.
+//
+// Deliberately ABSENT: acpi=off. Firecracker surfaces its VM Generation ID
+// (vmgenid) through ACPI, and a guest kernel built with CONFIG_VMGENID uses
+// that device to reseed its CRNG synchronously on snapshot restore — before
+// userspace runs — which is the only thing that closes the entropy window
+// between Action(Resume) and the post_resume reseed (see
+// plans/snapshot-clone-rng-userspace.md Phase C and Hazard 2 of the
+// Snapshot Clone Correctness doc). pci=off is fine — ACPI is a separate bus
+// — but acpi=off would silently disable that pre-userspace reseed. The
+// bootArgsKeepACPI invariant (bootargs_test.go) guards this line so a future
+// edit can't reintroduce it.
 const baseBootArgs = "console=ttyS0 reboot=k panic=1 pci=off nomodules quiet"
 
 func defaultBootArgs() string {

--- a/plans/snapshot-clone-rng-userspace.md
+++ b/plans/snapshot-clone-rng-userspace.md
@@ -1,0 +1,150 @@
+# Snapshot-clone RNG correctness: kernel reseed hardening + userspace gap
+
+Status: Phases A and B implemented; C/D proposed.
+Owner: runtime/firecracker + toolboxd.
+Related: `plans/snapshot-clone-fast-boot.md`, `cmd/toolboxd/quiesce_linux.go`.
+
+## Problem
+
+Firecracker snapshot-clone (the "boot once, photograph memory, stamp out
+fast clones" fast-boot path) duplicates the **entire** memory image of the
+template VM into every clone. That includes every random-number generator's
+internal seed state. Two clones that draw "random" bytes after resume can
+get **identical** streams — duplicate UUIDs, session tokens, crypto nonces,
+keypairs. For a security-positioned sandbox this is a disclosure-grade bug.
+
+There are two seeds at two layers:
+
+1. **Kernel CSPRNG** (`getrandom(2)`, `/dev/urandom`). Shared across clones
+   from the photographed pool.
+2. **Userspace PRNGs** inside long-lived processes baked into the snapshot
+   (e.g. a preloaded `python` with `numpy`/`random`/`secrets` already
+   imported). Their seed lives in *that process's* heap.
+
+A separate process (toolboxd) **cannot** reach into another process's heap
+to reseed #2. It can only fix #1 and signal #2 to fix itself.
+
+## Current state (pre-Phase-A)
+
+- Host `post_resume` vsock op fires on both clone paths
+  (`driver.go:739` cold snapshot-load, `warmacquire.go:230` warm clone).
+- Guest `OnPostResume` (`vsock.go:233`) calls `SetWallclock` +
+  `ReseedRandom` (`quiesce_linux.go`).
+- `ReseedRandom` does `RNDADDENTROPY` only — it *credits* the kernel input
+  pool but does not *force* the CRNG to consume it. On kernels < 5.18 the
+  CRNG may keep emitting the pre-snapshot stream until its own reseed
+  interval elapses, leaving a window. No `RNDRESEEDCRNG`, no vmgenid.
+- No userspace reseed of any kind.
+
+## Severity (p0–p5; p0 = drop everything)
+
+**Overall: P1.** Not P0 — the whole runtime is opt-in behind
+`SB_ENABLE_FIRECRACKER` (default false) and the vulnerable branch only fires
+for `runtime=firecracker` + snapshot-backed template + clone. No active
+production fleet. But it's a silent, security-relevant correctness bug on the
+feature's headline path; must be closed before snapshot-clone is marketed
+production-safe.
+
+| Component | Rating | Notes |
+|---|---|---|
+| Userspace PRNG dup in template-baked long-lived process | **P1** | Inherent to clone model; the advertised "preload Python+numpy" pattern |
+| Kernel CRNG not force-reseeded (`RNDADDENTROPY` w/o `RNDRESEEDCRNG`) | **P2** | Mitigated on modern kernels; residual version-dependent + resume-race window |
+| Kernel one-time secrets (ephemeral-port hash, TCP ISN) | **P3** | Latent — no virtio-net in forks yet |
+
+### Who actually faces it
+
+- **Implemented execution paths are safe after Phase A.** `exec_stream.go`
+  and `daytona_code_run.go` spawn a *fresh* process per run; it seeds from
+  the (now force-reseeded) kernel. The stateful Jupyter interpreter path is
+  **501 Not Implemented** (`main.go:291`) — toolboxd hosts no persistent
+  interpreter, so there is no in-product long-lived PRNG to leak.
+- **Residual P1 is user-owned processes** a template author leaves running
+  across the snapshot. toolboxd cannot fix those from outside; needs a
+  signal + cooperation (Phase B) or kernel-driven reseed (Phase C).
+
+## Plan
+
+### Phase A — Force the kernel CRNG reseed (P2, DONE)
+
+`quiesce_linux.go:ReseedRandom`: after `RNDADDENTROPY`, issue
+`RNDRESEEDCRNG` (Linux >= 5.10) on the same fd to force the CRNG to consume
+the freshly-credited entropy immediately. Tolerate `ENOTTY`/`EINVAL` on
+older kernels (entropy is already credited; CRNG reseeds on schedule).
+Ioctl factored behind a seam so a linux unit test asserts both ioctls fire
+in order without a real kernel.
+
+- Effect: closes the version-dependent window for any `getrandom` after
+  `post_resume`. Makes every fresh process spawned post-resume safe — which
+  is every implemented user-code path.
+- Boot-path impact: **none**. This is in the post-resume control path, not a
+  `CreateSandbox` boot-path callee. (Required PR call-out per CLAUDE.md.)
+- Snapshot-correctness call-out: improves clone entropy isolation; no change
+  to placement/FSM/host-port pool.
+
+### Phase B — Userspace reseed signal + SDK accessor + docs (P1, DONE)
+
+Key correction made during implementation: the five SDKs are **client-side**
+(they drive the sandbox over HTTP from the developer's machine), so a client
+SDK method **cannot** reseed an in-guest userspace PRNG. The load-bearing fix
+is therefore the in-guest signal + a documented in-guest snippet; the SDK
+method is a read-only clone *detector*. There is also no in-product
+persistent interpreter to reseed — the Daytona Jupyter path is `501` — so the
+residual exposure is strictly *user-owned* long-lived processes baked into a
+template.
+
+- **B1 — generation signal (`cmd/toolboxd/clonegen.go`).** A
+  `cloneGeneration` token, seeded at startup and **bumped in `OnPostResume`**
+  after the kernel reseed. Published two ways: the well-known guest file
+  `/run/aerolvm/clone-generation` (the primary in-guest mechanism — local,
+  no auth) and `GET /clone-generation` (unauthenticated like `/health`,
+  reachable through the auth'd v1 toolbox proxy). The token only needs to
+  *change* on clone; the reseed pulls clone-distinct entropy from the
+  Phase-A-reseeded kernel. (vmgenid mirroring deferred to Phase C.)
+- **B2 — `cloneGeneration()` read accessor in all five SDKs**
+  (TS/Py/Go/Rust/Java), returning `{generation, resumedAt}` via a thin GET
+  through the existing toolbox proxy. On both the client and the sandbox
+  handle. Read-only clone/migration detector — explicitly *not* an in-guest
+  reseed.
+- **B3 — docs page** `randomness-in-cloned-sandboxes.mdx` (registered under
+  the Snapshots group): the two-layer model, what AerolVM reseeds
+  automatically, the residual gap, the SDK detector, and the **in-guest
+  reseed snippet in all five languages** (read the token, reseed the stdlib
+  PRNG + numpy for Python, etc.). Recommends lazy interpreter start over
+  baking a started RNG-stateful process into a template.
+
+### Phase C — vmgenid in the VMM (P2, robust long-term)
+
+Attach Firecracker's vmgenid device + ensure the guest kernel has
+`CONFIG_VMGENID`. The kernel then auto-reseeds on resume *before userspace
+runs*, closing the resume race Phase A can't, and future vmgenid-aware
+libc/openssl pick it up for free. Larger: touches guest-kernel build +
+machine config + template rebuild. Track separately.
+
+### Phase D — kernel one-time secrets (P3, latent)
+
+Ephemeral-port hash key / TCP ISN secret are seeded once at boot and not
+re-derived by entropy-add. Revisit when virtio-net lands in forks; likely
+folds into Phase C or an explicit rekey.
+
+## Sequencing
+
+A (done) → B (done) → C/D as follow-ups.
+
+## Tests (A + B)
+
+- `cmd/toolboxd/quiesce_linux_test.go` (A): both ioctls fire in order;
+  old-kernel `RNDRESEEDCRNG` tolerated; `RNDADDENTROPY` failure surfaced.
+- `cmd/toolboxd/clonegen_test.go` (B1): token init/bump/persist, unwritable
+  path non-fatal, concurrency, `GET /clone-generation` route, and
+  `OnPostResume` bumps the generation.
+- Per-SDK (B2): a `cloneGeneration()` test in each SDK asserting the
+  `…/toolbox/clone-generation` GET path and the `{generation, resumedAt}`
+  mapping.
+- `make docs-build` (B3): the five-tab page renders and the sidebar entry
+  is present.
+
+## Tests
+
+- `cmd/toolboxd/quiesce_linux_test.go` (Phase A): both ioctls fire in order;
+  old-kernel `RNDRESEEDCRNG` failure tolerated.
+- Existing `vsock_test.go` handler tests unchanged (interface untouched).

--- a/plans/snapshot-clone-rng-userspace.md
+++ b/plans/snapshot-clone-rng-userspace.md
@@ -1,6 +1,9 @@
 # Snapshot-clone RNG correctness: kernel reseed hardening + userspace gap
 
-Status: Phases A and B implemented; C/D proposed.
+Status: Phases A and B implemented. Phase C in-repo parts (boot-args ACPI
+invariant + operator docs) implemented; its load-bearing preconditions are
+deploy-time artifacts (FC ≥ v1.8 binary, `CONFIG_VMGENID` guest kernel). Phase
+D deferred (latent until virtio-net lands in forks).
 Owner: runtime/firecracker + toolboxd.
 Related: `plans/snapshot-clone-fast-boot.md`, `cmd/toolboxd/quiesce_linux.go`.
 
@@ -112,13 +115,43 @@ template.
   PRNG + numpy for Python, etc.). Recommends lazy interpreter start over
   baking a started RNG-stateful process into a template.
 
-### Phase C — vmgenid in the VMM (P2, robust long-term)
+### Phase C — vmgenid (P2, robust long-term; in-repo parts DONE)
 
-Attach Firecracker's vmgenid device + ensure the guest kernel has
-`CONFIG_VMGENID`. The kernel then auto-reseeds on resume *before userspace
-runs*, closing the resume race Phase A can't, and future vmgenid-aware
-libc/openssl pick it up for free. Larger: touches guest-kernel build +
-machine config + template rebuild. Track separately.
+Correction made during implementation: there is **no daemon "attach vmgenid
+device" call**. Firecracker auto-manages the VM Generation ID — it regenerates
+the value and notifies the guest over ACPI on every snapshot restore (support
+landed in Firecracker v1.8). A guest kernel with `CONFIG_VMGENID` then reseeds
+the kernel CSPRNG *inside the resume path, before userspace runs*, closing the
+entropy window Phase A's reactive `post_resume` cannot. So "Phase C" is not a
+`pkg/firecracker` device — it is one in-code invariant plus two deploy-time
+artifact preconditions:
+
+- **In code (DONE).** vmgenid rides ACPI, so ACPI must stay enabled on the
+  kernel command line. `baseBootArgs`
+  (`internal/runtime/firecracker/driver.go`) deliberately omits `acpi=off`
+  (`pci=off` is unrelated and safe); a rationale comment records why and
+  `bootargs_test.go` (`TestBootArgsKeepACPI`) fails the build if a future edit
+  reintroduces a disabling flag. This is the only vmgenid lever the daemon
+  controls.
+- **In docs (DONE).** `engineering-snapshot-correctness.mdx` Hazard 2 gains a
+  "Closing the entropy window: vmgenid" subsection (synchronous in-kernel
+  reseed, composes with `post_resume` which still owns the clock); the
+  "Entropy window" known-gap bullet now points at it. The operator
+  precondition (FC ≥ v1.8 binary + `CONFIG_VMGENID=y` guest kernel) is stated
+  there.
+- **Deploy-time (operator, NOT daemon code).** `SB_FIRECRACKER_BINARY` ≥ v1.8
+  and `SB_FIRECRACKER_KERNEL` built with `CONFIG_VMGENID=y`. The repo does not
+  build the kernel or ship the FC binary (both are downloaded artifacts — see
+  Terraform `firecracker.kernel_url` / `binary_url`), so these are verified at
+  template-build / deploy time, not settable in Go. On a binary or kernel
+  without support, the system silently falls back to `post_resume`-only
+  (correct on the happy path; entropy window restored).
+
+Optional follow-up (not done): a one-shot `firecracker --version` preflight in
+`Driver.Ping` that warns when snapshot-clone is enabled against a pre-1.8
+binary. Deferred — it runs a subprocess on the health path and asserts a
+version constant; the doc precondition + boot-args guard cover the
+correctness-relevant surface without that risk.
 
 ### Phase D — kernel one-time secrets (P3, latent)
 
@@ -128,7 +161,9 @@ folds into Phase C or an explicit rekey.
 
 ## Sequencing
 
-A (done) → B (done) → C/D as follow-ups.
+A (done) → B (done) → C in-repo (done; boot-args invariant + docs) with
+deploy-time artifact preconditions to verify at rollout → D deferred until
+virtio-net lands in forks.
 
 ## Tests (A + B)
 

--- a/sdk/go/internal/apiclient/client.go
+++ b/sdk/go/internal/apiclient/client.go
@@ -461,6 +461,18 @@ func (c *Client) Mounts(ctx context.Context, id string) ([]models.MountSpecRedac
 	return response.Mounts, nil
 }
 
+// CloneGeneration is the toolbox clone-generation marker (wire shape).
+type CloneGeneration struct {
+	Generation string `json:"generation"`
+	ResumedAt  int64  `json:"resumed_at"`
+}
+
+func (c *Client) CloneGeneration(ctx context.Context, id string) (CloneGeneration, error) {
+	var response CloneGeneration
+	err := c.doJSON(ctx, http.MethodGet, c.versionPrefix+"/sandboxes/"+id+"/toolbox/clone-generation", nil, &response)
+	return response, err
+}
+
 func (c *Client) GetNetworkUsage(ctx context.Context, id string) (models.NetworkUsage, error) {
 	var response models.NetworkUsage
 	if err := c.doJSON(ctx, http.MethodGet, c.versionPrefix+"/sandboxes/"+id+"/network/usage", nil, &response); err != nil {

--- a/sdk/go/pkg/microvm/client.go
+++ b/sdk/go/pkg/microvm/client.go
@@ -209,6 +209,18 @@ func (c *Client) GetNetworkUsage(ctx context.Context, id string) (sdktypes.Netwo
 	return c.inner.GetNetworkUsage(ctx, id)
 }
 
+// CloneGeneration reads a sandbox's clone-generation token. The token changes
+// whenever the sandbox is resumed from a snapshot, so a change signals "this
+// is a clone." Read-only — the SDK cannot reseed a process inside the guest;
+// see the "Randomness in cloned sandboxes" docs for the in-guest pattern.
+func (c *Client) CloneGeneration(ctx context.Context, id string) (sdktypes.CloneGeneration, error) {
+	res, err := c.inner.CloneGeneration(ctx, id)
+	if err != nil {
+		return sdktypes.CloneGeneration{}, err
+	}
+	return sdktypes.CloneGeneration{Generation: res.Generation, ResumedAt: res.ResumedAt}, nil
+}
+
 // SetNetworkLimits raises or lifts the per-direction byte caps. Leave a field
 // nil to keep the current value; pass a pointer to zero to set "unlimited".
 // Raising a cap above current usage clears the per-IP iptables block on the
@@ -377,6 +389,12 @@ func (s *Sandbox) Exec(ctx context.Context, request sdktypes.ExecRequest) (sdkty
 
 func (s *Sandbox) ExecCommand(ctx context.Context, command string) (sdktypes.ExecResult, error) {
 	return s.client.inner.Exec(ctx, s.ID, sdktypes.ExecRequest{Command: command})
+}
+
+// CloneGeneration reads this sandbox's clone-generation token (changes on
+// resume-from-snapshot). Read-only; does not reseed in-guest PRNGs.
+func (s *Sandbox) CloneGeneration(ctx context.Context) (sdktypes.CloneGeneration, error) {
+	return s.client.CloneGeneration(ctx, s.ID)
 }
 
 func (s *Sandbox) ExecStream(ctx context.Context, options sdktypes.ExecStreamOptions) (*ExecStreamHandle, error) {

--- a/sdk/go/pkg/microvm/wrappers_test.go
+++ b/sdk/go/pkg/microvm/wrappers_test.go
@@ -50,6 +50,8 @@ func TestClientAndSandboxWrappers(t *testing.T) {
 			w.WriteHeader(http.StatusCreated)
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/sandboxes/sb1/toolbox/files/download":
 			_, _ = w.Write([]byte("file-data"))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/sandboxes/sb1/toolbox/clone-generation":
+			_ = json.NewEncoder(w).Encode(map[string]any{"generation": "2d0d8c69", "resumed_at": 1700000000000000000})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/sandboxes/sb1/ports/8080":
 			_ = json.NewEncoder(w).Encode(models.ExposePortResponse{Protocol: "http", PublicURL: "https://example.test"})
 		case r.Method == http.MethodDelete && r.URL.Path == "/v1/sandboxes/sb1/ports/8080":
@@ -83,6 +85,11 @@ func TestClientAndSandboxWrappers(t *testing.T) {
 	}
 	if _, err := client.Mounts(ctx, "sb1"); err != nil {
 		t.Fatalf("Mounts() error = %v", err)
+	}
+	if gen, err := client.CloneGeneration(ctx, "sb1"); err != nil {
+		t.Fatalf("CloneGeneration() error = %v", err)
+	} else if gen.Generation != "2d0d8c69" || gen.ResumedAt != 1700000000000000000 {
+		t.Fatalf("CloneGeneration() = %+v, want {2d0d8c69 1700000000000000000}", gen)
 	}
 	if _, err := client.GetNetworkUsage(ctx, "sb1"); err != nil {
 		t.Fatalf("GetNetworkUsage() error = %v", err)

--- a/sdk/go/pkg/types/types.go
+++ b/sdk/go/pkg/types/types.go
@@ -179,6 +179,20 @@ type BuildImageResult struct {
 	Pushed string
 }
 
+// CloneGeneration is a sandbox's clone-generation marker. Generation changes
+// every time the sandbox is resumed from a snapshot (i.e. it is a clone). A
+// long-lived process running inside the sandbox can poll this and reseed its
+// own userspace PRNGs when the token changes — two clones otherwise share the
+// snapshot's frozen seed state. Read-only: the SDK cannot reseed an in-guest
+// process from the client side. See the "Randomness in cloned sandboxes" docs.
+type CloneGeneration struct {
+	// Generation is an opaque token that changes on every resume-from-snapshot.
+	Generation string `json:"generation"`
+	// ResumedAt is the host wall-clock of the last resume, in unix nanoseconds.
+	// 0 means the sandbox has never been resumed.
+	ResumedAt int64 `json:"resumedAt"`
+}
+
 // RegisterSnapshotOptions is the input shape for Client.RegisterSnapshot.
 // Exactly one of Image (a pre-built registry reference) or
 // DockerfileContent (build inputs the daemon will compile) must be set.

--- a/sdk/java/src/main/java/ai/aerol/microvm/MicroVMClient.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/MicroVMClient.java
@@ -27,6 +27,7 @@ import ai.aerol.microvm.internal.api.v1.Paths;
 import ai.aerol.microvm.model.BuildImageOptions;
 import ai.aerol.microvm.model.BuildImagePushOptions;
 import ai.aerol.microvm.model.BuildImageResult;
+import ai.aerol.microvm.model.CloneGeneration;
 import ai.aerol.microvm.model.CreateOptions;
 import ai.aerol.microvm.model.CreateSessionOptions;
 import ai.aerol.microvm.model.CreateTemplateOptions;
@@ -371,6 +372,16 @@ public class MicroVMClient {
 
     public NetworkUsage getNetworkUsage(String sandboxId) {
         return doJson("GET", sandboxPath(sandboxId) + "/network/usage", null, NetworkUsage.class);
+    }
+
+    /**
+     * Reads a sandbox's clone-generation token. The token changes whenever the
+     * sandbox is resumed from a snapshot, so a change signals "this is a clone."
+     * Read-only — the SDK cannot reseed a process inside the guest; see the
+     * "Randomness in cloned sandboxes" docs for the in-guest reseed pattern.
+     */
+    public CloneGeneration cloneGeneration(String sandboxId) {
+        return doJson("GET", sandboxPath(sandboxId) + "/toolbox/clone-generation", null, CloneGeneration.class);
     }
 
     public NetworkUsage setNetworkLimits(String sandboxId, SetNetworkLimitsOptions options) {

--- a/sdk/java/src/main/java/ai/aerol/microvm/Sandbox.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/Sandbox.java
@@ -2,6 +2,7 @@ package ai.aerol.microvm;
 
 import java.util.List;
 
+import ai.aerol.microvm.model.CloneGeneration;
 import ai.aerol.microvm.model.CreateSessionOptions;
 import ai.aerol.microvm.model.CustomDomain;
 import ai.aerol.microvm.model.CustomDomainDnsRecords;
@@ -42,6 +43,14 @@ public class Sandbox extends SandboxData {
 
     public ExecResult exec(String command) {
         return client.exec(id, new ExecRequest().setCommand(command));
+    }
+
+    /**
+     * Reads this sandbox's clone-generation token (changes on
+     * resume-from-snapshot). Read-only; does not reseed in-guest PRNGs.
+     */
+    public CloneGeneration cloneGeneration() {
+        return client.cloneGeneration(id);
     }
 
     public ExecStreamHandle execStream(ExecStreamOptions options) {

--- a/sdk/java/src/main/java/ai/aerol/microvm/model/CloneGeneration.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/model/CloneGeneration.java
@@ -1,0 +1,22 @@
+package ai.aerol.microvm.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Clone-generation marker for a sandbox.
+ *
+ * <p>The {@code generation} token changes every time the sandbox is resumed
+ * from a snapshot (i.e. it is a clone). A long-lived process running
+ * <em>inside</em> the sandbox can poll this and reseed its own userspace PRNGs
+ * when the token changes — two clones otherwise share the snapshot's frozen
+ * seed state. Read-only: the SDK cannot reseed an in-guest process from the
+ * client side. See the "Randomness in cloned sandboxes" docs page.
+ */
+public class CloneGeneration {
+    /** Opaque token that changes on every resume-from-snapshot. */
+    public String generation = "";
+
+    /** Host wall-clock of the last resume, in unix nanoseconds. 0 = never resumed. */
+    @JsonProperty("resumed_at")
+    public long resumedAt;
+}

--- a/sdk/java/src/test/java/ai/aerol/microvm/MicroVMClientTest.java
+++ b/sdk/java/src/test/java/ai/aerol/microvm/MicroVMClientTest.java
@@ -172,6 +172,32 @@ class MicroVMClientTest {
     }
 
     @Test
+    void cloneGenerationReadsTokenViaToolboxProxy() throws Exception {
+        AtomicReference<String> seenPath = new AtomicReference<>();
+        AtomicReference<String> seenMethod = new AtomicReference<>();
+        HttpServer server = startServer(exchange -> {
+            seenMethod.set(exchange.getRequestMethod());
+            seenPath.set(exchange.getRequestURI().getPath());
+            writeJson(exchange, 200, mapOf(
+                "generation", "2d0d8c69",
+                "resumed_at", 1700000000000000000L
+            ));
+        });
+
+        try {
+            MicroVMClient client = clientFor(server);
+            ai.aerol.microvm.model.CloneGeneration gen = client.cloneGeneration("sb-clone");
+
+            assertEquals("GET", seenMethod.get());
+            assertEquals("/v1/sandboxes/sb-clone/toolbox/clone-generation", seenPath.get());
+            assertEquals("2d0d8c69", gen.generation);
+            assertEquals(1700000000000000000L, gen.resumedAt);
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
     void buildImageWithPushRejectsMissingCredentialsClientSide() throws Exception {
         // No HTTP server: validation must throw before any wire call. If a
         // request leaks out, the HttpClient will fail with a connect error

--- a/sdk/python/microvm/__init__.py
+++ b/sdk/python/microvm/__init__.py
@@ -3,6 +3,7 @@ from .image import Image
 from .types import (
     BuildImagePushOptions,
     BuildImageResult,
+    CloneGeneration,
     CustomDomain,
     CustomDomainDNSRecords,
     CustomDomainStatus,
@@ -20,6 +21,7 @@ from .types import (
 __all__ = [
     "BuildImagePushOptions",
     "BuildImageResult",
+    "CloneGeneration",
     "CustomDomain",
     "CustomDomainDNSRecords",
     "CustomDomainStatus",

--- a/sdk/python/microvm/client.py
+++ b/sdk/python/microvm/client.py
@@ -19,6 +19,7 @@ from .image import Image
 from .types import (
     BuildImagePushOptions,
     BuildImageResult,
+    CloneGeneration,
     CreateOptions,
     CreateSessionOptions,
     CreateTemplateOptions,
@@ -296,6 +297,14 @@ class Sandbox:
 
     def exec_command(self, command: str) -> ExecResult:
         return self._client.exec(self.id, {"command": command})
+
+    def clone_generation(self) -> CloneGeneration:
+        """Read this sandbox's clone-generation token (changes on resume-from-snapshot).
+
+        Read-only: does not reseed in-guest PRNGs. See the "Randomness in
+        cloned sandboxes" docs page for the in-guest reseed pattern.
+        """
+        return self._client.clone_generation(self.id)
 
     def exec_stream(self, options: ExecStreamOptions) -> ExecStreamHandle:
         return self._client.exec_stream(self.id, options)
@@ -643,6 +652,13 @@ class MicroVM:
         if not isinstance(mounts, list):
             return []
         return [_from_api_mount_spec_redacted(item) for item in mounts]
+
+    def clone_generation(self, sandbox_id: str) -> CloneGeneration:
+        payload = self._do_json("GET", f"{self._version_prefix}/sandboxes/{sandbox_id}/toolbox/clone-generation", None)
+        return CloneGeneration(
+            generation=str(_first_of(payload, "generation") or ""),
+            resumedAt=int(_first_of(payload, "resumed_at", "resumedAt") or 0),
+        )
 
     def get_network_usage(self, sandbox_id: str) -> NetworkUsage:
         payload = self._do_json("GET", f"{self._version_prefix}/sandboxes/{sandbox_id}/network/usage", None)

--- a/sdk/python/microvm/types.py
+++ b/sdk/python/microvm/types.py
@@ -36,6 +36,22 @@ class BuildImageResult:
     pushed: Optional[str] = None
 
 
+@dataclass(frozen=True)
+class CloneGeneration:
+    """Clone-generation marker for a sandbox.
+
+    ``generation`` changes every time the sandbox is resumed from a snapshot
+    (i.e. it is a clone). A long-lived process running *inside* the sandbox can
+    poll this and reseed its own userspace PRNGs when the token changes — two
+    clones otherwise share the snapshot's frozen seed state. Read-only: the SDK
+    cannot reseed an in-guest process from the client side. See the "Randomness
+    in cloned sandboxes" docs page.
+    """
+
+    generation: str
+    resumedAt: int = 0
+
+
 class RegisterSnapshotOptions(TypedDict, total=False):
     name: str
     image: str

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -1291,3 +1291,21 @@ class TemplateLifecycleTests(unittest.TestCase):
         with self.assertRaises(client_module.MicroVMHTTPError) as ctx:
             client.rebuild_template("tpl-pending")
         self.assertEqual(ctx.exception.status_code, 412)
+
+
+class CloneGenerationTest(unittest.TestCase):
+    def test_clone_generation_reads_token_via_toolbox_proxy(self):
+        class CloneGenMicroVM(RecordingMicroVM):
+            def _do_json(self, method, path, payload):  # type: ignore[override]
+                self.calls.append((method, path, payload))
+                return {"generation": "2d0d8c69", "resumed_at": 1700000000000000000}
+
+        client = CloneGenMicroVM()
+        gen = client.clone_generation("sb-clone")
+
+        self.assertEqual(
+            client.calls[0],
+            ("GET", "/v1/sandboxes/sb-clone/toolbox/clone-generation", None),
+        )
+        self.assertEqual(gen.generation, "2d0d8c69")
+        self.assertEqual(gen.resumedAt, 1700000000000000000)

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -26,7 +26,8 @@ pub use types::CreateSandboxResponse;
 use types::{CustomDomainListWire, ExposePortResponseWire};
 pub use types::{
     AddCustomDomainOptions, BuildImageOptions, BuildImagePushOptions, BuildImageResult,
-    ClientConfig, CreateOptions, CreateSessionOptions, CreateTemplateOptions, CustomDomain,
+    CloneGeneration, ClientConfig, CreateOptions, CreateSessionOptions, CreateTemplateOptions,
+    CustomDomain,
     CustomDomainDnsRecords,
     CustomDomainStatus, DnsRecord, ExecExitInfo, ExecRequest, ExecResult, ExposeOptions,
     ExposeProtocol, ExposeResult, ExposedPort, Failover, HealthStatus, IngressTarget, Lifecycle,
@@ -323,6 +324,12 @@ impl Sandbox {
 
     pub fn exec(&self, request: ExecRequest) -> Result<ExecResult, Error> {
         self.client.exec(&self.data.id, request)
+    }
+
+    /// Read this sandbox's clone-generation token (changes on
+    /// resume-from-snapshot). Read-only; does not reseed in-guest PRNGs.
+    pub fn clone_generation(&self) -> Result<CloneGeneration, Error> {
+        self.client.clone_generation(&self.data.id)
     }
 
     pub fn exec_stream(&self, options: ExecStreamOptions) -> Result<ExecStreamHandle, Error> {
@@ -913,6 +920,22 @@ impl Client {
             None,
         )?;
         Ok(raw.mounts)
+    }
+
+    /// Read a sandbox's clone-generation token. The token changes whenever the
+    /// sandbox is resumed from a snapshot, so a change signals "this is a
+    /// clone." Read-only — the SDK cannot reseed a process inside the guest;
+    /// see the "Randomness in cloned sandboxes" docs for the in-guest pattern.
+    pub fn clone_generation(&self, id: &str) -> Result<CloneGeneration, Error> {
+        self.do_json::<(), CloneGeneration>(
+            Method::GET,
+            &format!(
+                "{}/sandboxes/{}/toolbox/clone-generation",
+                self.version_prefix(),
+                id
+            ),
+            None,
+        )
     }
 
     pub fn get_network_usage(&self, id: &str) -> Result<NetworkUsage, Error> {
@@ -2547,6 +2570,30 @@ mod tests {
                 has_credentials: true,
             }]
         );
+    }
+
+    #[test]
+    fn clone_generation_reads_token_via_toolbox_proxy() {
+        let body = serde_json::json!({
+            "generation": "2d0d8c69",
+            "resumed_at": 1700000000000000000i64
+        })
+        .to_string();
+        let (url, request_rx) = spawn_json_server(body);
+
+        let client = Client::new(Some(&url), Some("pat-token")).expect("client should build");
+        let gen = client
+            .clone_generation("sb-1")
+            .expect("clone_generation should succeed");
+        let request = request_rx.recv().expect("request should be captured");
+
+        assert!(
+            request.starts_with("GET /v1/sandboxes/sb-1/toolbox/clone-generation HTTP/1.1\r\n"),
+            "unexpected request: {}",
+            request
+        );
+        assert_eq!(gen.generation, "2d0d8c69");
+        assert_eq!(gen.resumed_at, 1700000000000000000);
     }
 
     #[test]

--- a/sdk/rust/src/types.rs
+++ b/sdk/rust/src/types.rs
@@ -48,6 +48,23 @@ pub struct BuildImageResult {
     pub pushed: Option<String>,
 }
 
+/// Clone-generation marker for a sandbox.
+///
+/// `generation` changes every time the sandbox is resumed from a snapshot
+/// (i.e. it is a clone). A long-lived process running *inside* the sandbox can
+/// poll this and reseed its own userspace PRNGs when the token changes — two
+/// clones otherwise share the snapshot's frozen seed state. Read-only: the SDK
+/// cannot reseed an in-guest process from the client side. See the "Randomness
+/// in cloned sandboxes" docs page.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct CloneGeneration {
+    /// Opaque token that changes on every resume-from-snapshot.
+    pub generation: String,
+    /// Host wall-clock of the last resume, in unix nanoseconds. 0 = never resumed.
+    #[serde(default)]
+    pub resumed_at: i64,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct RegisterSnapshotOptions {
     /// Human-readable identifier other callers use in create-time snapshot references.

--- a/sdk/typescript/src/MicroVM.ts
+++ b/sdk/typescript/src/MicroVM.ts
@@ -4,6 +4,7 @@ import { Image } from "./Image.js";
 import type {
   BuildImageOptions,
   BuildImageResult,
+  CloneGeneration,
   CreateOptions,
   CreateSessionOptions,
   CreateTemplateOptions,
@@ -149,6 +150,16 @@ export class MicroVM {
 
   async mounts(sandboxID: string): Promise<MountSpecRedacted[]> {
     return this.client.mounts(sandboxID);
+  }
+
+  /**
+   * Read a sandbox's clone-generation token. The token changes whenever the
+   * sandbox is resumed from a snapshot, so a change signals "this is a clone."
+   * Read-only — the SDK cannot reseed a process inside the guest; see the
+   * "Randomness in cloned sandboxes" docs page for the in-guest reseed pattern.
+   */
+  async cloneGeneration(sandboxID: string): Promise<CloneGeneration> {
+    return this.client.cloneGeneration(sandboxID);
   }
 
   execStream(sandboxID: string, options: ExecStreamOptions): ExecStreamHandle {

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -9,6 +9,7 @@ export type {
   BuildImageOptions,
   BuildImagePushOptions,
   BuildImageResult,
+  CloneGeneration,
   CreateOptions,
   CreateSessionOptions,
   CreateTemplateOptions,

--- a/sdk/typescript/src/internal/client.test.ts
+++ b/sdk/typescript/src/internal/client.test.ts
@@ -22,6 +22,26 @@ test("internal client uses config object and auth header", async () => {
   assert.ok(sandbox instanceof SandboxResource);
 });
 
+test("internal client cloneGeneration reads token via toolbox proxy", async () => {
+  let seenRequest: Request | undefined;
+  const client = new APIClient({
+    baseURL: "https://api.example.com",
+    patToken: "pat-token",
+    fetch: async (input, init) => {
+      seenRequest = new Request(input, init);
+      return jsonResponse({ generation: "2d0d8c69", resumed_at: 1700000000000000000 });
+    },
+  });
+
+  const gen = await client.cloneGeneration("sb-clone");
+
+  assert.ok(seenRequest);
+  assert.equal(seenRequest.method, "GET");
+  assert.equal(seenRequest.url, "https://api.example.com/v1/sandboxes/sb-clone/toolbox/clone-generation");
+  assert.equal(gen.generation, "2d0d8c69");
+  assert.equal(gen.resumedAt, 1700000000000000000);
+});
+
 test("internal client create maps request and response", async () => {
   let seenRequest: Request | undefined;
   const client = new APIClient({

--- a/sdk/typescript/src/internal/client.ts
+++ b/sdk/typescript/src/internal/client.ts
@@ -17,6 +17,7 @@ import type {
   CreateSessionOptions,
   CreateTemplateOptions,
   CustomDomain,
+  CloneGeneration,
   CustomDomainDNSRecords,
   CustomDomainStatus,
   ExecExitInfo,
@@ -249,6 +250,11 @@ interface ApiHealthStatus {
   caddy: string;
   ssh_gateway?: string;
   version: string;
+}
+
+interface ApiCloneGeneration {
+  generation: string;
+  resumed_at: number;
 }
 
 interface ApiMountSpec {
@@ -700,6 +706,14 @@ export class APIClient {
     return response.mounts.map(fromApiMountSpecRedacted);
   }
 
+  async cloneGeneration(id: string): Promise<CloneGeneration> {
+    const response = await this.doJSON<ApiCloneGeneration>(
+      "GET",
+      `${this.versionPrefix}/sandboxes/${id}/toolbox/clone-generation`,
+    );
+    return fromApiCloneGeneration(response);
+  }
+
   async getNetworkUsage(id: string): Promise<NetworkUsage> {
     const response = await this.doJSON<ApiNetworkUsage>("GET", `${this.versionPrefix}/sandboxes/${id}/network/usage`);
     return fromApiNetworkUsage(response);
@@ -868,6 +882,16 @@ export class SandboxResource implements Sandbox {
 
   async exec(command: string | ExecRequest): Promise<ExecResult> {
     return this.client.exec(this.id, typeof command === "string" ? { command } : command);
+  }
+
+  /**
+   * Read this sandbox's clone-generation token. The token changes whenever the
+   * sandbox is resumed from a snapshot. Use it to detect that a sandbox is a
+   * clone (e.g. to re-run setup). It does NOT reseed in-guest PRNGs — see the
+   * "Randomness in cloned sandboxes" docs page for the in-guest pattern.
+   */
+  async cloneGeneration(): Promise<CloneGeneration> {
+    return this.client.cloneGeneration(this.id);
   }
 
   execStream(options: ExecStreamOptions): ExecStreamHandle {
@@ -1235,6 +1259,13 @@ function fromApiHealthStatus(status: ApiHealthStatus): HealthStatus {
     caddy: status.caddy,
     sshGateway: status.ssh_gateway ?? "",
     version: status.version,
+  };
+}
+
+function fromApiCloneGeneration(gen: ApiCloneGeneration): CloneGeneration {
+  return {
+    generation: gen.generation,
+    resumedAt: gen.resumed_at ?? 0,
   };
 }
 

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -512,6 +512,22 @@ export interface HealthStatus {
   version: string;
 }
 
+/**
+ * Clone-generation marker for a sandbox. The `generation` token changes every
+ * time the sandbox is resumed from a snapshot (i.e. it is a clone). A
+ * long-lived process running *inside* the sandbox can poll this and reseed its
+ * own userspace PRNGs when the token changes — two clones otherwise share the
+ * snapshot's frozen seed state. This is a read-only signal; the SDK cannot
+ * reseed an in-guest process from the client side. See the "Randomness in
+ * cloned sandboxes" docs page.
+ */
+export interface CloneGeneration {
+  /** Opaque token that changes on every resume-from-snapshot. */
+  generation: string;
+  /** Host wall-clock of the last resume, in unix nanoseconds. 0 = never resumed. */
+  resumedAt: number;
+}
+
 export type BinaryLike = Uint8Array | ArrayBuffer | Blob | string;
 
 /**


### PR DESCRIPTION
## Summary

- **Snapshot-clone RNG correctness for the Firecracker fast-boot path.** CoW snapshot clones duplicate the template's entire memory image, including every PRNG seed — two clones drawing "random" bytes after resume could produce identical UUIDs/tokens/nonces/keys. This closes that on the implemented paths and documents the residual.
  - **Phase A — kernel CRNG force-reseed.** `cmd/toolboxd/quiesce_linux.go` now issues `RNDRESEEDCRNG` after `RNDADDENTROPY` on the post-resume reseed, forcing the CRNG to consume the fresh entropy immediately (closes the version-dependent window on older kernels). Tolerates `ENOTTY`/`EINVAL` on kernels without it.
  - **Phase B — clone-generation signal + 5-SDK read accessor + docs.** A `cloneGeneration` token (`cmd/toolboxd/clonegen.go`), bumped in `OnPostResume`, published via the well-known guest file `/run/aerolvm/clone-generation` and `GET /clone-generation`. A read-only `cloneGeneration()` accessor in all five SDKs (TS/Py/Go/Rust/Java) for clone/migration detection. New docs page `randomness-in-cloned-sandboxes.mdx` with the in-guest reseed snippet in all five languages.
  - **Phase C — vmgenid (in-repo parts).** Documented Firecracker's vmgenid as the synchronous in-kernel reseed that closes the resume window Phase A cannot (`engineering-snapshot-correctness.mdx`, Hazard 2). Added the one daemon-controlled lever: `baseBootArgs` deliberately keeps ACPI enabled (vmgenid rides ACPI), guarded by `TestBootArgsKeepACPI`.
- Also bundles a standalone engineering doc page ("The Sandbox Runtime Nobody Built", `engineering-distributed-sandbox-runtime.mdx`) committed onto this branch.

## Sandbox boot impact

**N/A — no work added to the `CreateSandbox` boot path.** All runtime changes are on the **post-resume control path** (`OnPostResume`: the extra `RNDRESEEDCRNG` ioctl and the `cloneGeneration.bump`) and on **toolboxd startup** (initial token seed + file write). The `internal/runtime/firecracker/driver.go` change is a comment only; `bootargs_test.go` is a test. The SDK `cloneGeneration()` methods are client-side reads. Nothing runs in `CreateSandbox` or its callees.

## Idempotency

New API surface is read-only and idempotent by construction:
- `GET /clone-generation` (toolbox, unauthenticated like `/health`) and the five SDK `cloneGeneration()` methods are pure reads — repeated or concurrent calls return the current `{generation, resumedAt}`, with no allocation, no mutation, no host-port involvement.
- The internal `bump()` (fired on resume, not via an API) is last-writer-wins under a `sync.RWMutex`; the file write is best-effort (log-and-continue). No host-port pool walk, no "already exists" surface.

## Failure-path consistency

**N/A — no multi-step write touching both caddy and the store.** The clone-generation file write is best-effort and isolated; no caddy route or store row is involved.

## L4 / host-port-pool changes

**N/A — neither touched.** No change to `TryReserveHostPort`, the `host_port` partial unique index, `allocateHostPort`, `EnsureLayer4`, `EnsureLayer4Ready`, or the `l4Ready` latch.

### Snapshot-correctness note

The firecracker-driver change is a comment + a regression test only — **no change to placement/FSM, host-port pool, or resume behavior.** Phase C's load-bearing preconditions (Firecracker ≥ v1.8 binary, guest kernel `CONFIG_VMGENID=y`) are **deploy-time operator artifacts** the repo only references (`SB_FIRECRACKER_BINARY` / `SB_FIRECRACKER_KERNEL`, downloaded via Terraform), not daemon code. Without them the system silently falls back to `post_resume`-only behavior — correct on the happy path, with the sub-second resume window restored.

## Test plan

- `cmd/toolboxd/quiesce_linux_test.go` — both ioctls fire in order; old-kernel `RNDRESEEDCRNG` tolerated; `RNDADDENTROPY` failure surfaced.
- `cmd/toolboxd/clonegen_test.go` — token init/bump/persist, unwritable-path non-fatal, concurrency, `GET /clone-generation` route, `OnPostResume` bumps the generation.
- `internal/runtime/firecracker/bootargs_test.go` — `TestBootArgsKeepACPI` fails the build if `acpi=off`/`noacpi` is reintroduced (vmgenid depends on ACPI).
- Per-SDK `cloneGeneration()` tests: TypeScript (72), Python (53), Go, Rust, Java (36) — all green.
- `make test` green for `cmd/toolboxd` and `internal/runtime/firecracker` (full pkg suite 21.5s).
- `docs build` green (66 pages); five-tab page renders, sidebar entry present.
- Pre-existing, unrelated: `cmd/toolboxd/sessions` data race (`session.go:297` vs `:94`) surfaces only under `go test -race`; not introduced here, not fixed here.
