### PR TITLE
Fix WASM checkpoint registry leak; scale + DRY background sweeps

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -3680,8 +3680,15 @@ func (s *Service) reconcileMissingSelfOwnedPlacements(ctx context.Context, known
 // fallback for sandboxes that don't declare any per-sandbox timers. Without
 // either configured, the sweep still runs but is a no-op — kept on so a
 // later UpdateLifecycle call doesn't need to start a goroutine.
-func (s *Service) StartLifecycleSweep(ctx context.Context) {
-	ticker := time.NewTicker(time.Minute)
+// startPeriodic runs sweep on an interval ticker in its own goroutine until ctx
+// is cancelled, handing each invocation a fresh timeout-bounded context. It is
+// the single home for the daemon's background-sweep skeleton: reconcile, the
+// lifecycle sweep, both image janitors, the template janitor, and the wasm
+// module/checkpoint sweeps were each an identical copy of this select-loop
+// before. Callers keep their own enable/interval guards (the cadence and
+// preconditions differ per task); only the loop boilerplate is shared here.
+func (s *Service) startPeriodic(ctx context.Context, interval, timeout time.Duration, sweep func(context.Context)) {
+	ticker := time.NewTicker(interval)
 	go func() {
 		defer ticker.Stop()
 		for {
@@ -3689,12 +3696,16 @@ func (s *Service) StartLifecycleSweep(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				sweepCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-				s.runLifecycleSweep(sweepCtx)
+				sweepCtx, cancel := context.WithTimeout(ctx, timeout)
+				sweep(sweepCtx)
 				cancel()
 			}
 		}
 	}()
+}
+
+func (s *Service) StartLifecycleSweep(ctx context.Context) {
+	s.startPeriodic(ctx, time.Minute, 30*time.Second, s.runLifecycleSweep)
 }
 
 func (s *Service) runLifecycleSweep(ctx context.Context) {
@@ -4105,20 +4116,9 @@ func (s *Service) StartBuiltImageGC(ctx context.Context) {
 		s.logger.Warn("built-image GC disabled: docker events client is nil")
 		return
 	}
-	ticker := time.NewTicker(interval)
-	go func() {
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				sweepCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-				s.runBuiltImageGC(sweepCtx, s.events.ListBuiltImages)
-				cancel()
-			}
-		}
-	}()
+	s.startPeriodic(ctx, interval, 30*time.Second, func(c context.Context) {
+		s.runBuiltImageGC(c, s.events.ListBuiltImages)
+	})
 }
 
 // builtImageListFn is the indirection runBuiltImageGC takes so tests can
@@ -4177,20 +4177,7 @@ func (s *Service) StartPendingImageGC(ctx context.Context) {
 	if interval <= 0 {
 		return
 	}
-	ticker := time.NewTicker(interval)
-	go func() {
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				sweepCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-				s.runPendingImageGC(sweepCtx)
-				cancel()
-			}
-		}
-	}()
+	s.startPeriodic(ctx, interval, 30*time.Second, s.runPendingImageGC)
 }
 
 // pendingImageGCSweepLimit caps how many ledger rows one sweep
@@ -4277,22 +4264,11 @@ func (s *Service) StartReconcileLoop(ctx context.Context) {
 	if interval <= 0 {
 		return
 	}
-	ticker := time.NewTicker(interval)
-	go func() {
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				reconcileCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-				if err := s.Reconcile(reconcileCtx); err != nil {
-					s.logger.Warn("periodic reconcile failed", "error", err)
-				}
-				cancel()
-			}
+	s.startPeriodic(ctx, interval, 30*time.Second, func(c context.Context) {
+		if err := s.Reconcile(c); err != nil {
+			s.logger.Warn("periodic reconcile failed", "error", err)
 		}
-	}()
+	})
 }
 
 func (s *Service) StartClusterIngressReconcile(ctx context.Context) {

--- a/internal/service/template.go
+++ b/internal/service/template.go
@@ -490,20 +490,9 @@ func (s *Service) StartTemplateGC(ctx context.Context) {
 	if interval <= 0 {
 		return
 	}
-	ticker := time.NewTicker(interval)
-	go func() {
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				sweepCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-				s.runTemplateGC(sweepCtx, time.Now())
-				cancel()
-			}
-		}
-	}()
+	s.startPeriodic(ctx, interval, 30*time.Second, func(c context.Context) {
+		s.runTemplateGC(c, time.Now())
+	})
 }
 
 // runTemplateGC is one pass of the template janitor. Split from

--- a/internal/service/template_health_test.go
+++ b/internal/service/template_health_test.go
@@ -153,13 +153,12 @@ func TestMarkSnapshotCorrupt_IdempotentUnderConcurrency(t *testing.T) {
 		t.Fatal("rebuild never fired; MarkSnapshotCorrupt's first observer must kick a rebuild")
 	}
 
-	// After the rebuild succeeds the row is back in ready.
-	got, err := st.GetTemplate(context.Background(), tpl.ID)
-	if err != nil {
-		t.Fatalf("GetTemplate: %v", err)
-	}
-	if got.Status != models.TemplateStatusReady {
-		t.Errorf("post-rebuild status = %s, want ready", got.Status)
+	// snap.done fires when SnapshotTemplate returns, which is BEFORE the
+	// rebuild goroutine persists status=ready + has_snapshot=true. Poll for the
+	// terminal state rather than reading once, otherwise we race the persist.
+	got := waitForStatus(t, st, tpl.ID, models.TemplateStatusReady, 3*time.Second)
+	if got == nil || got.Status != models.TemplateStatusReady {
+		t.Fatalf("post-rebuild status = %v, want ready", got)
 	}
 	if !got.HasSnapshot {
 		t.Errorf("HasSnapshot = false after successful rebuild")
@@ -410,14 +409,13 @@ func TestRekickUnhealthyTemplatesAtStart_RekicksEachUnhealthyRow(t *testing.T) {
 		t.Errorf("snapshotter calls = %d, want 2 (one per unhealthy row)", calls)
 	}
 
-	// Both targets recovered; healthy row untouched.
+	// Both targets recovered; healthy row untouched. snap.done fires when
+	// SnapshotTemplate returns, before the rebuild goroutine persists ready, so
+	// poll for the terminal state rather than reading once.
 	for _, id := range []string{tplA.ID, tplB.ID} {
-		got, err := st.GetTemplate(context.Background(), id)
-		if err != nil {
-			t.Fatalf("GetTemplate %s: %v", id, err)
-		}
-		if got.Status != models.TemplateStatusReady {
-			t.Errorf("template %s post-rebuild status = %s, want ready", id, got.Status)
+		got := waitForStatus(t, st, id, models.TemplateStatusReady, 3*time.Second)
+		if got == nil || got.Status != models.TemplateStatusReady {
+			t.Errorf("template %s post-rebuild status = %v, want ready", id, got)
 		}
 	}
 	gotHealthy, err := st.GetTemplate(context.Background(), healthy.ID)
@@ -462,7 +460,13 @@ func TestRequestTemplateRebuild_ReadyTransitionsAndKicks(t *testing.T) {
 	svc, st, templatesDir := newHealthHarness(t)
 	tpl := seedReadyTemplate(t, st, templatesDir, "tpl-op-rebuild")
 
-	snap := &fakeTemplateSnapshotter{done: make(chan struct{}, 4)}
+	// Block the snapshotter so the kicked rebuild stays in flight while we
+	// assert the row left 'ready'. Without this the fake rebuild completes
+	// instantly and can flip the row back to ready before RequestTemplateRebuild
+	// re-reads it (a benign production outcome — the operator polls until ready —
+	// but a non-deterministic one to assert on). The block makes the
+	// "row is no longer ready" contract observable; we release it below.
+	snap := &fakeTemplateSnapshotter{done: make(chan struct{}, 4), block: make(chan struct{})}
 	svc.SetTemplateSnapshotter(snap)
 	svc.SetTemplateCIDAllocator(&fakeCIDAllocator{cid: 42})
 
@@ -473,14 +477,14 @@ func TestRequestTemplateRebuild_ReadyTransitionsAndKicks(t *testing.T) {
 	if got == nil {
 		t.Fatal("RequestTemplateRebuild returned nil template")
 	}
-	// MarkSnapshotCorrupt may have already been overtaken by the
-	// rebuild goroutine flipping the row to snapshotting/ready by the
-	// time we re-read. The contract is "row is no longer ready" — the
-	// rebuild is in flight.
+	// Rebuild is held in flight by snap.block, so the row is unhealthy or
+	// snapshotting — never back to ready yet.
 	if got.Status == models.TemplateStatusReady {
-		t.Errorf("status = ready after rebuild request; expected unhealthy/snapshotting/ready_no_snapshot or post-rebuild ready")
+		t.Errorf("status = ready after rebuild request; expected unhealthy/snapshotting/ready_no_snapshot")
 	}
 
+	// Release the blocked rebuild and confirm it fired exactly once.
+	close(snap.block)
 	select {
 	case <-snap.done:
 	case <-time.After(3 * time.Second):

--- a/internal/service/wasm_checkpoint_periodic.go
+++ b/internal/service/wasm_checkpoint_periodic.go
@@ -18,20 +18,9 @@ func (s *Service) StartWasmPeriodicCheckpoint(ctx context.Context) {
 	if interval <= 0 {
 		return
 	}
-	ticker := time.NewTicker(interval)
-	go func() {
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				sweepCtx, cancel := context.WithTimeout(ctx, s.cfg.WasmDrainTimeout)
-				_ = s.runWasmPeriodicCheckpoint(sweepCtx)
-				cancel()
-			}
-		}
-	}()
+	s.startPeriodic(ctx, interval, s.cfg.WasmDrainTimeout, func(c context.Context) {
+		_ = s.runWasmPeriodicCheckpoint(c)
+	})
 }
 
 func (s *Service) runWasmPeriodicCheckpoint(ctx context.Context) error {
@@ -39,7 +28,10 @@ func (s *Service) runWasmPeriodicCheckpoint(ctx context.Context) error {
 	if !ok {
 		return nil
 	}
-	known, err := s.store.List(ctx)
+	// Scan only WASM rows: this sweep checkpoints WASM sandboxes, so loading the
+	// docker/firecracker rows just to filter them out wastes a full-fleet decode
+	// every tick at scale.
+	known, err := s.store.ListByRuntime(ctx, models.RuntimeWasm)
 	if err != nil {
 		return err
 	}
@@ -77,24 +69,18 @@ func (s *Service) StartWasmDurablePushSweep(ctx context.Context) {
 	if interval <= 0 {
 		return
 	}
-	ticker := time.NewTicker(interval)
-	go func() {
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				sweepCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
-				s.runWasmDurablePushSweep(sweepCtx)
-				cancel()
-			}
-		}
-	}()
+	s.startPeriodic(ctx, interval, 5*time.Minute, s.runWasmDurablePushSweep)
 }
 
 func (s *Service) runWasmDurablePushSweep(ctx context.Context) {
-	known, err := s.store.List(ctx)
+	// Orphan-ref retry: drop the tracking rows that cleanupWasmSandboxArtifacts
+	// retained because their registry DeleteRef had not yet succeeded. This is
+	// the retry vehicle that lets destroy decline to forget a ref it could not
+	// clean up without leaving a permanent registry leak. Reuses this sweep's
+	// ticker + pusher precondition rather than standing up a fourth janitor.
+	s.runWasmOrphanRefSweep(ctx)
+
+	known, err := s.store.ListByRuntime(ctx, models.RuntimeWasm)
 	if err != nil {
 		s.logger.Warn("wasm durable push sweep: list failed", "error", err)
 		return
@@ -118,5 +104,36 @@ func (s *Service) runWasmDurablePushSweep(ctx context.Context) {
 		}
 		s.pushWasmCheckpointBestEffort(sb.ID, path)
 		_ = ctx
+	}
+}
+
+// runWasmOrphanRefSweep retries DeleteRef for push-history rows whose sandbox
+// is already gone, dropping each row once its manifest is confirmed absent
+// (DeleteRef returns nil, which includes the already-deleted case). A row whose
+// delete still fails is left for the next sweep, so a transient registry outage
+// delays reclamation but never strands the row permanently — closing the
+// no-vacuum gap left by destroy declining to block on the registry.
+func (s *Service) runWasmOrphanRefSweep(ctx context.Context) {
+	if s.wasmCheckpointPusher == nil || s.store == nil {
+		return
+	}
+	orphans, err := s.store.ListOrphanedWasmCheckpointPushes(ctx, 0)
+	if err != nil {
+		s.logger.Warn("wasm orphan-ref sweep: list failed", "error", err)
+		return
+	}
+	for _, p := range orphans {
+		ref := strings.TrimSpace(p.RegistryRef)
+		if ref != "" {
+			if err := s.wasmCheckpointPusher.DeleteRef(ctx, ref); err != nil {
+				s.logger.Warn("wasm orphan-ref sweep: delete failed; will retry",
+					"push_id", p.ID, "sandbox_id", p.SandboxID, "registry_ref", ref, "error", err)
+				continue
+			}
+		}
+		if err := s.store.DeleteWasmCheckpointPush(ctx, p.ID); err != nil {
+			s.logger.Warn("wasm orphan-ref sweep: row delete failed",
+				"push_id", p.ID, "sandbox_id", p.SandboxID, "error", err)
+		}
 	}
 }

--- a/internal/service/wasm_checkpoint_periodic_test.go
+++ b/internal/service/wasm_checkpoint_periodic_test.go
@@ -170,6 +170,12 @@ func TestWasmPeriodicAndDurableSweepErrorBranches(t *testing.T) {
 		}
 		svc.runWasmDurablePushSweep(ctx)
 	})
+
+	t.Run("orphan-ref sweep no-op without pusher", func(t *testing.T) {
+		svc, _, _ := newServiceRuntimeHarness(t, &recordingRuntime{})
+		svc.wasmCheckpointPusher = nil // push disabled (single-node / local)
+		svc.runWasmOrphanRefSweep(ctx) // must return without touching the store
+	})
 }
 
 func TestWasmPeriodicAndDurableSweepFilterBranches(t *testing.T) {

--- a/internal/service/wasm_cleanup.go
+++ b/internal/service/wasm_cleanup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/aerol-ai/microvm/internal/store"
 	"github.com/aerol-ai/microvm/pkg/models"
 )
 
@@ -22,51 +23,58 @@ func (s *Service) cleanupWasmSandboxArtifacts(ctx context.Context, sandbox *mode
 	// a rolling :latest tag; sandbox.WasmRegistryRef only names the most recent
 	// digest tag. Deleting just that ref would leak the older N-1 digest tags and
 	// the :latest tag in the registry — and once the wasm_checkpoint_pushes rows
-	// are gone there is no record left to GC them by, so the leak is permanent.
-	// Enumerate every tracked ref (+ :latest) and delete each first. Registry
-	// deletes are best-effort with loud logging, mirroring the caddy/image
-	// cleanup discipline elsewhere in the destroy path: a registry hiccup must
-	// not block the sandbox row from being removed.
+	// are gone there is no record left to GC them by, so the leak would be
+	// permanent.
 	//
-	// Residual tradeoff (phase 1): if a DeleteRef transiently fails we still drop
-	// the push-history rows below, so that specific manifest becomes an
-	// unrecoverable registry leak. Accepted because destroy cannot block on the
-	// registry; a future hardening is to hand failed refs to a janitor (like
-	// pending_image_gc) instead of dropping their tracking rows.
-	if s.wasmCheckpointPusher != nil {
-		refs := make(map[string]struct{})
-		if s.store != nil {
-			pushes, err := s.store.ListWasmCheckpointPushes(ctx, sandbox.ID)
-			if err != nil {
-				s.logger.Warn("wasm checkpoint push history list failed during cleanup",
-					"sandbox_id", sandbox.ID,
-					"error", err,
-				)
-			} else {
-				for _, p := range pushes {
-					if ref := strings.TrimSpace(p.RegistryRef); ref != "" {
-						refs[ref] = struct{}{}
-					}
-				}
-			}
+	// No-vacuum rule: a push-history row is the only record that ties a sandbox
+	// to its registry manifest, so a row is dropped ONLY after its ref is
+	// confirmed gone (DeleteRef returns nil — which now includes already-absent
+	// refs, see DeleteSnapshotRef). A ref whose delete transiently fails keeps
+	// its row, and the orphan-ref sweep in runWasmDurablePushSweep retries it
+	// after the sandbox row itself is gone. Destroy never blocks on the registry;
+	// it just declines to forget what it could not yet clean up.
+	if s.wasmCheckpointPusher != nil && s.store != nil {
+		pushes, err := s.store.ListWasmCheckpointPushes(ctx, sandbox.ID)
+		if err != nil {
+			s.logger.Warn("wasm checkpoint push history list failed during cleanup",
+				"sandbox_id", sandbox.ID,
+				"error", err,
+			)
 		}
-		if ref := strings.TrimSpace(sandbox.WasmRegistryRef); ref != "" {
-			refs[ref] = struct{}{}
-		}
-		if latest := strings.TrimSpace(s.wasmCheckpointPusher.DestRefTagged(sandbox.ID, "latest")); latest != "" {
-			refs[latest] = struct{}{}
-		}
-		for ref := range refs {
+		// The :latest rolling tag and any WasmRegistryRef not yet tracked by a
+		// push row have no tracking row to strand, so they are pure best-effort —
+		// a failure here is retried only via the per-row refs below or a manual
+		// cleanup, never leaving an untracked row behind.
+		for _, ref := range s.untrackedWasmRefs(sandbox, pushes) {
 			if err := s.wasmCheckpointPusher.DeleteRef(ctx, ref); err != nil {
 				s.logger.Warn("delete wasm checkpoint AOCR ref failed",
-					"sandbox_id", sandbox.ID,
-					"registry_ref", ref,
-					"error", err,
-				)
+					"sandbox_id", sandbox.ID, "registry_ref", ref, "error", err)
 			}
 		}
+		// Per-row refs: drop the row only when its manifest is confirmed gone.
+		for _, p := range pushes {
+			ref := strings.TrimSpace(p.RegistryRef)
+			if ref != "" {
+				if err := s.wasmCheckpointPusher.DeleteRef(ctx, ref); err != nil {
+					s.logger.Warn("delete wasm checkpoint AOCR ref failed; retaining tracking row for retry",
+						"sandbox_id", sandbox.ID, "registry_ref", ref, "error", err)
+					continue
+				}
+			}
+			if err := s.store.DeleteWasmCheckpointPush(ctx, p.ID); err != nil {
+				s.logger.Warn("delete wasm checkpoint push row failed",
+					"sandbox_id", sandbox.ID, "push_id", p.ID, "error", err)
+			}
+		}
+		if err := s.store.DeleteAllWasmStateKV(ctx, sandbox.ID); err != nil {
+			return err
+		}
+		return nil
 	}
 
+	// No pusher (durable AOCR push disabled — the common single-node / local
+	// case): there is no registry to leak into, so the tracking rows carry no
+	// recoverable obligation. Bulk-delete them as before.
 	if s.store != nil {
 		if err := s.store.DeleteAllWasmStateKV(ctx, sandbox.ID); err != nil {
 			return err
@@ -76,4 +84,30 @@ func (s *Service) cleanupWasmSandboxArtifacts(ctx context.Context, sandbox *mode
 		}
 	}
 	return nil
+}
+
+// untrackedWasmRefs returns the registry refs that have no push-history row to
+// strand — the rolling :latest tag and a WasmRegistryRef that is not already
+// covered by one of the supplied push rows. Deleting these is pure best-effort
+// (no row is dropped on success), so a transient failure here cannot leave an
+// orphaned tracking row.
+func (s *Service) untrackedWasmRefs(sandbox *models.Sandbox, pushes []store.WasmCheckpointPushRecord) []string {
+	tracked := make(map[string]struct{}, len(pushes))
+	for _, p := range pushes {
+		if ref := strings.TrimSpace(p.RegistryRef); ref != "" {
+			tracked[ref] = struct{}{}
+		}
+	}
+	var out []string
+	if latest := strings.TrimSpace(s.wasmCheckpointPusher.DestRefTagged(sandbox.ID, "latest")); latest != "" {
+		if _, ok := tracked[latest]; !ok {
+			out = append(out, latest)
+		}
+	}
+	if ref := strings.TrimSpace(sandbox.WasmRegistryRef); ref != "" {
+		if _, ok := tracked[ref]; !ok {
+			out = append(out, ref)
+		}
+	}
+	return out
 }

--- a/internal/service/wasm_cleanup_aocr_test.go
+++ b/internal/service/wasm_cleanup_aocr_test.go
@@ -171,6 +171,99 @@ func TestCleanupWasmSandboxArtifacts_NonWasmNoop(t *testing.T) {
 	}
 }
 
+// flakyDeleteWasmCheckpointStore fails the first failBudget DeleteRef calls,
+// then succeeds. Lets the test prove a transient registry failure retains the
+// tracking row (no premature drop) and the orphan-ref sweep reclaims it later.
+type flakyDeleteWasmCheckpointStore struct {
+	recordingWasmCheckpointStore
+	failBudget int
+}
+
+func (f *flakyDeleteWasmCheckpointStore) DeleteRef(_ context.Context, ref string) error {
+	if f.failBudget > 0 {
+		f.failBudget--
+		return errors.New("transient registry failure")
+	}
+	f.deleted = append(f.deleted, ref)
+	return nil
+}
+
+// TestCleanupWasmSandboxArtifacts_NoVacuumOnDeleteFailure is the regression test
+// for the data-vacuum fix: when a registry DeleteRef fails transiently, destroy
+// must NOT drop the push-history row (doing so would strand the manifest with no
+// record left to GC by — a permanent leak). The row is retained, and once the
+// sandbox itself is gone the orphan-ref sweep retries the delete and reclaims
+// the row, leaving zero vacuum.
+func TestCleanupWasmSandboxArtifacts_NoVacuumOnDeleteFailure(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	// Every DeleteRef during cleanup fails; the per-digest tracking row must
+	// survive so the sweep can retry it.
+	pusher := &flakyDeleteWasmCheckpointStore{failBudget: 1 << 30}
+	svc := &Service{
+		logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+		store:                st,
+		wasmCheckpointPusher: pusher,
+	}
+	ctx := context.Background()
+
+	const id = "wasm-leak"
+	sb := &models.Sandbox{
+		ID: id, Image: "registry/foo:wasm", Runtime: models.RuntimeWasm,
+		Status: models.SandboxStatusPassivated, Durability: models.DurabilityDurable,
+		ModuleRef: "registry/foo:wasm", WasmRegistryRef: "aocr://" + id + ":sha256-x",
+	}
+	if err := st.Create(ctx, sb); err != nil {
+		t.Fatalf("store.Create: %v", err)
+	}
+	if _, err := st.InsertWasmCheckpointPush(ctx, id, "aocr://"+id+":sha256-x", "d"); err != nil {
+		t.Fatalf("InsertWasmCheckpointPush: %v", err)
+	}
+
+	if err := svc.cleanupWasmSandboxArtifacts(ctx, sb); err != nil {
+		t.Fatalf("cleanupWasmSandboxArtifacts: %v", err)
+	}
+	// The failed delete must have RETAINED the tracking row.
+	pushes, err := st.ListWasmCheckpointPushes(ctx, id)
+	if err != nil {
+		t.Fatalf("ListWasmCheckpointPushes: %v", err)
+	}
+	if len(pushes) != 1 {
+		t.Fatalf("failed DeleteRef should retain the tracking row, got %d rows", len(pushes))
+	}
+
+	// Sandbox row goes away (destroy completes). The row is now orphaned but the
+	// sweep should not yet reclaim it while DeleteRef keeps failing.
+	if err := st.Delete(ctx, id); err != nil {
+		t.Fatalf("store.Delete: %v", err)
+	}
+	orphans, err := st.ListOrphanedWasmCheckpointPushes(ctx, 0)
+	if err != nil {
+		t.Fatalf("ListOrphanedWasmCheckpointPushes: %v", err)
+	}
+	if len(orphans) != 1 {
+		t.Fatalf("expected 1 orphaned push row, got %d", len(orphans))
+	}
+	svc.runWasmOrphanRefSweep(ctx) // DeleteRef still failing → row retained
+	if orphans, _ := st.ListOrphanedWasmCheckpointPushes(ctx, 0); len(orphans) != 1 {
+		t.Fatalf("orphan row must survive a failed sweep, got %d", len(orphans))
+	}
+
+	// Registry recovers: the next sweep deletes the ref and drops the row.
+	pusher.failBudget = 0
+	svc.runWasmOrphanRefSweep(ctx)
+	if orphans, _ := st.ListOrphanedWasmCheckpointPushes(ctx, 0); len(orphans) != 0 {
+		t.Fatalf("orphan-ref sweep must reclaim the row once DeleteRef succeeds, got %d", len(orphans))
+	}
+	if len(pusher.deleted) != 1 || pusher.deleted[0] != "aocr://"+id+":sha256-x" {
+		t.Fatalf("sweep deleted refs = %v, want the retained per-digest ref", pusher.deleted)
+	}
+}
+
 func TestCleanupWasmSandboxArtifacts_ErrorBranches(t *testing.T) {
 	ctx := context.Background()
 	svc, st, _ := newAOCRCleanupTestService(t)

--- a/internal/service/wasm_module_health.go
+++ b/internal/service/wasm_module_health.go
@@ -18,25 +18,14 @@ func (s *Service) StartWasmModuleGC(ctx context.Context) {
 	if interval <= 0 {
 		return
 	}
-	ticker := time.NewTicker(interval)
-	go func() {
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				sweepCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-				s.runWasmModuleGC(sweepCtx, time.Now())
-				// Catalogue GC reclaims rows; cache GC reclaims the on-disk
-				// content-addressed bytes those rows (and bare oci:// pulls) leave
-				// behind. Run it second so a row deleted above frees its digest for
-				// eviction in the same sweep.
-				s.runWasmCacheGC(sweepCtx, time.Now())
-				cancel()
-			}
-		}
-	}()
+	s.startPeriodic(ctx, interval, 30*time.Second, func(c context.Context) {
+		s.runWasmModuleGC(c, time.Now())
+		// Catalogue GC reclaims rows; cache GC reclaims the on-disk
+		// content-addressed bytes those rows (and bare oci:// pulls) leave
+		// behind. Run it second so a row deleted above frees its digest for
+		// eviction in the same sweep.
+		s.runWasmCacheGC(c, time.Now())
+	})
 }
 
 func (s *Service) runWasmModuleGC(ctx context.Context, now time.Time) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -217,6 +217,10 @@ func Open(path string) (*Store, error) {
 		);`,
 		`CREATE INDEX IF NOT EXISTS idx_sandboxes_status ON sandboxes(status);`,
 		`CREATE INDEX IF NOT EXISTS idx_sandboxes_last_active_at ON sandboxes(last_active_at);`,
+		// idx_sandboxes_runtime backs ListByRuntime so the per-runtime background
+		// sweeps (wasm periodic checkpoint, wasm durable-push retry) scan only
+		// their own rows instead of the full mixed-runtime fleet on every tick.
+		`CREATE INDEX IF NOT EXISTS idx_sandboxes_runtime ON sandboxes(runtime);`,
 		// idx_sandboxes_image powers HasActiveImageRef so image GC stays
 		// constant-cost as the destroyed-row history grows beyond the live
 		// sandbox count. Plain (image) is sufficient: SQLite filters on
@@ -1124,6 +1128,57 @@ func (s *Store) ListByOwner(ctx context.Context, ownerRef string) ([]*models.San
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate sandboxes by owner: %w", err)
+	}
+	return sandboxes, nil
+}
+
+// ListByRuntime returns the sandboxes for one runtime ("wasm", "firecracker",
+// "docker"), newest first. It is the runtime-scoped counterpart of List: the
+// per-runtime background sweeps (wasm periodic checkpoint, wasm durable-push
+// retry) use it instead of List so they scan only their own rows rather than
+// the whole fleet on every tick — at a node packing thousands of mixed-runtime
+// sandboxes, List would load (and scanSandbox-decode) every docker/firecracker
+// row just to filter them back out. Like ListByOwner, ports and custom domains
+// are not attached: the sweep callers only need identity + lifecycle fields.
+func (s *Store) ListByRuntime(ctx context.Context, runtime string) ([]*models.Sandbox, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, image, status, public_url, container_id, container_ip, cpu, memory_mb, disk_gb,
+			os_user, env_json, network_block_all, toolbox_enabled, toolbox_token, ssh_public_key,
+			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
+			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
+			failover_policy,
+			runtime, gpus_json,
+			net_bytes_in, net_bytes_out, net_bytes_in_limit, net_bytes_out_limit,
+			net_quota_exceeded, net_quota_exceeded_at,
+			registry_auth_sealed,
+			auto_import_pending,
+			serverless, wake_armed,
+			template_id,
+			overlay_size_gb,
+			durability,
+			module_ref, module_digest,
+			checkpoint_path, clone_generation,
+			wasm_registry_ref, wasm_registry_digest,
+			owner_ref, fleet_suspended
+		FROM sandboxes
+		WHERE runtime = ?
+		ORDER BY created_at DESC
+	`, strings.TrimSpace(runtime))
+	if err != nil {
+		return nil, fmt.Errorf("list sandboxes by runtime: %w", err)
+	}
+	defer rows.Close()
+
+	var sandboxes []*models.Sandbox
+	for rows.Next() {
+		sandbox, err := scanSandbox(rows)
+		if err != nil {
+			return nil, err
+		}
+		sandboxes = append(sandboxes, sandbox)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate sandboxes by runtime: %w", err)
 	}
 	return sandboxes, nil
 }
@@ -4734,6 +4789,38 @@ func (s *Store) ListWasmCheckpointPushes(ctx context.Context, sandboxID string) 
 		ORDER BY pushed_at DESC, id DESC`, strings.TrimSpace(sandboxID))
 	if err != nil {
 		return nil, fmt.Errorf("list wasm checkpoint pushes: %w", err)
+	}
+	defer rows.Close()
+	var out []WasmCheckpointPushRecord
+	for rows.Next() {
+		var rec WasmCheckpointPushRecord
+		if err := rows.Scan(&rec.ID, &rec.SandboxID, &rec.RegistryRef, &rec.Digest, &rec.PushedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, rec)
+	}
+	return out, rows.Err()
+}
+
+// ListOrphanedWasmCheckpointPushes returns push-history rows whose sandbox no
+// longer exists, capped at limit (<=0 means a default cap). These are the rows
+// a destroy/reconcile retained because its registry DeleteRef had not yet
+// succeeded; the orphan-ref sweep retries each ref and drops the row once the
+// manifest is confirmed gone, so the tracking table can never leak unbounded
+// rows for sandboxes that are already gone.
+func (s *Store) ListOrphanedWasmCheckpointPushes(ctx context.Context, limit int) ([]WasmCheckpointPushRecord, error) {
+	if limit <= 0 {
+		limit = 256
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT p.id, p.sandbox_id, p.registry_ref, p.digest, p.pushed_at
+		FROM wasm_checkpoint_pushes p
+		LEFT JOIN sandboxes s ON s.id = p.sandbox_id
+		WHERE s.id IS NULL
+		ORDER BY p.pushed_at ASC, p.id ASC
+		LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list orphaned wasm checkpoint pushes: %w", err)
 	}
 	defer rows.Close()
 	var out []WasmCheckpointPushRecord

--- a/internal/store/wasm_listbyruntime_test.go
+++ b/internal/store/wasm_listbyruntime_test.go
@@ -1,0 +1,79 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// TestListByRuntime confirms the per-runtime sweep query returns only the rows
+// for the requested runtime — the scaling fix relies on it not loading the
+// whole mixed-runtime fleet.
+func TestListByRuntime(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+
+	wasmA := sampleSandbox("sb-wasm-a")
+	wasmA.Runtime = models.RuntimeWasm
+	wasmB := sampleSandbox("sb-wasm-b")
+	wasmB.Runtime = models.RuntimeWasm
+	fc := sampleSandbox("sb-fc")
+	fc.Runtime = models.RuntimeFirecracker
+
+	for _, sb := range []*models.Sandbox{wasmA, wasmB, fc} {
+		if err := st.Create(ctx, sb); err != nil {
+			t.Fatalf("Create(%s): %v", sb.ID, err)
+		}
+	}
+
+	wasm, err := st.ListByRuntime(ctx, models.RuntimeWasm)
+	if err != nil {
+		t.Fatalf("ListByRuntime(wasm): %v", err)
+	}
+	if len(wasm) != 2 {
+		t.Fatalf("ListByRuntime(wasm) = %d, want 2", len(wasm))
+	}
+	for _, sb := range wasm {
+		if sb.Runtime != models.RuntimeWasm {
+			t.Fatalf("ListByRuntime(wasm) leaked %s (runtime %q)", sb.ID, sb.Runtime)
+		}
+	}
+
+	fcRows, err := st.ListByRuntime(ctx, models.RuntimeFirecracker)
+	if err != nil {
+		t.Fatalf("ListByRuntime(firecracker): %v", err)
+	}
+	if len(fcRows) != 1 || fcRows[0].ID != "sb-fc" {
+		t.Fatalf("ListByRuntime(firecracker) = %+v, want [sb-fc]", fcRows)
+	}
+}
+
+// TestListOrphanedWasmCheckpointPushes confirms only push rows whose sandbox is
+// gone are returned — the orphan-ref GC sweep depends on this to avoid touching
+// rows for live sandboxes.
+func TestListOrphanedWasmCheckpointPushes(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+
+	live := sampleSandbox("sb-live")
+	live.Runtime = models.RuntimeWasm
+	if err := st.Create(ctx, live); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := st.InsertWasmCheckpointPush(ctx, "sb-live", "aocr://sb-live:x", "d1"); err != nil {
+		t.Fatalf("InsertWasmCheckpointPush(live): %v", err)
+	}
+	// Push row for a sandbox that was never created / already destroyed.
+	if _, err := st.InsertWasmCheckpointPush(ctx, "sb-gone", "aocr://sb-gone:y", "d2"); err != nil {
+		t.Fatalf("InsertWasmCheckpointPush(gone): %v", err)
+	}
+
+	orphans, err := st.ListOrphanedWasmCheckpointPushes(ctx, 0)
+	if err != nil {
+		t.Fatalf("ListOrphanedWasmCheckpointPushes: %v", err)
+	}
+	if len(orphans) != 1 || orphans[0].SandboxID != "sb-gone" {
+		t.Fatalf("orphans = %+v, want exactly [sb-gone]", orphans)
+	}
+}

--- a/internal/store/wasm_listbyruntime_test.go
+++ b/internal/store/wasm_listbyruntime_test.go
@@ -77,3 +77,22 @@ func TestListOrphanedWasmCheckpointPushes(t *testing.T) {
 		t.Fatalf("orphans = %+v, want exactly [sb-gone]", orphans)
 	}
 }
+
+// TestListByRuntime_QueryErrorOnClosedDB covers the query-error branch.
+func TestListByRuntime_QueryErrorOnClosedDB(t *testing.T) {
+	st := newTestStore(t)
+	_ = st.Close()
+	if _, err := st.ListByRuntime(context.Background(), models.RuntimeWasm); err == nil {
+		t.Fatal("ListByRuntime on a closed DB must return an error")
+	}
+}
+
+// TestListOrphanedWasmCheckpointPushes_QueryErrorOnClosedDB covers the
+// query-error branch.
+func TestListOrphanedWasmCheckpointPushes_QueryErrorOnClosedDB(t *testing.T) {
+	st := newTestStore(t)
+	_ = st.Close()
+	if _, err := st.ListOrphanedWasmCheckpointPushes(context.Background(), 0); err == nil {
+		t.Fatal("ListOrphanedWasmCheckpointPushes on a closed DB must return an error")
+	}
+}

--- a/pkg/wasmmod/oras_delete.go
+++ b/pkg/wasmmod/oras_delete.go
@@ -2,9 +2,11 @@ package wasmmod
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
+	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 )
@@ -37,9 +39,21 @@ func DeleteSnapshotRef(ctx context.Context, cfg ORASPushConfig, registryRef stri
 	tag := registryTag(registryRef)
 	desc, err := repo.Resolve(ctx, tag)
 	if err != nil {
+		// A ref that is already gone is the success state for a delete: the
+		// caller (checkpoint cleanup / orphan-ref GC) only wants the manifest
+		// absent, and it may have been removed by a prior partial run or manual
+		// cleanup. Swallowing not-found here is what lets the caller safely drop
+		// its tracking row — otherwise an already-deleted ref would look like a
+		// permanent failure and the row would leak forever.
+		if errors.Is(err, errdef.ErrNotFound) {
+			return nil
+		}
 		return fmt.Errorf("oras delete resolve %s: %w", registryRef, err)
 	}
 	if err := repo.Delete(ctx, desc); err != nil {
+		if errors.Is(err, errdef.ErrNotFound) {
+			return nil
+		}
 		return fmt.Errorf("oras delete %s: %w", registryRef, err)
 	}
 	return nil

--- a/pkg/wasmmod/oras_snapshot_test.go
+++ b/pkg/wasmmod/oras_snapshot_test.go
@@ -101,6 +101,25 @@ func TestDeleteSnapshotRefMissingManifest(t *testing.T) {
 	}
 }
 
+// TestDeleteSnapshotRefResolveError covers the non-not-found resolve branch: a
+// transport-level failure (registry unreachable) must surface as an error, NOT
+// be swallowed like not-found — otherwise the caller would wrongly drop a
+// tracking row for a manifest that may still exist.
+func TestDeleteSnapshotRefResolveError(t *testing.T) {
+	reg := startTestOCIRegistry(t, "cluster/wasm-checkpoints/unreachable")
+	ref := reg.ref("latest")
+	reg.close() // server down → Resolve gets a connection error, not a 404
+
+	patFile := filepath.Join(t.TempDir(), "pat")
+	if err := os.WriteFile(patFile, []byte("cluster-pat"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := ORASPushConfig{Host: "h", ClusterID: "c1", PATPath: patFile}
+	if err := DeleteSnapshotRef(context.Background(), cfg, ref); err == nil {
+		t.Fatal("a transport error must not be treated as success")
+	}
+}
+
 func TestDeleteSnapshotRefRoundTrip(t *testing.T) {
 	reg := startTestOCIRegistry(t, "cluster/wasm-checkpoints/sb-del")
 	defer reg.close()

--- a/pkg/wasmmod/oras_snapshot_test.go
+++ b/pkg/wasmmod/oras_snapshot_test.go
@@ -83,6 +83,11 @@ func TestPushPullSnapshotArtifactRoundTrip(t *testing.T) {
 	}
 }
 
+// TestDeleteSnapshotRefMissingManifest pins the documented contract: a ref that
+// is already absent is the success state for a delete. This is load-bearing for
+// the no-vacuum checkpoint cleanup — the caller drops its tracking row only when
+// DeleteRef returns nil, so an already-gone manifest must NOT look like a
+// failure (otherwise the row would be retained and retried forever).
 func TestDeleteSnapshotRefMissingManifest(t *testing.T) {
 	reg := startTestOCIRegistry(t, "cluster/wasm-checkpoints/missing")
 	defer reg.close()
@@ -91,8 +96,8 @@ func TestDeleteSnapshotRefMissingManifest(t *testing.T) {
 		t.Fatal(err)
 	}
 	cfg := ORASPushConfig{Host: "h", ClusterID: "c1", PATPath: patFile}
-	if err := DeleteSnapshotRef(context.Background(), cfg, reg.ref("latest")); err == nil {
-		t.Fatal("expected resolve error for missing manifest")
+	if err := DeleteSnapshotRef(context.Background(), cfg, reg.ref("latest")); err != nil {
+		t.Fatalf("missing manifest must be treated as success, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **No-vacuum WASM checkpoint cleanup.** A `wasm_checkpoint_pushes` tracking row is now dropped **only after** its registry manifest is confirmed gone. Previously a transiently-failed `DeleteRef` still dropped the row, stranding the manifest with no record left to GC by — a permanent registry leak. Failed refs keep their row, and a new `runWasmOrphanRefSweep` retries them after the sandbox is gone (reusing the existing durable-push ticker — no new janitor goroutine). The no-pusher path (single-node / local) still bulk-deletes, unchanged.
- **Scaling.** The wasm periodic-checkpoint and durable-push sweeps now use a new `Store.ListByRuntime` (backed by a new `idx_sandboxes_runtime` index) instead of `Store.List`, so they scan only WASM rows instead of the whole mixed-runtime fleet on every tick — proportional to per-node WASM count at 100k-sandbox / 2000-node scale.
- **DRY.** Extracted `Service.startPeriodic` for the background-sweep loop skeleton that was copy-pasted across 8 sites (reconcile, lifecycle sweep, both image GCs, template GC, wasm module/cache GC, wasm checkpoint/push sweeps). Also fixed `DeleteSnapshotRef` to treat an already-absent ref as success, matching its long-standing doc comment.

## Sandbox boot impact

N/A - no work added to sandbox boot path. All changes are in background sweep loops and the destroy/cleanup path; `CreateSandbox` and its callees are untouched. The new `idx_sandboxes_runtime` index adds a negligible per-insert cost on the sandboxes table, not on the boot critical section specifically.

## Idempotency

N/A - no API surface changed. The affected paths are internal background sweeps and `cleanupWasmSandboxArtifacts` (destroy path). The cleanup and orphan-ref sweep are both idempotent under retry: a row is deleted only after its ref delete returns nil (which now includes already-absent), so re-running converges — a failed delete simply leaves the row for the next sweep.

## Failure-path consistency

`cleanupWasmSandboxArtifacts` touches the registry + store (not caddy). Rollback rule: the store row is the ledger and is dropped **only** after the registry manifest is confirmed gone; on partial failure the row is intentionally retained, and `runWasmOrphanRefSweep` (gated on the pusher being configured) is the documented retry owner that reclaims it later. Destroy never blocks on the registry. No caddy/store multi-step write was changed.

## L4 / host-port-pool changes

N/A - neither touched.

## Test plan

- New regression test `TestCleanupWasmSandboxArtifacts_NoVacuumOnDeleteFailure`: failed `DeleteRef` retains the tracking row; orphan-ref sweep is a no-op while the delete keeps failing; row is reclaimed once the registry recovers.
- New store tests `TestListByRuntime` and `TestListOrphanedWasmCheckpointPushes`.
- Updated `TestDeleteSnapshotRefMissingManifest` to pin the documented "missing = success" contract.
- Existing `TestCleanupWasmSandboxArtifacts_*` (happy path, non-wasm no-op, error branches) still pass — happy path still deletes all refs + clears all rows.
- `gofmt`, `go vet`, and full `go test ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)