### PR TITLE
fix(service): don't route tagged base images through AOCR snapshot fallback

### DIFF
--- a/internal/service/image_distribution.go
+++ b/internal/service/image_distribution.go
@@ -82,7 +82,14 @@ func (s *Service) NormalizeCreateImageDistribution(ctx context.Context, req *mod
 			// check. Only applies to bare identifiers — anything that
 			// looks like a registry ref or a local-only build tag goes
 			// through the normal classifier below.
-			if imageRegistryHost(req.Image) == "" && !docker.IsLocalOnlyImageRef(req.Image) {
+			// snapshotAOCRRef always appends `:latest`, so a cross-node
+			// snapshot name must be a bare identifier with no tag/digest of
+			// its own — otherwise we'd build a double-tagged ref like
+			// `snapshots/alpine:3.20:latest` that Docker rejects as
+			// "invalid reference format". A tagged ref (e.g. `alpine:3.20`)
+			// is a plain base image, not a snapshot, so fall through to the
+			// classifier below.
+			if imageRegistryHost(req.Image) == "" && !docker.IsLocalOnlyImageRef(req.Image) && !imageRefHasTagOrDigest(req.Image) {
 				if dest := s.snapshotPusher.DestRefFor(req.Image); dest != "" {
 					req.Image = dest
 					if req.ImageDistribution().IsZero() {
@@ -163,6 +170,24 @@ func normalizeImageDistributionMetadata(image string, meta models.ImageDistribut
 
 func ImageRequiresLocalPlacement(req models.CreateSandboxRequest) bool {
 	return req.ImageDistributionMode == models.ImageDistributionLocalOnly || docker.IsLocalOnlyImageRef(req.Image)
+}
+
+// imageRefHasTagOrDigest reports whether image carries an explicit `:tag` or
+// `@digest`. It inspects only the final path component so a registry host port
+// (e.g. `host:5000/repo`) is not mistaken for a tag.
+func imageRefHasTagOrDigest(image string) bool {
+	image = strings.TrimSpace(image)
+	if image == "" {
+		return false
+	}
+	if strings.Contains(image, "@") {
+		return true
+	}
+	last := image
+	if idx := strings.LastIndex(image, "/"); idx >= 0 {
+		last = image[idx+1:]
+	}
+	return strings.Contains(last, ":")
 }
 
 func imageRegistryHost(image string) string {

--- a/internal/service/image_distribution_test.go
+++ b/internal/service/image_distribution_test.go
@@ -182,6 +182,25 @@ func TestNormalizeCreateImageDistributionAOCRFallback(t *testing.T) {
 			wantMode:  models.ImageDistributionExternalRegistry,
 		},
 		{
+			// Regression: a tagged base image (no registry host) must NOT be
+			// mistaken for a cross-node snapshot. snapshotAOCRRef appends
+			// `:latest`, which would yield the double-tagged, Docker-rejected
+			// ref `snapshots/alpine:3.20:latest`. It must fall through to the
+			// classifier as a normal external-registry pull.
+			name:      "tagged base image is not treated as a snapshot",
+			image:     "alpine:3.20",
+			pusher:    pusher,
+			wantImage: "alpine:3.20",
+			wantMode:  models.ImageDistributionExternalRegistry,
+		},
+		{
+			name:      "digest-pinned base image is not treated as a snapshot",
+			image:     "alpine@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			pusher:    pusher,
+			wantImage: "alpine@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			wantMode:  models.ImageDistributionExternalRegistry,
+		},
+		{
 			name:      "registry ref is left alone",
 			image:     "ghcr.io/org/img:latest",
 			pusher:    pusher,


### PR DESCRIPTION
## Summary

- The cross-node snapshot fallback in `NormalizeCreateImageDistribution` treated **any** host-less image ref as a peer-pushed snapshot — including plain base images like `alpine:3.20`. Since `snapshotAOCRRef` always appends `:latest`, these were rewritten to double-tagged refs (`.../snapshots/alpine:3.20:latest--ttl-1h`) that Docker rejects as `invalid reference format`, failing nearly every `CreateSandbox` on a cluster and cascading into pull failure-backoff.
- Guard the fallback with `imageRefHasTagOrDigest`: a cross-node snapshot name must be a bare identifier (the ref builder supplies the tag), so any ref already carrying a `:tag` / `@digest` is a normal base image and falls through to the external-registry classifier.

Regression surfaced by `make integration-cluster-mixed` (33 create-path UC failures, all one root cause). Introduced in `25eaa0c`.

## Sandbox boot impact

Net-neutral. The change is in `NormalizeCreateImageDistribution` (boot path), but it only **narrows** an existing branch with a single in-memory string check (`imageRefHasTagOrDigest`) — no new DB query, HTTP round-trip, file I/O, or lock. For tagged base images it now skips a string rewrite and proceeds to the classifier that already ran in every other case. First-call behavior unchanged.

## Idempotency

N/A - no API surface changed. `NormalizeCreateImageDistribution` is side-effect free (no pull/push/store write); it only resolves image-distribution metadata on the request. Behavior is deterministic under retry and concurrent duplicate calls.

## Failure-path consistency

N/A - no multi-step write path changed.

## L4 / host-port-pool changes

N/A - neither touched.

## Cluster-correctness impact

The fallback exists specifically for cluster mode (peer takes a snapshot, pushes to the deterministic AOCR namespace, a node that never saw the row constructs the canonical ref). This change keeps that path intact for **bare** snapshot names and only excludes tagged/digest refs that could never be valid snapshot names anyway. No split-brain, replay, or leader-change semantics touched. Single-node: the fallback only fires when `snapshotPusher != nil` (cluster/push enabled), so single-node is unaffected either way.

## Test plan

- `go build ./...` clean
- Added two regression cases to `TestNormalizeCreateImageDistributionAOCRFallback`: tagged (`alpine:3.20`) and digest-pinned base images must classify as external-registry, not rewrite to an AOCR snapshot ref. All subtests pass.
- `go test ./internal/service/...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)