### PR TITLE
WASM standard modules + BYO OCI distribution (orchestration-only, per-tenant auth)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,32 @@ jobs:
           flags: go-main
           fail_ci_if_error: false
 
+  wasm-integration:
+    # Live-AOCR round-trip for the BYO module push/pull path (plan §7.2): proves
+    # the .wasm mediaType survives a real registry, which mocks can't. Gated
+    # behind the `integration` build tag AND the presence of AOCR creds — the
+    # test self-skips when AEROL_WASM_IT_* are unset, so forks and credential-less
+    # PRs stay green. Runs only when daemon Go code changed.
+    needs: changes
+    if: needs.changes.outputs.docs != 'true' && needs.changes.outputs.go_main == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run WASM module registry integration test
+        env:
+          AEROL_WASM_IT_REF: ${{ secrets.AEROL_WASM_IT_REF }}
+          AEROL_WASM_IT_USERNAME: ${{ secrets.AEROL_WASM_IT_USERNAME }}
+          AEROL_WASM_IT_TOKEN: ${{ secrets.AEROL_WASM_IT_TOKEN }}
+        run: go test -count=1 -tags integration -run TestIntegrationModulePushPullRoundTrip ./pkg/wasmmod/...
+
   go-sdk-tests:
     needs: changes
     if: needs.changes.outputs.docs != 'true' && needs.changes.outputs.go_sdk == 'true'

--- a/Ansible/playbooks/configure-ops.yml
+++ b/Ansible/playbooks/configure-ops.yml
@@ -90,6 +90,18 @@
       SB_FLEET_ENDPOINT: "{{ fleet_control_plane.endpoint }}"
       SB_FLEET_TOKEN: "{{ fleet.token }}"
       SB_FLEET_CONTRACT_REFRESH: "{{ fleet_control_plane.contract_refresh }}"
+      # WASM runtime + module distribution. SB_WASM_STANDARD_MODULES is derived
+      # from wasm.standard_modules so the reserved-keyword contract (alias ->
+      # "<alias>.wasm") is identical on every node — never DB-backed.
+      SB_ENABLE_WASM: "{{ wasm.enabled | default(false) | bool | string | lower }}"
+      SB_WASM_MODULES_DIR: "{{ wasm.modules_dir | default('/var/lib/sandboxd/wasm/modules') }}"
+      SB_WASM_CACHE_DIR: "{{ wasm.cache_dir | default('') }}"
+      SB_WASM_REGISTRY_ALLOWLIST: "{{ wasm.registry_allowlist | default('') }}"
+      SB_WASM_PULL_TIMEOUT: "{{ wasm.pull_timeout | default('60s') }}"
+      SB_WASM_REGISTRY_PUSH_HOST: "{{ wasm.push_host | default('') }}"
+      SB_WASM_REGISTRY_USERNAME: "{{ wasm.registry_username | default('') }}"
+      SB_WASM_REGISTRY_PAT_PATH: "{{ wasm.registry_pat_path | default('') }}"
+      SB_WASM_STANDARD_MODULES: "{{ wasm.standard_modules | default([]) | map(attribute='alias') | map('regex_replace', '^(.*)$', '\\1=\\1.wasm') | join(',') }}"
 
   pre_tasks:
     - name: Check base sandboxd env file

--- a/Ansible/playbooks/stage-wasm-modules.yml
+++ b/Ansible/playbooks/stage-wasm-modules.yml
@@ -1,0 +1,90 @@
+---
+# Pre-stage the curated WASM standard modules onto every node.
+#
+# Reads wasm.standard_modules from ../../config/cluster.yml (the same SoT
+# configure-ops.yml derives SB_WASM_STANDARD_MODULES from) and fetches each
+# entry's .wasm into wasm.modules_dir as "<alias>.wasm", verifying its sha256.
+# Idempotent: get_url / the digest check skip an already-correct file.
+#
+#   ansible-playbook playbooks/stage-wasm-modules.yml
+#
+# This is the fleet-wide reserved-keyword contract: after staging, tenants
+# reference a module as `module_ref: "<alias>"`. Run it whenever the standard
+# set changes, and as part of new-node bring-up.
+
+- name: Stage WASM standard modules
+  hosts: all
+  become: true
+  serial: 1
+  any_errors_fatal: true
+  gather_facts: false
+
+  vars_files:
+    - "../../config/cluster.yml"
+
+  tasks:
+    - name: Ensure WASM modules dir exists
+      ansible.builtin.file:
+        path: "{{ wasm.modules_dir | default('/var/lib/sandboxd/wasm/modules') }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+      when: wasm.enabled | default(false) | bool
+
+    - name: Fetch URL-sourced standard modules (checksum-verified)
+      ansible.builtin.get_url:
+        url: "{{ item.ref }}"
+        dest: "{{ wasm.modules_dir | default('/var/lib/sandboxd/wasm/modules') }}/{{ item.alias }}.wasm"
+        checksum: "{{ item.digest }}"
+        owner: root
+        group: root
+        mode: "0644"
+      loop: "{{ wasm.standard_modules | default([]) | selectattr('source', 'equalto', 'url') | list }}"
+      loop_control:
+        label: "{{ item.alias }}"
+      when: wasm.enabled | default(false) | bool
+
+    - name: Pull OCI-sourced standard modules via oras
+      # oras pull writes the module layer (module.wasm) into a temp dir; we
+      # move it to "<alias>.wasm". The digest is verified afterwards so a
+      # tampered registry artifact never goes live.
+      ansible.builtin.shell:
+        cmd: >
+          set -euo pipefail;
+          tmp="$(mktemp -d)";
+          oras pull "{{ item.ref }}" -o "$tmp" >/dev/null;
+          src="$(find "$tmp" -name '*.wasm' -type f | head -1)";
+          test -n "$src";
+          install -m 0644 "$src" "{{ wasm.modules_dir | default('/var/lib/sandboxd/wasm/modules') }}/{{ item.alias }}.wasm";
+          rm -rf "$tmp"
+      args:
+        creates: "{{ wasm.modules_dir | default('/var/lib/sandboxd/wasm/modules') }}/{{ item.alias }}.wasm"
+      loop: "{{ wasm.standard_modules | default([]) | selectattr('source', 'equalto', 'oci') | list }}"
+      loop_control:
+        label: "{{ item.alias }}"
+      when: wasm.enabled | default(false) | bool
+
+    - name: Verify staged module digests
+      ansible.builtin.stat:
+        path: "{{ wasm.modules_dir | default('/var/lib/sandboxd/wasm/modules') }}/{{ item.alias }}.wasm"
+        checksum_algorithm: sha256
+      register: staged_modules
+      loop: "{{ wasm.standard_modules | default([]) | list }}"
+      loop_control:
+        label: "{{ item.alias }}"
+      when: wasm.enabled | default(false) | bool
+
+    - name: Fail if any staged module digest mismatches
+      ansible.builtin.fail:
+        msg: >
+          Staged module {{ item.item.alias }} digest {{ item.stat.checksum }}
+          != expected {{ item.item.digest | regex_replace('^sha256:', '') }}
+      loop: "{{ staged_modules.results | default([]) }}"
+      loop_control:
+        label: "{{ item.item.alias | default('?') }}"
+      when:
+        - wasm.enabled | default(false) | bool
+        - item.stat is defined
+        - item.stat.exists | default(false)
+        - (item.item.digest | regex_replace('^sha256:', '')) != item.stat.checksum

--- a/Terraform/locals.tf
+++ b/Terraform/locals.tf
@@ -165,6 +165,22 @@ locals {
     token            = local.fleet_enabled ? local.cluster_secrets.fleet.token : ""
     contract_refresh = local.fleet_enabled ? local.cluster_ops.fleet_control_plane.contract_refresh : "5m"
   }
+
+  # WASM runtime + module distribution. standard_modules is flattened into the
+  # SB_WASM_STANDARD_MODULES "alias=alias.wasm,..." reserved-keyword contract so
+  # Terraform and Ansible render identical env on every node. try() keeps older
+  # cluster.yml files (no wasm: block) working.
+  wasm_cfg = {
+    enabled            = try(local.cluster_ops.wasm.enabled, false) ? "true" : "false"
+    modules_dir        = try(local.cluster_ops.wasm.modules_dir, "/var/lib/sandboxd/wasm/modules")
+    cache_dir          = try(local.cluster_ops.wasm.cache_dir, "")
+    registry_allowlist = try(local.cluster_ops.wasm.registry_allowlist, "")
+    pull_timeout       = try(local.cluster_ops.wasm.pull_timeout, "60s")
+    push_host          = try(local.cluster_ops.wasm.push_host, "")
+    registry_username  = try(local.cluster_ops.wasm.registry_username, "")
+    registry_pat_path  = try(local.cluster_ops.wasm.registry_pat_path, "")
+    standard_modules   = join(",", [for m in try(local.cluster_ops.wasm.standard_modules, []) : "${m.alias}=${m.alias}.wasm"])
+  }
 }
 
 # Plan-time validation of values that come from local.cluster_ops. Terraform

--- a/Terraform/nodes.tf
+++ b/Terraform/nodes.tf
@@ -141,6 +141,7 @@ resource "aws_instance" "seed" {
     fleet_endpoint         = local.fleet.endpoint
     fleet_token            = local.fleet.token
     fleet_contract_refresh = local.fleet.contract_refresh
+    wasm_cfg               = local.wasm_cfg
   })
 
   tags = merge(
@@ -289,6 +290,7 @@ resource "aws_instance" "joiner" {
     fleet_endpoint         = local.fleet.endpoint
     fleet_token            = local.fleet.token
     fleet_contract_refresh = local.fleet.contract_refresh
+    wasm_cfg               = local.wasm_cfg
   })
 
   depends_on = [aws_instance.seed]

--- a/Terraform/templates/bootstrap.sh.tftpl
+++ b/Terraform/templates/bootstrap.sh.tftpl
@@ -450,6 +450,18 @@ SB_FLEET_ENABLED=${fleet_enabled}
 SB_FLEET_ENDPOINT=${fleet_endpoint}
 SB_FLEET_TOKEN=${fleet_token}
 SB_FLEET_CONTRACT_REFRESH=${fleet_contract_refresh}
+# WASM runtime + module distribution. SB_WASM_STANDARD_MODULES is the
+# reserved-keyword contract (alias=alias.wasm,...); stage the .wasm files with
+# Ansible playbooks/stage-wasm-modules.yml so every node has identical bytes.
+SB_ENABLE_WASM=${wasm_cfg.enabled}
+SB_WASM_MODULES_DIR=${wasm_cfg.modules_dir}
+SB_WASM_CACHE_DIR=${wasm_cfg.cache_dir}
+SB_WASM_REGISTRY_ALLOWLIST=${wasm_cfg.registry_allowlist}
+SB_WASM_PULL_TIMEOUT=${wasm_cfg.pull_timeout}
+SB_WASM_REGISTRY_PUSH_HOST=${wasm_cfg.push_host}
+SB_WASM_REGISTRY_USERNAME=${wasm_cfg.registry_username}
+SB_WASM_REGISTRY_PAT_PATH=${wasm_cfg.registry_pat_path}
+SB_WASM_STANDARD_MODULES=${wasm_cfg.standard_modules}
 EOF
 %{ endif ~}
 

--- a/config/cluster.yml
+++ b/config/cluster.yml
@@ -85,6 +85,39 @@ firecracker:
   enabled: false
   kernel_path: "/var/lib/sandboxd/firecracker/vmlinux"
 
+# --- WASM runtime + module distribution -----------------------------------
+# enabled=true turns on the WASM/WASI runtime. registry_allowlist is the set
+# of registry hosts an oci:// module_ref may pull from (empty = deny all
+# remote pulls — the SSRF-safe default; list AOCR to allow BYO modules).
+# standard_modules pre-stages curated language-interpreter modules on every
+# node (the fleet-wide reserved-keyword contract): each entry's .wasm is
+# fetched into modules_dir and exposed as `module_ref: "<alias>"`. push_host
+# enables the stateless BYO upload proxy (POST /v1/wasm-modules/push); empty
+# disables it.
+wasm:
+  enabled: false
+  modules_dir: "/var/lib/sandboxd/wasm/modules"
+  cache_dir: "/var/lib/sandboxd/wasm/cache"
+  registry_allowlist: "aocr.aerol.ai"
+  pull_timeout: "60s"
+  push_host: ""
+  # registry login used only to pull the standard modules below (system
+  # identity). Tenant BYO pulls/pushes use per-request credentials, never this.
+  registry_username: ""
+  registry_pat_path: ""
+  # Curated standard modules. alias is the reserved keyword tenants reference;
+  # source is "url" or "oci"; ref is the URL or oci ref; digest is the sha256
+  # the staging step verifies. Filename is "<alias>.wasm" under modules_dir.
+  standard_modules: []
+  #  - alias: python
+  #    source: oci
+  #    ref: "aocr.aerol.ai/wasm/std/python:3.12"
+  #    digest: "sha256:..."
+  #  - alias: javascript
+  #    source: url
+  #    ref: "https://example.com/quickjs.wasm"
+  #    digest: "sha256:..."
+
 # --- AOCR mirror (Phase 4) ------------------------------------------------
 # Empty host disables mirror rewriting entirely. Upstreams maps upstream
 # hostnames to repository prefixes inside the mirror.

--- a/config/cluster.yml
+++ b/config/cluster.yml
@@ -105,18 +105,31 @@ wasm:
   # identity). Tenant BYO pulls/pushes use per-request credentials, never this.
   registry_username: ""
   registry_pat_path: ""
-  # Curated standard modules. alias is the reserved keyword tenants reference;
-  # source is "url" or "oci"; ref is the URL or oci ref; digest is the sha256
-  # the staging step verifies. Filename is "<alias>.wasm" under modules_dir.
+  # Curated standard modules. alias is the reserved keyword tenants reference
+  # (module_ref: "<alias>"); source is "url" or "oci"; ref is the URL or oci
+  # ref; digest is the sha256 the staging step verifies before the module goes
+  # live. Filename is "<alias>.wasm" under modules_dir. Run
+  # `ansible-playbook playbooks/stage-wasm-modules.yml` after editing this list.
+  #
+  # To populate it: grab (or build) a core-wasip1 .wasm, push it to AOCR under
+  # the protected wasm/std/* namespace (reaper-exempt, pull-only for tenants),
+  # capture its digest, and uncomment an entry below.
+  #
+  #   oras push aocr.aerol.ai/wasm/std/python:3.12 python.wasm:application/wasm
+  #   sha256sum python.wasm
+  #
+  # Public prebuilt runtimes you can source from instead of building:
+  #   Python     https://github.com/vmware-labs/webassembly-language-runtimes (wasi builds)
+  #   JavaScript https://github.com/bytecodealliance/javy (qjs/quickjs wasm)
   standard_modules: []
   #  - alias: python
   #    source: oci
   #    ref: "aocr.aerol.ai/wasm/std/python:3.12"
-  #    digest: "sha256:..."
+  #    digest: "sha256:<sha256sum of the pushed python.wasm>"
   #  - alias: javascript
   #    source: url
   #    ref: "https://example.com/quickjs.wasm"
-  #    digest: "sha256:..."
+  #    digest: "sha256:<sha256sum of quickjs.wasm>"
 
 # --- AOCR mirror (Phase 4) ------------------------------------------------
 # Empty host disables mirror rewriting entirely. Upstreams maps upstream

--- a/docs/src/content/docs/wasm-modules.mdx
+++ b/docs/src/content/docs/wasm-modules.mdx
@@ -277,4 +277,14 @@ Peers gossip `local_wasm_module_ids` via `/v1/capacity`. Placement prefers nodes
 
 ## Garbage collection
 
-Unreferenced catalogue rows older than `SB_WASM_MODULE_GC_TTL` are removed by the wasm module janitor when `SB_WASM_MODULE_GC_ENABLED=true`.
+When `SB_WASM_MODULE_GC_ENABLED=true`, the wasm module janitor runs two sweeps
+each `SB_WASM_MODULE_GC_INTERVAL`:
+
+- **Catalogue rows.** Unreferenced rows older than `SB_WASM_MODULE_GC_TTL` are
+  removed.
+- **`oci://` cache bytes.** Content-addressed files under `SB_WASM_CACHE_DIR`
+  (`<digest>.wasm`) are evicted when older than `SB_WASM_CACHE_GC_TTL` (default
+  24h), or oldest-first when the cache exceeds `SB_WASM_CACHE_MAX_BYTES`
+  (default unlimited). A digest still referenced by a sandbox or a catalogue row
+  is **never** evicted, regardless of age or disk pressure — eviction only
+  reclaims pull-on-create modules that nothing depends on.

--- a/docs/src/content/docs/wasm-modules.mdx
+++ b/docs/src/content/docs/wasm-modules.mdx
@@ -9,11 +9,157 @@ WASM sandboxes are created from a **module reference** (`module_ref`). The daemo
 
 ## Module references
 
-Supported forms mirror other artifact refs:
+A `module_ref` is resolved in this precedence order:
 
-- `file:///path/to/module.wasm` on the host
-- HTTP(S) URLs fetched into the module cache
-- AOCR refs when image distribution is configured
+1. **Standard-module keyword** — a short alias your operator staged on every
+   node (e.g. `python`, `javascript`). Recommended: no host paths, identical
+   fleet-wide. See [Standard modules](#standard-modules).
+2. **`oci://host/repo:tag`** — a registry artifact, pulled under your own
+   credentials and cached content-addressed. See
+   [Bring your own module](#bring-your-own-module).
+3. **Catalogue id** — a digest id returned by `createWasmModule`.
+4. **`file:///path/to/module.wasm`** / bare filename under `SB_WASM_MODULES_DIR`
+   — for self-managed hosts.
+
+Whatever the form, the daemon validates the artifact is a **core wasip1**
+module (WASI components are rejected), records the resolved digest, and pins it
+to the sandbox so a restart or failover boots the exact same bytes. Remote
+`oci://` pulls are restricted to the hosts in `SB_WASM_REGISTRY_ALLOWLIST`.
+
+## Standard modules
+
+Operators pre-stage a curated set of language modules on every node (via the
+`stage-wasm-modules` playbook) and expose them as reserved keywords through
+`SB_WASM_STANDARD_MODULES`. You reference one by name — no upload, no path:
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    await client.create({ module_ref: 'python', runtime: 'wasm' })
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    client.create({'module_ref': 'python', 'runtime': 'wasm'})
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    client.Create(ctx, types.CreateSandboxRequest{ModuleRef: "python", Runtime: types.RuntimeWasm})
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    client.create(CreateSandboxRequest {
+        module_ref: Some("python".into()),
+        runtime: Some("wasm".into()),
+        ..Default::default()
+    }).await?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    CreateSandboxRequest req = new CreateSandboxRequest();
+    req.setModuleRef("python");
+    req.setRuntime("wasm");
+    client.create(req);
+    ```
+  </TabItem>
+</Tabs>
+
+A standard-module keyword always wins over a same-named file in the modules
+dir, so the curated runtime can never be shadowed.
+
+## Bring your own module
+
+Compile your program to a **core wasip1** module (`GOOS=wasip1` for Go,
+`--target wasm32-wasip1` for Rust), then push it to the registry under your own
+credentials. The daemon **validates and forwards** the bytes — it never stores
+them or acts as a registry — and returns the `oci://` ref to use on create.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    import { readFile } from 'node:fs/promises'
+
+    const wasm = await readFile('app.wasm')
+    const pushed = await client.pushWasmModule({
+      name: 'tenant/app',
+      tag: 'v1',
+      module: new Uint8Array(wasm),
+      registryUsername: process.env.AOCR_USER,
+      registryToken: process.env.AOCR_TOKEN!,
+    })
+    await client.create({ module_ref: pushed.moduleRef, runtime: 'wasm' })
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    with open('app.wasm', 'rb') as f:
+        module = f.read()
+    pushed = client.push_wasm_module({
+        'name': 'tenant/app',
+        'tag': 'v1',
+        'module': module,
+        'registryUsername': os.environ['AOCR_USER'],
+        'registryToken': os.environ['AOCR_TOKEN'],
+    })
+    client.create({'module_ref': pushed['moduleRef'], 'runtime': 'wasm'})
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    wasm, _ := os.ReadFile("app.wasm")
+    pushed, err := client.PushWasmModule(ctx, types.PushWasmModuleOptions{
+        Name:             "tenant/app",
+        Tag:              "v1",
+        Module:           wasm,
+        RegistryUsername: os.Getenv("AOCR_USER"),
+        RegistryToken:    os.Getenv("AOCR_TOKEN"),
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+    client.Create(ctx, types.CreateSandboxRequest{ModuleRef: pushed.ModuleRef, Runtime: types.RuntimeWasm})
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let module = std::fs::read("app.wasm")?;
+    let pushed = client.push_wasm_module(PushWasmModuleOptions {
+        name: "tenant/app".into(),
+        tag: "v1".into(),
+        module,
+        registry_username: std::env::var("AOCR_USER")?,
+        registry_token: std::env::var("AOCR_TOKEN")?,
+    })?;
+    client.create(CreateSandboxRequest {
+        module_ref: Some(pushed.module_ref),
+        runtime: Some("wasm".into()),
+        ..Default::default()
+    }).await?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    byte[] module = Files.readAllBytes(Path.of("app.wasm"));
+    PushWasmModuleResponse pushed = client.pushWasmModule(new PushWasmModuleOptions()
+        .setName("tenant/app")
+        .setTag("v1")
+        .setModule(module)
+        .setRegistryUsername(System.getenv("AOCR_USER"))
+        .setRegistryToken(System.getenv("AOCR_TOKEN")));
+    CreateSandboxRequest req = new CreateSandboxRequest();
+    req.setModuleRef(pushed.moduleRef);
+    req.setRuntime("wasm");
+    client.create(req);
+    ```
+  </TabItem>
+</Tabs>
+
+You can also `oras push` your module to the registry directly and skip the
+daemon — then create with the `oci://` ref plus your `registry` credentials.
+Either way the registry is the source of truth and the daemon only pulls to run.
 
 ## Catalogue API
 

--- a/docs/src/content/docs/wasm-sandbox.mdx
+++ b/docs/src/content/docs/wasm-sandbox.mdx
@@ -9,7 +9,12 @@ WASM sandboxes run guest modules inside isolated worker processes on the host. T
 
 ## Create a WASM sandbox
 
-Pass `runtime: "wasm"` and a `module_ref` (or use `image` as an alias). Set `durability` to `passivatable` or `durable` when you need restart survival.
+Pass `runtime: "wasm"` and a `module_ref`. The simplest `module_ref` is a
+**standard-module keyword** your operator has staged on every node — e.g.
+`"python"` or `"javascript"` — so you never reference a host path. A
+`module_ref` can also be an `oci://` registry ref (for your own modules, see
+[WASM modules](/wasm-modules)) or, for self-managed hosts, a file path. Set
+`durability` to `passivatable` or `durable` when you need restart survival.
 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">
@@ -22,7 +27,7 @@ Pass `runtime: "wasm"` and a `module_ref` (or use `image` as an alias). Set `dur
     })
 
     const sandbox = await client.create({
-      module_ref: 'file:///var/lib/sandboxd/wasm/modules/app.wasm',
+      module_ref: 'python',
       runtime: 'wasm',
       cpu: 0.5,
       memoryMB: 256,
@@ -42,7 +47,7 @@ Pass `runtime: "wasm"` and a `module_ref` (or use `image` as an alias). Set `dur
     )
 
     sandbox = client.create({
-        'module_ref': 'file:///var/lib/sandboxd/wasm/modules/app.wasm',
+        'module_ref': 'python',
         'runtime': 'wasm',
         'cpu': 0.5,
         'memoryMB': 256,
@@ -72,7 +77,7 @@ Pass `runtime: "wasm"` and a `module_ref` (or use `image` as an alias). Set `dur
     }
 
     sb, err := client.Create(context.Background(), types.CreateSandboxRequest{
-        ModuleRef:  "file:///var/lib/sandboxd/wasm/modules/app.wasm",
+        ModuleRef:  "python",
         Runtime:    types.RuntimeWasm,
         CPU:        0.5,
         MemoryMB:   256,
@@ -93,7 +98,7 @@ Pass `runtime: "wasm"` and a `module_ref` (or use `image` as an alias). Set `dur
         let client = Client::new("https://sandbox.example.com", "your-token")?;
         let sandbox = client
             .create(CreateSandboxRequest {
-                module_ref: Some("file:///var/lib/sandboxd/wasm/modules/app.wasm".into()),
+                module_ref: Some("python".into()),
                 runtime: Some("wasm".into()),
                 cpu: Some(0.5),
                 memory_mb: Some(256),
@@ -115,7 +120,7 @@ Pass `runtime: "wasm"` and a `module_ref` (or use `image` as an alias). Set `dur
         public static void main(String[] args) throws Exception {
             MicroVM client = new MicroVM("https://sandbox.example.com", "your-token");
             CreateSandboxRequest req = new CreateSandboxRequest();
-            req.setModuleRef("file:///var/lib/sandboxd/wasm/modules/app.wasm");
+            req.setModuleRef("python");
             req.setRuntime("wasm");
             req.setCpu(0.5);
             req.setMemoryMB(256);

--- a/go.mod
+++ b/go.mod
@@ -15,9 +15,9 @@ require (
 	github.com/hashicorp/raft v1.7.3
 	github.com/hashicorp/raft-boltdb/v2 v2.3.1
 	github.com/klauspost/compress v1.17.11
+	github.com/mattn/go-sqlite3 v1.14.45
 	github.com/opencontainers/image-spec v1.1.0
 	github.com/tetratelabs/wazero v1.12.0
-	github.com/mattn/go-sqlite3 v1.14.45
 	golang.org/x/crypto v0.52.0
 	golang.org/x/sync v0.20.0
 	oras.land/oras-go/v2 v2.5.0
@@ -57,7 +57,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
-	github.com/miekg/dns v1.1.68 // indirect
+	github.com/miekg/dns v1.1.68
 	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
 	go.etcd.io/bbolt v1.3.5 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -397,9 +397,10 @@ type Config struct {
 	// WasmRegistryPATPath is the file holding the AOCR token for module pulls.
 	// SB_WASM_REGISTRY_PAT_PATH.
 	WasmRegistryPATPath string
-	// WasmRegistryPushHost is the AOCR host BYO module uploads
-	// (POST /v1/wasm-modules/push) are pushed to. Empty disables push.
-	// SB_WASM_REGISTRY_PUSH_HOST.
+	// WasmRegistryPushHost is the AOCR host the stateless module-push proxy
+	// (POST /v1/wasm-modules/push) forwards uploads to. Empty disables the
+	// proxy. The daemon never stores the bytes — it validates and forwards to
+	// AOCR under the caller's own PAT. SB_WASM_REGISTRY_PUSH_HOST.
 	WasmRegistryPushHost string
 	// WasmEngine selects the guest engine backend (wazero or wasmtime). Default wazero.
 	// wasmtime requires building sandboxd with -tags wasmtime. SB_WASM_ENGINE.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -375,6 +375,28 @@ type Config struct {
 	// WasmModulesDir is the content-addressed module + checkpoint cache root.
 	// Required when EnableWasm is true. SB_WASM_MODULES_DIR.
 	WasmModulesDir string
+	// WasmCacheDir holds oci:// pulled modules as <digest>.wasm, kept separate
+	// from the checkpoint root so eviction never touches a sandbox's mem.snap.
+	// Default WasmModulesDir/cache. SB_WASM_CACHE_DIR.
+	WasmCacheDir string
+	// WasmRegistryAllowlist is the set of registry hosts an oci:// module_ref
+	// may pull from. Empty = deny all remote pulls (the SSRF-safe default).
+	// Comma-separated. SB_WASM_REGISTRY_ALLOWLIST.
+	WasmRegistryAllowlist []string
+	// WasmPullTimeout bounds a single oci:// module pull so it cannot stall
+	// sandbox boot. 0 = no timeout. SB_WASM_PULL_TIMEOUT.
+	WasmPullTimeout time.Duration
+	// WasmStandardModules maps reserved-keyword aliases to staged filenames
+	// under WasmModulesDir (e.g. "python=python.wasm,javascript=quickjs.wasm").
+	// Provisioned identically on every node by Ansible — the fleet-wide
+	// standard-module contract, deliberately NOT DB-backed. SB_WASM_STANDARD_MODULES.
+	WasmStandardModules map[string]string
+	// WasmRegistryUsername is the AOCR login used for oci:// module pulls when
+	// the create request carries no per-tenant credentials. SB_WASM_REGISTRY_USERNAME.
+	WasmRegistryUsername string
+	// WasmRegistryPATPath is the file holding the AOCR token for module pulls.
+	// SB_WASM_REGISTRY_PAT_PATH.
+	WasmRegistryPATPath string
 	// WasmEngine selects the guest engine backend (wazero or wasmtime). Default wazero.
 	// wasmtime requires building sandboxd with -tags wasmtime. SB_WASM_ENGINE.
 	WasmEngine string
@@ -1188,6 +1210,12 @@ func Load() (Config, error) {
 		EnableWasm:                getEnvBool("SB_ENABLE_WASM", false),
 		WasmRunDir:                getEnv("SB_WASM_RUN_DIR", "/run/sandboxd/wasm"),
 		WasmModulesDir:            getEnv("SB_WASM_MODULES_DIR", "/var/lib/sandboxd/wasm/modules"),
+		WasmCacheDir:              getEnv("SB_WASM_CACHE_DIR", ""),
+		WasmRegistryAllowlist:     parseImageGCWhitelist(getEnv("SB_WASM_REGISTRY_ALLOWLIST", "")),
+		WasmPullTimeout:           getEnvDuration("SB_WASM_PULL_TIMEOUT", 60*time.Second),
+		WasmStandardModules:       parseWasmStandardModules(getEnv("SB_WASM_STANDARD_MODULES", "")),
+		WasmRegistryUsername:      getEnv("SB_WASM_REGISTRY_USERNAME", ""),
+		WasmRegistryPATPath:       getEnv("SB_WASM_REGISTRY_PAT_PATH", ""),
 		WasmEngine:                strings.ToLower(strings.TrimSpace(getEnv("SB_WASM_ENGINE", "wazero"))),
 		WasmMaxInstances:          getEnvInt("SB_WASM_MAX_INSTANCES", 0),
 		WasmDefaultMemoryMB:       getEnvInt("SB_WASM_DEFAULT_MEMORY_MB", 256),
@@ -1820,6 +1848,28 @@ func parseImageGCWhitelist(raw string) []string {
 		if entry := strings.TrimSpace(part); entry != "" {
 			out = append(out, entry)
 		}
+	}
+	return out
+}
+
+// parseWasmStandardModules parses the comma-separated alias=filename list for
+// SB_WASM_STANDARD_MODULES into a reserved-keyword map. Aliases are lowercased
+// (case-insensitive lookup). Malformed entries are skipped silently so one
+// typo doesn't drop the rest. Returns a non-nil map for unconditional reads.
+func parseWasmStandardModules(raw string) map[string]string {
+	out := map[string]string{}
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		alias, filename, ok := strings.Cut(part, "=")
+		alias = strings.ToLower(strings.TrimSpace(alias))
+		filename = strings.TrimSpace(filename)
+		if !ok || alias == "" || filename == "" {
+			continue
+		}
+		out[alias] = filename
 	}
 	return out
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -397,6 +397,10 @@ type Config struct {
 	// WasmRegistryPATPath is the file holding the AOCR token for module pulls.
 	// SB_WASM_REGISTRY_PAT_PATH.
 	WasmRegistryPATPath string
+	// WasmRegistryPushHost is the AOCR host BYO module uploads
+	// (POST /v1/wasm-modules/push) are pushed to. Empty disables push.
+	// SB_WASM_REGISTRY_PUSH_HOST.
+	WasmRegistryPushHost string
 	// WasmEngine selects the guest engine backend (wazero or wasmtime). Default wazero.
 	// wasmtime requires building sandboxd with -tags wasmtime. SB_WASM_ENGINE.
 	WasmEngine string
@@ -1216,6 +1220,7 @@ func Load() (Config, error) {
 		WasmStandardModules:       parseWasmStandardModules(getEnv("SB_WASM_STANDARD_MODULES", "")),
 		WasmRegistryUsername:      getEnv("SB_WASM_REGISTRY_USERNAME", ""),
 		WasmRegistryPATPath:       getEnv("SB_WASM_REGISTRY_PAT_PATH", ""),
+		WasmRegistryPushHost:      getEnv("SB_WASM_REGISTRY_PUSH_HOST", ""),
 		WasmEngine:                strings.ToLower(strings.TrimSpace(getEnv("SB_WASM_ENGINE", "wazero"))),
 		WasmMaxInstances:          getEnvInt("SB_WASM_MAX_INSTANCES", 0),
 		WasmDefaultMemoryMB:       getEnvInt("SB_WASM_DEFAULT_MEMORY_MB", 256),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -455,6 +455,17 @@ type Config struct {
 	// WasmModuleGCTTL drops unreferenced catalogue rows older than this.
 	// SB_WASM_MODULE_GC_TTL.
 	WasmModuleGCTTL time.Duration
+	// WasmCacheGCTTL evicts a content-addressed oci:// cache file
+	// (CacheDir/<digest>.wasm) whose mtime is older than this AND that no
+	// sandbox or catalogue row still references. Guards against unbounded disk
+	// growth from pull-on-create modules that were never registered. 0 disables
+	// TTL eviction. SB_WASM_CACHE_GC_TTL.
+	WasmCacheGCTTL time.Duration
+	// WasmCacheMaxBytes is a soft cap on the total size of the oci:// cache. When
+	// the cache exceeds it, the janitor evicts unreferenced files oldest-first
+	// until back under the cap, independent of TTL. 0 = unlimited.
+	// SB_WASM_CACHE_MAX_BYTES.
+	WasmCacheMaxBytes int64
 	// FirecrackerBinary is the absolute path to the `firecracker` VMM
 	// binary on this host. Required only when EnableFirecracker is true.
 	// Default /usr/local/bin/firecracker matches a typical install.
@@ -1241,6 +1252,8 @@ func Load() (Config, error) {
 		WasmModuleGCEnabled:     getEnvBool("SB_WASM_MODULE_GC_ENABLED", true),
 		WasmModuleGCInterval:    getEnvDuration("SB_WASM_MODULE_GC_INTERVAL", 15*time.Minute),
 		WasmModuleGCTTL:         getEnvDuration("SB_WASM_MODULE_GC_TTL", 7*24*time.Hour),
+		WasmCacheGCTTL:          getEnvDuration("SB_WASM_CACHE_GC_TTL", 24*time.Hour),
+		WasmCacheMaxBytes:       getEnvInt64("SB_WASM_CACHE_MAX_BYTES", 0),
 		WasmPoolEnabled:         getEnvBool("SB_WASM_POOL_ENABLED", false),
 		WasmPoolDepthDefault:    getEnvInt("SB_WASM_POOL_DEPTH_DEFAULT", 0),
 		WasmPoolRefillInterval:  getEnvDuration("SB_WASM_POOL_REFILL_INTERVAL", 5*time.Second),
@@ -1797,6 +1810,18 @@ func getEnvInt(key string, fallback int) int {
 		return fallback
 	}
 	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return fallback
+	}
+	return parsed
+}
+
+func getEnvInt64(key string, fallback int64) int64 {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback
+	}
+	parsed, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
 		return fallback
 	}

--- a/internal/runtime/wasm/create.go
+++ b/internal/runtime/wasm/create.go
@@ -28,7 +28,10 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 		return nil, fmt.Errorf("wasm runtime: module_ref or image is required")
 	}
 
-	resolved, err := d.resolver.Resolve(ctx, ref)
+	// Per-tenant registry creds ride the request (req.Registry), never global
+	// config — so a private oci:// module pulls under the caller's own AOCR
+	// identity. Falls back to the resolver's system identity when absent.
+	resolved, err := resolveWithRequestAuth(ctx, d.resolver, ref, req.Registry)
 	if err != nil {
 		return nil, fmt.Errorf("resolve module %q: %w", ref, err)
 	}

--- a/internal/runtime/wasm/create.go
+++ b/internal/runtime/wasm/create.go
@@ -62,6 +62,7 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 		sandboxID:    sandboxID,
 		moduleRef:    ref,
 		modulePath:   resolved.Path,
+		moduleSize:   resolved.SizeBytes,
 		moduleDigest: resolved.Digest,
 		socketPath:   socketPath,
 		workDir:      workDir,
@@ -177,12 +178,14 @@ func (d *Driver) runtimeState(inst *sandboxInstance) *models.SandboxRuntimeState
 		return nil
 	}
 	return &models.SandboxRuntimeState{
-		SandboxID:    inst.sandboxID,
-		ContainerID:  "wasm:" + inst.sandboxID,
-		ContainerIP:  wasmLoopbackIP,
-		Status:       inst.status,
-		ModuleRef:    inst.moduleRef,
-		ModuleDigest: inst.moduleDigest,
+		SandboxID:       inst.sandboxID,
+		ContainerID:     "wasm:" + inst.sandboxID,
+		ContainerIP:     wasmLoopbackIP,
+		Status:          inst.status,
+		ModuleRef:       inst.moduleRef,
+		ModuleDigest:    inst.moduleDigest,
+		ModulePath:      inst.modulePath,
+		ModuleSizeBytes: inst.moduleSize,
 	}
 }
 

--- a/internal/runtime/wasm/instance.go
+++ b/internal/runtime/wasm/instance.go
@@ -16,6 +16,7 @@ type sandboxInstance struct {
 	sandboxID    string
 	moduleRef    string
 	modulePath   string
+	moduleSize   int64
 	moduleDigest string
 	socketPath   string
 	workDir      string

--- a/internal/runtime/wasm/lifecycle.go
+++ b/internal/runtime/wasm/lifecycle.go
@@ -21,6 +21,28 @@ type digestResolver interface {
 	ResolveByDigest(digest string) (*wasmmod.ResolvedModule, bool)
 }
 
+// authResolver is the optional capability to resolve under caller-supplied
+// per-tenant registry credentials. Type-asserted so simple fakes still work.
+type authResolver interface {
+	ResolveWithAuth(ctx context.Context, ref string, authOverride *wasmmod.ModuleAuth) (*wasmmod.ResolvedModule, error)
+}
+
+// resolveWithRequestAuth resolves ref, passing the request's registry
+// credentials (per-tenant) through to an oci:// pull when present. When the
+// request carries no creds, or the resolver predates the auth seam, it falls
+// back to the plain Resolve (system identity).
+func resolveWithRequestAuth(ctx context.Context, r ModuleResolver, ref string, reg *models.RegistryAuth) (*wasmmod.ResolvedModule, error) {
+	if reg != nil && (strings.TrimSpace(reg.Username) != "" || strings.TrimSpace(reg.Password) != "") {
+		if ar, ok := r.(authResolver); ok {
+			return ar.ResolveWithAuth(ctx, ref, &wasmmod.ModuleAuth{
+				Username: reg.Username,
+				PAT:      reg.Password,
+			})
+		}
+	}
+	return r.Resolve(ctx, ref)
+}
+
 // resolvePinned resolves a sandbox's module preferring the digest pinned at
 // create over the (mutable) ref. On a frozen-copy cache hit it boots the exact
 // original bytes; on a miss it re-resolves the ref but REFUSES to boot if the

--- a/internal/runtime/wasm/lifecycle.go
+++ b/internal/runtime/wasm/lifecycle.go
@@ -11,7 +11,40 @@ import (
 	"github.com/aerol-ai/microvm/pkg/models"
 	"github.com/aerol-ai/microvm/pkg/mounts"
 	wasmengine "github.com/aerol-ai/microvm/pkg/wasm"
+	"github.com/aerol-ai/microvm/pkg/wasmmod"
 )
+
+// digestResolver is the optional capability a ModuleResolver exposes to boot a
+// sandbox from its content-addressed frozen copy. Type-asserted so test fakes
+// that only implement Resolve keep working.
+type digestResolver interface {
+	ResolveByDigest(digest string) (*wasmmod.ResolvedModule, bool)
+}
+
+// resolvePinned resolves a sandbox's module preferring the digest pinned at
+// create over the (mutable) ref. On a frozen-copy cache hit it boots the exact
+// original bytes; on a miss it re-resolves the ref but REFUSES to boot if the
+// bytes drifted from the pin — turning codex C2's silent code-swap into a loud,
+// recoverable error.
+func (d *Driver) resolvePinned(ctx context.Context, ref, pinnedDigest string) (*wasmmod.ResolvedModule, error) {
+	pinnedDigest = strings.TrimSpace(pinnedDigest)
+	if pinnedDigest != "" {
+		if dr, ok := d.resolver.(digestResolver); ok {
+			if resolved, hit := dr.ResolveByDigest(pinnedDigest); hit {
+				return resolved, nil
+			}
+		}
+	}
+	resolved, err := d.resolver.Resolve(ctx, ref)
+	if err != nil {
+		return nil, fmt.Errorf("resolve module %q: %w", ref, err)
+	}
+	if pinnedDigest != "" && resolved.Digest != "" && resolved.Digest != pinnedDigest {
+		return nil, fmt.Errorf("module %q pinned %s but now resolves to %s: %w",
+			ref, pinnedDigest, resolved.Digest, wasmmod.ErrModuleDigestMismatch)
+	}
+	return resolved, nil
+}
 
 func (d *Driver) Start(ctx context.Context, sandboxID string) (*models.SandboxRuntimeState, error) {
 	inst, err := d.instance(sandboxID)
@@ -72,9 +105,11 @@ func (d *Driver) StartSandbox(ctx context.Context, sandbox *models.Sandbox, host
 	if d.resolver == nil {
 		return nil, fmt.Errorf("wasm runtime: module resolver not configured: %w", models.ErrRuntimeNotImplemented)
 	}
-	resolved, err := d.resolver.Resolve(ctx, ref)
+	// Boot the digest pinned at create, not whatever the alias/tag points at
+	// now (codex C2). On drift with no frozen copy this fails loudly.
+	resolved, err := d.resolvePinned(ctx, ref, sandbox.ModuleDigest)
 	if err != nil {
-		return nil, fmt.Errorf("resolve module %q: %w", ref, err)
+		return nil, err
 	}
 
 	workDir := d.sandboxDir(sandbox.ID)

--- a/internal/runtime/wasm/lifecycle.go
+++ b/internal/runtime/wasm/lifecycle.go
@@ -43,12 +43,27 @@ func resolveWithRequestAuth(ctx context.Context, r ModuleResolver, ref string, r
 	return r.Resolve(ctx, ref)
 }
 
+// moduleAuthFromSandbox builds the per-tenant registry credential from a
+// sandbox's transient (unsealed) RegistryAuth, used so a failover peer pulls a
+// private oci:// module under the tenant's identity (codex C4). Nil when the
+// sandbox carries no creds (public/standard module).
+func moduleAuthFromSandbox(sandbox *models.Sandbox) *wasmmod.ModuleAuth {
+	if sandbox == nil || sandbox.RegistryAuth == nil {
+		return nil
+	}
+	ra := sandbox.RegistryAuth
+	if strings.TrimSpace(ra.Username) == "" && strings.TrimSpace(ra.Password) == "" {
+		return nil
+	}
+	return &wasmmod.ModuleAuth{Username: ra.Username, PAT: ra.Password}
+}
+
 // resolvePinned resolves a sandbox's module preferring the digest pinned at
 // create over the (mutable) ref. On a frozen-copy cache hit it boots the exact
-// original bytes; on a miss it re-resolves the ref but REFUSES to boot if the
-// bytes drifted from the pin — turning codex C2's silent code-swap into a loud,
-// recoverable error.
-func (d *Driver) resolvePinned(ctx context.Context, ref, pinnedDigest string) (*wasmmod.ResolvedModule, error) {
+// original bytes; on a miss it re-resolves the ref (under authOverride creds
+// when set) but REFUSES to boot if the bytes drifted from the pin — turning
+// codex C2's silent code-swap into a loud, recoverable error.
+func (d *Driver) resolvePinned(ctx context.Context, ref, pinnedDigest string, authOverride *wasmmod.ModuleAuth) (*wasmmod.ResolvedModule, error) {
 	pinnedDigest = strings.TrimSpace(pinnedDigest)
 	if pinnedDigest != "" {
 		if dr, ok := d.resolver.(digestResolver); ok {
@@ -57,7 +72,7 @@ func (d *Driver) resolvePinned(ctx context.Context, ref, pinnedDigest string) (*
 			}
 		}
 	}
-	resolved, err := d.resolver.Resolve(ctx, ref)
+	resolved, err := d.resolveRef(ctx, ref, authOverride)
 	if err != nil {
 		return nil, fmt.Errorf("resolve module %q: %w", ref, err)
 	}
@@ -66,6 +81,17 @@ func (d *Driver) resolvePinned(ctx context.Context, ref, pinnedDigest string) (*
 			ref, pinnedDigest, resolved.Digest, wasmmod.ErrModuleDigestMismatch)
 	}
 	return resolved, nil
+}
+
+// resolveRef resolves under authOverride creds when set and the resolver
+// supports the auth seam, else plain Resolve.
+func (d *Driver) resolveRef(ctx context.Context, ref string, authOverride *wasmmod.ModuleAuth) (*wasmmod.ResolvedModule, error) {
+	if authOverride != nil {
+		if ar, ok := d.resolver.(authResolver); ok {
+			return ar.ResolveWithAuth(ctx, ref, authOverride)
+		}
+	}
+	return d.resolver.Resolve(ctx, ref)
 }
 
 func (d *Driver) Start(ctx context.Context, sandboxID string) (*models.SandboxRuntimeState, error) {
@@ -129,7 +155,7 @@ func (d *Driver) StartSandbox(ctx context.Context, sandbox *models.Sandbox, host
 	}
 	// Boot the digest pinned at create, not whatever the alias/tag points at
 	// now (codex C2). On drift with no frozen copy this fails loudly.
-	resolved, err := d.resolvePinned(ctx, ref, sandbox.ModuleDigest)
+	resolved, err := d.resolvePinned(ctx, ref, sandbox.ModuleDigest, moduleAuthFromSandbox(sandbox))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runtime/wasm/passivate.go
+++ b/internal/runtime/wasm/passivate.go
@@ -50,9 +50,11 @@ func (d *Driver) RehydrateSandbox(ctx context.Context, sandbox *models.Sandbox, 
 	moduleDigest := sandbox.ModuleDigest
 	moduleRef := sandbox.ModuleRef
 	if d.resolver != nil && moduleRef != "" {
-		resolved, resolveErr := d.resolver.Resolve(ctx, moduleRef)
+		// Rehydrate the digest pinned at create, not the current alias/tag
+		// target (codex C2). Fails loudly on drift with no frozen copy.
+		resolved, resolveErr := d.resolvePinned(ctx, moduleRef, sandbox.ModuleDigest)
 		if resolveErr != nil {
-			return nil, fmt.Errorf("resolve module %q: %w", moduleRef, resolveErr)
+			return nil, resolveErr
 		}
 		modulePath = resolved.Path
 		if moduleDigest == "" {

--- a/internal/runtime/wasm/passivate.go
+++ b/internal/runtime/wasm/passivate.go
@@ -52,7 +52,7 @@ func (d *Driver) RehydrateSandbox(ctx context.Context, sandbox *models.Sandbox, 
 	if d.resolver != nil && moduleRef != "" {
 		// Rehydrate the digest pinned at create, not the current alias/tag
 		// target (codex C2). Fails loudly on drift with no frozen copy.
-		resolved, resolveErr := d.resolvePinned(ctx, moduleRef, sandbox.ModuleDigest)
+		resolved, resolveErr := d.resolvePinned(ctx, moduleRef, sandbox.ModuleDigest, moduleAuthFromSandbox(sandbox))
 		if resolveErr != nil {
 			return nil, resolveErr
 		}

--- a/internal/runtime/wasm/registry_auth_test.go
+++ b/internal/runtime/wasm/registry_auth_test.go
@@ -1,0 +1,77 @@
+package wasm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+	"github.com/aerol-ai/microvm/pkg/wasmmod"
+)
+
+// authRecordingResolver records the per-tenant creds passed to ResolveWithAuth
+// so the failover auth-threading (codex C4) can be asserted without a registry.
+type authRecordingResolver struct {
+	path      string
+	digest    string
+	gotAuth   *wasmmod.ModuleAuth
+	withAuth  bool
+	plainCall bool
+}
+
+func (r *authRecordingResolver) Resolve(_ context.Context, ref string) (*wasmmod.ResolvedModule, error) {
+	r.plainCall = true
+	return &wasmmod.ResolvedModule{Ref: ref, Path: r.path, Digest: r.digest, SizeBytes: 1}, nil
+}
+
+func (r *authRecordingResolver) ResolveWithAuth(_ context.Context, ref string, a *wasmmod.ModuleAuth) (*wasmmod.ResolvedModule, error) {
+	r.withAuth = true
+	r.gotAuth = a
+	return &wasmmod.ResolvedModule{Ref: ref, Path: r.path, Digest: r.digest, SizeBytes: 1}, nil
+}
+
+// A sandbox carrying unsealed tenant creds resolves its module via
+// ResolveWithAuth under those exact creds — so a failover peer pulls a private
+// module as the tenant, not anonymously (codex C4).
+func TestResolvePinnedThreadsTenantAuth(t *testing.T) {
+	res := &authRecordingResolver{path: "/tmp/m.wasm", digest: "pinned123"}
+	d := &Driver{resolver: res}
+
+	sandbox := &models.Sandbox{
+		ID:           "sb-priv",
+		ModuleRef:    "oci://aocr.aerol.ai/tenant/app:latest",
+		ModuleDigest: "pinned123",
+		RegistryAuth: &models.RegistryAuth{Username: "tenant-bob", Password: "tenant-pat-xyz"},
+	}
+
+	_, err := d.resolvePinned(context.Background(), sandbox.ModuleRef, sandbox.ModuleDigest, moduleAuthFromSandbox(sandbox))
+	if err != nil {
+		t.Fatalf("resolvePinned: %v", err)
+	}
+	if !res.withAuth {
+		t.Fatal("expected ResolveWithAuth to be used when sandbox carries tenant creds")
+	}
+	if res.gotAuth == nil || res.gotAuth.Username != "tenant-bob" || res.gotAuth.PAT != "tenant-pat-xyz" {
+		t.Fatalf("tenant creds not threaded: %+v", res.gotAuth)
+	}
+}
+
+// A sandbox with no creds resolves plainly (public/standard module, or the
+// resolver's own system identity).
+func TestResolvePinnedNoAuthFallsBackToPlain(t *testing.T) {
+	res := &authRecordingResolver{path: "/tmp/m.wasm", digest: "d1"}
+	d := &Driver{resolver: res}
+
+	sandbox := &models.Sandbox{ID: "sb-pub", ModuleRef: "python", ModuleDigest: "d1"}
+	if got := moduleAuthFromSandbox(sandbox); got != nil {
+		t.Fatalf("expected nil auth for credential-less sandbox, got %+v", got)
+	}
+	if _, err := d.resolvePinned(context.Background(), sandbox.ModuleRef, sandbox.ModuleDigest, moduleAuthFromSandbox(sandbox)); err != nil {
+		t.Fatal(err)
+	}
+	if res.withAuth {
+		t.Fatal("must not call ResolveWithAuth without creds")
+	}
+	if !res.plainCall {
+		t.Fatal("expected plain Resolve")
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1482,6 +1482,26 @@ func (s *Service) UnsealRegistry(sealed []byte) (*models.RegistryAuth, error) {
 	return &auth, nil
 }
 
+// attachWasmRegistryAuth unseals the sandbox's persisted registry creds into
+// its transient RegistryAuth field, so the WASM runtime can re-pull a private
+// oci:// module under the tenant's identity on a node that lacks it (codex C4).
+// Best-effort: an unseal failure is logged and leaves RegistryAuth nil, which
+// degrades to a public/system-identity pull rather than blocking start.
+func (s *Service) attachWasmRegistryAuth(sandbox *models.Sandbox) {
+	if sandbox == nil || len(sandbox.RegistryAuthSealed) == 0 {
+		return
+	}
+	auth, err := s.UnsealRegistry(sandbox.RegistryAuthSealed)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("wasm: unseal registry auth failed; private module pull may fail on this node",
+				"sandbox_id", sandbox.ID, "err", err)
+		}
+		return
+	}
+	sandbox.RegistryAuth = auth
+}
+
 // sealMounts marshals the user's mount specs and encrypts the JSON for
 // at-rest storage. Returns nil when there are no mounts.
 func (s *Service) sealMounts(specs []models.MountSpec) ([]byte, error) {
@@ -1659,6 +1679,10 @@ func (s *Service) StartSandbox(ctx context.Context, id string) (*models.Sandbox,
 	if s.isWasmSandbox(sandbox) {
 		if host, ok := s.wasm.(wasmruntime.StartHost); ok {
 			hostBinds := s.mounts.HostBindsFor(id)
+			// Unseal per-tenant registry creds so a private oci:// module
+			// re-pulls under the tenant's identity if this node lacks it
+			// (codex C4). Transient: never persisted or serialized.
+			s.attachWasmRegistryAuth(sandbox)
 			state, err = host.StartSandbox(ctx, sandbox, hostBinds)
 			if err != nil {
 				_ = s.mounts.UnmountAll(id)

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -155,6 +155,12 @@ type Service struct {
 	localReadyWasmModuleIDsCache   []string
 	localReadyWasmModuleIDsKnown   bool
 	localReadyWasmModuleIDsExpires time.Time
+	// Reserved standard-module aliases that actually resolve on this host,
+	// computed once: each resolve hashes a staged file up to 256MiB, so it must
+	// not run on every 5s inventory refresh (hard rule 2). Staged modules are
+	// immutable fleet-wide, so a single probe at first use is authoritative.
+	reservedModuleRefsOnce sync.Once
+	reservedModuleRefs     []string
 	// l4Ready latches true once caddy.EnsureLayer4 has succeeded — either at
 	// boot or lazily on the first TCP/TLS expose call. Boot bootstrap is
 	// best-effort (caddy may not be reachable yet on a cold start), so the
@@ -3235,6 +3241,14 @@ func (s *Service) LocalReadyWasmModuleInventory(ctx context.Context) ([]string, 
 		s.localReadyWasmModuleIDsMu.Unlock()
 		return out, known
 	}
+	// Reserved-keyword standard modules ("python", …) are filesystem/config
+	// backed and deliberately never DB-backed, so they never appear in the
+	// catalogue query above. Without folding them into local inventory, a
+	// fresh node advertises known-but-empty inventory and cluster placement
+	// rejects every `module_ref: "python"` create — yet the only way a row
+	// would ever appear is a create that placement just refused (codex P0
+	// deadlock). Advertise the staged aliases that actually resolve locally.
+	refs = s.appendResolvableReservedModules(ctx, refs)
 	s.localReadyWasmModuleIDsMu.Lock()
 	s.localReadyWasmModuleIDsCache = refs
 	s.localReadyWasmModuleIDsKnown = true
@@ -3242,6 +3256,41 @@ func (s *Service) LocalReadyWasmModuleInventory(ctx context.Context) ([]string, 
 	out := append([]string(nil), refs...)
 	s.localReadyWasmModuleIDsMu.Unlock()
 	return out, true
+}
+
+// appendResolvableReservedModules unions the reserved standard-module aliases
+// that resolve locally into refs (deduped). Resolution is probed once and
+// memoized — staged modules are immutable per node, and the resolve hashes a
+// large file, so it must not repeat on the inventory hot path.
+func (s *Service) appendResolvableReservedModules(ctx context.Context, refs []string) []string {
+	s.reservedModuleRefsOnce.Do(func() {
+		if s.wasmModuleResolver == nil || len(s.cfg.WasmStandardModules) == 0 {
+			return
+		}
+		for alias := range s.cfg.WasmStandardModules {
+			if _, err := s.wasmModuleResolver.Resolve(ctx, alias); err != nil {
+				if s.logger != nil {
+					s.logger.Warn("reserved wasm module not advertised: did not resolve",
+						"alias", alias, "error", err)
+				}
+				continue
+			}
+			s.reservedModuleRefs = append(s.reservedModuleRefs, alias)
+		}
+	})
+	if len(s.reservedModuleRefs) == 0 {
+		return refs
+	}
+	seen := make(map[string]struct{}, len(refs))
+	for _, r := range refs {
+		seen[r] = struct{}{}
+	}
+	for _, alias := range s.reservedModuleRefs {
+		if _, ok := seen[alias]; !ok {
+			refs = append(refs, alias)
+		}
+	}
+	return refs
 }
 
 // ReplayReservations re-populates the admitter from persistent state. Without

--- a/internal/service/wasm.go
+++ b/internal/service/wasm.go
@@ -135,6 +135,16 @@ func (s *Service) createWasmSandbox(ctx context.Context, req models.CreateSandbo
 		return nil, err
 	}
 
+	// Seal the per-tenant registry creds onto the row so a failover peer can
+	// re-pull a PRIVATE oci:// module under the tenant's identity (codex C4),
+	// mirroring the Docker image path. Nil/empty creds seal to nil.
+	sealedRegistry, err := s.sealRegistry(req.Registry)
+	if err != nil {
+		cleanupMounts()
+		releaseAdmission()
+		return nil, err
+	}
+
 	now := time.Now().UTC()
 	sandbox := &models.Sandbox{
 		ID:                   state.SandboxID,
@@ -165,6 +175,7 @@ func (s *Service) createWasmSandbox(ctx context.Context, req models.CreateSandbo
 		Durability:           req.Durability,
 		ModuleRef:            moduleRef,
 		ModuleDigest:         state.ModuleDigest,
+		RegistryAuthSealed:   sealedRegistry,
 	}
 	if len(req.CustomDomains) > 0 {
 		sandbox.CustomDomains = make([]models.CustomDomain, 0, len(req.CustomDomains))

--- a/internal/service/wasm.go
+++ b/internal/service/wasm.go
@@ -241,7 +241,7 @@ func (s *Service) createWasmSandbox(ctx context.Context, req models.CreateSandbo
 		}
 	}
 
-	s.registerWasmModuleCatalogue(ctx, sandbox, "", 0)
+	s.registerWasmModuleCatalogue(ctx, sandbox, state.ModulePath, state.ModuleSizeBytes)
 	s.invalidateWasmModuleInventoryCache()
 
 	s.logger.Info("audit sandbox created",

--- a/internal/service/wasm_checkpoint.go
+++ b/internal/service/wasm_checkpoint.go
@@ -283,6 +283,9 @@ func (s *Service) rehydrateWasmIfNeeded(ctx context.Context, sandbox *models.San
 	if !ok {
 		return nil, fmt.Errorf("wasm checkpoint host not available")
 	}
+	// Unseal per-tenant registry creds so a failover peer re-pulls a private
+	// oci:// base module under the tenant's identity (codex C4).
+	s.attachWasmRegistryAuth(sandbox)
 	state, err := host.RehydrateSandbox(ctx, sandbox, hostMounts)
 	if err != nil {
 		if errors.Is(err, models.ErrSnapshotCorrupt) || errors.Is(err, models.ErrSnapshotFenced) {

--- a/internal/service/wasm_module.go
+++ b/internal/service/wasm_module.go
@@ -18,6 +18,14 @@ func (s *Service) registerWasmModuleCatalogue(ctx context.Context, sandbox *mode
 	if ref == "" {
 		return
 	}
+	// Don't auto-register a row the catalogue resolver can't honor: a "ready"
+	// row with no local path is refused on lookup yet still advertised as
+	// inventory, which is misleading (codex P1). The digest-based GC protection
+	// a live sandbox needs already comes from its own sandboxes.module_digest
+	// row, so skipping here costs nothing.
+	if strings.TrimSpace(modulePath) == "" {
+		return
+	}
 	id := ref
 	if strings.Contains(ref, "://") {
 		id = sandbox.ModuleDigest

--- a/internal/service/wasm_module_api.go
+++ b/internal/service/wasm_module_api.go
@@ -19,11 +19,12 @@ import (
 // maxPushBytes caps a BYO upload body, mirroring wasmmod's 256MiB artifact cap.
 const maxPushBytes = 256 << 20
 
-// PushWasmModule validates a BYO .wasm upload and pushes it to the configured
-// registry as an oci artifact, returning the oci:// ref the caller uses on a
-// later create. The bytes are validated (core-wasip1, size) BEFORE upload so a
-// component or oversized artifact is rejected without touching the registry.
-func (s *Service) PushWasmModule(ctx context.Context, name, tag string, data io.Reader) (*models.PushWasmModuleResponse, error) {
+// PushWasmModule is a STATELESS proxy: it validates a BYO .wasm upload
+// (core-wasip1, size) and forwards it to the registry under the caller's own
+// per-tenant credentials, returning the oci:// ref for a later create. The
+// daemon never stores or serves the bytes — AOCR is the registry, this is just
+// orchestration convenience for clients without oras/docker.
+func (s *Service) PushWasmModule(ctx context.Context, name, tag, username, token string, data io.Reader) (*models.PushWasmModuleResponse, error) {
 	if !s.cfg.EnableWasm {
 		return nil, fmt.Errorf("wasm module push requires SB_ENABLE_WASM: %w", models.ErrRuntimeNotImplemented)
 	}
@@ -47,9 +48,9 @@ func (s *Service) PushWasmModule(ctx context.Context, name, tag string, data io.
 	tmpPath := tmp.Name()
 	defer os.Remove(tmpPath)
 
-	// Bounded copy + streaming digest: one read of the body computes the size,
-	// the content sha256, and writes the temp file. Reading one byte past the
-	// cap lets us reject an oversized upload without buffering it all.
+	// Bounded copy + streaming digest: one read computes size + content sha256
+	// and writes the temp file. Reading one byte past the cap lets us reject an
+	// oversized upload without buffering it all.
 	h := sha256.New()
 	n, copyErr := io.Copy(io.MultiWriter(tmp, h), io.LimitReader(data, maxPushBytes+1))
 	_ = tmp.Close()
@@ -66,7 +67,14 @@ func (s *Service) PushWasmModule(ctx context.Context, name, tag string, data io.
 	digest := hex.EncodeToString(h.Sum(nil))
 
 	registryRef := fmt.Sprintf("%s/%s:%s", host, name, tag)
-	auth := wasmmod.ModuleAuth{Username: s.cfg.WasmRegistryUsername, PATPath: s.cfg.WasmRegistryPATPath}
+	// Per-tenant creds from the request are required — the daemon forwards
+	// under the CALLER's identity, never a global one. The system config
+	// identity (WasmRegistryPATPath) exists only for pulling standard modules,
+	// not for tenant pushes.
+	if strings.TrimSpace(token) == "" {
+		return nil, fmt.Errorf("registry credentials required: supply X-Registry-Token")
+	}
+	auth := wasmmod.ModuleAuth{Username: strings.TrimSpace(username), PAT: strings.TrimSpace(token)}
 	if _, err := wasmmod.PushModuleArtifact(ctx, auth, tmpPath, registryRef); err != nil {
 		return nil, err
 	}

--- a/internal/service/wasm_module_api.go
+++ b/internal/service/wasm_module_api.go
@@ -2,8 +2,12 @@ package service
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -11,6 +15,67 @@ import (
 	"github.com/aerol-ai/microvm/pkg/models"
 	"github.com/aerol-ai/microvm/pkg/wasmmod"
 )
+
+// maxPushBytes caps a BYO upload body, mirroring wasmmod's 256MiB artifact cap.
+const maxPushBytes = 256 << 20
+
+// PushWasmModule validates a BYO .wasm upload and pushes it to the configured
+// registry as an oci artifact, returning the oci:// ref the caller uses on a
+// later create. The bytes are validated (core-wasip1, size) BEFORE upload so a
+// component or oversized artifact is rejected without touching the registry.
+func (s *Service) PushWasmModule(ctx context.Context, name, tag string, data io.Reader) (*models.PushWasmModuleResponse, error) {
+	if !s.cfg.EnableWasm {
+		return nil, fmt.Errorf("wasm module push requires SB_ENABLE_WASM: %w", models.ErrRuntimeNotImplemented)
+	}
+	host := strings.TrimRight(strings.TrimSpace(s.cfg.WasmRegistryPushHost), "/")
+	if host == "" {
+		return nil, errors.New("wasm module push is not configured (SB_WASM_REGISTRY_PUSH_HOST)")
+	}
+	name = strings.Trim(strings.TrimSpace(name), "/")
+	if name == "" || strings.Contains(name, "://") || strings.ContainsAny(name, " \t") {
+		return nil, fmt.Errorf("invalid module name %q", name)
+	}
+	tag = strings.TrimSpace(tag)
+	if tag == "" {
+		tag = "latest"
+	}
+
+	tmp, err := os.CreateTemp("", "aerol-wasm-push-*.wasm")
+	if err != nil {
+		return nil, err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	// Bounded copy + streaming digest: one read of the body computes the size,
+	// the content sha256, and writes the temp file. Reading one byte past the
+	// cap lets us reject an oversized upload without buffering it all.
+	h := sha256.New()
+	n, copyErr := io.Copy(io.MultiWriter(tmp, h), io.LimitReader(data, maxPushBytes+1))
+	_ = tmp.Close()
+	if copyErr != nil {
+		return nil, copyErr
+	}
+	if n > maxPushBytes {
+		return nil, fmt.Errorf("%w: upload exceeds %d bytes", wasmmod.ErrModuleTooLarge, int64(maxPushBytes))
+	}
+
+	if err := wasmmod.ValidateFile(tmpPath); err != nil {
+		return nil, err
+	}
+	digest := hex.EncodeToString(h.Sum(nil))
+
+	registryRef := fmt.Sprintf("%s/%s:%s", host, name, tag)
+	auth := wasmmod.ModuleAuth{Username: s.cfg.WasmRegistryUsername, PATPath: s.cfg.WasmRegistryPATPath}
+	if _, err := wasmmod.PushModuleArtifact(ctx, auth, tmpPath, registryRef); err != nil {
+		return nil, err
+	}
+	return &models.PushWasmModuleResponse{
+		ModuleRef: "oci://" + registryRef,
+		Digest:    digest,
+		SizeBytes: n,
+	}, nil
+}
 
 // WasmModuleResolver resolves a module reference to a local .wasm artifact.
 type WasmModuleResolver interface {
@@ -142,7 +207,7 @@ func (s *Service) DeleteWasmModule(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	referenced, err := s.store.IsWasmModuleReferenced(ctx, rec.ID, rec.ModuleRef)
+	referenced, err := s.store.IsWasmModuleReferenced(ctx, rec.ID, rec.ModuleRef, rec.Digest)
 	if err != nil {
 		return err
 	}

--- a/internal/service/wasm_module_api_test.go
+++ b/internal/service/wasm_module_api_test.go
@@ -62,6 +62,65 @@ func (s stubWasmModuleResolver) Resolve(_ context.Context, ref string) (*wasmmod
 	}, nil
 }
 
+// codex P0: reserved standard-module aliases are config/filesystem-backed and
+// never written to wasm_modules, so without folding them into local inventory a
+// fresh cluster node advertises known-but-empty inventory and placement rejects
+// every `module_ref: "python"` create. The resolvable aliases must appear.
+func TestLocalInventoryIncludesReservedAliases(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := newServiceRuntimeHarness(t, &recordingRuntime{})
+	svc.cfg.EnableWasm = true
+	svc.cfg.WasmStandardModules = map[string]string{"python": "python.wasm"}
+	svc.SetWasmModuleResolver(stubWasmModuleResolver{path: "/staged/python.wasm", digest: "pydigest"})
+
+	refs, known := svc.LocalReadyWasmModuleInventory(ctx)
+	if !known {
+		t.Fatal("inventory should be known")
+	}
+	found := false
+	for _, r := range refs {
+		if r == "python" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected reserved alias 'python' advertised, got %v", refs)
+	}
+}
+
+// An alias whose staged file does not resolve on this host must NOT be
+// advertised — otherwise placement routes work to a node that can't run it.
+// P1: auto-register must not write a ready row with an empty module_path.
+func TestRegisterWasmModuleCatalogueSkipsEmptyPath(t *testing.T) {
+	ctx := context.Background()
+	svc, st, _ := newServiceRuntimeHarness(t, &recordingRuntime{})
+	svc.cfg.EnableWasm = true
+	svc.registerWasmModuleCatalogue(ctx, &models.Sandbox{
+		ID:           "sb-wasm",
+		Runtime:      models.RuntimeWasm,
+		ModuleRef:    "python",
+		ModuleDigest: "pydigest",
+	}, "", 0)
+	if _, err := st.GetWasmModule(ctx, "python"); err == nil {
+		t.Fatal("catalogue row with empty path must not be registered")
+	}
+}
+
+func TestLocalInventoryExcludesUnresolvableReserved(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := newServiceRuntimeHarness(t, &recordingRuntime{})
+	svc.cfg.EnableWasm = true
+	svc.cfg.WasmStandardModules = map[string]string{"python": "python.wasm"}
+	svc.SetWasmModuleResolver(erroringWasmModuleResolver{err: errors.New("not staged")})
+
+	refs, _ := svc.LocalReadyWasmModuleInventory(ctx)
+	for _, r := range refs {
+		if r == "python" {
+			t.Fatalf("unresolvable alias must not be advertised, got %v", refs)
+		}
+	}
+}
+
 type wasmModuleAPIRemoveErrorRuntime struct {
 	wasmModuleAPINoopRuntime
 	err error

--- a/internal/service/wasm_module_health.go
+++ b/internal/service/wasm_module_health.go
@@ -45,7 +45,7 @@ func (s *Service) runWasmModuleGC(ctx context.Context, now time.Time) {
 		return
 	}
 	for _, rec := range records {
-		referenced, err := s.store.IsWasmModuleReferenced(ctx, rec.ID, rec.ModuleRef)
+		referenced, err := s.store.IsWasmModuleReferenced(ctx, rec.ID, rec.ModuleRef, rec.Digest)
 		if err != nil {
 			s.logger.Warn("wasm module gc reference check failed", "module_id", rec.ID, "error", err)
 			continue

--- a/internal/service/wasm_module_health.go
+++ b/internal/service/wasm_module_health.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 )
@@ -27,6 +28,11 @@ func (s *Service) StartWasmModuleGC(ctx context.Context) {
 			case <-ticker.C:
 				sweepCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 				s.runWasmModuleGC(sweepCtx, time.Now())
+				// Catalogue GC reclaims rows; cache GC reclaims the on-disk
+				// content-addressed bytes those rows (and bare oci:// pulls) leave
+				// behind. Run it second so a row deleted above frees its digest for
+				// eviction in the same sweep.
+				s.runWasmCacheGC(sweepCtx, time.Now())
 				cancel()
 			}
 		}
@@ -71,6 +77,114 @@ func (s *Service) runWasmModuleGC(ctx context.Context, now time.Time) {
 		}
 		s.invalidateWasmModuleInventoryCache()
 		s.logger.Info("wasm module gc removed unreferenced catalogue row", "module_id", rec.ID)
+	}
+}
+
+// runWasmCacheGC evicts content-addressed oci:// cache files
+// (CacheDir/<digest>.wasm) that no live sandbox or catalogue row references.
+// Two independent triggers, both refcount-gated:
+//
+//   - TTL: a file untouched (by mtime) for longer than WasmCacheGCTTL.
+//   - Size cap: when the cache total exceeds WasmCacheMaxBytes, evict
+//     unreferenced files oldest-first until back under the cap.
+//
+// Referenced files are NEVER evicted regardless of age or pressure — they still
+// count toward the total, so a cache full of in-use modules simply stops
+// shrinking rather than yanking live bytes (boot-path safety over disk).
+func (s *Service) runWasmCacheGC(ctx context.Context, now time.Time) {
+	ttl := s.cfg.WasmCacheGCTTL
+	maxBytes := s.cfg.WasmCacheMaxBytes
+	if ttl <= 0 && maxBytes <= 0 {
+		return
+	}
+	cacheDir := strings.TrimSpace(s.cfg.WasmCacheDir)
+	if cacheDir == "" {
+		cacheDir = filepath.Join(s.cfg.WasmModulesDir, "cache")
+	}
+	entries, err := os.ReadDir(cacheDir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			s.logger.Warn("wasm cache gc readdir failed", "dir", cacheDir, "error", err)
+		}
+		return
+	}
+
+	type cacheFile struct {
+		path   string
+		digest string
+		size   int64
+		mod    time.Time
+	}
+	var files []cacheFile
+	var total int64
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".wasm") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		f := cacheFile{
+			path:   filepath.Join(cacheDir, name),
+			digest: strings.TrimSuffix(name, ".wasm"),
+			size:   info.Size(),
+			mod:    info.ModTime(),
+		}
+		files = append(files, f)
+		total += f.size
+	}
+	// Oldest-first so both TTL and size-pressure eviction reclaim the least
+	// recently used bytes first.
+	sort.Slice(files, func(i, j int) bool { return files[i].mod.Before(files[j].mod) })
+
+	ttlCutoff := now.UTC().Add(-ttl)
+	for _, f := range files {
+		overCap := maxBytes > 0 && total > maxBytes
+		expired := ttl > 0 && f.mod.UTC().Before(ttlCutoff)
+		if !overCap && !expired {
+			// Files are sorted oldest-first: once we hit one that's neither
+			// expired nor needed for cap relief, every later file is younger and
+			// the total only shrinks, so nothing remaining can qualify.
+			break
+		}
+		// Refcount gate: skip (but keep counting) anything still in use.
+		referenced, err := s.store.IsWasmModuleReferenced(ctx, "", "", f.digest)
+		if err != nil {
+			s.logger.Warn("wasm cache gc reference check failed", "digest", f.digest, "error", err)
+			continue
+		}
+		if !referenced {
+			catalogued, err := s.store.IsWasmDigestCatalogued(ctx, f.digest)
+			if err != nil {
+				s.logger.Warn("wasm cache gc catalogue check failed", "digest", f.digest, "error", err)
+				continue
+			}
+			referenced = catalogued
+		}
+		if referenced {
+			continue
+		}
+		if err := os.Remove(f.path); err != nil {
+			if !os.IsNotExist(err) {
+				s.logger.Warn("wasm cache gc delete failed", "path", f.path, "error", err)
+			}
+			continue
+		}
+		total -= f.size
+		s.logger.Info("wasm cache gc evicted module", "digest", f.digest, "size_bytes", f.size, "reason", evictReason(expired, overCap))
+	}
+}
+
+func evictReason(expired, overCap bool) string {
+	switch {
+	case expired && overCap:
+		return "ttl+cap"
+	case expired:
+		return "ttl"
+	default:
+		return "cap"
 	}
 }
 

--- a/internal/service/wasm_module_health.go
+++ b/internal/service/wasm_module_health.go
@@ -59,15 +59,15 @@ func (s *Service) runWasmModuleGC(ctx context.Context, now time.Time) {
 		if referenced {
 			continue
 		}
-		if s.wasm != nil {
-			ref := rec.ModuleRef
-			if ref == "" {
-				ref = rec.ID
-			}
-			if err := s.wasm.RemoveImage(ctx, ref); err != nil {
-				s.logger.Warn("wasm module gc artifact delete failed", "module_id", rec.ID, "ref", ref, "error", err)
-				continue
-			}
+		// GC is strictly local — never hand a ref to RemoveImage here. An oci://
+		// ref would re-resolve during cleanup, re-pulling from the registry (and
+		// failing without the tenant's creds), which both does network I/O on the
+		// janitor and strands the row when it errors (codex P1). Reclaim by the
+		// recorded content digest (a local-only RemoveImage path that also drops
+		// the warm-pool entry) or, lacking a digest, the recorded local path; the
+		// content-addressed cache file is evicted separately by cache GC below.
+		if s.wasm != nil && rec.Digest != "" {
+			_ = s.wasm.RemoveImage(ctx, rec.Digest)
 		} else if wasmPathUnderDir(s.cfg.WasmModulesDir, rec.ModulePath) {
 			_ = os.RemoveAll(rec.ModulePath)
 		}
@@ -139,6 +139,19 @@ func (s *Service) runWasmCacheGC(ctx context.Context, now time.Time) {
 	// recently used bytes first.
 	sort.Slice(files, func(i, j int) bool { return files[i].mod.Before(files[j].mod) })
 
+	// Resolve the in-use set (sandbox-referenced ∪ catalogued) in ONE batched
+	// query for the whole sweep, rather than two DB probes per file against the
+	// single-writer store (codex P1). Membership is then an O(1) map lookup.
+	digests := make([]string, 0, len(files))
+	for _, f := range files {
+		digests = append(digests, f.digest)
+	}
+	inUse, err := s.store.WasmDigestsInUse(ctx, digests)
+	if err != nil {
+		s.logger.Warn("wasm cache gc in-use check failed", "error", err)
+		return
+	}
+
 	ttlCutoff := now.UTC().Add(-ttl)
 	for _, f := range files {
 		overCap := maxBytes > 0 && total > maxBytes
@@ -150,20 +163,7 @@ func (s *Service) runWasmCacheGC(ctx context.Context, now time.Time) {
 			break
 		}
 		// Refcount gate: skip (but keep counting) anything still in use.
-		referenced, err := s.store.IsWasmModuleReferenced(ctx, "", "", f.digest)
-		if err != nil {
-			s.logger.Warn("wasm cache gc reference check failed", "digest", f.digest, "error", err)
-			continue
-		}
-		if !referenced {
-			catalogued, err := s.store.IsWasmDigestCatalogued(ctx, f.digest)
-			if err != nil {
-				s.logger.Warn("wasm cache gc catalogue check failed", "digest", f.digest, "error", err)
-				continue
-			}
-			referenced = catalogued
-		}
-		if referenced {
+		if _, ok := inUse[f.digest]; ok {
 			continue
 		}
 		if err := os.Remove(f.path); err != nil {

--- a/internal/service/wasm_module_health_test.go
+++ b/internal/service/wasm_module_health_test.go
@@ -37,6 +37,86 @@ func TestWasmPathUnderDir(t *testing.T) {
 	}
 }
 
+// writeCacheFile drops a fake <digest>.wasm into dir with the given mtime.
+func writeCacheFile(t *testing.T, dir, digest string, size int, mod time.Time) string {
+	t.Helper()
+	p := filepath.Join(dir, digest+".wasm")
+	if err := os.WriteFile(p, make([]byte, size), 0o600); err != nil {
+		t.Fatalf("write cache file: %v", err)
+	}
+	if err := os.Chtimes(p, mod, mod); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	return p
+}
+
+func TestRunWasmCacheGCTTLEvictsUnreferenced(t *testing.T) {
+	ctx := context.Background()
+	svc, st, _ := newServiceRuntimeHarness(t, &recordingRuntime{})
+	cacheDir := t.TempDir()
+	svc.cfg.WasmCacheDir = cacheDir
+	svc.cfg.WasmCacheGCTTL = time.Hour
+
+	old := time.Now().Add(-2 * time.Hour)
+	fresh := time.Now()
+	stale := writeCacheFile(t, cacheDir, "deadbeefstale", 10, old)
+	young := writeCacheFile(t, cacheDir, "deadbeefyoung", 10, fresh)
+
+	// A catalogued digest must survive eviction even though it's old.
+	pinned := writeCacheFile(t, cacheDir, "deadbeefpinned", 10, old)
+	if err := st.UpsertWasmModule(ctx, store.WasmModuleRecord{
+		ID: "mod-pinned", ModuleRef: "oci://h/r:t", Digest: "deadbeefpinned", ModulePath: pinned,
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	svc.runWasmCacheGC(ctx, time.Now())
+
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Errorf("expected stale unreferenced file evicted, stat err=%v", err)
+	}
+	if _, err := os.Stat(young); err != nil {
+		t.Errorf("expected fresh file kept: %v", err)
+	}
+	if _, err := os.Stat(pinned); err != nil {
+		t.Errorf("expected catalogued digest kept: %v", err)
+	}
+}
+
+func TestRunWasmCacheGCSizeCapEvictsOldestFirst(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := newServiceRuntimeHarness(t, &recordingRuntime{})
+	cacheDir := t.TempDir()
+	svc.cfg.WasmCacheDir = cacheDir
+	svc.cfg.WasmCacheMaxBytes = 150 // room for one 100-byte file, not two
+
+	now := time.Now()
+	oldest := writeCacheFile(t, cacheDir, "aaa", 100, now.Add(-2*time.Hour))
+	newest := writeCacheFile(t, cacheDir, "bbb", 100, now)
+
+	svc.runWasmCacheGC(ctx, now)
+
+	if _, err := os.Stat(oldest); !os.IsNotExist(err) {
+		t.Errorf("expected oldest file evicted under cap, stat err=%v", err)
+	}
+	if _, err := os.Stat(newest); err != nil {
+		t.Errorf("expected newest file kept under cap: %v", err)
+	}
+}
+
+func TestRunWasmCacheGCDisabledNoop(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := newServiceRuntimeHarness(t, &recordingRuntime{})
+	cacheDir := t.TempDir()
+	svc.cfg.WasmCacheDir = cacheDir
+	// both knobs zero => disabled
+	f := writeCacheFile(t, cacheDir, "ccc", 10, time.Now().Add(-100*time.Hour))
+	svc.runWasmCacheGC(ctx, time.Now())
+	if _, err := os.Stat(f); err != nil {
+		t.Errorf("expected file untouched when cache gc disabled: %v", err)
+	}
+}
+
 func TestStartWasmModuleGC(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/service/wasm_module_health_test.go
+++ b/internal/service/wasm_module_health_test.go
@@ -104,6 +104,137 @@ func TestRunWasmCacheGCSizeCapEvictsOldestFirst(t *testing.T) {
 	}
 }
 
+func TestEvictReasonBranches(t *testing.T) {
+	if evictReason(true, true) != "ttl+cap" {
+		t.Fatal("ttl+cap")
+	}
+	if evictReason(true, false) != "ttl" {
+		t.Fatal("ttl")
+	}
+	if evictReason(false, true) != "cap" {
+		t.Fatal("cap")
+	}
+	if evictReason(false, false) != "cap" {
+		t.Fatal("default cap branch")
+	}
+}
+
+// P1: sandbox module_digest pins must protect cache files even when the
+// digest is absent from wasm_modules.
+func TestRunWasmCacheGCKeepsSandboxReferencedDigest(t *testing.T) {
+	ctx := context.Background()
+	svc, st, _ := newServiceRuntimeHarness(t, &recordingRuntime{})
+	cacheDir := t.TempDir()
+	svc.cfg.WasmCacheDir = cacheDir
+	svc.cfg.WasmCacheGCTTL = time.Hour
+
+	old := time.Now().Add(-2 * time.Hour)
+	pinned := writeCacheFile(t, cacheDir, "sandboxonly", 10, old)
+	now := time.Now().UTC()
+	if err := st.Create(ctx, &models.Sandbox{
+		ID:           "sb-pin",
+		Runtime:      models.RuntimeWasm,
+		ModuleDigest: "sandboxonly",
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	svc.runWasmCacheGC(ctx, time.Now())
+	if _, err := os.Stat(pinned); err != nil {
+		t.Fatalf("sandbox-referenced digest should survive gc: %v", err)
+	}
+}
+
+func TestRunWasmCacheGCInUseQueryError(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	st, err := store.Open(filepath.Join(dir, "state.db"))
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	cacheDir := t.TempDir()
+	writeCacheFile(t, cacheDir, "gone", 10, time.Now().Add(-2*time.Hour))
+	svc := &Service{
+		cfg:    config.Config{WasmCacheDir: cacheDir, WasmCacheGCTTL: time.Hour},
+		store:  st,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("store.Close: %v", err)
+	}
+	svc.runWasmCacheGC(ctx, time.Now())
+	if _, err := os.Stat(filepath.Join(cacheDir, "gone.wasm")); err != nil {
+		t.Fatalf("file should remain when in-use query fails: %v", err)
+	}
+}
+
+func TestRunWasmCacheGCReaddirFailure(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := newServiceRuntimeHarness(t, &recordingRuntime{})
+	cacheFile := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(cacheFile, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	svc.cfg.WasmCacheDir = cacheFile
+	svc.cfg.WasmCacheGCTTL = time.Hour
+	svc.runWasmCacheGC(ctx, time.Now())
+}
+
+func TestRunWasmCacheGCEvictsTTLAndCapTogether(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := newServiceRuntimeHarness(t, &recordingRuntime{})
+	cacheDir := t.TempDir()
+	svc.cfg.WasmCacheDir = cacheDir
+	svc.cfg.WasmCacheGCTTL = time.Hour
+	svc.cfg.WasmCacheMaxBytes = 50
+
+	old := time.Now().Add(-2 * time.Hour)
+	writeCacheFile(t, cacheDir, "evictme", 100, old)
+
+	svc.runWasmCacheGC(ctx, time.Now())
+	if _, err := os.Stat(filepath.Join(cacheDir, "evictme.wasm")); !os.IsNotExist(err) {
+		t.Fatalf("expected eviction under ttl+cap, stat err=%v", err)
+	}
+}
+
+func TestRunWasmCacheGCStopsAtYoungUnreferencedFiles(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := newServiceRuntimeHarness(t, &recordingRuntime{})
+	cacheDir := t.TempDir()
+	svc.cfg.WasmCacheDir = cacheDir
+	svc.cfg.WasmCacheGCTTL = time.Hour
+
+	now := time.Now()
+	old := writeCacheFile(t, cacheDir, "oldfile", 10, now.Add(-2*time.Hour))
+	young := writeCacheFile(t, cacheDir, "youngfile", 10, now)
+
+	svc.runWasmCacheGC(ctx, now)
+	if _, err := os.Stat(old); !os.IsNotExist(err) {
+		t.Fatalf("old file should be evicted")
+	}
+	if _, err := os.Stat(young); err != nil {
+		t.Fatalf("young file should remain: %v", err)
+	}
+}
+
+func TestRunWasmCacheGCSkipsDirectories(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := newServiceRuntimeHarness(t, &recordingRuntime{})
+	cacheDir := t.TempDir()
+	svc.cfg.WasmCacheDir = cacheDir
+	svc.cfg.WasmCacheGCTTL = time.Hour
+	if err := os.Mkdir(filepath.Join(cacheDir, ".manifest"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	stale := writeCacheFile(t, cacheDir, "onlywasm", 10, time.Now().Add(-2*time.Hour))
+	svc.runWasmCacheGC(ctx, time.Now())
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("expected stale wasm evicted")
+	}
+}
+
 func TestRunWasmCacheGCDisabledNoop(t *testing.T) {
 	ctx := context.Background()
 	svc, _, _ := newServiceRuntimeHarness(t, &recordingRuntime{})
@@ -166,9 +297,12 @@ func TestRunWasmModuleGCWithRuntimeRemovesImages(t *testing.T) {
 		t.Fatalf("write module: %v", err)
 	}
 	now := time.Now().UTC().Add(-2 * time.Hour)
+	// GC reclaims by the recorded content digest (a local-only RemoveImage
+	// path), never by the ref — an oci:// ref would re-pull during cleanup.
 	if err := st.UpsertWasmModule(ctx, store.WasmModuleRecord{
 		ID:         "mod-rt",
-		ModuleRef:  "sha256:rt",
+		ModuleRef:  "oci://h/r:t",
+		Digest:     "rtdigest",
 		Status:     "ready",
 		ModulePath: modPath,
 		CreatedAt:  now,
@@ -179,8 +313,8 @@ func TestRunWasmModuleGCWithRuntimeRemovesImages(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	svc.runWasmModuleGC(ctx, time.Now().UTC())
-	if len(rt.removeImages) != 1 || rt.removeImages[0] != "sha256:rt" {
-		t.Fatalf("removeImages = %v, want [sha256:rt]", rt.removeImages)
+	if len(rt.removeImages) != 1 || rt.removeImages[0] != "rtdigest" {
+		t.Fatalf("removeImages = %v, want [rtdigest]", rt.removeImages)
 	}
 	if _, err := st.GetWasmModule(ctx, "mod-rt"); err == nil {
 		t.Fatal("module should have been deleted")
@@ -318,7 +452,11 @@ func TestWasmModuleGCEdgeBranches(t *testing.T) {
 		}
 	})
 
-	t.Run("remove image error", func(t *testing.T) {
+	t.Run("remove image error does not strand row", func(t *testing.T) {
+		// A failed best-effort artifact delete must NOT strand the catalogue row:
+		// the row is the source of placement inventory, so leaving it behind on a
+		// transient remove error accumulates vacuum (codex P1). GC ignores the
+		// error and still deletes the row; cache GC reclaims the bytes later.
 		dir := t.TempDir()
 		dbPath := filepath.Join(dir, "state.db")
 		st, err := store.Open(dbPath)
@@ -328,7 +466,7 @@ func TestWasmModuleGCEdgeBranches(t *testing.T) {
 		t.Cleanup(func() { _ = st.Close() })
 		now := time.Now().UTC().Add(-2 * time.Hour)
 		if err := st.UpsertWasmModule(ctx, store.WasmModuleRecord{
-			ID: "mod-rm", ModuleRef: "file:///tmp/rm.wasm", Status: "ready", CreatedAt: now, UpdatedAt: now,
+			ID: "mod-rm", ModuleRef: "oci://h/r:t", Digest: "rmdigest", Status: "ready", CreatedAt: now, UpdatedAt: now,
 		}); err != nil {
 			t.Fatalf("UpsertWasmModule: %v", err)
 		}
@@ -350,8 +488,8 @@ func TestWasmModuleGCEdgeBranches(t *testing.T) {
 			wasm:   wasmModuleGCRuntime{removeErr: errors.New("remove failed")},
 		}
 		svc.runWasmModuleGC(ctx, time.Now())
-		if _, err := st.GetWasmModule(ctx, "mod-rm"); err != nil {
-			t.Fatalf("module should remain after remove failure: %v", err)
+		if _, err := st.GetWasmModule(ctx, "mod-rm"); err == nil {
+			t.Fatal("row should be deleted despite remove failure")
 		}
 	})
 
@@ -518,7 +656,10 @@ func TestRunWasmModuleGCAdditionalBranches(t *testing.T) {
 		}
 	})
 
-	t.Run("blank module ref falls back to module id for image removal", func(t *testing.T) {
+	t.Run("digest row reclaims by content digest", func(t *testing.T) {
+		// A row carrying a content digest reclaims via the local-only,
+		// digest-keyed RemoveImage path (which also drops the warm-pool entry),
+		// never via the ref.
 		dir := t.TempDir()
 		dbPath := filepath.Join(dir, "state.db")
 		st, err := store.Open(dbPath)
@@ -529,8 +670,9 @@ func TestRunWasmModuleGCAdditionalBranches(t *testing.T) {
 
 		now := time.Now().UTC().Add(-2 * time.Hour)
 		if err := st.UpsertWasmModule(ctx, store.WasmModuleRecord{
-			ID:         "mod-blank-ref",
-			ModuleRef:  "",
+			ID:         "mod-digest",
+			ModuleRef:  "oci://h/r:t",
+			Digest:     "blankdigest",
 			ModulePath: filepath.Join(dir, "blank-ref.wasm"),
 			Status:     "ready",
 			CreatedAt:  now,
@@ -542,7 +684,7 @@ func TestRunWasmModuleGCAdditionalBranches(t *testing.T) {
 		if err != nil {
 			t.Fatalf("sql.Open: %v", err)
 		}
-		if _, err := freshDB.ExecContext(ctx, `UPDATE wasm_modules SET updated_at = ? WHERE id = ?`, now.Add(-2*time.Hour), "mod-blank-ref"); err != nil {
+		if _, err := freshDB.ExecContext(ctx, `UPDATE wasm_modules SET updated_at = ? WHERE id = ?`, now.Add(-2*time.Hour), "mod-digest"); err != nil {
 			_ = freshDB.Close()
 			t.Fatalf("update wasm_modules updated_at: %v", err)
 		}
@@ -559,11 +701,11 @@ func TestRunWasmModuleGCAdditionalBranches(t *testing.T) {
 		}
 		svc.runWasmModuleGC(ctx, time.Now())
 
-		if len(rt.removeImages) != 1 || rt.removeImages[0] != "mod-blank-ref" {
-			t.Fatalf("removeImages = %v, want [mod-blank-ref]", rt.removeImages)
+		if len(rt.removeImages) != 1 || rt.removeImages[0] != "blankdigest" {
+			t.Fatalf("removeImages = %v, want [blankdigest]", rt.removeImages)
 		}
-		if _, err := st.GetWasmModule(ctx, "mod-blank-ref"); err == nil {
-			t.Fatal("blank-ref module row should be deleted")
+		if _, err := st.GetWasmModule(ctx, "mod-digest"); err == nil {
+			t.Fatal("digest module row should be deleted")
 		}
 	})
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -399,6 +399,11 @@ func Open(path string) (*Store, error) {
 			ON wasm_modules(updated_at);`,
 		`CREATE INDEX IF NOT EXISTS idx_wasm_modules_status_ref
 			ON wasm_modules(status, module_ref);`,
+		// Cache GC probes catalogued digests by content digest every sweep; without
+		// this index that degrades to a full wasm_modules scan per cache file at
+		// large cache/catalogue sizes (codex P1).
+		`CREATE INDEX IF NOT EXISTS idx_wasm_modules_digest
+			ON wasm_modules(digest) WHERE digest <> '';`,
 		// wasm_state_kv backs the durable host-KV capability (§4.6).
 		`CREATE TABLE IF NOT EXISTS wasm_state_kv (
 			sandbox_id TEXT NOT NULL,
@@ -4867,6 +4872,56 @@ func (s *Store) IsWasmDigestCatalogued(ctx context.Context, digest string) (bool
 		return false, err
 	}
 	return true, nil
+}
+
+// WasmDigestsInUse returns the subset of digests that are still referenced by a
+// live sandbox OR pinned by a catalogue row. The cache evictor calls this ONCE
+// per sweep with every candidate digest instead of two probes per file, so a
+// large cache no longer issues O(files) serialized queries against the
+// single-writer DB (codex P1). Digests are chunked to stay under SQLite's bound
+// parameter limit.
+func (s *Store) WasmDigestsInUse(ctx context.Context, digests []string) (map[string]struct{}, error) {
+	inUse := make(map[string]struct{})
+	const chunk = 400 // half the 999 bound-param limit (used twice per row)
+	for start := 0; start < len(digests); start += chunk {
+		end := start + chunk
+		if end > len(digests) {
+			end = len(digests)
+		}
+		batch := digests[start:end]
+		ph := make([]string, len(batch))
+		// One arg list reused for both the sandboxes and wasm_modules predicate.
+		args := make([]any, 0, len(batch)*2)
+		for i, d := range batch {
+			ph[i] = "?"
+			args = append(args, d)
+		}
+		for _, d := range batch {
+			args = append(args, d)
+		}
+		in := strings.Join(ph, ",")
+		q := `SELECT module_digest FROM sandboxes WHERE module_digest IN (` + in + `)
+		      UNION
+		      SELECT digest FROM wasm_modules WHERE digest IN (` + in + `)`
+		rows, err := s.db.QueryContext(ctx, q, args...)
+		if err != nil {
+			return nil, fmt.Errorf("wasm digests in use: %w", err)
+		}
+		for rows.Next() {
+			var d string
+			if err := rows.Scan(&d); err != nil {
+				rows.Close()
+				return nil, err
+			}
+			inUse[d] = struct{}{}
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		rows.Close()
+	}
+	return inUse, nil
 }
 
 // ErrWasmModuleIDConflict is returned when POST /v1/wasm-modules reuses an id

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4823,13 +4823,20 @@ func (s *Store) ListWasmModulesOlderThan(ctx context.Context, cutoff time.Time) 
 }
 
 // IsWasmModuleReferenced reports whether any sandbox still names moduleRef or digest id.
-func (s *Store) IsWasmModuleReferenced(ctx context.Context, moduleID, moduleRef string) (bool, error) {
+// IsWasmModuleReferenced reports whether any sandbox row still depends on this
+// module. The check spans ref, id, AND the resolved content digest: two
+// aliases/tags can share the same bytes, so deleting/evicting purely by ref
+// would yank a digest still in use by another sandbox (codex C5). A blank
+// moduleDigest simply contributes no extra match.
+func (s *Store) IsWasmModuleReferenced(ctx context.Context, moduleID, moduleRef, moduleDigest string) (bool, error) {
 	moduleID = strings.TrimSpace(moduleID)
 	moduleRef = strings.TrimSpace(moduleRef)
+	moduleDigest = strings.TrimSpace(moduleDigest)
 	row := s.db.QueryRowContext(ctx, `
 		SELECT 1 FROM sandboxes
-		WHERE module_ref = ? OR module_ref = ? OR module_digest = ?
-		LIMIT 1`, moduleRef, moduleID, moduleID)
+		WHERE module_ref = ? OR module_ref = ? OR module_digest = ? OR
+		      (? <> '' AND module_digest = ?)
+		LIMIT 1`, moduleRef, moduleID, moduleID, moduleDigest, moduleDigest)
 	var one int
 	err := row.Scan(&one)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4848,6 +4848,27 @@ func (s *Store) IsWasmModuleReferenced(ctx context.Context, moduleID, moduleRef,
 	return true, nil
 }
 
+// IsWasmDigestCatalogued reports whether any wasm_modules row pins this content
+// digest. The cache evictor consults it (alongside IsWasmModuleReferenced) so a
+// digest that backs a catalogue id — resolvable later by a fresh create — is
+// never reclaimed out from under the catalogue, even with no live sandbox.
+func (s *Store) IsWasmDigestCatalogued(ctx context.Context, digest string) (bool, error) {
+	digest = strings.TrimSpace(digest)
+	if digest == "" {
+		return false, nil
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT 1 FROM wasm_modules WHERE digest = ? LIMIT 1`, digest)
+	var one int
+	err := row.Scan(&one)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // ErrWasmModuleIDConflict is returned when POST /v1/wasm-modules reuses an id
 // bound to a different module_ref.
 var ErrWasmModuleIDConflict = errors.New("wasm module id already in use")

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2124,6 +2124,75 @@ func TestIsWasmModuleReferencedByDigest(t *testing.T) {
 	}
 }
 
+// WasmDigestsInUse batches sandbox + catalogue membership for cache GC instead
+// of per-file probes (codex P1).
+func TestWasmDigestsInUse(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+
+	sb := sampleSandbox("sb-digest-in-use")
+	sb.ModuleDigest = "digest-sandbox"
+	if err := st.Create(ctx, sb); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	now := time.Now().UTC()
+	if err := st.UpsertWasmModule(ctx, WasmModuleRecord{
+		ID: "mod-cat", ModuleRef: "oci://h/r:t", Digest: "digest-catalogue",
+		Status: "ready", CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("UpsertWasmModule: %v", err)
+	}
+
+	inUse, err := st.WasmDigestsInUse(ctx, []string{
+		"digest-sandbox", "digest-catalogue", "digest-free",
+	})
+	if err != nil {
+		t.Fatalf("WasmDigestsInUse: %v", err)
+	}
+	if _, ok := inUse["digest-sandbox"]; !ok {
+		t.Fatal("sandbox digest should be in use")
+	}
+	if _, ok := inUse["digest-catalogue"]; !ok {
+		t.Fatal("catalogue digest should be in use")
+	}
+	if _, ok := inUse["digest-free"]; ok {
+		t.Fatal("unreferenced digest must not be in use")
+	}
+
+	empty, err := st.WasmDigestsInUse(ctx, nil)
+	if err != nil {
+		t.Fatalf("WasmDigestsInUse empty: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("empty input should return empty set, got %v", empty)
+	}
+
+	// Chunking: >400 digests exercises the batched query path.
+	batch := make([]string, 0, 450)
+	for i := 0; i < 450; i++ {
+		batch = append(batch, fmt.Sprintf("free-%04d", i))
+	}
+	batch = append(batch, "digest-sandbox")
+	got, err := st.WasmDigestsInUse(ctx, batch)
+	if err != nil {
+		t.Fatalf("WasmDigestsInUse chunked: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("chunked in-use = %v, want only digest-sandbox", got)
+	}
+}
+
+func TestWasmDigestsInUseQueryError(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	if err := st.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := st.WasmDigestsInUse(ctx, []string{"x"}); err == nil {
+		t.Fatal("expected error on closed store")
+	}
+}
+
 func TestWasmStateKVCRUD(t *testing.T) {
 	ctx := context.Background()
 	st := newTestStore(t)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2089,6 +2089,41 @@ func TestWasmCheckpointColumnsRoundTrip(t *testing.T) {
 	}
 }
 
+// A module is "referenced" when a sandbox shares its content digest, even
+// though that sandbox's module_ref names a different alias/tag (codex C5).
+// Deleting/evicting purely by ref would otherwise stomp shared bytes.
+func TestIsWasmModuleReferencedByDigest(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+
+	// Sandbox booted from alias "python" but pinned to digest sha256X.
+	sb := sampleSandbox("sb-ref-digest")
+	sb.ModuleRef = "python"
+	sb.ModuleDigest = "sha256X"
+	if err := st.Create(ctx, sb); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// A catalogue row whose id/ref differ from the sandbox's, but whose
+	// resolved digest is the same bytes, must read as referenced.
+	referenced, err := st.IsWasmModuleReferenced(ctx, "some-other-id", "oci://aocr/x:latest", "sha256X")
+	if err != nil {
+		t.Fatalf("IsWasmModuleReferenced: %v", err)
+	}
+	if !referenced {
+		t.Fatal("module sharing the sandbox's digest must be referenced (C5)")
+	}
+
+	// An unrelated digest with no ref/id match is free to delete.
+	referenced, err = st.IsWasmModuleReferenced(ctx, "unrelated-id", "unrelated-ref", "sha256-OTHER")
+	if err != nil {
+		t.Fatalf("IsWasmModuleReferenced: %v", err)
+	}
+	if referenced {
+		t.Fatal("unrelated module must not be referenced")
+	}
+}
+
 func TestWasmStateKVCRUD(t *testing.T) {
 	ctx := context.Background()
 	st := newTestStore(t)

--- a/pkg/api/apihttp/apihttp.go
+++ b/pkg/api/apihttp/apihttp.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aerol-ai/microvm/pkg/capacity"
 	"github.com/aerol-ai/microvm/pkg/controlplane"
 	"github.com/aerol-ai/microvm/pkg/models"
+	"github.com/aerol-ai/microvm/pkg/wasmmod"
 )
 
 // admissionRetryAfterSeconds is the Retry-After hint sent with a 503 when the
@@ -130,6 +131,35 @@ func WriteStoreAwareError(logger *slog.Logger, w http.ResponseWriter, err error)
 	}
 	if errors.Is(err, models.ErrCustomDomainVerificationFailed) {
 		WriteError(w, http.StatusForbidden, err.Error())
+		return
+	}
+	// WASM module resolution taxonomy (plans/wasm-standard-modules-distribution.md).
+	// The SDK branches on these statuses: 404 = wrong ref, 403 = registry not
+	// allowlisted (SSRF guard) or digest drift, 401 = fix your token, 413 =
+	// too big, 422 = unsupported artifact, 502+Retry-After = transient, retry.
+	if errors.Is(err, wasmmod.ErrModuleNotFound) {
+		WriteError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	if errors.Is(err, wasmmod.ErrRegistryNotAllowed) || errors.Is(err, wasmmod.ErrModuleDigestMismatch) {
+		WriteError(w, http.StatusForbidden, err.Error())
+		return
+	}
+	if errors.Is(err, wasmmod.ErrRegistryAuth) {
+		WriteError(w, http.StatusUnauthorized, err.Error())
+		return
+	}
+	if errors.Is(err, wasmmod.ErrModuleTooLarge) {
+		WriteError(w, http.StatusRequestEntityTooLarge, err.Error())
+		return
+	}
+	if errors.Is(err, wasmmod.ErrComponentModelUnsupported) {
+		WriteError(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+	if errors.Is(err, wasmmod.ErrRegistryUnavailable) {
+		w.Header().Set("Retry-After", "5")
+		WriteError(w, http.StatusBadGateway, err.Error())
 		return
 	}
 	// Capacity rejections are 503 with a Retry-After hint so well-behaved

--- a/pkg/api/v1/routes.go
+++ b/pkg/api/v1/routes.go
@@ -123,6 +123,7 @@ func RegisterRoutes(mux *http.ServeMux, d Deps) {
 
 	// WASM module catalogue (plans/wasm-runtime.md). Per-host like templates.
 	mux.Handle("POST "+PathPrefix+"/wasm-modules", d.Auth(http.HandlerFunc(h.createWasmModule)))
+	mux.Handle("POST "+PathPrefix+"/wasm-modules/push", d.Auth(http.HandlerFunc(h.pushWasmModule)))
 	mux.Handle("GET "+PathPrefix+"/wasm-modules", d.Auth(http.HandlerFunc(h.listWasmModules)))
 	mux.Handle("GET "+PathPrefix+"/wasm-modules/{id}", d.Auth(http.HandlerFunc(h.getWasmModule)))
 	mux.Handle("DELETE "+PathPrefix+"/wasm-modules/{id}", d.Auth(http.HandlerFunc(h.deleteWasmModule)))

--- a/pkg/api/v1/wasm_module.go
+++ b/pkg/api/v1/wasm_module.go
@@ -24,13 +24,16 @@ func (h *handlers) createWasmModule(w http.ResponseWriter, r *http.Request) {
 	apihttp.WriteJSON(w, http.StatusCreated, mod)
 }
 
-// pushWasmModule accepts a raw .wasm body (application/octet-stream) and the
-// target repo as ?name=<repo>&tag=<tag>, pushes it to the registry, and returns
-// the oci:// ref the caller uses on create.
+// pushWasmModule is a stateless proxy: it accepts a raw .wasm body
+// (application/octet-stream) with the target repo as ?name=<repo>&tag=<tag>,
+// validates and forwards it to the registry under the caller's own PAT (from
+// request headers), and returns the oci:// ref. The daemon stores nothing.
 func (h *handlers) pushWasmModule(w http.ResponseWriter, r *http.Request) {
 	name := r.URL.Query().Get("name")
 	tag := r.URL.Query().Get("tag")
-	resp, err := h.deps.Service.PushWasmModule(r.Context(), name, tag, r.Body)
+	username := r.Header.Get("X-Registry-Username")
+	token := r.Header.Get("X-Registry-Token")
+	resp, err := h.deps.Service.PushWasmModule(r.Context(), name, tag, username, token, r.Body)
 	if err != nil {
 		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
 		return

--- a/pkg/api/v1/wasm_module.go
+++ b/pkg/api/v1/wasm_module.go
@@ -24,6 +24,20 @@ func (h *handlers) createWasmModule(w http.ResponseWriter, r *http.Request) {
 	apihttp.WriteJSON(w, http.StatusCreated, mod)
 }
 
+// pushWasmModule accepts a raw .wasm body (application/octet-stream) and the
+// target repo as ?name=<repo>&tag=<tag>, pushes it to the registry, and returns
+// the oci:// ref the caller uses on create.
+func (h *handlers) pushWasmModule(w http.ResponseWriter, r *http.Request) {
+	name := r.URL.Query().Get("name")
+	tag := r.URL.Query().Get("tag")
+	resp, err := h.deps.Service.PushWasmModule(r.Context(), name, tag, r.Body)
+	if err != nil {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
+		return
+	}
+	apihttp.WriteJSON(w, http.StatusCreated, resp)
+}
+
 func (h *handlers) listWasmModules(w http.ResponseWriter, r *http.Request) {
 	mods, err := h.deps.Service.ListWasmModules(r.Context())
 	if err != nil {

--- a/pkg/daemon/wasm_wiring.go
+++ b/pkg/daemon/wasm_wiring.go
@@ -83,6 +83,13 @@ func wireWasmRuntime(ctx context.Context, cfg config.Config, logger *slog.Logger
 			SpawnTimeout:   30 * time.Second,
 		}
 		go wasmpool.RunRefill(ctx, pool, refillCfg, spawner, logger)
+		// Pre-seed the warm pool with the standard modules so the first tenant
+		// create against "python" et al. hits a warm slot instead of paying cold
+		// worker boot. Without this, a reserved keyword is only NoteModule'd
+		// lazily on its first create — exactly the latency we staged the module
+		// fleet-wide to avoid. Done in the background (resolution hashes up to a
+		// 256MiB file) so it never blocks daemon startup (hard rule 2).
+		go seedStandardModules(ctx, resolver, pool, cfg.WasmStandardModules, logger)
 		logger.Info("wasm warm pool enabled",
 			"depth_default", cfg.WasmPoolDepthDefault,
 			"refill_interval", cfg.WasmPoolRefillInterval)
@@ -95,4 +102,28 @@ func wireWasmRuntime(ctx context.Context, cfg config.Config, logger *slog.Logger
 		"pool_enabled", cfg.WasmPoolEnabled,
 	)
 	return pool
+}
+
+// seedStandardModules resolves each reserved keyword to its content digest +
+// path and registers it as a warm-pool refill target, so the standard runtimes
+// are pre-warmed before any tenant references them. Best-effort: a missing or
+// invalid staged module is logged and skipped (the keyword still resolves on
+// create, it just won't be pre-warmed) rather than failing daemon boot.
+func seedStandardModules(ctx context.Context, resolver *wasmmod.ModuleResolver, pool *wasmpool.Pool, reserved map[string]string, logger *slog.Logger) {
+	if resolver == nil || pool == nil {
+		return
+	}
+	for alias := range reserved {
+		if ctx.Err() != nil {
+			return
+		}
+		resolved, err := resolver.Resolve(ctx, alias)
+		if err != nil {
+			logger.Warn("wasm warm pool seed skipped: standard module did not resolve",
+				"alias", alias, "error", err)
+			continue
+		}
+		pool.NoteModule(resolved.Digest, resolved.Path)
+		logger.Info("wasm warm pool seeded standard module", "alias", alias, "digest", resolved.Digest)
+	}
 }

--- a/pkg/daemon/wasm_wiring.go
+++ b/pkg/daemon/wasm_wiring.go
@@ -22,7 +22,20 @@ import (
 // it on daemon shutdown.
 func wireWasmRuntime(ctx context.Context, cfg config.Config, logger *slog.Logger, svc *service.Service, st *store.Store) *wasmpool.Pool {
 	driver := wasmruntime.New(wasmruntime.FromDaemonConfig(cfg), logger)
-	resolver := wasmmod.NewResolver(cfg.WasmModulesDir)
+	// One ModuleResolver chokepoint shared by the runtime driver (create-time
+	// resolution) and the service (CreateWasmModule registration), so allowlist
+	// + validation + content-addressed pull happen in exactly one place.
+	resolver := wasmmod.NewModuleResolver(cfg.WasmModulesDir, cfg.WasmCacheDir)
+	resolver.Reserved = cfg.WasmStandardModules
+	resolver.Allowlist = make(map[string]struct{}, len(cfg.WasmRegistryAllowlist))
+	for _, h := range cfg.WasmRegistryAllowlist {
+		resolver.Allowlist[h] = struct{}{}
+	}
+	resolver.PullTimeout = cfg.WasmPullTimeout
+	resolver.Auth = wasmmod.ModuleAuth{
+		Username: cfg.WasmRegistryUsername,
+		PATPath:  cfg.WasmRegistryPATPath,
+	}
 	supervisor := worker.NewSupervisor(worker.DefaultSpawner)
 	driver.SetModuleResolver(resolver)
 	driver.SetWorkerSupervisor(supervisor)

--- a/pkg/daemon/wasm_wiring.go
+++ b/pkg/daemon/wasm_wiring.go
@@ -36,6 +36,24 @@ func wireWasmRuntime(ctx context.Context, cfg config.Config, logger *slog.Logger
 		Username: cfg.WasmRegistryUsername,
 		PATPath:  cfg.WasmRegistryPATPath,
 	}
+	if st != nil {
+		// Wire step-3 of the resolution precedence: a BYO catalogue id
+		// (returned by CreateWasmModule) maps to its already-local, already
+		// validated path + pinned digest. Only "ready" rows with a real path
+		// resolve — a pending/failed row must fall through to a 404 rather than
+		// boot a half-staged artifact. Lookup is read-only and goes through the
+		// single-writer store like every other query.
+		resolver.CatalogueLookup = func(ctx context.Context, id string) (path, digest string, ok bool) {
+			rec, err := st.GetWasmModule(ctx, id)
+			if err != nil {
+				return "", "", false
+			}
+			if !strings.EqualFold(rec.Status, "ready") || strings.TrimSpace(rec.ModulePath) == "" {
+				return "", "", false
+			}
+			return rec.ModulePath, rec.Digest, true
+		}
+	}
 	supervisor := worker.NewSupervisor(worker.DefaultSpawner)
 	driver.SetModuleResolver(resolver)
 	driver.SetWorkerSupervisor(supervisor)

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -55,6 +55,12 @@ type SandboxRuntimeState struct {
 	// WASM-only: resolved module metadata returned by the wasm driver on create.
 	ModuleRef    string
 	ModuleDigest string
+	// ModulePath / ModuleSizeBytes are the resolved local artifact location and
+	// size. The service persists them onto the catalogue row so the row is
+	// resolvable by catalogue id instead of a misleading empty-path "ready" row
+	// (codex P1). Empty when resolution did not yield a local path.
+	ModulePath      string
+	ModuleSizeBytes int64
 }
 
 // User-facing runtime identifiers. These are the values the API, SDK, and

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -660,6 +660,12 @@ type Sandbox struct {
 	// the credentials back to the new owner's docker pull. Never serialized
 	// over the API — it is internal store ↔ service plumbing.
 	RegistryAuthSealed []byte `json:"-"`
+	// RegistryAuth is the transient, UNSEALED registry credential. It is never
+	// persisted (no column) nor serialized (json:"-"); the service unseals
+	// RegistryAuthSealed into it in-memory right before a WASM start/rehydrate
+	// so a failover peer can re-pull a private oci:// module under the tenant's
+	// identity (codex C4). Nil on the create/public path.
+	RegistryAuth *RegistryAuth `json:"-"`
 	// NetworkBytesIn / NetworkBytesOut are cumulative byte counters
 	// maintained by the netstats poller. They survive container restarts —
 	// a new veth resets in-memory baseline math but the persisted total is

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -1175,6 +1175,17 @@ type CreateWasmModuleRequest struct {
 	Entrypoint string `json:"entrypoint,omitempty"`
 }
 
+// PushWasmModuleOptions is the SDK-side input for a BYO module upload. The
+// wire form is the raw .wasm body plus name/tag query params and the caller's
+// registry credentials as headers; this struct is the Go SDK's ergonomic shape.
+type PushWasmModuleOptions struct {
+	Name             string
+	Tag              string
+	Module           []byte
+	RegistryUsername string
+	RegistryToken    string
+}
+
 // PushWasmModuleResponse is returned by POST /v1/wasm-modules/push after the
 // daemon validates a BYO .wasm upload and forwards it to the registry. The
 // daemon stores nothing; the caller references ModuleRef (an oci:// ref) on a

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -1168,3 +1168,13 @@ type CreateWasmModuleRequest struct {
 	ModuleRef  string `json:"module_ref"`
 	Entrypoint string `json:"entrypoint,omitempty"`
 }
+
+// PushWasmModuleResponse is returned by POST /v1/wasm-modules/push after a BYO
+// .wasm upload is validated and pushed to the registry. The caller references
+// ModuleRef (an oci:// ref) on a subsequent create, or registers it in the
+// catalogue.
+type PushWasmModuleResponse struct {
+	ModuleRef string `json:"module_ref"`
+	Digest    string `json:"digest"`
+	SizeBytes int64  `json:"size_bytes"`
+}

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -1169,10 +1169,10 @@ type CreateWasmModuleRequest struct {
 	Entrypoint string `json:"entrypoint,omitempty"`
 }
 
-// PushWasmModuleResponse is returned by POST /v1/wasm-modules/push after a BYO
-// .wasm upload is validated and pushed to the registry. The caller references
-// ModuleRef (an oci:// ref) on a subsequent create, or registers it in the
-// catalogue.
+// PushWasmModuleResponse is returned by POST /v1/wasm-modules/push after the
+// daemon validates a BYO .wasm upload and forwards it to the registry. The
+// daemon stores nothing; the caller references ModuleRef (an oci:// ref) on a
+// subsequent create.
 type PushWasmModuleResponse struct {
 	ModuleRef string `json:"module_ref"`
 	Digest    string `json:"digest"`

--- a/pkg/wasmmod/errors.go
+++ b/pkg/wasmmod/errors.go
@@ -1,0 +1,27 @@
+package wasmmod
+
+import "errors"
+
+// Module-resolution error taxonomy. The service layer maps these to HTTP
+// status via apihttp.WriteStoreAwareError so the SDK can tell a terminal
+// failure (fix your ref / token) from a transient one (retry the pull).
+//
+// ErrComponentModelUnsupported (validate.go) is the sixth member of this set;
+// it is mapped to 422 the same way.
+var (
+	// ErrModuleNotFound: the ref named no reserved keyword, catalogue id, or
+	// local file. The service surfaces the valid reserved keywords alongside.
+	ErrModuleNotFound = errors.New("wasm module not found")
+	// ErrRegistryNotAllowed: an oci:// ref named a host outside
+	// SB_WASM_REGISTRY_ALLOWLIST. This is the SSRF guard — never relax it to
+	// a warning.
+	ErrRegistryNotAllowed = errors.New("wasm module registry not allowed")
+	// ErrRegistryAuth: the registry rejected our credentials (bad/expired PAT).
+	// Terminal — retrying without fixing the token will not help.
+	ErrRegistryAuth = errors.New("wasm module registry authentication failed")
+	// ErrRegistryUnavailable: network/registry transient failure. Retryable.
+	ErrRegistryUnavailable = errors.New("wasm module registry unavailable")
+	// ErrModuleTooLarge: the artifact exceeded the size cap mid-stream. We
+	// abort the pull rather than buffer an unbounded body.
+	ErrModuleTooLarge = errors.New("wasm module exceeds size cap")
+)

--- a/pkg/wasmmod/errors.go
+++ b/pkg/wasmmod/errors.go
@@ -24,4 +24,9 @@ var (
 	// ErrModuleTooLarge: the artifact exceeded the size cap mid-stream. We
 	// abort the pull rather than buffer an unbounded body.
 	ErrModuleTooLarge = errors.New("wasm module exceeds size cap")
+	// ErrModuleDigestMismatch: a sandbox pinned digest X at create, but the
+	// alias/tag it referenced now resolves to different bytes and the frozen
+	// copy is gone. We fail loudly rather than silently boot different code on
+	// restart/failover (codex C2).
+	ErrModuleDigestMismatch = errors.New("wasm module digest drift")
 )

--- a/pkg/wasmmod/oras_core.go
+++ b/pkg/wasmmod/oras_core.go
@@ -1,0 +1,196 @@
+package wasmmod
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/content/file"
+	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras-go/v2/registry/remote/auth"
+)
+
+// Shared ORAS transport. Both the checkpoint artifacts (oras_push.go /
+// oras_pull.go) and the BYO module artifacts (below) ride this one auth +
+// remote-repository setup so there is a single place to maintain AOCR
+// credential handling, host parsing, and error classification.
+
+// moduleArtifactType / moduleLayerMediaType describe a single-layer .wasm
+// artifact. Distinct from the snapshot artifact type so AOCR + tooling can
+// tell a module from a checkpoint.
+const (
+	moduleArtifactType   = "application/vnd.aerolvm.wasm-module.v1"
+	moduleLayerMediaType = "application/wasm"
+	// moduleLayerName is the file name the layer unpacks to on pull.
+	moduleLayerName = "module.wasm"
+)
+
+// newAuthedRepo builds an AOCR-authenticated remote repository for registryRef.
+// username is the registry login (cluster id for checkpoints, tenant id for
+// modules); pat is the already-read token. Single source of truth for the
+// auth.Client wiring.
+func newAuthedRepo(registryRef, username, pat string) (*remote.Repository, error) {
+	repo, err := remote.NewRepository(registryRef)
+	if err != nil {
+		return nil, fmt.Errorf("oras: repository %q: %w", registryRef, err)
+	}
+	host := registryHost(registryRef)
+	repo.Client = &auth.Client{
+		Client:     auth.DefaultClient.Client,
+		Cache:      auth.DefaultCache,
+		Credential: auth.StaticCredential(host, auth.Credential{Username: username, Password: pat}),
+	}
+	return repo, nil
+}
+
+// ModuleAuth carries the registry credentials for a BYO module pull/push.
+// Username is the AOCR login (tenant). PATPath is re-read on every call so a
+// rotated token takes effect without a restart, matching checkpoint semantics.
+type ModuleAuth struct {
+	Username string
+	PATPath  string
+}
+
+// PushModuleArtifact uploads a single local .wasm file to registryRef as a
+// one-layer OCI artifact. Returns the manifest digest. wasmPath must already
+// be a validated core module (caller runs ValidateFile).
+func PushModuleArtifact(ctx context.Context, a ModuleAuth, wasmPath, registryRef string) (digest string, err error) {
+	wasmPath = strings.TrimSpace(wasmPath)
+	registryRef = strings.TrimSpace(registryRef)
+	if wasmPath == "" || registryRef == "" {
+		return "", fmt.Errorf("oras push module: wasm path and registry ref required")
+	}
+	pat, err := readPATFile(a.PATPath)
+	if err != nil {
+		return "", fmt.Errorf("oras push module: read PAT: %w", err)
+	}
+
+	staging, err := os.MkdirTemp("", "aerol-wasm-module-push-*")
+	if err != nil {
+		return "", err
+	}
+	defer os.RemoveAll(staging)
+
+	fs, err := file.New(staging)
+	if err != nil {
+		return "", fmt.Errorf("oras push module: file store: %w", err)
+	}
+	defer fs.Close()
+
+	layerDesc, err := fs.Add(ctx, moduleLayerName, moduleLayerMediaType, wasmPath)
+	if err != nil {
+		return "", fmt.Errorf("oras push module: add layer: %w", err)
+	}
+	manifestDesc, err := oras.PackManifest(ctx, fs, oras.PackManifestVersion1_1, moduleArtifactType, oras.PackManifestOptions{
+		Layers: []ocispec.Descriptor{layerDesc},
+	})
+	if err != nil {
+		return "", fmt.Errorf("oras push module: pack manifest: %w", err)
+	}
+
+	repo, err := newAuthedRepo(registryRef, a.Username, pat)
+	if err != nil {
+		return "", err
+	}
+	tag := registryTag(registryRef)
+	if err := fs.Tag(ctx, manifestDesc, tag); err != nil {
+		return "", fmt.Errorf("oras push module: tag: %w", err)
+	}
+	if _, err := oras.Copy(ctx, fs, tag, repo, tag, oras.DefaultCopyOptions); err != nil {
+		return "", fmt.Errorf("oras push module: copy to %s: %w", registryRef, classifyRegistryErr(err))
+	}
+	return manifestDesc.Digest.String(), nil
+}
+
+// PullModuleArtifact downloads a single-layer .wasm artifact from registryRef
+// into dstDir and returns the unpacked file path. The caller is responsible
+// for validation (ValidateFile) and content-addressed publishing — this
+// function only does the transport. dstDir should be a caller-owned temp dir.
+//
+// maxBytes (>0) bounds the download: the manifest is resolved and its layer
+// sizes summed BEFORE any layer blob is fetched, so an oversized artifact is
+// rejected without buffering it. This is the DoS/SSRF size guard — a malicious
+// registry cannot make us pull an unbounded body.
+func PullModuleArtifact(ctx context.Context, a ModuleAuth, registryRef, dstDir string, maxBytes int64) (wasmPath string, err error) {
+	registryRef = strings.TrimSpace(registryRef)
+	dstDir = strings.TrimSpace(dstDir)
+	if registryRef == "" || dstDir == "" {
+		return "", fmt.Errorf("oras pull module: registry ref and dst dir required")
+	}
+	pat, err := readPATFile(a.PATPath)
+	if err != nil {
+		return "", fmt.Errorf("oras pull module: read PAT: %w", err)
+	}
+	if err := os.MkdirAll(dstDir, 0o700); err != nil {
+		return "", err
+	}
+
+	fs, err := file.New(dstDir)
+	if err != nil {
+		return "", fmt.Errorf("oras pull module: file store: %w", err)
+	}
+	defer fs.Close()
+
+	repo, err := newAuthedRepo(registryRef, a.Username, pat)
+	if err != nil {
+		return "", err
+	}
+	tag := registryTag(registryRef)
+
+	// Size preflight: resolve + fetch the manifest, sum layer sizes, reject
+	// before downloading blobs.
+	if maxBytes > 0 {
+		manifestDesc, rErr := repo.Resolve(ctx, tag)
+		if rErr != nil {
+			return "", fmt.Errorf("oras pull module: resolve %s: %w", registryRef, classifyRegistryErr(rErr))
+		}
+		manifestBytes, fErr := content.FetchAll(ctx, repo, manifestDesc)
+		if fErr != nil {
+			return "", fmt.Errorf("oras pull module: fetch manifest: %w", classifyRegistryErr(fErr))
+		}
+		var man ocispec.Manifest
+		if jErr := json.Unmarshal(manifestBytes, &man); jErr != nil {
+			return "", fmt.Errorf("oras pull module: parse manifest: %w", jErr)
+		}
+		var total int64
+		for _, l := range man.Layers {
+			total += l.Size
+		}
+		if total > maxBytes {
+			return "", fmt.Errorf("%w: artifact layers %d bytes > cap %d", ErrModuleTooLarge, total, maxBytes)
+		}
+	}
+
+	if _, err := oras.Copy(ctx, repo, tag, fs, tag, oras.DefaultCopyOptions); err != nil {
+		return "", fmt.Errorf("oras pull module: copy from %s: %w", registryRef, classifyRegistryErr(err))
+	}
+	out := filepath.Join(dstDir, moduleLayerName)
+	if st, statErr := os.Stat(out); statErr != nil || st.IsDir() {
+		return "", fmt.Errorf("oras pull module: unpacked artifact missing %s in %s", moduleLayerName, dstDir)
+	}
+	return out, nil
+}
+
+// classifyRegistryErr maps an ORAS/registry transport error onto the typed
+// taxonomy so the service can pick the right HTTP status. Auth failures are
+// terminal; everything else network-ish is retryable.
+func classifyRegistryErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "unauthorized") || strings.Contains(msg, "401") ||
+		strings.Contains(msg, "forbidden") || strings.Contains(msg, "403") ||
+		strings.Contains(msg, "credential") || strings.Contains(msg, "denied"):
+		return fmt.Errorf("%w: %v", ErrRegistryAuth, err)
+	default:
+		return fmt.Errorf("%w: %v", ErrRegistryUnavailable, err)
+	}
+}

--- a/pkg/wasmmod/oras_core.go
+++ b/pkg/wasmmod/oras_core.go
@@ -50,11 +50,34 @@ func newAuthedRepo(registryRef, username, pat string) (*remote.Repository, error
 }
 
 // ModuleAuth carries the registry credentials for a BYO module pull/push.
-// Username is the AOCR login (tenant). PATPath is re-read on every call so a
-// rotated token takes effect without a restart, matching checkpoint semantics.
+// Username is the AOCR login.
+//
+// Two credential sources, by design:
+//   - PAT: an inline token. This is the PER-TENANT path — the token rides the
+//     create/push request (req.Registry.Password) and is never persisted in
+//     plaintext. Thousands of tenants each supply their own; nothing is
+//     configured globally.
+//   - PATPath: a token file. This is the SYSTEM path — the operator's identity
+//     for pulling the curated standard modules. Set once, re-read each call so
+//     rotation needs no restart.
+//
+// PAT wins when both are set.
 type ModuleAuth struct {
 	Username string
+	PAT      string
 	PATPath  string
+}
+
+// token resolves the effective credential: the inline per-tenant PAT if
+// present, else the system token file.
+func (a ModuleAuth) token() (string, error) {
+	if strings.TrimSpace(a.PAT) != "" {
+		return strings.TrimSpace(a.PAT), nil
+	}
+	if strings.TrimSpace(a.PATPath) == "" {
+		return "", fmt.Errorf("no registry credential: neither inline token nor PAT file set")
+	}
+	return readPATFile(a.PATPath)
 }
 
 // PushModuleArtifact uploads a single local .wasm file to registryRef as a
@@ -66,9 +89,9 @@ func PushModuleArtifact(ctx context.Context, a ModuleAuth, wasmPath, registryRef
 	if wasmPath == "" || registryRef == "" {
 		return "", fmt.Errorf("oras push module: wasm path and registry ref required")
 	}
-	pat, err := readPATFile(a.PATPath)
+	pat, err := a.token()
 	if err != nil {
-		return "", fmt.Errorf("oras push module: read PAT: %w", err)
+		return "", fmt.Errorf("oras push module: %w", err)
 	}
 
 	staging, err := os.MkdirTemp("", "aerol-wasm-module-push-*")
@@ -123,9 +146,9 @@ func PullModuleArtifact(ctx context.Context, a ModuleAuth, registryRef, dstDir s
 	if registryRef == "" || dstDir == "" {
 		return "", fmt.Errorf("oras pull module: registry ref and dst dir required")
 	}
-	pat, err := readPATFile(a.PATPath)
+	pat, err := a.token()
 	if err != nil {
-		return "", fmt.Errorf("oras pull module: read PAT: %w", err)
+		return "", fmt.Errorf("oras pull module: %w", err)
 	}
 	if err := os.MkdirAll(dstDir, 0o700); err != nil {
 		return "", err

--- a/pkg/wasmmod/oras_core.go
+++ b/pkg/wasmmod/oras_core.go
@@ -131,6 +131,32 @@ func PushModuleArtifact(ctx context.Context, a ModuleAuth, wasmPath, registryRef
 	return manifestDesc.Digest.String(), nil
 }
 
+// ResolveModuleManifestDigest performs a credentialed manifest HEAD/GET and
+// returns the manifest content digest WITHOUT downloading any layer blob. It is
+// the cheap, per-caller authorization + cache-key step the resolver runs before
+// a full pull: every caller still authenticates to the registry here (so a
+// cache shortcut never bypasses registry authz), but only ONE of N concurrent
+// duplicate creates goes on to download the blobs (codex P0 single-flight).
+func ResolveModuleManifestDigest(ctx context.Context, a ModuleAuth, registryRef string) (string, error) {
+	registryRef = strings.TrimSpace(registryRef)
+	if registryRef == "" {
+		return "", fmt.Errorf("oras resolve module: registry ref required")
+	}
+	pat, err := a.token()
+	if err != nil {
+		return "", fmt.Errorf("oras resolve module: %w", err)
+	}
+	repo, err := newAuthedRepo(registryRef, a.Username, pat)
+	if err != nil {
+		return "", err
+	}
+	desc, err := repo.Resolve(ctx, registryTag(registryRef))
+	if err != nil {
+		return "", fmt.Errorf("oras resolve module: resolve %s: %w", registryRef, classifyRegistryErr(err))
+	}
+	return desc.Digest.String(), nil
+}
+
 // PullModuleArtifact downloads a single-layer .wasm artifact from registryRef
 // into dstDir and returns the unpacked file path. The caller is responsible
 // for validation (ValidateFile) and content-addressed publishing — this

--- a/pkg/wasmmod/oras_module_integration_test.go
+++ b/pkg/wasmmod/oras_module_integration_test.go
@@ -1,0 +1,69 @@
+//go:build integration
+
+// Live-registry integration test for the BYO module push/pull round-trip.
+// Gated behind the `integration` build tag so the default `go test` stays
+// hermetic; CI runs it with `go test -tags integration` when AOCR creds are
+// present. Validates the two things mocks can't: real token auth and that the
+// .wasm artifact mediaType round-trips through the registry (plan §7.2).
+//
+// Required env:
+//
+//	AEROL_WASM_IT_REF       full registry ref, e.g. aocr.aerol.ai/tenant/it-test:latest
+//	AEROL_WASM_IT_USERNAME  registry login
+//	AEROL_WASM_IT_TOKEN     registry PAT (inline)
+package wasmmod
+
+import (
+	"context"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIntegrationModulePushPullRoundTrip(t *testing.T) {
+	ref := os.Getenv("AEROL_WASM_IT_REF")
+	username := os.Getenv("AEROL_WASM_IT_USERNAME")
+	token := os.Getenv("AEROL_WASM_IT_TOKEN")
+	if ref == "" || token == "" {
+		t.Skip("set AEROL_WASM_IT_REF + AEROL_WASM_IT_TOKEN to run the live-AOCR integration test")
+	}
+	ctx := context.Background()
+	auth := ModuleAuth{Username: username, PAT: token}
+
+	// Push a minimal valid core-wasip1 module.
+	srcDir := t.TempDir()
+	src := WriteMinimalWasm(t, srcDir, "it.wasm")
+	wantDigestBytes, _, err := fileDigest(src)
+	if err != nil {
+		t.Fatalf("digest source: %v", err)
+	}
+
+	if _, err := PushModuleArtifact(ctx, auth, src, ref); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+
+	// Pull it back and assert the bytes are identical (digest round-trips).
+	dstDir := t.TempDir()
+	got, err := PullModuleArtifact(ctx, auth, ref, dstDir, maxModuleBytes)
+	if err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+	if err := ValidateFile(got); err != nil {
+		t.Fatalf("pulled artifact failed validation: %v", err)
+	}
+	gotDigest, _, err := fileDigest(got)
+	if err != nil {
+		t.Fatalf("digest pulled: %v", err)
+	}
+	if gotDigest != wantDigestBytes {
+		t.Fatalf("round-trip digest mismatch: pushed %s pulled %s", wantDigestBytes, gotDigest)
+	}
+	if filepath.Base(got) != moduleLayerName {
+		t.Fatalf("unexpected unpacked layer name %q", filepath.Base(got))
+	}
+	// Sanity: digest is hex sha256.
+	if _, err := hex.DecodeString(gotDigest); err != nil || len(gotDigest) != 64 {
+		t.Fatalf("digest not sha256 hex: %q", gotDigest)
+	}
+}

--- a/pkg/wasmmod/oras_pull.go
+++ b/pkg/wasmmod/oras_pull.go
@@ -8,8 +8,6 @@ import (
 
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content/file"
-	"oras.land/oras-go/v2/registry/remote"
-	"oras.land/oras-go/v2/registry/remote/auth"
 )
 
 // ORASPullConfig wires AOCR auth for WASM checkpoint pull (failover-from-snapshot).
@@ -59,15 +57,9 @@ func PullSnapshotArtifact(ctx context.Context, cfg ORASPullConfig, registryRef, 
 	}
 	defer fs.Close()
 
-	repo, err := remote.NewRepository(registryRef)
+	repo, err := newAuthedRepo(registryRef, cfg.ClusterID, pat)
 	if err != nil {
-		return fmt.Errorf("oras pull: repository: %w", err)
-	}
-	repoHost := registryHost(registryRef)
-	repo.Client = &auth.Client{
-		Client:     auth.DefaultClient.Client,
-		Cache:      auth.DefaultCache,
-		Credential: auth.StaticCredential(repoHost, auth.Credential{Username: cfg.ClusterID, Password: pat}),
+		return err
 	}
 
 	tag := registryTag(registryRef)

--- a/pkg/wasmmod/oras_push.go
+++ b/pkg/wasmmod/oras_push.go
@@ -152,9 +152,23 @@ func registryHost(ref string) string {
 	return ref
 }
 
+// registryTag returns the tag or digest portion of a registry ref. The host
+// (and any :port on it) is stripped first so "host:port/repo" no longer parses
+// the port colon as a tag, and a "host/repo@sha256:<digest>" pin resolves to
+// the digest reference rather than treating the last colon as a tag delimiter
+// (codex P2). Used by push (always a tag) and pull/resolve (tag OR digest).
 func registryTag(ref string) string {
-	if i := strings.LastIndex(ref, ":"); i >= 0 && i < len(ref)-1 {
-		return ref[i+1:]
+	ref = strings.TrimSpace(ref)
+	rest := ref
+	if i := strings.Index(ref, "/"); i >= 0 {
+		rest = ref[i+1:]
+	}
+	// A digest pin (repo@sha256:<hex>) wins over tag parsing.
+	if i := strings.Index(rest, "@"); i >= 0 && i < len(rest)-1 {
+		return rest[i+1:]
+	}
+	if i := strings.LastIndex(rest, ":"); i >= 0 && i < len(rest)-1 {
+		return rest[i+1:]
 	}
 	return "latest"
 }

--- a/pkg/wasmmod/oras_push.go
+++ b/pkg/wasmmod/oras_push.go
@@ -11,8 +11,6 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content/file"
-	"oras.land/oras-go/v2/registry/remote"
-	"oras.land/oras-go/v2/registry/remote/auth"
 )
 
 var snapshotLayerMediaTypes = map[string]string{
@@ -131,15 +129,9 @@ func PushSnapshotArtifact(ctx context.Context, cfg ORASPushConfig, memSnapDir, r
 		return "", fmt.Errorf("oras push: pack manifest: %w", err)
 	}
 
-	repo, err := remote.NewRepository(registryRef)
+	repo, err := newAuthedRepo(registryRef, cfg.ClusterID, pat)
 	if err != nil {
-		return "", fmt.Errorf("oras push: repository: %w", err)
-	}
-	repoHost := registryHost(registryRef)
-	repo.Client = &auth.Client{
-		Client:     auth.DefaultClient.Client,
-		Cache:      auth.DefaultCache,
-		Credential: auth.StaticCredential(repoHost, auth.Credential{Username: cfg.ClusterID, Password: pat}),
+		return "", err
 	}
 
 	tag := registryTag(registryRef)

--- a/pkg/wasmmod/oras_push_test.go
+++ b/pkg/wasmmod/oras_push_test.go
@@ -94,6 +94,23 @@ func TestRegistryHelpers(t *testing.T) {
 	if registryTag("host/path") != "latest" {
 		t.Fatal("registryTag failed")
 	}
+	// codex P2: a :port on the host must not be parsed as the tag, and an
+	// @sha256:<digest> pin must resolve to the digest reference.
+	cases := map[string]string{
+		"host:5000/repo:v1":           "v1",
+		"host:5000/repo":              "latest",
+		"host/repo@sha256:abc123":     "sha256:abc123",
+		"host:5000/ns/repo@sha256:de": "sha256:de",
+		"host:5000/ns/repo":           "latest",
+	}
+	for ref, want := range cases {
+		if got := registryTag(ref); got != want {
+			t.Fatalf("registryTag(%q) = %q, want %q", ref, got, want)
+		}
+	}
+	if registryHost("host:5000/repo:v1") != "host:5000" {
+		t.Fatal("registryHost should preserve :port")
+	}
 }
 
 func TestORASPushConfigValidation(t *testing.T) {

--- a/pkg/wasmmod/resolve.go
+++ b/pkg/wasmmod/resolve.go
@@ -1,0 +1,197 @@
+package wasmmod
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ModuleResolver is the single resolution chokepoint for every module_ref
+// shape. ALL callers (sandbox create, CreateWasmModule, start/rehydrate by
+// pinned digest, failover) go through Resolve so that allowlist enforcement,
+// core-wasip1 validation, digest computation, and atomic cache publishing
+// happen in exactly one place. Splitting this logic across call sites is how
+// the SSRF allowlist or the validation gets silently skipped on one path.
+//
+// Resolution precedence (a single ref grammar with explicit ordering — see
+// codex C3, the alias/bare-file collision):
+//
+//  1. reserved keyword  ("python")      -> ModulesDir/<staged filename>
+//  2. oci:// ref        ("oci://h/r:t") -> allowlist -> pull -> cache/<digest>.wasm
+//  3. catalogue id      (BYO digest id) -> CatalogueLookup -> local path
+//  4. file:// / abs / bare filename     -> ModulesDir (legacy Resolver)
+//
+// Reserved keywords win over a same-named bare file on disk, so a stray
+// ModulesDir/python file can never shadow the standard "python" runtime.
+type ModuleResolver struct {
+	// file does steps 1/4 local resolution + validation + digest.
+	file *Resolver
+	// CacheDir holds pulled oci:// modules as <digest>.wasm. Distinct from the
+	// checkpoint root so eviction never walks a passivated sandbox's mem.snap.
+	CacheDir string
+	// Reserved maps a standard keyword to its staged filename under ModulesDir
+	// (e.g. "python" -> "python.wasm"). Provisioned by Ansible, identical fleet
+	// wide; never DB-backed (codex C1).
+	Reserved map[string]string
+	// Allowlist is the set of registry hosts an oci:// ref may target. Empty
+	// means "deny all remote pulls" — the safe default until configured.
+	Allowlist map[string]struct{}
+	// PullTimeout bounds a single oci:// pull so it cannot stall sandbox boot.
+	PullTimeout time.Duration
+	// MaxBytes caps a pulled artifact (mirrors ValidateFile's 256MiB).
+	MaxBytes int64
+	// Auth carries the default registry credentials for oci:// pulls. A
+	// per-tenant override can be passed to ResolveWithAuth (failover, BYO).
+	Auth ModuleAuth
+	// CatalogueLookup resolves a BYO catalogue id to an already-local path +
+	// digest. Optional; nil disables step 3.
+	CatalogueLookup func(ctx context.Context, id string) (path, digest string, ok bool)
+}
+
+// NewModuleResolver builds a chokepoint over modulesDir. cacheDir defaults to
+// modulesDir/cache when empty.
+func NewModuleResolver(modulesDir, cacheDir string) *ModuleResolver {
+	if strings.TrimSpace(cacheDir) == "" {
+		cacheDir = filepath.Join(modulesDir, "cache")
+	}
+	return &ModuleResolver{
+		file:      &Resolver{ModulesDir: modulesDir},
+		CacheDir:  cacheDir,
+		Reserved:  map[string]string{},
+		Allowlist: map[string]struct{}{},
+		MaxBytes:  maxModuleBytes,
+	}
+}
+
+// Resolve resolves ref using the default Auth.
+func (r *ModuleResolver) Resolve(ctx context.Context, ref string) (*ResolvedModule, error) {
+	return r.ResolveWithAuth(ctx, ref, nil)
+}
+
+// ResolveWithAuth resolves ref, using authOverride for an oci:// pull when
+// non-nil (failover hands the original tenant's sealed creds here so a private
+// module re-pulls on the new owner — codex C4).
+func (r *ModuleResolver) ResolveWithAuth(ctx context.Context, ref string, authOverride *ModuleAuth) (*ResolvedModule, error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return nil, fmt.Errorf("%w: empty ref", ErrModuleNotFound)
+	}
+
+	// 1. Reserved keyword (exact, case-insensitive, no scheme/slash).
+	if !strings.Contains(ref, "/") && !strings.Contains(ref, "://") {
+		if filename, ok := r.Reserved[strings.ToLower(ref)]; ok {
+			return r.file.Resolve(ctx, filename)
+		}
+	}
+
+	// 2. oci:// remote ref.
+	if strings.HasPrefix(ref, "oci://") {
+		return r.resolveOCI(ctx, ref, authOverride)
+	}
+
+	// 3. BYO catalogue id.
+	if r.CatalogueLookup != nil {
+		if path, digest, ok := r.CatalogueLookup(ctx, ref); ok {
+			if err := ValidateFile(path); err != nil {
+				return nil, err
+			}
+			return &ResolvedModule{Ref: ref, Path: path, Digest: digest}, nil
+		}
+	}
+
+	// 4. file:// / absolute / bare filename under ModulesDir.
+	resolved, err := r.file.Resolve(ctx, ref)
+	if err != nil {
+		// Normalize a missing-file into the typed not-found so the service can
+		// answer 404 with the valid reserved keywords.
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("%w: %q", ErrModuleNotFound, ref)
+		}
+		return nil, err
+	}
+	return resolved, nil
+}
+
+// resolveOCI enforces the allowlist, then pulls (single artifact) into a temp
+// dir, validates, digests, and atomically publishes to CacheDir/<digest>.wasm.
+// A cache hit (same digest already published) skips the network entirely on
+// the second-and-later resolve of the same bytes.
+func (r *ModuleResolver) resolveOCI(ctx context.Context, ref string, authOverride *ModuleAuth) (*ResolvedModule, error) {
+	registryRef := strings.TrimPrefix(ref, "oci://")
+	host := registryHost(registryRef)
+	if host == "" {
+		return nil, fmt.Errorf("%w: oci ref has no host", ErrModuleNotFound)
+	}
+	if _, ok := r.Allowlist[host]; !ok {
+		return nil, fmt.Errorf("%w: %q", ErrRegistryNotAllowed, host)
+	}
+
+	auth := r.Auth
+	if authOverride != nil {
+		auth = *authOverride
+	}
+
+	if err := os.MkdirAll(r.CacheDir, 0o700); err != nil {
+		return nil, err
+	}
+
+	pullCtx := ctx
+	if r.PullTimeout > 0 {
+		var cancel context.CancelFunc
+		pullCtx, cancel = context.WithTimeout(ctx, r.PullTimeout)
+		defer cancel()
+	}
+
+	tmpDir, err := os.MkdirTemp(r.CacheDir, ".pull-*")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	wasmPath, err := PullModuleArtifact(pullCtx, auth, registryRef, tmpDir, r.MaxBytes)
+	if err != nil {
+		return nil, err
+	}
+	// Validate (core-wasip1, size, magic) BEFORE the bytes are publishable.
+	if err := ValidateFile(wasmPath); err != nil {
+		return nil, err
+	}
+	digest, size, err := fileDigest(wasmPath)
+	if err != nil {
+		return nil, err
+	}
+
+	final := filepath.Join(r.CacheDir, digest+".wasm")
+	if st, statErr := os.Stat(final); statErr == nil && !st.IsDir() {
+		// Cache hit: identical bytes already published by a prior resolve.
+		return &ResolvedModule{Ref: ref, Path: final, Digest: digest, SizeBytes: st.Size()}, nil
+	}
+
+	// Atomic publish: fsync the temp file, then rename into place. A reader
+	// only ever sees an absent file or the complete artifact — never a
+	// half-written one (hard rule 4).
+	if err := fsyncFile(wasmPath); err != nil {
+		return nil, err
+	}
+	if err := os.Rename(wasmPath, final); err != nil {
+		// Lost a publish race with a concurrent resolve of the same digest;
+		// the existing file is byte-identical, so treat it as a hit.
+		if st, statErr := os.Stat(final); statErr == nil && !st.IsDir() {
+			return &ResolvedModule{Ref: ref, Path: final, Digest: digest, SizeBytes: st.Size()}, nil
+		}
+		return nil, err
+	}
+	return &ResolvedModule{Ref: ref, Path: final, Digest: digest, SizeBytes: size}, nil
+}
+
+func fsyncFile(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return f.Sync()
+}

--- a/pkg/wasmmod/resolve.go
+++ b/pkg/wasmmod/resolve.go
@@ -7,6 +7,16 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// ociResolveManifestFunc and ociPullArtifactFunc are the network boundary for
+// resolveOCI. Tests swap them to exercise cache/single-flight without a live
+// registry.
+var (
+	ociResolveManifestFunc = ResolveModuleManifestDigest
+	ociPullArtifactFunc    = PullModuleArtifact
 )
 
 // ModuleResolver is the single resolution chokepoint for every module_ref
@@ -49,6 +59,14 @@ type ModuleResolver struct {
 	// CatalogueLookup resolves a BYO catalogue id to an already-local path +
 	// digest. Optional; nil disables step 3.
 	CatalogueLookup func(ctx context.Context, id string) (path, digest string, ok bool)
+
+	// pullGroup collapses concurrent oci:// blob downloads of the same manifest
+	// digest to a single network pull. N duplicate creates of one module_ref
+	// (e.g. a 100k-wide warm-up of "oci://…/python:1") download once and share
+	// the published cache file, instead of each racing its own pull (codex P0).
+	// Keyed on the manifest digest, NOT the ref, so each caller has already
+	// passed its own credentialed manifest resolve before joining the group.
+	pullGroup singleflight.Group
 }
 
 // NewModuleResolver builds a chokepoint over modulesDir. cacheDir defaults to
@@ -115,10 +133,12 @@ func (r *ModuleResolver) ResolveWithAuth(ctx context.Context, ref string, authOv
 	return resolved, nil
 }
 
-// resolveOCI enforces the allowlist, then pulls (single artifact) into a temp
-// dir, validates, digests, and atomically publishes to CacheDir/<digest>.wasm.
-// A cache hit (same digest already published) skips the network entirely on
-// the second-and-later resolve of the same bytes.
+// resolveOCI enforces the allowlist, resolves the manifest digest with the
+// caller's own credentials (cheap, no blob download), and short-circuits to the
+// content-addressed cache when that manifest's bytes are already local — so the
+// second-and-later resolve of the same tag does ZERO blob I/O. Only on a true
+// cache miss does it pull, and that pull is single-flighted on the manifest
+// digest so 100k concurrent duplicate creates download exactly once (codex P0).
 func (r *ModuleResolver) resolveOCI(ctx context.Context, ref string, authOverride *ModuleAuth) (*ResolvedModule, error) {
 	registryRef := strings.TrimPrefix(ref, "oci://")
 	host := registryHost(registryRef)
@@ -145,13 +165,77 @@ func (r *ModuleResolver) resolveOCI(ctx context.Context, ref string, authOverrid
 		defer cancel()
 	}
 
+	// Per-caller credentialed manifest resolve: this both authorizes the caller
+	// against the registry AND yields the cache key, all without fetching a blob.
+	// A registry that refuses our token fails here, so the cache shortcut below
+	// can never serve bytes to an unauthorized caller.
+	manifestDigest, err := ociResolveManifestFunc(pullCtx, auth, registryRef)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache shortcut: the manifest digest points at a previously-published
+	// content file. No blob download, no single-flight needed.
+	if rm, ok := r.lookupByManifest(manifestDigest); ok {
+		rm.Ref = ref
+		return rm, nil
+	}
+
+	// True miss: single-flight the blob pull on the manifest digest so duplicate
+	// concurrent creates collapse to one download. Every joiner already passed
+	// its own manifest resolve above.
+	v, err, _ := r.pullGroup.Do(manifestDigest, func() (interface{}, error) {
+		// Re-check the cache inside the group: an earlier in-flight pull for this
+		// same manifest may have published while we were queued.
+		if rm, ok := r.lookupByManifest(manifestDigest); ok {
+			return rm, nil
+		}
+		return r.pullAndPublish(pullCtx, registryRef, manifestDigest, auth)
+	})
+	if err != nil {
+		return nil, err
+	}
+	rm := *(v.(*ResolvedModule))
+	rm.Ref = ref
+	return &rm, nil
+}
+
+// manifestPointer is the on-disk hint mapping a manifest digest to the content
+// digest of the published .wasm, so a repeat resolve of a mutable tag can hit
+// the cache after a single credentialed manifest resolve (no blob download).
+func (r *ModuleResolver) manifestPointer(manifestDigest string) string {
+	return filepath.Join(r.CacheDir, ".manifest", sanitizeDigest(manifestDigest))
+}
+
+// lookupByManifest returns the published module for a manifest digest if both
+// the pointer and the content file it names are present.
+func (r *ModuleResolver) lookupByManifest(manifestDigest string) (*ResolvedModule, bool) {
+	b, err := os.ReadFile(r.manifestPointer(manifestDigest))
+	if err != nil {
+		return nil, false
+	}
+	contentDigest := strings.TrimSpace(string(b))
+	if contentDigest == "" {
+		return nil, false
+	}
+	final := filepath.Join(r.CacheDir, contentDigest+".wasm")
+	st, err := os.Stat(final)
+	if err != nil || st.IsDir() {
+		return nil, false
+	}
+	return &ResolvedModule{Path: final, Digest: contentDigest, SizeBytes: st.Size()}, true
+}
+
+// pullAndPublish downloads, validates, digests, atomically publishes the blob,
+// and records the manifest→content pointer. Runs under the single-flight group.
+func (r *ModuleResolver) pullAndPublish(ctx context.Context, registryRef, manifestDigest string, auth ModuleAuth) (*ResolvedModule, error) {
 	tmpDir, err := os.MkdirTemp(r.CacheDir, ".pull-*")
 	if err != nil {
 		return nil, err
 	}
 	defer os.RemoveAll(tmpDir)
 
-	wasmPath, err := PullModuleArtifact(pullCtx, auth, registryRef, tmpDir, r.MaxBytes)
+	wasmPath, err := ociPullArtifactFunc(ctx, auth, registryRef, tmpDir, r.MaxBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +251,8 @@ func (r *ModuleResolver) resolveOCI(ctx context.Context, ref string, authOverrid
 	final := filepath.Join(r.CacheDir, digest+".wasm")
 	if st, statErr := os.Stat(final); statErr == nil && !st.IsDir() {
 		// Cache hit: identical bytes already published by a prior resolve.
-		return &ResolvedModule{Ref: ref, Path: final, Digest: digest, SizeBytes: st.Size()}, nil
+		r.writeManifestPointer(manifestDigest, digest)
+		return &ResolvedModule{Path: final, Digest: digest, SizeBytes: st.Size()}, nil
 	}
 
 	// Atomic publish: fsync the temp file, then rename into place. A reader
@@ -180,11 +265,41 @@ func (r *ModuleResolver) resolveOCI(ctx context.Context, ref string, authOverrid
 		// Lost a publish race with a concurrent resolve of the same digest;
 		// the existing file is byte-identical, so treat it as a hit.
 		if st, statErr := os.Stat(final); statErr == nil && !st.IsDir() {
-			return &ResolvedModule{Ref: ref, Path: final, Digest: digest, SizeBytes: st.Size()}, nil
+			r.writeManifestPointer(manifestDigest, digest)
+			return &ResolvedModule{Path: final, Digest: digest, SizeBytes: st.Size()}, nil
 		}
 		return nil, err
 	}
-	return &ResolvedModule{Ref: ref, Path: final, Digest: digest, SizeBytes: size}, nil
+	r.writeManifestPointer(manifestDigest, digest)
+	return &ResolvedModule{Path: final, Digest: digest, SizeBytes: size}, nil
+}
+
+// writeManifestPointer records the manifest→content hint atomically. Best
+// effort: a failed write only costs a future blob re-pull, never correctness.
+func (r *ModuleResolver) writeManifestPointer(manifestDigest, contentDigest string) {
+	dir := filepath.Join(r.CacheDir, ".manifest")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return
+	}
+	tmp, err := os.CreateTemp(dir, ".ptr-*")
+	if err != nil {
+		return
+	}
+	tmpName := tmp.Name()
+	_, werr := tmp.WriteString(contentDigest)
+	cerr := tmp.Close()
+	if werr != nil || cerr != nil {
+		_ = os.Remove(tmpName)
+		return
+	}
+	if err := os.Rename(tmpName, r.manifestPointer(manifestDigest)); err != nil {
+		_ = os.Remove(tmpName)
+	}
+}
+
+// sanitizeDigest makes a manifest digest ("sha256:abc…") safe as a filename.
+func sanitizeDigest(d string) string {
+	return strings.ReplaceAll(strings.TrimSpace(d), ":", "-")
 }
 
 // ResolveByDigest returns the content-addressed cached module for digest, if a

--- a/pkg/wasmmod/resolve.go
+++ b/pkg/wasmmod/resolve.go
@@ -187,6 +187,23 @@ func (r *ModuleResolver) resolveOCI(ctx context.Context, ref string, authOverrid
 	return &ResolvedModule{Ref: ref, Path: final, Digest: digest, SizeBytes: size}, nil
 }
 
+// ResolveByDigest returns the content-addressed cached module for digest, if a
+// frozen copy exists in CacheDir. start/rehydrate use this to boot the EXACT
+// bytes pinned at create rather than re-resolving a mutable alias/tag (codex
+// C2). Reports ok=false on a cache miss; the caller then falls back to ref
+// resolution with a digest-match assertion.
+func (r *ModuleResolver) ResolveByDigest(digest string) (*ResolvedModule, bool) {
+	digest = strings.TrimSpace(digest)
+	if digest == "" {
+		return nil, false
+	}
+	p := filepath.Join(r.CacheDir, digest+".wasm")
+	if st, err := os.Stat(p); err == nil && !st.IsDir() {
+		return &ResolvedModule{Ref: digest, Path: p, Digest: digest, SizeBytes: st.Size()}, true
+	}
+	return nil, false
+}
+
 func fsyncFile(path string) error {
 	f, err := os.Open(path)
 	if err != nil {

--- a/pkg/wasmmod/resolve_oci_test.go
+++ b/pkg/wasmmod/resolve_oci_test.go
@@ -1,0 +1,404 @@
+package wasmmod
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func swapOCIFunc[T any](target *T, stub T) func() {
+	prev := *target
+	*target = stub
+	return func() { *target = prev }
+}
+
+// P0: manifest resolve happens before any blob download; a warm manifest
+// pointer must short-circuit resolveOCI without calling the pull transport.
+func TestResolveOCISkipsPullWhenManifestPointerWarm(t *testing.T) {
+	mr := newTestModuleResolver(t)
+	mr.Allowlist = map[string]struct{}{"registry.example": {}}
+
+	src := WriteMinimalWasm(t, t.TempDir(), "m.wasm")
+	digest, _, err := fileDigest(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(mr.CacheDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	copyFile(t, src, filepath.Join(mr.CacheDir, digest+".wasm"))
+
+	const manifest = "sha256:warmmanifest"
+	mr.writeManifestPointer(manifest, digest)
+
+	var pulls int32
+	restoreManifest := swapOCIFunc(&ociResolveManifestFunc, func(context.Context, ModuleAuth, string) (string, error) {
+		return manifest, nil
+	})
+	defer restoreManifest()
+	restorePull := swapOCIFunc(&ociPullArtifactFunc, func(context.Context, ModuleAuth, string, string, int64) (string, error) {
+		atomic.AddInt32(&pulls, 1)
+		return "", errors.New("pull should not run")
+	})
+	defer restorePull()
+
+	got, err := mr.Resolve(context.Background(), "oci://registry.example/org/mod:v1")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if pulls != 0 {
+		t.Fatalf("expected zero pulls on manifest cache hit, got %d", pulls)
+	}
+	if got.Digest != digest || got.Path != filepath.Join(mr.CacheDir, digest+".wasm") {
+		t.Fatalf("unexpected resolved module: %+v", got)
+	}
+	if got.Ref != "oci://registry.example/org/mod:v1" {
+		t.Fatalf("ref = %q", got.Ref)
+	}
+}
+
+// P0: concurrent resolves of the same manifest digest must single-flight the
+// blob pull so only one download runs.
+func TestResolveOCISingleFlightCollapsesConcurrentPulls(t *testing.T) {
+	mr := newTestModuleResolver(t)
+	mr.Allowlist = map[string]struct{}{"registry.example": {}}
+
+	const manifest = "sha256:singleflight"
+	var pulls int32
+	var gate sync.WaitGroup
+	gate.Add(1)
+
+	restoreManifest := swapOCIFunc(&ociResolveManifestFunc, func(context.Context, ModuleAuth, string) (string, error) {
+		return manifest, nil
+	})
+	defer restoreManifest()
+	restorePull := swapOCIFunc(&ociPullArtifactFunc, func(_ context.Context, _ ModuleAuth, _ string, dstDir string, _ int64) (string, error) {
+		if atomic.AddInt32(&pulls, 1) == 1 {
+			gate.Done()
+			time.Sleep(30 * time.Millisecond)
+		} else {
+			t.Fatal("pull invoked more than once")
+		}
+		return WriteMinimalWasm(t, dstDir, moduleLayerName), nil
+	})
+	defer restorePull()
+
+	const workers = 16
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := mr.Resolve(context.Background(), "oci://registry.example/org/mod:v1")
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+	}
+	if pulls != 1 {
+		t.Fatalf("expected exactly 1 pull, got %d", pulls)
+	}
+}
+
+// P0: a credentialed manifest resolve failure must abort before any pull.
+func TestResolveOCIManifestAuthFailureSkipsPull(t *testing.T) {
+	mr := newTestModuleResolver(t)
+	mr.Allowlist = map[string]struct{}{"registry.example": {}}
+
+	var pulls int32
+	restoreManifest := swapOCIFunc(&ociResolveManifestFunc, func(context.Context, ModuleAuth, string) (string, error) {
+		return "", fmt.Errorf("%w: denied", ErrRegistryAuth)
+	})
+	defer restoreManifest()
+	restorePull := swapOCIFunc(&ociPullArtifactFunc, func(context.Context, ModuleAuth, string, string, int64) (string, error) {
+		atomic.AddInt32(&pulls, 1)
+		return "", nil
+	})
+	defer restorePull()
+
+	_, err := mr.Resolve(context.Background(), "oci://registry.example/org/mod:v1")
+	if !errors.Is(err, ErrRegistryAuth) {
+		t.Fatalf("want ErrRegistryAuth, got %v", err)
+	}
+	if pulls != 0 {
+		t.Fatalf("pull ran after manifest auth failure")
+	}
+}
+
+func TestResolveOCIRejectsMissingHost(t *testing.T) {
+	mr := newTestModuleResolver(t)
+	mr.Allowlist = map[string]struct{}{"": {}}
+	_, err := mr.Resolve(context.Background(), "oci://")
+	if !errors.Is(err, ErrModuleNotFound) {
+		t.Fatalf("want ErrModuleNotFound, got %v", err)
+	}
+}
+
+func TestPullAndPublishPublishesAndRecordsManifestPointer(t *testing.T) {
+	mr := newTestModuleResolver(t)
+	if err := os.MkdirAll(mr.CacheDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	const manifest = "sha256:publishmanifest"
+	restorePull := swapOCIFunc(&ociPullArtifactFunc, func(_ context.Context, _ ModuleAuth, _ string, dstDir string, _ int64) (string, error) {
+		return WriteMinimalWasm(t, dstDir, moduleLayerName), nil
+	})
+	defer restorePull()
+
+	got, err := mr.pullAndPublish(context.Background(), "registry.example/org/mod:v1", manifest, ModuleAuth{})
+	if err != nil {
+		t.Fatalf("pullAndPublish: %v", err)
+	}
+	if _, err := os.Stat(got.Path); err != nil {
+		t.Fatalf("published file missing: %v", err)
+	}
+	if _, ok := mr.lookupByManifest(manifest); !ok {
+		t.Fatal("manifest pointer not written after publish")
+	}
+}
+
+func TestPullAndPublishReusesExistingContentFile(t *testing.T) {
+	mr := newTestModuleResolver(t)
+	src := WriteMinimalWasm(t, t.TempDir(), "m.wasm")
+	digest, _, err := fileDigest(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(mr.CacheDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	final := filepath.Join(mr.CacheDir, digest+".wasm")
+	copyFile(t, src, final)
+
+	const manifest = "sha256:reusecontent"
+	restorePull := swapOCIFunc(&ociPullArtifactFunc, func(_ context.Context, _ ModuleAuth, _ string, dstDir string, _ int64) (string, error) {
+		// Return different temp bytes with the same digest path already present.
+		return WriteMinimalWasm(t, dstDir, moduleLayerName), nil
+	})
+	defer restorePull()
+
+	got, err := mr.pullAndPublish(context.Background(), "registry.example/org/mod:v1", manifest, ModuleAuth{})
+	if err != nil {
+		t.Fatalf("pullAndPublish: %v", err)
+	}
+	if got.Path != final {
+		t.Fatalf("path = %q, want %q", got.Path, final)
+	}
+	if _, ok := mr.lookupByManifest(manifest); !ok {
+		t.Fatal("manifest pointer should be recorded on content cache hit")
+	}
+}
+
+func TestFsyncFile(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "sync.wasm")
+	if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsyncFile(p); err != nil {
+		t.Fatalf("fsyncFile: %v", err)
+	}
+	if err := fsyncFile(filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestSanitizeDigest(t *testing.T) {
+	if got := sanitizeDigest("sha256:abc"); got != "sha256-abc" {
+		t.Fatalf("sanitizeDigest = %q", got)
+	}
+}
+
+func TestNewModuleResolverDefaultCacheDir(t *testing.T) {
+	modules := t.TempDir()
+	mr := NewModuleResolver(modules, "")
+	if mr.CacheDir != filepath.Join(modules, "cache") {
+		t.Fatalf("CacheDir = %q, want %q", mr.CacheDir, filepath.Join(modules, "cache"))
+	}
+}
+
+func TestResolveOCIAppliesPullTimeout(t *testing.T) {
+	mr := newTestModuleResolver(t)
+	mr.Allowlist = map[string]struct{}{"registry.example": {}}
+	mr.PullTimeout = time.Millisecond
+
+	restoreManifest := swapOCIFunc(&ociResolveManifestFunc, func(ctx context.Context, _ ModuleAuth, _ string) (string, error) {
+		<-ctx.Done()
+		return "", ctx.Err()
+	})
+	defer restoreManifest()
+
+	_, err := mr.Resolve(context.Background(), "oci://registry.example/org/mod:v1")
+	if err == nil {
+		t.Fatal("expected timeout/cancel error")
+	}
+}
+
+func TestResolveOCIMkdirCacheFailure(t *testing.T) {
+	mr := newTestModuleResolver(t)
+	mr.Allowlist = map[string]struct{}{"registry.example": {}}
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mr.CacheDir = filepath.Join(blocker, "cache")
+
+	restoreManifest := swapOCIFunc(&ociResolveManifestFunc, func(context.Context, ModuleAuth, string) (string, error) {
+		return "sha256:never", nil
+	})
+	defer restoreManifest()
+
+	_, err := mr.Resolve(context.Background(), "oci://registry.example/org/mod:v1")
+	if err == nil {
+		t.Fatal("expected mkdir failure")
+	}
+}
+
+func TestPullAndPublishPullTransportError(t *testing.T) {
+	mr := newTestModuleResolver(t)
+	if err := os.MkdirAll(mr.CacheDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	restorePull := swapOCIFunc(&ociPullArtifactFunc, func(context.Context, ModuleAuth, string, string, int64) (string, error) {
+		return "", errors.New("network down")
+	})
+	defer restorePull()
+
+	_, err := mr.pullAndPublish(context.Background(), "registry.example/org/mod:v1", "sha256:net", ModuleAuth{})
+	if err == nil || !strings.Contains(err.Error(), "network down") {
+		t.Fatalf("pull error = %v", err)
+	}
+}
+
+func TestPullAndPublishRejectsInvalidArtifact(t *testing.T) {
+	mr := newTestModuleResolver(t)
+	if err := os.MkdirAll(mr.CacheDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	restorePull := swapOCIFunc(&ociPullArtifactFunc, func(_ context.Context, _ ModuleAuth, _ string, dstDir string, _ int64) (string, error) {
+		p := filepath.Join(dstDir, moduleLayerName)
+		if err := os.WriteFile(p, []byte("not wasm"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return p, nil
+	})
+	defer restorePull()
+
+	_, err := mr.pullAndPublish(context.Background(), "registry.example/org/mod:v1", "sha256:bad", ModuleAuth{})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+// Inside single-flight, a waiter must observe a manifest pointer written by the
+// leader without issuing its own pull.
+func TestPullAndPublishConcurrentPublishRace(t *testing.T) {
+	mr := newTestModuleResolver(t)
+	if err := os.MkdirAll(mr.CacheDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	const manifest = "sha256:race"
+	restorePull := swapOCIFunc(&ociPullArtifactFunc, func(_ context.Context, _ ModuleAuth, _ string, dstDir string, _ int64) (string, error) {
+		return WriteMinimalWasm(t, dstDir, moduleLayerName), nil
+	})
+	defer restorePull()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	errs := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := mr.pullAndPublish(context.Background(), "registry.example/org/mod:v1", manifest, ModuleAuth{})
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("pullAndPublish: %v", err)
+		}
+	}
+	if _, ok := mr.lookupByManifest(manifest); !ok {
+		t.Fatal("manifest pointer missing after concurrent publish")
+	}
+}
+
+func TestWriteManifestPointerBestEffortOnReadOnlyDir(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root can write through read-only dirs on some platforms")
+	}
+	mr := newTestModuleResolver(t)
+	dir := filepath.Join(mr.CacheDir, ".manifest")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+	// Must not panic; a failed write only costs a future re-pull.
+	mr.writeManifestPointer("sha256:readonly", "sha256:content")
+}
+
+func TestResolveOCISingleFlightWaitsOnLeaderPublish(t *testing.T) {
+	mr := newTestModuleResolver(t)
+	mr.Allowlist = map[string]struct{}{"registry.example": {}}
+
+	const manifest = "sha256:leaderpublish"
+	var pulls int32
+	start := make(chan struct{})
+
+	restoreManifest := swapOCIFunc(&ociResolveManifestFunc, func(context.Context, ModuleAuth, string) (string, error) {
+		return manifest, nil
+	})
+	defer restoreManifest()
+	restorePull := swapOCIFunc(&ociPullArtifactFunc, func(_ context.Context, _ ModuleAuth, _ string, dstDir string, _ int64) (string, error) {
+		if atomic.AddInt32(&pulls, 1) != 1 {
+			t.Fatal("only leader may pull")
+		}
+		close(start)
+		time.Sleep(40 * time.Millisecond)
+		return WriteMinimalWasm(t, dstDir, moduleLayerName), nil
+	})
+	defer restorePull()
+
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, err := mr.Resolve(context.Background(), "oci://registry.example/org/mod:v1")
+		errs <- err
+	}()
+	<-start
+	go func() {
+		defer wg.Done()
+		_, err := mr.Resolve(context.Background(), "oci://registry.example/org/mod:v2")
+		errs <- err
+	}()
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+	}
+	if pulls != 1 {
+		t.Fatalf("pulls = %d, want 1", pulls)
+	}
+}

--- a/pkg/wasmmod/resolve_pinned_test.go
+++ b/pkg/wasmmod/resolve_pinned_test.go
@@ -45,6 +45,57 @@ func TestResolveByDigestMiss(t *testing.T) {
 	}
 }
 
+// The manifest→content pointer lets a repeat resolve of a mutable tag hit the
+// cache after only a cheap credentialed manifest resolve — no blob download.
+// This is the steady-state half of the codex P0 single-flight fix.
+func TestManifestPointerRoundTrip(t *testing.T) {
+	mr := newTestModuleResolver(t)
+	src := WriteMinimalWasm(t, t.TempDir(), "m.wasm")
+	digest, _, err := fileDigest(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(mr.CacheDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	copyFile(t, src, filepath.Join(mr.CacheDir, digest+".wasm"))
+
+	const manifestDigest = "sha256:manifestabc"
+	// Before the pointer exists, the manifest lookup misses.
+	if _, ok := mr.lookupByManifest(manifestDigest); ok {
+		t.Fatal("expected miss before pointer written")
+	}
+	mr.writeManifestPointer(manifestDigest, digest)
+	got, ok := mr.lookupByManifest(manifestDigest)
+	if !ok {
+		t.Fatalf("expected hit after pointer written")
+	}
+	if got.Digest != digest {
+		t.Fatalf("pointer resolved to %q, want %q", got.Digest, digest)
+	}
+	// A pointer whose content file was evicted must miss (and trigger a re-pull),
+	// never return a dangling path.
+	if err := os.Remove(filepath.Join(mr.CacheDir, digest+".wasm")); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := mr.lookupByManifest(manifestDigest); ok {
+		t.Fatal("expected miss after content file evicted")
+	}
+}
+
+func TestLookupByManifestRejectsBlankPointer(t *testing.T) {
+	mr := newTestModuleResolver(t)
+	if err := os.MkdirAll(filepath.Join(mr.CacheDir, ".manifest"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mr.manifestPointer("sha256:blank"), []byte("  \n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := mr.lookupByManifest("sha256:blank"); ok {
+		t.Fatal("blank pointer must miss")
+	}
+}
+
 func copyFile(t *testing.T, src, dst string) {
 	t.Helper()
 	b, err := os.ReadFile(src)

--- a/pkg/wasmmod/resolve_pinned_test.go
+++ b/pkg/wasmmod/resolve_pinned_test.go
@@ -1,0 +1,57 @@
+package wasmmod
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ResolveByDigest returns the frozen cached copy, ignoring any alias retarget.
+// This is the byte-freezing half of the codex C2 fix: a sandbox that pinned a
+// digest at create boots those exact bytes on restart even if its alias now
+// points elsewhere.
+func TestResolveByDigestCacheHit(t *testing.T) {
+	mr := newTestModuleResolver(t)
+	// Simulate a previously-pulled module published in the content cache.
+	src := WriteMinimalWasm(t, t.TempDir(), "m.wasm")
+	digest, _, err := fileDigest(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(mr.CacheDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	frozen := filepath.Join(mr.CacheDir, digest+".wasm")
+	copyFile(t, src, frozen)
+
+	got, ok := mr.ResolveByDigest(digest)
+	if !ok {
+		t.Fatalf("expected cache hit for %s", digest)
+	}
+	if got.Path != frozen || got.Digest != digest {
+		t.Fatalf("unexpected: %+v", got)
+	}
+}
+
+// A digest with no frozen copy misses, so the caller falls back to ref
+// resolution (and its drift assertion).
+func TestResolveByDigestMiss(t *testing.T) {
+	mr := newTestModuleResolver(t)
+	if _, ok := mr.ResolveByDigest("deadbeef"); ok {
+		t.Fatal("expected miss for uncached digest")
+	}
+	if _, ok := mr.ResolveByDigest(""); ok {
+		t.Fatal("empty digest must miss")
+	}
+}
+
+func copyFile(t *testing.T, src, dst string) {
+	t.Helper()
+	b, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/wasmmod/resolve_test.go
+++ b/pkg/wasmmod/resolve_test.go
@@ -1,0 +1,130 @@
+package wasmmod
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func newTestModuleResolver(t *testing.T) *ModuleResolver {
+	t.Helper()
+	modulesDir := t.TempDir()
+	cacheDir := t.TempDir()
+	mr := NewModuleResolver(modulesDir, cacheDir)
+	return mr
+}
+
+// Reserved keyword resolves to its staged filename under ModulesDir.
+func TestResolveReservedKeyword(t *testing.T) {
+	mr := newTestModuleResolver(t)
+	WriteMinimalWasm(t, mr.file.ModulesDir, "python.wasm")
+	mr.Reserved = map[string]string{"python": "python.wasm"}
+
+	got, err := mr.Resolve(context.Background(), "python")
+	if err != nil {
+		t.Fatalf("resolve reserved: %v", err)
+	}
+	if got.Path != filepath.Join(mr.file.ModulesDir, "python.wasm") || got.Digest == "" {
+		t.Fatalf("unexpected: %+v", got)
+	}
+}
+
+// A reserved keyword must win over a same-named bare file on disk (codex C3).
+func TestResolveReservedKeywordBeatsBareFile(t *testing.T) {
+	mr := newTestModuleResolver(t)
+	// Stray file literally named "python" (no .wasm) sitting in modules dir.
+	WriteMinimalWasm(t, mr.file.ModulesDir, "python")
+	// The staged standard runtime.
+	WriteMinimalWasm(t, mr.file.ModulesDir, "python.wasm")
+	mr.Reserved = map[string]string{"python": "python.wasm"}
+
+	got, err := mr.Resolve(context.Background(), "python")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(got.Path) != "python.wasm" {
+		t.Fatalf("reserved keyword shadowed by bare file: %q", got.Path)
+	}
+}
+
+// SECURITY: an oci:// host not on the allowlist is rejected before any network
+// call. This is the SSRF guard.
+func TestResolveOCIRejectsNonAllowlistedHost(t *testing.T) {
+	mr := newTestModuleResolver(t)
+	mr.Allowlist = map[string]struct{}{"aocr.aerol.ai": {}}
+
+	for _, ref := range []string{
+		"oci://169.254.169.254/tenant/app:latest",
+		"oci://attacker.example.com/x:1",
+		"oci://localhost:5000/y:1",
+	} {
+		_, err := mr.Resolve(context.Background(), ref)
+		if !errors.Is(err, ErrRegistryNotAllowed) {
+			t.Fatalf("ref %q: want ErrRegistryNotAllowed, got %v", ref, err)
+		}
+	}
+}
+
+// An empty allowlist denies all remote pulls (safe default).
+func TestResolveOCIEmptyAllowlistDeniesAll(t *testing.T) {
+	mr := newTestModuleResolver(t)
+	_, err := mr.Resolve(context.Background(), "oci://aocr.aerol.ai/t/app:latest")
+	if !errors.Is(err, ErrRegistryNotAllowed) {
+		t.Fatalf("want ErrRegistryNotAllowed, got %v", err)
+	}
+}
+
+// Bare filename under ModulesDir still resolves (legacy path preserved).
+func TestResolveBareFile(t *testing.T) {
+	mr := newTestModuleResolver(t)
+	WriteMinimalWasm(t, mr.file.ModulesDir, "agent.wasm")
+	got, err := mr.Resolve(context.Background(), "agent.wasm")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(got.Path) != "agent.wasm" {
+		t.Fatalf("path = %q", got.Path)
+	}
+}
+
+// A ref that matches nothing yields the typed not-found.
+func TestResolveNotFound(t *testing.T) {
+	mr := newTestModuleResolver(t)
+	_, err := mr.Resolve(context.Background(), "nope.wasm")
+	if !errors.Is(err, ErrModuleNotFound) {
+		t.Fatalf("want ErrModuleNotFound, got %v", err)
+	}
+}
+
+// BYO catalogue id resolves through CatalogueLookup to a local path.
+func TestResolveCatalogueID(t *testing.T) {
+	mr := newTestModuleResolver(t)
+	path := WriteMinimalWasm(t, mr.file.ModulesDir, "byo.wasm")
+	mr.CatalogueLookup = func(_ context.Context, id string) (string, string, bool) {
+		if id == "sha256abc" {
+			return path, "sha256abc", true
+		}
+		return "", "", false
+	}
+	got, err := mr.Resolve(context.Background(), "sha256abc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Path != path || got.Digest != "sha256abc" {
+		t.Fatalf("unexpected: %+v", got)
+	}
+}
+
+// classifyRegistryErr maps auth-ish failures to terminal, others to retryable.
+func TestClassifyRegistryErr(t *testing.T) {
+	if err := classifyRegistryErr(errors.New("401 unauthorized")); !errors.Is(err, ErrRegistryAuth) {
+		t.Fatalf("want ErrRegistryAuth, got %v", err)
+	}
+	if err := classifyRegistryErr(errors.New("connection refused")); !errors.Is(err, ErrRegistryUnavailable) {
+		t.Fatalf("want ErrRegistryUnavailable, got %v", err)
+	}
+	if err := classifyRegistryErr(nil); err != nil {
+		t.Fatalf("nil should stay nil, got %v", err)
+	}
+}

--- a/pkg/wasmmod/validate.go
+++ b/pkg/wasmmod/validate.go
@@ -10,6 +10,10 @@ import (
 
 var wasmMagic = []byte{0x00, 0x61, 0x73, 0x6d} // \0asm
 
+// maxModuleBytes caps a .wasm artifact (256MiB). Enforced both post-download
+// (ValidateFile) and as the pre-download manifest-size bound on oci:// pulls.
+const maxModuleBytes = 256 << 20
+
 // ErrComponentModelUnsupported flags a WASI Component Model artifact. Neither
 // engine in this repo (wazero, nor wasmtime-go which has no component API) can
 // instantiate a component — both run core wasip1 modules only. Detecting it here
@@ -28,7 +32,7 @@ func ValidateFile(path string) error {
 	if st.Size() == 0 {
 		return fmt.Errorf("wasm module %q is empty", path)
 	}
-	if st.Size() > 256<<20 {
+	if st.Size() > maxModuleBytes {
 		return fmt.Errorf("wasm module %q exceeds 256MiB cap", path)
 	}
 	head := make([]byte, 8)

--- a/plans/wasm-standard-modules-distribution.md
+++ b/plans/wasm-standard-modules-distribution.md
@@ -1,0 +1,390 @@
+# WASM Standard Modules & OCI Distribution Plan
+
+Status: **Draft / not started**
+Owner: @sumansaurabh
+Created: 2026-06-12
+
+## 1. Problem statement
+
+Today a WASM sandbox is created with a `module_ref` that the create-path resolver
+(`pkg/wasmmod/resolver.go`) can only interpret as a **local file** on the daemon
+host (`file://`, absolute path, or a bare name under `SB_WASM_MODULES_DIR`).
+
+That is unworkable for a multi-tenant SaaS:
+
+- A customer using the SDK cannot know or reference a path on our server disk.
+- There is no way to pull a module from a registry at create time. The ORAS code
+  that exists (`pkg/wasmmod/oras_pull.go`, `oras_push.go`) is **checkpoint-only**
+  (`PushSnapshotArtifact` / `PullSnapshotArtifact` operate on `mem.snap`
+  directories for failover), not general module distribution.
+- We ship **no standard language modules**. There is no `python.wasm`,
+  `quickjs.wasm`, etc. baked into the platform.
+
+We already operate **AOCR** — an authenticated OCI-distribution registry backed by
+S3 (`registry/config.yml`) whose mirror proxy already accepts
+`application/vnd.oci.image.manifest.v1+json` (`mirror/proxy.go:24`). So AOCR can
+store WASM as ORAS artifacts today; only the consumption side is missing.
+
+### Goal
+
+Two complementary distribution channels, end to end (server + SDK + docs + IaC):
+
+1. **Standard modules** — a curated set of language-interpreter `.wasm` modules
+   (Python, JS/QuickJS, Ruby, etc.) **pre-staged onto every sandboxd node via
+   Ansible/Terraform**, referenced by a short stable alias
+   (`module_ref: "python"`), with **zero per-create network cost**.
+2. **Bring-your-own (BYO) modules** — customers `push` their own `.wasm` to AOCR
+   and `pull` it by an `oci://` ref, resolved + content-addressed + cached at
+   create time.
+
+Both must flow through the **snapshot/checkpoint** machinery so that a created
+WASM sandbox (whether from a standard module or a BYO module) can be passivated,
+checkpointed, pushed to AOCR, and rehydrated on failover — the "default way WASM
+is created" in both the snapshot and runtime cases.
+
+## 2. Current-state findings (grounded)
+
+| Area | Finding | File |
+|---|---|---|
+| Module resolution | File-only: `file://`, abs path, bare name under modules dir | `pkg/wasmmod/resolver.go:25-64` |
+| OCI pull | Exists but checkpoint-only (`mem.snap` dirs) | `pkg/wasmmod/oras_pull.go` |
+| OCI push | Exists but checkpoint-only | `pkg/wasmmod/oras_push.go` |
+| Validation | Core wasip1 only; rejects components; 256MiB cap; sha256 digest | `pkg/wasmmod/validate.go` |
+| Module catalogue | `CreateWasmModule` upserts a row keyed by digest; **create path does NOT look up by catalogue id** | `internal/service/wasm_module_api.go:29`, `internal/runtime/wasm/create.go:26-31` |
+| Create resolution | Calls `resolver.Resolve(ref)` directly on `module_ref` | `internal/runtime/wasm/create.go:26-31` |
+| Config | `SB_WASM_MODULES_DIR` default `/var/lib/sandboxd/wasm/modules`; required when `SB_ENABLE_WASM` | `internal/config/config.go:1190,1426` |
+| SDK | `moduleRef` field present; a TS test references an `https://` ref the server can't honor | `sdk/typescript/src/MicroVM.ts:236`, `MicroVM.test.ts:1067` |
+| AOCR | OCI-distribution + S3 + token auth; accepts OCI artifact manifests | `aocr.sh/registry/config.yml`, `aocr.sh/mirror/proxy.go:24` |
+| Ansible | Playbooks only, no roles dir yet | `Ansible/playbooks/` |
+| Terraform | `nodes.tf` + `templates/` for node provisioning | `Terraform/` |
+
+### Gap summary
+
+- **No `oci://` scheme** in the resolver.
+- **No generic module pull** (only checkpoint pull).
+- **No standard-module staging** in Ansible/Terraform.
+- **No alias → module mapping** so `module_ref: "python"` resolves stably.
+- **SDK/docs** assume a host file path.
+
+## 3. Use cases (target: 50+)
+
+### A. Standard module provisioning (operator / IaC)
+1. Operator declares a list of standard modules in Terraform vars and they appear on every node.
+2. Operator adds a new standard module (e.g. `php`) by editing one Ansible var, re-running the role.
+3. Operator pins a standard module to an exact digest for reproducibility.
+4. Operator upgrades a standard module version cluster-wide via a rolling Ansible run.
+5. Operator removes a deprecated standard module from all nodes.
+6. New node joins the cluster and is auto-provisioned with the full standard-module set on boot.
+7. Standard modules are sourced from AOCR (single registry of record), pulled during provisioning.
+8. Standard modules are alternatively sourced from a pinned upstream release URL (no AOCR round-trip).
+9. Provisioning verifies each module's sha256 digest before activating it.
+10. Provisioning rejects a WASI-component artifact early with a clear operator error.
+11. Provisioning is idempotent — re-running the role does not re-download unchanged modules.
+12. Standard modules land in `SB_WASM_MODULES_DIR` with correct perms/ownership for sandboxd.
+13. A node missing a standard module surfaces a health/metric signal, not a silent failure.
+14. Air-gapped install: modules are bundled in a local artifact store, no public egress needed.
+15. Operator runs a single command to list which standard modules each node currently has.
+
+### B. Standard module consumption (SDK user)
+16. User creates a WASM sandbox with `module_ref: "python"` (alias) — no host path.
+17. User lists available standard modules via the SDK and picks one.
+18. User creates a Python sandbox and runs a user-supplied `.py` script via the toolbox.
+19. User creates a JS sandbox (QuickJS) and runs user-supplied JS.
+20. User creates a Ruby sandbox and runs a user-supplied `.rb` script.
+21. User references a standard module by alias **and** gets a deterministic digest in the response.
+22. User passes an unknown alias and gets a clear `module not found` error listing valid aliases.
+23. User creates many sandboxes off the same standard module with warm-pool reuse (no cold pull).
+24. Standard-module create has the same boot latency whether it is the first or Nth call.
+25. User pins `module_ref: "python@<digest>"` to lock a version across a deployment.
+
+### C. Bring-your-own module push (SDK user)
+26. User pushes their own `.wasm` to AOCR via the SDK and gets back an `oci://` ref + digest.
+27. Push validates core-wasip1 + size locally before upload (fast failure).
+28. Push is idempotent — re-pushing identical bytes is a no-op returning the same digest.
+29. Push to a tag (`myapp:latest`) and to an immutable digest both work.
+30. User pushes a new version of an existing module; old digest remains pullable.
+31. Push respects AOCR per-user auth (PAT) and tenant repository scoping.
+32. User deletes their pushed module from AOCR via the SDK.
+33. Push surfaces a clear error when the artifact is a WASI component.
+34. Push surfaces registry auth failure distinctly from network failure.
+
+### D. Bring-your-own module pull / create (SDK user)
+35. User creates a sandbox with `module_ref: "oci://aocr.aerol.ai/<tenant>/myapp:latest"`.
+36. First create pulls + caches the module; subsequent creates hit the local cache.
+37. Pull is content-addressed; a tag re-pointed upstream is re-pulled on cache miss.
+38. Concurrent duplicate creates of the same uncached oci ref pull once (single-flight), not N times.
+39. Pull failure (auth/network/not-found) yields a precise, retryable error to the SDK.
+40. A pulled BYO module is validated (core-wasip1, size) before it is allowed to run.
+41. BYO module digest is recorded in the catalogue and sandbox record.
+42. Cache eviction reclaims disk for unreferenced BYO modules without breaking running sandboxes.
+43. Pull honors a configurable timeout so create boot-latency is bounded.
+44. `oci://` ref with an explicit digest skips the tag→digest resolution round-trip.
+
+### E. Snapshot / checkpoint / failover (the "default way" WASM is created)
+45. A standard-module sandbox is passivated → checkpoint written → rehydrated on daemon restart.
+46. A BYO-module sandbox is passivated and rehydrated identically.
+47. A `durable` WASM sandbox pushes its checkpoint to AOCR and fails over to a peer.
+48. Failover peer that lacks the **base module** pulls it from AOCR before rehydrating the checkpoint.
+49. Checkpoint push/pull reuses the same AOCR auth + ORAS path as module distribution.
+50. Snapshot-created and runtime-created WASM sandboxes share one create entry point (no version branching).
+51. A standard module upgraded under a running passivatable sandbox does not corrupt its checkpoint (digest pinned to the instance).
+52. Recreate-from-snapshot resolves the original module digest, not the current alias target.
+
+### F. SDK / docs / DX
+53. All five SDKs (TS, Python, Go, Rust, Java) expose `module_ref` alias + `oci://` + push/pull in lockstep.
+54. Docs show "use a standard module" (alias) as the primary path, host paths as advanced.
+55. Docs show the BYO push→create flow with five-language tabs.
+56. Docs document the core-wasip1 requirement and how to produce one per language.
+57. SDK `listModules()` distinguishes standard (operator-staged) vs BYO (tenant) modules.
+
+> 57 use cases enumerated (≥50 target met). Sections E/F are the integration glue.
+
+## 4. Architecture / approach
+
+```
+                 push (.wasm)                      pull (oci://)
+  SDK user ───────────────────► AOCR (OCI/S3) ◄────────────────── sandboxd resolver
+                                   ▲                                   │
+                                   │ provisioning pull                 │ cache + validate
+                          Ansible/Terraform                           ▼
+                          stage standard modules ──► SB_WASM_MODULES_DIR ──► create/run
+```
+
+### Resolver extension (server)
+Generalize `pkg/wasmmod` resolution to accept, in priority order:
+1. `oci://host/repo[:tag|@sha256:...]` → ORAS pull into a content-addressed cache under `SB_WASM_MODULES_DIR/_oci/<digest>.wasm`, then validate.
+2. Alias (no scheme, no slash, in alias map) → resolve to a staged standard module.
+3. `file://` / abs / bare-name → existing behavior (unchanged).
+
+Add a **generic module ORAS pull** (separate from the checkpoint pull): a
+`PullModuleArtifact(ctx, cfg, ref, dstDir) (digest, path, error)` alongside the
+existing `PullSnapshotArtifact`, sharing auth/host helpers.
+
+### Alias map
+Operator-controlled mapping `alias → {oci ref | filename}` provisioned by Ansible
+into a config file (e.g. `SB_WASM_MODULES_DIR/aliases.json`) or env. The catalogue
+(`CreateWasmModule`) is the natural store; provisioning calls the create-module
+API per standard module so `module_ref: "python"` resolves via catalogue → digest.
+**Decision needed** (see §7): alias map file vs. catalogue-backed lookup wired
+into the create path.
+
+### Single-flight + cache
+`oci://` pulls use the lazy-bootstrap single-flight pattern (`atomic.Bool` latch +
+`sync.Mutex`) per the repo's idempotency rule (CLAUDE.md hard rule 3), keyed by
+ref/digest, so concurrent duplicate creates pull once. Boot-latency impact MUST be
+documented in the PR (hard rule 2) — first-create pull cost called out explicitly.
+
+## 5. Implementation phases
+
+### Phase 0 — Spike & decisions (no code)
+- Confirm ORAS artifact mediaType we will use for `.wasm` and that AOCR round-trips it (`oras push`/`oras pull` smoke test against a dev AOCR).
+- Resolve §7 open questions.
+
+### Phase 1 — Server: generic module pull + resolver `oci://`
+- `pkg/wasmmod/oras_pull.go`: add `PullModuleArtifact` (single `.wasm`, content-addressed).
+- `pkg/wasmmod/resolver.go`: add scheme dispatch (`oci://`, alias, file). Keep file path untouched.
+- Cache dir `_oci/<digest>.wasm`; validate via existing `ValidateFile`.
+- Single-flight latch; bounded timeout (`SB_WASM_PULL_TIMEOUT`).
+- Tests: `resolver_test.go` (scheme matrix), pull single-flight, validation reject (component), cache hit/miss.
+- **Touches create boot path** → follow `/touch-create-sandbox`, PR call-out on latency + idempotency.
+
+### Phase 2 — Server: alias resolution + catalogue wiring
+- Wire create path to resolve alias via catalogue (or alias file) → digest before `resolver.Resolve`.
+- `CreateWasmModule` accepts an `alias` field; store an `alias` column (use `/add-store-column`, with host-port-pool-style regression test discipline).
+- Recreate/snapshot path pins the instance's original digest (use case 52).
+
+### Phase 3 — Server: module push + delete API
+- `pkg/wasmmod`: `PushModuleArtifact` (generic, mirrors checkpoint push).
+- New `/v1` routes: `POST /v1/wasm/modules/push`, `DELETE /v1/wasm/modules/{id}` (use `/add-v1-endpoint`).
+- Idempotent push (digest-keyed), component rejection, auth error mapping via `apihttp.WriteStoreAwareError`.
+
+### Phase 4 — SDK lockstep (all 5)
+- Add to each SDK (use `/add-sdk-method`): `listModules`, `pushModule`, `deleteModule`; `create({ moduleRef })` already supports alias/oci string (string passthrough — verify each transport).
+- Keep `pkg/models` DTO lean (CLAUDE.md convention).
+
+### Phase 5 — IaC: standard module staging
+- **Ansible role** `roles/wasm-standard-modules/`: var-driven list `wasm_standard_modules: [{alias, source(oci|url), ref, digest}]`; tasks: pull/fetch → verify digest → place in `SB_WASM_MODULES_DIR` (perms) → register via module API → idempotent.
+- Hook role into the sandboxd install/update flow (`playbooks/update-sandboxd.yml` companion playbook).
+- **Terraform**: expose `wasm_standard_modules` variable + render into the node provisioning template (`Terraform/templates/`), pass through to Ansible/cloud-init.
+- Health: emit a metric/log when a declared standard module is absent (use case 13).
+
+### Phase 6 — Docs
+- Rewrite `docs/src/content/docs/wasm-sandbox.mdx`: alias as primary (`module_ref: "python"`), host path demoted to "advanced".
+- New page `wasm-modules-distribution.mdx` (register in `content.config.ts`): standard vs BYO, push→create flow, five-language tabs, core-wasip1 callout. Follow `/add-docs-page` (no curl, all five SDK langs, `syncKey="lang"`).
+
+### Phase 7 — Snapshot/failover integration
+- Ensure failover peer pulls the **base module** (via Phase 1 `PullModuleArtifact`) before checkpoint rehydrate (use case 48).
+- Regression tests next to `recovery_*` / `wasm_checkpoint_*`.
+
+## 6. AOCR-side work (separate repo: `aocr.sh`)
+- Confirm token-auth scoping allows per-tenant `wasm/<tenant>/<name>` repositories.
+- Confirm reaper/TTL policy does not evict pinned standard-module digests (they must be `latest`-stable or digest-pinned).
+- Verify `notifications`/hooks don't choke on artifact (non-image) manifests.
+- Possibly publish the curated standard-module set to a well-known `wasm/std/*` namespace.
+
+## 7. Decisions (resolved in /plan-eng-review 2026-06-12)
+
+1. **Alias source of truth** — RESOLVED. Standard language modules are **reserved
+   keywords** (`python`, `javascript`, `ruby`, …) resolved to staged filenames on
+   disk, **staged identically on every node by Ansible**. The fleet contract comes
+   from Ansible, NOT the per-node SQLite catalogue (which gossips local DB state and
+   would drift — codex finding #1). BYO modules use the catalogue (inherently
+   per-tenant, per-create with an explicit ref, so per-node state is acceptable).
+2. **OCI mediaType** — Phase 0 spike must confirm the `.wasm` artifact mediaType
+   round-trips through AOCR (gated live integration test covers this; `mirror/proxy.go:24`
+   already accepts `application/vnd.oci.image.manifest.v1+json`).
+3. **Cache eviction** — RESOLVED. Per-digest **reference counting**, evict at zero
+   refs (codex finding #5). Eviction scans ONLY `SB_WASM_CACHE_DIR`, never checkpoint
+   `<sandboxID>/` dirs.
+4. **`oci://` at create vs pre-register** — RESOLVED: **support both**. Register-time
+   pull (`CreateWasmModule`) AND lazy pull-on-create. Both go through the single
+   `ResolveModule` chokepoint; both enforce the registry allowlist; pull-on-create
+   uses a single-flight latch and bounded `SB_WASM_PULL_TIMEOUT`.
+5. **Registry trust** — RESOLVED. `SB_WASM_REGISTRY_ALLOWLIST` (default: AOCR host
+   only) enforced in the chokepoint before any network call; size cap enforced
+   DURING the pull stream, not just post-download.
+6. Standard-module **default set** (initial): `python`, `javascript` (QuickJS),
+   `ruby` — confirm available core-wasip1 builds in Phase 0.
+
+## 7a. Review resolutions (architecture / code-quality / perf)
+
+| # | Decision | Rule |
+|---|---|---|
+| I1 | Pull happens at register-time AND lazily on create; both gated | rule 2/3 |
+| I2 | `SB_WASM_REGISTRY_ALLOWLIST` (AOCR default) + streaming size cap | SSRF |
+| I3 | Single `pkg/wasmmod.ResolveModule` chokepoint: classify → allowlist → fetch/find → ValidateFile → digest → atomic publish. All 4 ref kinds + both oci paths delegate to it. | DRY |
+| I4 | Pulled modules in separate `SB_WASM_CACHE_DIR`; write `<digest>.tmp` → fsync → ValidateFile → atomic rename. Eviction never touches checkpoint dirs. | rule 4 |
+| I5 | Extract shared ORAS transport core (`oras_core.go: newAuthedRepo`); module + checkpoint push/pull are thin callers. | DRY |
+| I6 | Typed error taxonomy → HTTP via `WriteStoreAwareError`: ErrModuleNotFound(404+aliases), ErrRegistryNotAllowed(403), ErrRegistryAuth(401/502), ErrRegistryUnavailable(502+Retry-After), ErrComponentUnsupported(422), ErrModuleTooLarge(413). | explicit |
+| I7 | Reserved-keyword standard aliases resolve via filesystem (no DB, no per-create query); BYO via catalogue + cached inventory. | rule 2 |
+
+## 7b. Codex outside-voice gaps (folded in as required work)
+
+| # | Gap | Fix |
+|---|---|---|
+| C2 | `StartSandbox`/`RehydrateSandbox` re-resolve `ModuleRef` every time → alias/tag move silently boots different bytes after restart/failover (`lifecycle.go:56-110`, `passivate.go:49-64`). **Correctness bug.** | Pin resolved digest onto the sandbox record at create; start/rehydrate/recreate boot the **frozen digest**, never re-resolve. Mandatory regression test. |
+| C3 | Alias grammar collides with bare-file refs (`resolver.go:25-63`) — `python` alias vs a real `modules/python`. | Explicit precedence in `ResolveModule`: reserved keyword → catalogue id → bare file. Documented collision policy. |
+| C4 | Private `oci://` modules have no failover auth lifecycle (`types.go:657-662`). Work on creator node, fail on next owner. | Persist per-module registry auth mirroring `RegistryAuthSealed`; hand to failover peer's `ResolveModule`. |
+| C5 | Delete/GC keyed on `module_ref` not digest (`wasm_module_health.go:36-74`, `wasm_module_api.go:136-161`) → shared bytes stomp each other. | Per-digest reference accounting (same as I4 eviction); delete only at zero refs. |
+| C6 | Non-SDK entrypoints bypass the new logic: `facadeutil.TranslateWasmCreate` (Daytona) + cluster capacity gossip off local inventory (`facadeutil/wasm.go:20-43`, `daemon.go:482-488`). | Route facade create through `ResolveModule`; verify gossip inventory reflects reserved keywords + catalogued modules. |
+| C1 | (TENSION, resolved) DB-backed alias map drifts per node. | Sidestepped — standard modules are Ansible-staged reserved keywords, not DB rows (see §7.1). |
+
+## 7c. NOT in scope
+
+- **`wasm32-wasip2` / WASI Component Model support** — runtime executes core
+  modules only (`validate.go:51`); components rejected, not lowered. Deferred.
+- **In-server `.wasm` compilation** — users/operators bring compiled modules.
+- **A web UI for module management** — API + SDK + IaC only.
+- **Multi-registry federation** — allowlist supports >1 host but no mirroring/
+  failover across registries; AOCR is the registry of record.
+- **Automatic interpreter-module sourcing** — the curated standard set (`python`,
+  etc.) is operator-provided; no auto-discovery of upstream builds.
+
+## 7d. What already exists (reuse, don't rebuild)
+
+- `pkg/wasmmod/resolver.go` — bare-filename resolution already works (standard
+  modules need ZERO new resolution code; reserved keywords ARE staged filenames).
+- `pkg/wasmmod/oras_pull.go` / `oras_push.go` — checkpoint ORAS; **factor** the
+  shared transport (I5) rather than duplicate.
+- `internal/service/wasm_module_api.go` — `CreateWasmModule` is the register-time
+  ingest; extend it, don't replace.
+- `RegistryAuthSealed` (`types.go:657`, `service.go:1451-1482`) — the exact pattern
+  for C4 module-auth failover; mirror it.
+- `localReadyWasmModuleIDs` cache (`wasm_module_api.go:105,181`) — reuse for BYO
+  inventory; standard keywords skip it entirely.
+- `AOCR` — OCI-distribution + S3 + token auth + artifact manifests already accepted.
+
+## 7e. Failure modes (new codepaths)
+
+| Codepath | Realistic failure | Test? | Error handling? | User sees? |
+|---|---|---|---|---|
+| pull-on-create | registry down mid-boot | yes (mock) | ErrRegistryUnavailable 502 + Retry-After | clear, retryable |
+| pull atomic publish | process killed mid-pull | **mandatory** | tmp file discarded, never visible | n/a (invisible) |
+| allowlist check | tenant passes internal IP | **mandatory** | ErrRegistryNotAllowed 403 | clear |
+| start/rehydrate | alias retargeted post-create | **mandatory** | boots frozen digest | correct bytes (no surprise) |
+| failover module pull | peer lacks private-module auth | **mandatory** | sealed auth handed to peer | rehydrate succeeds |
+| GC/delete | shared digest, one alias deleted | **mandatory** | refcount > 0 blocks delete | other sandbox unaffected |
+
+**Critical gap flagged:** C2 (silent code-swap on restart) had NO test and NO
+error handling in the original plan — it would fail **silently** (sandbox boots
+different code, no error). Now mandatory-tested + digest-pinned.
+
+## 7f. Worktree parallelization
+
+| Lane | Modules | Depends on |
+|---|---|---|
+| A | `pkg/wasmmod/` (ResolveModule, oras_core, push/pull module) | — |
+| B | `internal/store/` (alias/digest columns, refcount) | — |
+| C | `internal/service/` + `internal/runtime/wasm/` (create/start/rehydrate digest pin, GC refcount, auth seal) | A, B |
+| D | `pkg/api/v1/` + `pkg/api/facadeutil/` (routes, Daytona) | C |
+| E | `sdk/*` (5 SDKs, independent of each other) | D (API shape) |
+| F | `Ansible/` + `Terraform/` (standard-module staging) | — (only needs filenames) |
+| G | `docs/` | D (final API shape) |
+
+Execution: **Launch A, B, F in parallel.** Merge A+B → build C. Then D → E (5 SDK
+sub-lanes parallel) and G. F lands anytime. Conflict flag: C touches both service
+and runtime/wasm — keep as one lane, no sub-split.
+
+## 7g. Implementation Tasks
+Synthesized from this review. P1 blocks ship; P2 same branch; P3 follow-up.
+
+- [ ] **T1 (P1)** — wasmmod — Single `ResolveModule` chokepoint (classify/allowlist/validate/digest/atomic-publish)
+  - Surfaced by: Arch I3. Files: `pkg/wasmmod/resolve.go`. Verify: `resolver_test.go` scheme matrix + allowlist reject.
+- [ ] **T2 (P1)** — wasmmod — Registry allowlist + in-stream size cap
+  - Surfaced by: Arch I2 (SSRF). Files: `pkg/wasmmod/resolve.go`, `internal/config/config.go`. Verify: rejects internal IP / non-allowlisted host.
+- [ ] **T3 (P1)** — wasmmod — Extract shared ORAS transport; add Pull/PushModuleArtifact
+  - Surfaced by: CodeQual I5. Files: `pkg/wasmmod/oras_core.go`, `oras_pull.go`, `oras_push.go`. Verify: module + checkpoint roundtrip via one auth path.
+- [ ] **T4 (P1)** — service/runtime — Pin resolved digest at create; start/rehydrate/recreate boot frozen digest
+  - Surfaced by: Codex C2 (correctness). Files: `internal/runtime/wasm/lifecycle.go`, `passivate.go`, store column. Verify: alias retarget → restart boots original bytes.
+- [ ] **T5 (P1)** — store — alias + module_digest + refcount columns (host-port-pool test discipline)
+  - Surfaced by: Test review + C5. Files: `internal/store/store.go`. Verify: `store_test.go`.
+- [ ] **T6 (P1)** — service — Single-flight pull latch on create
+  - Surfaced by: Test review (rule 3). Files: `internal/service/wasm.go`. Verify: N concurrent creates → 1 pull.
+- [ ] **T7 (P1)** — cluster — Failover peer pulls base module (+ sealed auth) before rehydrate
+  - Surfaced by: Codex C4 + rule 6. Files: `internal/cluster/recovery_*.go`, `internal/service`. Verify: peer-lacking-module test.
+- [ ] **T8 (P2)** — service — Per-digest GC refcounting; delete only at zero refs
+  - Surfaced by: Codex C5. Files: `wasm_module_api.go`, `wasm_module_health.go`. Verify: shared-digest delete blocked.
+- [ ] **T9 (P2)** — service — Typed error taxonomy → WriteStoreAwareError
+  - Surfaced by: CodeQual I6. Files: `pkg/models`, `pkg/api/apihttp`. Verify: status-code matrix test.
+- [ ] **T10 (P2)** — api/facade — `POST/DELETE /v1/wasm/modules`; route `TranslateWasmCreate` through chokepoint
+  - Surfaced by: Codex C6 + Phase 3. Files: `pkg/api/v1/`, `pkg/api/facadeutil/wasm.go`. Verify: Daytona create reaches alias/oci logic.
+- [ ] **T11 (P2)** — sdk — `listModules`/`pushModule`/`deleteModule` across 5 SDKs
+  - Surfaced by: Phase 4. Files: `sdk/*`. Verify: per-SDK transport tests.
+- [ ] **T12 (P2)** — infra — Ansible role + Terraform var: stage reserved-keyword modules
+  - Surfaced by: Phase 5. Files: `Ansible/roles/wasm-standard-modules/`, `Terraform/`. Verify: idempotent re-run; digest verify.
+- [ ] **T13 (P2)** — docs — alias-primary `wasm-sandbox.mdx` + BYO `wasm-modules-distribution.mdx` (5 tabs)
+  - Surfaced by: Phase 6. Files: `docs/`. Verify: no curl, all 5 langs.
+- [ ] **T14 (P3)** — test — Gated live-AOCR integration suite (`-tags integration`)
+  - Surfaced by: Test review. Files: `pkg/wasmmod/*_integration_test.go`. Verify: CI runs with creds.
+
+## 8. Risks
+- **Boot latency** on first `oci://` create (network pull) — mitigate with pre-staging + warm pool + bounded timeout; document per hard rule 2.
+- **Idempotency** under concurrent duplicate creates — single-flight latch mandatory (hard rule 3).
+- **Failure-path consistency** — partial pull/validate must not leave a half-written cache file referenced as ready (hard rule 4): write to temp, fsync, atomic rename, then mark ready.
+- **Cluster fragility** — failover module pull path needs a regression test (hard rule 6).
+- **Component artifacts** — validate early everywhere (push, pull, stage).
+
+## 9. Definition of done
+- `module_ref: "python"` works from all 5 SDKs against a stock-provisioned node.
+- `pushModule` → `create({moduleRef: "oci://..."})` round-trips from all 5 SDKs.
+- Standard modules are declared once in Terraform and present on every node.
+- A `durable` WASM sandbox fails over to a peer that pulls the base module + checkpoint.
+- Docs cover both flows in five languages; no curl.
+- All new fragile paths (resolver, pull single-flight, alias, failover pull) have regression tests; PR call-outs per CLAUDE.md hard rules.
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | — |
+| Codex Review | `/codex review` | Independent 2nd opinion | 1 | issues_found | 6 misses, 4 folded as required, 1 tension resolved, 1 absorbed |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | issues_open | 11 issues (4 arch, 2 code-qual, 1 perf, 4 codex) + 1 critical gap (C2 silent code-swap), all resolved/folded |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | — |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | — |
+
+- **CODEX:** Caught the load-bearing correctness bug the review missed — start/rehydrate re-resolve `ModuleRef`, silently booting different bytes after restart (C2). Plus failover module-auth (C4), per-digest GC refcount (C5), Daytona/gossip entrypoints (C6). All folded in as P1/P2 tasks.
+- **CROSS-MODEL:** Review and Codex agreed on the security/idempotency posture; the one tension (alias source of truth) resolved in the review's favor — standard modules are Ansible-staged reserved keywords, not DB rows, so the per-node SQLite drift Codex flagged doesn't apply to the fleet contract.
+- **VERDICT:** ENG review complete, scope = FULL. Plan hardened: 14 implementation tasks (7×P1, 6×P2, 1×P3), 6 mandatory tests, 1 critical gap closed. Not CLEARED for ship — this is a plan-stage review; implement T1–T14 then run `/review` on the diff before landing.
+
+**UNRESOLVED DECISIONS:**
+- OCI mediaType for `.wasm` artifacts (decision §7.2) — deferred to Phase 0 spike; the gated live-AOCR integration test (T14) validates the round-trip before it can bite.

--- a/sdk/go/internal/apiclient/client.go
+++ b/sdk/go/internal/apiclient/client.go
@@ -441,6 +441,49 @@ func (c *Client) DeleteWasmModule(ctx context.Context, id string) error {
 	return c.doJSON(ctx, http.MethodDelete, c.versionPrefix+"/wasm-modules/"+id, nil, nil)
 }
 
+// PushWasmModule uploads a compiled core-wasip1 module to the registry under
+// the caller's own credentials and returns the oci:// ref to use as ModuleRef
+// on a later create. The daemon validates and forwards the bytes; it never
+// stores them.
+func (c *Client) PushWasmModule(ctx context.Context, opts models.PushWasmModuleOptions) (models.PushWasmModuleResponse, error) {
+	if strings.TrimSpace(opts.Name) == "" {
+		return models.PushWasmModuleResponse{}, errors.New("name is required")
+	}
+	if strings.TrimSpace(opts.RegistryToken) == "" {
+		return models.PushWasmModuleResponse{}, errors.New("registry token is required")
+	}
+	query := url.Values{"name": {opts.Name}}
+	if strings.TrimSpace(opts.Tag) != "" {
+		query.Set("tag", opts.Tag)
+	}
+	path := c.baseURL + c.versioned("/wasm-modules/push") + "?" + query.Encode()
+	response, err := c.doWithRetry(ctx, func() (*http.Request, error) {
+		req, reqErr := http.NewRequestWithContext(ctx, http.MethodPost, path, bytes.NewReader(opts.Module))
+		if reqErr != nil {
+			return nil, reqErr
+		}
+		req.Header.Set("Content-Type", "application/octet-stream")
+		req.Header.Set("X-Registry-Token", opts.RegistryToken)
+		if strings.TrimSpace(opts.RegistryUsername) != "" {
+			req.Header.Set("X-Registry-Username", opts.RegistryUsername)
+		}
+		c.addAuth(req)
+		return req, nil
+	})
+	if err != nil {
+		return models.PushWasmModuleResponse{}, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode >= 400 {
+		return models.PushWasmModuleResponse{}, decodeError(response)
+	}
+	var out models.PushWasmModuleResponse
+	if err := json.NewDecoder(response.Body).Decode(&out); err != nil {
+		return models.PushWasmModuleResponse{}, err
+	}
+	return out, nil
+}
+
 // RebuildTemplate kicks an operator-triggered snapshot rebuild. Idempotent
 // under concurrent retry — the daemon's CAS collapses N parallel calls for
 // the same ready template into one rebuild kick. Returns the row in its

--- a/sdk/go/pkg/microvm/client.go
+++ b/sdk/go/pkg/microvm/client.go
@@ -330,6 +330,13 @@ func (c *Client) GetWasmModule(ctx context.Context, id string) (sdktypes.WasmMod
 	return c.inner.GetWasmModule(ctx, id)
 }
 
+// PushWasmModule uploads a compiled core-wasip1 module to the registry under
+// your own credentials and returns the oci:// ref to use as ModuleRef on a
+// later Create. The daemon validates and forwards the bytes; it never stores them.
+func (c *Client) PushWasmModule(ctx context.Context, opts sdktypes.PushWasmModuleOptions) (sdktypes.PushWasmModuleResponse, error) {
+	return c.inner.PushWasmModule(ctx, opts)
+}
+
 func (c *Client) DeleteWasmModule(ctx context.Context, id string) error {
 	return c.inner.DeleteWasmModule(ctx, id)
 }

--- a/sdk/go/pkg/types/types.go
+++ b/sdk/go/pkg/types/types.go
@@ -47,6 +47,12 @@ type WasmModule = models.WasmModule
 // CreateWasmModuleOptions is the request body for Client.CreateWasmModule.
 type CreateWasmModuleOptions = models.CreateWasmModuleRequest
 
+// PushWasmModuleOptions is the input for Client.PushWasmModule (BYO upload).
+type PushWasmModuleOptions = models.PushWasmModuleOptions
+
+// PushWasmModuleResponse is the result of Client.PushWasmModule.
+type PushWasmModuleResponse = models.PushWasmModuleResponse
+
 // WasmModuleStatus is the catalogue lifecycle for WASM modules.
 type WasmModuleStatus = models.WasmModuleStatus
 

--- a/sdk/java/src/main/java/ai/aerol/microvm/MicroVMClient.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/MicroVMClient.java
@@ -10,7 +10,9 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
@@ -32,6 +34,8 @@ import ai.aerol.microvm.model.CreateOptions;
 import ai.aerol.microvm.model.CreateSessionOptions;
 import ai.aerol.microvm.model.CreateTemplateOptions;
 import ai.aerol.microvm.model.CreateWasmModuleOptions;
+import ai.aerol.microvm.model.PushWasmModuleOptions;
+import ai.aerol.microvm.model.PushWasmModuleResponse;
 import ai.aerol.microvm.model.CustomDomain;
 import ai.aerol.microvm.model.CustomDomainDnsRecords;
 import ai.aerol.microvm.model.DnsRecord;
@@ -364,6 +368,40 @@ public class MicroVMClient {
 
     public void deleteWasmModule(String moduleId) {
         doNoContent("DELETE", versioned("/wasm-modules/" + moduleId), null);
+    }
+
+    /**
+     * Upload a compiled core-wasip1 module to the registry under your own
+     * credentials and get back the {@code oci://} ref to use as
+     * {@code moduleRef} on a later create. The daemon validates and forwards
+     * the bytes; it never stores them.
+     */
+    public PushWasmModuleResponse pushWasmModule(PushWasmModuleOptions options) {
+        if (options == null || options.getName() == null || options.getName().isBlank()) {
+            throw new MicroVMException("name is required");
+        }
+        if (options.getRegistryToken() == null || options.getRegistryToken().isBlank()) {
+            throw new MicroVMException("registryToken is required");
+        }
+        String tag = (options.getTag() == null || options.getTag().isBlank()) ? "latest" : options.getTag();
+        String path = versioned("/wasm-modules/push")
+            + "?name=" + encodeQueryValue(options.getName())
+            + "&tag=" + encodeQueryValue(tag);
+        Map<String, String> headers = new HashMap<>();
+        headers.put("X-Registry-Token", options.getRegistryToken());
+        if (options.getRegistryUsername() != null && !options.getRegistryUsername().isBlank()) {
+            headers.put("X-Registry-Username", options.getRegistryUsername());
+        }
+        byte[] module = options.getModule() != null ? options.getModule() : new byte[0];
+        HttpResponse<byte[]> response = sendRequest(
+            "POST",
+            path,
+            HttpRequest.BodyPublishers.ofByteArray(module),
+            "application/octet-stream",
+            headers
+        );
+        ensureSuccess(response);
+        return JsonSupport.read(response.body(), PushWasmModuleResponse.class);
     }
 
     /**
@@ -884,16 +922,25 @@ public class MicroVMClient {
     }
 
     private HttpResponse<byte[]> sendRequest(String method, String path, HttpRequest.BodyPublisher bodyPublisher, String contentType) {
+        return sendRequest(method, path, bodyPublisher, contentType, null);
+    }
+
+    private HttpResponse<byte[]> sendRequest(String method, String path, HttpRequest.BodyPublisher bodyPublisher, String contentType, Map<String, String> extraHeaders) {
         int maxRetries = retryConfig.maxRetries != null ? retryConfig.maxRetries : 3;
         int baseDelay = retryConfig.baseDelayMs != null ? retryConfig.baseDelayMs : 200;
         int maxDelay = retryConfig.maxDelayMs != null ? retryConfig.maxDelayMs : 5000;
-        
+
         Exception lastException = null;
 
         for (int attempt = 0; attempt <= maxRetries; attempt++) {
             HttpRequest.Builder builder = HttpRequest.newBuilder(resolve(path)).method(method, bodyPublisher);
             if (contentType != null) {
                 builder.header("Content-Type", contentType);
+            }
+            if (extraHeaders != null) {
+                for (Map.Entry<String, String> entry : extraHeaders.entrySet()) {
+                    builder.header(entry.getKey(), entry.getValue());
+                }
             }
             builder.header("Authorization", authorizationHeaderValue());
 

--- a/sdk/java/src/main/java/ai/aerol/microvm/model/PushWasmModuleOptions.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/model/PushWasmModuleOptions.java
@@ -1,0 +1,64 @@
+package ai.aerol.microvm.model;
+
+/**
+ * Input for {@link ai.aerol.microvm.MicroVMClient#pushWasmModule}: a BYO
+ * compiled core-wasip1 upload. The daemon validates and forwards the bytes to
+ * the registry under your own credentials; it never stores them.
+ */
+public class PushWasmModuleOptions {
+    /** Target repository path, e.g. {@code tenant/my-app}. */
+    public String name;
+    /** Image tag; defaults to {@code latest} when null/blank. */
+    public String tag;
+    /** The compiled core-wasip1 module bytes. */
+    public byte[] module;
+    /** Registry login (your AOCR username). */
+    public String registryUsername;
+    /** Registry token (your AOCR PAT). Required. */
+    public String registryToken;
+
+    public PushWasmModuleOptions setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public PushWasmModuleOptions setTag(String tag) {
+        this.tag = tag;
+        return this;
+    }
+
+    public PushWasmModuleOptions setModule(byte[] module) {
+        this.module = module;
+        return this;
+    }
+
+    public PushWasmModuleOptions setRegistryUsername(String registryUsername) {
+        this.registryUsername = registryUsername;
+        return this;
+    }
+
+    public PushWasmModuleOptions setRegistryToken(String registryToken) {
+        this.registryToken = registryToken;
+        return this;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getTag() {
+        return tag;
+    }
+
+    public byte[] getModule() {
+        return module;
+    }
+
+    public String getRegistryUsername() {
+        return registryUsername;
+    }
+
+    public String getRegistryToken() {
+        return registryToken;
+    }
+}

--- a/sdk/java/src/main/java/ai/aerol/microvm/model/PushWasmModuleResponse.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/model/PushWasmModuleResponse.java
@@ -1,0 +1,17 @@
+package ai.aerol.microvm.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Result of {@link ai.aerol.microvm.MicroVMClient#pushWasmModule}.
+ */
+public class PushWasmModuleResponse {
+    /** The {@code oci://} ref to pass as {@code moduleRef} on create. */
+    @JsonProperty("module_ref")
+    public String moduleRef;
+    /** sha256 content digest of the uploaded module. */
+    public String digest;
+    /** Uploaded size in bytes. */
+    @JsonProperty("size_bytes")
+    public long sizeBytes;
+}

--- a/sdk/python/microvm/client.py
+++ b/sdk/python/microvm/client.py
@@ -51,6 +51,8 @@ from .types import (
     SetNetworkLimitsOptions,
     Template,
     WasmModule,
+    PushWasmModuleOptions,
+    PushWasmModuleResult,
 )
 
 STREAM_PREFIX_STDOUT = 0x01
@@ -653,6 +655,35 @@ class MicroVM:
     def delete_wasm_module(self, module_id: str) -> None:
         self._do_json("DELETE", f"{self._version_prefix}/wasm-modules/{module_id}", None)
 
+    def push_wasm_module(self, options: PushWasmModuleOptions) -> PushWasmModuleResult:
+        """Upload a compiled core-wasip1 module to the registry under your own
+        credentials, returning the ``oci://`` ref to use as ``moduleRef`` on a
+        later ``create``. The daemon validates and forwards the bytes; it never
+        stores them.
+        """
+        name = options.get("name", "")
+        query = urllib.parse.urlencode(
+            {"name": name, "tag": options["tag"]} if options.get("tag") else {"name": name}
+        )
+        headers: Dict[str, str] = {"X-Registry-Token": options.get("registryToken", "")}
+        username = options.get("registryUsername")
+        if username:
+            headers["X-Registry-Username"] = username
+        url = f"{self._url(self._versioned('/wasm-modules/push'))}?{query}"
+        raw = self._request(
+            "POST",
+            url,
+            body=options.get("module", b""),
+            content_type="application/octet-stream",
+            extra_headers=headers,
+        )
+        data = json.loads(raw.decode("utf-8")) if raw else {}
+        return PushWasmModuleResult(
+            moduleRef=data.get("module_ref", ""),
+            digest=data.get("digest", ""),
+            sizeBytes=data.get("size_bytes", 0),
+        )
+
     def rebuild_template(self, template_id: str) -> Template:
         """Re-run the snapshot phase against an existing template.
 
@@ -896,18 +927,20 @@ class MicroVM:
     def _url(self, path: str) -> str:
         return f"{self.api_url}{path}"
 
-    def _request(self, method: str, url: str, body: Optional[bytes] = None, content_type: Optional[str] = None) -> bytes:
+    def _request(self, method: str, url: str, body: Optional[bytes] = None, content_type: Optional[str] = None, extra_headers: Optional[Dict[str, str]] = None) -> bytes:
         max_retries = self._retry_config["maxRetries"]
         base_delay_ms = self._retry_config["baseDelayMs"]
         max_delay_ms = self._retry_config["maxDelayMs"]
-        
+
         last_exc: Optional[Exception] = None
-        
+
         for attempt in range(max_retries + 1):
             request = urllib.request.Request(url, data=body, method=method)
             request.add_header("Authorization", f"Bearer {self.pat_token}")
             if content_type is not None:
                 request.add_header("Content-Type", content_type)
+            for header_key, header_val in (extra_headers or {}).items():
+                request.add_header(header_key, header_val)
 
             try:
                 with urllib.request.urlopen(request) as response:

--- a/sdk/python/microvm/types.py
+++ b/sdk/python/microvm/types.py
@@ -517,3 +517,17 @@ class WasmModule(TypedDict, total=False):
     createdAt: str
     updatedAt: str
     readyAt: str
+
+
+class PushWasmModuleOptions(TypedDict, total=False):
+    name: str  # required: target repo path, e.g. "tenant/my-app"
+    tag: str  # defaults to "latest"
+    module: bytes  # required: compiled core-wasip1 bytes
+    registryUsername: str
+    registryToken: str  # required: your registry PAT
+
+
+class PushWasmModuleResult(TypedDict, total=False):
+    moduleRef: str
+    digest: str
+    sizeBytes: int

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -35,7 +35,8 @@ pub use types::{
     MountSpec, MountSpecRedacted, MountType, NetworkUsage, RegisterSnapshotOptions, RegistryAuth,
     ResizeOptions, RetryConfig, Sandbox as SandboxData, SandboxSnapshot, Session, SessionList,
     SessionStatus, SetNetworkLimitsOptions, Template, TemplatePushState, TemplateStatus,
-    UpdateLifecycleOptions, WasmModule, WasmModuleStatus,
+    UpdateLifecycleOptions, WasmModule, WasmModuleStatus, PushWasmModuleOptions,
+    PushWasmModuleResponse,
 };
 
 const DEFAULT_API_URL: &str = "http://127.0.0.1:21212";
@@ -895,6 +896,46 @@ impl Client {
             &format!("{}/wasm-modules/{}", self.version_prefix(), id),
             None,
         )
+    }
+
+    /// Upload a compiled core-wasip1 module to the registry under your own
+    /// credentials and get back the `oci://` ref to use as `module_ref` on a
+    /// later `create`. The daemon validates and forwards the bytes; it never
+    /// stores them.
+    pub fn push_wasm_module(
+        &self,
+        opts: PushWasmModuleOptions,
+    ) -> Result<PushWasmModuleResponse, Error> {
+        if opts.name.trim().is_empty() {
+            return Err(Error::Api("name is required".to_string()));
+        }
+        if opts.registry_token.trim().is_empty() {
+            return Err(Error::Api("registry_token is required".to_string()));
+        }
+        let tag = if opts.tag.trim().is_empty() {
+            "latest"
+        } else {
+            opts.tag.as_str()
+        };
+        let path = format!(
+            "{}/wasm-modules/push?name={}&tag={}",
+            self.version_prefix(),
+            urlencoding::encode(&opts.name),
+            urlencoding::encode(tag),
+        );
+        let url = self.full_url(&path);
+        let mut builder = self
+            .inner
+            .post(&url)
+            .bearer_auth(&self.pat_token)
+            .header("Content-Type", "application/octet-stream")
+            .header("X-Registry-Token", &opts.registry_token)
+            .body(opts.module);
+        if !opts.registry_username.trim().is_empty() {
+            builder = builder.header("X-Registry-Username", &opts.registry_username);
+        }
+        let response = self.handle_response(builder.send()?)?;
+        response.json().map_err(Error::Reqwest)
     }
 
     /// Re-run the snapshot phase against an existing template. Idempotent

--- a/sdk/rust/src/types.rs
+++ b/sdk/rust/src/types.rs
@@ -817,6 +817,36 @@ pub struct CreateWasmModuleOptions {
     pub entrypoint: Option<String>,
 }
 
+/// Input for [`Client::push_wasm_module`]: a BYO compiled core-wasip1 upload.
+/// The daemon validates and forwards the bytes to the registry under your own
+/// credentials; it never stores them.
+#[derive(Debug, Clone, Default)]
+pub struct PushWasmModuleOptions {
+    /// Target repository path, e.g. `tenant/my-app`.
+    pub name: String,
+    /// Image tag; defaults to `latest` when empty.
+    pub tag: String,
+    /// The compiled core-wasip1 module bytes.
+    pub module: Vec<u8>,
+    /// Registry login (your AOCR username).
+    pub registry_username: String,
+    /// Registry token (your AOCR PAT). Required.
+    pub registry_token: String,
+}
+
+/// Result of [`Client::push_wasm_module`].
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PushWasmModuleResponse {
+    /// The `oci://` ref to pass as `module_ref` on create.
+    #[serde(rename = "module_ref")]
+    pub module_ref: String,
+    /// sha256 content digest of the uploaded module.
+    pub digest: String,
+    /// Uploaded size in bytes.
+    #[serde(rename = "size_bytes")]
+    pub size_bytes: i64,
+}
+
 /// Patch body for [`Client::set_network_limits`]. Each field is `Option`-wrapped
 /// so an unset key serializes as missing (server reads as "leave alone");
 /// `Some(0)` means unlimited.

--- a/sdk/typescript/src/MicroVM.ts
+++ b/sdk/typescript/src/MicroVM.ts
@@ -9,6 +9,8 @@ import type {
   CreateSessionOptions,
   CreateTemplateOptions,
   CreateWasmModuleOptions,
+  PushWasmModuleOptions,
+  PushWasmModuleResult,
   ExecStreamHandle,
   ExecStreamOptions,
   HealthStatus,
@@ -249,6 +251,15 @@ export class MicroVM {
 
   async deleteWasmModule(id: string): Promise<void> {
     await this.client.deleteWasmModule(id);
+  }
+
+  /**
+   * Upload a compiled core-wasip1 module to the registry under your own
+   * credentials and get back the `oci://` ref to use as `moduleRef` on create.
+   * The daemon validates and forwards the bytes; it never stores them.
+   */
+  async pushWasmModule(options: PushWasmModuleOptions): Promise<PushWasmModuleResult> {
+    return this.client.pushWasmModule(options);
   }
 
   /**

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -50,5 +50,7 @@ export type {
   TemplateStatus,
   WasmModule,
   WasmModuleStatus,
+  PushWasmModuleOptions,
+  PushWasmModuleResult,
   UpdateLifecycleOptions,
 } from "./types.js";

--- a/sdk/typescript/src/internal/client.ts
+++ b/sdk/typescript/src/internal/client.ts
@@ -17,6 +17,8 @@ import type {
   CreateSessionOptions,
   CreateTemplateOptions,
   CreateWasmModuleOptions,
+  PushWasmModuleOptions,
+  PushWasmModuleResult,
   CustomDomain,
   CloneGeneration,
   CustomDomainDNSRecords,
@@ -791,6 +793,30 @@ export class APIClient {
 
   async deleteWasmModule(id: string): Promise<void> {
     await this.doJSON<void>("DELETE", `${this.versionPrefix}/wasm-modules/${id}`);
+  }
+
+  async pushWasmModule(options: PushWasmModuleOptions): Promise<PushWasmModuleResult> {
+    const params = new URLSearchParams({ name: options.name });
+    if (options.tag) {
+      params.set("tag", options.tag);
+    }
+    const headers: Record<string, string> = {
+      "Content-Type": "application/octet-stream",
+      "X-Registry-Token": options.registryToken,
+    };
+    if (options.registryUsername) {
+      headers["X-Registry-Username"] = options.registryUsername;
+    }
+    const response = await this.request(
+      "POST",
+      this.versioned(`/wasm-modules/push?${params.toString()}`),
+      { body: options.module as unknown as BodyInit, headers },
+    );
+    if (!response.ok) {
+      throw await decodeError(response);
+    }
+    const r = (await response.json()) as { module_ref: string; digest: string; size_bytes: number };
+    return { moduleRef: r.module_ref, digest: r.digest, sizeBytes: r.size_bytes };
   }
 
   async rebuildTemplate(id: string): Promise<Template> {

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -653,3 +653,31 @@ export interface CreateWasmModuleOptions {
   /** WASI entry export; defaults to `_start` on the daemon. */
   entrypoint?: string;
 }
+
+/**
+ * Upload a compiled core-wasip1 `.wasm` to the registry. The daemon validates
+ * and forwards it under YOUR registry credentials — it never stores the bytes.
+ * The returned {@link PushWasmModuleResult.moduleRef} is what you pass as
+ * `moduleRef` on a later `create`.
+ */
+export interface PushWasmModuleOptions {
+  /** Target repository path, e.g. `tenant/my-app`. */
+  name: string;
+  /** Image tag; defaults to `latest`. */
+  tag?: string;
+  /** The compiled core-wasip1 module bytes. */
+  module: Uint8Array;
+  /** Registry login (your AOCR username). */
+  registryUsername?: string;
+  /** Registry token (your AOCR PAT). Required. */
+  registryToken: string;
+}
+
+export interface PushWasmModuleResult {
+  /** The `oci://` ref to pass as `moduleRef` on create. */
+  moduleRef: string;
+  /** sha256 content digest of the uploaded module. */
+  digest: string;
+  /** Uploaded size in bytes. */
+  sizeBytes: number;
+}


### PR DESCRIPTION
## Summary

- **Standard WASM modules + BYO distribution.** A `module_ref` now resolves
  through one chokepoint: reserved-keyword (`python`) > `oci://` registry ref >
  catalogue id > host file. Standard modules are staged identically on every
  node by Ansible (fleet-wide reserved-keyword contract, never DB-backed);
  tenants bring their own via `oci://` or a stateless push proxy.
- **Daemon stays orchestration-only.** It pulls module images to run them and
  offers a *stateless* push pass-through to the registry, but never stores or
  serves `.wasm`. AOCR is the source of truth. Snapshot/checkpoint push (the
  daemon's own runtime state) is unchanged.
- **Per-tenant credentials, never global.** Private module pulls/pushes use the
  caller's own PAT (request `registry` / `X-Registry-Token`), sealed at rest for
  failover. The global config identity is only for pulling standard modules.

## Sandbox boot impact

Yes — called out explicitly:
- **Standard-keyword / file refs:** no added boot work — filesystem resolve, no
  DB query (reserved keywords are staged filenames).
- **`oci://` pull-on-create (first call only):** a bounded registry pull inside
  the WASM create path, guarded by `SB_WASM_PULL_TIMEOUT` (default 60s),
  single-flight latched so concurrent duplicate creates pull once, and
  content-addressed cached so the second-and-later create is a local cache hit.
  Allowlist + size cap are enforced *before* any network call. Subsequent boots
  of the same digest do zero network I/O.
- **start/rehydrate:** resolve the pinned digest from the local cache (no
  network on the hot path); a re-pull only happens on a cache miss on a peer.

## Idempotency

- `POST /v1/wasm-modules/push`: stateless; re-push of identical bytes yields the
  same content digest. Concurrent pushes are independent (no shared state).
- `oci://` create: single-flight latch keys on the pull so N concurrent
  duplicate creates pull once; content-addressed cache makes resolution
  idempotent. Atomic temp+fsync+rename means a reader sees either the absent or
  the complete artifact, never a partial one.
- `CreateWasmModule`: unchanged idempotency (digest-keyed catalogue upsert).

## Failure-path consistency

- Module pull writes to `<cache>/<digest>.tmp`, fsyncs, validates (core-wasip1 +
  size), then `os.Rename` into place — a killed pull leaves only a temp file
  that is never referenced. No caddy interaction on this path.
- Digest drift on start/rehydrate fails **loudly** (`ErrModuleDigestMismatch`,
  HTTP 403) rather than silently booting different bytes.
- Per-digest GC refcounting: a module is only deleted/evicted when no sandbox
  references it by ref, id, OR resolved digest — shared bytes are never stomped.
- No multi-step caddy+store write was added.

## L4 / host-port-pool changes

N/A - neither touched.

## Cluster-correctness impact

- New code is a no-op when `cfg.EnableWasm` is false.
- Failover: a private-module sandbox now seals `req.Registry` onto its row
  (mirroring the Docker `RegistryAuthSealed` path) and the service unseals it
  into a transient field before start/rehydrate, so a peer re-pulls the base
  module under the tenant's identity. Credential-less sandboxes resolve plainly.
  No change to placement, the FSM, or the capacity/heartbeat path. Single-node
  behavior unchanged. Regression test: `registry_auth_test.go`.

## Test plan

- `go test ./pkg/wasmmod/... ./internal/runtime/wasm/ ./internal/service/ ./internal/store/ ./internal/config/ ./pkg/api/v1/ ./pkg/api/apihttp/` — green.
- Mandatory regression tests: allowlist reject / SSRF (`resolve_test.go`),
  digest-pin freeze (`resolve_pinned_test.go`), C4 tenant-auth threading
  (`registry_auth_test.go`), C5 per-digest reference (`store_test.go`).
- Gated live-AOCR push/pull round-trip (`-tags integration`, skips without creds).
- All 5 SDKs build + existing suites pass (TS 75 pass, Go green); Java/Rust compile.
- `terraform validate` Success; `ansible-playbook --syntax-check` clean; docs build clean (70 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
