### PR TITLE
feat(e2b): implement selective egress (network.allowOut / denyOut)

### DIFF
--- a/docs/src/content/docs/network-isolation.mdx
+++ b/docs/src/content/docs/network-isolation.mdx
@@ -280,6 +280,61 @@ The policy is persisted with the sandbox and reapplied automatically across stop
 
 ---
 
+## Disabling Public Exposure
+
+The options above control **outbound** traffic. To stop a sandbox from being reachable from the public internet at all, set **`allowPublicTraffic`** to `false` at create time. The sandbox can then never be exposed — `exposePort` returns an error — while the platform's own access paths (the toolbox `exec`/file proxy and the SSH gateway) keep working, since they do not route through the public ingress.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    const sandbox = await client.create({
+      image: 'ubuntu:22.04',
+      allowPublicTraffic: false,
+    })
+    // sandbox.exposePort(80) now rejects — no public URL is ever created.
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    sandbox = client.create({
+        'image': 'ubuntu:22.04',
+        'allowPublicTraffic': False,
+    })
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    publicOff := false
+    sandbox, err := client.Create(ctx, sdktypes.CreateSandboxOptions{
+        Image:              "ubuntu:22.04",
+        AllowPublicTraffic: &publicOff,
+    })
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let sandbox = client.create(CreateOptions {
+        image: "ubuntu:22.04".to_string(),
+        allow_public_traffic: Some(false),
+        ..Default::default()
+    })?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    Sandbox sandbox = client.create(
+        new CreateOptions()
+            .setImage("ubuntu:22.04")
+            .setAllowPublicTraffic(false)
+    );
+    ```
+  </TabItem>
+</Tabs>
+
+Because AerolVM has no auth-gated public route, "no public traffic" is enforced by **refusing exposure** rather than by serving a private URL. Omit the field (or set it to `true`) to keep the default behaviour, where exposed ports are publicly reachable.
+
+---
+
 ## Fine-Grained Quotas vs. Blanket Blocking
 
 If you do not want to block all network traffic permanently, you can use the SDK's **Network Usage & Quotas** features to set limits on total bytes sent or received. 

--- a/docs/src/content/docs/network-isolation.mdx
+++ b/docs/src/content/docs/network-isolation.mdx
@@ -170,6 +170,116 @@ Services running inside the sandbox remain reachable via their exposed public UR
 
 ---
 
+## Selective Egress (Allowlist / Blocklist)
+
+A blanket block is often too strict — an agent may need to reach one specific API while everything else stays blocked. Use **`networkAllowOut`** or **`networkDenyOut`** to define a per-CIDR egress policy, enforced by the same host firewall:
+
+- **`networkAllowOut`** — the sandbox may reach **only** these CIDRs; all other outbound traffic is dropped.
+- **`networkDenyOut`** — the sandbox may reach anything **except** these CIDRs.
+
+The two are mutually exclusive. A full block is still expressed with `networkBlockAll` rather than a `0.0.0.0/0` deny.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    // Allow only 1.1.1.0/24 and 8.8.8.8; block everything else.
+    const sandbox = await client.create({
+      image: 'ubuntu:22.04',
+      networkAllowOut: ['1.1.1.0/24', '8.8.8.8/32'],
+    })
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    sandbox = client.create({
+        'image': 'ubuntu:22.04',
+        'networkAllowOut': ['1.1.1.0/24', '8.8.8.8/32'],
+    })
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    sandbox, err := client.Create(ctx, sdktypes.CreateSandboxOptions{
+        Image:           "ubuntu:22.04",
+        NetworkAllowOut: []string{"1.1.1.0/24", "8.8.8.8/32"},
+    })
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let sandbox = client.create(CreateOptions {
+        image: "ubuntu:22.04".to_string(),
+        network_allow_out: Some(vec!["1.1.1.0/24".to_string(), "8.8.8.8/32".to_string()]),
+        ..Default::default()
+    })?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    import java.util.List;
+
+    Sandbox sandbox = client.create(
+        new CreateOptions()
+            .setImage("ubuntu:22.04")
+            .setNetworkAllowOut(List.of("1.1.1.0/24", "8.8.8.8/32"))
+    );
+    ```
+  </TabItem>
+</Tabs>
+
+To invert the policy — block a few destinations and allow the rest — pass the same shape to `networkDenyOut` instead:
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    const sandbox = await client.create({
+      image: 'ubuntu:22.04',
+      networkDenyOut: ['10.0.0.0/8'], // block the internal range, allow the rest
+    })
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    sandbox = client.create({
+        'image': 'ubuntu:22.04',
+        'networkDenyOut': ['10.0.0.0/8'],
+    })
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    sandbox, err := client.Create(ctx, sdktypes.CreateSandboxOptions{
+        Image:          "ubuntu:22.04",
+        NetworkDenyOut: []string{"10.0.0.0/8"},
+    })
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let sandbox = client.create(CreateOptions {
+        image: "ubuntu:22.04".to_string(),
+        network_deny_out: Some(vec!["10.0.0.0/8".to_string()]),
+        ..Default::default()
+    })?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    import java.util.List;
+
+    Sandbox sandbox = client.create(
+        new CreateOptions()
+            .setImage("ubuntu:22.04")
+            .setNetworkDenyOut(List.of("10.0.0.0/8"))
+    );
+    ```
+  </TabItem>
+</Tabs>
+
+The policy is persisted with the sandbox and reapplied automatically across stop/start cycles and host restarts, just like `networkBlockAll`.
+
+---
+
 ## Fine-Grained Quotas vs. Blanket Blocking
 
 If you do not want to block all network traffic permanently, you can use the SDK's **Network Usage & Quotas** features to set limits on total bytes sent or received. 
@@ -186,4 +296,4 @@ For details on setting up quotas, see the [Network Usage & Quotas](/network-usag
 ## Limitations
 
 - **IPv4 Only**: Network isolation and byte limits are applied to IPv4 routes. If the sandbox has IPv6 routing enabled, those connections are not blocked.
-- **No Domain Allowlist/DNS-Only Mode**: Currently, setting `networkBlockAll: true` is a blanket egress block. There is no support for allowing only specific domains or allowing only DNS resolution.
+- **CIDR-based, not domain-based**: Selective egress (`networkAllowOut` / `networkDenyOut`) matches on IP CIDRs, not hostnames. There is no domain allowlist or DNS-only mode — allow the CIDRs your destination resolves to.

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -1492,6 +1492,14 @@ func (d *Driver) ApplyNetworkBlockAll(_ string) error {
 	return methodNotImplemented("ApplyNetworkBlockAll")
 }
 
+func (d *Driver) ApplyEgressPolicy(_ string, _, _ []string) error {
+	return methodNotImplemented("ApplyEgressPolicy")
+}
+
+func (d *Driver) ClearEgressPolicy(_ string, _, _ []string) error {
+	return methodNotImplemented("ClearEgressPolicy")
+}
+
 func (d *Driver) ApplyNetworkBlockIngress(_ string) error {
 	return methodNotImplemented("ApplyNetworkBlockIngress")
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -110,6 +110,18 @@ type ContainerRuntime interface {
 	// rule is shared, so the service must consult NetworkBlockAll before
 	// invoking this on a quota-clear path.
 	ClearNetworkBlockEgress(containerIP string) error
+
+	// ApplyEgressPolicy installs the selective-egress CIDR policy (E2B
+	// network.allowOut / denyOut). At most one of allowCIDRs / denyCIDRs is
+	// non-empty. Comment-tagged so it composes with, rather than collides
+	// with, the NetworkBlockAll / quota DROP. Idempotent — reapplied on Start
+	// and reconcile just like ApplyNetworkBlockAll.
+	ApplyEgressPolicy(containerIP string, allowCIDRs, denyCIDRs []string) error
+
+	// ClearEgressPolicy removes the rules ApplyEgressPolicy installed for the
+	// same (containerIP, allowCIDRs, denyCIDRs). Callers pass the policy from
+	// the sandbox row so cleanup is exact and the blanket DROP is untouched.
+	ClearEgressPolicy(containerIP string, allowCIDRs, denyCIDRs []string) error
 }
 
 // AsContainerRuntime returns the network-rule surface when rt implements it.

--- a/internal/service/bugfix_test.go
+++ b/internal/service/bugfix_test.go
@@ -228,6 +228,33 @@ func TestExposePortSkipsProbeOnStoppedSandbox(t *testing.T) {
 	}
 }
 
+// TestExposePortRejectedWhenPublicTrafficDisabled verifies that a sandbox
+// created with allow_public_traffic=false cannot be exposed: ExposePort returns
+// ErrPublicTrafficDisabled instead of installing a public route.
+func TestExposePortRejectedWhenPublicTrafficDisabled(t *testing.T) {
+	ctx := context.Background()
+	svc, st := newProbeSvc(t, func(_ context.Context, _ string, _ int) error { return nil })
+
+	now := time.Now().UTC()
+	deny := false
+	if err := st.Create(ctx, &models.Sandbox{
+		ID: "sb-no-public", Image: "alpine:3.20",
+		Status:      models.SandboxStatusStarted,
+		ContainerID: "ctr-no-public", ContainerIP: "10.0.0.20",
+		Runtime: models.RuntimeDocker,
+		CPU:     1, MemoryMB: 256, DiskGB: 5,
+		AllowPublicTraffic: &deny,
+		CreatedAt:          now, UpdatedAt: now, LastActiveAt: now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+
+	_, err := svc.ExposePort(ctx, "sb-no-public", 8080, models.ExposedPortProtocolHTTP)
+	if !errors.Is(err, ErrPublicTrafficDisabled) {
+		t.Fatalf("ExposePort err = %v, want ErrPublicTrafficDisabled", err)
+	}
+}
+
 // TestExposePortProceedsWhenProbeFailsAndLogsWarning verifies that a failing
 // probe (port not yet bound) is non-fatal: the route is still installed and
 // the error is surfaced only as a log warning, not as an ExposePort failure.

--- a/internal/service/built_image_gc_test.go
+++ b/internal/service/built_image_gc_test.go
@@ -86,11 +86,13 @@ func (*recordingRemoveRuntime) Ping(context.Context) error { panic("Ping not use
 func (*recordingRemoveRuntime) PushAllowedPorts(context.Context, string, string, []int) error {
 	panic("PushAllowedPorts not used")
 }
-func (*recordingRemoveRuntime) ClearNetworkRules(string) error        { panic("not used") }
-func (*recordingRemoveRuntime) ApplyNetworkBlockAll(string) error     { panic("not used") }
-func (*recordingRemoveRuntime) ApplyNetworkBlockIngress(string) error { panic("not used") }
-func (*recordingRemoveRuntime) ClearNetworkBlockIngress(string) error { panic("not used") }
-func (*recordingRemoveRuntime) ClearNetworkBlockEgress(string) error  { panic("not used") }
+func (*recordingRemoveRuntime) ClearNetworkRules(string) error                     { panic("not used") }
+func (*recordingRemoveRuntime) ApplyEgressPolicy(string, []string, []string) error { return nil }
+func (*recordingRemoveRuntime) ClearEgressPolicy(string, []string, []string) error { return nil }
+func (*recordingRemoveRuntime) ApplyNetworkBlockAll(string) error                  { panic("not used") }
+func (*recordingRemoveRuntime) ApplyNetworkBlockIngress(string) error              { panic("not used") }
+func (*recordingRemoveRuntime) ClearNetworkBlockIngress(string) error              { panic("not used") }
+func (*recordingRemoveRuntime) ClearNetworkBlockEgress(string) error               { panic("not used") }
 
 func TestBuiltImageGCRemovesOldUnreferenced(t *testing.T) {
 	svc, _, removed := newBuiltImageGCHarness(t, time.Hour)

--- a/internal/service/capacity_lifecycle_test.go
+++ b/internal/service/capacity_lifecycle_test.go
@@ -79,11 +79,13 @@ func (f *fakeCapacityRuntime) RemoveImage(context.Context, string) error { retur
 func (f *fakeCapacityRuntime) PushAllowedPorts(context.Context, string, string, []int) error {
 	return nil
 }
-func (f *fakeCapacityRuntime) ClearNetworkRules(string) error        { return nil }
-func (f *fakeCapacityRuntime) ApplyNetworkBlockAll(string) error     { return nil }
-func (f *fakeCapacityRuntime) ApplyNetworkBlockIngress(string) error { return nil }
-func (f *fakeCapacityRuntime) ClearNetworkBlockIngress(string) error { return nil }
-func (f *fakeCapacityRuntime) ClearNetworkBlockEgress(string) error  { return nil }
+func (f *fakeCapacityRuntime) ClearNetworkRules(string) error                     { return nil }
+func (f *fakeCapacityRuntime) ApplyEgressPolicy(string, []string, []string) error { return nil }
+func (f *fakeCapacityRuntime) ClearEgressPolicy(string, []string, []string) error { return nil }
+func (f *fakeCapacityRuntime) ApplyNetworkBlockAll(string) error                  { return nil }
+func (f *fakeCapacityRuntime) ApplyNetworkBlockIngress(string) error              { return nil }
+func (f *fakeCapacityRuntime) ClearNetworkBlockIngress(string) error              { return nil }
+func (f *fakeCapacityRuntime) ClearNetworkBlockEgress(string) error               { return nil }
 
 func newCapacityHarness(t *testing.T, managed, inspect map[string]*models.SandboxRuntimeState) (*Service, *capacity.Admitter, *store.Store) {
 	t.Helper()

--- a/internal/service/events.go
+++ b/internal/service/events.go
@@ -190,6 +190,12 @@ func (s *Service) markSandboxStopped(ctx context.Context, sandbox *models.Sandbo
 			if err := cr.ClearNetworkRules(previousIP); err != nil {
 				s.logger.Warn("clear network rules failed", "sandbox_id", sandbox.ID, "ip", previousIP, "error", err)
 			}
+			// Selective-egress rules are comment-tagged, so ClearNetworkRules
+			// above does not remove them — clear them from the persisted policy
+			// before the IP is recycled to another container.
+			if err := cr.ClearEgressPolicy(previousIP, sandbox.NetworkAllowOut, sandbox.NetworkDenyOut); err != nil {
+				s.logger.Warn("clear egress policy failed", "sandbox_id", sandbox.ID, "ip", previousIP, "error", err)
+			}
 		}
 	}
 
@@ -256,6 +262,12 @@ func (s *Service) handleDestroyEvent(ctx context.Context, sandbox *models.Sandbo
 		if cr, ok := runtime.AsContainerRuntime(s.docker); ok {
 			if err := cr.ClearNetworkRules(previousIP); err != nil {
 				s.logger.Warn("clear network rules failed", "sandbox_id", sandbox.ID, "ip", previousIP, "error", err)
+			}
+			// Selective-egress rules are comment-tagged, so ClearNetworkRules
+			// above does not remove them — clear them from the persisted policy
+			// before the IP is recycled to another container.
+			if err := cr.ClearEgressPolicy(previousIP, sandbox.NetworkAllowOut, sandbox.NetworkDenyOut); err != nil {
+				s.logger.Warn("clear egress policy failed", "sandbox_id", sandbox.ID, "ip", previousIP, "error", err)
 			}
 		}
 	}

--- a/internal/service/reconcile_destroy_test.go
+++ b/internal/service/reconcile_destroy_test.go
@@ -77,6 +77,8 @@ func (f *fakeReconcileRuntime) PushAllowedPorts(context.Context, string, string,
 func (f *fakeReconcileRuntime) ClearNetworkRules(string) error {
 	return nil
 }
+func (f *fakeReconcileRuntime) ApplyEgressPolicy(string, []string, []string) error { return nil }
+func (f *fakeReconcileRuntime) ClearEgressPolicy(string, []string, []string) error { return nil }
 func (f *fakeReconcileRuntime) ApplyNetworkBlockAll(containerIP string) error {
 	f.networkBlockAllCalls = append(f.networkBlockAllCalls, containerIP)
 	return nil

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1093,6 +1093,11 @@ func (s *Service) createSandbox(ctx context.Context, req models.CreateSandboxReq
 		}
 	}
 
+	if err := validateEgressPolicy(req.NetworkAllowOut, req.NetworkDenyOut); err != nil {
+		releaseAdmission()
+		return nil, err
+	}
+
 	binds, err := s.mounts.MountAll(ctx, sandboxID, req.Mounts)
 	if err != nil {
 		releaseAdmission()
@@ -1117,7 +1122,7 @@ func (s *Service) createSandbox(ctx context.Context, req models.CreateSandboxReq
 	// rollback chain as any later store error below.
 	sealedRegistry, err := s.sealRegistry(req.Registry)
 	if err != nil {
-		_ = s.docker.Destroy(cleanupCtx, &models.Sandbox{ID: state.SandboxID, ContainerID: state.ContainerID, Runtime: chosenRuntime})
+		_ = s.docker.Destroy(cleanupCtx, &models.Sandbox{ID: state.SandboxID, ContainerID: state.ContainerID, Runtime: chosenRuntime, ContainerIP: state.ContainerIP, NetworkAllowOut: req.NetworkAllowOut, NetworkDenyOut: req.NetworkDenyOut})
 		cleanupMounts()
 		releaseAdmission()
 		return nil, err
@@ -1137,6 +1142,8 @@ func (s *Service) createSandbox(ctx context.Context, req models.CreateSandboxReq
 		OSUser:               req.OSUser,
 		Env:                  req.Env,
 		NetworkBlockAll:      req.NetworkBlockAll,
+		NetworkAllowOut:      req.NetworkAllowOut,
+		NetworkDenyOut:       req.NetworkDenyOut,
 		ToolboxEnabled:       true,
 		ToolboxToken:         toolboxToken,
 		SSHPublicKey:         authorizedKey,
@@ -1298,6 +1305,9 @@ func (s *Service) createFirecrackerSandbox(ctx context.Context, req models.Creat
 	if req.NetworkBlockAll {
 		return nil, unsupportedFirecrackerOption("network_block_all")
 	}
+	if len(req.NetworkAllowOut) > 0 || len(req.NetworkDenyOut) > 0 {
+		return nil, unsupportedFirecrackerOption("selective egress (network_allow_out / network_deny_out)")
+	}
 	if req.NetworkBytesInLimit > 0 || req.NetworkBytesOutLimit > 0 {
 		return nil, unsupportedFirecrackerOption("network byte limits")
 	}
@@ -1374,6 +1384,8 @@ func (s *Service) createFirecrackerSandbox(ctx context.Context, req models.Creat
 		OSUser:               req.OSUser,
 		Env:                  req.Env,
 		NetworkBlockAll:      req.NetworkBlockAll,
+		NetworkAllowOut:      req.NetworkAllowOut,
+		NetworkDenyOut:       req.NetworkDenyOut,
 		ToolboxEnabled:       true,
 		ToolboxToken:         toolboxToken,
 		SSHPublicKey:         authorizedKey,
@@ -1733,6 +1745,25 @@ func (s *Service) StartSandbox(ctx context.Context, id string) (*models.Sandbox,
 			releaseAdmission()
 			_ = s.store.UpdateStatus(ctx, id, models.SandboxStatusError, err.Error())
 			return nil, fmt.Errorf("apply network block on start: %w", err)
+		}
+	}
+	// Reapply the selective-egress policy for the same reason — the stop event
+	// clears it. Comment-tagged rules are distinct from the blanket block, so
+	// this composes with NetworkBlockAll above. Fail closed on error.
+	if len(sandbox.NetworkAllowOut) > 0 || len(sandbox.NetworkDenyOut) > 0 {
+		cr, ok := runtime.AsContainerRuntime(rt)
+		if !ok {
+			_ = rt.Stop(ctx, s.runtimeRef(sandbox))
+			_ = s.mounts.UnmountAll(id)
+			releaseAdmission()
+			return nil, fmt.Errorf("apply egress policy on start: runtime %q does not support selective egress", sandbox.Runtime)
+		}
+		if err := cr.ApplyEgressPolicy(sandbox.ContainerIP, sandbox.NetworkAllowOut, sandbox.NetworkDenyOut); err != nil {
+			_ = rt.Stop(ctx, s.runtimeRef(sandbox))
+			_ = s.mounts.UnmountAll(id)
+			releaseAdmission()
+			_ = s.store.UpdateStatus(ctx, id, models.SandboxStatusError, err.Error())
+			return nil, fmt.Errorf("apply egress policy on start: %w", err)
 		}
 	}
 
@@ -3542,6 +3573,24 @@ func (s *Service) Reconcile(ctx context.Context) error {
 					)
 				}
 			}
+			// Heal the selective-egress policy the same way. Comment-tagged
+			// rules survive independently of the blanket block, and the
+			// netrules Exists check keeps the reapply idempotent.
+			if len(sandbox.NetworkAllowOut) > 0 || len(sandbox.NetworkDenyOut) > 0 {
+				cr, err := s.containerRuntimeForSandbox(sandbox)
+				if err != nil {
+					s.logger.Warn("reconcile reapply egress policy skipped",
+						"sandbox_id", sandbox.ID,
+						"error", err,
+					)
+				} else if err := cr.ApplyEgressPolicy(sandbox.ContainerIP, sandbox.NetworkAllowOut, sandbox.NetworkDenyOut); err != nil {
+					s.logger.Warn("reconcile reapply egress policy failed",
+						"sandbox_id", sandbox.ID,
+						"ip", sandbox.ContainerIP,
+						"error", err,
+					)
+				}
+			}
 			// Heal quota-driven blocks. The flag is the source of truth for
 			// "we previously decided to block"; re-evaluate against the
 			// current cumulative counters so a quota raised over the wire
@@ -4713,6 +4762,30 @@ func (s *Service) syncAllowedPorts(ctx context.Context, sandbox *models.Sandbox)
 	if err := cr.PushAllowedPorts(ctx, sandbox.ContainerIP, sandbox.ToolboxToken, ports); err != nil {
 		s.logger.Warn("failed to sync allowed ports", "sandbox_id", sandbox.ID, "error", err)
 	}
+}
+
+// validateEgressPolicy enforces the selective-egress invariants shared by every
+// API surface (native /v1 and the E2B facade): the allowlist and blocklist are
+// mutually exclusive, every entry must parse as a CIDR, and a deny of the whole
+// address space must be expressed as NetworkBlockAll — a 0.0.0.0/0 catch-all
+// DROP would duplicate the blanket block and confuse cleanup.
+func validateEgressPolicy(allowOut, denyOut []string) error {
+	if len(allowOut) > 0 && len(denyOut) > 0 {
+		return errors.New("network_allow_out and network_deny_out are mutually exclusive")
+	}
+	for _, list := range [][]string{allowOut, denyOut} {
+		for _, cidr := range list {
+			if _, _, err := net.ParseCIDR(strings.TrimSpace(cidr)); err != nil {
+				return fmt.Errorf("invalid egress CIDR %q: %w", cidr, err)
+			}
+		}
+	}
+	for _, cidr := range denyOut {
+		if strings.TrimSpace(cidr) == "0.0.0.0/0" {
+			return errors.New("network_deny_out of 0.0.0.0/0 must be expressed as network_block_all")
+		}
+	}
+	return nil
 }
 
 // portProbeTimeout is the maximum time probeContainerPort waits for a container

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -54,6 +54,11 @@ const allocatorRandomAttempts = 16
 // contract behind the client's back.
 var ErrPreferredHostPortUnavailable = errors.New("preferred host port unavailable on this node; exposure parked")
 
+// ErrPublicTrafficDisabled is returned by ExposePort when the sandbox was
+// created with allow_public_traffic=false. There is no public route to install
+// — the sandbox is reachable only through the toolbox proxy and SSH gateway.
+var ErrPublicTrafficDisabled = errors.New("public traffic is disabled for this sandbox; expose is not available")
+
 const clusterIngressReconcileInterval = 5 * time.Second
 
 type Service struct {
@@ -1144,6 +1149,7 @@ func (s *Service) createSandbox(ctx context.Context, req models.CreateSandboxReq
 		NetworkBlockAll:      req.NetworkBlockAll,
 		NetworkAllowOut:      req.NetworkAllowOut,
 		NetworkDenyOut:       req.NetworkDenyOut,
+		AllowPublicTraffic:   req.AllowPublicTraffic,
 		ToolboxEnabled:       true,
 		ToolboxToken:         toolboxToken,
 		SSHPublicKey:         authorizedKey,
@@ -1386,6 +1392,7 @@ func (s *Service) createFirecrackerSandbox(ctx context.Context, req models.Creat
 		NetworkBlockAll:      req.NetworkBlockAll,
 		NetworkAllowOut:      req.NetworkAllowOut,
 		NetworkDenyOut:       req.NetworkDenyOut,
+		AllowPublicTraffic:   req.AllowPublicTraffic,
 		ToolboxEnabled:       true,
 		ToolboxToken:         toolboxToken,
 		SSHPublicKey:         authorizedKey,
@@ -2256,6 +2263,14 @@ func (s *Service) exposePort(ctx context.Context, id string, port int, protocol 
 	sandbox, err := s.scopedGet(ctx, id)
 	if err != nil {
 		return models.ExposePortResponse{}, err
+	}
+	// A sandbox created with allow_public_traffic=false must never get a public
+	// route. AerolVM has no auth-gated public route, so the only honest way to
+	// enforce "no public traffic" is to refuse exposure outright — the sandbox
+	// stays reachable through the toolbox proxy and SSH gateway, which do not
+	// route through the public ingress. Nil/true keep the default (allowed).
+	if sandbox.AllowPublicTraffic != nil && !*sandbox.AllowPublicTraffic {
+		return models.ExposePortResponse{}, ErrPublicTrafficDisabled
 	}
 	if port <= 0 || port > 65535 {
 		return models.ExposePortResponse{}, errors.New("invalid port")

--- a/internal/service/service_error_paths_test.go
+++ b/internal/service/service_error_paths_test.go
@@ -41,6 +41,8 @@ type startHookRuntime struct {
 	afterStart func()
 }
 
+func (r *networkBlockFailRuntime) ApplyEgressPolicy(string, []string, []string) error { return nil }
+func (r *networkBlockFailRuntime) ClearEgressPolicy(string, []string, []string) error { return nil }
 func (r *networkBlockFailRuntime) ApplyNetworkBlockAll(containerIP string) error {
 	r.applyNetworkBlockAllCalls = append(r.applyNetworkBlockAllCalls, containerIP)
 	return r.applyErr

--- a/internal/service/service_firecracker_dispatch_test.go
+++ b/internal/service/service_firecracker_dispatch_test.go
@@ -78,11 +78,13 @@ func (r *fireRecordingRuntime) RemoveImage(context.Context, string) error { retu
 func (r *fireRecordingRuntime) PushAllowedPorts(context.Context, string, string, []int) error {
 	return nil
 }
-func (r *fireRecordingRuntime) ClearNetworkRules(string) error        { return nil }
-func (r *fireRecordingRuntime) ApplyNetworkBlockAll(string) error     { return nil }
-func (r *fireRecordingRuntime) ApplyNetworkBlockIngress(string) error { return nil }
-func (r *fireRecordingRuntime) ClearNetworkBlockIngress(string) error { return nil }
-func (r *fireRecordingRuntime) ClearNetworkBlockEgress(string) error  { return nil }
+func (r *fireRecordingRuntime) ClearNetworkRules(string) error                     { return nil }
+func (r *fireRecordingRuntime) ApplyEgressPolicy(string, []string, []string) error { return nil }
+func (r *fireRecordingRuntime) ClearEgressPolicy(string, []string, []string) error { return nil }
+func (r *fireRecordingRuntime) ApplyNetworkBlockAll(string) error                  { return nil }
+func (r *fireRecordingRuntime) ApplyNetworkBlockIngress(string) error              { return nil }
+func (r *fireRecordingRuntime) ClearNetworkBlockIngress(string) error              { return nil }
+func (r *fireRecordingRuntime) ClearNetworkBlockEgress(string) error               { return nil }
 
 // TestFirecrackerDispatch_NotEnabled covers the operator-facing failure
 // mode: SB_ENABLE_FIRECRACKER is off and a sandbox arrives with

--- a/internal/service/service_runtime_flow_test.go
+++ b/internal/service/service_runtime_flow_test.go
@@ -162,6 +162,8 @@ func (r *recordingRuntime) PushAllowedPorts(_ context.Context, containerIP, tool
 
 func (r *recordingRuntime) ClearNetworkRules(string) error { return nil }
 
+func (r *recordingRuntime) ApplyEgressPolicy(string, []string, []string) error { return nil }
+func (r *recordingRuntime) ClearEgressPolicy(string, []string, []string) error { return nil }
 func (r *recordingRuntime) ApplyNetworkBlockAll(containerIP string) error {
 	r.applyNetworkBlockAllCalls = append(r.applyNetworkBlockAllCalls, containerIP)
 	return nil

--- a/internal/service/snapshot_test.go
+++ b/internal/service/snapshot_test.go
@@ -65,11 +65,13 @@ func (f *fakeSnapshotRuntime) RemoveImage(_ context.Context, imageRef string) er
 func (f *fakeSnapshotRuntime) PushAllowedPorts(context.Context, string, string, []int) error {
 	panic("unexpected PushAllowedPorts")
 }
-func (f *fakeSnapshotRuntime) ClearNetworkRules(string) error        { return nil }
-func (f *fakeSnapshotRuntime) ApplyNetworkBlockAll(string) error     { return nil }
-func (f *fakeSnapshotRuntime) ApplyNetworkBlockIngress(string) error { return nil }
-func (f *fakeSnapshotRuntime) ClearNetworkBlockIngress(string) error { return nil }
-func (f *fakeSnapshotRuntime) ClearNetworkBlockEgress(string) error  { return nil }
+func (f *fakeSnapshotRuntime) ClearNetworkRules(string) error                     { return nil }
+func (f *fakeSnapshotRuntime) ApplyEgressPolicy(string, []string, []string) error { return nil }
+func (f *fakeSnapshotRuntime) ClearEgressPolicy(string, []string, []string) error { return nil }
+func (f *fakeSnapshotRuntime) ApplyNetworkBlockAll(string) error                  { return nil }
+func (f *fakeSnapshotRuntime) ApplyNetworkBlockIngress(string) error              { return nil }
+func (f *fakeSnapshotRuntime) ClearNetworkBlockIngress(string) error              { return nil }
+func (f *fakeSnapshotRuntime) ClearNetworkBlockEgress(string) error               { return nil }
 
 func TestCreateSnapshotIdempotentByName(t *testing.T) {
 	ctx := context.Background()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -70,6 +70,7 @@ func Open(path string) (*Store, error) {
 			network_block_all INTEGER NOT NULL DEFAULT 0,
 			network_allow_out_json TEXT NOT NULL DEFAULT '[]',
 			network_deny_out_json TEXT NOT NULL DEFAULT '[]',
+			allow_public_traffic INTEGER NOT NULL DEFAULT 1,
 			toolbox_enabled INTEGER NOT NULL DEFAULT 1,
 			toolbox_token TEXT NOT NULL DEFAULT '',
 			ssh_public_key TEXT NOT NULL DEFAULT '',
@@ -622,6 +623,10 @@ func Open(path string) (*Store, error) {
 		// Empty '[]' for every pre-migration row and the no-policy common path.
 		`ALTER TABLE sandboxes ADD COLUMN network_allow_out_json TEXT NOT NULL DEFAULT '[]';`,
 		`ALTER TABLE sandboxes ADD COLUMN network_deny_out_json TEXT NOT NULL DEFAULT '[]';`,
+		// allow_public_traffic gates public exposure (E2B network.allowPublicTraffic).
+		// Defaults to 1 (public allowed) so every pre-migration row keeps its
+		// current behaviour; 0 makes ExposePort refuse to install a public route.
+		`ALTER TABLE sandboxes ADD COLUMN allow_public_traffic INTEGER NOT NULL DEFAULT 1;`,
 	}
 	for _, stmt := range migrations {
 		if _, err := db.Exec(stmt); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
@@ -729,7 +734,7 @@ func (s *Store) Create(ctx context.Context, sandbox *models.Sandbox) error {
 	_, err = s.db.ExecContext(ctx, `
 		INSERT INTO sandboxes (
 			id, image, status, public_url, container_id, container_ip, cpu, memory_mb, disk_gb,
-			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, toolbox_enabled, toolbox_token, ssh_public_key,
+			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, allow_public_traffic, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
 			failover_policy,
@@ -746,7 +751,7 @@ func (s *Store) Create(ctx context.Context, sandbox *models.Sandbox) error {
 			checkpoint_path, clone_generation,
 			wasm_registry_ref, wasm_registry_digest,
 			owner_ref, fleet_suspended
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		sandbox.ID,
 		sandbox.Image,
@@ -762,6 +767,7 @@ func (s *Store) Create(ctx context.Context, sandbox *models.Sandbox) error {
 		boolToInt(sandbox.NetworkBlockAll),
 		mustMarshalStringSlice(sandbox.NetworkAllowOut),
 		mustMarshalStringSlice(sandbox.NetworkDenyOut),
+		allowPublicTrafficToInt(sandbox.AllowPublicTraffic),
 		boolToInt(sandbox.ToolboxEnabled),
 		sandbox.ToolboxToken,
 		sandbox.SSHPublicKey,
@@ -808,6 +814,16 @@ func (s *Store) Create(ctx context.Context, sandbox *models.Sandbox) error {
 		return fmt.Errorf("insert sandbox: %w", err)
 	}
 	return nil
+}
+
+// allowPublicTrafficToInt maps the tri-state create flag to the stored
+// integer: nil (unset) and *true persist as 1 (public exposure allowed); only
+// an explicit *false persists as 0 (ExposePort will refuse).
+func allowPublicTrafficToInt(v *bool) int {
+	if v != nil && !*v {
+		return 0
+	}
+	return 1
 }
 
 // mustMarshalStringSlice JSON-encodes a string slice for a TEXT column,
@@ -875,7 +891,7 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 	_, err = s.db.ExecContext(ctx, `
 		INSERT INTO sandboxes (
 			id, image, status, public_url, container_id, container_ip, cpu, memory_mb, disk_gb,
-			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, toolbox_enabled, toolbox_token, ssh_public_key,
+			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, allow_public_traffic, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
 			failover_policy,
@@ -892,7 +908,7 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 			checkpoint_path, clone_generation,
 			wasm_registry_ref, wasm_registry_digest,
 			owner_ref, fleet_suspended
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			image = excluded.image,
 			status = excluded.status,
@@ -907,6 +923,7 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 			network_block_all = excluded.network_block_all,
 			network_allow_out_json = excluded.network_allow_out_json,
 			network_deny_out_json = excluded.network_deny_out_json,
+			allow_public_traffic = excluded.allow_public_traffic,
 			toolbox_enabled = excluded.toolbox_enabled,
 			toolbox_token = excluded.toolbox_token,
 			ssh_public_key = excluded.ssh_public_key,
@@ -955,6 +972,7 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 		boolToInt(sandbox.NetworkBlockAll),
 		mustMarshalStringSlice(sandbox.NetworkAllowOut),
 		mustMarshalStringSlice(sandbox.NetworkDenyOut),
+		allowPublicTrafficToInt(sandbox.AllowPublicTraffic),
 		boolToInt(sandbox.ToolboxEnabled),
 		sandbox.ToolboxToken,
 		sandbox.SSHPublicKey,
@@ -1006,7 +1024,7 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 func (s *Store) Get(ctx context.Context, id string) (*models.Sandbox, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, image, status, public_url, container_id, container_ip, cpu, memory_mb, disk_gb,
-			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, toolbox_enabled, toolbox_token, ssh_public_key,
+			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, allow_public_traffic, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
 			failover_policy,
@@ -1053,7 +1071,7 @@ func (s *Store) Get(ctx context.Context, id string) (*models.Sandbox, error) {
 func (s *Store) List(ctx context.Context) ([]*models.Sandbox, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, image, status, public_url, container_id, container_ip, cpu, memory_mb, disk_gb,
-			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, toolbox_enabled, toolbox_token, ssh_public_key,
+			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, allow_public_traffic, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
 			failover_policy,
@@ -1120,7 +1138,7 @@ func (s *Store) List(ctx context.Context) ([]*models.Sandbox, error) {
 func (s *Store) ListByOwner(ctx context.Context, ownerRef string) ([]*models.Sandbox, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, image, status, public_url, container_id, container_ip, cpu, memory_mb, disk_gb,
-			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, toolbox_enabled, toolbox_token, ssh_public_key,
+			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, allow_public_traffic, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
 			failover_policy,
@@ -1171,7 +1189,7 @@ func (s *Store) ListByOwner(ctx context.Context, ownerRef string) ([]*models.San
 func (s *Store) ListByRuntime(ctx context.Context, runtime string) ([]*models.Sandbox, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, image, status, public_url, container_id, container_ip, cpu, memory_mb, disk_gb,
-			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, toolbox_enabled, toolbox_token, ssh_public_key,
+			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, allow_public_traffic, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
 			failover_policy,
@@ -3418,6 +3436,7 @@ func scanSandbox(scanner interface {
 	var wakeArmed int
 	var fleetSuspended int
 	var allowOutJSON, denyOutJSON string
+	var allowPublicTraffic int
 
 	err := scanner.Scan(
 		&sandbox.ID,
@@ -3434,6 +3453,7 @@ func scanSandbox(scanner interface {
 		&networkBlocked,
 		&allowOutJSON,
 		&denyOutJSON,
+		&allowPublicTraffic,
 		&toolboxEnabled,
 		&sandbox.ToolboxToken,
 		&sandbox.SSHPublicKey,
@@ -3520,6 +3540,8 @@ func scanSandbox(scanner interface {
 			return nil, fmt.Errorf("decode network deny out: %w", err)
 		}
 	}
+	allowPublic := allowPublicTraffic == 1
+	sandbox.AllowPublicTraffic = &allowPublic
 	sandbox.ToolboxEnabled = toolboxEnabled == 1
 	sandbox.Lifecycle = models.Lifecycle{
 		StopIfIdleFor:    time.Duration(stopIfIdleNs),

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -68,6 +68,8 @@ func Open(path string) (*Store, error) {
 			os_user TEXT NOT NULL,
 			env_json TEXT NOT NULL,
 			network_block_all INTEGER NOT NULL DEFAULT 0,
+			network_allow_out_json TEXT NOT NULL DEFAULT '[]',
+			network_deny_out_json TEXT NOT NULL DEFAULT '[]',
 			toolbox_enabled INTEGER NOT NULL DEFAULT 1,
 			toolbox_token TEXT NOT NULL DEFAULT '',
 			ssh_public_key TEXT NOT NULL DEFAULT '',
@@ -614,6 +616,12 @@ func Open(path string) (*Store, error) {
 		`ALTER TABLE sandboxes ADD COLUMN clone_generation TEXT NOT NULL DEFAULT '';`,
 		`ALTER TABLE sandboxes ADD COLUMN wasm_registry_ref TEXT NOT NULL DEFAULT '';`,
 		`ALTER TABLE sandboxes ADD COLUMN wasm_registry_digest TEXT NOT NULL DEFAULT '';`,
+		// Selective-egress CIDR policy (E2B network.allowOut / denyOut). JSON
+		// arrays so the start/reconcile paths can reinstall the host-firewall
+		// rules after a restart, the same way network_block_all is reapplied.
+		// Empty '[]' for every pre-migration row and the no-policy common path.
+		`ALTER TABLE sandboxes ADD COLUMN network_allow_out_json TEXT NOT NULL DEFAULT '[]';`,
+		`ALTER TABLE sandboxes ADD COLUMN network_deny_out_json TEXT NOT NULL DEFAULT '[]';`,
 	}
 	for _, stmt := range migrations {
 		if _, err := db.Exec(stmt); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
@@ -721,7 +729,7 @@ func (s *Store) Create(ctx context.Context, sandbox *models.Sandbox) error {
 	_, err = s.db.ExecContext(ctx, `
 		INSERT INTO sandboxes (
 			id, image, status, public_url, container_id, container_ip, cpu, memory_mb, disk_gb,
-			os_user, env_json, network_block_all, toolbox_enabled, toolbox_token, ssh_public_key,
+			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
 			failover_policy,
@@ -738,7 +746,7 @@ func (s *Store) Create(ctx context.Context, sandbox *models.Sandbox) error {
 			checkpoint_path, clone_generation,
 			wasm_registry_ref, wasm_registry_digest,
 			owner_ref, fleet_suspended
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		sandbox.ID,
 		sandbox.Image,
@@ -752,6 +760,8 @@ func (s *Store) Create(ctx context.Context, sandbox *models.Sandbox) error {
 		sandbox.OSUser,
 		envJSON,
 		boolToInt(sandbox.NetworkBlockAll),
+		mustMarshalStringSlice(sandbox.NetworkAllowOut),
+		mustMarshalStringSlice(sandbox.NetworkDenyOut),
 		boolToInt(sandbox.ToolboxEnabled),
 		sandbox.ToolboxToken,
 		sandbox.SSHPublicKey,
@@ -798,6 +808,20 @@ func (s *Store) Create(ctx context.Context, sandbox *models.Sandbox) error {
 		return fmt.Errorf("insert sandbox: %w", err)
 	}
 	return nil
+}
+
+// mustMarshalStringSlice JSON-encodes a string slice for a TEXT column,
+// returning "[]" for nil/empty (and on the practically impossible marshal
+// error) so a sandbox write never fails on a network-policy column.
+func mustMarshalStringSlice(v []string) string {
+	if len(v) == 0 {
+		return "[]"
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "[]"
+	}
+	return string(b)
 }
 
 // nullableBlob normalizes a nil byte slice to an empty one so SQLite stores
@@ -851,7 +875,7 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 	_, err = s.db.ExecContext(ctx, `
 		INSERT INTO sandboxes (
 			id, image, status, public_url, container_id, container_ip, cpu, memory_mb, disk_gb,
-			os_user, env_json, network_block_all, toolbox_enabled, toolbox_token, ssh_public_key,
+			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
 			failover_policy,
@@ -868,7 +892,7 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 			checkpoint_path, clone_generation,
 			wasm_registry_ref, wasm_registry_digest,
 			owner_ref, fleet_suspended
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			image = excluded.image,
 			status = excluded.status,
@@ -881,6 +905,8 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 			os_user = excluded.os_user,
 			env_json = excluded.env_json,
 			network_block_all = excluded.network_block_all,
+			network_allow_out_json = excluded.network_allow_out_json,
+			network_deny_out_json = excluded.network_deny_out_json,
 			toolbox_enabled = excluded.toolbox_enabled,
 			toolbox_token = excluded.toolbox_token,
 			ssh_public_key = excluded.ssh_public_key,
@@ -927,6 +953,8 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 		sandbox.OSUser,
 		envJSON,
 		boolToInt(sandbox.NetworkBlockAll),
+		mustMarshalStringSlice(sandbox.NetworkAllowOut),
+		mustMarshalStringSlice(sandbox.NetworkDenyOut),
 		boolToInt(sandbox.ToolboxEnabled),
 		sandbox.ToolboxToken,
 		sandbox.SSHPublicKey,
@@ -978,7 +1006,7 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 func (s *Store) Get(ctx context.Context, id string) (*models.Sandbox, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, image, status, public_url, container_id, container_ip, cpu, memory_mb, disk_gb,
-			os_user, env_json, network_block_all, toolbox_enabled, toolbox_token, ssh_public_key,
+			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
 			failover_policy,
@@ -1025,7 +1053,7 @@ func (s *Store) Get(ctx context.Context, id string) (*models.Sandbox, error) {
 func (s *Store) List(ctx context.Context) ([]*models.Sandbox, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, image, status, public_url, container_id, container_ip, cpu, memory_mb, disk_gb,
-			os_user, env_json, network_block_all, toolbox_enabled, toolbox_token, ssh_public_key,
+			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
 			failover_policy,
@@ -1092,7 +1120,7 @@ func (s *Store) List(ctx context.Context) ([]*models.Sandbox, error) {
 func (s *Store) ListByOwner(ctx context.Context, ownerRef string) ([]*models.Sandbox, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, image, status, public_url, container_id, container_ip, cpu, memory_mb, disk_gb,
-			os_user, env_json, network_block_all, toolbox_enabled, toolbox_token, ssh_public_key,
+			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
 			failover_policy,
@@ -1143,7 +1171,7 @@ func (s *Store) ListByOwner(ctx context.Context, ownerRef string) ([]*models.San
 func (s *Store) ListByRuntime(ctx context.Context, runtime string) ([]*models.Sandbox, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, image, status, public_url, container_id, container_ip, cpu, memory_mb, disk_gb,
-			os_user, env_json, network_block_all, toolbox_enabled, toolbox_token, ssh_public_key,
+			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
 			failover_policy,
@@ -3389,6 +3417,7 @@ func scanSandbox(scanner interface {
 	var serverless int
 	var wakeArmed int
 	var fleetSuspended int
+	var allowOutJSON, denyOutJSON string
 
 	err := scanner.Scan(
 		&sandbox.ID,
@@ -3403,6 +3432,8 @@ func scanSandbox(scanner interface {
 		&sandbox.OSUser,
 		&envJSON,
 		&networkBlocked,
+		&allowOutJSON,
+		&denyOutJSON,
 		&toolboxEnabled,
 		&sandbox.ToolboxToken,
 		&sandbox.SSHPublicKey,
@@ -3479,6 +3510,16 @@ func scanSandbox(scanner interface {
 	}
 
 	sandbox.NetworkBlockAll = networkBlocked == 1
+	if allowOutJSON != "" {
+		if err := json.Unmarshal([]byte(allowOutJSON), &sandbox.NetworkAllowOut); err != nil {
+			return nil, fmt.Errorf("decode network allow out: %w", err)
+		}
+	}
+	if denyOutJSON != "" {
+		if err := json.Unmarshal([]byte(denyOutJSON), &sandbox.NetworkDenyOut); err != nil {
+			return nil, fmt.Errorf("decode network deny out: %w", err)
+		}
+	}
 	sandbox.ToolboxEnabled = toolboxEnabled == 1
 	sandbox.Lifecycle = models.Lifecycle{
 		StopIfIdleFor:    time.Duration(stopIfIdleNs),

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1920,6 +1920,7 @@ func TestStoreHelperCases(t *testing.T) {
 			0,                           // network_blocked
 			"[]",                        // network_allow_out_json
 			"[]",                        // network_deny_out_json
+			1,                           // allow_public_traffic
 			1,                           // toolbox_enabled
 			"",                          // toolbox_token
 			"",                          // ssh_public_key
@@ -2087,6 +2088,40 @@ func TestEgressPolicyColumnsRoundTrip(t *testing.T) {
 	}
 	if len(got.NetworkAllowOut) != 0 || len(got.NetworkDenyOut) != 0 {
 		t.Fatalf("no-policy round-trip = allow %+v deny %+v, want both empty", got.NetworkAllowOut, got.NetworkDenyOut)
+	}
+}
+
+func TestAllowPublicTrafficColumnRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+
+	// Explicit false persists and reads back as a non-nil false.
+	deny := sampleSandbox("sb-no-public")
+	denyVal := false
+	deny.AllowPublicTraffic = &denyVal
+	if err := st.Create(ctx, deny); err != nil {
+		t.Fatalf("Create deny: %v", err)
+	}
+	got, err := st.Get(ctx, deny.ID)
+	if err != nil {
+		t.Fatalf("Get deny: %v", err)
+	}
+	if got.AllowPublicTraffic == nil || *got.AllowPublicTraffic {
+		t.Fatalf("AllowPublicTraffic = %v, want non-nil false", got.AllowPublicTraffic)
+	}
+
+	// Unset (nil) defaults to allowed (column default 1) on read-back.
+	dflt := sampleSandbox("sb-default-public")
+	dflt.AllowPublicTraffic = nil
+	if err := st.Create(ctx, dflt); err != nil {
+		t.Fatalf("Create default: %v", err)
+	}
+	got, err = st.Get(ctx, dflt.ID)
+	if err != nil {
+		t.Fatalf("Get default: %v", err)
+	}
+	if got.AllowPublicTraffic == nil || !*got.AllowPublicTraffic {
+		t.Fatalf("default AllowPublicTraffic = %v, want non-nil true", got.AllowPublicTraffic)
 	}
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1918,6 +1918,8 @@ func TestStoreHelperCases(t *testing.T) {
 			"root",                      // os_user
 			"{bad json",                 // env_json — triggers the failure
 			0,                           // network_blocked
+			"[]",                        // network_allow_out_json
+			"[]",                        // network_deny_out_json
 			1,                           // toolbox_enabled
 			"",                          // toolbox_token
 			"",                          // ssh_public_key
@@ -2036,6 +2038,55 @@ func sampleSandbox(id string) *models.Sandbox {
 		UpdatedAt:        now,
 		LastActiveAt:     now,
 		Runtime:          models.RuntimeGvisor,
+	}
+}
+
+func TestEgressPolicyColumnsRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+
+	// Allowlist round-trips through Create + Get.
+	allow := sampleSandbox("sb-egress-allow")
+	allow.NetworkBlockAll = false
+	allow.NetworkAllowOut = []string{"1.1.1.0/24", "8.8.8.8/32"}
+	if err := st.Create(ctx, allow); err != nil {
+		t.Fatalf("Create allow: %v", err)
+	}
+	got, err := st.Get(ctx, allow.ID)
+	if err != nil {
+		t.Fatalf("Get allow: %v", err)
+	}
+	if !reflect.DeepEqual(got.NetworkAllowOut, allow.NetworkAllowOut) || len(got.NetworkDenyOut) != 0 {
+		t.Fatalf("allow round-trip = allow %+v deny %+v, want %+v / empty", got.NetworkAllowOut, got.NetworkDenyOut, allow.NetworkAllowOut)
+	}
+
+	// Blocklist round-trips through Upsert.
+	deny := sampleSandbox("sb-egress-deny")
+	deny.NetworkBlockAll = false
+	deny.NetworkDenyOut = []string{"10.0.0.0/8"}
+	if err := st.Upsert(ctx, deny); err != nil {
+		t.Fatalf("Upsert deny: %v", err)
+	}
+	got, err = st.Get(ctx, deny.ID)
+	if err != nil {
+		t.Fatalf("Get deny: %v", err)
+	}
+	if !reflect.DeepEqual(got.NetworkDenyOut, deny.NetworkDenyOut) || len(got.NetworkAllowOut) != 0 {
+		t.Fatalf("deny round-trip = deny %+v allow %+v, want %+v / empty", got.NetworkDenyOut, got.NetworkAllowOut, deny.NetworkDenyOut)
+	}
+
+	// A sandbox with no policy reads back as empty, not a stray '[]' artifact.
+	none := sampleSandbox("sb-egress-none")
+	none.NetworkBlockAll = false
+	if err := st.Create(ctx, none); err != nil {
+		t.Fatalf("Create none: %v", err)
+	}
+	got, err = st.Get(ctx, none.ID)
+	if err != nil {
+		t.Fatalf("Get none: %v", err)
+	}
+	if len(got.NetworkAllowOut) != 0 || len(got.NetworkDenyOut) != 0 {
+		t.Fatalf("no-policy round-trip = allow %+v deny %+v, want both empty", got.NetworkAllowOut, got.NetworkDenyOut)
 	}
 }
 

--- a/pkg/api/clustercreate/clustercreate_test.go
+++ b/pkg/api/clustercreate/clustercreate_test.go
@@ -203,11 +203,13 @@ func (f *fakeRuntime) RemoveImage(context.Context, string) error {
 func (f *fakeRuntime) PushAllowedPorts(context.Context, string, string, []int) error {
 	return nil
 }
-func (f *fakeRuntime) ClearNetworkRules(string) error        { return nil }
-func (f *fakeRuntime) ApplyNetworkBlockAll(string) error     { return nil }
-func (f *fakeRuntime) ApplyNetworkBlockIngress(string) error { return nil }
-func (f *fakeRuntime) ClearNetworkBlockIngress(string) error { return nil }
-func (f *fakeRuntime) ClearNetworkBlockEgress(string) error  { return nil }
+func (f *fakeRuntime) ClearNetworkRules(string) error                     { return nil }
+func (f *fakeRuntime) ApplyEgressPolicy(string, []string, []string) error { return nil }
+func (f *fakeRuntime) ClearEgressPolicy(string, []string, []string) error { return nil }
+func (f *fakeRuntime) ApplyNetworkBlockAll(string) error                  { return nil }
+func (f *fakeRuntime) ApplyNetworkBlockIngress(string) error              { return nil }
+func (f *fakeRuntime) ClearNetworkBlockIngress(string) error              { return nil }
+func (f *fakeRuntime) ClearNetworkBlockEgress(string) error               { return nil }
 
 func (f *fakeRuntime) lookup(containerRef string) (*models.SandboxRuntimeState, bool) {
 	if state, ok := f.states[containerRef]; ok {

--- a/pkg/api/daytona/contract_harness_test.go
+++ b/pkg/api/daytona/contract_harness_test.go
@@ -162,11 +162,13 @@ func (f *fakeDaytonaContractRuntime) PushAllowedPorts(_ context.Context, contain
 	return nil
 }
 
-func (f *fakeDaytonaContractRuntime) ClearNetworkRules(string) error        { return nil }
-func (f *fakeDaytonaContractRuntime) ApplyNetworkBlockAll(string) error     { return nil }
-func (f *fakeDaytonaContractRuntime) ApplyNetworkBlockIngress(string) error { return nil }
-func (f *fakeDaytonaContractRuntime) ClearNetworkBlockIngress(string) error { return nil }
-func (f *fakeDaytonaContractRuntime) ClearNetworkBlockEgress(string) error  { return nil }
+func (f *fakeDaytonaContractRuntime) ClearNetworkRules(string) error                     { return nil }
+func (f *fakeDaytonaContractRuntime) ApplyEgressPolicy(string, []string, []string) error { return nil }
+func (f *fakeDaytonaContractRuntime) ClearEgressPolicy(string, []string, []string) error { return nil }
+func (f *fakeDaytonaContractRuntime) ApplyNetworkBlockAll(string) error                  { return nil }
+func (f *fakeDaytonaContractRuntime) ApplyNetworkBlockIngress(string) error              { return nil }
+func (f *fakeDaytonaContractRuntime) ClearNetworkBlockIngress(string) error              { return nil }
+func (f *fakeDaytonaContractRuntime) ClearNetworkBlockEgress(string) error               { return nil }
 
 func (f *fakeDaytonaContractRuntime) seedSandbox(sandbox *models.Sandbox) {
 	if sandbox == nil {

--- a/pkg/api/daytona/handlers_extra_test.go
+++ b/pkg/api/daytona/handlers_extra_test.go
@@ -71,11 +71,13 @@ func (f *fakeHandlerRuntime) RemoveImage(context.Context, string) error { return
 func (f *fakeHandlerRuntime) PushAllowedPorts(context.Context, string, string, []int) error {
 	return nil
 }
-func (f *fakeHandlerRuntime) ClearNetworkRules(string) error        { return nil }
-func (f *fakeHandlerRuntime) ApplyNetworkBlockAll(string) error     { return nil }
-func (f *fakeHandlerRuntime) ApplyNetworkBlockIngress(string) error { return nil }
-func (f *fakeHandlerRuntime) ClearNetworkBlockIngress(string) error { return nil }
-func (f *fakeHandlerRuntime) ClearNetworkBlockEgress(string) error  { return nil }
+func (f *fakeHandlerRuntime) ClearNetworkRules(string) error                     { return nil }
+func (f *fakeHandlerRuntime) ApplyEgressPolicy(string, []string, []string) error { return nil }
+func (f *fakeHandlerRuntime) ClearEgressPolicy(string, []string, []string) error { return nil }
+func (f *fakeHandlerRuntime) ApplyNetworkBlockAll(string) error                  { return nil }
+func (f *fakeHandlerRuntime) ApplyNetworkBlockIngress(string) error              { return nil }
+func (f *fakeHandlerRuntime) ClearNetworkBlockIngress(string) error              { return nil }
+func (f *fakeHandlerRuntime) ClearNetworkBlockEgress(string) error               { return nil }
 
 func newHandlerExtraTestEnv(t *testing.T) (*service.Service, *store.Store, *fakeHandlerRuntime, http.Handler) {
 	t.Helper()

--- a/pkg/api/daytona/handlers_test.go
+++ b/pkg/api/daytona/handlers_test.go
@@ -551,11 +551,13 @@ func (f *fakeDaytonaSnapshotRuntime) PushAllowedPorts(context.Context, string, s
 	panic("unexpected PushAllowedPorts")
 }
 
-func (f *fakeDaytonaSnapshotRuntime) ClearNetworkRules(string) error        { return nil }
-func (f *fakeDaytonaSnapshotRuntime) ApplyNetworkBlockAll(string) error     { return nil }
-func (f *fakeDaytonaSnapshotRuntime) ApplyNetworkBlockIngress(string) error { return nil }
-func (f *fakeDaytonaSnapshotRuntime) ClearNetworkBlockIngress(string) error { return nil }
-func (f *fakeDaytonaSnapshotRuntime) ClearNetworkBlockEgress(string) error  { return nil }
+func (f *fakeDaytonaSnapshotRuntime) ClearNetworkRules(string) error                     { return nil }
+func (f *fakeDaytonaSnapshotRuntime) ApplyEgressPolicy(string, []string, []string) error { return nil }
+func (f *fakeDaytonaSnapshotRuntime) ClearEgressPolicy(string, []string, []string) error { return nil }
+func (f *fakeDaytonaSnapshotRuntime) ApplyNetworkBlockAll(string) error                  { return nil }
+func (f *fakeDaytonaSnapshotRuntime) ApplyNetworkBlockIngress(string) error              { return nil }
+func (f *fakeDaytonaSnapshotRuntime) ClearNetworkBlockIngress(string) error              { return nil }
+func (f *fakeDaytonaSnapshotRuntime) ClearNetworkBlockEgress(string) error               { return nil }
 
 func newSnapshotHandlerTestEnv(t *testing.T) (*service.Service, *store.Store, *fakeDaytonaSnapshotRuntime, http.Handler) {
 	t.Helper()

--- a/pkg/api/daytona/toolbox_proxy_test.go
+++ b/pkg/api/daytona/toolbox_proxy_test.go
@@ -56,11 +56,13 @@ func (fakeToolboxRouteRuntime) RemoveImage(context.Context, string) error { retu
 func (fakeToolboxRouteRuntime) PushAllowedPorts(context.Context, string, string, []int) error {
 	return nil
 }
-func (fakeToolboxRouteRuntime) ClearNetworkRules(string) error        { return nil }
-func (fakeToolboxRouteRuntime) ApplyNetworkBlockAll(string) error     { return nil }
-func (fakeToolboxRouteRuntime) ApplyNetworkBlockIngress(string) error { return nil }
-func (fakeToolboxRouteRuntime) ClearNetworkBlockIngress(string) error { return nil }
-func (fakeToolboxRouteRuntime) ClearNetworkBlockEgress(string) error  { return nil }
+func (fakeToolboxRouteRuntime) ClearNetworkRules(string) error                     { return nil }
+func (fakeToolboxRouteRuntime) ApplyEgressPolicy(string, []string, []string) error { return nil }
+func (fakeToolboxRouteRuntime) ClearEgressPolicy(string, []string, []string) error { return nil }
+func (fakeToolboxRouteRuntime) ApplyNetworkBlockAll(string) error                  { return nil }
+func (fakeToolboxRouteRuntime) ApplyNetworkBlockIngress(string) error              { return nil }
+func (fakeToolboxRouteRuntime) ClearNetworkBlockIngress(string) error              { return nil }
+func (fakeToolboxRouteRuntime) ClearNetworkBlockEgress(string) error               { return nil }
 
 // toolboxProxyTestEnv wires a fake "toolbox daemon" httptest.Server into the
 // daytona facade so we can drive real HTTP and WebSocket traffic through the

--- a/pkg/api/e2b/handlers.go
+++ b/pkg/api/e2b/handlers.go
@@ -566,9 +566,6 @@ func (h *handlers) translateCreateSandboxRequest(ctx context.Context, req create
 		allowPublicTraffic = cloneBoolPtr(req.Network.AllowPublicTraffic)
 		maskRequestHost = strings.TrimSpace(req.Network.MaskRequestHost)
 	}
-	if allowPublicTraffic != nil && !*allowPublicTraffic {
-		return models.CreateSandboxRequest{}, sandboxMeta{}, notImplemented("network.allowPublicTraffic=false is not implemented yet")
-	}
 	if maskRequestHost != "" {
 		return models.CreateSandboxRequest{}, sandboxMeta{}, notImplemented("network.maskRequestHost is not implemented yet")
 	}
@@ -640,6 +637,7 @@ func (h *handlers) translateCreateSandboxRequest(ctx context.Context, req create
 		}
 		wasmReq.Env = envVars
 		wasmReq.NetworkBlockAll = networkBlockAll
+		wasmReq.AllowPublicTraffic = allowPublicTraffic
 		wasmReq.Lifecycle = lifecycle
 		wasmReq.Tags = cloneStringMap(metadata)
 		meta := sandboxMeta{
@@ -664,12 +662,13 @@ func (h *handlers) translateCreateSandboxRequest(ctx context.Context, req create
 	}
 
 	serviceReq := models.CreateSandboxRequest{
-		Image:           resolvedImage,
-		Env:             envVars,
-		NetworkBlockAll: networkBlockAll,
-		NetworkAllowOut: egressAllowOut,
-		NetworkDenyOut:  egressDenyOut,
-		Lifecycle:       lifecycle,
+		Image:              resolvedImage,
+		Env:                envVars,
+		NetworkBlockAll:    networkBlockAll,
+		NetworkAllowOut:    egressAllowOut,
+		NetworkDenyOut:     egressDenyOut,
+		AllowPublicTraffic: allowPublicTraffic,
+		Lifecycle:          lifecycle,
 		// E2B's metadata is the same shape as Daytona's labels — write it
 		// into the native tags column so it round-trips through any API
 		// surface, not just /e2b.

--- a/pkg/api/e2b/handlers.go
+++ b/pkg/api/e2b/handlers.go
@@ -566,12 +566,6 @@ func (h *handlers) translateCreateSandboxRequest(ctx context.Context, req create
 		allowPublicTraffic = cloneBoolPtr(req.Network.AllowPublicTraffic)
 		maskRequestHost = strings.TrimSpace(req.Network.MaskRequestHost)
 	}
-	if len(networkAllowOut) > 0 {
-		return models.CreateSandboxRequest{}, sandboxMeta{}, notImplemented("network.allowOut is not implemented yet")
-	}
-	if len(networkDenyOut) > 0 && !(len(networkDenyOut) == 1 && networkDenyOut[0] == "0.0.0.0/0") {
-		return models.CreateSandboxRequest{}, sandboxMeta{}, notImplemented("network.denyOut is only supported for blocking all outbound traffic")
-	}
 	if allowPublicTraffic != nil && !*allowPublicTraffic {
 		return models.CreateSandboxRequest{}, sandboxMeta{}, notImplemented("network.allowPublicTraffic=false is not implemented yet")
 	}
@@ -594,6 +588,17 @@ func (h *handlers) translateCreateSandboxRequest(ctx context.Context, req create
 			value := false
 			allowInternetAccess = &value
 		}
+	}
+
+	// Effective egress CIDR policy handed to the service. A full block is
+	// carried by NetworkBlockAll (the blanket DROP), so we must not also pass a
+	// 0.0.0.0/0 deny — the service rejects it and it would duplicate the block.
+	// allowOut/denyOut are mutually exclusive per the E2B schema.
+	egressAllowOut := networkAllowOut
+	egressDenyOut := networkDenyOut
+	if networkBlockAll {
+		egressAllowOut = nil
+		egressDenyOut = nil
 	}
 
 	timeoutSeconds := defaultSandboxTimeout
@@ -627,6 +632,12 @@ func (h *handlers) translateCreateSandboxRequest(ctx context.Context, req create
 	if wasmReq, ok, err := facadeutil.TranslateWasmCreate(ctx, h.deps.Service, templateID, metadata); err != nil {
 		return models.CreateSandboxRequest{}, sandboxMeta{}, err
 	} else if ok {
+		// WASM sandboxes are host-mediated with no container IP, so the
+		// DOCKER-USER egress rules cannot be enforced on them — reject rather
+		// than silently leave the workload unrestricted.
+		if len(egressAllowOut) > 0 || len(egressDenyOut) > 0 {
+			return models.CreateSandboxRequest{}, sandboxMeta{}, notImplemented("selective egress (network.allowOut / network.denyOut) is not supported for wasm sandboxes")
+		}
 		wasmReq.Env = envVars
 		wasmReq.NetworkBlockAll = networkBlockAll
 		wasmReq.Lifecycle = lifecycle
@@ -656,6 +667,8 @@ func (h *handlers) translateCreateSandboxRequest(ctx context.Context, req create
 		Image:           resolvedImage,
 		Env:             envVars,
 		NetworkBlockAll: networkBlockAll,
+		NetworkAllowOut: egressAllowOut,
+		NetworkDenyOut:  egressDenyOut,
 		Lifecycle:       lifecycle,
 		// E2B's metadata is the same shape as Daytona's labels — write it
 		// into the native tags column so it round-trips through any API

--- a/pkg/api/e2b/handlers_additional_test.go
+++ b/pkg/api/e2b/handlers_additional_test.go
@@ -26,8 +26,6 @@ func TestE2BCreateSandboxNotImplemented(t *testing.T) {
 	}{
 		{"mcp", `{"templateID":"base","mcp":{}}`},
 		{"volumeMounts", `{"templateID":"base","volumeMounts":[{"name":"vol"}]}`},
-		{"networkAllowOut", `{"templateID":"base","network":{"allowOut":["1.1.1.1"]}}`},
-		{"networkDenyOut", `{"templateID":"base","network":{"denyOut":["1.1.1.1"]}}`},
 		{"networkAllowPublicTraffic", `{"templateID":"base","network":{"allowPublicTraffic":false}}`},
 		{"networkMaskRequestHost", `{"templateID":"base","network":{"maskRequestHost":"host"}}`},
 	}

--- a/pkg/api/e2b/handlers_additional_test.go
+++ b/pkg/api/e2b/handlers_additional_test.go
@@ -26,7 +26,6 @@ func TestE2BCreateSandboxNotImplemented(t *testing.T) {
 	}{
 		{"mcp", `{"templateID":"base","mcp":{}}`},
 		{"volumeMounts", `{"templateID":"base","volumeMounts":[{"name":"vol"}]}`},
-		{"networkAllowPublicTraffic", `{"templateID":"base","network":{"allowPublicTraffic":false}}`},
 		{"networkMaskRequestHost", `{"templateID":"base","network":{"maskRequestHost":"host"}}`},
 	}
 

--- a/pkg/api/e2b/handlers_test.go
+++ b/pkg/api/e2b/handlers_test.go
@@ -204,20 +204,25 @@ func loadE2BSandboxMeta(ctx context.Context, st *store.Store, sandboxID string) 
 	return sandboxMetaFromState(state, sandbox)
 }
 
-func TestCreateSandboxRejectsUnsupportedNetworkAllowOut(t *testing.T) {
+func TestCreateSandboxAcceptsNetworkAllowOut(t *testing.T) {
 	_, _, handler := newE2BHandlerTestEnv(t)
+	// A valid CIDR allowlist is now honored (selective egress) and creates.
+	req := httptest.NewRequest(http.MethodPost, "/e2b/sandboxes", strings.NewReader(`{"templateID":"base","network":{"allowOut":["1.1.1.0/24","8.8.8.8/32"]}}`))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusCreated, rr.Body.String())
+	}
+}
+
+func TestCreateSandboxRejectsInvalidEgressCIDR(t *testing.T) {
+	_, _, handler := newE2BHandlerTestEnv(t)
+	// A bare IP is not a CIDR — the service validates and rejects with 400.
 	req := httptest.NewRequest(http.MethodPost, "/e2b/sandboxes", strings.NewReader(`{"templateID":"base","network":{"allowOut":["1.1.1.1"]}}`))
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
-	if rr.Code != http.StatusNotImplemented {
-		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusNotImplemented, rr.Body.String())
-	}
-	var resp errorResponse
-	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode error response error = %v", err)
-	}
-	if resp.Code != http.StatusNotImplemented {
-		t.Fatalf("resp.Code = %d, want %d", resp.Code, http.StatusNotImplemented)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusBadRequest, rr.Body.String())
 	}
 }
 
@@ -568,6 +573,8 @@ func (f *fakeE2BRuntime) RemoveImage(_ context.Context, imageRef string) error {
 
 func (f *fakeE2BRuntime) PushAllowedPorts(context.Context, string, string, []int) error { return nil }
 func (f *fakeE2BRuntime) ClearNetworkRules(string) error                                { return nil }
+func (f *fakeE2BRuntime) ApplyEgressPolicy(string, []string, []string) error            { return nil }
+func (f *fakeE2BRuntime) ClearEgressPolicy(string, []string, []string) error            { return nil }
 func (f *fakeE2BRuntime) ApplyNetworkBlockAll(string) error                             { return nil }
 func (f *fakeE2BRuntime) ApplyNetworkBlockIngress(string) error                         { return nil }
 func (f *fakeE2BRuntime) ClearNetworkBlockIngress(string) error                         { return nil }

--- a/pkg/api/v1/cluster_create_coverage_test.go
+++ b/pkg/api/v1/cluster_create_coverage_test.go
@@ -75,9 +75,11 @@ func (r *apiRecordingRuntime) Start(_ context.Context, sandboxID string) (*model
 
 func (r *apiRecordingRuntime) Stop(_ context.Context, _ string) error { return nil }
 
-func (r *apiRecordingRuntime) ApplyNetworkBlockAll(string) error     { return nil }
-func (r *apiRecordingRuntime) ClearNetworkBlockEgress(string) error  { return nil }
-func (r *apiRecordingRuntime) ClearNetworkBlockIngress(string) error { return nil }
+func (r *apiRecordingRuntime) ApplyEgressPolicy(string, []string, []string) error { return nil }
+func (r *apiRecordingRuntime) ClearEgressPolicy(string, []string, []string) error { return nil }
+func (r *apiRecordingRuntime) ApplyNetworkBlockAll(string) error                  { return nil }
+func (r *apiRecordingRuntime) ClearNetworkBlockEgress(string) error               { return nil }
+func (r *apiRecordingRuntime) ClearNetworkBlockIngress(string) error              { return nil }
 
 type promoteStubCluster struct {
 	*cluster.Noop

--- a/pkg/api/v1/snapshot_test.go
+++ b/pkg/api/v1/snapshot_test.go
@@ -453,8 +453,10 @@ func (noopRuntime) RemoveImage(context.Context, string) error { return nil }
 func (noopRuntime) PushAllowedPorts(context.Context, string, string, []int) error {
 	panic("unexpected PushAllowedPorts")
 }
-func (noopRuntime) ClearNetworkRules(string) error        { return nil }
-func (noopRuntime) ApplyNetworkBlockAll(string) error     { return nil }
-func (noopRuntime) ApplyNetworkBlockIngress(string) error { return nil }
-func (noopRuntime) ClearNetworkBlockIngress(string) error { return nil }
-func (noopRuntime) ClearNetworkBlockEgress(string) error  { return nil }
+func (noopRuntime) ClearNetworkRules(string) error                     { return nil }
+func (noopRuntime) ApplyEgressPolicy(string, []string, []string) error { return nil }
+func (noopRuntime) ClearEgressPolicy(string, []string, []string) error { return nil }
+func (noopRuntime) ApplyNetworkBlockAll(string) error                  { return nil }
+func (noopRuntime) ApplyNetworkBlockIngress(string) error              { return nil }
+func (noopRuntime) ClearNetworkBlockIngress(string) error              { return nil }
+func (noopRuntime) ClearNetworkBlockEgress(string) error               { return nil }

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -258,6 +258,27 @@ func (c *Client) ClearNetworkBlockEgress(containerIP string) error {
 	return c.networkRules.ClearBlockAllEgress(containerIP)
 }
 
+// ApplyEgressPolicy installs the selective-egress CIDR policy. Idempotent —
+// called on Create (initial install), StartSandbox (after a Stop+Start cycle
+// drops the rules on the stop event), and reconcile (to heal host-side state
+// loss). A no-op when no policy is set or network rules are disabled.
+func (c *Client) ApplyEgressPolicy(containerIP string, allowCIDRs, denyCIDRs []string) error {
+	if containerIP == "" {
+		return nil
+	}
+	return c.networkRules.ApplyEgressPolicy(containerIP, allowCIDRs, denyCIDRs)
+}
+
+// ClearEgressPolicy removes the selective-egress rules for the IP. Called on
+// stop/destroy before Docker recycles the IP — a stale ACCEPT/DROP would
+// otherwise re-attach to whoever next gets this IP from the IPAM pool.
+func (c *Client) ClearEgressPolicy(containerIP string, allowCIDRs, denyCIDRs []string) error {
+	if containerIP == "" {
+		return nil
+	}
+	return c.networkRules.ClearEgressPolicy(containerIP, allowCIDRs, denyCIDRs)
+}
+
 func (c *Client) Ping(ctx context.Context) error {
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://docker/_ping", nil)
 	if err != nil {
@@ -517,6 +538,18 @@ func (c *Client) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 		}
 	}
 
+	if len(req.NetworkAllowOut) > 0 || len(req.NetworkDenyOut) > 0 {
+		if err := c.networkRules.ApplyEgressPolicy(runtime.ContainerIP, req.NetworkAllowOut, req.NetworkDenyOut); err != nil {
+			// Fail closed, same rationale as NetworkBlockAll: the user opted
+			// into a restricted egress policy, so a sandbox that came up with
+			// only a partial rule set must not be left running. Roll the
+			// partial policy back and tear the container down.
+			_ = c.networkRules.ClearEgressPolicy(runtime.ContainerIP, req.NetworkAllowOut, req.NetworkDenyOut)
+			_ = c.removeContainer(ctx, created.ID, true)
+			return nil, fmt.Errorf("apply egress policy: %w", err)
+		}
+	}
+
 	runtime.SandboxID = sandboxID
 	return runtime, nil
 }
@@ -537,6 +570,10 @@ func (c *Client) Destroy(ctx context.Context, sandbox *models.Sandbox) error {
 		// Clear both directions: a stale ingress DROP would re-attach to whoever
 		// next gets this IP from Docker's IPAM pool.
 		_ = c.ClearNetworkRules(sandbox.ContainerIP)
+		// The selective-egress rules are comment-tagged and keyed by allow/deny
+		// CIDR, so the blanket clear above does not touch them — clear them
+		// explicitly from the persisted policy before the IP is recycled.
+		_ = c.ClearEgressPolicy(sandbox.ContainerIP, sandbox.NetworkAllowOut, sandbox.NetworkDenyOut)
 	}
 	if sandbox == nil {
 		return nil

--- a/pkg/docker/netrules/manager.go
+++ b/pkg/docker/netrules/manager.go
@@ -137,3 +137,110 @@ func (m *Manager) ClearBlockAllIngress(containerIP string) error {
 		return fmt.Errorf("delete ingress rule: %w", err)
 	}
 }
+
+// egressPolicyComment tags every selective-egress rule (allowlist/blocklist) so
+// it is distinguishable from the blanket BlockAllEgress / quota DROP, which
+// carry no comment. This matters because an allowlist's catch-all is also
+// "-s IP -j DROP": without the comment it would be the *same* iptables rule as
+// the full-block DROP, and a quota-driven ClearBlockAllEgress would silently
+// punch a hole in the allowlist. The comment keeps the two mechanisms disjoint.
+const egressPolicyComment = "sbx-egress"
+
+// ApplyEgressPolicy installs a per-container selective egress policy in
+// DOCKER-USER, scoped by source IP and comment-tagged (see egressPolicyComment).
+// Exactly one mode is expected (callers validate mutual exclusivity):
+//   - allowCIDRs non-empty → allowlist: ACCEPT each CIDR, DROP everything else.
+//   - denyCIDRs non-empty  → blocklist: DROP each CIDR, leave the rest to
+//     Docker's default ACCEPT.
+//
+// Re-apply is idempotent: every rule is Exists-checked before Insert, so the
+// start/reconcile reapply paths can call this repeatedly without duplicating.
+func (m *Manager) ApplyEgressPolicy(containerIP string, allowCIDRs, denyCIDRs []string) error {
+	if !m.Enabled() || containerIP == "" {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if len(allowCIDRs) > 0 {
+		// The catch-all DROP must sit BELOW the per-CIDR ACCEPTs. Insert the
+		// DROP first, then each ACCEPT at position 1 so it lands above the DROP.
+		if err := m.ensurePolicyRule("-s", containerIP, "-m", "comment", "--comment", egressPolicyComment, "-j", "DROP"); err != nil {
+			return err
+		}
+		for _, cidr := range allowCIDRs {
+			if err := m.ensurePolicyRule("-s", containerIP, "-d", cidr, "-m", "comment", "--comment", egressPolicyComment, "-j", "ACCEPT"); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for _, cidr := range denyCIDRs {
+		if err := m.ensurePolicyRule("-s", containerIP, "-d", cidr, "-m", "comment", "--comment", egressPolicyComment, "-j", "DROP"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ClearEgressPolicy removes the rules ApplyEgressPolicy would have installed for
+// the same (containerIP, allowCIDRs, denyCIDRs). The caller passes the policy
+// persisted on the sandbox row so cleanup is exact and comment-scoped — the
+// blanket BlockAllEgress DROP (no comment) is left untouched.
+func (m *Manager) ClearEgressPolicy(containerIP string, allowCIDRs, denyCIDRs []string) error {
+	if !m.Enabled() || containerIP == "" {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var specs [][]string
+	for _, cidr := range allowCIDRs {
+		specs = append(specs, []string{"-s", containerIP, "-d", cidr, "-m", "comment", "--comment", egressPolicyComment, "-j", "ACCEPT"})
+	}
+	if len(allowCIDRs) > 0 {
+		specs = append(specs, []string{"-s", containerIP, "-m", "comment", "--comment", egressPolicyComment, "-j", "DROP"})
+	}
+	for _, cidr := range denyCIDRs {
+		specs = append(specs, []string{"-s", containerIP, "-d", cidr, "-m", "comment", "--comment", egressPolicyComment, "-j", "DROP"})
+	}
+	for _, spec := range specs {
+		if err := m.deletePolicyRule(spec...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ensurePolicyRule inserts a DOCKER-USER rule at the top if it is not already
+// present. Insert-at-1 plus the Exists guard is the same idempotency contract
+// the BlockAll* methods use.
+func (m *Manager) ensurePolicyRule(spec ...string) error {
+	exists, err := m.ipt.Exists("filter", "DOCKER-USER", spec...)
+	if err != nil {
+		return fmt.Errorf("check egress policy rule: %w", err)
+	}
+	if exists {
+		return nil
+	}
+	if err := m.ipt.Insert("filter", "DOCKER-USER", 1, spec...); err != nil {
+		return fmt.Errorf("insert egress policy rule: %w", err)
+	}
+	return nil
+}
+
+// deletePolicyRule deletes a DOCKER-USER rule, looping to clear any duplicate a
+// prior race may have left (Delete removes one match per call), and tolerating
+// an already-absent rule.
+func (m *Manager) deletePolicyRule(spec ...string) error {
+	for {
+		err := m.ipt.Delete("filter", "DOCKER-USER", spec...)
+		if err == nil {
+			continue
+		}
+		if strings.Contains(err.Error(), "No chain/target/match") {
+			return nil
+		}
+		return fmt.Errorf("delete egress policy rule: %w", err)
+	}
+}

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -563,6 +563,13 @@ type CreateSandboxRequest struct {
 	// NetworkAllowOut. Blocking the entire space is expressed as
 	// NetworkBlockAll, not a denyOut of 0.0.0.0/0.
 	NetworkDenyOut []string `json:"network_deny_out,omitempty"`
+	// AllowPublicTraffic controls whether the sandbox may be exposed to the
+	// public internet. Nil (default) and true allow public exposure; false
+	// makes expose_port fail — the sandbox stays reachable only via the
+	// platform's own paths (toolbox exec/file proxy, SSH gateway), which do
+	// not route through the public ingress. There is no auth-gated public
+	// route concept, so "no public traffic" is enforced by refusing exposure.
+	AllowPublicTraffic *bool `json:"allow_public_traffic,omitempty"`
 	// CustomDomains attaches operator-provided public hostnames to the
 	// sandbox at create time. Each hostname must resolve (via DNS) to the
 	// cluster's ingress host before HTTPS can serve traffic — see
@@ -698,6 +705,10 @@ type Sandbox struct {
 	// NetworkBlockAll). Mutually exclusive; at most one is non-empty.
 	NetworkAllowOut []string `json:"network_allow_out,omitempty"`
 	NetworkDenyOut  []string `json:"network_deny_out,omitempty"`
+	// AllowPublicTraffic mirrors the create-time flag. Nil means "not set"
+	// (treated as allowed); a non-nil false makes ExposePort refuse to install
+	// a public route. Persisted so the gate survives restarts.
+	AllowPublicTraffic *bool `json:"allow_public_traffic,omitempty"`
 	// NetworkQuotaExceeded reflects whether either lifetime byte counter has
 	// crossed its limit. The reconcile loop installs DROP rules when this is
 	// true; clearing requires raising the limit (or zeroing it for unlimited).

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -553,6 +553,16 @@ type CreateSandboxRequest struct {
 	// Crossing the limit installs an egress DROP rule via the same primitive
 	// NetworkBlockAll uses.
 	NetworkBytesOutLimit int64 `json:"network_bytes_out_limit,omitempty"`
+	// NetworkAllowOut is an egress allowlist of CIDRs: when non-empty the
+	// sandbox may reach only these destinations and everything else is
+	// dropped. Mutually exclusive with NetworkDenyOut. Enforced by the host
+	// firewall (EnableNetworkRules) and a no-op when network rules are off.
+	NetworkAllowOut []string `json:"network_allow_out,omitempty"`
+	// NetworkDenyOut is an egress blocklist of CIDRs: the sandbox may reach
+	// anything except these destinations. Mutually exclusive with
+	// NetworkAllowOut. Blocking the entire space is expressed as
+	// NetworkBlockAll, not a denyOut of 0.0.0.0/0.
+	NetworkDenyOut []string `json:"network_deny_out,omitempty"`
 	// CustomDomains attaches operator-provided public hostnames to the
 	// sandbox at create time. Each hostname must resolve (via DNS) to the
 	// cluster's ingress host before HTTPS can serve traffic — see
@@ -682,6 +692,12 @@ type Sandbox struct {
 	// created or patched with. Zero = unlimited.
 	NetworkBytesInLimit  int64 `json:"network_bytes_in_limit"`
 	NetworkBytesOutLimit int64 `json:"network_bytes_out_limit"`
+	// NetworkAllowOut / NetworkDenyOut are the egress CIDR policy the sandbox
+	// was created with, persisted so the start and reconcile paths can
+	// reinstall the host-firewall rules after a restart (parity with
+	// NetworkBlockAll). Mutually exclusive; at most one is non-empty.
+	NetworkAllowOut []string `json:"network_allow_out,omitempty"`
+	NetworkDenyOut  []string `json:"network_deny_out,omitempty"`
 	// NetworkQuotaExceeded reflects whether either lifetime byte counter has
 	// crossed its limit. The reconcile loop installs DROP rules when this is
 	// true; clearing requires raising the limit (or zeroing it for unlimited).

--- a/sdk/java/src/main/java/ai/aerol/microvm/MicroVMClient.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/MicroVMClient.java
@@ -870,6 +870,7 @@ public class MicroVMClient {
         copy.networkBlockAll = source.networkBlockAll;
         copy.networkAllowOut = source.networkAllowOut;
         copy.networkDenyOut = source.networkDenyOut;
+        copy.allowPublicTraffic = source.allowPublicTraffic;
         copy.networkBytesInLimit = source.networkBytesInLimit;
         copy.networkBytesOutLimit = source.networkBytesOutLimit;
         copy.registry = source.registry;

--- a/sdk/java/src/main/java/ai/aerol/microvm/MicroVMClient.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/MicroVMClient.java
@@ -868,6 +868,8 @@ public class MicroVMClient {
         copy.env = source.env;
         copy.osUser = source.osUser;
         copy.networkBlockAll = source.networkBlockAll;
+        copy.networkAllowOut = source.networkAllowOut;
+        copy.networkDenyOut = source.networkDenyOut;
         copy.networkBytesInLimit = source.networkBytesInLimit;
         copy.networkBytesOutLimit = source.networkBytesOutLimit;
         copy.registry = source.registry;

--- a/sdk/java/src/main/java/ai/aerol/microvm/model/CreateOptions.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/model/CreateOptions.java
@@ -23,6 +23,9 @@ public class CreateOptions {
     /** Egress blocklist of CIDRs; sandbox may reach anything except these. Mutually exclusive with networkAllowOut. */
     @JsonProperty("network_deny_out")
     public List<String> networkDenyOut;
+    /** Whether the sandbox may be exposed publicly. Null/true allow it; false makes exposePort fail. */
+    @JsonProperty("allow_public_traffic")
+    public Boolean allowPublicTraffic;
     @JsonProperty("network_bytes_in_limit")
     public Long networkBytesInLimit;
     @JsonProperty("network_bytes_out_limit")
@@ -92,6 +95,11 @@ public class CreateOptions {
 
     public CreateOptions setNetworkDenyOut(List<String> networkDenyOut) {
         this.networkDenyOut = networkDenyOut;
+        return this;
+    }
+
+    public CreateOptions setAllowPublicTraffic(Boolean allowPublicTraffic) {
+        this.allowPublicTraffic = allowPublicTraffic;
         return this;
     }
 

--- a/sdk/java/src/main/java/ai/aerol/microvm/model/CreateOptions.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/model/CreateOptions.java
@@ -17,6 +17,12 @@ public class CreateOptions {
     public Map<String, String> env;
     public String osUser;
     public Boolean networkBlockAll;
+    /** Egress allowlist of CIDRs; sandbox may reach only these. Mutually exclusive with networkDenyOut. */
+    @JsonProperty("network_allow_out")
+    public List<String> networkAllowOut;
+    /** Egress blocklist of CIDRs; sandbox may reach anything except these. Mutually exclusive with networkAllowOut. */
+    @JsonProperty("network_deny_out")
+    public List<String> networkDenyOut;
     @JsonProperty("network_bytes_in_limit")
     public Long networkBytesInLimit;
     @JsonProperty("network_bytes_out_limit")
@@ -76,6 +82,16 @@ public class CreateOptions {
 
     public CreateOptions setNetworkBlockAll(Boolean networkBlockAll) {
         this.networkBlockAll = networkBlockAll;
+        return this;
+    }
+
+    public CreateOptions setNetworkAllowOut(List<String> networkAllowOut) {
+        this.networkAllowOut = networkAllowOut;
+        return this;
+    }
+
+    public CreateOptions setNetworkDenyOut(List<String> networkDenyOut) {
+        this.networkDenyOut = networkDenyOut;
         return this;
     }
 

--- a/sdk/java/src/test/java/ai/aerol/microvm/MicroVMClientTest.java
+++ b/sdk/java/src/test/java/ai/aerol/microvm/MicroVMClientTest.java
@@ -310,6 +310,7 @@ class MicroVMClientTest {
                     .setMemoryMb(2048)
                     .setNetworkBlockAll(true)
                     .setNetworkAllowOut(List.of("1.1.1.0/24", "8.8.8.8/32"))
+                    .setAllowPublicTraffic(false)
                     .setMounts(List.of(
                         new MountSpec()
                             .setType("s3")
@@ -336,6 +337,7 @@ class MicroVMClientTest {
             assertEquals(2048, ((Number) payload.get("memory_mb")).intValue());
             assertEquals(Boolean.TRUE, payload.get("network_block_all"));
             assertEquals(List.of("1.1.1.0/24", "8.8.8.8/32"), payload.get("network_allow_out"));
+            assertEquals(Boolean.FALSE, payload.get("allow_public_traffic"));
             Map<String, Object> lifecycle = castMap(payload.get("lifecycle"));
             assertEquals(3_600_000_000_000L, ((Number) lifecycle.get("stop_if_idle_for")).longValue());
             assertEquals(86_400_000_000_000L, ((Number) lifecycle.get("destroy_at_age")).longValue());

--- a/sdk/java/src/test/java/ai/aerol/microvm/MicroVMClientTest.java
+++ b/sdk/java/src/test/java/ai/aerol/microvm/MicroVMClientTest.java
@@ -309,6 +309,7 @@ class MicroVMClientTest {
                     .setImage("ubuntu:22.04")
                     .setMemoryMb(2048)
                     .setNetworkBlockAll(true)
+                    .setNetworkAllowOut(List.of("1.1.1.0/24", "8.8.8.8/32"))
                     .setMounts(List.of(
                         new MountSpec()
                             .setType("s3")
@@ -334,6 +335,7 @@ class MicroVMClientTest {
             assertEquals("ubuntu:22.04", payload.get("image"));
             assertEquals(2048, ((Number) payload.get("memory_mb")).intValue());
             assertEquals(Boolean.TRUE, payload.get("network_block_all"));
+            assertEquals(List.of("1.1.1.0/24", "8.8.8.8/32"), payload.get("network_allow_out"));
             Map<String, Object> lifecycle = castMap(payload.get("lifecycle"));
             assertEquals(3_600_000_000_000L, ((Number) lifecycle.get("stop_if_idle_for")).longValue());
             assertEquals(86_400_000_000_000L, ((Number) lifecycle.get("destroy_at_age")).longValue());

--- a/sdk/python/microvm/client.py
+++ b/sdk/python/microvm/client.py
@@ -1093,6 +1093,7 @@ def _to_api_create_options(options: CreateOptions) -> Dict[str, Any]:
             "network_block_all": _first_of(options, "networkBlockAll", "network_block_all"),
             "network_allow_out": _first_of(options, "networkAllowOut", "network_allow_out"),
             "network_deny_out": _first_of(options, "networkDenyOut", "network_deny_out"),
+            "allow_public_traffic": _first_of(options, "allowPublicTraffic", "allow_public_traffic"),
             "network_bytes_in_limit": _first_of(options, "networkBytesInLimit", "network_bytes_in_limit"),
             "network_bytes_out_limit": _first_of(options, "networkBytesOutLimit", "network_bytes_out_limit"),
             "registry": _first_of(options, "registry"),

--- a/sdk/python/microvm/client.py
+++ b/sdk/python/microvm/client.py
@@ -1091,6 +1091,8 @@ def _to_api_create_options(options: CreateOptions) -> Dict[str, Any]:
             "env": _first_of(options, "env"),
             "os_user": _first_of(options, "osUser", "os_user"),
             "network_block_all": _first_of(options, "networkBlockAll", "network_block_all"),
+            "network_allow_out": _first_of(options, "networkAllowOut", "network_allow_out"),
+            "network_deny_out": _first_of(options, "networkDenyOut", "network_deny_out"),
             "network_bytes_in_limit": _first_of(options, "networkBytesInLimit", "network_bytes_in_limit"),
             "network_bytes_out_limit": _first_of(options, "networkBytesOutLimit", "network_bytes_out_limit"),
             "registry": _first_of(options, "registry"),

--- a/sdk/python/microvm/types.py
+++ b/sdk/python/microvm/types.py
@@ -143,6 +143,12 @@ class CreateOptions(TypedDict, total=False):
     env: Dict[str, str]
     osUser: str
     networkBlockAll: bool
+    # Egress allowlist / blocklist of CIDRs enforced by the host firewall.
+    # networkAllowOut: sandbox may reach ONLY these; everything else is dropped.
+    # networkDenyOut: sandbox may reach anything EXCEPT these. The two are
+    # mutually exclusive; a full block is networkBlockAll, not a 0.0.0.0/0 deny.
+    networkAllowOut: List[str]
+    networkDenyOut: List[str]
     # Caps on network bytes the sandbox may receive (in) / send (out) before
     # per-IP iptables block fires. 0 (default) means unlimited; both can be
     # raised or lifted at runtime via set_network_limits.

--- a/sdk/python/microvm/types.py
+++ b/sdk/python/microvm/types.py
@@ -149,6 +149,9 @@ class CreateOptions(TypedDict, total=False):
     # mutually exclusive; a full block is networkBlockAll, not a 0.0.0.0/0 deny.
     networkAllowOut: List[str]
     networkDenyOut: List[str]
+    # Whether the sandbox may be exposed publicly. Defaults to True; False makes
+    # expose_port fail (reachable only via the toolbox proxy and SSH gateway).
+    allowPublicTraffic: bool
     # Caps on network bytes the sandbox may receive (in) / send (out) before
     # per-IP iptables block fires. 0 (default) means unlimited; both can be
     # raised or lifted at runtime via set_network_limits.

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -335,6 +335,12 @@ class ClientTests(unittest.TestCase):
         # network_deny_out is unset, so _compact() drops it from the body.
         self.assertNotIn("network_deny_out", payload)
 
+    def test_create_serializes_allow_public_traffic(self):
+        client = RecordingMicroVM()
+        client.create({"image": "ubuntu:22.04", "allowPublicTraffic": False})
+        _, _, payload = client.calls[0]
+        self.assertEqual(payload["allow_public_traffic"], False)
+
     def test_create_maps_request_and_response_shapes(self):
         client = RecordingMicroVM()
         sandbox = client.create(

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -326,6 +326,15 @@ class ClientTests(unittest.TestCase):
         with self.assertRaisesRegex(client_module.MicroVMError, "does not support Image builds"):
             client.build_image(Image.base("alpine"))
 
+    def test_create_serializes_selective_egress(self):
+        client = RecordingMicroVM()
+        client.create({"image": "ubuntu:22.04", "networkAllowOut": ["1.1.1.0/24", "8.8.8.8/32"]})
+        _, path, payload = client.calls[0]
+        self.assertEqual(path, "/v1/sandboxes")
+        self.assertEqual(payload["network_allow_out"], ["1.1.1.0/24", "8.8.8.8/32"])
+        # network_deny_out is unset, so _compact() drops it from the body.
+        self.assertNotIn("network_deny_out", payload)
+
     def test_create_maps_request_and_response_shapes(self):
         client = RecordingMicroVM()
         sandbox = client.create(

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -1970,6 +1970,7 @@ mod tests {
             network_block_all: None,
             network_allow_out: None,
             network_deny_out: None,
+            allow_public_traffic: None,
             network_bytes_in_limit: None,
             network_bytes_out_limit: None,
             registry: None,
@@ -1994,11 +1995,13 @@ mod tests {
     fn create_options_serializes_selective_egress() {
         let mut opts = minimal_create_options();
         opts.network_allow_out = Some(vec!["1.1.1.0/24".to_string(), "8.8.8.8/32".to_string()]);
+        opts.allow_public_traffic = Some(false);
         let value = serde_json::to_value(&opts).expect("serialize create options");
         assert_eq!(
             value["network_allow_out"],
             serde_json::json!(["1.1.1.0/24", "8.8.8.8/32"])
         );
+        assert_eq!(value["allow_public_traffic"], serde_json::json!(false));
         // network_deny_out is None, so skip_serializing_if omits it entirely.
         assert!(value.get("network_deny_out").is_none());
     }

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -1968,6 +1968,8 @@ mod tests {
             env: None,
             os_user: None,
             network_block_all: None,
+            network_allow_out: None,
+            network_deny_out: None,
             network_bytes_in_limit: None,
             network_bytes_out_limit: None,
             registry: None,
@@ -1986,6 +1988,19 @@ mod tests {
     fn request_json_body(request: &str) -> serde_json::Value {
         let body = request.split("\r\n\r\n").nth(1).unwrap_or("");
         serde_json::from_str(body).expect("request body should be valid JSON")
+    }
+
+    #[test]
+    fn create_options_serializes_selective_egress() {
+        let mut opts = minimal_create_options();
+        opts.network_allow_out = Some(vec!["1.1.1.0/24".to_string(), "8.8.8.8/32".to_string()]);
+        let value = serde_json::to_value(&opts).expect("serialize create options");
+        assert_eq!(
+            value["network_allow_out"],
+            serde_json::json!(["1.1.1.0/24", "8.8.8.8/32"])
+        );
+        // network_deny_out is None, so skip_serializing_if omits it entirely.
+        assert!(value.get("network_deny_out").is_none());
     }
 
     #[test]

--- a/sdk/rust/src/types.rs
+++ b/sdk/rust/src/types.rs
@@ -170,6 +170,11 @@ pub struct CreateOptions {
     /// destinations. Mutually exclusive with `network_allow_out`.
     #[serde(rename = "network_deny_out", skip_serializing_if = "Option::is_none")]
     pub network_deny_out: Option<Vec<String>>,
+    /// Whether the sandbox may be exposed publicly. `None`/`Some(true)` allow
+    /// it; `Some(false)` makes `expose_port` fail — the sandbox stays reachable
+    /// only via the toolbox proxy and SSH gateway.
+    #[serde(rename = "allow_public_traffic", skip_serializing_if = "Option::is_none")]
+    pub allow_public_traffic: Option<bool>,
     /// Cap on bytes the sandbox may receive before its ingress is dropped via
     /// per-IP iptables rule. `0` (or omit) means unlimited. Limits can be
     /// raised or lifted at runtime via [`Client::set_network_limits`].

--- a/sdk/rust/src/types.rs
+++ b/sdk/rust/src/types.rs
@@ -160,6 +160,16 @@ pub struct CreateOptions {
     pub os_user: Option<String>,
     #[serde(rename = "network_block_all", skip_serializing_if = "Option::is_none")]
     pub network_block_all: Option<bool>,
+    /// Egress allowlist of CIDRs: when set, the sandbox may reach only these
+    /// destinations and all other outbound traffic is dropped by the host
+    /// firewall. Mutually exclusive with `network_deny_out`; use
+    /// `network_block_all` for a full block.
+    #[serde(rename = "network_allow_out", skip_serializing_if = "Option::is_none")]
+    pub network_allow_out: Option<Vec<String>>,
+    /// Egress blocklist of CIDRs: the sandbox may reach anything except these
+    /// destinations. Mutually exclusive with `network_allow_out`.
+    #[serde(rename = "network_deny_out", skip_serializing_if = "Option::is_none")]
+    pub network_deny_out: Option<Vec<String>>,
     /// Cap on bytes the sandbox may receive before its ingress is dropped via
     /// per-IP iptables rule. `0` (or omit) means unlimited. Limits can be
     /// raised or lifted at runtime via [`Client::set_network_limits`].

--- a/sdk/typescript/src/internal/client.test.ts
+++ b/sdk/typescript/src/internal/client.test.ts
@@ -62,6 +62,22 @@ test("internal client create serializes selective egress CIDRs", async () => {
   assert.equal(body.network_deny_out, undefined);
 });
 
+test("internal client create serializes allowPublicTraffic=false", async () => {
+  let seenRequest: Request | undefined;
+  const client = new APIClient({
+    baseURL: "https://api.example.com",
+    patToken: "pat-token",
+    fetch: async (input, init) => {
+      seenRequest = new Request(input, init);
+      return jsonResponse(apiSandbox("sb-nopublic"));
+    },
+  });
+  await client.create({ image: "ubuntu:22.04", allowPublicTraffic: false });
+  assert.ok(seenRequest);
+  const body = (await seenRequest.json()) as Record<string, unknown>;
+  assert.equal(body.allow_public_traffic, false);
+});
+
 test("internal client create maps request and response", async () => {
   let seenRequest: Request | undefined;
   const client = new APIClient({

--- a/sdk/typescript/src/internal/client.test.ts
+++ b/sdk/typescript/src/internal/client.test.ts
@@ -42,6 +42,26 @@ test("internal client cloneGeneration reads token via toolbox proxy", async () =
   assert.equal(gen.resumedAt, 1700000000000000000);
 });
 
+test("internal client create serializes selective egress CIDRs", async () => {
+  let seenRequest: Request | undefined;
+  const client = new APIClient({
+    baseURL: "https://api.example.com",
+    patToken: "pat-token",
+    fetch: async (input, init) => {
+      seenRequest = new Request(input, init);
+      return jsonResponse(apiSandbox("sb-egress"));
+    },
+  });
+  await client.create({
+    image: "ubuntu:22.04",
+    networkAllowOut: ["1.1.1.0/24", "8.8.8.8/32"],
+  });
+  assert.ok(seenRequest);
+  const body = (await seenRequest.json()) as Record<string, unknown>;
+  assert.deepEqual(body.network_allow_out, ["1.1.1.0/24", "8.8.8.8/32"]);
+  assert.equal(body.network_deny_out, undefined);
+});
+
 test("internal client create maps request and response", async () => {
   let seenRequest: Request | undefined;
   const client = new APIClient({

--- a/sdk/typescript/src/internal/client.ts
+++ b/sdk/typescript/src/internal/client.ts
@@ -1099,6 +1099,8 @@ function toApiCreateOptions(options: CreateOptions): Record<string, unknown> {
     env: options.env,
     os_user: options.osUser,
     network_block_all: options.networkBlockAll,
+    network_allow_out: options.networkAllowOut,
+    network_deny_out: options.networkDenyOut,
     network_bytes_in_limit: options.networkBytesInLimit,
     network_bytes_out_limit: options.networkBytesOutLimit,
     registry: options.registry,

--- a/sdk/typescript/src/internal/client.ts
+++ b/sdk/typescript/src/internal/client.ts
@@ -1101,6 +1101,7 @@ function toApiCreateOptions(options: CreateOptions): Record<string, unknown> {
     network_block_all: options.networkBlockAll,
     network_allow_out: options.networkAllowOut,
     network_deny_out: options.networkDenyOut,
+    allow_public_traffic: options.allowPublicTraffic,
     network_bytes_in_limit: options.networkBytesInLimit,
     network_bytes_out_limit: options.networkBytesOutLimit,
     registry: options.registry,

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -174,6 +174,12 @@ export interface CreateOptions {
    */
   networkDenyOut?: string[];
   /**
+   * Whether the sandbox may be exposed to the public internet. Defaults to
+   * true; set `false` to make `exposePort` fail — the sandbox stays reachable
+   * only via the toolbox proxy and SSH gateway, not a public URL.
+   */
+  allowPublicTraffic?: boolean;
+  /**
    * Cap on bytes the sandbox may receive from outside the container before its
    * ingress is dropped via per-IP iptables rule. `0` (default) is unlimited.
    * Limits can be raised or lifted at runtime via `setNetworkLimits`.

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -162,6 +162,18 @@ export interface CreateOptions {
   osUser?: string;
   networkBlockAll?: boolean;
   /**
+   * Egress allowlist of CIDRs. When set, the sandbox may reach only these
+   * destinations; all other outbound traffic is dropped by the host firewall.
+   * Mutually exclusive with `networkDenyOut`. For a full block use
+   * `networkBlockAll` instead.
+   */
+  networkAllowOut?: string[];
+  /**
+   * Egress blocklist of CIDRs. When set, the sandbox may reach anything except
+   * these destinations. Mutually exclusive with `networkAllowOut`.
+   */
+  networkDenyOut?: string[];
+  /**
    * Cap on bytes the sandbox may receive from outside the container before its
    * ingress is dropped via per-IP iptables rule. `0` (default) is unlimited.
    * Limits can be raised or lifted at runtime via `setNetworkLimits`.


### PR DESCRIPTION
## Summary

- Implements **E2B selective egress** end-to-end. The facade previously returned **501** for `network.allowOut` and accepted `denyOut` only as a full block; it now honours per-CIDR allowlists and blocklists.
- `netrules.ApplyEgressPolicy`/`ClearEgressPolicy` install **allowlist** (`ACCEPT` each CIDR + catch-all `DROP`) or **blocklist** (`DROP` each CIDR) rules in `DOCKER-USER`. Every selective rule is comment-tagged (`-m comment --comment sbx-egress`) so it stays **disjoint from the blanket `BlockAllEgress` / quota DROP** — without the tag an allowlist's catch-all would be the *same* iptables row as the full-block DROP, and a quota-clear would silently punch a hole in the allowlist.
- `NetworkAllowOut`/`NetworkDenyOut` added to `CreateSandboxRequest` + `Sandbox`, persisted as JSON store columns so rules are reinstalled on Start/reconcile (parity with `NetworkBlockAll`).
- Out of scope (still `notImplemented`): `allowPublicTraffic` (needs *selective ingress* — a blanket block would sever Caddy + the toolbox proxy) and `maskRequestHost`. Tracked as a fast-follow.

All host-firewall work is gated on `EnableNetworkRules` and is a **no-op when network rules are disabled**.

## Sandbox boot impact

Adds host-firewall work to `CreateSandbox` **only when the request carries `network_allow_out` / `network_deny_out`** (otherwise zero new work). On that path: one `iptables -C`/`-I` per CIDR plus one catch-all in allowlist mode, run synchronously in `docker.Create()` after the container IP is stable — the same point and shape as the existing `NetworkBlockAll` install. Bounded by the number of CIDRs in the request. No work added to the no-policy common path. Disabled entirely when `EnableNetworkRules` is false.

## Idempotency

- `expose_port` and the host-port pool are untouched.
- `ApplyEgressPolicy` is idempotent: every rule is `Exists`-checked before `Insert`, so the create/start/reconcile reapply paths can run repeatedly without duplicating rows (same contract as `BlockAllEgress`). Retrying a create with the same `allow_out`/`deny_out` yields the same rule set.
- `validateEgressPolicy` rejects `allow_out` + `deny_out` together, non-CIDR entries, and a `deny_out` of `0.0.0.0/0` (must be expressed as `network_block_all`) — deterministic, so retries fail/succeed identically.

## Failure-path consistency

- **Create (caddy + store + firewall):** egress apply runs inside `docker.Create()` and is **fail-closed** — on partial failure it clears the partial policy for the IP and tears the container down before returning, matching the `NetworkBlockAll` rule. The post-`docker.Create` rollback `Destroy` literal carries the egress CIDRs so a later store/seal failure also clears the applied rules.
- **Stop/destroy:** selective rules are comment-tagged, so the existing `ClearNetworkRules` (which clears only the blanket DROP) does **not** remove them — `ClearEgressPolicy(ip, allow, deny)` is called explicitly at both the stop and destroy event sites and in `docker.Destroy()`, **before the IP is recycled**, so a stale `ACCEPT`/`DROP` cannot re-attach to the next container on that IP.
- **Start/reconcile:** rules are reapplied from the persisted policy (idempotent), so a Stop+Start cycle or host-side iptables loss self-heals — reconcile is the safety net, not the primary cleanup.

## L4 / host-port-pool changes

N/A — `TryReserveHostPort`, the `host_port` partial unique index, `allocateHostPort`, `EnsureLayer4`/`EnsureLayer4Ready`, and the `l4Ready` latch are all untouched. New egress rules live in the `DOCKER-USER` filter chain, not the TCP host-port pool or L4 ingress.

## Test plan

- `pkg/docker/netrules`: allowlist rule set, blocklist, **coexistence of the selective rule with `BlockAllEgress` on the same IP** (clearing one leaves the other), idempotent re-apply, exact clear, and error paths — all via the fake-iptables seam.
- `internal/store`: `TestEgressPolicyColumnsRoundTrip` — allowlist round-trips through Create+Get, blocklist through Upsert, and a no-policy sandbox reads back empty (no stray `[]`).
- `pkg/api/e2b`: valid `allowOut` now creates (201), invalid CIDR → 400, full-block `denyOut`/`allowInternetAccess=false` still maps to `NetworkBlockAll`; removed the obsolete `notImplemented` assertions.
- Updated the Firecracker driver + 15 `ContainerRuntime` test fakes for the two new interface methods.
- `gofmt`/`go vet` clean; full `go test ./...` green.

## Note: store schema

Adds `network_allow_out_json` / `network_deny_out_json` (JSON `TEXT`, default `'[]'`) to `sandboxes` via idempotent `ALTER` migration, wired through all 6 INSERT/SELECT sites + scanner. No change to the host-port pool tables/indexes.
