### PR TITLE
fix(cluster): gossip bootstrap rejoin and gVisor runtime advertisement

### DIFF
--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -130,6 +130,10 @@ func TestSupportedRuntimesForConfig(t *testing.T) {
 		{name: "firecracker_enabled_advertises_fc", cfg: config.Config{EnableFirecracker: true}, want: []string{models.RuntimeDocker, models.RuntimeFirecracker}},
 		{name: "both_enabled", cfg: config.Config{EnableFirecracker: true, EnableWasm: true}, want: []string{models.RuntimeDocker, models.RuntimeFirecracker, models.RuntimeWasm}},
 		{name: "explicit_host_runtimes_override", cfg: config.Config{HostSupportedRuntimes: []string{models.RuntimeGvisor}, EnableWasm: true}, want: []string{models.RuntimeGvisor, models.RuntimeWasm}},
+		// What install.sh --with-gvisor writes (SB_HOST_RUNTIMES=docker,gvisor):
+		// gVisor has no enable flag, so the install script must advertise it
+		// explicitly or placement rejects every gVisor create in cluster mode.
+		{name: "gvisor_install_advertises_gvisor", cfg: config.Config{HostSupportedRuntimes: []string{models.RuntimeDocker, models.RuntimeGvisor}, EnableWasm: true}, want: []string{models.RuntimeDocker, models.RuntimeGvisor, models.RuntimeWasm}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -705,6 +705,17 @@ SB_L4_PORT_RANGE_END=23000
 SB_L4_TLS_LISTEN=$L4_TLS_LISTEN_DEFAULT
 SB_L4_TLS_FALLBACK=127.0.0.1:8443
 EOF
+	# gVisor has no SB_ENABLE_* flag of its own: registering runsc in
+	# /etc/docker/daemon.json lets a sandbox opt into runtime:"runsc", but
+	# the daemon still defaults SB_HOST_RUNTIMES to {"docker"} and only
+	# appends firecracker/wasm from their enable flags. In cluster mode that
+	# means a --with-gvisor node never advertises "gvisor" to placement, so
+	# every gVisor create is rejected with ErrNoPlacementTarget even though
+	# runsc is installed. Advertise it explicitly here so the host the runsc
+	# binary landed on also tells the cluster it can place gVisor sandboxes.
+	if [[ "$WITH_GVISOR" == "true" ]]; then
+		echo "SB_HOST_RUNTIMES=docker,gvisor" >> /etc/sandboxd/sandboxd.env
+	fi
 	chmod 0600 /etc/sandboxd/sandboxd.env
 }
 


### PR DESCRIPTION
## Summary

- **Gossip bootstrap rejoin:** On each member-index refresh tick, re-attempt `memberlist.Join` against configured bootstrap peers when no *other* live control-plane member (server role with a usable API/internal URL) is visible. Fixes workers (and isolated servers) that remain in a one-node gossip view after transient partition or seed loss without requiring a daemon restart.
- **gVisor install advertisement:** When `install.sh --with-gvisor` registers `runsc`, also write `SB_HOST_RUNTIMES=docker,gvisor` so cluster placement sees the host as a valid gVisor target (gVisor has no `SB_ENABLE_*` flag of its own).

## Sandbox boot impact

N/A - no work added to sandbox boot path.

## Idempotency

N/A - no API surface changed.

## Failure-path consistency

N/A - no multi-step write path changed.

## L4 / host-port-pool changes

N/A - neither touched.

## Cluster correctness

- Rejoin is gated on `hasLiveControlPlaneMember`: alive server role with non-empty API or internal URL, excluding self. Workers-only or dead/missing-endpoint views trigger rejoin; a healthy peer server suppresses it.
- Uses the existing `memberlist.Join` path (same as initial bootstrap); join failures are logged at warn and retried on the next refresh interval.
- Cluster mode remains a no-op when `cfg.EnableCluster` is false (`Noop` path unchanged).
- Single-node / non-cluster deployments are unaffected.

## Test plan

- [x] `go test ./internal/cluster/... -run 'TestHasLiveControlPlane|TestMaybeRejoin'`
- [x] `go test ./pkg/daemon/... -run TestSupportedRuntimesForConfig`
- [ ] Cluster integration: verify a worker rejoins gossip after seed transiently unavailable (hetero scenario)


Made with [Cursor](https://cursor.com)