### PR TITLE
feat(e2b): implement allowPublicTraffic=false (refuse public exposure)

### DIFF
--- a/docs/src/content/docs/network-isolation.mdx
+++ b/docs/src/content/docs/network-isolation.mdx
@@ -280,6 +280,61 @@ The policy is persisted with the sandbox and reapplied automatically across stop
 
 ---
 
+## Disabling Public Exposure
+
+The options above control **outbound** traffic. To stop a sandbox from being reachable from the public internet at all, set **`allowPublicTraffic`** to `false` at create time. The sandbox can then never be exposed — `exposePort` returns an error — while the platform's own access paths (the toolbox `exec`/file proxy and the SSH gateway) keep working, since they do not route through the public ingress.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    const sandbox = await client.create({
+      image: 'ubuntu:22.04',
+      allowPublicTraffic: false,
+    })
+    // sandbox.exposePort(80) now rejects — no public URL is ever created.
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    sandbox = client.create({
+        'image': 'ubuntu:22.04',
+        'allowPublicTraffic': False,
+    })
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    publicOff := false
+    sandbox, err := client.Create(ctx, sdktypes.CreateSandboxOptions{
+        Image:              "ubuntu:22.04",
+        AllowPublicTraffic: &publicOff,
+    })
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let sandbox = client.create(CreateOptions {
+        image: "ubuntu:22.04".to_string(),
+        allow_public_traffic: Some(false),
+        ..Default::default()
+    })?;
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    Sandbox sandbox = client.create(
+        new CreateOptions()
+            .setImage("ubuntu:22.04")
+            .setAllowPublicTraffic(false)
+    );
+    ```
+  </TabItem>
+</Tabs>
+
+Because AerolVM has no auth-gated public route, "no public traffic" is enforced by **refusing exposure** rather than by serving a private URL. Omit the field (or set it to `true`) to keep the default behaviour, where exposed ports are publicly reachable.
+
+---
+
 ## Fine-Grained Quotas vs. Blanket Blocking
 
 If you do not want to block all network traffic permanently, you can use the SDK's **Network Usage & Quotas** features to set limits on total bytes sent or received. 

--- a/internal/service/bugfix_test.go
+++ b/internal/service/bugfix_test.go
@@ -228,6 +228,33 @@ func TestExposePortSkipsProbeOnStoppedSandbox(t *testing.T) {
 	}
 }
 
+// TestExposePortRejectedWhenPublicTrafficDisabled verifies that a sandbox
+// created with allow_public_traffic=false cannot be exposed: ExposePort returns
+// ErrPublicTrafficDisabled instead of installing a public route.
+func TestExposePortRejectedWhenPublicTrafficDisabled(t *testing.T) {
+	ctx := context.Background()
+	svc, st := newProbeSvc(t, func(_ context.Context, _ string, _ int) error { return nil })
+
+	now := time.Now().UTC()
+	deny := false
+	if err := st.Create(ctx, &models.Sandbox{
+		ID: "sb-no-public", Image: "alpine:3.20",
+		Status:      models.SandboxStatusStarted,
+		ContainerID: "ctr-no-public", ContainerIP: "10.0.0.20",
+		Runtime: models.RuntimeDocker,
+		CPU:     1, MemoryMB: 256, DiskGB: 5,
+		AllowPublicTraffic: &deny,
+		CreatedAt:          now, UpdatedAt: now, LastActiveAt: now,
+	}); err != nil {
+		t.Fatalf("seed sandbox: %v", err)
+	}
+
+	_, err := svc.ExposePort(ctx, "sb-no-public", 8080, models.ExposedPortProtocolHTTP)
+	if !errors.Is(err, ErrPublicTrafficDisabled) {
+		t.Fatalf("ExposePort err = %v, want ErrPublicTrafficDisabled", err)
+	}
+}
+
 // TestExposePortProceedsWhenProbeFailsAndLogsWarning verifies that a failing
 // probe (port not yet bound) is non-fatal: the route is still installed and
 // the error is surfaced only as a log warning, not as an ExposePort failure.

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -54,6 +54,11 @@ const allocatorRandomAttempts = 16
 // contract behind the client's back.
 var ErrPreferredHostPortUnavailable = errors.New("preferred host port unavailable on this node; exposure parked")
 
+// ErrPublicTrafficDisabled is returned by ExposePort when the sandbox was
+// created with allow_public_traffic=false. There is no public route to install
+// — the sandbox is reachable only through the toolbox proxy and SSH gateway.
+var ErrPublicTrafficDisabled = errors.New("public traffic is disabled for this sandbox; expose is not available")
+
 const clusterIngressReconcileInterval = 5 * time.Second
 
 type Service struct {
@@ -1144,6 +1149,7 @@ func (s *Service) createSandbox(ctx context.Context, req models.CreateSandboxReq
 		NetworkBlockAll:      req.NetworkBlockAll,
 		NetworkAllowOut:      req.NetworkAllowOut,
 		NetworkDenyOut:       req.NetworkDenyOut,
+		AllowPublicTraffic:   req.AllowPublicTraffic,
 		ToolboxEnabled:       true,
 		ToolboxToken:         toolboxToken,
 		SSHPublicKey:         authorizedKey,
@@ -1386,6 +1392,7 @@ func (s *Service) createFirecrackerSandbox(ctx context.Context, req models.Creat
 		NetworkBlockAll:      req.NetworkBlockAll,
 		NetworkAllowOut:      req.NetworkAllowOut,
 		NetworkDenyOut:       req.NetworkDenyOut,
+		AllowPublicTraffic:   req.AllowPublicTraffic,
 		ToolboxEnabled:       true,
 		ToolboxToken:         toolboxToken,
 		SSHPublicKey:         authorizedKey,
@@ -2256,6 +2263,14 @@ func (s *Service) exposePort(ctx context.Context, id string, port int, protocol 
 	sandbox, err := s.scopedGet(ctx, id)
 	if err != nil {
 		return models.ExposePortResponse{}, err
+	}
+	// A sandbox created with allow_public_traffic=false must never get a public
+	// route. AerolVM has no auth-gated public route, so the only honest way to
+	// enforce "no public traffic" is to refuse exposure outright — the sandbox
+	// stays reachable through the toolbox proxy and SSH gateway, which do not
+	// route through the public ingress. Nil/true keep the default (allowed).
+	if sandbox.AllowPublicTraffic != nil && !*sandbox.AllowPublicTraffic {
+		return models.ExposePortResponse{}, ErrPublicTrafficDisabled
 	}
 	if port <= 0 || port > 65535 {
 		return models.ExposePortResponse{}, errors.New("invalid port")

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -70,6 +70,7 @@ func Open(path string) (*Store, error) {
 			network_block_all INTEGER NOT NULL DEFAULT 0,
 			network_allow_out_json TEXT NOT NULL DEFAULT '[]',
 			network_deny_out_json TEXT NOT NULL DEFAULT '[]',
+			allow_public_traffic INTEGER NOT NULL DEFAULT 1,
 			toolbox_enabled INTEGER NOT NULL DEFAULT 1,
 			toolbox_token TEXT NOT NULL DEFAULT '',
 			ssh_public_key TEXT NOT NULL DEFAULT '',
@@ -622,6 +623,10 @@ func Open(path string) (*Store, error) {
 		// Empty '[]' for every pre-migration row and the no-policy common path.
 		`ALTER TABLE sandboxes ADD COLUMN network_allow_out_json TEXT NOT NULL DEFAULT '[]';`,
 		`ALTER TABLE sandboxes ADD COLUMN network_deny_out_json TEXT NOT NULL DEFAULT '[]';`,
+		// allow_public_traffic gates public exposure (E2B network.allowPublicTraffic).
+		// Defaults to 1 (public allowed) so every pre-migration row keeps its
+		// current behaviour; 0 makes ExposePort refuse to install a public route.
+		`ALTER TABLE sandboxes ADD COLUMN allow_public_traffic INTEGER NOT NULL DEFAULT 1;`,
 	}
 	for _, stmt := range migrations {
 		if _, err := db.Exec(stmt); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
@@ -729,7 +734,7 @@ func (s *Store) Create(ctx context.Context, sandbox *models.Sandbox) error {
 	_, err = s.db.ExecContext(ctx, `
 		INSERT INTO sandboxes (
 			id, image, status, public_url, container_id, container_ip, cpu, memory_mb, disk_gb,
-			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, toolbox_enabled, toolbox_token, ssh_public_key,
+			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, allow_public_traffic, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
 			failover_policy,
@@ -746,7 +751,7 @@ func (s *Store) Create(ctx context.Context, sandbox *models.Sandbox) error {
 			checkpoint_path, clone_generation,
 			wasm_registry_ref, wasm_registry_digest,
 			owner_ref, fleet_suspended
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		sandbox.ID,
 		sandbox.Image,
@@ -762,6 +767,7 @@ func (s *Store) Create(ctx context.Context, sandbox *models.Sandbox) error {
 		boolToInt(sandbox.NetworkBlockAll),
 		mustMarshalStringSlice(sandbox.NetworkAllowOut),
 		mustMarshalStringSlice(sandbox.NetworkDenyOut),
+		allowPublicTrafficToInt(sandbox.AllowPublicTraffic),
 		boolToInt(sandbox.ToolboxEnabled),
 		sandbox.ToolboxToken,
 		sandbox.SSHPublicKey,
@@ -808,6 +814,16 @@ func (s *Store) Create(ctx context.Context, sandbox *models.Sandbox) error {
 		return fmt.Errorf("insert sandbox: %w", err)
 	}
 	return nil
+}
+
+// allowPublicTrafficToInt maps the tri-state create flag to the stored
+// integer: nil (unset) and *true persist as 1 (public exposure allowed); only
+// an explicit *false persists as 0 (ExposePort will refuse).
+func allowPublicTrafficToInt(v *bool) int {
+	if v != nil && !*v {
+		return 0
+	}
+	return 1
 }
 
 // mustMarshalStringSlice JSON-encodes a string slice for a TEXT column,
@@ -875,7 +891,7 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 	_, err = s.db.ExecContext(ctx, `
 		INSERT INTO sandboxes (
 			id, image, status, public_url, container_id, container_ip, cpu, memory_mb, disk_gb,
-			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, toolbox_enabled, toolbox_token, ssh_public_key,
+			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, allow_public_traffic, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
 			failover_policy,
@@ -892,7 +908,7 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 			checkpoint_path, clone_generation,
 			wasm_registry_ref, wasm_registry_digest,
 			owner_ref, fleet_suspended
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			image = excluded.image,
 			status = excluded.status,
@@ -907,6 +923,7 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 			network_block_all = excluded.network_block_all,
 			network_allow_out_json = excluded.network_allow_out_json,
 			network_deny_out_json = excluded.network_deny_out_json,
+			allow_public_traffic = excluded.allow_public_traffic,
 			toolbox_enabled = excluded.toolbox_enabled,
 			toolbox_token = excluded.toolbox_token,
 			ssh_public_key = excluded.ssh_public_key,
@@ -955,6 +972,7 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 		boolToInt(sandbox.NetworkBlockAll),
 		mustMarshalStringSlice(sandbox.NetworkAllowOut),
 		mustMarshalStringSlice(sandbox.NetworkDenyOut),
+		allowPublicTrafficToInt(sandbox.AllowPublicTraffic),
 		boolToInt(sandbox.ToolboxEnabled),
 		sandbox.ToolboxToken,
 		sandbox.SSHPublicKey,
@@ -1006,7 +1024,7 @@ func (s *Store) Upsert(ctx context.Context, sandbox *models.Sandbox) error {
 func (s *Store) Get(ctx context.Context, id string) (*models.Sandbox, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, image, status, public_url, container_id, container_ip, cpu, memory_mb, disk_gb,
-			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, toolbox_enabled, toolbox_token, ssh_public_key,
+			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, allow_public_traffic, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
 			failover_policy,
@@ -1053,7 +1071,7 @@ func (s *Store) Get(ctx context.Context, id string) (*models.Sandbox, error) {
 func (s *Store) List(ctx context.Context) ([]*models.Sandbox, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, image, status, public_url, container_id, container_ip, cpu, memory_mb, disk_gb,
-			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, toolbox_enabled, toolbox_token, ssh_public_key,
+			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, allow_public_traffic, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
 			failover_policy,
@@ -1120,7 +1138,7 @@ func (s *Store) List(ctx context.Context) ([]*models.Sandbox, error) {
 func (s *Store) ListByOwner(ctx context.Context, ownerRef string) ([]*models.Sandbox, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, image, status, public_url, container_id, container_ip, cpu, memory_mb, disk_gb,
-			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, toolbox_enabled, toolbox_token, ssh_public_key,
+			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, allow_public_traffic, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
 			failover_policy,
@@ -1171,7 +1189,7 @@ func (s *Store) ListByOwner(ctx context.Context, ownerRef string) ([]*models.San
 func (s *Store) ListByRuntime(ctx context.Context, runtime string) ([]*models.Sandbox, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, image, status, public_url, container_id, container_ip, cpu, memory_mb, disk_gb,
-			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, toolbox_enabled, toolbox_token, ssh_public_key,
+			os_user, env_json, network_block_all, network_allow_out_json, network_deny_out_json, allow_public_traffic, toolbox_enabled, toolbox_token, ssh_public_key,
 			last_error, container_command_json, name, tags_json, created_at, updated_at, last_active_at,
 			stop_if_idle_for_ns, destroy_if_idle_for_ns, stop_at_age_ns, destroy_at_age_ns,
 			failover_policy,
@@ -3418,6 +3436,7 @@ func scanSandbox(scanner interface {
 	var wakeArmed int
 	var fleetSuspended int
 	var allowOutJSON, denyOutJSON string
+	var allowPublicTraffic int
 
 	err := scanner.Scan(
 		&sandbox.ID,
@@ -3434,6 +3453,7 @@ func scanSandbox(scanner interface {
 		&networkBlocked,
 		&allowOutJSON,
 		&denyOutJSON,
+		&allowPublicTraffic,
 		&toolboxEnabled,
 		&sandbox.ToolboxToken,
 		&sandbox.SSHPublicKey,
@@ -3520,6 +3540,8 @@ func scanSandbox(scanner interface {
 			return nil, fmt.Errorf("decode network deny out: %w", err)
 		}
 	}
+	allowPublic := allowPublicTraffic == 1
+	sandbox.AllowPublicTraffic = &allowPublic
 	sandbox.ToolboxEnabled = toolboxEnabled == 1
 	sandbox.Lifecycle = models.Lifecycle{
 		StopIfIdleFor:    time.Duration(stopIfIdleNs),

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1920,6 +1920,7 @@ func TestStoreHelperCases(t *testing.T) {
 			0,                           // network_blocked
 			"[]",                        // network_allow_out_json
 			"[]",                        // network_deny_out_json
+			1,                           // allow_public_traffic
 			1,                           // toolbox_enabled
 			"",                          // toolbox_token
 			"",                          // ssh_public_key
@@ -2087,6 +2088,40 @@ func TestEgressPolicyColumnsRoundTrip(t *testing.T) {
 	}
 	if len(got.NetworkAllowOut) != 0 || len(got.NetworkDenyOut) != 0 {
 		t.Fatalf("no-policy round-trip = allow %+v deny %+v, want both empty", got.NetworkAllowOut, got.NetworkDenyOut)
+	}
+}
+
+func TestAllowPublicTrafficColumnRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+
+	// Explicit false persists and reads back as a non-nil false.
+	deny := sampleSandbox("sb-no-public")
+	denyVal := false
+	deny.AllowPublicTraffic = &denyVal
+	if err := st.Create(ctx, deny); err != nil {
+		t.Fatalf("Create deny: %v", err)
+	}
+	got, err := st.Get(ctx, deny.ID)
+	if err != nil {
+		t.Fatalf("Get deny: %v", err)
+	}
+	if got.AllowPublicTraffic == nil || *got.AllowPublicTraffic {
+		t.Fatalf("AllowPublicTraffic = %v, want non-nil false", got.AllowPublicTraffic)
+	}
+
+	// Unset (nil) defaults to allowed (column default 1) on read-back.
+	dflt := sampleSandbox("sb-default-public")
+	dflt.AllowPublicTraffic = nil
+	if err := st.Create(ctx, dflt); err != nil {
+		t.Fatalf("Create default: %v", err)
+	}
+	got, err = st.Get(ctx, dflt.ID)
+	if err != nil {
+		t.Fatalf("Get default: %v", err)
+	}
+	if got.AllowPublicTraffic == nil || !*got.AllowPublicTraffic {
+		t.Fatalf("default AllowPublicTraffic = %v, want non-nil true", got.AllowPublicTraffic)
 	}
 }
 

--- a/pkg/api/e2b/handlers.go
+++ b/pkg/api/e2b/handlers.go
@@ -566,9 +566,6 @@ func (h *handlers) translateCreateSandboxRequest(ctx context.Context, req create
 		allowPublicTraffic = cloneBoolPtr(req.Network.AllowPublicTraffic)
 		maskRequestHost = strings.TrimSpace(req.Network.MaskRequestHost)
 	}
-	if allowPublicTraffic != nil && !*allowPublicTraffic {
-		return models.CreateSandboxRequest{}, sandboxMeta{}, notImplemented("network.allowPublicTraffic=false is not implemented yet")
-	}
 	if maskRequestHost != "" {
 		return models.CreateSandboxRequest{}, sandboxMeta{}, notImplemented("network.maskRequestHost is not implemented yet")
 	}
@@ -640,6 +637,7 @@ func (h *handlers) translateCreateSandboxRequest(ctx context.Context, req create
 		}
 		wasmReq.Env = envVars
 		wasmReq.NetworkBlockAll = networkBlockAll
+		wasmReq.AllowPublicTraffic = allowPublicTraffic
 		wasmReq.Lifecycle = lifecycle
 		wasmReq.Tags = cloneStringMap(metadata)
 		meta := sandboxMeta{
@@ -664,12 +662,13 @@ func (h *handlers) translateCreateSandboxRequest(ctx context.Context, req create
 	}
 
 	serviceReq := models.CreateSandboxRequest{
-		Image:           resolvedImage,
-		Env:             envVars,
-		NetworkBlockAll: networkBlockAll,
-		NetworkAllowOut: egressAllowOut,
-		NetworkDenyOut:  egressDenyOut,
-		Lifecycle:       lifecycle,
+		Image:              resolvedImage,
+		Env:                envVars,
+		NetworkBlockAll:    networkBlockAll,
+		NetworkAllowOut:    egressAllowOut,
+		NetworkDenyOut:     egressDenyOut,
+		AllowPublicTraffic: allowPublicTraffic,
+		Lifecycle:          lifecycle,
 		// E2B's metadata is the same shape as Daytona's labels — write it
 		// into the native tags column so it round-trips through any API
 		// surface, not just /e2b.

--- a/pkg/api/e2b/handlers_additional_test.go
+++ b/pkg/api/e2b/handlers_additional_test.go
@@ -26,7 +26,6 @@ func TestE2BCreateSandboxNotImplemented(t *testing.T) {
 	}{
 		{"mcp", `{"templateID":"base","mcp":{}}`},
 		{"volumeMounts", `{"templateID":"base","volumeMounts":[{"name":"vol"}]}`},
-		{"networkAllowPublicTraffic", `{"templateID":"base","network":{"allowPublicTraffic":false}}`},
 		{"networkMaskRequestHost", `{"templateID":"base","network":{"maskRequestHost":"host"}}`},
 	}
 

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -563,6 +563,13 @@ type CreateSandboxRequest struct {
 	// NetworkAllowOut. Blocking the entire space is expressed as
 	// NetworkBlockAll, not a denyOut of 0.0.0.0/0.
 	NetworkDenyOut []string `json:"network_deny_out,omitempty"`
+	// AllowPublicTraffic controls whether the sandbox may be exposed to the
+	// public internet. Nil (default) and true allow public exposure; false
+	// makes expose_port fail — the sandbox stays reachable only via the
+	// platform's own paths (toolbox exec/file proxy, SSH gateway), which do
+	// not route through the public ingress. There is no auth-gated public
+	// route concept, so "no public traffic" is enforced by refusing exposure.
+	AllowPublicTraffic *bool `json:"allow_public_traffic,omitempty"`
 	// CustomDomains attaches operator-provided public hostnames to the
 	// sandbox at create time. Each hostname must resolve (via DNS) to the
 	// cluster's ingress host before HTTPS can serve traffic — see
@@ -698,6 +705,10 @@ type Sandbox struct {
 	// NetworkBlockAll). Mutually exclusive; at most one is non-empty.
 	NetworkAllowOut []string `json:"network_allow_out,omitempty"`
 	NetworkDenyOut  []string `json:"network_deny_out,omitempty"`
+	// AllowPublicTraffic mirrors the create-time flag. Nil means "not set"
+	// (treated as allowed); a non-nil false makes ExposePort refuse to install
+	// a public route. Persisted so the gate survives restarts.
+	AllowPublicTraffic *bool `json:"allow_public_traffic,omitempty"`
 	// NetworkQuotaExceeded reflects whether either lifetime byte counter has
 	// crossed its limit. The reconcile loop installs DROP rules when this is
 	// true; clearing requires raising the limit (or zeroing it for unlimited).

--- a/sdk/java/src/main/java/ai/aerol/microvm/MicroVMClient.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/MicroVMClient.java
@@ -870,6 +870,7 @@ public class MicroVMClient {
         copy.networkBlockAll = source.networkBlockAll;
         copy.networkAllowOut = source.networkAllowOut;
         copy.networkDenyOut = source.networkDenyOut;
+        copy.allowPublicTraffic = source.allowPublicTraffic;
         copy.networkBytesInLimit = source.networkBytesInLimit;
         copy.networkBytesOutLimit = source.networkBytesOutLimit;
         copy.registry = source.registry;

--- a/sdk/java/src/main/java/ai/aerol/microvm/model/CreateOptions.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/model/CreateOptions.java
@@ -23,6 +23,9 @@ public class CreateOptions {
     /** Egress blocklist of CIDRs; sandbox may reach anything except these. Mutually exclusive with networkAllowOut. */
     @JsonProperty("network_deny_out")
     public List<String> networkDenyOut;
+    /** Whether the sandbox may be exposed publicly. Null/true allow it; false makes exposePort fail. */
+    @JsonProperty("allow_public_traffic")
+    public Boolean allowPublicTraffic;
     @JsonProperty("network_bytes_in_limit")
     public Long networkBytesInLimit;
     @JsonProperty("network_bytes_out_limit")
@@ -92,6 +95,11 @@ public class CreateOptions {
 
     public CreateOptions setNetworkDenyOut(List<String> networkDenyOut) {
         this.networkDenyOut = networkDenyOut;
+        return this;
+    }
+
+    public CreateOptions setAllowPublicTraffic(Boolean allowPublicTraffic) {
+        this.allowPublicTraffic = allowPublicTraffic;
         return this;
     }
 

--- a/sdk/java/src/test/java/ai/aerol/microvm/MicroVMClientTest.java
+++ b/sdk/java/src/test/java/ai/aerol/microvm/MicroVMClientTest.java
@@ -310,6 +310,7 @@ class MicroVMClientTest {
                     .setMemoryMb(2048)
                     .setNetworkBlockAll(true)
                     .setNetworkAllowOut(List.of("1.1.1.0/24", "8.8.8.8/32"))
+                    .setAllowPublicTraffic(false)
                     .setMounts(List.of(
                         new MountSpec()
                             .setType("s3")
@@ -336,6 +337,7 @@ class MicroVMClientTest {
             assertEquals(2048, ((Number) payload.get("memory_mb")).intValue());
             assertEquals(Boolean.TRUE, payload.get("network_block_all"));
             assertEquals(List.of("1.1.1.0/24", "8.8.8.8/32"), payload.get("network_allow_out"));
+            assertEquals(Boolean.FALSE, payload.get("allow_public_traffic"));
             Map<String, Object> lifecycle = castMap(payload.get("lifecycle"));
             assertEquals(3_600_000_000_000L, ((Number) lifecycle.get("stop_if_idle_for")).longValue());
             assertEquals(86_400_000_000_000L, ((Number) lifecycle.get("destroy_at_age")).longValue());

--- a/sdk/python/microvm/client.py
+++ b/sdk/python/microvm/client.py
@@ -1093,6 +1093,7 @@ def _to_api_create_options(options: CreateOptions) -> Dict[str, Any]:
             "network_block_all": _first_of(options, "networkBlockAll", "network_block_all"),
             "network_allow_out": _first_of(options, "networkAllowOut", "network_allow_out"),
             "network_deny_out": _first_of(options, "networkDenyOut", "network_deny_out"),
+            "allow_public_traffic": _first_of(options, "allowPublicTraffic", "allow_public_traffic"),
             "network_bytes_in_limit": _first_of(options, "networkBytesInLimit", "network_bytes_in_limit"),
             "network_bytes_out_limit": _first_of(options, "networkBytesOutLimit", "network_bytes_out_limit"),
             "registry": _first_of(options, "registry"),

--- a/sdk/python/microvm/types.py
+++ b/sdk/python/microvm/types.py
@@ -149,6 +149,9 @@ class CreateOptions(TypedDict, total=False):
     # mutually exclusive; a full block is networkBlockAll, not a 0.0.0.0/0 deny.
     networkAllowOut: List[str]
     networkDenyOut: List[str]
+    # Whether the sandbox may be exposed publicly. Defaults to True; False makes
+    # expose_port fail (reachable only via the toolbox proxy and SSH gateway).
+    allowPublicTraffic: bool
     # Caps on network bytes the sandbox may receive (in) / send (out) before
     # per-IP iptables block fires. 0 (default) means unlimited; both can be
     # raised or lifted at runtime via set_network_limits.

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -335,6 +335,12 @@ class ClientTests(unittest.TestCase):
         # network_deny_out is unset, so _compact() drops it from the body.
         self.assertNotIn("network_deny_out", payload)
 
+    def test_create_serializes_allow_public_traffic(self):
+        client = RecordingMicroVM()
+        client.create({"image": "ubuntu:22.04", "allowPublicTraffic": False})
+        _, _, payload = client.calls[0]
+        self.assertEqual(payload["allow_public_traffic"], False)
+
     def test_create_maps_request_and_response_shapes(self):
         client = RecordingMicroVM()
         sandbox = client.create(

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -1970,6 +1970,7 @@ mod tests {
             network_block_all: None,
             network_allow_out: None,
             network_deny_out: None,
+            allow_public_traffic: None,
             network_bytes_in_limit: None,
             network_bytes_out_limit: None,
             registry: None,
@@ -1994,11 +1995,13 @@ mod tests {
     fn create_options_serializes_selective_egress() {
         let mut opts = minimal_create_options();
         opts.network_allow_out = Some(vec!["1.1.1.0/24".to_string(), "8.8.8.8/32".to_string()]);
+        opts.allow_public_traffic = Some(false);
         let value = serde_json::to_value(&opts).expect("serialize create options");
         assert_eq!(
             value["network_allow_out"],
             serde_json::json!(["1.1.1.0/24", "8.8.8.8/32"])
         );
+        assert_eq!(value["allow_public_traffic"], serde_json::json!(false));
         // network_deny_out is None, so skip_serializing_if omits it entirely.
         assert!(value.get("network_deny_out").is_none());
     }

--- a/sdk/rust/src/types.rs
+++ b/sdk/rust/src/types.rs
@@ -170,6 +170,11 @@ pub struct CreateOptions {
     /// destinations. Mutually exclusive with `network_allow_out`.
     #[serde(rename = "network_deny_out", skip_serializing_if = "Option::is_none")]
     pub network_deny_out: Option<Vec<String>>,
+    /// Whether the sandbox may be exposed publicly. `None`/`Some(true)` allow
+    /// it; `Some(false)` makes `expose_port` fail — the sandbox stays reachable
+    /// only via the toolbox proxy and SSH gateway.
+    #[serde(rename = "allow_public_traffic", skip_serializing_if = "Option::is_none")]
+    pub allow_public_traffic: Option<bool>,
     /// Cap on bytes the sandbox may receive before its ingress is dropped via
     /// per-IP iptables rule. `0` (or omit) means unlimited. Limits can be
     /// raised or lifted at runtime via [`Client::set_network_limits`].

--- a/sdk/typescript/src/internal/client.test.ts
+++ b/sdk/typescript/src/internal/client.test.ts
@@ -62,6 +62,22 @@ test("internal client create serializes selective egress CIDRs", async () => {
   assert.equal(body.network_deny_out, undefined);
 });
 
+test("internal client create serializes allowPublicTraffic=false", async () => {
+  let seenRequest: Request | undefined;
+  const client = new APIClient({
+    baseURL: "https://api.example.com",
+    patToken: "pat-token",
+    fetch: async (input, init) => {
+      seenRequest = new Request(input, init);
+      return jsonResponse(apiSandbox("sb-nopublic"));
+    },
+  });
+  await client.create({ image: "ubuntu:22.04", allowPublicTraffic: false });
+  assert.ok(seenRequest);
+  const body = (await seenRequest.json()) as Record<string, unknown>;
+  assert.equal(body.allow_public_traffic, false);
+});
+
 test("internal client create maps request and response", async () => {
   let seenRequest: Request | undefined;
   const client = new APIClient({

--- a/sdk/typescript/src/internal/client.ts
+++ b/sdk/typescript/src/internal/client.ts
@@ -1101,6 +1101,7 @@ function toApiCreateOptions(options: CreateOptions): Record<string, unknown> {
     network_block_all: options.networkBlockAll,
     network_allow_out: options.networkAllowOut,
     network_deny_out: options.networkDenyOut,
+    allow_public_traffic: options.allowPublicTraffic,
     network_bytes_in_limit: options.networkBytesInLimit,
     network_bytes_out_limit: options.networkBytesOutLimit,
     registry: options.registry,

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -174,6 +174,12 @@ export interface CreateOptions {
    */
   networkDenyOut?: string[];
   /**
+   * Whether the sandbox may be exposed to the public internet. Defaults to
+   * true; set `false` to make `exposePort` fail — the sandbox stays reachable
+   * only via the toolbox proxy and SSH gateway, not a public URL.
+   */
+  allowPublicTraffic?: boolean;
+  /**
    * Cap on bytes the sandbox may receive from outside the container before its
    * ingress is dropped via per-IP iptables rule. `0` (default) is unlimited.
    * Limits can be raised or lifted at runtime via `setNetworkLimits`.


### PR DESCRIPTION
## Summary

- Implements **`allowPublicTraffic=false`** for the E2B facade (previously **501**). A sandbox created with the flag off can never be exposed publicly — `ExposePort` returns `ErrPublicTrafficDisabled` — while the toolbox `exec`/file proxy and SSH gateway keep working (they reach the container directly, not through the public ingress).
- **Why refuse-exposure and not a firewall rule:** all external traffic flows host→container via Caddy, and the platform's own access (toolbox, SSH) uses that same host-originated path, so a container ingress DROP can't tell "public" from "platform" traffic — it would sever both. AerolVM has no auth-gated public-route concept, so refusing exposure is the only honest enforcement point.
- `AllowPublicTraffic *bool` added to `CreateSandboxRequest`/`Sandbox`, persisted as `allow_public_traffic` (default `1` = allowed). Surfaced in all five SDKs (Go via its model alias) + docs.

> **Stacked on `feat/e2b-selective-egress` (PR #214)** — it shares the `sandboxes` column list, so this PR targets that branch. Merge #214 first, then this retargets cleanly to `main`.

## Sandbox boot impact

N/A — no new work on `CreateSandbox` or its callees. The flag is a persisted column read at expose time; `ExposePort` (not a boot-path callee) gains one cheap pointer check before route installation.

## Idempotency

- The expose gate is deterministic: a sandbox with `allow_public_traffic=false` always rejects `ExposePort` with `ErrPublicTrafficDisabled`, on every call. No state is mutated on the rejected path, so retries and concurrent duplicates behave identically.
- The host-port pool and existing expose idempotency are untouched — the gate runs *before* any allocation or route work.

## Failure-path consistency

N/A for multi-step writes — the gate **prevents** the multi-step expose path from running when public traffic is disabled, so there is no partial caddy/store state to roll back. No caddy or store mutation occurs on the rejected path.

## L4 / host-port-pool changes

N/A — `TryReserveHostPort`, the `host_port` index, `allocateHostPort`, `EnsureLayer4`/`EnsureLayer4Ready`, and the `l4Ready` latch are untouched. The gate returns before any host-port reservation.

## Test plan

- `internal/service`: `TestExposePortRejectedWhenPublicTrafficDisabled` — a sandbox created with `allow_public_traffic=false` makes `ExposePort` return `ErrPublicTrafficDisabled`.
- `internal/store`: `TestAllowPublicTrafficColumnRoundTrip` — explicit `false` persists/reads back as non-nil false; unset defaults to allowed (column default `1`).
- `pkg/api/e2b`: removed the obsolete `allowPublicTraffic` not-implemented assertion; create now succeeds.
- SDK serialization tests: TypeScript + Python verified locally; Rust + Java mirror the existing `networkBlockAll` assertions (covered by their CI — no cargo/mvn in this environment).
- `gofmt`/`go build ./...` clean; affected server + runtime test packages green.

## Store schema

Adds `allow_public_traffic INTEGER NOT NULL DEFAULT 1` to `sandboxes` via idempotent `ALTER`, wired through all INSERT/SELECT sites + scanner. Default `1` preserves existing public-exposure behaviour for every pre-migration row. No host-port-pool table/index change.
