### PR TITLE
Harden API request handling and auth token comparison

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aerol-ai/microvm
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/bytecodealliance/wasmtime-go/v37 v37.0.0

--- a/internal/cluster/capacity_lease_additional_test.go
+++ b/internal/cluster/capacity_lease_additional_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/aerol-ai/microvm/internal/config"
 	"github.com/aerol-ai/microvm/pkg/capacity"
 )
 
@@ -93,5 +96,48 @@ func TestFetchMemberCapacityFallsBackToPublicAPI(t *testing.T) {
 	}
 	if snap.HostCPUCores != 8 || snap.HostMemoryTotalMB != 16384 {
 		t.Fatalf("fetchMemberCapacity() snapshot = %+v", snap)
+	}
+}
+
+func TestRefreshCapacityLeasesHandlesErrorsAndFallbacks(t *testing.T) {
+	internalError := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	defer internalError.Close()
+
+	internalFallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("retry public"))
+	}))
+	defer internalFallback.Close()
+
+	public := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(capacity.Snapshot{HostCPUCores: 6, HostMemoryTotalMB: 12288})
+	}))
+	defer public.Close()
+
+	c := &Cluster{
+		nodeID:         "self",
+		httpClient:     public.Client(),
+		internalClient: internalError.Client(),
+		logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		capacityLeases: newCapacityLeaseCache("self", capacity.New(capacity.HostInfo{CPUCores: 2}, capacity.Limits{}, nil), time.Second, nil),
+		gossip: &gossipNode{
+			memberIndex: newGossipMemberIndex(),
+		},
+	}
+	c.gossip.memberIndex.upsert(Member{NodeID: "skip-empty", Alive: true, Role: config.NodeRoleWorker})
+	c.gossip.memberIndex.upsert(Member{NodeID: "dead-node", Alive: false, Role: config.NodeRoleWorker, APIURL: public.URL})
+	c.gossip.memberIndex.upsert(Member{NodeID: "error-node", Alive: true, Role: config.NodeRoleWorker, APIURL: public.URL, InternalURL: internalError.URL})
+	c.gossip.memberIndex.upsert(Member{NodeID: "fallback-node", Alive: true, Role: config.NodeRoleWorker, APIURL: public.URL, InternalURL: internalFallback.URL})
+
+	c.refreshCapacityLeases(context.Background())
+
+	if lease, ok := c.capacityLeases.leases["fallback-node"]; !ok || lease.snapshot.HostCPUCores != 6 || lease.snapshot.HostMemoryTotalMB != 12288 {
+		t.Fatalf("refreshCapacityLeases() fallback lease = %+v ok=%v", lease, ok)
+	}
+	if _, ok := c.capacityLeases.leases["skip-empty"]; ok {
+		t.Fatal("refreshCapacityLeases() created a lease for skip-empty member")
 	}
 }

--- a/internal/cluster/coverage_push_test.go
+++ b/internal/cluster/coverage_push_test.go
@@ -608,6 +608,14 @@ func TestFollowerForwardRemoveMemberViaPublicAPI(t *testing.T) {
 	waitForLeader(t, leader, 10*time.Second)
 	waitForVoter(t, leader, follower.nodeID, 20*time.Second)
 
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.HasPrefix(follower.LeaderAPIURL(), "http://") {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
 	leader.gossip.memberIndex.upsert(Member{NodeID: "gone-node", Alive: false, Role: config.NodeRoleServer})
 	err := follower.forwardRemoveMemberToLeader(context.Background(), "gone-node", true)
 	if err == nil || errors.Is(err, ErrNotLeader) {

--- a/internal/cluster/recovery_store_additional_test.go
+++ b/internal/cluster/recovery_store_additional_test.go
@@ -126,3 +126,32 @@ func TestWriteGCManifestError(t *testing.T) {
 		t.Fatal("writeGCManifest() accepted a non-directory path")
 	}
 }
+
+func TestPlacementRecoveryFileStorePutTempError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(dir, 0o755)
+	})
+
+	store := &placementRecoveryFileStore{dir: dir}
+	if _, err := store.Put("sandbox-temp-fail", placementRecovery{}); err == nil {
+		t.Fatal("Put() accepted a read-only directory")
+	}
+}
+
+func TestPlacementRecoveryFileStorePutMkdirError(t *testing.T) {
+	file, err := os.CreateTemp("", "recovery-put-file")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	defer os.Remove(file.Name())
+	defer file.Close()
+
+	store := &placementRecoveryFileStore{dir: file.Name()}
+	if _, err := store.Put("sandbox-mkdir-fail", placementRecovery{}); err == nil {
+		t.Fatal("Put() accepted a file path as its directory")
+	}
+}

--- a/pkg/api/apihttp/apihttp.go
+++ b/pkg/api/apihttp/apihttp.go
@@ -25,6 +25,22 @@ import (
 // a client retries promptly once the control plane's first standing poll lands.
 const admissionRetryAfterSeconds = 15
 
+// MaxJSONBodyBytes caps JSON request bodies decoded via DecodeJSON. Control
+// requests are small (a create payload with env vars is well under 64 KiB);
+// the cap exists so an authed caller can't balloon daemon memory with a
+// multi-GiB body. Bulk payloads (file uploads, build contexts) stream through
+// dedicated handlers and don't go through DecodeJSON.
+const MaxJSONBodyBytes = 1 << 20 // 1 MiB
+
+// DecodeJSON decodes a JSON request body into dst with the body capped at
+// MaxJSONBodyBytes. All versioned handlers must use this instead of
+// json.NewDecoder(r.Body) directly so the size cap is uniform across v1 and
+// the facades. The caller writes its own error envelope on failure.
+func DecodeJSON(w http.ResponseWriter, r *http.Request, dst any) error {
+	r.Body = http.MaxBytesReader(w, r.Body, MaxJSONBodyBytes)
+	return json.NewDecoder(r.Body).Decode(dst)
+}
+
 // WriteJSON serializes value as JSON and writes it with the given status.
 func WriteJSON(w http.ResponseWriter, status int, value any) {
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/api/daytona/handlers.go
+++ b/pkg/api/daytona/handlers.go
@@ -35,7 +35,7 @@ func newHandlers(d Deps) *handlers {
 
 func (h *handlers) createSandbox(w http.ResponseWriter, r *http.Request) {
 	var req createSandboxRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &req); err != nil {
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
@@ -236,7 +236,7 @@ func (h *handlers) deleteSnapshot(w http.ResponseWriter, r *http.Request) {
 // state=active synchronously, so its poll loop exits on the first read.
 func (h *handlers) createSnapshotFromImage(w http.ResponseWriter, r *http.Request) {
 	var req createSnapshotRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &req); err != nil {
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
@@ -461,7 +461,7 @@ func (h *handlers) stopSandbox(w http.ResponseWriter, r *http.Request) {
 
 func (h *handlers) createSnapshot(w http.ResponseWriter, r *http.Request) {
 	var req createSandboxSnapshotRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &req); err != nil {
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
@@ -493,7 +493,7 @@ func (h *handlers) resizeSandbox(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req resizeSandboxRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &req); err != nil {
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
@@ -554,7 +554,7 @@ func (h *handlers) replaceLabels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req sandboxLabelsResponse
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &req); err != nil {
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}

--- a/pkg/api/daytona/toolbox.go
+++ b/pkg/api/daytona/toolbox.go
@@ -128,7 +128,7 @@ func normalizeToolboxPath(path string) string {
 
 func (h *handlers) executeCommand(w http.ResponseWriter, r *http.Request, sandboxID string) {
 	var req executeRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &req); err != nil {
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
@@ -224,7 +224,7 @@ func (h *handlers) bulkUpload(w http.ResponseWriter, r *http.Request, sandboxID 
 
 func (h *handlers) bulkDownload(w http.ResponseWriter, r *http.Request, sandboxID string) {
 	var req filesDownloadRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &req); err != nil {
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}

--- a/pkg/api/e2b/handlers.go
+++ b/pkg/api/e2b/handlers.go
@@ -19,6 +19,7 @@ import (
 
 	svcmetrics "github.com/aerol-ai/microvm/internal/service"
 	"github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/api/apihttp"
 	"github.com/aerol-ai/microvm/pkg/api/clustercreate"
 	"github.com/aerol-ai/microvm/pkg/api/facadeutil"
 	"github.com/aerol-ai/microvm/pkg/models"
@@ -44,7 +45,7 @@ func newHandlers(d Deps) *handlers {
 
 func (h *handlers) createSandbox(w http.ResponseWriter, r *http.Request) {
 	var req createSandboxRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &req); err != nil {
 		WriteError(w, http.StatusBadRequest, "Invalid JSON body")
 		return
 	}
@@ -250,7 +251,7 @@ func (h *handlers) deleteSandbox(w http.ResponseWriter, r *http.Request) {
 
 func (h *handlers) connectSandbox(w http.ResponseWriter, r *http.Request) {
 	var req connectSandboxRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &req); err != nil {
 		WriteError(w, http.StatusBadRequest, "Invalid JSON body")
 		return
 	}
@@ -331,7 +332,7 @@ func (h *handlers) pauseSandbox(w http.ResponseWriter, r *http.Request) {
 
 func (h *handlers) updateTimeout(w http.ResponseWriter, r *http.Request) {
 	var req timeoutRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &req); err != nil {
 		WriteError(w, http.StatusBadRequest, "Invalid JSON body")
 		return
 	}
@@ -370,7 +371,7 @@ func (h *handlers) updateTimeout(w http.ResponseWriter, r *http.Request) {
 
 func (h *handlers) createSnapshot(w http.ResponseWriter, r *http.Request) {
 	var req createSnapshotRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &req); err != nil {
 		WriteError(w, http.StatusBadRequest, "Invalid JSON body")
 		return
 	}

--- a/pkg/api/middleware.go
+++ b/pkg/api/middleware.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bufio"
+	"crypto/subtle"
 	"errors"
 	"log/slog"
 	"net"
@@ -43,6 +44,14 @@ func extractBearerToken(r *http.Request) string {
 	return ""
 }
 
+// isPATToken compares a caller credential against the operator PAT in
+// constant time — the PAT grants fleet-wide access, so a byte-wise `==`
+// would leak match-prefix length as a timing side channel.
+func (s *Server) isPATToken(candidate string) bool {
+	return candidate != "" &&
+		subtle.ConstantTimeCompare([]byte(candidate), []byte(s.patToken)) == 1
+}
+
 // requireAuth wraps next with bearer-token authentication. All API versions
 // share this middleware via the Deps.Auth callback in their RegisterRoutes —
 // there is no per-version auth.
@@ -58,7 +67,7 @@ func extractBearerToken(r *http.Request) string {
 func (s *Server) requireAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		token := extractBearerToken(r)
-		if token == s.patToken {
+		if s.isPATToken(token) {
 			next.ServeHTTP(w, s.withOperatorAccess(r))
 			return
 		}
@@ -74,7 +83,7 @@ func (s *Server) requireE2BAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		token := extractBearerToken(r)
 		apiKey := strings.TrimSpace(r.Header.Get("X-API-KEY"))
-		if apiKey == s.patToken || token == s.patToken {
+		if s.isPATToken(apiKey) || s.isPATToken(token) {
 			next.ServeHTTP(w, s.withOperatorAccess(r))
 			return
 		}

--- a/pkg/api/v1/build.go
+++ b/pkg/api/v1/build.go
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -49,7 +48,7 @@ type buildImageResponse struct {
 
 func (h *handlers) buildImage(w http.ResponseWriter, r *http.Request) {
 	var req buildImageRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &req); err != nil {
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}

--- a/pkg/api/v1/cluster_handler.go
+++ b/pkg/api/v1/cluster_handler.go
@@ -1039,7 +1039,7 @@ func (h *handlers) clusterInternalPlacementsQuery(w http.ResponseWriter, r *http
 		return
 	}
 	var filter cluster.PlacementShardFilter
-	if err := json.NewDecoder(r.Body).Decode(&filter); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &filter); err != nil {
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
@@ -1057,7 +1057,7 @@ func (h *handlers) clusterInternalPlacementsPage(w http.ResponseWriter, r *http.
 		return
 	}
 	var req cluster.PlacementPageRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &req); err != nil {
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
@@ -1085,7 +1085,7 @@ func (h *handlers) clusterInternalRecoveryPut(w http.ResponseWriter, r *http.Req
 		return
 	}
 	var blob cluster.RecoveryBlob
-	if err := json.NewDecoder(r.Body).Decode(&blob); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &blob); err != nil {
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
@@ -1133,7 +1133,7 @@ func (h *handlers) clusterInternalSelectPlacement(w http.ResponseWriter, r *http
 		return
 	}
 	var req cluster.SelectPlacementRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &req); err != nil {
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
@@ -1166,7 +1166,7 @@ func (h *handlers) clusterWasmMigrate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req service.WasmMigrateRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &req); err != nil {
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}

--- a/pkg/api/v1/handlers.go
+++ b/pkg/api/v1/handlers.go
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"strconv"
@@ -36,7 +35,7 @@ func (h *handlers) capacity(w http.ResponseWriter, r *http.Request) {
 
 func (h *handlers) createSandbox(w http.ResponseWriter, r *http.Request) {
 	var req models.CreateSandboxRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &req); err != nil {
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
@@ -123,7 +122,7 @@ func (h *handlers) stopSandbox(w http.ResponseWriter, r *http.Request) {
 
 func (h *handlers) createSnapshot(w http.ResponseWriter, r *http.Request) {
 	var req models.CreateSandboxSnapshotRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &req); err != nil {
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
@@ -137,7 +136,7 @@ func (h *handlers) createSnapshot(w http.ResponseWriter, r *http.Request) {
 
 func (h *handlers) resizeSandbox(w http.ResponseWriter, r *http.Request) {
 	var req models.ResizeSandboxRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &req); err != nil {
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
@@ -154,7 +153,7 @@ func (h *handlers) resizeSandbox(w http.ResponseWriter, r *http.Request) {
 
 func (h *handlers) updateLifecycle(w http.ResponseWriter, r *http.Request) {
 	var req models.UpdateLifecycleRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &req); err != nil {
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
@@ -181,7 +180,7 @@ func (h *handlers) exposePort(w http.ResponseWriter, r *http.Request) {
 	// working unchanged.
 	var req models.ExposePortRequest
 	if r.ContentLength > 0 {
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if err := apihttp.DecodeJSON(w, r, &req); err != nil {
 			apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
 			return
 		}
@@ -229,7 +228,7 @@ func (h *handlers) unexposePort(w http.ResponseWriter, r *http.Request) {
 // 404 = sandbox not found.
 func (h *handlers) addCustomDomain(w http.ResponseWriter, r *http.Request) {
 	var req models.AddCustomDomainRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &req); err != nil {
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
@@ -321,7 +320,7 @@ func (h *handlers) getNetworkUsage(w http.ResponseWriter, r *http.Request) {
 
 func (h *handlers) updateNetworkLimits(w http.ResponseWriter, r *http.Request) {
 	var req models.UpdateNetworkLimitsRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &req); err != nil {
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}

--- a/pkg/api/v1/snapshot.go
+++ b/pkg/api/v1/snapshot.go
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -47,7 +46,7 @@ type registerSnapshotRequest struct {
 // non-empty ContextHashes return 501 today.
 func (h *handlers) registerSnapshot(w http.ResponseWriter, r *http.Request) {
 	var req registerSnapshotRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &req); err != nil {
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}

--- a/pkg/api/v1/template.go
+++ b/pkg/api/v1/template.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/aerol-ai/microvm/pkg/api/apihttp"
@@ -21,7 +20,7 @@ import (
 // /v1/templates/{id} to observe READY (or FAILED with last_error).
 func (h *handlers) createTemplate(w http.ResponseWriter, r *http.Request) {
 	var req models.CreateTemplateRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &req); err != nil {
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}

--- a/pkg/api/v1/wasm_module.go
+++ b/pkg/api/v1/wasm_module.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/aerol-ai/microvm/pkg/api/apihttp"
@@ -12,7 +11,7 @@ import (
 
 func (h *handlers) createWasmModule(w http.ResponseWriter, r *http.Request) {
 	var req models.CreateWasmModuleRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := apihttp.DecodeJSON(w, r, &req); err != nil {
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -689,6 +689,11 @@ func Run(ctx context.Context, logger *slog.Logger, makeProvider ProviderFactory)
 		Addr:              cfg.ListenAddr(),
 		Handler:           server.Handler(),
 		ReadHeaderTimeout: 10 * time.Second,
+		// No ReadTimeout/WriteTimeout: exec/log streams and WebSocket
+		// attaches are long-lived by design. IdleTimeout only reaps
+		// keep-alive connections sitting between requests, so it can't
+		// kill an in-flight stream but does bound idle-connection buildup.
+		IdleTimeout: 2 * time.Minute,
 	}
 
 	go func() {
@@ -769,6 +774,7 @@ func Run(ctx context.Context, logger *slog.Logger, makeProvider ProviderFactory)
 			Addr:              cfg.InternalIngressAddr,
 			Handler:           ingressMux,
 			ReadHeaderTimeout: 10 * time.Second,
+			IdleTimeout:       2 * time.Minute,
 		}
 		logger.Info("ingress proxy listening",
 			"addr", cfg.InternalIngressAddr,


### PR DESCRIPTION
## Summary

- Bump Go toolchain to 1.26.4.
- Add `apihttp.DecodeJSON` with a 1 MiB body cap and route all v1/Daytona/E2B JSON handlers through it to prevent unbounded memory use from oversized request bodies.
- Use constant-time comparison for PAT token checks in auth middleware to mitigate timing side channels.
- Set `IdleTimeout` (2 min) on the main and internal ingress HTTP servers to bound idle keep-alive connection buildup without affecting long-lived streams.
- Add cluster tests for capacity-lease refresh error/fallback paths, recovery store Put failures, and a flaky-test stabilization in follower forward-remove coverage.

## Sandbox boot impact

N/A - no work added to sandbox boot path.

## Idempotency

N/A - no behavioral change to sandbox API semantics. Oversized JSON bodies now fail with 413/bad-request at decode time instead of unbounded read; retries with the same valid payload behave as before.

## Failure-path consistency

N/A - no multi-step write path changed.

## L4 / host-port-pool changes

N/A - neither touched.

## Test plan

- [x] `go test ./internal/cluster/...` (new capacity-lease refresh, recovery store Put, follower forward-remove stabilization)
- [x] Existing API handler compile path verified via `go build ./pkg/api/...`
- [x] CI green on merge


Made with [Cursor](https://cursor.com)