### PR TITLE
docs(claude): document wasm/firecracker/integration subsystems + add …

### DIFF
--- a/.claude/skills/maintain-coverage/SKILL.md
+++ b/.claude/skills/maintain-coverage/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: maintain-coverage
+description: Keep the Go tree at its ~85% line-coverage bar when new or changed code lands. Finds the packages your branch touched, measures their coverage, locates the uncovered lines, and writes table-driven tests in the package's existing style. Use before opening any PR, or when the user says "add tests", "the new code has no tests", "check coverage", "bring this up to 85%", or "why did coverage drop". Proactively suggest right after a new package/driver/handler is written and before the PR goes up.
+---
+
+# Maintain the ~85% coverage bar
+
+The Go tree (`./cmd/... ./internal/... ./pkg/...`) sits at **~85% line
+coverage**. CI uploads the profile to Codecov on every push but does **not**
+hard-fail below a threshold (no `codecov.yml` gate). The bar is therefore a
+**team convention you enforce by hand** — new code that ships with no tests
+silently drags the number down. This skill is the recipe to stop that.
+
+## When this applies
+
+- A new file or package was added (driver, pool, resolver, handler, client).
+- An existing function grew new branches (error paths, retries, edge cases).
+- Coverage "mysteriously" dropped on a PR.
+
+## Recipe
+
+### 1. Find what your branch changed
+
+```sh
+git diff --name-only origin/main...HEAD -- '*.go' | grep -v '_test.go$'
+```
+
+Map each changed `.go` file to its Go package (its directory). Those are the
+packages whose coverage you must check. Ignore files under
+`integration-tests/` (tag-gated, see §6) and generated code.
+
+### 2. Measure per-package coverage
+
+Run the **same command CI runs** (`.github/workflows/test.yml`), but you can
+scope it to the packages you touched for a fast loop:
+
+```sh
+go test -count=1 -coverprofile=coverage.out ./internal/runtime/wasm/...
+go tool cover -func=coverage.out | tail -n 1     # the package/total %
+```
+
+For the whole tree (what CI reports):
+
+```sh
+go test -count=1 -coverprofile=coverage.out ./cmd/... ./internal/... ./pkg/...
+go tool cover -func=coverage.out | tail -n 1
+```
+
+A package below ~85% needs work. New packages frequently start near 0%.
+
+### 3. Locate the uncovered lines
+
+```sh
+go tool cover -func=coverage.out | grep <yourpackage>   # per-function %
+go tool cover -html=coverage.out -o coverage.html        # visual: red = uncovered
+```
+
+The per-function view tells you *which* functions are 0% / partial. The HTML
+view (or reading the red spans) tells you *which branches* — usually error
+paths, the `default:` of a switch, or a guard clause.
+
+### 4. Write tests in the package's existing style
+
+- **Match the table-driven pattern already in the package.** Don't invent a
+  new harness. Canonical examples to copy from:
+  - `internal/store/store_test.go` — store CRUD + host-port pool regression.
+  - `internal/service/layer4_bootstrap_test.go` — latch / single-flight.
+  - the `_test.go` next to whatever package you're covering.
+- **Cover branches, not just lines.** Each error return, each `case`, each
+  guard wants at least one test that reaches it.
+- **Keep it offline.** No real network, AWS, or Docker in a plain `_test.go`
+  (see §6). Use fakes/interfaces the package already exposes.
+- **Comments explain WHY** (a tricky setup, a non-obvious edge), per the repo
+  convention — not WHAT the assertion does.
+
+### 5. Re-measure and confirm
+
+Re-run §2 for the package. Confirm it's back at/above ~85% and the total
+didn't regress. State the before/after numbers in the PR description.
+
+### 6. What does NOT belong in unit tests
+
+Live behavior that mocks can't prove is **tag-gated**, never in a plain
+`_test.go`:
+
+- `//go:build integration` → `integration-tests/suite/` and the
+  `wasm-integration` CI job. Run via `make integration-*` (real AWS, costs
+  money) or `go test -tags=integration`.
+- `//go:build e2e` → ACME end-to-end, `make test-acme-e2e` (needs local
+  Docker).
+
+These do not count toward the `make test` / Codecov number, so don't try to
+lift coverage by adding them.
+
+## Mandatory regression tests (the floor, not the ceiling)
+
+These areas require a regression test **and** a PR call-out regardless of the
+coverage number (see `CLAUDE.md` Hard rules + `pr-review.md`):
+
+- TCP host-port pool: `Store.TryReserveHostPort`, the `host_port` partial
+  unique index, `Service.allocateHostPort` → `internal/store/store_test.go`.
+- L4 bootstrap latch: `EnsureLayer4` / `EnsureLayer4Ready` / `l4Ready` →
+  `internal/service/layer4_bootstrap_test.go`.
+- `internal/network/tap` allocator (fragile like the host-port pool) →
+  test next to `pool.go`.
+- Cluster FSM / placement / recovery / heartbeat →
+  `internal/cluster/*_test.go`.
+
+## Checklist before the PR
+
+- [ ] Every changed package re-measured at ~85%+ (numbers in PR description).
+- [ ] New package/file has a `_test.go` beside it.
+- [ ] New error paths / switch branches each have a test.
+- [ ] Fragile-area changes (above) have their named regression test + call-out.
+- [ ] No network/AWS/Docker in plain `_test.go`; live checks are tag-gated.

--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ integration-tests/scenarios/domains.yml
 # Curated WASM runtime binaries are large; keep modules.yml + fetch.sh tracked,
 # ignore the downloaded .wasm payloads (fetch.sh re-downloads + verifies them).
 integration-tests/fixtures/wasm/*.wasm
+# Go coverage profiles
+*.out

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,30 @@ these axes):
    regression). Cluster-mode code must remain a no-op when `cfg.EnableCluster`
    is false — `Noop` exists for that.
 
+### Testing & coverage
+
+The Go tree (`./cmd/... ./internal/... ./pkg/...`) sits at **~85% line
+coverage** and CI uploads the profile to Codecov on every push
+(`.github/workflows/test.yml`). There is no hard CI gate, so the bar is a
+team convention you must uphold — **new code ships with tests that keep its
+package at or above 85%.** Don't let a feature land with a bare handful of
+tests.
+
+1. **Every new package / file gets a `_test.go` next to it.** A new driver,
+   pool, resolver, or handler is not done until its package is back at ~85%.
+   Run `/maintain-coverage` (or the recipe in that skill) to find the gap
+   before opening the PR.
+2. **The fragile areas above already mandate regression tests** (host-port
+   pool, L4 latch, cluster FSM, `network/tap` allocator). Those are the
+   floor, not the ceiling.
+3. **`make test` is offline and never touches AWS.** Live behavior that mocks
+   can't prove goes in `integration-tests/` behind the `integration` build
+   tag, or in a tag-gated test like `test-acme-e2e` / the `wasm-integration`
+   CI job. Never put network/AWS calls in a plain `_test.go`.
+4. **Match the existing table-driven style** of the package you're testing;
+   don't invent a new harness when `store_test.go` / `layer4_bootstrap_test.go`
+   already show the pattern.
+
 ## Repository map
 
 ```
@@ -69,8 +93,27 @@ internal/
                  the cross-node HTTP reverse proxy. High-risk area — touching
                  anything in here needs the same care as the TCP pool.
   config/        Env-driven config loader.
+  network/       Host networking primitives for VM runtimes. network/tap/ is
+                 the TAP+IPv4 slot allocator (pool.go = allocation bookkeeping,
+                 host.go = realization via `ip`). Idempotent Ensure/Remove.
+                 FRAGILE like the TCP host-port pool — changes need a
+                 regression test next to the file.
   observability/ OTEL traces + expvar metrics exporter for sandboxd.
-  runtime/       Runtime.Runtime interface (Docker today, gVisor/Kata later).
+  pool/          Warm pools for fast boot. pool/vmm/ holds pre-booted
+                 Firecracker snapshots (snapshot-load fast-boot); pool/wasm/
+                 holds pre-spawned WASM workers. Both publish expvar
+                 hit/miss/orphan metrics and refill on a ticker.
+  runtime/       Runtime.Runtime interface + drivers. runtime.go defines
+                 Runtime (Create/Start/Stop/Destroy/Snapshot/Inspect/…) and
+                 ContainerRuntime (adds the network-rule methods); use
+                 AsContainerRuntime to test for the latter. Drivers:
+                 docker (pkg/docker/client.go, both interfaces),
+                 firecracker/ (both interfaces, Jailer + TAP + vsock),
+                 wasm/ (Runtime only — host-mediated networking, no per-IP
+                 iptables; wasm/toolhost/ is the host-side file/exec/sessions
+                 HTTP handler, wasm/statekv/ is the durable per-sandbox KV
+                 store backed by the wasm_state_kv table). See "Runtime
+                 drivers" below.
   scaleobs/      Scale-out observability metrics (admission / placement).
   service/       Business logic. Version-agnostic. Owns Service struct,
                  CreateSandbox / CreateSandboxWithID / RecreateSandbox entry
@@ -92,6 +135,18 @@ pkg/
     daytona/     Daytona-SDK compatibility facade (/daytona/...).
   caddy/         Caddy admin API client (L7 routes + L4 routes for TCP).
   capacity/      Host capacity detection + admission control (Admitter).
+  clonegen/      Clone-generation token (detects a sandbox resumed from a
+                 snapshot); shared by in-guest toolboxd + WASM checkpoint
+                 fencing.
+  controlplane/  Neutral seam for a managed control plane (token validation,
+                 usage reporting, fleet enforcement). Open-source build wires
+                 a no-op Provider — keep it a no-op by default.
+  daemon/        Boot sequence (Run). Wires config → store → docker → caddy →
+                 runtimes → pools → service → api server. Shared between the
+                 open-source and managed builds; cmd/sandboxd is a thin shim
+                 over this.
+  firecracker/   Thin HTTP-over-Unix-socket REST client for the Firecracker
+                 VMM API (mirrors pkg/caddy/client.go). client.go.
   docker/        Docker client, /events stream, image GC, netrules (egress fw).
   models/        Wire types + validation (CreateSandboxRequest, Sandbox,
                  ExposedPort, Lifecycle, Mount, Runtime constants, E2B/Daytona
@@ -99,8 +154,18 @@ pkg/
                  facades depend on it.
   mounts/        External-storage mount manager (S3, NFS, SSHFS, rclone).
                  Mount inputs run on the host — see pr-review.md §5.
+  oci/           OCI image → ext4 rootfs builder (skopeo + umoci +
+                 mkfs.ext4 pipeline). Used by the Firecracker cold-boot path
+                 when a prebuilt template isn't available.
   secrets/       Credential AEAD cipher (env_json + sealed mount blobs).
   sshgateway/    SSH gateway for per-sandbox Ed25519 keys.
+  wasm/          WASM engine abstraction. wazero is the default backend;
+                 wasmtime is optional behind `//go:build wasmtime`. Owns the
+                 network hook, snapshot codec, and fuel metering.
+                 NewEngineFor(ctx, name) selects the backend.
+  wasmmod/       WASM module resolver + OCI registry (ORAS push/pull/delete).
+                 Resolves a ref (path, file://, bare name) → local .wasm and
+                 validates the artifact.
 sdk/
   typescript/    @aerol-ai/aerolvm-sdk. src/MicroVM.ts + Sandbox.ts; transport
                  in src/internal/api/v1/.
@@ -112,6 +177,12 @@ sdk/
 docs/
   src/content/docs/   Astro/Starlight .md / .mdx pages.
   src/content.config.ts   Sidebar nav config (register new pages here).
+integration-tests/   Live AWS integration suite (provisions REAL AWS via the
+  suite/             prod TF module against isolated state — costs money).
+  suite/harness/     Behind the `integration` build tag, so `make test` never
+  reports/           touches it. harness/ holds the scenario loader + use-case
+                     registry; reports/ gets per-scenario .md/.json matrices.
+                     Run with the `make integration-*` targets. See its README.
 plans/
   sdk-compatibility/  Daytona + E2B compat planning & support matrices.
   *.md                Active design docs.
@@ -140,12 +211,22 @@ Makefile         fmt, test, build, build-sandboxd, build-toolboxd, docs-*.
 
 ```
 make fmt                          # go fmt ./...
-make test                         # go test ./...   (server + SDK Go)
+make test                         # go test ./...   (server + SDK Go; offline)
 go test ./internal/service/...    # narrow run
 go test -run TestEnsureLayer4 ./internal/service/...
 make build                        # sandboxd + toolboxd into bin/
 make docs-dev                     # local Astro dev server
 make docs-build                   # static docs build
+
+# Coverage (mirrors the CI step in .github/workflows/test.yml) — keep ~85%:
+go test -count=1 -coverprofile=coverage.out ./cmd/... ./internal/... ./pkg/...
+go tool cover -func=coverage.out | tail -n 1          # total %
+go tool cover -func=coverage.out | grep <pkg>         # per-function gaps
+go tool cover -html=coverage.out                      # visual gaps
+
+# Tag-gated tests (not run by `make test`):
+make test-acme-e2e                # ACME end-to-end, needs local Docker
+go test -tags=integration ./...   # wasm-integration etc., needs creds
 ```
 
 Per-SDK tests:
@@ -161,6 +242,11 @@ Per-SDK tests:
 CI is path-filtered (`.github/workflows/test.yml`): touching `docs/**`
 short-circuits the Go and SDK jobs, and each SDK only runs when its own folder
 changes.
+
+Live integration runs (`make integration-single`, `integration-cluster-*`,
+`integration-all`) provision **real AWS** via the prod Terraform module and
+cost money — they are operator-run, not part of `make test`. `make
+integration-reap` terminates leaked instances. See `integration-tests/README.md`.
 
 ## Project skills
 
@@ -179,12 +265,19 @@ exact files to touch. Prefer invoking the skill over working from memory.
 | `/add-daytona-route` | Adding to the Daytona compatibility facade |
 | `/add-e2b-route` | Adding to the (planned) E2B compatibility facade |
 | `/add-mount-adapter` | Adding an external-storage mount adapter |
+| `/maintain-coverage` | Before opening any PR — find under-tested new/changed Go code and bring its package back to the ~85% bar |
 
 For changes that don't match a skill, the file-level "where to look" map is:
 
 | Task | Start here |
 |---|---|
 | Add server business logic | `internal/service/service.go` (or new file in same package) |
+| Firecracker VM runtime / Jailer / snapshots | `internal/runtime/firecracker/driver.go`, REST client `pkg/firecracker/client.go`, warm pool `internal/pool/vmm/`, rootfs `pkg/oci/`, TAP `internal/network/tap/` |
+| WASM runtime / engine / modules | `internal/runtime/wasm/driver.go`, host handler `internal/runtime/wasm/toolhost/`, KV `internal/runtime/wasm/statekv/`, engine `pkg/wasm/`, modules `pkg/wasmmod/`, warm pool `internal/pool/wasm/` |
+| Add/run a runtime driver (the interface itself) | `internal/runtime/runtime.go` (Runtime + ContainerRuntime) |
+| Daemon boot wiring (new subsystem into Run) | `pkg/daemon/` |
+| Managed control-plane seam | `pkg/controlplane/` (keep open-source build a no-op) |
+| Live AWS integration scenarios | `integration-tests/suite/` + `harness/`; run via `make integration-*` |
 | Cluster placement / Raft FSM / gossip / failover | `internal/cluster/` — see `cluster.go` for the package overview, `fsm.go` + `placement.go` for owner assignment, `recovery_*.go` for failover replicas |
 | OTEL traces / expvar metrics exporter | `internal/observability/` |
 | Caddy route / TLS / L4 wiring | `pkg/caddy/client.go` |


### PR DESCRIPTION
## What

Brings `CLAUDE.md` back in sync with the current tree and adds a `/maintain-coverage` skill to hold the line on the ~85% coverage convention.

### CLAUDE.md
- **Repository map** now documents what already exists in code but was undocumented:
  - `internal/network/` (TAP allocator — flagged fragile like the host-port pool), `internal/pool/` (vmm + wasm warm pools), and an expanded `internal/runtime/` covering the `Runtime`/`ContainerRuntime` interfaces and the docker/firecracker/wasm drivers (incl. `wasm/toolhost/` + `wasm/statekv/`).
  - `pkg/`: `clonegen`, `controlplane`, `daemon`, `firecracker`, `oci`, `wasm`, `wasmmod`.
  - `integration-tests/` suite (suite/harness/reports, `integration` build tag, real-AWS cost warning).
- **New "Testing & coverage" hard rule**: the ~85% bar is a team convention (no CI hard-gate — there is no `codecov.yml`), new packages ship with a `_test.go`, and live/AWS behavior must be tag-gated, not in plain `_test.go`.
- Build/test section gains the coverage commands (mirroring `.github/workflows/test.yml`), tag-gated targets, and `make integration-*` notes.
- "Where to look" + skills tables updated for the firecracker/wasm runtimes, runtime interface, daemon wiring, control-plane seam, integration scenarios, and the new skill.

### New skill: `/maintain-coverage`
Recipe: `git diff` changed packages -> measure with `go tool cover -func` -> locate uncovered branches via `-html` -> write table-driven tests in the package's existing style -> re-measure. Restates the mandatory regression-test floor (host-port pool, L4 latch, `network/tap`, cluster FSM) and clarifies tag-gated integration/e2e tests don't count toward the number.

### Housekeeping
- `*.out` coverage profiles added to `.gitignore`.

## Why
The daemon grew Firecracker + WASM runtimes, warm pools, and a live integration suite that `CLAUDE.md` never mentioned, and new code was landing under-tested. This documents the real structure and gives a repeatable way to keep coverage at bar.

## Notes
- Docs/skill-only change. No Go code touched, so the path-filtered CI Go/SDK jobs short-circuit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)