### PR TITLE
fix(daemon): advertise wasm in host SupportedRuntimes so wasm sandboxes can be placed

### DIFF
--- a/integration-tests/lib/common.sh
+++ b/integration-tests/lib/common.sh
@@ -73,6 +73,78 @@ dump_service_logs() {
   echo "===== end ${svc} @ ${target} ====="
 }
 
+# stage_wasm_modules <fixtures_dir> <config_cluster_yml> <caps_domain> <targets_json>
+# Copies the curated standard .wasm modules onto every node's modules_dir under
+# their reserved alias filename, then restarts sandboxd. Returns non-zero on any
+# failure so the caller can mark the scenario inconclusive.
+#
+# WHY this exists: the harness provisions with Terraform ONLY (never Ansible).
+# Terraform flattens wasm.standard_modules to the "alias=alias.wasm" contract
+# (SB_WASM_STANDARD_MODULES) but does NOT stage the bytes — that is Ansible's
+# playbooks/stage-wasm-modules.yml. sandboxd's seedStandardModules resolves each
+# alias to a PRE-STAGED local file and does not fetch URL-sourced modules at
+# boot. So without this step modules_dir is empty, the node advertises no wasm
+# inventory, and cluster placement (every scenario runs cluster-init, so even
+# single-node is a 1-member real cluster) rejects each wasm create with
+# ErrNoPlacementTarget. This mirrors what stage-wasm-modules.yml does, but reuses
+# the committed, digest-verified fixture bytes instead of re-downloading on-box.
+stage_wasm_modules() {
+  local fxdir="$1" config_cluster="$2" caps_domain="$3" targets="$4"
+  local modules_dir
+  modules_dir=$(yq -r '.wasm.modules_dir // "/var/lib/sandboxd/wasm/modules"' "$config_cluster")
+
+  # Ensure the (gitignored) fixture bytes exist + match their pinned sha256.
+  if ! bash "${fxdir}/fetch.sh"; then
+    echo "stage_wasm: fetching fixture modules failed" >&2
+    return 1
+  fi
+
+  # Resolve the per-node IP set: domain scenarios stage every node so a sandbox
+  # can be placed anywhere; IP/local scenarios have only the seed.
+  local ips=()
+  if [[ "$caps_domain" == "true" ]]; then
+    while IFS= read -r ip; do [[ -n "$ip" ]] && ips+=("$ip"); done \
+      < <(echo "$targets" | jq -r '.nodes[].public_ip')
+  else
+    ips+=("$(echo "$targets" | jq -r '.seed_ip')")
+  fi
+  [[ "${#ips[@]}" -gt 0 ]] || { echo "stage_wasm: no node IPs in targets" >&2; return 1; }
+
+  local n
+  n=$(yq -r '.standard_modules | length' "${fxdir}/modules.yml")
+  [[ "$n" =~ ^[0-9]+$ && "$n" -gt 0 ]] || { echo "stage_wasm: no modules in ${fxdir}/modules.yml" >&2; return 1; }
+
+  local ip tgt i alias ref file
+  for ip in "${ips[@]}"; do
+    tgt="ubuntu@${ip}"
+    if ! ssh "${SSH_OPTS[@]}" "$tgt" "sudo mkdir -p '${modules_dir}'"; then
+      echo "stage_wasm: mkdir ${modules_dir} on ${tgt} failed" >&2
+      return 1
+    fi
+    for i in $(seq 0 $((n - 1))); do
+      alias=$(yq -r ".standard_modules[$i].alias" "${fxdir}/modules.yml")
+      ref=$(yq -r ".standard_modules[$i].ref" "${fxdir}/modules.yml")
+      # fetch.sh names each local file after the URL basename (sans query).
+      file="${fxdir}/$(basename "${ref%\?*}")"
+      # ubuntu can't write modules_dir directly; land in /tmp then sudo-install
+      # under the reserved alias filename SB_WASM_STANDARD_MODULES expects.
+      if ! scp "${SSH_OPTS[@]}" "$file" "${tgt}:/tmp/${alias}.wasm" \
+        || ! ssh "${SSH_OPTS[@]}" "$tgt" \
+             "sudo install -m 0644 '/tmp/${alias}.wasm' '${modules_dir}/${alias}.wasm' && rm -f '/tmp/${alias}.wasm'"; then
+        echo "stage_wasm: staging ${alias} on ${tgt} failed" >&2
+        return 1
+      fi
+    done
+    # sandboxd seeds standard modules only at boot, so restart to pick up the
+    # now-staged files and re-advertise the node's wasm inventory to placement.
+    if ! ssh "${SSH_OPTS[@]}" "$tgt" "sudo systemctl restart sandboxd"; then
+      echo "stage_wasm: restarting sandboxd on ${tgt} failed" >&2
+      return 1
+    fi
+    echo "stage_wasm: ${tgt} staged ${n} modules + restarted sandboxd"
+  done
+}
+
 # wait_for_health <base_url> <pat> [timeout_s]
 # Polls /v1/capacity (authenticated) until HTTP 200 or timeout.
 wait_for_health() {

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -265,6 +265,21 @@ run_one() {
     fi
   fi
 
+  # Stage the curated wasm standard modules before the suite runs. Terraform
+  # only renders the SB_WASM_STANDARD_MODULES alias contract; the bytes are
+  # normally staged by Ansible (which the harness never runs), and sandboxd does
+  # not fetch them at boot. Without this every wasm create fails placement with
+  # ErrNoPlacementTarget. Restarts sandboxd, so re-probe health afterwards.
+  if [[ "$inconclusive" != "1" && "$caps_wasm" == "true" ]]; then
+    echo "=== staging wasm standard modules on ${scenario} ==="
+    if stage_wasm_modules "${HERE}/fixtures/wasm" "${overlay}/cluster.yml" "$caps_domain" "$targets"; then
+      wait_for_health "$base_url" "$pat" || inconclusive=1
+    else
+      echo "scenario ${scenario}: wasm module staging failed" >&2
+      inconclusive=1
+    fi
+  fi
+
   # Expected cluster size, if the scenario's caps.yml declares one. Drives
   # AEROL_EXPECTED_MEMBERS so the cluster UCs assert an exact node count.
   local expected_members

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -196,13 +196,7 @@ func Run(ctx context.Context, logger *slog.Logger, makeProvider ProviderFactory)
 	host.DiskTotalGB = max(cfg.HostDiskGB, 0)
 	host.GPUCount = cfg.HostGPUCount
 	host.GPUVendor = cfg.HostGPUVendor
-	host.SupportedRuntimes = cfg.HostSupportedRuntimes
-	if len(host.SupportedRuntimes) == 0 {
-		host.SupportedRuntimes = []string{models.RuntimeDocker}
-	}
-	if cfg.EnableFirecracker {
-		host.SupportedRuntimes = appendRuntimeIfMissing(host.SupportedRuntimes, models.RuntimeFirecracker)
-	}
+	host.SupportedRuntimes = supportedRuntimesForConfig(cfg)
 	// Phase 5: the per-VMM RSS sampler is constructed up front when
 	// firecracker is enabled so admission can be wired against it from
 	// the start (capacity holds the RSSSource by reference, not value).
@@ -1358,6 +1352,30 @@ func readBypassMarker(path string) bool {
 		return false
 	}
 	return string(bytesTrimSpace(data)) == "true"
+}
+
+// supportedRuntimesForConfig builds the host's advertised runtime list from the
+// daemon config. This is what cluster placement (placement.go nodeFits) filters
+// candidate nodes against: a runtime absent here makes the host an invalid
+// placement target for that runtime and every create is rejected with
+// ErrNoPlacementTarget — even single-node, which runs as a 1-member cluster.
+//
+// SB_HOST_RUNTIMES (cfg.HostSupportedRuntimes) is the explicit override; when
+// unset we default to docker and then advertise each runtime the host actually
+// has enabled. Firecracker and WASM each gate on their own enable flag so a
+// host that wired the driver also tells the cluster it can place that runtime.
+func supportedRuntimesForConfig(cfg config.Config) []string {
+	runtimes := cfg.HostSupportedRuntimes
+	if len(runtimes) == 0 {
+		runtimes = []string{models.RuntimeDocker}
+	}
+	if cfg.EnableFirecracker {
+		runtimes = appendRuntimeIfMissing(runtimes, models.RuntimeFirecracker)
+	}
+	if cfg.EnableWasm {
+		runtimes = appendRuntimeIfMissing(runtimes, models.RuntimeWasm)
+	}
+	return runtimes
 }
 
 func appendRuntimeIfMissing(runtimes []string, runtimeName string) []string {

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -3,8 +3,10 @@ package daemon
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
+	"github.com/aerol-ai/microvm/internal/config"
 	"github.com/aerol-ai/microvm/pkg/models"
 )
 
@@ -109,5 +111,31 @@ func TestAppendRuntimeIfMissing(t *testing.T) {
 	got = appendRuntimeIfMissing([]string{models.RuntimeDocker}, " ")
 	if len(got) != 1 || got[0] != models.RuntimeDocker {
 		t.Fatalf("appendRuntimeIfMissing blank changed runtimes: %v", got)
+	}
+}
+
+// TestSupportedRuntimesForConfig is the regression guard for the cluster
+// placement bug: a wasm-enabled host that never advertised "wasm" in
+// SupportedRuntimes made every wasm create fail with ErrNoPlacementTarget (the
+// firecracker advertisement existed, the wasm one was missing). Each enable
+// flag must surface its runtime; SB_HOST_RUNTIMES overrides the docker default.
+func TestSupportedRuntimesForConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  config.Config
+		want []string
+	}{
+		{name: "docker_only_default", cfg: config.Config{}, want: []string{models.RuntimeDocker}},
+		{name: "wasm_enabled_advertises_wasm", cfg: config.Config{EnableWasm: true}, want: []string{models.RuntimeDocker, models.RuntimeWasm}},
+		{name: "firecracker_enabled_advertises_fc", cfg: config.Config{EnableFirecracker: true}, want: []string{models.RuntimeDocker, models.RuntimeFirecracker}},
+		{name: "both_enabled", cfg: config.Config{EnableFirecracker: true, EnableWasm: true}, want: []string{models.RuntimeDocker, models.RuntimeFirecracker, models.RuntimeWasm}},
+		{name: "explicit_host_runtimes_override", cfg: config.Config{HostSupportedRuntimes: []string{models.RuntimeGvisor}, EnableWasm: true}, want: []string{models.RuntimeGvisor, models.RuntimeWasm}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := supportedRuntimesForConfig(tt.cfg); !slices.Equal(got, tt.want) {
+				t.Fatalf("supportedRuntimesForConfig = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- A wasm-enabled host never advertised `wasm` in `host.SupportedRuntimes`. The daemon appended `firecracker` under `EnableFirecracker` but had no equivalent for `EnableWasm`, so cluster placement (`placement.go` `nodeFits`) rejected every `runtime=wasm` create with `ErrNoPlacementTarget` — even single-node, which runs as a 1-member cluster via `cluster-init`.
- Fix: extract `supportedRuntimesForConfig(cfg)` in `pkg/daemon/daemon.go` and append `wasm` when `cfg.EnableWasm`. Add `TestSupportedRuntimesForConfig`.
- Integration harness: stage the curated wasm standard modules onto each node before the suite. The harness provisions with Terraform only (never Ansible's `stage-wasm-modules.yml`) and sandboxd does not fetch URL-sourced standard modules at boot, so `modules_dir` was empty and a wasm create couldn't resolve its module even after placement was fixed. `stage_wasm_modules` scps the committed, digest-verified fixture bytes under the reserved alias filename and restarts sandboxd.

## Sandbox boot impact

N/A - no work added to the sandbox boot path. The change only affects how `host.SupportedRuntimes` is assembled once at daemon startup (`Run`), not `CreateSandbox` or its callees.

## Idempotency

N/A - no API surface changed. The fix changes a startup-time capacity-advertisement list; placement filtering behavior is unchanged except that wasm-enabled nodes now correctly appear as candidates.

## Failure-path consistency

N/A - no multi-step write path changed.

## L4 / host-port-pool changes

N/A - neither touched.

## Cluster-correctness impact

Placement only: a wasm-enabled node now advertises `wasm` in its gossiped capacity snapshot, so `nodeFits` accepts it as a candidate for `runtime=wasm` creates. No FSM, replay, leader-change, or recovery path is touched. Single-node behavior is restored (wasm creates succeed instead of `ErrNoPlacementTarget`); multi-node behavior is unchanged for non-wasm runtimes. `SB_HOST_RUNTIMES` remains the explicit override.

## Test plan

- `go test ./pkg/daemon/...` — passes, including new `TestSupportedRuntimesForConfig` (docker-only default, wasm-enabled, firecracker-enabled, both, `SB_HOST_RUNTIMES` override).
- `go build ./pkg/daemon/...` + `go vet ./pkg/daemon/...` clean; `gofmt` clean.
- Note: the integration harness installs sandboxd from `releases/latest/download/`, so end-to-end UC-26 (`single-node-wasm`, `cluster-3-mixed-wasm`, `cluster-hetero`) will pass once this fix is in the released binary the nodes download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)