### PR TITLE
test(integration): cover untested SDK methods (UC-68..UC-77)

### DIFF
--- a/integration-tests/suite/dns_test.go
+++ b/integration-tests/suite/dns_test.go
@@ -1,0 +1,47 @@
+//go:build integration
+
+package suite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/integration-tests/suite/harness"
+	sdktypes "github.com/aerol-ai/microvm/sdk/go/pkg/types"
+)
+
+// UC-77 — A domain-mode deployment publishes its ingress target: the hostname
+// and/or IP set that custom-domain DNS records must point at. Source classifies
+// the shape so callers know whether to render a CNAME or A/AAAA hint, and a
+// non-unknown source must carry a matching address.
+func TestDNSIngressTarget(t *testing.T) {
+	harness.Require(t, sc, "UC-77")
+	c := client(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	target, err := c.SDK().DNSTarget(ctx)
+	if err != nil {
+		t.Fatalf("dns target: %v", err)
+	}
+
+	switch target.Source {
+	case sdktypes.IngressTargetSourceHostname:
+		if target.Hostname == "" {
+			t.Fatalf("source=hostname but Hostname is empty: %+v", target)
+		}
+	case sdktypes.IngressTargetSourceIPs:
+		if len(target.IPs) == 0 {
+			t.Fatalf("source=ips but IPs is empty: %+v", target)
+		}
+	case sdktypes.IngressTargetSourceMixed:
+		if target.Hostname == "" && len(target.IPs) == 0 {
+			t.Fatalf("source=mixed but neither Hostname nor IPs set: %+v", target)
+		}
+	case sdktypes.IngressTargetSourceUnknown:
+		// Acceptable: a deployment can legitimately not yet know its target.
+	default:
+		t.Fatalf("unexpected ingress target source %q", target.Source)
+	}
+}

--- a/integration-tests/suite/exec_more_test.go
+++ b/integration-tests/suite/exec_more_test.go
@@ -1,0 +1,200 @@
+//go:build integration
+
+package suite
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/integration-tests/suite/harness"
+	sdktypes "github.com/aerol-ai/microvm/sdk/go/pkg/types"
+)
+
+// UC-68 — The streaming exec transport carries stdin to the process and its
+// stdout back, and Wait reports the real exit code. This is a different code
+// path from the blocking Exec (UC-39): a long-lived bidirectional stream over
+// the toolbox proxy, not a single request/response.
+func TestExecStreamInteractive(t *testing.T) {
+	harness.Require(t, sc, "UC-68")
+	c := client(t)
+	sb := c.NewSandbox(t, sdktypes.CreateSandboxOptions{Name: harness.UniqueName(sc, t)})
+	waitRunning(t, sb)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	// OnStdout fires on the SDK's read-loop goroutine, so the buffer it writes
+	// into is shared across goroutines — guard it with a mutex.
+	var mu sync.Mutex
+	var out strings.Builder
+	// Command runs under `/bin/sh -c`, so `read` consumes the line we write to
+	// stdin; the process then exits 0 on its own (no need to half-close stdin).
+	handle, err := sb.ExecStream(ctx, sdktypes.ExecStreamOptions{
+		Command: `read line; echo "echoed:$line"`,
+		OnStdout: func(b []byte) {
+			mu.Lock()
+			out.Write(b)
+			mu.Unlock()
+		},
+	})
+	if err != nil {
+		t.Fatalf("exec stream: %v", err)
+	}
+	if err := handle.WriteString("marker-68\n"); err != nil {
+		t.Fatalf("write stdin: %v", err)
+	}
+	info, err := handle.Wait()
+	if err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	if info.Code != 0 {
+		t.Fatalf("stream exit code = %d, want 0", info.Code)
+	}
+	mu.Lock()
+	got := out.String()
+	mu.Unlock()
+	if !strings.Contains(got, "echoed:marker-68") {
+		t.Fatalf("stream stdout = %q, want it to contain echoed:marker-68", got)
+	}
+}
+
+// UC-69 — Exec honours the full request shape: a working directory and
+// per-exec environment, not just a bare command string (UC-39 covers the
+// string sugar).
+func TestExecWithWorkdirAndEnv(t *testing.T) {
+	harness.Require(t, sc, "UC-69")
+	c := client(t)
+	sb := c.NewSandbox(t, sdktypes.CreateSandboxOptions{Name: harness.UniqueName(sc, t)})
+	waitRunning(t, sb)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	res, err := sb.Exec(ctx, sdktypes.ExecRequest{
+		Command: `pwd; echo "var=$UC69"`,
+		WorkDir: "/tmp",
+		Env:     map[string]string{"UC69": "value-69"},
+	})
+	if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if !strings.Contains(res.Stdout, "/tmp") {
+		t.Fatalf("workdir not honoured: stdout = %q, want it to contain /tmp", res.Stdout)
+	}
+	if !strings.Contains(res.Stdout, "var=value-69") {
+		t.Fatalf("env not honoured: stdout = %q, want it to contain var=value-69", res.Stdout)
+	}
+}
+
+// UC-70 — The full session lifecycle beyond create+log (UC-42): a live PTY
+// session is listed, fetched by id, resized, and terminated via a signal.
+func TestSessionLifecycle(t *testing.T) {
+	harness.Require(t, sc, "UC-70")
+	c := client(t)
+	sb := c.NewSandbox(t, sdktypes.CreateSandboxOptions{Name: harness.UniqueName(sc, t)})
+	waitRunning(t, sb)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	// A long-lived PTY shell so the session stays "running" while we exercise
+	// list/get/resize before we signal it dead.
+	sess, err := sb.CreateSession(ctx, sdktypes.CreateSessionOptions{
+		Name:    "uc70",
+		Command: "sleep 300",
+		PTY:     true,
+		Cols:    80,
+		Rows:    24,
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	t.Cleanup(func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer ccancel()
+		_ = sb.DeleteSession(cctx, sess.ID)
+	})
+
+	// List includes it.
+	list, err := sb.ListSessions(ctx)
+	if err != nil {
+		t.Fatalf("list sessions: %v", err)
+	}
+	found := false
+	for _, s := range list {
+		if s.ID == sess.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("session %s not in list (%d sessions)", sess.ID, len(list))
+	}
+
+	// Get by id returns the same row.
+	got, err := sb.GetSession(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if got.ID != sess.ID {
+		t.Fatalf("get returned session %q, want %q", got.ID, sess.ID)
+	}
+
+	// Resize the PTY (no-op assertion: the contract is that it's accepted).
+	if err := sb.ResizeSession(ctx, sess.ID, 120, 40); err != nil {
+		t.Fatalf("resize session: %v", err)
+	}
+
+	// Signal it dead and confirm it leaves the running state.
+	if err := sb.SignalSession(ctx, sess.ID, "TERM"); err != nil {
+		t.Fatalf("signal session: %v", err)
+	}
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		s, err := sb.GetSession(ctx, sess.ID)
+		if err == nil && s.Status != sdktypes.SessionStatusRunning {
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatal("session never left the running state after TERM")
+}
+
+// UC-71 — A session's recording (asciinema cast) is downloadable. Recording is
+// always-on in the toolbox agent, so after a PTY session has produced output
+// the cast file exists and SessionRecording returns its bytes.
+func TestSessionRecordingDownloadable(t *testing.T) {
+	harness.Require(t, sc, "UC-71")
+	c := client(t)
+	sb := c.NewSandbox(t, sdktypes.CreateSandboxOptions{Name: harness.UniqueName(sc, t)})
+	waitRunning(t, sb)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	sess, err := sb.CreateSession(ctx, sdktypes.CreateSessionOptions{
+		Name:    "uc71",
+		Command: `echo recorded-71; sleep 1`,
+		PTY:     true,
+		Cols:    80,
+		Rows:    24,
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	t.Cleanup(func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer ccancel()
+		_ = sb.DeleteSession(cctx, sess.ID)
+	})
+
+	// The cast is flushed as the session produces output; poll until non-empty.
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		rec, err := sb.SessionRecording(ctx, sess.ID)
+		if err == nil && len(rec) > 0 {
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatal("session recording never became available")
+}

--- a/integration-tests/suite/harness/usecases.go
+++ b/integration-tests/suite/harness/usecases.go
@@ -149,6 +149,24 @@ var Registry = []UseCase{
 	{ID: "UC-64", Title: "/v1/metrics scrape returns output", Requires: nil, Implemented: true},
 	{ID: "UC-65", Title: "Concurrent duplicate create (serial)", Requires: []Capability{CapDocker}, Implemented: true},
 	{ID: "UC-66", Title: "mounts list", Requires: []Capability{CapDocker}, Implemented: true},
+
+	// I. SDK API surface — gap-fill. These exercise SDK methods that the suite
+	// above leaves untested even though the daemon supports them: the streaming
+	// exec transport, the full session lifecycle (beyond create+log), tag-filtered
+	// list, the build-then-create / register-snapshot ergonomic wrappers, the
+	// clone-generation token, the rich Dockerfile builder, and the DNS ingress
+	// target. The suite doubles as the Go-SDK integration test (see client.go), so
+	// an SDK method with no UC here is an untested public method.
+	{ID: "UC-68", Title: "Interactive exec stream (stdin -> stdout, exit code)", Requires: []Capability{CapDocker}, Implemented: true},
+	{ID: "UC-69", Title: "Exec with workdir + env", Requires: []Capability{CapDocker}, Implemented: true},
+	{ID: "UC-70", Title: "Session lifecycle (list/get/signal/resize)", Requires: []Capability{CapDocker}, Implemented: true},
+	{ID: "UC-71", Title: "Session recording downloadable", Requires: []Capability{CapDocker}, Implemented: true},
+	{ID: "UC-72", Title: "Clone-generation token returned", Requires: []Capability{CapDocker}, Implemented: true},
+	{ID: "UC-73", Title: "List filtered by tags", Requires: []Capability{CapDocker}, Implemented: true},
+	{ID: "UC-74", Title: "Create with built image graph (CreateWithImage)", Requires: []Capability{CapDocker}, Implemented: true},
+	{ID: "UC-75", Title: "Register snapshot + create from it", Requires: []Capability{CapDocker}, Implemented: true},
+	{ID: "UC-76", Title: "Rich Dockerfile builder (env/workdir/entrypoint/cmd/user/expose)", Requires: []Capability{CapDocker}, Implemented: true},
+	{ID: "UC-77", Title: "DNS ingress target published", Requires: []Capability{CapDomain}, Implemented: true},
 }
 
 // byID is a lookup built once for the report generator.

--- a/integration-tests/suite/images_more_test.go
+++ b/integration-tests/suite/images_more_test.go
@@ -1,0 +1,62 @@
+//go:build integration
+
+package suite
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/integration-tests/suite/harness"
+	microvm "github.com/aerol-ai/microvm/sdk/go/pkg/microvm"
+)
+
+// UC-76 — The fluent Dockerfile builder emits every directive it supports and
+// the daemon builds the result. UC-46 only exercised BaseImage+RunCommands;
+// this covers Env/Workdir/Entrypoint/Cmd/User/Expose in one graph. The compiled
+// Dockerfile is asserted directive-by-directive (deterministic, offline) and
+// then handed to the daemon to prove it accepts the multi-directive build.
+func TestRichImageBuilder(t *testing.T) {
+	harness.Require(t, sc, "UC-76")
+	c := client(t)
+
+	img := microvm.BaseImage("alpine:3.20").
+		Env(map[string]string{"UC76": "value-76"}).
+		Workdir("/opt/app").
+		RunCommands("echo rich-builder-76 > /opt/app/uc76.txt").
+		Expose(8080).
+		User("root").
+		Entrypoint("/bin/sh", "-c").
+		Cmd("sleep", "300")
+	if err := img.Err(); err != nil {
+		t.Fatalf("rich image spec: %v", err)
+	}
+
+	// Each builder method must have emitted its directive.
+	df := img.Dockerfile()
+	for _, want := range []string{
+		"FROM alpine:3.20",
+		"ENV UC76=value-76",
+		"WORKDIR /opt/app",
+		"RUN echo rich-builder-76",
+		"EXPOSE 8080",
+		"USER root",
+		"ENTRYPOINT [",
+		"CMD [",
+	} {
+		if !strings.Contains(df, want) {
+			t.Fatalf("compiled Dockerfile missing %q:\n%s", want, df)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	tag, err := c.SDK().BuildImage(ctx, img)
+	if err != nil {
+		t.Fatalf("build rich image: %v", err)
+	}
+	if tag == "" {
+		t.Fatal("build returned empty image tag")
+	}
+}

--- a/integration-tests/suite/lifecycle_extra_test.go
+++ b/integration-tests/suite/lifecycle_extra_test.go
@@ -1,0 +1,160 @@
+//go:build integration
+
+package suite
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/integration-tests/suite/harness"
+	microvm "github.com/aerol-ai/microvm/sdk/go/pkg/microvm"
+	sdktypes "github.com/aerol-ai/microvm/sdk/go/pkg/types"
+)
+
+// UC-72 — The clone-generation token is readable and stable for a sandbox that
+// has never been resumed from a snapshot. A fresh sandbox has ResumedAt==0, and
+// two consecutive reads return the same token (it only changes on resume).
+func TestCloneGenerationToken(t *testing.T) {
+	harness.Require(t, sc, "UC-72")
+	c := client(t)
+	sb := c.NewSandbox(t, sdktypes.CreateSandboxOptions{Name: harness.UniqueName(sc, t)})
+	waitRunning(t, sb)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	first, err := sb.CloneGeneration(ctx)
+	if err != nil {
+		t.Fatalf("clone generation: %v", err)
+	}
+	second, err := sb.CloneGeneration(ctx)
+	if err != nil {
+		t.Fatalf("clone generation (2nd read): %v", err)
+	}
+	if first.Generation != second.Generation {
+		t.Fatalf("token changed without a resume: %q -> %q", first.Generation, second.Generation)
+	}
+}
+
+// UC-73 — List filters by tag (AND semantics). A sandbox tagged uc73=yes is
+// returned when filtering on that pair and absent when filtering on a pair it
+// doesn't carry.
+func TestListFilteredByTags(t *testing.T) {
+	harness.Require(t, sc, "UC-73")
+	c := client(t)
+	sb := c.NewSandbox(t, sdktypes.CreateSandboxOptions{
+		Name: harness.UniqueName(sc, t),
+		Tags: map[string]string{"uc73": "yes"},
+	})
+	waitRunning(t, sb)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	matching, err := c.SDK().List(ctx, microvm.WithTags(map[string]string{"uc73": "yes"}))
+	if err != nil {
+		t.Fatalf("list with matching tag: %v", err)
+	}
+	if !containsSandbox(matching, sb.ID) {
+		t.Fatalf("tag-filtered list (%d) did not include %s", len(matching), sb.ID)
+	}
+
+	other, err := c.SDK().List(ctx, microvm.WithTags(map[string]string{"uc73": "no"}))
+	if err != nil {
+		t.Fatalf("list with non-matching tag: %v", err)
+	}
+	if containsSandbox(other, sb.ID) {
+		t.Fatalf("list filtered on uc73=no still returned %s", sb.ID)
+	}
+}
+
+func containsSandbox(list []*microvm.Sandbox, id string) bool {
+	for _, s := range list {
+		if s.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// UC-74 — CreateWithImage compiles an Image-builder graph to a content-addressed
+// tag and creates the sandbox from it in one call. The built artifact is present
+// in the running sandbox.
+func TestCreateWithImage(t *testing.T) {
+	harness.Require(t, sc, "UC-74")
+	c := client(t)
+	img := microvm.BaseImage("alpine:3.20").
+		RunCommands("echo created-with-image-74 > /uc74.txt")
+	if err := img.Err(); err != nil {
+		t.Fatalf("build image spec: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	sb, err := c.SDK().CreateWithImage(ctx, img, sdktypes.CreateSandboxOptions{
+		Name: harness.UniqueName(sc, t),
+	})
+	if err != nil {
+		t.Fatalf("create with image: %v", err)
+	}
+	t.Cleanup(func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), time.Minute)
+		defer ccancel()
+		_ = c.SDK().Destroy(cctx, sb.ID)
+	})
+	waitRunning(t, sb)
+
+	res, err := sb.ExecCommand(ctx, "cat /uc74.txt")
+	if err != nil {
+		t.Fatalf("exec cat: %v", err)
+	}
+	if !strings.Contains(res.Stdout, "created-with-image-74") {
+		t.Fatalf("built artifact missing: stdout = %q", res.Stdout)
+	}
+}
+
+// UC-75 — RegisterSnapshot persists a named snapshot from a pre-built image; a
+// sandbox can then be created from the snapshot's resolved image reference.
+func TestRegisterSnapshotAndCreate(t *testing.T) {
+	harness.Require(t, sc, "UC-75")
+	c := client(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	snap, err := c.SDK().RegisterSnapshot(ctx, sdktypes.RegisterSnapshotOptions{
+		Name:  harness.UniqueName(sc, t) + "-reg",
+		Image: "alpine:3.20",
+	})
+	if err != nil {
+		t.Fatalf("register snapshot: %v", err)
+	}
+	if snap.Image == "" {
+		t.Fatal("registered snapshot has empty image reference")
+	}
+
+	// Create from the resolved image. In cluster mode a derived create can land
+	// on a node before the snapshot image has propagated, so retry the transient
+	// pull-404 window rather than hard-failing (mirrors UC-21).
+	var derived *microvm.Sandbox
+	deadline := time.Now().Add(3 * time.Minute)
+	for {
+		derived, err = c.SDK().Create(ctx, sdktypes.CreateSandboxOptions{
+			Image: snap.Image,
+			Name:  harness.UniqueName(sc, t),
+		})
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("create from registered snapshot never succeeded: %v", err)
+		}
+		time.Sleep(5 * time.Second)
+	}
+	t.Cleanup(func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), time.Minute)
+		defer ccancel()
+		_ = c.SDK().Destroy(cctx, derived.ID)
+	})
+	waitRunning(t, derived)
+}


### PR DESCRIPTION
## What

The live integration suite doubles as the Go-SDK integration test (`harness/client.go` drives the real `sdk/go` client). A public SDK method with no use-case in the registry is therefore an **untested public method**. This maps the full SDK surface against the registry and fills the gaps with **10 new capability-gated use-cases (UC-68–UC-77)**.

| UC | Previously-untested SDK surface |
|----|----|
| UC-68 | `ExecStream` + `ExecStreamHandle` (streaming transport, distinct from blocking `Exec`) |
| UC-69 | `Sandbox.Exec` full `ExecRequest` (workdir + env) |
| UC-70 | `ListSessions`/`GetSession`/`ResizeSession`/`SignalSession` |
| UC-71 | `SessionRecording` |
| UC-72 | `CloneGeneration` |
| UC-73 | `List(WithTags(...))` |
| UC-74 | `CreateWithImage` |
| UC-75 | `RegisterSnapshot` |
| UC-76 | `Image` builder breadth (`Env`/`Workdir`/`Entrypoint`/`Cmd`/`User`/`Expose`) |
| UC-77 | `DNSTarget` |

## Conventions

All new tests follow the existing harness contract: `harness.Require(t, sc, "UC-NN")` for the capability gate + `ucid=` report marker, `c.NewSandbox` for guaranteed cleanup, and capability gating (`CapDocker`/`CapDomain`) so they **skip rather than fail** where unsupported. Grounded against real daemon behavior (exec runs via `/bin/sh -c`; session recording is always-on; create-from-snapshot uses the propagation-retry loop from UC-21).

## Testing

These are `//go:build integration` tests — they run only under `make integration-*` against a live deployment, never in `make test`. Verified offline:

- `go vet -tags=integration ./integration-tests/suite/...` → exit 0 (compiles clean)
- `go test ./integration-tests/suite/harness/...` → ok (`TestRegistryWellFormed`: no dup IDs, valid caps)
- `go test ./integration-tests/report/...` → ok (report generator consumes expanded registry)
- `gofmt -l` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)