### PR TITLE
feat: Adds fleet-visible vmgenid readiness checks 

### DIFF
--- a/Ansible/README.md
+++ b/Ansible/README.md
@@ -493,9 +493,11 @@ What the play actually does, per host:
 4. Downloads `firecracker-<ver>-<arch>.tgz` + its `.sha256.txt` sidecar
    from `github.com/firecracker-microvm/firecracker/releases`, verifies with
    `sha256sum -c`, extracts, installs binary + jailer.
-5. Downloads the guest kernel from `s3.amazonaws.com/spec.ccfc.min`
-   (the upstream-blessed CI bucket) to `firecracker.kernel_path`. The
-   defaults are pinned to a known-good combination (see below).
+5. Downloads the guest kernel and matching `.config` sidecar from
+   `s3.amazonaws.com/spec.ccfc.min` (the upstream-blessed CI bucket) to
+   `firecracker.kernel_path` and `firecracker.kernel_path + ".config"`.
+   The defaults are pinned to a known-good combination (see below), and the
+   playbook fails fast if the config does not enable `CONFIG_VMGENID=y`.
 6. Creates `firecracker.run_dir`, `templates_dir`, and `jailer_chroot_base`.
 
 ### Pins and overrides
@@ -510,6 +512,7 @@ Defaults in `inventory/group_vars/all/defaults.yml`:
 | `firecracker_binary_url` | `""` | Set in `local.yml` to pull binary from a private mirror; bypasses upstream + checksum |
 | `firecracker_jailer_url` | `""` | Same for the jailer |
 | `firecracker_kernel_url` | `""` | Same for the kernel; useful if you ship a hand-built `vmlinux` |
+| `firecracker_kernel_config_url` | `""` | Same for the kernel config; defaults to `firecracker_kernel_url + ".config"` when the kernel URL is overridden |
 
 Bump the version pins together: when Firecracker releases `v1.16.0`, set
 `firecracker_version: "v1.16.0"` and `firecracker_kernel_ci_version: "v1.16"`,

--- a/Ansible/inventory/group_vars/all/defaults.yml
+++ b/Ansible/inventory/group_vars/all/defaults.yml
@@ -76,8 +76,9 @@ sandboxd_auto_import_cluster_pat_src: ""
 #     firecracker_version, SHA256-verified against the release's published
 #     .sha256.txt sidecar (same trust model install.sh uses for runsc).
 #   - a guest kernel image from the AWS spec.ccfc.min bucket pinned to
-#     firecracker_kernel_ci_version / firecracker_kernel_version. Both
-#     x86_64 and aarch64 paths exist there; unsupported arches fail fast.
+#     firecracker_kernel_ci_version / firecracker_kernel_version, plus its
+#     .config sidecar so sandboxd can prove CONFIG_VMGENID=y.
+#     Both x86_64 and aarch64 paths exist there; unsupported arches fail fast.
 # Only x86_64 / aarch64 hosts are supported (Firecracker upstream constraint).
 # Override any of the *_url vars in local.yml to pull from a private mirror
 # instead — the override skips the upstream URL construction entirely.
@@ -87,3 +88,4 @@ firecracker_kernel_version: "5.10.245"
 firecracker_binary_url: ""
 firecracker_jailer_url: ""
 firecracker_kernel_url: ""
+firecracker_kernel_config_url: ""

--- a/Ansible/playbooks/configure-ops.yml
+++ b/Ansible/playbooks/configure-ops.yml
@@ -301,6 +301,8 @@
         # layout is firecracker-ci/<ci_version>/<arch>/vmlinux-<kernel_version>.
         firecracker_kernel_default_url: >-
           https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/{{ firecracker_kernel_ci_version }}/{{ firecracker_arch }}/vmlinux-{{ firecracker_kernel_version }}
+        firecracker_kernel_config_default_url: >-
+          https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/{{ firecracker_kernel_ci_version }}/{{ firecracker_arch }}/vmlinux-{{ firecracker_kernel_version }}.config
 
     - name: Ensure Firecracker install directories exist
       when: firecracker.enabled | default(false) | bool
@@ -438,6 +440,23 @@
         owner: root
         group: root
         force: no
+
+    - name: Download Firecracker guest kernel config
+      # sandboxd uses this sidecar to prove CONFIG_VMGENID=y before advertising
+      # snapshot-clone entropy correctness on /health.
+      when: firecracker.enabled | default(false) | bool
+      ansible.builtin.get_url:
+        url: "{{ firecracker_kernel_config_url if (firecracker_kernel_config_url | length > 0) else (firecracker_kernel_url ~ '.config' if (firecracker_kernel_url | length > 0) else firecracker_kernel_config_default_url) }}"
+        dest: "{{ firecracker.kernel_path | default('/var/lib/sandboxd/firecracker/vmlinux') }}.config"
+        mode: "0644"
+        owner: root
+        group: root
+        force: no
+
+    - name: Verify Firecracker guest kernel enables vmgenid
+      when: firecracker.enabled | default(false) | bool
+      ansible.builtin.command: "grep -qx CONFIG_VMGENID=y {{ firecracker.kernel_path | default('/var/lib/sandboxd/firecracker/vmlinux') }}.config"
+      changed_when: false
 
     # Upstream wrap key (Phase 4 F17). Two delivery modes:
     #   * shared SoT      -> aocr.upstream_wrap_key in config/secrets.yml

--- a/Terraform/README.md
+++ b/Terraform/README.md
@@ -172,8 +172,8 @@ making operators smuggle everything through `extra_user_data`.
 2. Fill the `firecracker` object in `config/terraform.tfvars`.
 3. Choose one of two bootstrap modes:
 
-- **Artifact-download mode**: set `firecracker.binary_url`, `firecracker.jailer_url`, and `firecracker.kernel_url`. Terraform bootstrap installs `skopeo`, `umoci`, `e2fsprogs`, and `iproute2`, downloads those artifacts, writes the matching `SB_ENABLE_FIRECRACKER` / `SB_FIRECRACKER_*` env vars into `/etc/sandboxd/cluster.env`, and restarts `sandboxd`.
-- **Pre-baked AMI mode**: leave the URLs empty and make sure the AMI already has the binaries and kernel at `firecracker.binary_path`, `firecracker.jailer_path`, and `firecracker.kernel_path`.
+- **Artifact-download mode**: set `firecracker.binary_url`, `firecracker.jailer_url`, and `firecracker.kernel_url`. Terraform bootstrap installs `skopeo`, `umoci`, `e2fsprogs`, and `iproute2`, downloads those artifacts plus the kernel config sidecar, writes the matching `SB_ENABLE_FIRECRACKER` / `SB_FIRECRACKER_*` env vars into `/etc/sandboxd/cluster.env`, and restarts `sandboxd`.
+- **Pre-baked AMI mode**: leave the URLs empty and make sure the AMI already has the binaries, kernel, and kernel config at `firecracker.binary_path`, `firecracker.jailer_path`, `firecracker.kernel_path`, and `firecracker.kernel_path + ".config"`.
 
 Example:
 
@@ -184,6 +184,7 @@ firecracker = {
   binary_url               = "https://example.com/firecracker"
   jailer_url               = "https://example.com/jailer"
   kernel_url               = "https://example.com/vmlinux"
+  kernel_config_url        = "https://example.com/vmlinux.config"
   kernel_path              = "/var/lib/sandboxd/firecracker/vmlinux"
   use_jailer               = true
   tap_base_cidr            = "172.16.0.0/20"

--- a/Terraform/nodes.tf
+++ b/Terraform/nodes.tf
@@ -56,6 +56,7 @@ resource "aws_instance" "seed" {
     firecracker_binary_url                   = var.firecracker.binary_url
     firecracker_jailer_url                   = var.firecracker.jailer_url
     firecracker_kernel_url                   = var.firecracker.kernel_url
+    firecracker_kernel_config_url            = var.firecracker.kernel_config_url
     firecracker_binary_path                  = var.firecracker.binary_path
     firecracker_jailer_path                  = var.firecracker.jailer_path
     firecracker_kernel_path                  = var.firecracker.kernel_path
@@ -203,6 +204,7 @@ resource "aws_instance" "joiner" {
     firecracker_binary_url                   = var.firecracker.binary_url
     firecracker_jailer_url                   = var.firecracker.jailer_url
     firecracker_kernel_url                   = var.firecracker.kernel_url
+    firecracker_kernel_config_url            = var.firecracker.kernel_config_url
     firecracker_binary_path                  = var.firecracker.binary_path
     firecracker_jailer_path                  = var.firecracker.jailer_path
     firecracker_kernel_path                  = var.firecracker.kernel_path

--- a/Terraform/templates/bootstrap.sh.tftpl
+++ b/Terraform/templates/bootstrap.sh.tftpl
@@ -8,6 +8,7 @@
 #   with_firecracker (bool), with_gvisor (bool), with_nvidia_gpu (bool), with_amd_gpu (bool),
 #   idle_timeout_min (number; 0 disables),
 #   firecracker_binary_url, firecracker_jailer_url, firecracker_kernel_url,
+#   firecracker_kernel_config_url,
 #   firecracker_binary_path, firecracker_jailer_path, firecracker_kernel_path,
 #   firecracker_run_dir, firecracker_templates_dir,
 #   firecracker_use_jailer, firecracker_jailer_chroot_base,
@@ -284,12 +285,28 @@ if [ -n '${firecracker_kernel_url}' ]; then
   install -m 0644 /tmp/vmlinux '${firecracker_kernel_path}'
 fi
 
+if [ -n '${firecracker_kernel_config_url}' ]; then
+  curl -fL --retry 5 --retry-delay 2 --retry-connrefused '${firecracker_kernel_config_url}' -o /tmp/vmlinux.config
+  install -m 0644 /tmp/vmlinux.config '${firecracker_kernel_path}.config'
+elif [ -n '${firecracker_kernel_url}' ]; then
+  curl -fL --retry 5 --retry-delay 2 --retry-connrefused '${firecracker_kernel_url}.config' -o /tmp/vmlinux.config
+  install -m 0644 /tmp/vmlinux.config '${firecracker_kernel_path}.config'
+fi
+
 if [ ! -x '${firecracker_binary_path}' ]; then
   echo "[bootstrap] firecracker binary missing or not executable at ${firecracker_binary_path}" >&2
   exit 1
 fi
 if [ ! -f '${firecracker_kernel_path}' ]; then
   echo "[bootstrap] firecracker kernel missing at ${firecracker_kernel_path}" >&2
+  exit 1
+fi
+if [ ! -f '${firecracker_kernel_path}.config' ]; then
+  echo "[bootstrap] firecracker kernel config missing at ${firecracker_kernel_path}.config" >&2
+  exit 1
+fi
+if ! grep -qx 'CONFIG_VMGENID=y' '${firecracker_kernel_path}.config'; then
+  echo "[bootstrap] firecracker kernel config at ${firecracker_kernel_path}.config does not enable CONFIG_VMGENID=y" >&2
   exit 1
 fi
 if [ '${firecracker_use_jailer}' = 'true' ] && [ ! -x '${firecracker_jailer_path}' ]; then

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -311,12 +311,15 @@ variable "firecracker" {
     The *_url fields are optional so pre-baked AMIs remain supported:
     leave them empty if the AMI already ships the artifacts at the matching
     *_path values. kernel_path must point at a real vmlinux image on the host
-    by the time sandboxd restarts or config validation will fail at boot.
+    and kernel_path.config must point at that image's kernel config by the time
+    sandboxd restarts or health will degrade because vmgenid support cannot be
+    proven.
   EOT
   type = object({
     binary_url                   = optional(string, "")
     jailer_url                   = optional(string, "")
     kernel_url                   = optional(string, "")
+    kernel_config_url            = optional(string, "")
     binary_path                  = optional(string, "/usr/local/bin/firecracker")
     jailer_path                  = optional(string, "/usr/local/bin/jailer")
     kernel_path                  = optional(string, "/var/lib/sandboxd/firecracker/vmlinux")

--- a/cmd/toolboxd/clonegen.go
+++ b/cmd/toolboxd/clonegen.go
@@ -59,11 +59,11 @@ func newCloneGeneration(path string, logger *slog.Logger) *cloneGeneration {
 		path = defaultCloneGenPath
 	}
 	c := &cloneGeneration{
-		token:  randomToken(),
+		token:  randomToken(0),
 		path:   path,
 		logger: logger,
 	}
-	c.writeFile()
+	c.writeFile(c.token)
 	return c
 }
 
@@ -77,10 +77,11 @@ func (c *cloneGeneration) bump(resumedAtUnixNs int64) {
 		return
 	}
 	c.mu.Lock()
-	c.token = randomToken()
+	nextToken := randomToken(resumedAtUnixNs)
+	c.token = nextToken
 	c.resumedAt = resumedAtUnixNs
+	c.writeFileLocked(nextToken)
 	c.mu.Unlock()
-	c.writeFile()
 }
 
 // current returns the token and the last resume time for HTTP responses.
@@ -100,38 +101,69 @@ func (c *cloneGeneration) current() (token string, resumedAt int64) {
 // writeFile persists the current token to the well-known path. Best-effort:
 // failures are logged at Debug and swallowed so a read-only/missing /run
 // never breaks the sandbox — the HTTP endpoint remains the source of truth.
-func (c *cloneGeneration) writeFile() {
-	token, _ := c.current()
+func (c *cloneGeneration) writeFile(token string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.writeFileLocked(token)
+}
+
+// writeFileLocked persists token to the well-known path using a temp-file +
+// rename publish. Callers must hold c.mu if they need HTTP readers to see
+// the same generation only after the file is committed.
+func (c *cloneGeneration) writeFileLocked(token string) {
 	if err := os.MkdirAll(filepath.Dir(c.path), 0o755); err != nil {
 		c.logger.Debug("clone-generation: mkdir failed", "path", c.path, "error", err)
 		return
 	}
+	tmp, err := os.CreateTemp(filepath.Dir(c.path), ".clone-generation-*")
+	if err != nil {
+		c.logger.Debug("clone-generation: temp file create failed", "path", c.path, "error", err)
+		return
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+	}()
 	// Trailing newline so `cat` / shell `$(<file)` reads are clean.
-	if err := os.WriteFile(c.path, []byte(token+"\n"), 0o644); err != nil {
-		c.logger.Debug("clone-generation: write failed", "path", c.path, "error", err)
+	if _, err := tmp.Write([]byte(token + "\n")); err != nil {
+		c.logger.Debug("clone-generation: temp write failed", "path", c.path, "error", err)
+		return
+	}
+	if err := tmp.Chmod(0o644); err != nil {
+		c.logger.Debug("clone-generation: temp chmod failed", "path", c.path, "error", err)
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		c.logger.Debug("clone-generation: temp close failed", "path", c.path, "error", err)
+		return
+	}
+	if err := os.Rename(tmpName, c.path); err != nil {
+		c.logger.Debug("clone-generation: rename failed", "path", c.path, "error", err)
 	}
 }
 
 // fallbackCounter guarantees randomToken's fallback path varies between
 // calls even if crypto/rand is somehow unavailable. See randomToken.
 var fallbackCounter atomic.Uint64
+var randRead = rand.Read
 
 // randomToken returns 16 bytes of crypto entropy as hex. crypto/rand reads
 // the OS CSPRNG, which the resume path reseeds before bump() is ever called,
 // so successive clones get distinct tokens.
-func randomToken() string {
+func randomToken(resumeUnixNs int64) string {
 	var b [16]byte
-	if _, err := rand.Read(b[:]); err != nil {
+	if _, err := randRead(b[:]); err != nil {
 		// crypto/rand.Read effectively never fails on a booted Linux guest.
 		// If it somehow does we must STILL return a value that *changes*
 		// between calls: the token's entire job is to differ on each resume,
 		// and a constant fallback would make a second bump a silent no-op,
-		// hiding a clone from in-guest pollers. Mix a process-lifetime
-		// monotonic counter with the wall-clock nanosecond so successive
-		// fallbacks are distinct. (The kernel reseed is the real entropy
-		// guarantee; this token is only a change signal, so non-crypto
-		// uniqueness here is fine.)
-		return fmt.Sprintf("fallback-%d-%d", time.Now().UnixNano(), fallbackCounter.Add(1))
+		// hiding a clone from in-guest pollers. Mix the host-provided resume
+		// timestamp (not snapshotted), a process-lifetime counter, and the
+		// local wall clock so the degraded path does not rely solely on frozen
+		// process state. The kernel reseed is the real entropy guarantee; this
+		// token is only a change signal, so non-crypto uniqueness here is fine.
+		return fmt.Sprintf("fallback-%d-%d-%d", resumeUnixNs, time.Now().UnixNano(), fallbackCounter.Add(1))
 	}
 	return hex.EncodeToString(b[:])
 }

--- a/cmd/toolboxd/clonegen_test.go
+++ b/cmd/toolboxd/clonegen_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -61,6 +62,30 @@ func TestCloneGeneration_BumpChangesTokenAndPersists(t *testing.T) {
 	}
 	if strings.TrimSpace(string(got)) != after {
 		t.Errorf("file token = %q, want %q", strings.TrimSpace(string(got)), after)
+	}
+}
+
+// TestCloneGeneration_BumpPublishesAtomically asserts the on-disk token is
+// replaced via rename semantics: readers should only ever see the full old or
+// full new token, never an empty/truncated intermediate write.
+func TestCloneGeneration_BumpPublishesAtomically(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "clone-generation")
+	c := newCloneGeneration(path, nil)
+	before, _ := c.current()
+
+	c.bump(1700000000000000000)
+
+	after, _ := c.current()
+	if after == before {
+		t.Fatalf("token unchanged after bump: %q", after)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read clone-generation file: %v", err)
+	}
+	fileToken := strings.TrimSpace(string(got))
+	if fileToken != before && fileToken != after {
+		t.Fatalf("file token = %q, want old %q or new %q", fileToken, before, after)
 	}
 }
 
@@ -166,4 +191,22 @@ func TestCloneGeneration_NilReceiverIsSafe(t *testing.T) {
 	}
 	// Must not panic.
 	cg.bump(123)
+}
+
+func TestRandomTokenFallbackUsesResumeTimestamp(t *testing.T) {
+	oldRandRead := randRead
+	randRead = func([]byte) (int, error) { return 0, errors.New("entropy unavailable") }
+	defer func() { randRead = oldRandRead }()
+
+	a := randomToken(111)
+	b := randomToken(222)
+	if a == b {
+		t.Fatalf("fallback token collision: %q", a)
+	}
+	if !strings.Contains(a, "fallback-111-") {
+		t.Fatalf("fallback token %q does not include resume timestamp", a)
+	}
+	if !strings.Contains(b, "fallback-222-") {
+		t.Fatalf("fallback token %q does not include resume timestamp", b)
+	}
 }

--- a/config/cluster.yml
+++ b/config/cluster.yml
@@ -79,7 +79,8 @@ image_build_gc:
 # --- Firecracker runtime bootstrap ---------------------------------------
 # Host-level Firecracker enablement is opt-in. The bootstrap path must
 # install the runtime binaries and provide a kernel image at the configured
-# path before sandboxd starts with SB_ENABLE_FIRECRACKER=true.
+# path, plus <kernel_path>.config with CONFIG_VMGENID=y, before sandboxd
+# starts with SB_ENABLE_FIRECRACKER=true.
 firecracker:
   enabled: false
   kernel_path: "/var/lib/sandboxd/firecracker/vmlinux"

--- a/config/terraform.tfvars.example
+++ b/config/terraform.tfvars.example
@@ -67,6 +67,7 @@ default_volume_type       = "gp3"
 #   binary_url               = "https://example.com/firecracker"
 #   jailer_url               = "https://example.com/jailer"
 #   kernel_url               = "https://example.com/vmlinux"
+#   kernel_config_url        = "https://example.com/vmlinux.config"
 #   kernel_path              = "/var/lib/sandboxd/firecracker/vmlinux"
 #   use_jailer               = true
 #   tap_base_cidr            = "172.16.0.0/20"

--- a/docs/src/content/docs/cluster-setup.md
+++ b/docs/src/content/docs/cluster-setup.md
@@ -176,11 +176,12 @@ firecracker = {
   binary_url  = "https://example.com/firecracker"
   jailer_url  = "https://example.com/jailer"
   kernel_url  = "https://example.com/vmlinux"
+  kernel_config_url = "https://example.com/vmlinux.config"
   kernel_path = "/var/lib/sandboxd/firecracker/vmlinux"
 }
 ```
 
-Set the `*_url` fields to download locations for the binaries. Leave them empty if your server image already has the files installed at those paths - Terraform will skip the download step.
+Set the `*_url` fields to download locations for the binaries and kernel artifacts. If `kernel_config_url` is empty, Terraform tries `kernel_url + ".config"`. Leave them empty only if your server image already has the files installed at those paths, including `/var/lib/sandboxd/firecracker/vmlinux.config`.
 
 After deployment, you register container images as Firecracker templates and then create sandboxes using the `firecracker` runtime. See [Firecracker Templates](/firecracker-templates) for the step-by-step workflow.
 

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -35,6 +35,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -119,6 +121,13 @@ type Driver struct {
 	clients  map[string]VMMClient // sandbox-id -> API client
 	vmms     map[string]VMMHandle // sandbox-id -> VMM handle (for Destroy)
 	guestCID map[string]uint32    // sandbox-id -> CID baked into the running guest
+	healthMu sync.Mutex
+	// runtimeHealth caches the vmgenid-capability probe result. The Firecracker
+	// binary path and kernel artifact are static for a daemon lifetime, so
+	// recomputing on every /health call just burns a subprocess and disk reads
+	// without adding signal.
+	runtimeHealth string
+	healthReady   bool
 }
 
 // TapPool is the interface Driver depends on for network allocation.
@@ -1333,6 +1342,119 @@ func (d *Driver) Ping(_ context.Context) error {
 		}
 	}
 	return nil
+}
+
+var firecrackerVersionRE = regexp.MustCompile(`(?i)\bv?(\d+)\.(\d+)\.(\d+)\b`)
+
+// RuntimeHealth reports whether this node can prove the vmgenid prerequisites
+// needed to close the pre-userspace snapshot-clone entropy window. "ok" means
+// the daemon validated its local Firecracker binary and found a neighboring
+// kernel config artifact with CONFIG_VMGENID=y; any other string is an
+// operator-facing degradation reason suitable for /health.
+func (d *Driver) RuntimeHealth(ctx context.Context) string {
+	d.healthMu.Lock()
+	defer d.healthMu.Unlock()
+	if d.healthReady {
+		return d.runtimeHealth
+	}
+	status := "ok"
+	if err := d.Ping(ctx); err != nil {
+		status = err.Error()
+	} else if err := d.validateVMGenIDCapability(ctx); err != nil {
+		status = err.Error()
+	}
+	d.runtimeHealth = status
+	d.healthReady = true
+	return status
+}
+
+func (d *Driver) validateVMGenIDCapability(ctx context.Context) error {
+	if err := d.requireFirecrackerVersion(ctx, 1, 8, 0); err != nil {
+		return err
+	}
+	if err := d.requireKernelVMGenID(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *Driver) requireFirecrackerVersion(ctx context.Context, wantMajor, wantMinor, wantPatch int) error {
+	out, err := exec.CommandContext(ctx, d.cfg.FirecrackerBinary, "--version").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("firecracker runtime: vmgenid capability check failed to exec %q --version: %w",
+			d.cfg.FirecrackerBinary, err)
+	}
+	m := firecrackerVersionRE.FindStringSubmatch(string(out))
+	if len(m) != 4 {
+		return fmt.Errorf("firecracker runtime: vmgenid capability check could not parse firecracker version from %q",
+			strings.TrimSpace(string(out)))
+	}
+	gotMajor, _ := strconv.Atoi(m[1])
+	gotMinor, _ := strconv.Atoi(m[2])
+	gotPatch, _ := strconv.Atoi(m[3])
+	if versionLess(gotMajor, gotMinor, gotPatch, wantMajor, wantMinor, wantPatch) {
+		return fmt.Errorf("firecracker runtime: vmgenid requires Firecracker >= %d.%d.%d, found %d.%d.%d",
+			wantMajor, wantMinor, wantPatch, gotMajor, gotMinor, gotPatch)
+	}
+	return nil
+}
+
+func versionLess(gotMajor, gotMinor, gotPatch, wantMajor, wantMinor, wantPatch int) bool {
+	if gotMajor != wantMajor {
+		return gotMajor < wantMajor
+	}
+	if gotMinor != wantMinor {
+		return gotMinor < wantMinor
+	}
+	return gotPatch < wantPatch
+}
+
+func (d *Driver) requireKernelVMGenID() error {
+	if d.cfg.KernelImage == "" {
+		return errors.New("firecracker runtime: vmgenid capability check cannot verify guest kernel because SB_FIRECRACKER_KERNEL is not set")
+	}
+	paths := kernelConfigCandidates(d.cfg.KernelImage)
+	sawConfig := false
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return fmt.Errorf("firecracker runtime: vmgenid capability check could not read kernel config %q: %w", path, err)
+		}
+		sawConfig = true
+		if kernelConfigEnablesVMGenID(data) {
+			return nil
+		}
+		return fmt.Errorf("firecracker runtime: guest kernel config %q does not enable CONFIG_VMGENID=y", path)
+	}
+	if sawConfig {
+		return errors.New("firecracker runtime: vmgenid capability check could not verify guest kernel CONFIG_VMGENID")
+	}
+	return fmt.Errorf("firecracker runtime: vmgenid capability check could not find a kernel config near %q; looked for %s",
+		d.cfg.KernelImage, strings.Join(paths, ", "))
+}
+
+func kernelConfigCandidates(kernelPath string) []string {
+	dir := filepath.Dir(kernelPath)
+	base := filepath.Base(kernelPath)
+	return []string{
+		kernelPath + ".config",
+		filepath.Join(dir, base+".config"),
+		filepath.Join(dir, "config"),
+		filepath.Join(dir, "config-"+base),
+	}
+}
+
+func kernelConfigEnablesVMGenID(data []byte) bool {
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "CONFIG_VMGENID=y" {
+			return true
+		}
+	}
+	return false
 }
 
 // RemoveImage is a Docker concept; on the Firecracker path images are

--- a/internal/runtime/firecracker/driver_test.go
+++ b/internal/runtime/firecracker/driver_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/aerol-ai/microvm/internal/runtime"
@@ -18,6 +19,65 @@ import (
 // compile — which is the right place to catch the drift.
 func TestDriverImplementsRuntime(t *testing.T) {
 	var _ runtime.Runtime = (*Driver)(nil)
+}
+
+func TestRuntimeHealthVMGenIDCapability(t *testing.T) {
+	dir := t.TempDir()
+	fcBin := filepath.Join(dir, "firecracker")
+	jailerBin := filepath.Join(dir, "jailer")
+	kernel := filepath.Join(dir, "vmlinux")
+	kernelConfig := kernel + ".config"
+	for _, tc := range []struct {
+		name       string
+		versionOut string
+		kernelCfg  string
+		want       string
+		wantSubstr string
+	}{
+		{
+			name:       "ok",
+			versionOut: "Firecracker v1.8.0\n",
+			kernelCfg:  "CONFIG_VMGENID=y\n",
+			want:       "ok",
+		},
+		{
+			name:       "old firecracker",
+			versionOut: "Firecracker v1.7.0\n",
+			kernelCfg:  "CONFIG_VMGENID=y\n",
+			wantSubstr: "requires Firecracker >= 1.8.0",
+		},
+		{
+			name:       "kernel config missing flag",
+			versionOut: "Firecracker v1.8.0\n",
+			kernelCfg:  "# CONFIG_VMGENID is not set\n",
+			wantSubstr: "does not enable CONFIG_VMGENID=y",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			script := "#!/bin/sh\nprintf '%s' '" + strings.ReplaceAll(tc.versionOut, "'", "'\"'\"'") + "'\n"
+			if err := os.WriteFile(fcBin, []byte(script), 0o755); err != nil {
+				t.Fatalf("write firecracker: %v", err)
+			}
+			if err := os.WriteFile(jailerBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+				t.Fatalf("write jailer: %v", err)
+			}
+			if err := os.WriteFile(kernel, []byte{}, 0o644); err != nil {
+				t.Fatalf("write kernel: %v", err)
+			}
+			if err := os.WriteFile(kernelConfig, []byte(tc.kernelCfg), 0o644); err != nil {
+				t.Fatalf("write kernel config: %v", err)
+			}
+
+			d := New(Config{FirecrackerBinary: fcBin, JailerBinary: jailerBin, KernelImage: kernel}, nil)
+			got := d.RuntimeHealth(context.Background())
+			if tc.want != "" && got != tc.want {
+				t.Fatalf("RuntimeHealth() = %q, want %q", got, tc.want)
+			}
+			if tc.wantSubstr != "" && !strings.Contains(got, tc.wantSubstr) {
+				t.Fatalf("RuntimeHealth() = %q, want substring %q", got, tc.wantSubstr)
+			}
+		})
+	}
 }
 
 // TestPing confirms the binary-existence checks behave as expected:

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -2819,8 +2819,27 @@ func (s *Service) Health(ctx context.Context) (models.HealthStatus, error) {
 		}
 	}
 
+	firecrackerStatus := "disabled"
+	if s.cfg.EnableFirecracker {
+		switch rt := s.firecracker.(type) {
+		case interface{ RuntimeHealth(context.Context) string }:
+			firecrackerStatus = rt.RuntimeHealth(ctx)
+		case nil:
+			firecrackerStatus = fmt.Sprintf("runtime %q: driver not registered", models.RuntimeFirecracker)
+		default:
+			if err := rt.Ping(ctx); err != nil {
+				firecrackerStatus = err.Error()
+			} else {
+				firecrackerStatus = "ok"
+			}
+		}
+	}
+
 	status := "ok"
 	if dockerStatus != "ok" || caddyStatus != "ok" {
+		status = "degraded"
+	}
+	if s.cfg.EnableFirecracker && firecrackerStatus != "ok" {
 		status = "degraded"
 	}
 	// SSH gateway being down only degrades health when it's expected to be up.
@@ -2847,6 +2866,7 @@ func (s *Service) Health(ctx context.Context) (models.HealthStatus, error) {
 		Sandboxes:       live,
 		Docker:          dockerStatus,
 		Caddy:           caddyStatus,
+		Firecracker:     firecrackerStatus,
 		SSHGateway:      sshStatus,
 		ClusterTopology: clusterTopology,
 		ClusterNodes:    clusterNodes,

--- a/internal/service/service_runtime_flow_test.go
+++ b/internal/service/service_runtime_flow_test.go
@@ -47,6 +47,7 @@ type recordingRuntime struct {
 	destroyIDs []string
 
 	pingErr error
+	health  string
 
 	pushes []allowedPortsPush
 
@@ -139,6 +140,13 @@ func (r *recordingRuntime) ListManaged(_ context.Context) (map[string]*models.Sa
 }
 
 func (r *recordingRuntime) Ping(context.Context) error { return r.pingErr }
+
+func (r *recordingRuntime) RuntimeHealth(context.Context) string {
+	if r.health == "" {
+		return "ok"
+	}
+	return r.health
+}
 
 func (r *recordingRuntime) RemoveImage(_ context.Context, imageRef string) error {
 	r.removeImages = append(r.removeImages, imageRef)
@@ -288,7 +296,7 @@ func TestServiceLifecycleStopStartDestroyAndHealth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Health() error = %v", err)
 	}
-	if health.Status != "ok" || health.Sandboxes != 1 || health.Docker != "ok" || health.Caddy != "ok" {
+	if health.Status != "ok" || health.Sandboxes != 1 || health.Docker != "ok" || health.Caddy != "ok" || health.Firecracker != "disabled" {
 		t.Fatalf("initial health = %+v, want ok with one live sandbox", health)
 	}
 
@@ -356,6 +364,25 @@ func TestServiceLifecycleStopStartDestroyAndHealth(t *testing.T) {
 	}
 	if _, err := st.Get(ctx, resp.ID); !errors.Is(err, storepkg.ErrNotFound) {
 		t.Fatalf("sandbox still present after destroy: %v", err)
+	}
+}
+
+func TestHealthReportsFirecrackerCapabilityDegraded(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{health: "firecracker runtime: vmgenid capability check could not find a kernel config"}
+	svc, _, _ := newServiceRuntimeHarness(t, rt)
+	svc.cfg.EnableFirecracker = true
+	svc.SetFirecrackerRuntime(rt)
+
+	health, err := svc.Health(ctx)
+	if err != nil {
+		t.Fatalf("Health() error = %v", err)
+	}
+	if health.Status != "degraded" {
+		t.Fatalf("health status = %q, want degraded", health.Status)
+	}
+	if health.Firecracker != rt.health {
+		t.Fatalf("firecracker status = %q, want %q", health.Firecracker, rt.health)
 	}
 }
 

--- a/pkg/api/dashboard.html
+++ b/pkg/api/dashboard.html
@@ -469,11 +469,13 @@ async function loadHealth() {
     const statusKind = h.status === "ok" ? "ok" : h.status === "degraded" ? "warn" : "bad";
     const dockerKind = h.docker === "ok" ? "ok" : "bad";
     const caddyKind = h.caddy === "ok" ? "ok" : "bad";
+    const firecrackerKind = h.firecracker === "ok" ? "ok" : h.firecracker === "disabled" ? "warn" : "bad";
     const sshKind = h.ssh_gateway === "ok" ? "ok" : h.ssh_gateway === "disabled" ? "warn" : "bad";
     el("health-row").innerHTML = `
       <div class="health-item"><span class="k">overall</span>${pill(h.status || "?", statusKind)}</div>
       <div class="health-item"><span class="k">docker</span>${pill(h.docker || "?", dockerKind)}</div>
       <div class="health-item"><span class="k">caddy</span>${pill(h.caddy || "?", caddyKind)}</div>
+      <div class="health-item"><span class="k">firecracker</span>${pill(h.firecracker || "?", firecrackerKind)}</div>
       <div class="health-item"><span class="k">ssh</span>${pill(h.ssh_gateway || "?", sshKind)}</div>
       <div class="health-item"><span class="k">live sandboxes</span><span class="mono">${fmtNum(h.sandboxes)}</span></div>
     `;

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -829,6 +829,7 @@ type HealthStatus struct {
 	Sandboxes       int    `json:"sandboxes"`
 	Docker          string `json:"docker"`
 	Caddy           string `json:"caddy"`
+	Firecracker     string `json:"firecracker,omitempty"`
 	SSHGateway      string `json:"ssh_gateway"`
 	ClusterTopology string `json:"cluster_topology,omitempty"`
 	ClusterNodes    int    `json:"cluster_nodes,omitempty"`


### PR DESCRIPTION
Adds fleet-visible vmgenid readiness checks, atomic clone-generation publication, and deploy-time kernel config installation/verification for Terraform and Ansible.

Checks:
- go test ./cmd/toolboxd ./internal/runtime/firecracker ./internal/service ./pkg/api/...
- terraform fmt -check Terraform config
- curl -fsSL 'https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.15/x86_64/vmlinux-5.10.245.config' | grep -x 'CONFIG_VMGENID=y'