### PR TITLE
[codex] Fix cluster gossip bootstrap rejoin

### DIFF
--- a/internal/cluster/gossip.go
+++ b/internal/cluster/gossip.go
@@ -143,11 +143,13 @@ func (d *gossipDelegate) MergeRemoteState([]byte, bool)   {}
 // gossipNode wraps memberlist + the delegate so Close can stop the refresh
 // loop alongside leaving the cluster.
 type gossipNode struct {
-	ml          *memberlist.Memberlist
-	delegate    *gossipDelegate
-	memberIndex *gossipMemberIndex
-	stopRefresh context.CancelFunc
-	logger      *slog.Logger
+	ml                 *memberlist.Memberlist
+	delegate           *gossipDelegate
+	memberIndex        *gossipMemberIndex
+	stopRefresh        context.CancelFunc
+	logger             *slog.Logger
+	bootstrapPeers     []string
+	joinBootstrapPeers func([]string) (int, error)
 }
 
 type gossipMemberIndex struct {
@@ -464,11 +466,13 @@ func setupGossip(cfg gossipSetupConfig, admitter *capacity.Admitter, logger *slo
 	}
 	refreshCtx, cancel := context.WithCancel(context.Background())
 	gn := &gossipNode{
-		ml:          ml,
-		delegate:    delegate,
-		memberIndex: memberIndex,
-		stopRefresh: cancel,
-		logger:      logger,
+		ml:                 ml,
+		delegate:           delegate,
+		memberIndex:        memberIndex,
+		stopRefresh:        cancel,
+		logger:             logger,
+		bootstrapPeers:     append([]string(nil), cfg.BootstrapPeers...),
+		joinBootstrapPeers: ml.Join,
 	}
 	gn.refreshMemberIndex()
 	go gn.runRefreshLoop(refreshCtx, interval)
@@ -490,8 +494,58 @@ func (g *gossipNode) runRefreshLoop(ctx context.Context, interval time.Duration)
 			return
 		case <-t.C:
 			g.refreshMemberIndex()
+			g.maybeRejoinBootstrapPeers(g.memberlistNodes())
 		}
 	}
+}
+
+func (g *gossipNode) memberlistNodes() []*memberlist.Node {
+	if g == nil || g.ml == nil {
+		return nil
+	}
+	return g.ml.Members()
+}
+
+func (g *gossipNode) maybeRejoinBootstrapPeers(nodes []*memberlist.Node) {
+	if g == nil || len(g.bootstrapPeers) == 0 || g.joinBootstrapPeers == nil {
+		return
+	}
+	selfNodeID := ""
+	if g.delegate != nil {
+		selfNodeID = g.delegate.nodeID
+	}
+	if hasLiveControlPlaneMember(nodes, selfNodeID) {
+		return
+	}
+	joined, err := g.joinBootstrapPeers(g.bootstrapPeers)
+	if err != nil {
+		if g.logger != nil {
+			g.logger.Warn("cluster gossip bootstrap rejoin failed", "peers", g.bootstrapPeers, "error", err)
+		}
+		return
+	}
+	if joined > 0 && g.logger != nil {
+		g.logger.Info("cluster gossip bootstrap rejoined peers", "joined", joined, "peers", g.bootstrapPeers)
+	}
+}
+
+func hasLiveControlPlaneMember(nodes []*memberlist.Node, selfNodeID string) bool {
+	if len(nodes) == 0 {
+		return false
+	}
+	for _, n := range nodes {
+		if n == nil || n.State != memberlist.StateAlive {
+			continue
+		}
+		m := memberFromMemberlistNode(n)
+		if selfNodeID != "" && m.NodeID == selfNodeID {
+			continue
+		}
+		if m.NodeID != "" && CanServeControlPlaneRole(m.Role) && (m.APIURL != "" || m.InternalURL != "") {
+			return true
+		}
+	}
+	return false
 }
 
 // members returns peer state, including self. Self's metadata is sourced from

--- a/internal/cluster/gossip_additional_test.go
+++ b/internal/cluster/gossip_additional_test.go
@@ -2,10 +2,12 @@ package cluster
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"testing"
 	"time"
 
+	"github.com/aerol-ai/microvm/internal/config"
 	"github.com/hashicorp/memberlist"
 )
 
@@ -85,4 +87,79 @@ func TestGossipRefreshLoopExitsOnCancel(t *testing.T) {
 	case <-time.After(1 * time.Second):
 		t.Fatal("runRefreshLoop did not exit")
 	}
+}
+
+func TestHasLiveControlPlaneMemberRequiresUsableServer(t *testing.T) {
+	nodes := []*memberlist.Node{
+		gossipTestNode(t, "worker", config.NodeRoleWorker, "http://worker:21212", "", memberlist.StateAlive),
+		gossipTestNode(t, "dead-server", config.NodeRoleServer, "http://dead-server:21212", "", memberlist.StateDead),
+		gossipTestNode(t, "missing-endpoint", config.NodeRoleServer, "", "", memberlist.StateAlive),
+	}
+
+	if hasLiveControlPlaneMember(nodes, "self") {
+		t.Fatal("hasLiveControlPlaneMember = true, want false without a live server endpoint")
+	}
+
+	nodes = append(nodes, gossipTestNode(t, "seed", config.NodeRoleServer, "http://seed:21212", "", memberlist.StateAlive))
+	if !hasLiveControlPlaneMember(nodes, "self") {
+		t.Fatal("hasLiveControlPlaneMember = false, want true for live server endpoint")
+	}
+
+	nodes = []*memberlist.Node{
+		gossipTestNode(t, "self", config.NodeRoleServer, "http://self:21212", "", memberlist.StateAlive),
+	}
+	if hasLiveControlPlaneMember(nodes, "self") {
+		t.Fatal("hasLiveControlPlaneMember = true, want false when the only server is self")
+	}
+}
+
+func TestMaybeRejoinBootstrapPeersOnlyWithoutControlPlane(t *testing.T) {
+	var calls int
+	gn := &gossipNode{
+		delegate:       &gossipDelegate{nodeID: "self"},
+		bootstrapPeers: []string{"10.42.1.215:7001"},
+		joinBootstrapPeers: func(peers []string) (int, error) {
+			calls++
+			if len(peers) != 1 || peers[0] != "10.42.1.215:7001" {
+				t.Fatalf("join peers = %v, want configured seed", peers)
+			}
+			return 1, nil
+		},
+	}
+
+	gn.maybeRejoinBootstrapPeers([]*memberlist.Node{
+		gossipTestNode(t, "worker", config.NodeRoleWorker, "http://worker:21212", "", memberlist.StateAlive),
+	})
+	if calls != 1 {
+		t.Fatalf("join calls = %d, want 1 when no live control-plane member is visible", calls)
+	}
+
+	gn.maybeRejoinBootstrapPeers([]*memberlist.Node{
+		gossipTestNode(t, "self", config.NodeRoleServer, "http://self:21212", "", memberlist.StateAlive),
+	})
+	if calls != 2 {
+		t.Fatalf("join calls = %d, want 2 when only self is visible as control plane", calls)
+	}
+
+	gn.maybeRejoinBootstrapPeers([]*memberlist.Node{
+		gossipTestNode(t, "server", config.NodeRoleServer, "http://server:21212", "", memberlist.StateAlive),
+		gossipTestNode(t, "worker", config.NodeRoleWorker, "http://worker:21212", "", memberlist.StateAlive),
+	})
+	if calls != 2 {
+		t.Fatalf("join calls = %d, want unchanged when a live control-plane member is visible", calls)
+	}
+}
+
+func gossipTestNode(t *testing.T, nodeID, role, apiURL, internalURL string, state memberlist.NodeStateType) *memberlist.Node {
+	t.Helper()
+	encoded, err := json.Marshal(nodeMeta{
+		NodeID:      nodeID,
+		APIURL:      apiURL,
+		InternalURL: internalURL,
+		Role:        role,
+	})
+	if err != nil {
+		t.Fatalf("marshal node meta: %v", err)
+	}
+	return &memberlist.Node{Name: nodeID, State: state, Meta: encoded}
 }


### PR DESCRIPTION
## Summary
- periodically rejoin configured gossip bootstrap peers when no remote control-plane member is visible
- ignore the local node when deciding whether a control-plane member is available, so isolated server joiners recover too
- add regression coverage for ingress/worker partitions and server self-only partitions

## Root Cause
Cluster gossip only joined `SB_BOOTSTRAP_PEERS` once at startup. In the heterogeneous integration scenario, restarts during WASM module staging could leave ingress/worker nodes without any server-role control-plane members in their memberlist view. A server joiner could also incorrectly count itself as available and suppress rejoin.

## Validation
- `go test ./internal/cluster -run 'Test(HasLiveControlPlaneMemberRequiresUsableServer|MaybeRejoinBootstrapPeersOnlyWithoutControlPlane|GossipRefreshLoopExitsOnCancel|GossipMemberIndex)' -count=1 -timeout=30s`\n\nNote: the broader `go test ./internal/cluster` was not used as final validation because it previously hung locally.