### PR TITLE
fix(terraform): write SB_ENABLE_WASM outside the fleet_enabled block

### DIFF
--- a/Terraform/templates/bootstrap.sh.tftpl
+++ b/Terraform/templates/bootstrap.sh.tftpl
@@ -523,9 +523,20 @@ SB_FLEET_ENABLED=${fleet_enabled}
 SB_FLEET_ENDPOINT=${fleet_endpoint}
 SB_FLEET_TOKEN=${fleet_token}
 SB_FLEET_CONTRACT_REFRESH=${fleet_contract_refresh}
-# WASM runtime + module distribution. SB_WASM_STANDARD_MODULES is the
-# reserved-keyword contract (alias=alias.wasm,...); stage the .wasm files with
-# Ansible playbooks/stage-wasm-modules.yml so every node has identical bytes.
+EOF
+%{ endif ~}
+
+# WASM runtime + module distribution. Written UNCONDITIONALLY: wasm enablement
+# is independent of the fleet control plane, so it must not be nested in the
+# fleet_enabled block above. (It once was, which silently left SB_ENABLE_WASM
+# unset on every fleet-disabled deploy — e.g. the integration harness, which
+# always disables fleet — so the daemon booted with EnableWasm=false and every
+# wasm create failed placement with ErrNoPlacementTarget.) SB_WASM_STANDARD_MODULES
+# is the reserved-keyword contract (alias=alias.wasm,...); stage the .wasm files
+# with Ansible playbooks/stage-wasm-modules.yml so every node has identical bytes.
+cat >> /tmp/aerolvm-ops.env <<'EOF'
+
+# Managed by Terraform bootstrap: WASM runtime + module distribution.
 SB_ENABLE_WASM=${wasm_cfg.enabled}
 SB_WASM_MODULES_DIR=${wasm_cfg.modules_dir}
 SB_WASM_CACHE_DIR=${wasm_cfg.cache_dir}
@@ -536,7 +547,6 @@ SB_WASM_REGISTRY_USERNAME=${wasm_cfg.registry_username}
 SB_WASM_REGISTRY_PAT_PATH=${wasm_cfg.registry_pat_path}
 SB_WASM_STANDARD_MODULES=${wasm_cfg.standard_modules}
 EOF
-%{ endif ~}
 
 sudo tee -a /etc/sandboxd/cluster.env < /tmp/aerolvm-ops.env >/dev/null
 sudo systemctl restart sandboxd


### PR DESCRIPTION
## Summary

- The WASM runtime env block (`SB_ENABLE_WASM` + the `SB_WASM_*` module-distribution vars) was nested inside the `%{ if fleet_enabled ~}` heredoc in `Terraform/templates/bootstrap.sh.tftpl`. wasm enablement is independent of the fleet control plane, so on any **fleet-disabled** deploy the whole block was skipped and `SB_ENABLE_WASM` never reached the daemon.
- Effect: the daemon booted with `EnableWasm=false`, so the wasm driver was never registered and the host never advertised `wasm` in `SupportedRuntimes`. Cluster placement (`placement.go` `nodeFits`) then rejected every `runtime=wasm` create with `ErrNoPlacementTarget` — before the local "wasm not enabled" error path could run. This hit the integration harness (which always disables fleet) and any open-source / fleet-disabled production cluster.
- Fix: move the WASM env into its own unconditional heredoc, written like the other always-on ops env.

This is the missing piece behind UC-26 (`WASM-runtime sandbox runs`) failing with `cluster: no worker placement target available` even after the daemon advertised wasm (#218) and the harness staged the modules — the gating env var simply wasn't on the box.

## Sandbox boot impact

N/A - no work added to the sandbox boot path. Change is to node provisioning (which env vars land in `/etc/sandboxd/cluster.env`).

## Idempotency

N/A - no API surface changed.

## Failure-path consistency

N/A - no multi-step write path changed.

## L4 / host-port-pool changes

N/A - neither touched.

## Cluster-correctness impact

Placement-only and strictly corrective: fleet-disabled wasm-enabled nodes now actually set `SB_ENABLE_WASM`, so the daemon advertises `wasm` and becomes a valid placement target. No FSM/replay/leader-change behavior is touched. Non-wasm runtimes are unaffected; fleet-enabled deploys are unaffected (the fleet block still emits its own vars, just no longer the wasm ones).

## Test plan

- `terraform validate` passes; `%{ if }`/`%{ endif }` balance unchanged (19/19).
- End-to-end: re-run `make integration-single-wasm` (LE staging). With this + the released daemon fix (#218, in v0.5.4) + harness module staging, UC-26 should pass and the node's boot log should show `host_supported_runtimes=[docker wasm]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)