### PR TITLE
fix(volumes): replicate attachments and close cluster delete/reclaim races

### DIFF
--- a/internal/cluster/agent_volumes.go
+++ b/internal/cluster/agent_volumes.go
@@ -22,6 +22,7 @@ type VolumeQueryResponse struct {
 	Volume  *models.Volume  `json:"volume,omitempty"`
 	Volumes []models.Volume `json:"volumes,omitempty"`
 	Exists  bool            `json:"exists,omitempty"`
+	Count   int             `json:"count,omitempty"`
 }
 
 func (a *Agent) VolumeUpsert(ctx context.Context, v models.Volume, maxPerTenant int) (models.Volume, bool, error) {
@@ -119,6 +120,34 @@ func (a *Agent) VolumeExistsForSource(ctx context.Context, source string) (bool,
 		return false, err
 	}
 	return resp.Exists, nil
+}
+
+func (a *Agent) VolumeAttachmentCount(ctx context.Context, tenant, id string) (int, error) {
+	q := url.Values{"kind": {"attachment_count"}, "tenant": {tenant}, "id": {id}}
+	resp, err := a.queryVolumes(ctx, q)
+	if err != nil {
+		return 0, err
+	}
+	return resp.Count, nil
+}
+
+func (a *Agent) PutVolumeAttachments(ctx context.Context, attachments []models.VolumeAttachment) error {
+	if len(attachments) == 0 {
+		return nil
+	}
+	err := a.applyCommand(ctx, command{Op: opPutVolumeAttach, VolumeAttachments: attachments})
+	if errors.Is(err, ErrUnknownVolume) {
+		return ErrUnknownVolume
+	}
+	return err
+}
+
+func (a *Agent) DeleteVolumeAttachmentsForSandbox(ctx context.Context, sandboxID string) error {
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		return nil
+	}
+	return a.applyCommand(ctx, command{Op: opDeleteVolumeAttach, VolumeSandboxID: sandboxID})
 }
 
 func (a *Agent) queryVolumes(ctx context.Context, q url.Values) (VolumeQueryResponse, error) {

--- a/internal/cluster/agent_volumes_test.go
+++ b/internal/cluster/agent_volumes_test.go
@@ -1,0 +1,182 @@
+package cluster
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func TestAgentDelegatesVolumeReadWriteToServerControlPlane(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test: requires real raft/memberlist sockets")
+	}
+
+	apiListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("api listen: %v", err)
+	}
+	serverAPIURL := "http://" + apiListener.Addr().String()
+	server, cleanupServer := newTestClusterWithAPI(t, "srv-agent-vol", true, nil, serverAPIURL)
+	defer cleanupServer()
+	waitForLeader(t, server, 10*time.Second)
+
+	srv := startAgentControlPlaneServerWithVolumes(t, server, apiListener)
+	defer srv.Close()
+
+	agent, cleanupAgent := newTestAgentWithRole(t, "wkr-agent-vol", config.NodeRoleWorker,
+		[]string{server.gossip.ml.LocalNode().Address()})
+	defer cleanupAgent()
+	waitForGossipMember(t, server, "wkr-agent-vol", 10*time.Second)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	v := models.Volume{ID: "vol-agent", Tenant: "t-a", Name: "data", Backend: "s3", Source: "bucket/t-a/data"}
+	row, created, err := agent.VolumeUpsert(ctx, v, 0)
+	if err != nil || !created || row.ID != "vol-agent" {
+		t.Fatalf("agent VolumeUpsert = %+v created=%v err=%v", row, created, err)
+	}
+	if got, err := agent.VolumeByID(ctx, "t-a", "vol-agent"); err != nil || got.Name != "data" {
+		t.Fatalf("agent VolumeByID = %+v, %v", got, err)
+	}
+	vols, err := agent.VolumesForTenant(ctx, "t-a")
+	if err != nil || len(vols) != 1 {
+		t.Fatalf("agent VolumesForTenant = %+v, %v", vols, err)
+	}
+	exists, err := agent.VolumeExistsForSource(ctx, "bucket/t-a/data")
+	if err != nil || !exists {
+		t.Fatalf("agent VolumeExistsForSource = %v, %v", exists, err)
+	}
+	attach := models.VolumeAttachment{
+		Tenant: "t-a", VolumeID: "vol-agent", SandboxID: "sb-1", Target: "/data", Source: "bucket/t-a/data",
+	}
+	if err := agent.PutVolumeAttachments(ctx, []models.VolumeAttachment{attach}); err != nil {
+		t.Fatalf("agent PutVolumeAttachments: %v", err)
+	}
+	count, err := agent.VolumeAttachmentCount(ctx, "t-a", "vol-agent")
+	if err != nil || count != 1 {
+		t.Fatalf("agent VolumeAttachmentCount = %d, %v", count, err)
+	}
+	if err := agent.DeleteVolumeAttachmentsForSandbox(ctx, "sb-1"); err != nil {
+		t.Fatalf("agent DeleteVolumeAttachmentsForSandbox: %v", err)
+	}
+	if err := agent.VolumeDelete(ctx, "t-a", "vol-agent"); err != nil {
+		t.Fatalf("agent VolumeDelete: %v", err)
+	}
+}
+
+func TestAgentVolumeValidation(t *testing.T) {
+	a := &Agent{}
+	ctx := context.Background()
+	_, _, err := a.VolumeUpsert(ctx, models.Volume{Name: "n"}, 0)
+	if err == nil {
+		t.Fatal("VolumeUpsert validation: expected error")
+	}
+	if err := a.VolumeDelete(ctx, "", "vol-1"); err == nil {
+		t.Fatal("VolumeDelete validation: expected error")
+	}
+	if err := a.PutVolumeAttachments(ctx, nil); err != nil {
+		t.Fatalf("PutVolumeAttachments empty: %v", err)
+	}
+	if err := a.DeleteVolumeAttachmentsForSandbox(ctx, " "); err != nil {
+		t.Fatalf("DeleteVolumeAttachmentsForSandbox whitespace: %v", err)
+	}
+}
+
+func startAgentControlPlaneServerWithVolumes(t *testing.T, c *Cluster, ln net.Listener) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc(PublicInternalApplyPath, func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := c.ApplyEncoded(r.Context(), body); err != nil {
+			if err == ErrNotLeader {
+				http.Error(w, err.Error(), http.StatusServiceUnavailable)
+				return
+			}
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc(PublicInternalVolumePath, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		q := r.URL.Query()
+		tenant := q.Get("tenant")
+		switch q.Get("kind") {
+		case "id":
+			v, err := c.VolumeByID(r.Context(), tenant, q.Get("id"))
+			if err != nil {
+				http.Error(w, "no such volume", http.StatusNotFound)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(VolumeQueryResponse{Volume: &v})
+		case "name":
+			v, err := c.VolumeByName(r.Context(), tenant, q.Get("name"))
+			if err != nil {
+				http.Error(w, "no such volume", http.StatusNotFound)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(VolumeQueryResponse{Volume: &v})
+		case "list":
+			vols, err := c.VolumesForTenant(r.Context(), tenant)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(VolumeQueryResponse{Volumes: vols})
+		case "source":
+			exists, err := c.VolumeExistsForSource(r.Context(), q.Get("source"))
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(VolumeQueryResponse{Exists: exists})
+		case "attachment_count":
+			count, err := c.VolumeAttachmentCount(r.Context(), tenant, q.Get("id"))
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(VolumeQueryResponse{Count: count})
+		default:
+			http.Error(w, "unknown volume query kind", http.StatusBadRequest)
+		}
+	})
+	mux.HandleFunc(PublicInternalPlacementPath, func(w http.ResponseWriter, r *http.Request) {
+		id := strings.TrimPrefix(r.URL.Path, PublicInternalPlacementPath)
+		p, ok := c.PlacementOf(id)
+		if !ok {
+			http.Error(w, "no placement record", http.StatusNotFound)
+			return
+		}
+		owner, err := c.OwnerOf(id)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		p.SecretRef = ""
+		p.SecretVersion = 0
+		p.SealedSecrets = nil
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(PlacementLookupResponse{SandboxID: id, Placement: p, Owner: owner})
+	})
+	srv := &httptest.Server{Listener: ln, Config: &http.Server{Handler: mux}}
+	srv.Start()
+	return srv
+}

--- a/internal/cluster/client_volumes.go
+++ b/internal/cluster/client_volumes.go
@@ -95,3 +95,26 @@ func (c *Cluster) VolumesForTenant(_ context.Context, tenant string) ([]models.V
 func (c *Cluster) VolumeExistsForSource(_ context.Context, source string) (bool, error) {
 	return c.fsm.LiveVolumeExistsForSource(source), nil
 }
+
+func (c *Cluster) VolumeAttachmentCount(_ context.Context, tenant, id string) (int, error) {
+	return c.fsm.VolumeAttachmentCount(tenant, id), nil
+}
+
+func (c *Cluster) PutVolumeAttachments(ctx context.Context, attachments []models.VolumeAttachment) error {
+	if len(attachments) == 0 {
+		return nil
+	}
+	err := c.applyCommand(ctx, command{Op: opPutVolumeAttach, VolumeAttachments: attachments})
+	if errors.Is(err, ErrUnknownVolume) {
+		return ErrUnknownVolume
+	}
+	return err
+}
+
+func (c *Cluster) DeleteVolumeAttachmentsForSandbox(ctx context.Context, sandboxID string) error {
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		return nil
+	}
+	return c.applyCommand(ctx, command{Op: opDeleteVolumeAttach, VolumeSandboxID: sandboxID})
+}

--- a/internal/cluster/client_volumes_test.go
+++ b/internal/cluster/client_volumes_test.go
@@ -1,0 +1,125 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func TestClusterVolumeClientRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test: requires real raft sockets")
+	}
+
+	c, cleanup := newTestCluster(t, "ldr-vol-client", true, nil)
+	defer cleanup()
+	waitForLeader(t, c, 10*time.Second)
+	ctx := context.Background()
+
+	v := models.Volume{ID: "vol-1", Tenant: "t-a", Name: "data", Backend: "s3", Source: "bucket/t-a/data"}
+	row, created, err := c.VolumeUpsert(ctx, v, 0)
+	if err != nil || !created || row.ID != "vol-1" {
+		t.Fatalf("VolumeUpsert = %+v created=%v err=%v", row, created, err)
+	}
+	if _, created, err := c.VolumeUpsert(ctx, v, 0); err != nil || created {
+		t.Fatalf("idempotent VolumeUpsert created=%v err=%v", created, err)
+	}
+	if got, err := c.VolumeByID(ctx, "t-a", "vol-1"); err != nil || got.Name != "data" {
+		t.Fatalf("VolumeByID = %+v, %v", got, err)
+	}
+	vols, err := c.VolumesForTenant(ctx, "t-a")
+	if err != nil || len(vols) != 1 {
+		t.Fatalf("VolumesForTenant = %+v, %v", vols, err)
+	}
+	if exists, err := c.VolumeExistsForSource(ctx, "bucket/t-a/data"); err != nil || !exists {
+		t.Fatalf("VolumeExistsForSource = %v, %v", exists, err)
+	}
+
+	attach := models.VolumeAttachment{
+		Tenant: "t-a", VolumeID: "vol-1", SandboxID: "sb-1", Target: "/data", Source: "bucket/t-a/data",
+	}
+	if err := c.PutVolumeAttachments(ctx, []models.VolumeAttachment{attach}); err != nil {
+		t.Fatalf("PutVolumeAttachments: %v", err)
+	}
+	count, err := c.VolumeAttachmentCount(ctx, "t-a", "vol-1")
+	if err != nil || count != 1 {
+		t.Fatalf("VolumeAttachmentCount = %d, %v", count, err)
+	}
+	if err := c.VolumeDelete(ctx, "t-a", "vol-1"); !errors.Is(err, ErrVolumeInUse) {
+		t.Fatalf("VolumeDelete attached = %v, want ErrVolumeInUse", err)
+	}
+	if err := c.DeleteVolumeAttachmentsForSandbox(ctx, "sb-1"); err != nil {
+		t.Fatalf("DeleteVolumeAttachmentsForSandbox: %v", err)
+	}
+	if err := c.VolumeDelete(ctx, "t-a", "vol-1"); err != nil {
+		t.Fatalf("VolumeDelete: %v", err)
+	}
+	if _, err := c.VolumeByID(ctx, "t-a", "vol-1"); !errors.Is(err, ErrUnknownVolume) {
+		t.Fatalf("VolumeByID after delete = %v", err)
+	}
+}
+
+func TestClusterVolumeUpsertReadbackOnFollower(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test: requires real raft sockets")
+	}
+
+	apiListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("api listen: %v", err)
+	}
+	leaderAPIURL := "http://" + apiListener.Addr().String()
+
+	leader, cleanupLeader := newTestClusterWithAPI(t, "ldr-vol-rb", true, nil, leaderAPIURL)
+	defer cleanupLeader()
+	waitForLeader(t, leader, 10*time.Second)
+
+	srv := startInternalApplyServer(t, leader, apiListener)
+	defer srv.Close()
+
+	follower, cleanupFollower := newTestCluster(t, "fol-vol-rb", false, []string{leader.gossip.ml.LocalNode().Address()})
+	defer cleanupFollower()
+	waitForVoter(t, leader, "fol-vol-rb", 20*time.Second)
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.HasPrefix(follower.LeaderAPIURL(), "http://") {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if got := follower.LeaderAPIURL(); !strings.HasPrefix(got, "http://") {
+		t.Fatalf("follower never resolved leader API URL (got %q)", got)
+	}
+
+	ctx := context.Background()
+	v := models.Volume{ID: "vol-rb", Tenant: "t-a", Name: "logs", Backend: "s3", Source: "bucket/t-a/logs"}
+	row, created, err := follower.VolumeUpsert(ctx, v, 0)
+	if err != nil || !created || row.ID != "vol-rb" {
+		t.Fatalf("follower VolumeUpsert = %+v created=%v err=%v", row, created, err)
+	}
+}
+
+func TestClusterVolumeClientValidation(t *testing.T) {
+	c := &Cluster{}
+	ctx := context.Background()
+
+	_, _, err := c.VolumeUpsert(ctx, models.Volume{Tenant: "t-a", Name: "n"}, 0)
+	if err == nil {
+		t.Fatal("VolumeUpsert missing id/backend: expected error")
+	}
+	if err := c.VolumeDelete(ctx, "", "vol-1"); err == nil {
+		t.Fatal("VolumeDelete empty tenant: expected error")
+	}
+	if err := c.PutVolumeAttachments(ctx, nil); err != nil {
+		t.Fatalf("PutVolumeAttachments empty: %v", err)
+	}
+	if err := c.DeleteVolumeAttachmentsForSandbox(ctx, "  "); err != nil {
+		t.Fatalf("DeleteVolumeAttachmentsForSandbox whitespace: %v", err)
+	}
+}

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -552,6 +552,12 @@ type Client interface {
 	// VolumeExistsForSource reports whether any replicated row points at source
 	// (the reclaim worker's cluster-wide live-data guard).
 	VolumeExistsForSource(ctx context.Context, source string) (bool, error)
+	// VolumeAttachmentCount returns the cluster-wide live attachment count for a
+	// volume. Put/Delete keep this index in the same raft log as volume metadata
+	// so Daytona delete cannot miss a sandbox that lives on another worker.
+	VolumeAttachmentCount(ctx context.Context, tenant, id string) (int, error)
+	PutVolumeAttachments(ctx context.Context, attachments []models.VolumeAttachment) error
+	DeleteVolumeAttachmentsForSandbox(ctx context.Context, sandboxID string) error
 
 	// RemoveMember explicitly removes nodeID from the raft configuration after
 	// marking it drained and orphaning any placements it owned. Unknown raft

--- a/internal/cluster/fsm.go
+++ b/internal/cluster/fsm.go
@@ -39,6 +39,8 @@ const (
 	opRemoveCustomDomain opCode = 14 // release one previously-bound hostname
 	opUpsertVolume       opCode = 15 // get-or-create a platform-volume metadata row (cluster-wide)
 	opDeleteVolume       opCode = 16 // remove a platform-volume metadata row
+	opPutVolumeAttach    opCode = 17 // upsert platform-volume attachment rows (cluster-wide)
+	opDeleteVolumeAttach opCode = 18 // drop all platform-volume attachments for one sandbox
 )
 
 // command is the wire format for one raft log entry. New writers externalize
@@ -96,10 +98,12 @@ type command struct {
 	// metadata for opUpsertVolume / opDeleteVolume. The volume row is replicated
 	// so any node answers Daytona get/list/delete-by-id after tenant ownership
 	// moves; the data itself is deterministic in S3/NFS and never in raft.
-	Volume       *models.Volume `json:"volume,omitempty"`
-	VolumeTenant string         `json:"volume_tenant,omitempty"`
-	VolumeID     string         `json:"volume_id,omitempty"`
-	MaxPerTenant int            `json:"max_per_tenant,omitempty"`
+	Volume            *models.Volume            `json:"volume,omitempty"`
+	VolumeTenant      string                    `json:"volume_tenant,omitempty"`
+	VolumeID          string                    `json:"volume_id,omitempty"`
+	MaxPerTenant      int                       `json:"max_per_tenant,omitempty"`
+	VolumeAttachments []models.VolumeAttachment `json:"volume_attachments,omitempty"`
+	VolumeSandboxID   string                    `json:"volume_sandbox_id,omitempty"`
 }
 
 type reservationCommand struct {
@@ -272,6 +276,12 @@ type placementFSM struct {
 	// is deterministic in S3/NFS, so only this small metadata table is replicated.
 	volumes         map[string]models.Volume
 	volumeNameIndex map[string]string
+	// volumeAttachments is the cluster-wide live-reference index. It mirrors the
+	// single-node SQLite volume_attachments table but lives in raft so a delete
+	// request on any node sees sandboxes attached on every worker.
+	volumeAttachments          map[string]models.VolumeAttachment
+	volumeAttachmentsByVolume  map[string]map[string]struct{}
+	volumeAttachmentsBySandbox map[string]map[string]struct{}
 
 	// subMu guards subscribers. Separate from mu so a slow subscriber accept
 	// can't block FSM reads — Apply takes mu briefly to write, releases it,
@@ -345,6 +355,9 @@ func newPlacementFSMWithRecoveryStore(store placementRecoveryStore) *placementFS
 		customHostnameIndex:          make(map[string]string),
 		volumes:                      make(map[string]models.Volume),
 		volumeNameIndex:              make(map[string]string),
+		volumeAttachments:            make(map[string]models.VolumeAttachment),
+		volumeAttachmentsByVolume:    make(map[string]map[string]struct{}),
+		volumeAttachmentsBySandbox:   make(map[string]map[string]struct{}),
 	}
 }
 
@@ -353,6 +366,9 @@ func newPlacementFSMWithRecoveryStore(store placementRecoveryStore) *placementFS
 // concatenation is unambiguous.
 func volumeKey(tenant, id string) string       { return tenant + "\x00" + id }
 func volumeNameKey(tenant, name string) string { return tenant + "\x00" + name }
+func volumeAttachmentKey(tenant, volumeID, sandboxID, target string) string {
+	return tenant + "\x00" + volumeID + "\x00" + sandboxID + "\x00" + target
+}
 
 func newPlacementIDIndex() *btree.BTreeG[string] {
 	return btree.NewG[string](32, func(a, b string) bool { return a < b })
@@ -550,6 +566,7 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 				f.releasePendingReservationOwnerLocked(cmd.SandboxID, existing.OwnerNodeID)
 			}
 		}
+		f.releaseVolumeAttachmentsForSandboxLocked(cmd.SandboxID)
 		f.deletePlacementRecoveryLocked(cmd.SandboxID)
 		delete(f.placements, cmd.SandboxID)
 		return nil
@@ -914,8 +931,45 @@ func (f *placementFSM) apply(log *raft.Log) interface{} {
 		if !ok {
 			return ErrUnknownVolume
 		}
+		if n := f.volumeAttachmentCountLocked(tenant, id); n > 0 {
+			return fmt.Errorf("%w: %d attachments", ErrVolumeInUse, n)
+		}
 		delete(f.volumes, key)
 		delete(f.volumeNameIndex, volumeNameKey(tenant, row.Name))
+		return nil
+	case opPutVolumeAttach:
+		if len(cmd.VolumeAttachments) == 0 {
+			return nil
+		}
+		cleaned := make([]models.VolumeAttachment, 0, len(cmd.VolumeAttachments))
+		for _, a := range cmd.VolumeAttachments {
+			tenant := strings.TrimSpace(a.Tenant)
+			volumeID := strings.TrimSpace(a.VolumeID)
+			sandboxID := strings.TrimSpace(a.SandboxID)
+			target := strings.TrimSpace(a.Target)
+			source := strings.TrimSpace(a.Source)
+			if tenant == "" || volumeID == "" || sandboxID == "" || target == "" || source == "" {
+				return fmt.Errorf("placementFSM: opPutVolumeAttach requires tenant, volume_id, sandbox_id, target, and source")
+			}
+			if _, ok := f.volumes[volumeKey(tenant, volumeID)]; !ok {
+				return ErrUnknownVolume
+			}
+			a.Tenant, a.VolumeID, a.SandboxID, a.Target, a.Source = tenant, volumeID, sandboxID, target, source
+			if a.CreatedAt.IsZero() {
+				a.CreatedAt = time.Unix(now, 0).UTC()
+			}
+			cleaned = append(cleaned, a)
+		}
+		for _, a := range cleaned {
+			f.putVolumeAttachmentLocked(a)
+		}
+		return nil
+	case opDeleteVolumeAttach:
+		sandboxID := strings.TrimSpace(cmd.VolumeSandboxID)
+		if sandboxID == "" {
+			return fmt.Errorf("placementFSM: opDeleteVolumeAttach requires sandbox_id")
+		}
+		f.releaseVolumeAttachmentsForSandboxLocked(sandboxID)
 		return nil
 	default:
 		return fmt.Errorf("placementFSM: unknown op %d", cmd.Op)
@@ -1956,7 +2010,8 @@ type fsmSnapshotPayload struct {
 	DrainedNodes map[string]bool
 	// Volumes is the replicated platform-volume metadata. Optional; older
 	// snapshots decode it as nil and the FSM treats that as "no volumes."
-	Volumes []models.Volume
+	Volumes           []models.Volume
+	VolumeAttachments []models.VolumeAttachment
 }
 
 type placementSnapshotRow struct {
@@ -1983,7 +2038,15 @@ func (f *placementFSM) Snapshot() (raft.FSMSnapshot, error) {
 	for k, v := range f.drainedNodes {
 		drained[k] = v
 	}
-	return &fsmSnapshot{version: version, rows: rows, drainedNodes: drained, volumes: f.volumesSnapshotLocked(), recoveryStore: f.recoveryStore, recoveryRefs: recoveryRefs}, nil
+	return &fsmSnapshot{
+		version:           version,
+		rows:              rows,
+		drainedNodes:      drained,
+		volumes:           f.volumesSnapshotLocked(),
+		volumeAttachments: f.volumeAttachmentsSnapshotLocked(),
+		recoveryStore:     f.recoveryStore,
+		recoveryRefs:      recoveryRefs,
+	}, nil
 }
 
 // Restore loads state from a previously written snapshot. Replaces in-memory
@@ -2055,6 +2118,9 @@ func (f *placementFSM) Restore(rc io.ReadCloser) (err error) {
 	// Rebuild the replicated volume table + name index from the snapshot.
 	f.volumes = make(map[string]models.Volume, len(payload.Volumes))
 	f.volumeNameIndex = make(map[string]string, len(payload.Volumes))
+	f.volumeAttachments = make(map[string]models.VolumeAttachment, len(payload.VolumeAttachments))
+	f.volumeAttachmentsByVolume = make(map[string]map[string]struct{})
+	f.volumeAttachmentsBySandbox = make(map[string]map[string]struct{})
 	for _, v := range payload.Volumes {
 		tenant := strings.TrimSpace(v.Tenant)
 		id := strings.TrimSpace(v.ID)
@@ -2065,6 +2131,20 @@ func (f *placementFSM) Restore(rc io.ReadCloser) (err error) {
 		if name := strings.TrimSpace(v.Name); name != "" {
 			f.volumeNameIndex[volumeNameKey(tenant, name)] = id
 		}
+	}
+	for _, a := range payload.VolumeAttachments {
+		a.Tenant = strings.TrimSpace(a.Tenant)
+		a.VolumeID = strings.TrimSpace(a.VolumeID)
+		a.SandboxID = strings.TrimSpace(a.SandboxID)
+		a.Target = strings.TrimSpace(a.Target)
+		a.Source = strings.TrimSpace(a.Source)
+		if a.Tenant == "" || a.VolumeID == "" || a.SandboxID == "" || a.Target == "" || a.Source == "" {
+			continue
+		}
+		if _, ok := f.volumes[volumeKey(a.Tenant, a.VolumeID)]; !ok {
+			continue
+		}
+		f.putVolumeAttachmentLocked(a)
 	}
 	for id, p := range payload.Placements {
 		full := p
@@ -2117,12 +2197,13 @@ func (f *placementFSM) Restore(rc io.ReadCloser) (err error) {
 }
 
 type fsmSnapshot struct {
-	version       uint64
-	rows          []placementSnapshotRow
-	drainedNodes  map[string]bool
-	volumes       []models.Volume
-	recoveryStore placementRecoveryStore
-	recoveryRefs  []string
+	version           uint64
+	rows              []placementSnapshotRow
+	drainedNodes      map[string]bool
+	volumes           []models.Volume
+	volumeAttachments []models.VolumeAttachment
+	recoveryStore     placementRecoveryStore
+	recoveryRefs      []string
 }
 
 func (s *fsmSnapshot) Persist(sink raft.SnapshotSink) (err error) {
@@ -2132,7 +2213,13 @@ func (s *fsmSnapshot) Persist(sink raft.SnapshotSink) (err error) {
 		recordSnapshotPersist(time.Since(start), counting.bytes, len(s.rows), err)
 	}()
 	enc := gob.NewEncoder(counting)
-	if err := enc.Encode(fsmSnapshotPayload{Version: s.version, Rows: s.rows, DrainedNodes: s.drainedNodes, Volumes: s.volumes}); err != nil {
+	if err := enc.Encode(fsmSnapshotPayload{
+		Version:           s.version,
+		Rows:              s.rows,
+		DrainedNodes:      s.drainedNodes,
+		Volumes:           s.volumes,
+		VolumeAttachments: s.volumeAttachments,
+	}); err != nil {
 		_ = sink.Cancel()
 		return fmt.Errorf("fsmSnapshot: encode: %w", err)
 	}

--- a/internal/cluster/fsm_volumes.go
+++ b/internal/cluster/fsm_volumes.go
@@ -21,6 +21,9 @@ var (
 	// ErrUnknownVolume is returned by volume reads/deletes when no replicated row
 	// exists for the (tenant, id).
 	ErrUnknownVolume = errors.New("cluster: unknown volume")
+	// ErrVolumeInUse is returned when a delete races with or follows a sandbox
+	// attachment that still points at the volume.
+	ErrVolumeInUse = errors.New("cluster: volume is still attached")
 )
 
 // VolumeByID returns the replicated row for (tenant, id) or ErrUnknownVolume.
@@ -86,6 +89,21 @@ func (f *placementFSM) VolumeCountForTenant(tenant string) int {
 	return n
 }
 
+// VolumeAttachmentCount returns the number of live replicated sandbox
+// attachments for (tenant, volumeID).
+func (f *placementFSM) VolumeAttachmentCount(tenant, volumeID string) int {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.volumeAttachmentCountLocked(strings.TrimSpace(tenant), strings.TrimSpace(volumeID))
+}
+
+func (f *placementFSM) volumeAttachmentCountLocked(tenant, volumeID string) int {
+	if tenant == "" || volumeID == "" {
+		return 0
+	}
+	return len(f.volumeAttachmentsByVolume[volumeKey(tenant, volumeID)])
+}
+
 // LiveVolumeExistsForSource reports whether any replicated row resolves to
 // source. The reclaim worker uses it cluster-wide instead of a single node's
 // SQLite so it never deletes bytes a recreated volume still owns.
@@ -109,4 +127,59 @@ func (f *placementFSM) volumesSnapshotLocked() []models.Volume {
 		out = append(out, v)
 	}
 	return out
+}
+
+func (f *placementFSM) volumeAttachmentsSnapshotLocked() []models.VolumeAttachment {
+	out := make([]models.VolumeAttachment, 0, len(f.volumeAttachments))
+	for _, a := range f.volumeAttachments {
+		out = append(out, a)
+	}
+	return out
+}
+
+func (f *placementFSM) putVolumeAttachmentLocked(a models.VolumeAttachment) {
+	key := volumeAttachmentKey(a.Tenant, a.VolumeID, a.SandboxID, a.Target)
+	if existing, ok := f.volumeAttachments[key]; ok {
+		f.releaseVolumeAttachmentKeyLocked(key, existing)
+	}
+	f.volumeAttachments[key] = a
+	vKey := volumeKey(a.Tenant, a.VolumeID)
+	if f.volumeAttachmentsByVolume[vKey] == nil {
+		f.volumeAttachmentsByVolume[vKey] = make(map[string]struct{})
+	}
+	f.volumeAttachmentsByVolume[vKey][key] = struct{}{}
+	if f.volumeAttachmentsBySandbox[a.SandboxID] == nil {
+		f.volumeAttachmentsBySandbox[a.SandboxID] = make(map[string]struct{})
+	}
+	f.volumeAttachmentsBySandbox[a.SandboxID][key] = struct{}{}
+}
+
+func (f *placementFSM) releaseVolumeAttachmentKeyLocked(key string, a models.VolumeAttachment) {
+	delete(f.volumeAttachments, key)
+	vKey := volumeKey(a.Tenant, a.VolumeID)
+	if refs := f.volumeAttachmentsByVolume[vKey]; refs != nil {
+		delete(refs, key)
+		if len(refs) == 0 {
+			delete(f.volumeAttachmentsByVolume, vKey)
+		}
+	}
+	if refs := f.volumeAttachmentsBySandbox[a.SandboxID]; refs != nil {
+		delete(refs, key)
+		if len(refs) == 0 {
+			delete(f.volumeAttachmentsBySandbox, a.SandboxID)
+		}
+	}
+}
+
+func (f *placementFSM) releaseVolumeAttachmentsForSandboxLocked(sandboxID string) {
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		return
+	}
+	refs := f.volumeAttachmentsBySandbox[sandboxID]
+	for key := range refs {
+		if a, ok := f.volumeAttachments[key]; ok {
+			f.releaseVolumeAttachmentKeyLocked(key, a)
+		}
+	}
 }

--- a/internal/cluster/fsm_volumes_test.go
+++ b/internal/cluster/fsm_volumes_test.go
@@ -57,6 +57,10 @@ func TestFSMVolumeUpsertIdempotent(t *testing.T) {
 	if n := fsm.VolumeCountForTenant("t-a"); n != 1 {
 		t.Fatalf("tenant count = %d, want 1", n)
 	}
+	vols := fsm.VolumesForTenant("t-a")
+	if len(vols) != 1 || vols[0].ID != "vol-1" {
+		t.Fatalf("VolumesForTenant = %+v", vols)
+	}
 }
 
 func TestFSMVolumeQuota(t *testing.T) {
@@ -116,6 +120,67 @@ func TestFSMVolumeAttachmentsBlockDeleteUntilSandboxReleased(t *testing.T) {
 	}
 	if got := fsm.Apply(&raft.Log{Index: 5, Data: mustEncode(t, command{Op: opDeleteVolume, VolumeTenant: "t-a", VolumeID: "vol-1"})}); got != nil {
 		t.Fatalf("delete after release returned %v", got)
+	}
+}
+
+func TestFSMPutVolumeAttachValidationAndUpsert(t *testing.T) {
+	fsm := newPlacementFSM()
+	if got := fsm.Apply(&raft.Log{Index: 1, Data: mustEncode(t, command{Op: opPutVolumeAttach})}); got != nil {
+		t.Fatalf("empty put should no-op, got %v", got)
+	}
+	got := fsm.Apply(&raft.Log{Index: 2, Data: mustEncode(t, command{
+		Op: opPutVolumeAttach,
+		VolumeAttachments: []models.VolumeAttachment{{
+			Tenant: "t-a", VolumeID: "vol-1", SandboxID: "", Target: "/data", Source: "s/d",
+		}},
+	})})
+	if got == nil {
+		t.Fatal("expected validation error for missing sandbox_id")
+	}
+	fsm.Apply(&raft.Log{Index: 3, Data: mustEncode(t, volCmd(models.Volume{ID: "vol-1", Tenant: "t-a", Name: "data", Backend: "s3", Source: "s/d"}, 0))})
+	got = fsm.Apply(&raft.Log{Index: 4, Data: mustEncode(t, command{
+		Op: opPutVolumeAttach,
+		VolumeAttachments: []models.VolumeAttachment{{
+			Tenant: "t-a", VolumeID: "vol-missing", SandboxID: "sb-1", Target: "/data", Source: "s/d",
+		}},
+	})})
+	if err, _ := got.(error); !errors.Is(err, ErrUnknownVolume) {
+		t.Fatalf("unknown volume attach = %v, want ErrUnknownVolume", got)
+	}
+	attach := models.VolumeAttachment{Tenant: "t-a", VolumeID: "vol-1", SandboxID: "sb-1", Target: "/data", Source: "s/d"}
+	fsm.Apply(&raft.Log{Index: 5, Data: mustEncode(t, command{Op: opPutVolumeAttach, VolumeAttachments: []models.VolumeAttachment{attach}})})
+	attach.Source = "s/d-updated"
+	fsm.Apply(&raft.Log{Index: 6, Data: mustEncode(t, command{Op: opPutVolumeAttach, VolumeAttachments: []models.VolumeAttachment{attach}})})
+	if n := fsm.VolumeAttachmentCount("t-a", "vol-1"); n != 1 {
+		t.Fatalf("upsert should keep one attachment, got %d", n)
+	}
+}
+
+func TestFSMDeletePlacementReleasesVolumeAttachments(t *testing.T) {
+	fsm := newPlacementFSM()
+	fsm.Apply(&raft.Log{Index: 1, Data: mustEncode(t, command{
+		Op: opPlace, SandboxID: "sb-1", OwnerNodeID: "node-a",
+	})})
+	fsm.Apply(&raft.Log{Index: 2, Data: mustEncode(t, volCmd(models.Volume{ID: "vol-1", Tenant: "t-a", Name: "data", Backend: "s3", Source: "s/d"}, 0))})
+	fsm.Apply(&raft.Log{Index: 3, Data: mustEncode(t, command{Op: opPutVolumeAttach, VolumeAttachments: []models.VolumeAttachment{{
+		Tenant: "t-a", VolumeID: "vol-1", SandboxID: "sb-1", Target: "/data", Source: "s/d",
+	}}})})
+	if n := fsm.VolumeAttachmentCount("t-a", "vol-1"); n != 1 {
+		t.Fatalf("attachment count = %d, want 1", n)
+	}
+	if got := fsm.Apply(&raft.Log{Index: 4, Data: mustEncode(t, command{Op: opDelete, SandboxID: "sb-1"})}); got != nil {
+		t.Fatalf("opDelete returned %v", got)
+	}
+	if n := fsm.VolumeAttachmentCount("t-a", "vol-1"); n != 0 {
+		t.Fatalf("attachments not released on placement delete: %d", n)
+	}
+}
+
+func TestFSMDeleteVolumeAttachRequiresSandboxID(t *testing.T) {
+	fsm := newPlacementFSM()
+	got := fsm.Apply(&raft.Log{Index: 1, Data: mustEncode(t, command{Op: opDeleteVolumeAttach})})
+	if got == nil {
+		t.Fatal("expected validation error for missing sandbox_id")
 	}
 }
 

--- a/internal/cluster/fsm_volumes_test.go
+++ b/internal/cluster/fsm_volumes_test.go
@@ -94,6 +94,55 @@ func TestFSMVolumeDelete(t *testing.T) {
 	}
 }
 
+func TestFSMVolumeAttachmentsBlockDeleteUntilSandboxReleased(t *testing.T) {
+	fsm := newPlacementFSM()
+	fsm.Apply(&raft.Log{Index: 1, Data: mustEncode(t, volCmd(models.Volume{ID: "vol-1", Tenant: "t-a", Name: "data", Backend: "s3", Source: "s/d"}, 0))})
+	attach := models.VolumeAttachment{Tenant: "t-a", VolumeID: "vol-1", SandboxID: "sb-1", Target: "/data", Source: "s/d"}
+	if got := fsm.Apply(&raft.Log{Index: 2, Data: mustEncode(t, command{Op: opPutVolumeAttach, VolumeAttachments: []models.VolumeAttachment{attach}})}); got != nil {
+		t.Fatalf("put attachment returned %v", got)
+	}
+	if n := fsm.VolumeAttachmentCount("t-a", "vol-1"); n != 1 {
+		t.Fatalf("attachment count = %d, want 1", n)
+	}
+	got := fsm.Apply(&raft.Log{Index: 3, Data: mustEncode(t, command{Op: opDeleteVolume, VolumeTenant: "t-a", VolumeID: "vol-1"})})
+	if err, _ := got.(error); !errors.Is(err, ErrVolumeInUse) {
+		t.Fatalf("delete attached volume = %v, want ErrVolumeInUse", got)
+	}
+	if got := fsm.Apply(&raft.Log{Index: 4, Data: mustEncode(t, command{Op: opDeleteVolumeAttach, VolumeSandboxID: "sb-1"})}); got != nil {
+		t.Fatalf("delete attachments returned %v", got)
+	}
+	if n := fsm.VolumeAttachmentCount("t-a", "vol-1"); n != 0 {
+		t.Fatalf("attachment count after release = %d, want 0", n)
+	}
+	if got := fsm.Apply(&raft.Log{Index: 5, Data: mustEncode(t, command{Op: opDeleteVolume, VolumeTenant: "t-a", VolumeID: "vol-1"})}); got != nil {
+		t.Fatalf("delete after release returned %v", got)
+	}
+}
+
+func TestFSMVolumeAttachmentsSurviveSnapshotRoundtrip(t *testing.T) {
+	src := newPlacementFSM()
+	src.Apply(&raft.Log{Index: 1, Data: mustEncode(t, volCmd(models.Volume{ID: "vol-1", Tenant: "t-a", Name: "data", Backend: "s3", Source: "s/d"}, 0))})
+	src.Apply(&raft.Log{Index: 2, Data: mustEncode(t, command{Op: opPutVolumeAttach, VolumeAttachments: []models.VolumeAttachment{{
+		Tenant: "t-a", VolumeID: "vol-1", SandboxID: "sb-1", Target: "/data", Source: "s/d",
+	}}})})
+
+	snap, err := src.Snapshot()
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	sink := &fakeSnapshotSink{Buffer: &bytes.Buffer{}}
+	if err := snap.Persist(sink); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+	dst := newPlacementFSM()
+	if err := dst.Restore(io.NopCloser(sink.Buffer)); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if n := dst.VolumeAttachmentCount("t-a", "vol-1"); n != 1 {
+		t.Fatalf("restored attachment count = %d, want 1", n)
+	}
+}
+
 // The replicated volume table must survive a snapshot/restore cold start —
 // otherwise a follower resync or leader restart would lose every Daytona volume.
 func TestFSMVolumesSurviveSnapshotRoundtrip(t *testing.T) {

--- a/internal/cluster/noop.go
+++ b/internal/cluster/noop.go
@@ -24,9 +24,12 @@ type Noop struct {
 	// happens to route through the cluster seam). Real deployments with
 	// EnableCluster=false use the SQLite store directly; this just keeps the
 	// interface honest rather than silently dropping writes.
-	volMu    sync.Mutex
-	volumes  map[string]models.Volume // key: tenant\x00id
-	volNames map[string]string        // key: tenant\x00name -> id
+	volMu                   sync.Mutex
+	volumes                 map[string]models.Volume // key: tenant\x00id
+	volNames                map[string]string        // key: tenant\x00name -> id
+	volAttachments          map[string]models.VolumeAttachment
+	volAttachmentsByVolume  map[string]map[string]struct{}
+	volAttachmentsBySandbox map[string]map[string]struct{}
 }
 
 // NewNoop returns a single-node Client. nodeID and apiURL are reported back
@@ -137,6 +140,9 @@ func (n *Noop) VolumeDelete(_ context.Context, tenant, id string) error {
 	if !ok {
 		return ErrUnknownVolume
 	}
+	if n.volumeAttachmentCountLocked(tenant, id) > 0 {
+		return ErrVolumeInUse
+	}
 	delete(n.volumes, volumeKey(tenant, id))
 	delete(n.volNames, volumeNameKey(tenant, row.Name))
 	return nil
@@ -186,6 +192,108 @@ func (n *Noop) VolumeExistsForSource(_ context.Context, source string) (bool, er
 		}
 	}
 	return false, nil
+}
+
+func (n *Noop) VolumeAttachmentCount(_ context.Context, tenant, id string) (int, error) {
+	n.volMu.Lock()
+	defer n.volMu.Unlock()
+	return n.volumeAttachmentCountLocked(strings.TrimSpace(tenant), strings.TrimSpace(id)), nil
+}
+
+func (n *Noop) PutVolumeAttachments(_ context.Context, attachments []models.VolumeAttachment) error {
+	if len(attachments) == 0 {
+		return nil
+	}
+	n.volMu.Lock()
+	defer n.volMu.Unlock()
+	n.ensureVolumeAttachmentMapsLocked()
+	for _, a := range attachments {
+		tenant := strings.TrimSpace(a.Tenant)
+		volumeID := strings.TrimSpace(a.VolumeID)
+		sandboxID := strings.TrimSpace(a.SandboxID)
+		target := strings.TrimSpace(a.Target)
+		source := strings.TrimSpace(a.Source)
+		if tenant == "" || volumeID == "" || sandboxID == "" || target == "" || source == "" {
+			return ErrUnknownVolume
+		}
+		if _, ok := n.volumes[volumeKey(tenant, volumeID)]; !ok {
+			return ErrUnknownVolume
+		}
+		a.Tenant, a.VolumeID, a.SandboxID, a.Target, a.Source = tenant, volumeID, sandboxID, target, source
+		if a.CreatedAt.IsZero() {
+			a.CreatedAt = time.Now().UTC()
+		}
+		n.putVolumeAttachmentLocked(a)
+	}
+	return nil
+}
+
+func (n *Noop) DeleteVolumeAttachmentsForSandbox(_ context.Context, sandboxID string) error {
+	n.volMu.Lock()
+	defer n.volMu.Unlock()
+	n.releaseVolumeAttachmentsForSandboxLocked(strings.TrimSpace(sandboxID))
+	return nil
+}
+
+func (n *Noop) ensureVolumeAttachmentMapsLocked() {
+	if n.volAttachments == nil {
+		n.volAttachments = make(map[string]models.VolumeAttachment)
+		n.volAttachmentsByVolume = make(map[string]map[string]struct{})
+		n.volAttachmentsBySandbox = make(map[string]map[string]struct{})
+	}
+}
+
+func (n *Noop) volumeAttachmentCountLocked(tenant, volumeID string) int {
+	if tenant == "" || volumeID == "" {
+		return 0
+	}
+	return len(n.volAttachmentsByVolume[volumeKey(tenant, volumeID)])
+}
+
+func (n *Noop) putVolumeAttachmentLocked(a models.VolumeAttachment) {
+	n.ensureVolumeAttachmentMapsLocked()
+	key := volumeAttachmentKey(a.Tenant, a.VolumeID, a.SandboxID, a.Target)
+	if existing, ok := n.volAttachments[key]; ok {
+		n.releaseVolumeAttachmentKeyLocked(key, existing)
+	}
+	n.volAttachments[key] = a
+	vKey := volumeKey(a.Tenant, a.VolumeID)
+	if n.volAttachmentsByVolume[vKey] == nil {
+		n.volAttachmentsByVolume[vKey] = make(map[string]struct{})
+	}
+	n.volAttachmentsByVolume[vKey][key] = struct{}{}
+	if n.volAttachmentsBySandbox[a.SandboxID] == nil {
+		n.volAttachmentsBySandbox[a.SandboxID] = make(map[string]struct{})
+	}
+	n.volAttachmentsBySandbox[a.SandboxID][key] = struct{}{}
+}
+
+func (n *Noop) releaseVolumeAttachmentKeyLocked(key string, a models.VolumeAttachment) {
+	delete(n.volAttachments, key)
+	vKey := volumeKey(a.Tenant, a.VolumeID)
+	if refs := n.volAttachmentsByVolume[vKey]; refs != nil {
+		delete(refs, key)
+		if len(refs) == 0 {
+			delete(n.volAttachmentsByVolume, vKey)
+		}
+	}
+	if refs := n.volAttachmentsBySandbox[a.SandboxID]; refs != nil {
+		delete(refs, key)
+		if len(refs) == 0 {
+			delete(n.volAttachmentsBySandbox, a.SandboxID)
+		}
+	}
+}
+
+func (n *Noop) releaseVolumeAttachmentsForSandboxLocked(sandboxID string) {
+	if sandboxID == "" {
+		return
+	}
+	for key := range n.volAttachmentsBySandbox[sandboxID] {
+		if a, ok := n.volAttachments[key]; ok {
+			n.releaseVolumeAttachmentKeyLocked(key, a)
+		}
+	}
 }
 func (n *Noop) RemoveMember(ctx context.Context, nodeID string, force bool) error {
 	return ErrUnknownMember

--- a/internal/cluster/noop_volumes_test.go
+++ b/internal/cluster/noop_volumes_test.go
@@ -1,0 +1,73 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func TestNoopVolumeAttachmentsRoundTrip(t *testing.T) {
+	n := NewNoop("standalone", "http://self", "")
+	ctx := context.Background()
+	v := models.Volume{ID: "vol-1", Tenant: "t-a", Name: "data", Backend: "s3", Source: "bucket/t-a/data"}
+	if _, _, err := n.VolumeUpsert(ctx, v, 0); err != nil {
+		t.Fatalf("VolumeUpsert: %v", err)
+	}
+	attach := models.VolumeAttachment{
+		Tenant: "t-a", VolumeID: "vol-1", SandboxID: "sb-1", Target: "/data", Source: "bucket/t-a/data",
+	}
+	if err := n.PutVolumeAttachments(ctx, []models.VolumeAttachment{attach}); err != nil {
+		t.Fatalf("PutVolumeAttachments: %v", err)
+	}
+	count, err := n.VolumeAttachmentCount(ctx, "t-a", "vol-1")
+	if err != nil || count != 1 {
+		t.Fatalf("VolumeAttachmentCount = %d, %v", count, err)
+	}
+	if err := n.VolumeDelete(ctx, "t-a", "vol-1"); !errors.Is(err, ErrVolumeInUse) {
+		t.Fatalf("VolumeDelete attached = %v, want ErrVolumeInUse", err)
+	}
+	if err := n.DeleteVolumeAttachmentsForSandbox(ctx, "sb-1"); err != nil {
+		t.Fatalf("DeleteVolumeAttachmentsForSandbox: %v", err)
+	}
+	if err := n.VolumeDelete(ctx, "t-a", "vol-1"); err != nil {
+		t.Fatalf("VolumeDelete after detach: %v", err)
+	}
+}
+
+func TestNoopPutVolumeAttachmentsRequiresKnownVolume(t *testing.T) {
+	n := NewNoop("standalone", "http://self", "")
+	err := n.PutVolumeAttachments(context.Background(), []models.VolumeAttachment{{
+		Tenant: "t-a", VolumeID: "missing", SandboxID: "sb-1", Target: "/data", Source: "s/x",
+	}})
+	if !errors.Is(err, ErrUnknownVolume) {
+		t.Fatalf("PutVolumeAttachments unknown volume = %v, want ErrUnknownVolume", err)
+	}
+}
+
+func TestNoopVolumeReadsAndSourceIndex(t *testing.T) {
+	n := NewNoop("standalone", "http://self", "")
+	ctx := context.Background()
+	v := models.Volume{ID: "vol-2", Tenant: "t-a", Name: "logs", Backend: "s3", Source: "bucket/t-a/logs"}
+	if _, _, err := n.VolumeUpsert(ctx, v, 0); err != nil {
+		t.Fatalf("VolumeUpsert: %v", err)
+	}
+	if got, err := n.VolumeByName(ctx, "t-a", "logs"); err != nil || got.ID != "vol-2" {
+		t.Fatalf("VolumeByName = %+v, %v", got, err)
+	}
+	if got, err := n.VolumeByID(ctx, "t-a", "vol-2"); err != nil || got.Name != "logs" {
+		t.Fatalf("VolumeByID = %+v, %v", got, err)
+	}
+	list, err := n.VolumesForTenant(ctx, "t-a")
+	if err != nil || len(list) != 1 {
+		t.Fatalf("VolumesForTenant = %+v, %v", list, err)
+	}
+	exists, err := n.VolumeExistsForSource(ctx, "bucket/t-a/logs")
+	if err != nil || !exists {
+		t.Fatalf("VolumeExistsForSource = %v, %v", exists, err)
+	}
+	if err := n.PutVolumeAttachments(ctx, nil); err != nil {
+		t.Fatalf("PutVolumeAttachments empty: %v", err)
+	}
+}

--- a/internal/service/platform_volumes.go
+++ b/internal/service/platform_volumes.go
@@ -174,13 +174,44 @@ func (s *Service) cleanupCreatedPlatformVolumes(ctx context.Context, attachments
 			continue
 		}
 		seen[key] = struct{}{}
-		if err := s.deleteVolumeRowIfUnattached(ctx, models.Volume{ID: a.VolumeID, Tenant: a.Tenant, Source: a.Source}); err != nil &&
+		vol, err := s.volumeMeta().ByID(ctx, a.Tenant, a.VolumeID)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				continue
+			}
+			if s.logger != nil {
+				s.logger.Warn("cleanup platform volume lookup failed",
+					"volume_id", a.VolumeID, "tenant", a.Tenant, "err", err)
+			}
+			continue
+		}
+		if err := s.deleteVolumeRowIfUnattached(ctx, *vol); err != nil &&
 			!errors.Is(err, store.ErrNotFound) &&
 			!errors.Is(err, store.ErrVolumeInUse) {
 			if s.logger != nil {
 				s.logger.Warn("cleanup platform volume created by failed sandbox create failed",
 					"volume_id", a.VolumeID, "tenant", a.Tenant, "err", err)
 			}
+		}
+	}
+}
+
+func (s *Service) cleanupPlatformVolumeAttachments(ctx context.Context, attachments []models.VolumeAttachment) {
+	if len(attachments) == 0 {
+		return
+	}
+	seen := map[string]struct{}{}
+	for _, a := range attachments {
+		if a.SandboxID == "" {
+			continue
+		}
+		if _, ok := seen[a.SandboxID]; ok {
+			continue
+		}
+		seen[a.SandboxID] = struct{}{}
+		if err := s.volumeMeta().DeleteAttachmentsForSandbox(ctx, a.SandboxID); err != nil && s.logger != nil {
+			s.logger.Warn("cleanup platform volume attachments failed",
+				"sandbox_id", a.SandboxID, "err", err)
 		}
 	}
 }

--- a/internal/service/platform_volumes_cleanup_test.go
+++ b/internal/service/platform_volumes_cleanup_test.go
@@ -1,0 +1,130 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/cluster"
+	"github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func TestVolumeMetaSQLiteAttachmentsPath(t *testing.T) {
+	s := enabledVolumeService(t)
+	ctx := context.Background()
+
+	v, err := s.CreatePlatformVolume(ctx, "data")
+	if err != nil {
+		t.Fatalf("CreatePlatformVolume: %v", err)
+	}
+	now := time.Now().UTC()
+	if err := s.store.Create(ctx, &models.Sandbox{
+		ID: "sb-local", Image: "alpine:3.20", Status: models.SandboxStatusStarted,
+		Runtime: models.RuntimeDocker, CreatedAt: now, UpdatedAt: now, LastActiveAt: now,
+	}); err != nil {
+		t.Fatalf("Create sandbox: %v", err)
+	}
+	if err := s.volumeMeta().PutAttachments(ctx, []models.VolumeAttachment{{
+		Tenant: v.Tenant, VolumeID: v.ID, SandboxID: "sb-local", Target: "/data", Source: v.Source,
+	}}); err != nil {
+		t.Fatalf("PutAttachments: %v", err)
+	}
+	count, err := s.volumeMeta().AttachmentCount(ctx, v.Tenant, v.ID)
+	if err != nil || count != 1 {
+		t.Fatalf("AttachmentCount = %d, %v", count, err)
+	}
+	if err := s.volumeMeta().DeleteAttachmentsForSandbox(ctx, "sb-local"); err != nil {
+		t.Fatalf("DeleteAttachmentsForSandbox: %v", err)
+	}
+	count, err = s.volumeMeta().AttachmentCount(ctx, v.Tenant, v.ID)
+	if err != nil || count != 0 {
+		t.Fatalf("AttachmentCount after delete = %d, %v", count, err)
+	}
+}
+
+func TestCleanupPlatformVolumeAttachmentsDedupesSandbox(t *testing.T) {
+	s := enabledVolumeService(t)
+	s.cfg.EnableCluster = true
+	s.AttachCluster(cluster.NewNoop("self", "http://self", ""))
+	ctx := context.Background()
+
+	v, err := s.CreatePlatformVolume(ctx, "data")
+	if err != nil {
+		t.Fatalf("CreatePlatformVolume: %v", err)
+	}
+	if err := s.volumeMeta().PutAttachments(ctx, []models.VolumeAttachment{{
+		Tenant: v.Tenant, VolumeID: v.ID, SandboxID: "sb-1", Target: "/data", Source: v.Source,
+	}}); err != nil {
+		t.Fatalf("PutAttachments: %v", err)
+	}
+	s.cleanupPlatformVolumeAttachments(ctx, []models.VolumeAttachment{
+		{SandboxID: "sb-1"},
+		{SandboxID: "sb-1"},
+		{SandboxID: ""},
+	})
+	count, err := s.volumeMeta().AttachmentCount(ctx, v.Tenant, v.ID)
+	if err != nil || count != 0 {
+		t.Fatalf("attachments after cleanup = %d, %v", count, err)
+	}
+}
+
+func TestCleanupCreatedPlatformVolumesSkipsMissingVolume(t *testing.T) {
+	s := enabledVolumeService(t)
+	s.cfg.EnableCluster = true
+	s.AttachCluster(cluster.NewNoop("self", "http://self", ""))
+	s.cleanupCreatedPlatformVolumes(context.Background(), []models.VolumeAttachment{{
+		Tenant: "t-a", VolumeID: "vol-missing", CreatedVolume: true,
+	}})
+}
+
+func TestCleanupCreatedPlatformVolumesLogsLookupFailure(t *testing.T) {
+	s := enabledVolumeService(t)
+	s.cfg.EnableCluster = true
+	s.logger = slog.Default()
+	s.AttachCluster(&failingVolumeLookupCluster{Noop: cluster.NewNoop("self", "http://self", "")})
+	s.cleanupCreatedPlatformVolumes(context.Background(), []models.VolumeAttachment{{
+		Tenant: "t-a", VolumeID: "vol-1", CreatedVolume: true,
+	}})
+}
+
+func TestDestroySandboxClearsClusterVolumeAttachments(t *testing.T) {
+	svc, st, _ := newServiceRuntimeHarness(t, &recordingRuntime{})
+	svc.cfg.EnableCluster = true
+	svc.cfg.PlatformVolumes = enabledVolumeService(t).cfg.PlatformVolumes
+	svc.cfg.PATToken = "operator-pat"
+	svc.AttachCluster(cluster.NewNoop("self", "http://self", ""))
+	ctx := context.Background()
+
+	v, err := svc.CreatePlatformVolume(ctx, "data")
+	if err != nil {
+		t.Fatalf("CreatePlatformVolume: %v", err)
+	}
+	seedStartedSandbox(t, st, "sb-destroy")
+	if err := svc.volumeMeta().PutAttachments(ctx, []models.VolumeAttachment{{
+		Tenant: v.Tenant, VolumeID: v.ID, SandboxID: "sb-destroy", Target: "/data", Source: v.Source,
+	}}); err != nil {
+		t.Fatalf("PutAttachments: %v", err)
+	}
+	if err := svc.DestroySandbox(ctx, "sb-destroy"); err != nil {
+		t.Fatalf("DestroySandbox: %v", err)
+	}
+	count, err := svc.volumeMeta().AttachmentCount(ctx, v.Tenant, v.ID)
+	if err != nil || count != 0 {
+		t.Fatalf("attachments after destroy = %d, %v", count, err)
+	}
+}
+
+type failingVolumeLookupCluster struct {
+	*cluster.Noop
+}
+
+func (f *failingVolumeLookupCluster) VolumeByID(context.Context, string, string) (models.Volume, error) {
+	return models.Volume{}, errors.New("lookup failed")
+}
+
+func (f *failingVolumeLookupCluster) VolumeDelete(context.Context, string, string) error {
+	return store.ErrNotFound
+}

--- a/internal/service/platform_volumes_crud.go
+++ b/internal/service/platform_volumes_crud.go
@@ -129,14 +129,15 @@ func (s *Service) DeletePlatformVolume(ctx context.Context, id string) error {
 
 // deleteVolumeRowIfUnattached enforces the no-live-attacher rule, schedules
 // backend reclaim, then removes the metadata row (from SQLite or the cluster FSM
-// per volumeMeta). The attachment index is still per-node SQLite, so this check
-// is authoritative on a single node and best-effort across a cluster (cluster-
-// wide attachment visibility is the tracked follow-up). The pending-deletion
-// ledger is written BEFORE the row is removed so backend bytes never lose their
-// reconciliation coordinates; the row's frozen Source is authoritative, falling
-// back to a recompute only for pre-migration rows.
+// per volumeMeta). In cluster mode both the metadata row and attachment count are
+// read from raft, so a delete cannot miss an attachment created on another
+// worker. The pending-deletion ledger is written BEFORE the row is removed so
+// backend bytes never lose their reconciliation coordinates; the row's frozen
+// Source is authoritative, falling back to a recompute only for pre-migration
+// rows.
 func (s *Service) deleteVolumeRowIfUnattached(ctx context.Context, vol models.Volume) error {
-	attachers, err := s.store.CountVolumeAttachments(ctx, vol.Tenant, vol.ID)
+	meta := s.volumeMeta()
+	attachers, err := meta.AttachmentCount(ctx, vol.Tenant, vol.ID)
 	if err != nil {
 		return err
 	}
@@ -153,7 +154,7 @@ func (s *Service) deleteVolumeRowIfUnattached(ctx context.Context, vol models.Vo
 	if err := s.store.SchedulePendingVolumeDeletion(ctx, vol, source); err != nil {
 		return err
 	}
-	return s.volumeMeta().DeleteRow(ctx, vol.Tenant, vol.ID)
+	return meta.DeleteRow(ctx, vol.Tenant, vol.ID)
 }
 
 // volumeTenant resolves the calling tenant's scope segment from the request

--- a/internal/service/platform_volumes_reclaim.go
+++ b/internal/service/platform_volumes_reclaim.go
@@ -2,9 +2,11 @@ package service
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
+	"github.com/aerol-ai/microvm/internal/store"
 	"github.com/aerol-ai/microvm/pkg/models"
 )
 
@@ -107,7 +109,17 @@ func (s *Service) runVolumeReclaim(ctx context.Context) {
 // owns the source (resurrection guard), otherwise delete the backend bytes and
 // clear the row. Errors are logged and the row left for the next tick to retry.
 func (s *Service) reclaimOne(ctx context.Context, p models.PendingVolumeDeletion) {
-	live, err := s.volumeMeta().ExistsForSource(ctx, p.Source)
+	meta := s.volumeMeta()
+	if v, err := meta.ByID(ctx, p.Tenant, p.VolumeID); err == nil && v.Source == p.Source {
+		// The delete path writes the ledger before removing the user-visible row.
+		// If the janitor catches that in-between state, keep the row so the next
+		// tick can reclaim after the delete commits.
+		return
+	} else if err != nil && !errors.Is(err, store.ErrNotFound) {
+		s.logger.Warn("volume reclaim live-row check failed", "volume_id", p.VolumeID, "error", err)
+		return
+	}
+	live, err := meta.ExistsForSource(ctx, p.Source)
 	if err != nil {
 		s.logger.Warn("volume reclaim live-source check failed", "volume_id", p.VolumeID, "error", err)
 		return

--- a/internal/service/platform_volumes_reclaim_test.go
+++ b/internal/service/platform_volumes_reclaim_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/aerol-ai/microvm/internal/cluster"
 	"github.com/aerol-ai/microvm/pkg/models"
 )
 
@@ -79,6 +80,34 @@ func TestRunVolumeReclaimSkipsLiveSource(t *testing.T) {
 	pending, _ := s.store.ListPendingVolumeDeletions(ctx)
 	if len(pending) != 0 {
 		t.Fatalf("stale ledger row should be cleared: %+v", pending)
+	}
+}
+
+func TestRunVolumeReclaimKeepsLedgerWhenDeleteStillApplying(t *testing.T) {
+	s := enabledVolumeService(t)
+	s.cfg.EnableCluster = true
+	s.AttachCluster(cluster.NewNoop("self", "http://self", ""))
+	s.logger = slog.Default()
+	fr := &fakeReclaimer{}
+	s.SetVolumeReclaimer(fr)
+	ctx := context.Background()
+
+	v, err := s.CreatePlatformVolume(ctx, "data")
+	if err != nil {
+		t.Fatalf("CreatePlatformVolume: %v", err)
+	}
+	if err := s.store.SchedulePendingVolumeDeletion(ctx, *v, v.Source); err != nil {
+		t.Fatalf("SchedulePendingVolumeDeletion: %v", err)
+	}
+
+	s.runVolumeReclaim(ctx)
+
+	if len(fr.calls) != 0 {
+		t.Fatalf("reclaimer must not run before delete applies, got %+v", fr.calls)
+	}
+	pending, _ := s.store.ListPendingVolumeDeletions(ctx)
+	if len(pending) != 1 {
+		t.Fatalf("ledger row should remain while same volume is live: %+v", pending)
 	}
 }
 

--- a/internal/service/platform_volumes_test.go
+++ b/internal/service/platform_volumes_test.go
@@ -138,6 +138,34 @@ func TestResolvePlatformVolumes_DockerS3(t *testing.T) {
 	}
 }
 
+func TestResolvePlatformVolumesForReplication(t *testing.T) {
+	s := enabledVolumeService(t)
+	s.cfg.EnableCluster = true
+	ctx := controlplane.ContextWithAccess(context.Background(), controlplane.Access{
+		Identity: controlplane.Identity{OwnerRef: "tenant-xyz"},
+		Operator: false,
+	})
+	v, err := s.CreatePlatformVolume(ctx, "data")
+	if err != nil {
+		t.Fatalf("CreatePlatformVolume: %v", err)
+	}
+	req := models.CreateSandboxRequest{
+		PlatformVolumes: []models.PlatformVolumeMount{{Name: "data", Path: "/workspace", ReadOnly: true}},
+	}
+	if err := s.ResolvePlatformVolumesForReplication(ctx, &req); err != nil {
+		t.Fatalf("ResolvePlatformVolumesForReplication: %v", err)
+	}
+	if len(req.PlatformVolumes) != 0 {
+		t.Fatalf("PlatformVolumes not cleared: %+v", req.PlatformVolumes)
+	}
+	if len(req.Mounts) != 1 || req.Mounts[0].Source != v.Source {
+		t.Fatalf("mounts = %+v, want frozen source %q", req.Mounts, v.Source)
+	}
+	if err := s.ResolvePlatformVolumesForReplication(ctx, nil); err != nil {
+		t.Fatalf("nil req: %v", err)
+	}
+}
+
 // An existing volume must mount from its frozen source even after the operator
 // reconfigures the bucket/prefix — the stored coordinate is authoritative, so a
 // config change can never silently move a live volume to a new location.

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1020,6 +1020,7 @@ func (s *Service) createSandbox(ctx context.Context, req models.CreateSandboxReq
 	platformVolumesCommitted := false
 	defer func() {
 		if !platformVolumesCommitted {
+			s.cleanupPlatformVolumeAttachments(cleanupCtx, platformAttachments)
 			s.cleanupCreatedPlatformVolumes(cleanupCtx, platformAttachments)
 		}
 	}()
@@ -1245,7 +1246,7 @@ func (s *Service) createSandbox(ctx context.Context, req models.CreateSandboxReq
 		for i := range platformAttachments {
 			platformAttachments[i].SandboxID = sandbox.ID
 		}
-		if err := s.store.PutVolumeAttachments(ctx, platformAttachments); err != nil {
+		if err := s.volumeMeta().PutAttachments(ctx, platformAttachments); err != nil {
 			_ = s.store.Delete(ctx, sandbox.ID)
 			_ = s.caddy.DeleteSandboxRoute(cleanupCtx, sandbox.ID)
 			_ = s.docker.Destroy(cleanupCtx, sandbox)
@@ -1893,6 +1894,11 @@ func (s *Service) DestroySandbox(ctx context.Context, id string) error {
 	}
 	if err := s.store.Delete(ctx, id); err != nil {
 		return err
+	}
+	if err := s.volumeMeta().DeleteAttachmentsForSandbox(ctx, id); err != nil {
+		if s.logger != nil {
+			s.logger.Warn("platform volume attachment cleanup after destroy failed", "sandbox_id", id, "error", err)
+		}
 	}
 	if err := s.cleanupWasmSandboxArtifacts(ctx, sandbox); err != nil {
 		return err

--- a/internal/service/volume_meta.go
+++ b/internal/service/volume_meta.go
@@ -25,6 +25,9 @@ type volumeMetaStore interface {
 	List(ctx context.Context, tenant string) ([]models.Volume, error)
 	DeleteRow(ctx context.Context, tenant, id string) error
 	ExistsForSource(ctx context.Context, source string) (bool, error)
+	AttachmentCount(ctx context.Context, tenant, id string) (int, error)
+	PutAttachments(ctx context.Context, attachments []models.VolumeAttachment) error
+	DeleteAttachmentsForSandbox(ctx context.Context, sandboxID string) error
 }
 
 // volumeMeta returns the cluster-FSM-backed store when clustering is enabled and
@@ -60,6 +63,15 @@ func (m sqliteVolumeMeta) DeleteRow(ctx context.Context, tenant, id string) erro
 }
 func (m sqliteVolumeMeta) ExistsForSource(ctx context.Context, source string) (bool, error) {
 	return m.store.LiveVolumeExistsForSource(ctx, source)
+}
+func (m sqliteVolumeMeta) AttachmentCount(ctx context.Context, tenant, id string) (int, error) {
+	return m.store.CountVolumeAttachments(ctx, tenant, id)
+}
+func (m sqliteVolumeMeta) PutAttachments(ctx context.Context, attachments []models.VolumeAttachment) error {
+	return m.store.PutVolumeAttachments(ctx, attachments)
+}
+func (m sqliteVolumeMeta) DeleteAttachmentsForSandbox(ctx context.Context, sandboxID string) error {
+	return m.store.DeleteVolumeAttachmentsForSandbox(ctx, sandboxID)
 }
 
 // clusterVolumeMeta adapts the replicated cluster volume API to the service
@@ -100,10 +112,25 @@ func (m clusterVolumeMeta) DeleteRow(ctx context.Context, tenant, id string) err
 func (m clusterVolumeMeta) ExistsForSource(ctx context.Context, source string) (bool, error) {
 	return m.c.VolumeExistsForSource(ctx, source)
 }
+func (m clusterVolumeMeta) AttachmentCount(ctx context.Context, tenant, id string) (int, error) {
+	return m.c.VolumeAttachmentCount(ctx, tenant, id)
+}
+func (m clusterVolumeMeta) PutAttachments(ctx context.Context, attachments []models.VolumeAttachment) error {
+	if err := m.c.PutVolumeAttachments(ctx, attachments); err != nil {
+		return mapVolumeNotFound(err)
+	}
+	return nil
+}
+func (m clusterVolumeMeta) DeleteAttachmentsForSandbox(ctx context.Context, sandboxID string) error {
+	return m.c.DeleteVolumeAttachmentsForSandbox(ctx, sandboxID)
+}
 
 func mapVolumeNotFound(err error) error {
 	if errors.Is(err, cluster.ErrUnknownVolume) {
 		return store.ErrNotFound
+	}
+	if errors.Is(err, cluster.ErrVolumeInUse) {
+		return store.ErrVolumeInUse
 	}
 	return err
 }

--- a/internal/service/volume_meta_test.go
+++ b/internal/service/volume_meta_test.go
@@ -79,3 +79,61 @@ func TestVolumeMetaClusterQuota(t *testing.T) {
 		t.Fatalf("expected quota error, got %v", err)
 	}
 }
+
+func TestVolumeMetaClusterAttachmentsBlockDelete(t *testing.T) {
+	s := enabledVolumeService(t)
+	s.cfg.EnableCluster = true
+	c := cluster.NewNoop("self", "http://self", "")
+	s.AttachCluster(c)
+	ctx := context.Background()
+
+	v, err := s.CreatePlatformVolume(ctx, "data")
+	if err != nil {
+		t.Fatalf("CreatePlatformVolume: %v", err)
+	}
+	if err := s.volumeMeta().PutAttachments(ctx, []models.VolumeAttachment{{
+		Tenant:    v.Tenant,
+		VolumeID:  v.ID,
+		SandboxID: "sb-remote",
+		Target:    "/data",
+		Source:    v.Source,
+	}}); err != nil {
+		t.Fatalf("PutAttachments: %v", err)
+	}
+
+	if err := s.DeletePlatformVolume(ctx, v.ID); !errors.Is(err, models.ErrPlatformVolumeInUse) {
+		t.Fatalf("DeletePlatformVolume attached = %v, want ErrPlatformVolumeInUse", err)
+	}
+	if err := s.volumeMeta().DeleteAttachmentsForSandbox(ctx, "sb-remote"); err != nil {
+		t.Fatalf("DeleteAttachmentsForSandbox: %v", err)
+	}
+	if err := s.DeletePlatformVolume(ctx, v.ID); err != nil {
+		t.Fatalf("DeletePlatformVolume after detach: %v", err)
+	}
+}
+
+func TestCleanupCreatedPlatformVolumesPreservesClusterBackend(t *testing.T) {
+	s := enabledVolumeService(t)
+	s.cfg.EnableCluster = true
+	s.AttachCluster(cluster.NewNoop("self", "http://self", ""))
+	ctx := context.Background()
+
+	v, err := s.CreatePlatformVolume(ctx, "data")
+	if err != nil {
+		t.Fatalf("CreatePlatformVolume: %v", err)
+	}
+	s.cleanupCreatedPlatformVolumes(ctx, []models.VolumeAttachment{{
+		Tenant:        v.Tenant,
+		VolumeID:      v.ID,
+		Source:        v.Source,
+		CreatedVolume: true,
+	}})
+
+	pending, err := s.store.ListPendingVolumeDeletions(ctx)
+	if err != nil {
+		t.Fatalf("ListPendingVolumeDeletions: %v", err)
+	}
+	if len(pending) != 1 || pending[0].Backend != "s3" || pending[0].Name != "data" {
+		t.Fatalf("pending deletion = %+v, want backend/name from full cluster volume row", pending)
+	}
+}

--- a/internal/service/volume_meta_test.go
+++ b/internal/service/volume_meta_test.go
@@ -112,6 +112,58 @@ func TestVolumeMetaClusterAttachmentsBlockDelete(t *testing.T) {
 	}
 }
 
+func TestVolumeMetaClusterExistsForSource(t *testing.T) {
+	s := enabledVolumeService(t)
+	s.cfg.EnableCluster = true
+	s.AttachCluster(cluster.NewNoop("self", "http://self", ""))
+	ctx := context.Background()
+
+	if exists, err := s.volumeMeta().ExistsForSource(ctx, "bucket/t-a/missing"); err != nil || exists {
+		t.Fatalf("ExistsForSource missing = %v, %v", exists, err)
+	}
+	v, err := s.CreatePlatformVolume(ctx, "data")
+	if err != nil {
+		t.Fatalf("CreatePlatformVolume: %v", err)
+	}
+	exists, err := s.volumeMeta().ExistsForSource(ctx, v.Source)
+	if err != nil || !exists {
+		t.Fatalf("ExistsForSource live = %v, %v", exists, err)
+	}
+}
+
+func TestVolumeMetaClusterPutAttachmentsEmpty(t *testing.T) {
+	s := enabledVolumeService(t)
+	s.cfg.EnableCluster = true
+	s.AttachCluster(cluster.NewNoop("self", "http://self", ""))
+	if err := s.volumeMeta().PutAttachments(context.Background(), nil); err != nil {
+		t.Fatalf("PutAttachments empty: %v", err)
+	}
+}
+
+func TestVolumeMetaClusterPutAttachmentsUnknownVolume(t *testing.T) {
+	s := enabledVolumeService(t)
+	s.cfg.EnableCluster = true
+	s.AttachCluster(cluster.NewNoop("self", "http://self", ""))
+	err := s.volumeMeta().PutAttachments(context.Background(), []models.VolumeAttachment{{
+		Tenant: "t-a", VolumeID: "missing", SandboxID: "sb-1", Target: "/data", Source: "s/x",
+	}})
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("PutAttachments unknown volume = %v, want ErrNotFound", err)
+	}
+}
+
+func TestMapVolumeNotFoundSentinels(t *testing.T) {
+	if !errors.Is(mapVolumeNotFound(cluster.ErrUnknownVolume), store.ErrNotFound) {
+		t.Fatal("expected ErrNotFound for ErrUnknownVolume")
+	}
+	if !errors.Is(mapVolumeNotFound(cluster.ErrVolumeInUse), store.ErrVolumeInUse) {
+		t.Fatal("expected ErrVolumeInUse for ErrVolumeInUse")
+	}
+	if err := mapVolumeNotFound(errors.New("other")); err.Error() != "other" {
+		t.Fatalf("unexpected passthrough: %v", err)
+	}
+}
+
 func TestCleanupCreatedPlatformVolumesPreservesClusterBackend(t *testing.T) {
 	s := enabledVolumeService(t)
 	s.cfg.EnableCluster = true

--- a/internal/store/volumes.go
+++ b/internal/store/volumes.go
@@ -288,6 +288,20 @@ func (s *Store) CountVolumeAttachments(ctx context.Context, tenant, volumeID str
 	return n, nil
 }
 
+// DeleteVolumeAttachmentsForSandbox removes the indexed platform-volume
+// references for sandboxID. SQLite normally reaches this through the sandbox FK
+// cascade, but the explicit method lets service code share the cluster-mode
+// cleanup path and is idempotent for rollback.
+func (s *Store) DeleteVolumeAttachmentsForSandbox(ctx context.Context, sandboxID string) error {
+	_, err := s.db.ExecContext(ctx, `
+		DELETE FROM volume_attachments WHERE sandbox_id = ?
+	`, strings.TrimSpace(sandboxID))
+	if err != nil {
+		return fmt.Errorf("delete volume attachments for sandbox: %w", err)
+	}
+	return nil
+}
+
 // DeleteVolumeIfUnattached schedules backend cleanup and removes the volume row
 // only when no indexed attachments remain. The pending cleanup row is inserted
 // in the same transaction before the metadata row is removed, so remote data

--- a/internal/store/volumes_test.go
+++ b/internal/store/volumes_test.go
@@ -301,6 +301,54 @@ func TestDeletePendingVolumeDeletionIdempotent(t *testing.T) {
 	}
 }
 
+func TestSchedulePendingVolumeDeletion(t *testing.T) {
+	st := newTestStore(t)
+	ctx := context.Background()
+	v := models.Volume{ID: "v1", Tenant: "t-a", Name: "data", Backend: "s3", Source: "bucket/t-a/data"}
+	if err := st.SchedulePendingVolumeDeletion(ctx, v, v.Source); err != nil {
+		t.Fatalf("SchedulePendingVolumeDeletion: %v", err)
+	}
+	pending, err := st.ListPendingVolumeDeletions(ctx)
+	if err != nil || len(pending) != 1 || pending[0].Backend != "s3" || pending[0].Name != "data" {
+		t.Fatalf("pending = %+v, %v", pending, err)
+	}
+	// Refresh the same row (idempotent upsert).
+	if err := st.SchedulePendingVolumeDeletion(ctx, v, "override-source"); err != nil {
+		t.Fatalf("SchedulePendingVolumeDeletion refresh: %v", err)
+	}
+	pending, _ = st.ListPendingVolumeDeletions(ctx)
+	if len(pending) != 1 || pending[0].Source != "override-source" {
+		t.Fatalf("refresh pending = %+v", pending)
+	}
+}
+
+func TestDeleteVolumeAttachmentsForSandbox(t *testing.T) {
+	st := newTestStore(t)
+	ctx := context.Background()
+
+	if err := st.CreateVolume(ctx, &models.Volume{ID: "v1", Tenant: "t-a", Name: "data", Backend: "s3", Source: "bucket/t-a/data"}); err != nil {
+		t.Fatalf("CreateVolume: %v", err)
+	}
+	if err := st.Create(ctx, sampleSandbox("sb-1")); err != nil {
+		t.Fatalf("Create sandbox: %v", err)
+	}
+	if err := st.PutVolumeAttachments(ctx, []models.VolumeAttachment{{
+		Tenant: "t-a", VolumeID: "v1", SandboxID: "sb-1", Target: "/data", Source: "bucket/t-a/data",
+	}}); err != nil {
+		t.Fatalf("PutVolumeAttachments: %v", err)
+	}
+	if err := st.DeleteVolumeAttachmentsForSandbox(ctx, "sb-1"); err != nil {
+		t.Fatalf("DeleteVolumeAttachmentsForSandbox: %v", err)
+	}
+	count, err := st.CountVolumeAttachments(ctx, "t-a", "v1")
+	if err != nil || count != 0 {
+		t.Fatalf("CountVolumeAttachments after explicit delete = %d, %v", count, err)
+	}
+	if err := st.DeleteVolumeAttachmentsForSandbox(ctx, "sb-1"); err != nil {
+		t.Fatalf("idempotent delete: %v", err)
+	}
+}
+
 func TestLiveVolumeExistsForSource(t *testing.T) {
 	st := newTestStore(t)
 	ctx := context.Background()

--- a/pkg/api/v1/cluster_handler.go
+++ b/pkg/api/v1/cluster_handler.go
@@ -1059,6 +1059,13 @@ func (h *handlers) clusterInternalVolume(w http.ResponseWriter, r *http.Request)
 			return
 		}
 		apihttp.WriteJSON(w, http.StatusOK, cluster.VolumeQueryResponse{Exists: exists})
+	case "attachment_count":
+		count, err := c.VolumeAttachmentCount(r.Context(), tenant, q.Get("id"))
+		if err != nil {
+			apihttp.WriteError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		apihttp.WriteJSON(w, http.StatusOK, cluster.VolumeQueryResponse{Count: count})
 	default:
 		apihttp.WriteError(w, http.StatusBadRequest, "unknown volume query kind")
 	}

--- a/pkg/api/v1/cluster_internal_test.go
+++ b/pkg/api/v1/cluster_internal_test.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"io"
@@ -10,8 +11,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aerol-ai/microvm/internal/cluster"
 	"github.com/aerol-ai/microvm/internal/config"
 	"github.com/aerol-ai/microvm/internal/service"
+	"github.com/aerol-ai/microvm/pkg/models"
 )
 
 func newClusterInternalHandler(t *testing.T) *handlers {
@@ -151,6 +154,57 @@ func TestClusterInternalHandlers_BasicCoverage(t *testing.T) {
 		h.clusterInternalDrainState(rr, req)
 		if rr.Code != http.StatusOK {
 			t.Fatalf("status = %d, want 200", rr.Code)
+		}
+	})
+
+	t.Run("volume_query_kinds", func(t *testing.T) {
+		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+		svc := service.New(config.Config{EnableCluster: true, PATToken: "op"}, logger, nil, nil, nil, nil, nil, nil, nil)
+		c := cluster.NewNoop("self", "http://self", "")
+		svc.AttachCluster(c)
+		h := &handlers{deps: Deps{Service: svc, Logger: logger}}
+		ctx := context.Background()
+		v := models.Volume{ID: "vol-1", Tenant: "t-a", Name: "data", Backend: "s3", Source: "bucket/t-a/data"}
+		if _, _, err := c.VolumeUpsert(ctx, v, 0); err != nil {
+			t.Fatalf("seed volume: %v", err)
+		}
+		_ = c.PutVolumeAttachments(ctx, []models.VolumeAttachment{{
+			Tenant: "t-a", VolumeID: "vol-1", SandboxID: "sb-1", Target: "/data", Source: "bucket/t-a/data",
+		}})
+
+		cases := []struct {
+			kind   string
+			query  string
+			status int
+		}{
+			{"id", "kind=id&tenant=t-a&id=vol-1", http.StatusOK},
+			{"name", "kind=name&tenant=t-a&name=data", http.StatusOK},
+			{"list", "kind=list&tenant=t-a", http.StatusOK},
+			{"source", "kind=source&source=bucket/t-a/data", http.StatusOK},
+			{"attachment_count", "kind=attachment_count&tenant=t-a&id=vol-1", http.StatusOK},
+			{"missing id", "kind=id&tenant=t-a&id=missing", http.StatusNotFound},
+			{"bad kind", "kind=unknown", http.StatusBadRequest},
+		}
+		for _, tc := range cases {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/v1/cluster/internal/volume?"+tc.query, nil)
+			h.clusterInternalVolume(rr, req)
+			if rr.Code != tc.status {
+				t.Fatalf("%s: status = %d, want %d; body=%s", tc.kind, rr.Code, tc.status, rr.Body.String())
+			}
+		}
+	})
+
+	t.Run("volume_no_cluster", func(t *testing.T) {
+		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+		svc := service.New(config.Config{EnableCluster: true}, logger, nil, nil, nil, nil, nil, nil, nil)
+		svc.ClearClusterForTest()
+		h := &handlers{deps: Deps{Service: svc, Logger: logger}}
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/v1/cluster/internal/volume?kind=id&tenant=t-a&id=vol-1", nil)
+		h.clusterInternalVolume(rr, req)
+		if rr.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want 503", rr.Code)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Replicate platform-volume **attachments** through the Raft FSM (new `opPutVolumeAttach` / `opDeleteVolumeAttach`, snapshot/restore, agent read forwarding) so `DeletePlatformVolume` sees live attachers cluster-wide, not just on the handling node.
- Fix the **reclaim race** where a pending-deletion ledger row could be cleared while the same volume ID was still live in FSM (delete schedules ledger before metadata removal); janitor now waits until the row is gone.
- Route create/destroy attachment bookkeeping through `volumeMeta()` (cluster FSM in cluster mode, SQLite single-node) and preserve full volume metadata on failed-create cleanup.

## Sandbox boot impact

**Yes — bounded, on the create path when platform volumes are attached.**

- `CreateSandbox` now calls `volumeMeta().PutAttachments` (Raft apply in cluster mode) after the sandbox row is persisted. This is one extra ordered-log write per sandbox that mounts platform volumes; it fires only when `req.PlatformVolumes` is non-empty and Docker runtime is chosen. Latency is one Raft round-trip on cluster nodes (same order of magnitude as placement writes already on create). Single-node mode remains a local SQLite upsert.
- Destroy path adds a best-effort `DeleteAttachmentsForSandbox` Raft apply; not on boot.

## Idempotency

- **Volume delete:** FSM `opDeleteVolume` is idempotent on unknown rows (`ErrUnknownVolume`); in-use delete returns `ErrVolumeInUse` consistently under retry.
- **Attachment put:** upsert by `(tenant, volume_id, sandbox_id, target)` — safe under retry and concurrent identical calls.
- **Attachment delete for sandbox:** idempotent no-op when sandbox has no attachments.
- **Reclaim janitor:** at-least-once; keeps ledger row on failure, skips backend delete when same volume ID still owns the source.

## Failure-path consistency

- **Create + platform volumes:** rollback defer now clears replicated attachments (best-effort) before attempting to delete created volume rows; attachment put failure rolls back sandbox row + routes + container as before.
- **Delete volume:** pending-deletion ledger is written before FSM metadata delete; reclaim worker is the backend cleanup path.
- **Destroy sandbox:** attachment cleanup is best-effort logged; placement delete (`opDelete`) also releases attachments for defense in depth.

## L4 / host-port-pool changes

N/A - neither touched.

## Cluster correctness

- **FSM:** new volume-attachment ops + snapshot envelope field; regression tests in `fsm_volumes_test.go` (delete blocked while attached, snapshot roundtrip).
- **Agent reads:** `attachment_count` kind on internal volume query endpoint.
- Cluster-mode code remains no-op when `EnableCluster=false` via existing `Noop` / SQLite `volumeMeta` selection.

## Test plan

- [x] `go test ./internal/cluster ./internal/store ./internal/service ./pkg/api/v1`
- [x] `fsm_volumes_test.go`: attachment blocks delete, attachments survive snapshot restore
- [x] `volume_meta_test.go`: cluster attachments block delete; cleanup preserves backend/name
- [x] `platform_volumes_reclaim_test.go`: ledger retained when delete still applying


Made with [Cursor](https://cursor.com)