### PR TITLE
test(integration): add UC-78 offline foreign-arch snapshot guard test

### DIFF
--- a/integration-tests/suite/snapshots_arch_integration_test.go
+++ b/integration-tests/suite/snapshots_arch_integration_test.go
@@ -12,6 +12,37 @@ import (
 	sdktypes "github.com/aerol-ai/microvm/sdk/go/pkg/types"
 )
 
+// UC-78 — offline arch guard: a create from an AOCR cluster-snapshot ref whose
+// --arch-<goarch> tag doesn't match the host is rejected up front in
+// NormalizeCreateImageDistribution, before any placement, pull, or runtime
+// dispatch. Runs on every scenario (Requires: nil) — it needs neither
+// firecracker nor a cluster, just the AOCR ref classifier (the provider
+// defaults its host to aocr.aerol.ai even when the mirror is disabled).
+//
+// We tag the ref with an architecture that matches no host (riscv64) so the
+// guard fires deterministically whether the runner is amd64 or arm64; UC-79
+// covers the realistic amd64-snapshot-on-arm64-host live case.
+func TestUC78_ForeignArchSnapshotRefRejectedOffline(t *testing.T) {
+	harness.Require(t, sc, "UC-78")
+
+	c := client(t)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	foreignRef := "aocr.aerol.ai/cluster/itest/snapshots/uc78-foreign:latest--arch-riscv64"
+	sb, err := c.SDK().Create(ctx, sdktypes.CreateSandboxOptions{
+		Image: foreignRef,
+		Name:  harness.UniqueName(sc, t),
+	})
+	if err == nil {
+		_ = c.SDK().Destroy(ctx, sb.ID)
+		t.Fatal("expected create from foreign-arch snapshot ref to be rejected offline")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "arch") {
+		t.Fatalf("error should mention architecture mismatch, got: %v", err)
+	}
+}
+
 // UC-79 — live homogeneity enforcement: an arm64 cluster refuses an x86-tagged
 // AOCR snapshot ref instead of loading garbage into the VMM.
 func TestUC79_ForeignArchSnapshotRejectedOnARM64Cluster(t *testing.T) {


### PR DESCRIPTION
## Summary

- UC-78 (`Foreign-arch snapshot ref rejected (offline guard)`) was declared `Implemented: true` in the use-case registry but had **no test** emitting its `ucid=UC-78` marker, so the report classifier flagged it `missing` on every scenario (including `single-node-wasm`). Only UC-79 (the live amd64-on-arm64 cluster case) existed.
- Add the offline-guard test: a create from an AOCR cluster-snapshot ref with a foreign `--arch-<goarch>` tag is rejected in `NormalizeCreateImageDistribution` before placement, pull, or runtime dispatch.
- Uses an arch that matches no host (`riscv64`) so the guard fires deterministically on both amd64 and arm64 runners; needs neither firecracker nor a cluster (`Requires: nil`), complementing UC-79.

## Test plan

- `go vet -tags=integration ./integration-tests/suite/...` passes.
- The assertion mirrors UC-79: create must fail and the error must mention `arch`itecture.
- End-to-end: `make integration-single-wasm` should now report UC-78 ✅ instead of `missing` (the `missing` count drops to 0).

## Notes

This is pre-existing test-coverage debt surfaced while bringing up the wasm integration scenarios — unrelated to the wasm placement fix (#218) or the bootstrap env fix (#220), but it's the last non-green line on the `single-node-wasm` matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)