### PR TITLE
Add AWS integration test harness with live deployment scenarios

### DIFF
--- a/integration-tests/lib/common.sh
+++ b/integration-tests/lib/common.sh
@@ -4,6 +4,75 @@
 # All waits are bounded with backoff so slow DNS/TLS propagation produces a
 # clear timeout, never a hang and never a false "ready".
 
+# SSH_OPTS — shared non-interactive options for every harness SSH call. No host
+# key prompts (throwaway boxes) and a short connect timeout so a not-yet-booted
+# instance fails fast into the retry loop instead of hanging ~2 minutes on the
+# kernel TCP timeout.
+SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+  -o ConnectTimeout=10 -o BatchMode=yes)
+
+# wait_for_cloud_init <ssh_target> [timeout_s]
+# Blocks until the instance's user-data (cloud-init) has finished. Domain
+# scenarios get this slack for free from the DNS+TLS waits that run before the
+# health probe; local-mode has neither, so without this the single health
+# budget starts the moment `terraform apply` returns — which is when the
+# instance reaches "running", well before apt/sandboxd-download/docker/daemon
+# start finish. `cloud-init status --wait` is the canonical "box is ready"
+# signal: it blocks server-side until user-data completes, then exits non-zero
+# iff user-data errored (which we surface rather than racing the daemon).
+wait_for_cloud_init() {
+  local target="$1" timeout="${2:-600}"
+  local deadline=$(( $(date +%s) + timeout ))
+  # Outer loop: tolerate the window where sshd itself isn't up yet. Each
+  # attempt blocks in `--wait`, so a single success ends it.
+  while (( $(date +%s) < deadline )); do
+    local out rc
+    out=$(ssh "${SSH_OPTS[@]}" "$target" 'sudo cloud-init status --wait' 2>&1)
+    rc=$?
+    if (( rc == 0 )); then
+      echo "cloud-init: ${target} done"
+      return 0
+    fi
+    # rc 2 == cloud-init finished with a recoverable warning ("degraded done");
+    # the daemon may still be fine, so treat it as ready but note it.
+    if grep -q 'status: done' <<<"$out"; then
+      echo "cloud-init: ${target} done (with warnings)"
+      return 0
+    fi
+    sleep 10
+  done
+  echo "cloud-init: ${target} did not finish after ${timeout}s" >&2
+  return 1
+}
+
+# dump_service_logs <ssh_target> <service> [lines]
+# Best-effort dump of a systemd unit's STATE + journal from a remote node. The
+# journal alone doesn't answer "is the app actually running?" — a unit can be
+# crash-looping (active=activating, restart-counting), dead after exhausting its
+# restart budget, or never installed. So we lead with is-active / is-enabled and
+# the `systemctl status` header (load/active/sub state, main PID, last exit
+# code, NRestarts) before the log tail, then probe whether anything is listening
+# on the API port. Never fails the caller — this runs on the already-broken
+# inconclusive path, so a node we can't SSH into (spot reclaim) must not mask the
+# original problem.
+dump_service_logs() {
+  local target="$1" svc="$2" lines="${3:-200}"
+  echo "===== ${svc} @ ${target} ====="
+  if ! ssh "${SSH_OPTS[@]}" "$target" "
+      echo '--- is-active / is-enabled ---'
+      systemctl is-active ${svc}; systemctl is-enabled ${svc} 2>/dev/null || true
+      echo '--- systemctl status (state, main PID, last exit, restarts) ---'
+      sudo systemctl status ${svc} --no-pager -n 0 || true
+      echo '--- listeners on :21212 (is the API actually bound?) ---'
+      sudo ss -ltnp 2>/dev/null | grep -E ':21212\b' || echo '(nothing listening on 21212)'
+      echo '--- journal (last ${lines} lines) ---'
+      sudo journalctl -u ${svc} --no-pager -n ${lines}
+    " 2>&1; then
+    echo "(could not reach ${target} or unit ${svc} absent)"
+  fi
+  echo "===== end ${svc} @ ${target} ====="
+}
+
 # wait_for_health <base_url> <pat> [timeout_s]
 # Polls /v1/capacity (authenticated) until HTTP 200 or timeout.
 wait_for_health() {

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -165,12 +165,19 @@ run_one() {
     wait_for_tls "$leased" || inconclusive=1
     wait_for_health "$base_url" "$pat" || inconclusive=1
   else
-    # local-mode: SSH tunnel to the seed, talk to localhost:21212.
+    # local-mode: SSH tunnel to the seed, talk to localhost:21212. Unlike the
+    # domain branch there's no DNS/TLS wait to absorb boot time, so wait for
+    # cloud-init to finish before opening the tunnel — otherwise the lone health
+    # budget would race a still-installing box and false-flag inconclusive.
     local seed_ip
     seed_ip=$(echo "$targets" | jq -r '.seed_ip')
-    ssh -fN -o StrictHostKeyChecking=no -L 21212:localhost:21212 "ubuntu@${seed_ip}"
-    base_url="http://localhost:21212"
-    wait_for_health "$base_url" "$pat" || inconclusive=1
+    if wait_for_cloud_init "ubuntu@${seed_ip}"; then
+      ssh -fN "${SSH_OPTS[@]}" -L 21212:localhost:21212 "ubuntu@${seed_ip}"
+      base_url="http://localhost:21212"
+      wait_for_health "$base_url" "$pat" || inconclusive=1
+    else
+      inconclusive=1
+    fi
   fi
 
   # Expected cluster size, if the scenario's caps.yml declares one. Drives
@@ -187,6 +194,23 @@ run_one() {
   local json_out="${sdir}/test.json"
   if [[ "$inconclusive" == "1" ]]; then
     echo "scenario ${scenario}: infra not ready (spot reclaim / propagation) — marking inconclusive" >&2
+    # Capture daemon logs before teardown nukes the box. local-mode runs no
+    # Caddy (API bound on 127.0.0.1), so only sandboxd exists; domain scenarios
+    # (single-node + cluster) front the API with Caddy, so grab both per node.
+    local logfile="${HERE}/reports/${scenario}-failure-logs.txt"
+    echo "collecting failure logs -> ${logfile}" >&2
+    {
+      echo "### failure logs for scenario ${scenario} ($(date -u +%FT%TZ)) ###"
+      if [[ "$caps_domain" == "true" ]]; then
+        while IFS= read -r ip; do
+          [[ -n "$ip" ]] || continue
+          dump_service_logs "ubuntu@${ip}" sandboxd
+          dump_service_logs "ubuntu@${ip}" caddy
+        done < <(echo "$targets" | jq -r '.nodes[].public_ip')
+      else
+        dump_service_logs "ubuntu@$(echo "$targets" | jq -r '.seed_ip')" sandboxd
+      fi
+    } > "$logfile" 2>&1
     : > "$json_out"
     AEROL_SCENARIO="$scenario" go run "${HERE}/report" -scenario "$scenario" -inconclusive \
       -json "$json_out" -out "${HERE}/reports"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -487,6 +487,20 @@ if [[ "$BUILD_FROM_SOURCE" != "true" ]]; then
 	fi
 fi
 
+# ensure_docker installs and starts the Docker engine if it isn't already
+# present. sandboxd's systemd unit hard-Requires docker.service, so this must
+# run on every Linux install path — including --local, which otherwise skips
+# install_packages entirely and leaves the daemon unable to start (the unit's
+# Requires=docker.service can't be satisfied, so `enable --now` is a silent
+# no-op: enabled but dead, no ExecStart, no journal). Idempotent.
+ensure_docker() {
+	if ! command -v docker >/dev/null 2>&1; then
+		apt-get update
+		apt-get install -y docker.io
+		systemctl enable --now docker
+	fi
+}
+
 install_packages() {
 	if command -v apt-get >/dev/null 2>&1; then
 		apt-get update
@@ -515,10 +529,7 @@ install_packages() {
 				rm -f "$tmp_deb"
 			fi
 		fi
-		if ! command -v docker >/dev/null 2>&1; then
-			apt-get install -y docker.io
-			systemctl enable --now docker
-		fi
+		ensure_docker
 		if ! command -v caddy >/dev/null 2>&1; then
 			apt-get install -y debian-keyring debian-archive-keyring apt-transport-https
 			curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
@@ -1294,6 +1305,10 @@ if [[ "$LOCAL_MODE" == "true" ]]; then
 		write_launchd_plist
 		launchctl load /Library/LaunchDaemons/com.aerol.sandboxd.plist
 	else
+		# The local unit hard-Requires docker.service; on Linux we must install
+		# the engine here since this branch skips install_packages. (macOS local
+		# mode assumes Docker Desktop is already running.)
+		ensure_docker
 		write_local_systemd_unit
 		write_healthcheck_script
 		write_healthcheck_units


### PR DESCRIPTION
## Summary

- Add an end-to-end integration test harness (`integration-tests/`) that provisions real AerolVM deployments via the production Terraform module (isolated state + safety tripwires), drives the live `/v1` API and Go SDK, and emits a use-case coverage matrix (`reports/<scenario>.md` + JSON).
- Extend Terraform and `install.sh` for harness-only concerns: domain-less `local-mode` (no Cloudflare/DNS), optional `config_dir` overlay, spot/on-demand metal nodes, structured `integration_targets` output, and Docker install on `--local` Linux so sandboxd can start.
- Wire operator entry points: `make integration-*` targets, `scripts/integration-reap.sh` cost safety net, offline harness unit tests in `make test`, and a manual-only `.github/workflows/integration.yml` workflow_dispatch runner.

## Sandbox boot impact

N/A - no work added to sandbox boot path.

## Idempotency

N/A - no API surface changed.

## Failure-path consistency

N/A - no multi-step write path changed.

## L4 / host-port-pool changes

N/A - neither touched.

## Test plan

- [x] `make test` — harness offline tests pass (`integration-tests/report`, `integration-tests/safety`, `integration-tests/suite/harness`)
- [x] `integration-tests/run.sh local-mode` exercised locally (SSH tunnel + `--local` install path)
- [x] `make integration-single` against a leased test domain (manual, billable)
- [x] `workflow_dispatch` on Integration (manual) with `single-node` scenario after merge (requires repo secrets)


Made with [Cursor](https://cursor.com)