### PR TITLE
fix(cluster): hetero scenario failures — gVisor advertise, FC chroot, SSH ingress, mount diagnostics

### DIFF
--- a/integration-tests/suite/harness/usecases.go
+++ b/integration-tests/suite/harness/usecases.go
@@ -194,6 +194,20 @@ var Registry = []UseCase{
 	{ID: "UC-84", Title: "Read-only volume mount rejects writes", Requires: []Capability{CapDocker, CapPlatformVolumes}, Implemented: true},
 	{ID: "UC-85", Title: "Platform volumes rejected on WASM runtime", Requires: []Capability{CapWasm, CapPlatformVolumes}, Implemented: true},
 	{ID: "UC-86", Title: "Platform volumes rejected on Firecracker runtime", Requires: []Capability{CapFirecracker, CapPlatformVolumes}, Implemented: true},
+	// Regression guards for the cluster-hetero fix pass (plans/cluster-hetero-failures-fix.md).
+	// UC-87 guards B1: a node that runs a specialized runtime must ADVERTISE it
+	// in gossip capacity, or placement rejects every create for that runtime
+	// ("no worker placement target available"). The bug was a --with-gvisor node
+	// advertising only [docker wasm].
+	{ID: "UC-87", Title: "Specialized runtimes are advertised in gossip capacity", Requires: []Capability{CapCluster}, Implemented: true},
+	// UC-88 guards B2: the firecracker cold-boot OCI path must build a rootfs
+	// into the per-sandbox jailer chroot. The bug was mkfs writing into a chroot
+	// dir that didn't exist yet ("No such file or directory ... filesystem size").
+	{ID: "UC-88", Title: "Firecracker cold-boots a sandbox from a plain OCI image", Requires: []Capability{CapFirecracker}, Implemented: true},
+	// UC-89 guards B4: the SSH gateway must listen on the ingress public host.
+	// The bug gated it on IsWorker() only, so the public :2220 (which DNS points
+	// at the ingress) refused every connection.
+	{ID: "UC-89", Title: "SSH gateway listens on the ingress public host", Requires: []Capability{CapCluster, CapDomain}, Implemented: true},
 }
 
 // byID is a lookup built once for the report generator.

--- a/integration-tests/suite/regression_fixes_test.go
+++ b/integration-tests/suite/regression_fixes_test.go
@@ -1,0 +1,191 @@
+//go:build integration
+
+package suite
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/integration-tests/suite/harness"
+	sdktypes "github.com/aerol-ai/microvm/sdk/go/pkg/types"
+)
+
+// This file holds the regression guards for the cluster-hetero fix pass
+// (plans/cluster-hetero-failures-fix.md). Each test pins a specific bug that the
+// full-suite UCs (UC-24/25/43) exercised only indirectly:
+//
+//   - UC-87 (B1): UC-25 proves a gVisor sandbox *runs*, but a create can succeed
+//     by luck of placement even while a node mis-advertises its runtimes. UC-87
+//     asserts the capability is actually published in gossip — the layer that
+//     was broken (a --with-gvisor node advertised only [docker wasm]).
+//   - UC-88 (B2): UC-24 creates with the default image, which may take the
+//     template fast-path. UC-88 forces the cold-boot OCI->ext4 path that mkfs'd
+//     into a not-yet-created jailer chroot.
+//   - UC-89 (B4): UC-43 retries SSH through route/placement lag and can mask a
+//     missing listener. UC-89 dials the raw TCP port on the ingress public host
+//     and asserts a gateway is actually listening there.
+
+// capacityView is the slice of /v1/cluster/members we need to assert on the
+// advertised runtime set. It intentionally re-decodes (rather than sharing
+// cluster_test.go's clusterMember) so the capacity shape lives next to the test
+// that depends on it.
+type capacityView struct {
+	Members []struct {
+		NodeID   string `json:"node_id"`
+		Role     string `json:"role"`
+		Capacity struct {
+			SupportedRuntimes []string `json:"supported_runtimes"`
+		} `json:"capacity"`
+	} `json:"members"`
+}
+
+// UC-87 — every specialized runtime the scenario advertises a capability for
+// must appear in at least one member's gossiped supported_runtimes. This is the
+// direct guard for B1: the daemon ran gVisor locally but never told the cluster,
+// so placement rejected every gVisor create with "no worker placement target
+// available". Generalized to firecracker/wasm so the same advertise-or-be-
+// invisible contract is enforced for each specialized runtime.
+func TestClusterAdvertisesSpecializedRuntimes(t *testing.T) {
+	harness.Require(t, sc, "UC-87")
+	c := client(t)
+
+	// Map the scenario's runtime capabilities to the runtime string each node
+	// must advertise. Docker is always present and not interesting here.
+	want := map[harness.Capability]string{
+		harness.CapGvisor:      "gvisor",
+		harness.CapFirecracker: "firecracker",
+		harness.CapWasm:        "wasm",
+	}
+	var expect []string
+	for cap, runtime := range want {
+		if sc.Has(cap) {
+			expect = append(expect, runtime)
+		}
+	}
+	if len(expect) == 0 {
+		t.Skip("scenario advertises no specialized runtime capability")
+	}
+
+	// Gossip capacity can lag node boot by a few heartbeats; poll until every
+	// expected runtime is advertised somewhere, or fail with what was missing.
+	deadline := time.Now().Add(90 * time.Second)
+	var missing []string
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		var cv capacityView
+		err := c.GetJSON(ctx, "/v1/cluster/members", &cv)
+		cancel()
+		if err != nil {
+			time.Sleep(3 * time.Second)
+			continue
+		}
+
+		advertised := map[string]string{} // runtime -> node that advertises it
+		for _, m := range cv.Members {
+			for _, rt := range m.Capacity.SupportedRuntimes {
+				if _, ok := advertised[rt]; !ok {
+					advertised[rt] = m.NodeID
+				}
+			}
+		}
+		missing = missing[:0]
+		for _, rt := range expect {
+			if _, ok := advertised[rt]; !ok {
+				missing = append(missing, rt)
+			}
+		}
+		if len(missing) == 0 {
+			for _, rt := range expect {
+				t.Logf("runtime %q advertised by node %s", rt, advertised[rt])
+			}
+			return
+		}
+		time.Sleep(3 * time.Second)
+	}
+	t.Fatalf("specialized runtimes never advertised in gossip capacity: %v (regression: a node runs the runtime but does not publish it, so placement rejects every create for it)", missing)
+}
+
+// UC-88 — create a firecracker sandbox from a plain OCI image (no template) and
+// exec inside it. This forces the cold-boot OCI->ext4 pipeline: skopeo + umoci +
+// `mkfs.ext4 -d <bundle> <runDir>/rootfs.ext4`. B2's bug was that <runDir> (the
+// jailer chroot root) did not exist when mkfs ran, so the build failed with
+// "mkfs.ext4: No such file or directory while trying to determine filesystem
+// size". A successful exec proves the rootfs was built into the chroot and the
+// VM booted.
+func TestFirecrackerColdBootFromImage(t *testing.T) {
+	harness.Require(t, sc, "UC-88")
+	c := client(t)
+
+	// DefaultImage is a small public image with no prebuilt firecracker
+	// template, so Create takes the OCI cold-boot path rather than a snapshot
+	// load. AEROL_FC_COLDBOOT_IMAGE can override it if the scenario stages a
+	// different no-template image.
+	image := os.Getenv("AEROL_FC_COLDBOOT_IMAGE")
+	if image == "" {
+		image = harness.DefaultImage
+	}
+	sb := c.NewSandbox(t, sdktypes.CreateSandboxOptions{
+		Name:    harness.UniqueName(sc, t),
+		Runtime: "firecracker",
+		Image:   image,
+	})
+	waitRunning(t, sb)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	res, err := sb.ExecCommand(ctx, "echo fc-coldboot-ok")
+	if err != nil {
+		t.Fatalf("exec in cold-booted firecracker sandbox: %v (regression: OCI rootfs build into the jailer chroot failed)", err)
+	}
+	if !strings.Contains(res.Stdout, "fc-coldboot-ok") {
+		t.Fatalf("exec stdout = %q, want fc-coldboot-ok", res.Stdout)
+	}
+}
+
+// UC-89 — the SSH gateway must be listening on the ingress public host. B4's bug
+// gated the gateway on IsWorker(), so a pure-ingress node (where the public
+// SB_SSH_LISTEN_ADDR and wildcard DNS resolve) bound nothing and every dial got
+// "connection refused". We dial the raw TCP port and read the SSH identification
+// banner ("SSH-2.0-...") — proving a gateway is up, independent of any sandbox
+// existing or of per-sandbox routing.
+func TestSSHGatewayListensOnPublicHost(t *testing.T) {
+	harness.Require(t, sc, "UC-89")
+
+	port := os.Getenv("AEROL_SSH_PORT")
+	if port == "" {
+		port = "2220" // matches SB_SSH_LISTEN_ADDR default
+	}
+	addr := net.JoinHostPort(sc.Domain, port)
+
+	// Retry to absorb the gateway-startup window after the cluster forms; the
+	// terminal state we assert is a real SSH banner, not a refused connection.
+	deadline := time.Now().Add(90 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 10*time.Second)
+		if err != nil {
+			lastErr = err
+			time.Sleep(3 * time.Second)
+			continue
+		}
+		_ = conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+		banner, err := bufio.NewReader(conn).ReadString('\n')
+		_ = conn.Close()
+		if err != nil {
+			lastErr = err
+			time.Sleep(3 * time.Second)
+			continue
+		}
+		if !strings.HasPrefix(banner, "SSH-") {
+			t.Fatalf("port %s on ingress answered but not with an SSH banner: %q", addr, strings.TrimSpace(banner))
+		}
+		t.Logf("ingress SSH gateway banner: %s", strings.TrimSpace(banner))
+		return
+	}
+	t.Fatalf("SSH gateway never reachable on ingress public host %s: %v (regression: gateway not bound on the ingress role)", addr, lastErr)
+}

--- a/internal/runtime/firecracker/create_rundir_test.go
+++ b/internal/runtime/firecracker/create_rundir_test.go
@@ -1,0 +1,60 @@
+package firecracker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// TestCreate_CreatesRunDirBeforeStaging is the regression guard for the
+// firecracker cold-boot mkfs failure (cluster-hetero UC-24):
+//
+//	oci: mkfs.ext4 -d <bundle> -F <runDir>/rootfs.ext4 ...:
+//	  mkfs.ext4: No such file or directory while trying to determine
+//	  filesystem size
+//
+// In jailer mode handle.RunDir() is the chroot root
+// (<chroot-base>/firecracker/<id>/root), which the jailer binary only
+// materializes when it execs firecracker — i.e. at Start, AFTER the driver
+// stages the rootfs into it. The driver must MkdirAll(handle.RunDir()) before
+// staging or the OCI build writes into a directory that doesn't exist.
+//
+// The default fixture spawner pre-creates the runDir, which would mask the
+// bug; this test overrides it with a jailer-shaped spawner that returns a
+// runDir it deliberately does NOT create, then asserts Create still succeeds
+// (the fakeRootfs writes its output into the runDir, so a missing dir fails
+// Build exactly like real mkfs).
+func TestCreate_CreatesRunDirBeforeStaging(t *testing.T) {
+	f := newDriverFixture(t)
+
+	chrootRoot := filepath.Join(t.TempDir(), "jailer", "firecracker", "sb-jailer", "root")
+	f.driver.SetSpawner(func(_ Config, sandboxID string) (VMMHandle, error) {
+		f.vmm.id = sandboxID
+		f.vmm.runDir = chrootRoot // intentionally not created — mimics the jailer chroot
+		f.vmm.apiSocket = filepath.Join(chrootRoot, "api.sock")
+		return f.vmm, nil
+	})
+
+	if _, err := os.Stat(chrootRoot); !os.IsNotExist(err) {
+		t.Fatalf("precondition: chrootRoot must not exist yet, stat err = %v", err)
+	}
+
+	if _, err := f.driver.Create(context.Background(), models.CreateSandboxRequest{
+		Image:    "alpine:3.20",
+		CPU:      1,
+		MemoryMB: 256,
+		DiskGB:   1,
+	}, "sb-jailer", "tok", nil); err != nil {
+		t.Fatalf("Create with non-existent runDir: %v (regression: driver must MkdirAll runDir before staging)", err)
+	}
+
+	if f.rootfs.builds != 1 {
+		t.Fatalf("rootfs builds = %d, want 1", f.rootfs.builds)
+	}
+	if _, err := os.Stat(chrootRoot); err != nil {
+		t.Fatalf("runDir not created by driver before staging: %v", err)
+	}
+}

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -512,9 +512,8 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 		return state, nil
 	}
 
-	// Step 2: spawn the VMM (creates the runDir we need before staging
-	// the rootfs). We spawn but do NOT yet Start — the rootfs must be
-	// in place inside the runDir before firecracker boots.
+	// Step 2: spawn the VMM. We spawn but do NOT yet Start — the rootfs must
+	// be in place inside the runDir before firecracker boots.
 	handle, err := d.spawn(d.cfg, allocID)
 	if err != nil {
 		return nil, fmt.Errorf("firecracker runtime: spawn handle: %w", err)
@@ -534,6 +533,20 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 			cleanupVMM()
 		}
 	}()
+
+	// Ensure the runDir exists before staging. In jailer mode handle.RunDir()
+	// is the chroot root (<chroot-base>/firecracker/<id>/root) which the jailer
+	// binary only materializes when it execs firecracker — i.e. at Start, AFTER
+	// we stage the rootfs into it here. Without this MkdirAll, the cold-boot OCI
+	// path's `mkfs.ext4 -d <bundle> <runDir>/rootfs.ext4` fails with "No such
+	// file or directory while trying to determine filesystem size" because its
+	// output directory doesn't exist yet. Pre-creating the chroot root as the
+	// daemon UID is safe: the jailer populates and re-owns the chroot contents
+	// at Start. Idempotent — a no-op on the direct-mode path where the spawner
+	// already created <RunDir>/<id>.
+	if err := os.MkdirAll(handle.RunDir(), 0o755); err != nil {
+		return nil, fmt.Errorf("firecracker runtime: create runDir %s: %w", handle.RunDir(), err)
+	}
 
 	// Step 3: provision the rootfs.ext4 inside the runDir.
 	//

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -680,7 +680,7 @@ func Run(ctx context.Context, logger *slog.Logger, makeProvider ProviderFactory)
 		}
 	}
 
-	if cfg.EnableSSHGateway && cfg.IsWorker() {
+	if shouldStartSSHGateway(cfg) {
 		sshCfg := sshgateway.Config{
 			ListenAddr:  cfg.SSHListenAddr,
 			HostKeyPath: cfg.SSHHostKeyPath,
@@ -1394,10 +1394,38 @@ func readBypassMarker(path string) bool {
 // unset we default to docker and then advertise each runtime the host actually
 // has enabled. Firecracker and WASM each gate on their own enable flag so a
 // host that wired the driver also tells the cluster it can place that runtime.
+//
+// gVisor is the exception: it has no SB_ENABLE_* flag (it rides on the docker
+// driver + a runsc OCI runtime registered in daemon.json). Its capability is
+// only advertised via SB_HOST_RUNTIMES — which install.sh --with-gvisor now
+// writes. But a node configured with SB_RUNTIME=gvisor as its *default* runtime
+// can clearly run gVisor too, so infer the advertisement from cfg.Runtime as
+// well. Without this, such a node runs gVisor locally yet is invisible to
+// cluster placement and every gVisor create is rejected with
+// ErrNoPlacementTarget (the same class of bug the firecracker/wasm flags fixed).
+// shouldStartSSHGateway decides whether this node binds the per-sandbox SSH
+// gateway. Workers run it because they own sandboxes locally. The ingress runs
+// it too: the public SSH endpoint (SB_SSH_LISTEN_ADDR, default :2220) and the
+// wildcard DNS both point at the ingress, so without a gateway there every
+// `ssh sandbox.<domain>` lands on a closed port (cluster-hetero UC-43/67:
+// "connection refused"). An ingress-hosted gateway bridges to the owning node
+// via Config.RemoteAPIBaseURL exactly like the worker path, so a connection for
+// a sandbox the ingress doesn't own is forwarded, not dropped.
+//
+// Multi-ingress note: every ingress that binds the gateway must present the
+// same SSH host key (SB_SSH_HOST_KEY_PATH material shared across ingress nodes)
+// or clients see host-key churn as they round-robin between ingress IPs.
+func shouldStartSSHGateway(cfg config.Config) bool {
+	return cfg.EnableSSHGateway && (cfg.IsWorker() || cfg.IsIngress())
+}
+
 func supportedRuntimesForConfig(cfg config.Config) []string {
 	runtimes := cfg.HostSupportedRuntimes
 	if len(runtimes) == 0 {
 		runtimes = []string{models.RuntimeDocker}
+	}
+	if cfg.Runtime == models.RuntimeGvisor {
+		runtimes = appendRuntimeIfMissing(runtimes, models.RuntimeGvisor)
 	}
 	if cfg.EnableFirecracker {
 		runtimes = appendRuntimeIfMissing(runtimes, models.RuntimeFirecracker)

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -10,6 +10,36 @@ import (
 	"github.com/aerol-ai/microvm/pkg/models"
 )
 
+// TestShouldStartSSHGateway is the regression guard for cluster-hetero
+// UC-43/67: the SSH gateway was gated on IsWorker() only, so the ingress —
+// which is where the public :2220 endpoint and wildcard DNS resolve — never
+// bound a gateway and every `ssh sandbox.<domain>` got "connection refused".
+// The gateway must run on workers AND ingress (and on mixed nodes, which are
+// both), but not on a pure server.
+func TestShouldStartSSHGateway(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  config.Config
+		want bool
+	}{
+		{name: "worker_starts", cfg: config.Config{EnableSSHGateway: true, NodeRole: config.NodeRoleWorker}, want: true},
+		{name: "ingress_starts", cfg: config.Config{EnableSSHGateway: true, NodeRole: config.NodeRoleIngress}, want: true},
+		{name: "server_does_not_start", cfg: config.Config{EnableSSHGateway: true, NodeRole: config.NodeRoleServer}, want: false},
+		{name: "mixed_starts", cfg: config.Config{EnableSSHGateway: true, NodeRole: config.NodeRoleMixed}, want: true},
+		{name: "empty_role_is_mixed_starts", cfg: config.Config{EnableSSHGateway: true}, want: true},
+		{name: "worker_ingress_hybrid_starts", cfg: config.Config{EnableSSHGateway: true, NodeRole: "worker,ingress"}, want: true},
+		{name: "disabled_never_starts", cfg: config.Config{EnableSSHGateway: false, NodeRole: config.NodeRoleWorker}, want: false},
+		{name: "disabled_ingress_never_starts", cfg: config.Config{EnableSSHGateway: false, NodeRole: config.NodeRoleIngress}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldStartSSHGateway(tt.cfg); got != tt.want {
+				t.Fatalf("shouldStartSSHGateway(%+v) = %v, want %v", tt.cfg, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestReadBypassMarkerMissingReadsFalse: first boot has no marker file
 // — the safer default is "previous run had bypass off", so no rollback
 // force-reconcile fires.
@@ -134,6 +164,14 @@ func TestSupportedRuntimesForConfig(t *testing.T) {
 		// gVisor has no enable flag, so the install script must advertise it
 		// explicitly or placement rejects every gVisor create in cluster mode.
 		{name: "gvisor_install_advertises_gvisor", cfg: config.Config{HostSupportedRuntimes: []string{models.RuntimeDocker, models.RuntimeGvisor}, EnableWasm: true}, want: []string{models.RuntimeDocker, models.RuntimeGvisor, models.RuntimeWasm}},
+		// gVisor has no enable flag, so a node whose default runtime is gvisor
+		// (SB_RUNTIME=gvisor) but which never set SB_HOST_RUNTIMES must still
+		// advertise gvisor or cluster placement rejects every gVisor create.
+		{name: "default_runtime_gvisor_advertises_gvisor", cfg: config.Config{Runtime: models.RuntimeGvisor}, want: []string{models.RuntimeDocker, models.RuntimeGvisor}},
+		{name: "default_runtime_gvisor_with_wasm", cfg: config.Config{Runtime: models.RuntimeGvisor, EnableWasm: true}, want: []string{models.RuntimeDocker, models.RuntimeGvisor, models.RuntimeWasm}},
+		// Idempotent: explicit SB_HOST_RUNTIMES already containing gvisor must
+		// not double-append when cfg.Runtime is also gvisor.
+		{name: "default_runtime_gvisor_no_dup", cfg: config.Config{Runtime: models.RuntimeGvisor, HostSupportedRuntimes: []string{models.RuntimeDocker, models.RuntimeGvisor}}, want: []string{models.RuntimeDocker, models.RuntimeGvisor}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/mounts/manager.go
+++ b/pkg/mounts/manager.go
@@ -50,6 +50,7 @@ type mountState struct {
 	hostPath   string
 	plan       adapters.Plan
 	cmd        *exec.Cmd
+	output     *capturedOutput // captured stdout+stderr of the FUSE mount tool
 	startedAt  time.Time
 	restarts   int
 	lastCrash  time.Time
@@ -292,22 +293,21 @@ func (m *Manager) mountOne(ctx context.Context, sandboxID string, index int, spe
 		return state, bind, nil
 	}
 
-	// User-space FUSE: spawn and supervise.
-	cmd := exec.Command(plan.Argv[0], plan.Argv[1:]...)
-	if len(plan.Env) > 0 {
-		cmd.Env = append(os.Environ(), plan.Env...)
-	}
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	if err := cmd.Start(); err != nil {
+	// User-space FUSE: spawn and supervise. stdout+stderr are captured so a
+	// mount that never becomes ready surfaces the tool's own error instead of a
+	// bare "timed out waiting for mount" (cluster-hetero UC-81..84).
+	cmd, out, err := spawnMountProcess(plan)
+	if err != nil {
 		m.cleanupCred(plan)
 		return nil, ContainerBind{}, fmt.Errorf("spawn mount tool: %w", err)
 	}
 	state.cmd = cmd
+	state.output = out
 
 	if err := waitForMountProbe(hostPath, m.waitTimeout); err != nil {
 		_ = killMount(cmd)
 		m.cleanupCred(plan)
-		return nil, ContainerBind{}, err
+		return nil, ContainerBind{}, mountWaitError(err, out)
 	}
 
 	if plan.UnlinkCred && plan.CredFile != "" {
@@ -358,6 +358,7 @@ func (m *Manager) superviseExit(state *mountState) {
 		"index", state.index,
 		"type", string(state.spec.Type),
 		"error", err,
+		"output", state.output.String(),
 		"restarts", state.restarts,
 		"within_30s", withinWindow,
 	)
@@ -373,17 +374,14 @@ func (m *Manager) superviseExit(state *mountState) {
 	if state.plan.CredFile != "" {
 		_ = writeCredFile(state.plan.CredFile, state.plan.CredBody)
 	}
-	cmd := exec.Command(state.plan.Argv[0], state.plan.Argv[1:]...)
-	if len(state.plan.Env) > 0 {
-		cmd.Env = append(os.Environ(), state.plan.Env...)
-	}
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	if err := cmd.Start(); err != nil {
+	cmd, out, err := spawnMountProcess(state.plan)
+	if err != nil {
 		state.disabled = true
 		m.logger.Warn("mount restart spawn failed", "sandbox_id", state.sandboxID, "index", state.index, "error", err)
 		return
 	}
 	state.cmd = cmd
+	state.output = out
 
 	go m.superviseExit(state)
 }

--- a/pkg/mounts/process.go
+++ b/pkg/mounts/process.go
@@ -1,0 +1,89 @@
+package mounts
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/aerol-ai/microvm/pkg/mounts/adapters"
+)
+
+// maxCapturedMountBytes caps how much mount-tool output we retain per process.
+// Mount tools (mount-s3, rclone, sshfs) print the actionable failure line just
+// before they exit, so we keep the TAIL: a 4 KiB window is plenty for a stack
+// of credential/region/endpoint errors without letting a chatty --debug run
+// balloon memory across many sandboxes.
+const maxCapturedMountBytes = 4 << 10
+
+// capturedOutput is a threadsafe io.Writer that retains the last
+// maxCapturedMountBytes bytes written to it. It backs cmd.Stdout/cmd.Stderr for
+// supervised FUSE mount processes so a mount that never becomes ready (bad
+// creds, wrong region, unreachable endpoint) is diagnosable. Before this, the
+// FUSE process's stderr was discarded entirely and the only signal was a bare
+// "timed out waiting for mount" (cluster-hetero UC-81..84).
+type capturedOutput struct {
+	mu  sync.Mutex
+	buf []byte
+}
+
+func (c *capturedOutput) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.buf = append(c.buf, p...)
+	if len(c.buf) > maxCapturedMountBytes {
+		// Keep the tail; drop the oldest bytes.
+		c.buf = c.buf[len(c.buf)-maxCapturedMountBytes:]
+	}
+	return len(p), nil
+}
+
+// String returns the captured output with surrounding whitespace trimmed. Safe
+// on a nil receiver so callers don't have to nil-check before logging.
+func (c *capturedOutput) String() string {
+	if c == nil {
+		return ""
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return strings.TrimSpace(string(c.buf))
+}
+
+// spawnMountProcess starts a supervised FUSE mount tool with its stdout and
+// stderr teed into a capped buffer. Shared by the initial mount (mountOne) and
+// the supervisor's restart path so both surface the tool's output identically.
+// SysProcAttr.Setpgid keeps the process in its own group; killMount signals the
+// whole group so FUSE helper children die with it.
+func spawnMountProcess(plan adapters.Plan) (*exec.Cmd, *capturedOutput, error) {
+	cmd := exec.Command(plan.Argv[0], plan.Argv[1:]...)
+	if len(plan.Env) > 0 {
+		cmd.Env = append(os.Environ(), plan.Env...)
+	}
+	out := &capturedOutput{}
+	cmd.Stdout = out
+	cmd.Stderr = out
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		return nil, nil, err
+	}
+	return cmd, out, nil
+}
+
+// mountWaitError wraps the readiness-probe error with the captured mount-tool
+// output so a mount that never became ready is actionable instead of a bare
+// timeout. The original probe error is wrapped with %w so callers/tests
+// matching on "timed out waiting for mount" still match.
+//
+// We deliberately do NOT report whether the process is still alive: on the
+// failure path nobody has reaped it, so an exited tool lingers as a zombie that
+// a signal-0 probe still reports as "running". The captured stderr is the
+// reliable signal — a tool that failed fast prints its reason here; a genuinely
+// hung tool leaves this empty.
+func mountWaitError(probeErr error, out *capturedOutput) error {
+	if tail := out.String(); tail != "" {
+		return fmt.Errorf("%w (mount tool output: %s)", probeErr, tail)
+	}
+	return fmt.Errorf("%w (mount tool produced no output before timeout)", probeErr)
+}

--- a/pkg/mounts/process_test.go
+++ b/pkg/mounts/process_test.go
@@ -1,0 +1,52 @@
+package mounts
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+	"github.com/aerol-ai/microvm/pkg/mounts/adapters"
+)
+
+// shFailAdapter mimics a FUSE mount tool (mount-s3, rclone) that prints a
+// diagnostic to stderr and exits non-zero — the real-world "bad creds / wrong
+// region / unreachable endpoint" case. The mount never becomes ready, so the
+// readiness probe times out.
+type shFailAdapter struct{}
+
+func (shFailAdapter) Build(_ string, _ int, _ models.MountSpec, _, _ string) (adapters.Plan, error) {
+	return adapters.Plan{
+		Argv:          []string{"sh", "-c", "echo 'mount-s3 fatal: bucket unreachable' >&2; exit 2"},
+		IsKernelMount: false,
+	}, nil
+}
+
+// TestMountWaitErrorSurfacesToolOutput is the regression guard for
+// cluster-hetero UC-81..84: a failing S3 mount produced only a bare "timed out
+// waiting for mount" because the FUSE process's stderr was discarded. The
+// mount-tool output and process-liveness hint must now appear in the error so
+// the failure is diagnosable.
+func TestMountWaitErrorSurfacesToolOutput(t *testing.T) {
+	m := newTestManager(t, map[models.MountType]adapters.Adapter{
+		models.MountTypeS3: shFailAdapter{},
+	})
+
+	_, err := m.MountAll(context.Background(), "sb-s3-fail", []models.MountSpec{
+		{Type: models.MountTypeS3, Source: "s3://bucket", Target: "/data"},
+	})
+	if err == nil {
+		t.Fatal("expected MountAll to fail")
+	}
+	msg := err.Error()
+	// Backward-compatible: the original timeout phrasing is still present so the
+	// integration assertion ("timed out waiting for mount") keeps matching.
+	if !strings.Contains(msg, "timed out waiting for mount") {
+		t.Errorf("error missing timeout phrase: %q", msg)
+	}
+	// New diagnostic: the tool's captured stderr line is surfaced so the
+	// failure reason (bad bucket/creds/region) is visible instead of discarded.
+	if !strings.Contains(msg, "mount-s3 fatal: bucket unreachable") {
+		t.Errorf("error missing captured tool output: %q", msg)
+	}
+}

--- a/plans/cluster-hetero-failures-fix.md
+++ b/plans/cluster-hetero-failures-fix.md
@@ -429,6 +429,24 @@ Synthesized from this review. P1 blocks the scenario; P2 same-branch; P3 follow-
 - [ ] **T7 (P3 ticket)** — design — Decide B3 template routing (product catalogue vs test-only)
 - [ ] **T8 (P3 ticket)** — test — B8 triage WASM scheduling-vs-resolution before changing fixtures
 
+## 9b. New integration regression guards (added 2026-06-23)
+
+Behind the `integration` build tag in `integration-tests/suite/regression_fixes_test.go`,
+registered in `harness/usecases.go`. These pin the fixes more tightly than the
+broad full-suite UCs they sit beside:
+
+| UC | Guards | Asserts |
+|----|--------|---------|
+| UC-87 | B1 | every specialized runtime the scenario has a capability for (gvisor/firecracker/wasm) appears in some member's gossiped `capacity.supported_runtimes` — the layer that was broken, vs UC-25 which only checks a gVisor create happens to succeed |
+| UC-88 | B2 | a firecracker sandbox cold-boots from a plain OCI image (no template) and execs — forces the `mkfs.ext4` → jailer-chroot path UC-24 may skip via the template fast-path |
+| UC-89 | B4 | a raw TCP dial to the ingress public host `:2220` returns an `SSH-…` banner — proves a gateway is bound on the ingress, independent of sandbox routing/retry that UC-43 hides behind |
+
+Run on a live cluster via the existing `make integration-cluster-hetero` path; they
+SKIP where the scenario lacks the capability (e.g. UC-88 on a non-firecracker
+scenario). B6's error-surfacing is covered offline by `pkg/mounts/process_test.go`;
+a live negative volume test is deferred until the mount-s3 stderr from a real run
+confirms the failure shape.
+
 ## 10. Landing order
 
 1. **B1 daemon harden** (T1) — install.sh already shipped + verified.

--- a/plans/cluster-hetero-failures-fix.md
+++ b/plans/cluster-hetero-failures-fix.md
@@ -223,12 +223,32 @@ partly downstream. exec/stream **does** upgrade (status 101) when owned locally.
 working case was local-owner; the failing case was cross-node forwarded. The
 drop point is **not located**.
 
-**Investigate (step 1, no fix yet):** reproduce by forcing a sessions/attach to a
-non-owner node; capture where the upgrade drops. Codex's steer: the likely cause
-is the **two-hop** sessions/toolbox path, request-context lifetime, or session
-close semantics — *not* generic `httputil.ReverseProxy` upgrade stripping (the
-repo already relies on ReverseProxy for upgrades). A `forward.go` unit test can
-pass while UC-45 still fails.
+**Investigation done (code-level, 2026-06-23) — two mechanical causes RULED OUT:**
+
+1. **Not HTTP/2-vs-websocket.** The cluster-internal mTLS channel is HTTP/1.1 on
+   both ends: `clientConfig()` / `serverConfig()` (`internal/cluster/tls.go:74,88`)
+   set no `NextProtos`, and the mtls proxy transport (`client.go:204`) has a
+   non-nil `TLSClientConfig` without `ForceAttemptHTTP2`, so Go does not
+   auto-enable h2. HTTP/1.1 supports the 101 upgrade + hijack a websocket needs.
+2. **Not a server write-timeout cutting the stream.** The owner's internal mTLS
+   server (`internal_server.go:105`) sets only `ReadHeaderTimeout: 10s` — no
+   `WriteTimeout` / `IdleTimeout` to kill a long-lived hijacked conn.
+
+The forward proxy (`forward.go:47`) is a standard upgrade-capable `ReverseProxy`,
+and the toolbox hop is the *same* `ServeToolboxReverseProxy` code that exec/stream
+(UC-44) upgrades through fine when local. So the delta is purely the **cross-node
+forward hop**, and the remaining suspect is the double-proxy 101 interaction:
+the ingress `ReverseProxy` must surface the owner's switched-protocol conn while
+the owner's internal server simultaneously hijacks for its own toolbox upgrade
+(ReverseProxy-over-ReverseProxy for a 101). This needs a live/integration
+reproduction to pin — not fixable blind.
+
+**Reproduction recipe (next step):** a two-node integration test (or the live
+cluster) that creates a session on node B, then dials
+`wss://<nodeA>/v1/sandboxes/<id>/sessions/<sid>/attach` so the request is
+forwarded A→B. Capture on both nodes whether the 101 is emitted by the toolbox,
+reaches node B's internal server, and survives the mTLS hop back to A. Codex's
+steer stands: it's the two-hop/close semantics, not generic proxy stripping.
 
 **Test requirement once located:** an **end-to-end v1 route test** through
 `clusterForwardWrap → sessionsProxy → ServeToolboxReverseProxy`, not just a
@@ -251,17 +271,30 @@ NOT rclone — `pkg/mounts/adapters/s3.go:29` shells out to `mount-s3`. (rclone 
 installed for a *different* mount type.) The earlier plan's "capture rclone
 stderr" was wrong and would not explain these failures.
 
-**Investigate (step 1, instrument):**
-1. Capture `mount-s3` stderr on failure in `pkg/mounts/adapters/s3.go` /
-   `pkg/mounts/manager.go` and surface it in the returned error (today it's
-   swallowed behind a bare "timed out waiting for mount").
-2. Audit the mount-process race: `mountOne` starts the FUSE process without
-   stderr capture, and timeout cleanup can race the supervisor's `cmd.Wait`
-   (`pkg/mounts/manager.go:266`). Fix diagnostics around process ownership first.
+**Instrumentation DONE (2026-06-23):**
+1. ✅ Capture `mount-s3` stdout+stderr into a capped buffer and surface the tail
+   in the returned error — `pkg/mounts/process.go` (new: `capturedOutput`,
+   `spawnMountProcess`, `mountWaitError`), wired into `mountOne` and the
+   supervisor restart in `pkg/mounts/manager.go`. The error keeps the
+   backward-compatible "timed out waiting for mount" phrase and now appends
+   `(mount tool output: …)`. Test: `pkg/mounts/process_test.go`.
+   - Liveness hint (alive-vs-exited) was prototyped then **dropped**: on the
+     failure path nobody reaps the process, so an exited tool lingers as a
+     zombie that a signal-0 probe still reports as "running". The captured
+     stderr is the reliable signal; a misleading hint is worse than none.
+
+**Still investigate-first (needs the captured stderr from a live run):**
+2. The fast-fail gap: a mount tool that exits immediately still burns the full
+   `SB_MOUNT_WAIT_TIMEOUT` because `waitForMountProbe` only polls the mountpoint.
+   Racing the probe against process exit needs a single-owner `cmd.Wait`
+   refactor (the supervisor also calls `cmd.Wait`), so it's deferred until the
+   stderr proves the actual failure is fast-exit vs. hang.
 3. Cross-node volume metadata: the lookup's role matters — worker/agent reads go
    through the agent control-plane endpoint; voters read local FSM. Identify
    **which role timed out** before changing any timeout/retry; the "longer
-   timeout" idea is a guess until then.
+   timeout" idea is a guess until then. (Server-side `/internal/volume` answered
+   in microseconds in the captured logs, so the bare-timeout was the mount, not
+   this lookup — but confirm with the new stderr.)
 
 **Files (TBD after instrument):** `pkg/mounts/adapters/s3.go`,
 `pkg/mounts/manager.go`, the volume-lookup client; tests in `pkg/mounts`.
@@ -381,14 +414,15 @@ Synthesized from this review. P1 blocks the scenario; P2 same-branch; P3 follow-
   - Surfaced by: Architecture review — public :2220 → ingress has no gateway (daemon.go:683)
   - Files: `pkg/daemon/daemon.go`, `pkg/daemon/daemon_test.go`; host-key call-out in code comment
   - Verify: `TestShouldStartSSHGateway` ✅ pass; integration UC-43/67 (live)
-- [ ] **T4 (P2, human: ~2h / CC: ~30min)** — pkg/mounts — Capture mount-s3 stderr + audit timeout/cmd.Wait race
-  - Surfaced by: Performance/Code review + Codex — stderr swallowed, race at manager.go:266; tool is mount-s3 not rclone (s3.go:29)
-  - Files: `pkg/mounts/adapters/s3.go`, `pkg/mounts/manager.go`
-  - Verify: forced-failure test surfaces stderr; then re-triage UC-81..84
-- [ ] **T5 (P2, human: ~2h / CC: ~30min)** — pkg/api/v1 — Reproduce + locate session-attach forward drop; add end-to-end route test
+- [x] **T4 (P2)** — pkg/mounts — Capture mount-s3 stdout+stderr, surface in error ✅ INSTRUMENT DONE
+  - Surfaced by: Performance/Code review + Codex — stderr swallowed; tool is mount-s3 not rclone (s3.go:29)
+  - Files: `pkg/mounts/process.go` (new), `pkg/mounts/manager.go`, `pkg/mounts/process_test.go` (new)
+  - Verify: `TestMountWaitErrorSurfacesToolOutput` ✅ pass. Fast-fail refactor + cross-node lookup still deferred to live re-triage.
+- [~] **T5 (P2)** — pkg/api/v1 — Locate session-attach forward drop 🔎 INVESTIGATED, not fixed
   - Surfaced by: Test review + Codex — root cause not located; forward unit test passes vacuously
-  - Files: TBD (`pkg/api/v1`, maybe `internal/cluster/forward.go`)
-  - Verify: e2e route test through clusterForwardWrap→sessionsProxy; integration UC-45
+  - Findings: ruled out h2 (both ends HTTP/1.1) and server write-timeout; narrowed to the double-proxy 101 interaction on the cross-node hop. Needs a 2-node reproduction.
+  - Files: TBD (`internal/cluster/forward.go` / internal server / `pkg/api/v1`)
+  - Verify: two-node integration test dialing a forwarded `/sessions/<id>/attach`; integration UC-45
 - [ ] **T6 (P3, human: — / CC: —)** — verify — Re-run UC-74 after B1; if still failing, fix both create-placement paths
   - Surfaced by: Codex — `cluster_handler.go` vs `clustercreate/` divergence
   - Files: `pkg/api/v1/cluster_handler.go`, `pkg/api/clustercreate/clustercreate.go`

--- a/plans/cluster-hetero-failures-fix.md
+++ b/plans/cluster-hetero-failures-fix.md
@@ -1,0 +1,425 @@
+# Plan — Fix `cluster-hetero` integration failures
+
+Status: reviewed (plan-eng-review + Codex outside voice) · Author: investigation
+from live `make integration-cluster-hetero keep` run (2026-06-22) · Scenario
+report: `integration-tests/reports/cluster-hetero.md` (pass 60 · fail 17 · skip 9).
+
+This plan fixes the failing use cases in the `cluster-hetero` scenario. After
+review it is partitioned into three lanes:
+
+- **Fix-now** (located root cause, writable test): **B1** (done + daemon harden),
+  **B2** (firecracker driver), **B4** (SSH gateway gate).
+- **Investigate-first** (reproduce → locate → test → fix): **B5** (session-attach
+  forward), **B6** (S3 volume mount).
+- **Tickets** (separate work, not this plan's PRs): **B3** (template routing —
+  blocked on a design decision), **B8** (WASM test-data triage). **B7** folds
+  into B1 verification.
+
+Cluster under test: 1 ingress, 3 Raft servers, 4 role-specialized workers
+(`worker-docker`, `worker-fc`, `worker-gvisor`, `worker-wasm`).
+
+```
+                          fix-now            investigate-first        tickets
+  B1 gvisor advertise  ──► install.sh ✅
+                          daemon harden ►
+  B2 fc mkfs           ──► driver MkdirAll ►
+  B4 ssh gateway       ──► gate relax ►
+  B5 session attach    ─────────────────────► reproduce → fix
+  B6 s3 mount          ─────────────────────► instrument(mount-s3) → fix
+  B3 template routing  ────────────────────────────────────────────► decide first
+  B7 createWithImage   ──► verify after B1 (folds in)
+  B8 wasm ref          ────────────────────────────────────────────► triage fixtures
+```
+
+---
+
+## 1. Use-case / bug inventory (≥40)
+
+Legend — **Class**: `BUG` product/code · `INFRA` install/bootstrap · `TEST`
+harness/data · `REGRESS` must-not-break. **Lane**: `FIX` fix-now · `INV`
+investigate-first · `TKT` ticket.
+
+| # | UC | Behavior | Class | Bug | Lane | Current |
+|---|----|----------|-------|-----|------|---------|
+| 1 | UC-25 | gVisor sandbox runs in cluster | INFRA | B1 | FIX | ❌ no placement target |
+| 2 | UC-74 | CreateWithImage lands on a worker | BUG | B1/B7 | FIX | ❌ no placement target |
+| 3 | — | gVisor node advertises `gvisor` in gossip | INFRA | B1 | FIX | ❌ `[docker wasm]` |
+| 4 | — | gVisor create routes to gVisor worker | BUG | B1 | FIX | ❌ filtered by placement |
+| 5 | — | `--with-gvisor` install self-sufficient | INFRA | B1 | FIX | ❌ needs manual env |
+| 6 | — | Node with `SB_RUNTIME=gvisor` advertises it | BUG | B1 | FIX | ❌ daemon ignores cfg.Runtime |
+| 7 | UC-24 | Firecracker sandbox runs (cold boot) | BUG | B2 | FIX | ❌ `mkfs.ext4: No such file or directory` |
+| 8 | — | OCI→ext4 build has an existing output dir | BUG | B2 | FIX | ❌ jailer chroot not yet created |
+| 9 | — | Firecracker overlay path has its dir | BUG | B2 | FIX | ❌ same RunDir, same gap |
+| 10 | UC-80 | FC template clones distinct RNG | TEST | B2/B3 | TKT | ❌ needs FC build + routing |
+| 11 | UC-47 | Create template | BUG | B3 | TKT | ❌ requires FC on serving node |
+| 12 | UC-48 | List + get template | BUG | B3 | TKT | ❌ same |
+| 13 | UC-49 | Rebuild template | BUG | B3 | TKT | ❌ same |
+| 14 | UC-50 | Delete template | BUG | B3 | TKT | ❌ same |
+| 15 | — | Template ops route to FC-capable node | BUG | B3 | TKT | ❌ node-local only |
+| 16 | — | GET/LIST/DELETE/rebuild after routed create | BUG | B3 | TKT | ❌ per-host design |
+| 17 | — | Later sandbox lands on template-bearing node | BUG | B3 | TKT | ⚠️ template-aware placement (placement.go:220) |
+| 18 | UC-43 | SSH per-sandbox key over `:2220` | BUG | B4 | FIX | ❌ connection refused |
+| 19 | UC-67 | Cross-node SSH rejects forged key | BUG | B4 | FIX | ❌ no gateway listening |
+| 20 | — | SSH gateway reachable via ingress | BUG | B4 | FIX | ❌ gateway worker-only |
+| 21 | — | Ingress-hosted gateway bridges to owner | BUG | B4 | FIX | ❌ not wired |
+| 22 | — | Multi-ingress shares SSH host key | INFRA | B4 | FIX | ⚠️ host-key churn risk |
+| 23 | UC-45 | Sessions attach websocket streams | BUG | B5 | INV | ❌ unexpected EOF |
+| 24 | UC-44 | Exec on every available runtime | BUG | B5/B1/B2 | INV | ❌ no output |
+| 25 | — | Session attach forwards to non-owner node | BUG | B5 | INV | ❌ EOF on forwarded hop |
+| 26 | — | Exec/stream websocket forward (local owner) | REGRESS | B5 | INV | ✅ works (status 101) |
+| 27 | UC-81 | Attach volume; write + read-back | BUG | B6 | INV | ❌ s3 mount timeout |
+| 28 | UC-82 | Volume persists across destroy | BUG | B6 | INV | ❌ s3 mount timeout |
+| 29 | UC-83 | Two sandboxes share one volume | BUG | B6 | INV | ❌ s3 mount timeout |
+| 30 | UC-84 | Read-only volume rejects writes | BUG | B6 | INV | ❌ s3 mount timeout |
+| 31 | — | mount-s3 process completes within timeout | BUG | B6 | INV | ❌ never ready |
+| 32 | — | mount-s3 stderr captured on failure | BUG | B6 | INV | ❌ swallowed |
+| 33 | — | Mount timeout cleanup vs cmd.Wait race | BUG | B6 | INV | ⚠️ manager.go:266 |
+| 34 | — | Cross-node volume metadata lookup reliable | BUG | B6 | INV | ⚠️ `context deadline exceeded` |
+| 35 | UC-26 | WASM sandbox from registered module | TEST | B8 | TKT | ❌ snapshot ref not found |
+| 36 | — | Identify scheduling-vs-resolution failure | TEST | B8 | TKT | ❓ unknown which hop |
+| 37 | UC-85 | Volumes rejected on WASM | REGRESS | B6 | — | ✅ keep |
+| 38 | UC-86 | Volumes rejected on Firecracker | REGRESS | B6 | — | ✅ keep |
+| 39 | UC-53 | New sandbox gets a placement | REGRESS | B1 | — | ✅ keep |
+| 40 | UC-54 | Non-owner request forwards to owner | REGRESS | B5 | — | ✅ keep |
+| 41 | UC-55 | Sandbox index consistent across nodes | REGRESS | B7 | — | ✅ keep |
+| 42 | UC-11/23 | Docker sandbox runs | REGRESS | B1 | — | ✅ keep (advertise change) |
+| 43 | UC-61 | `/v1/capacity` reports host capacity | REGRESS | B1 | — | ✅ keep |
+| 44 | UC-28 | GPU + gVisor rejected (negative) | REGRESS | B1 | — | ✅ keep |
+
+---
+
+## 2. Fix-now lane
+
+### B1 — gVisor never advertised to placement  ✅ install.sh done · daemon harden pending
+
+**Symptom:** UC-25 / UC-74 fail `cluster: no worker placement target available`.
+`worker-gvisor` advertised `["docker","wasm"]` — no `gvisor`.
+
+**Root cause:** gVisor has no `SB_ENABLE_*` flag.
+`supportedRuntimesForConfig` (`pkg/daemon/daemon.go:1397`) builds the advertised
+list from `SB_HOST_RUNTIMES` (default `["docker"]`) plus firecracker/wasm enable
+flags — it consults neither gVisor nor `cfg.Runtime`. `install.sh --with-gvisor`
+installs `runsc` + registers it in docker but never writes `SB_HOST_RUNTIMES`.
+
+**Fix (two parts):**
+
+1. **install.sh (done, verified live):** `write_environment()` appends
+   `SB_HOST_RUNTIMES=docker,gvisor` when `WITH_GVISOR == "true"`.
+2. **Daemon harden (pending — review decision):** in `supportedRuntimesForConfig`,
+   advertise gvisor when `cfg.Runtime == models.RuntimeGvisor`, so any deploy
+   path (hand-set `SB_RUNTIME`, pre-installed runsc) advertises correctly — not
+   just `--with-gvisor`. Keeps the flag-driven pattern for wasm/firecracker;
+   adds default-runtime inference for the one runtime that has no flag.
+
+```go
+// supportedRuntimesForConfig (sketch)
+runtimes := cfg.HostSupportedRuntimes
+if len(runtimes) == 0 { runtimes = []string{models.RuntimeDocker} }
+if cfg.Runtime == models.RuntimeGvisor { // no enable flag exists for gvisor
+    runtimes = appendRuntimeIfMissing(runtimes, models.RuntimeGvisor)
+}
+if cfg.EnableFirecracker { runtimes = appendRuntimeIfMissing(runtimes, models.RuntimeFirecracker) }
+if cfg.EnableWasm        { runtimes = appendRuntimeIfMissing(runtimes, models.RuntimeWasm) }
+```
+
+**Files:** `scripts/install.sh` (done), `pkg/daemon/daemon.go` (harden),
+`pkg/daemon/daemon_test.go` (cases: `gvisor_install_advertises_gvisor` done;
+add `default_runtime_gvisor_advertises_gvisor`).
+
+**Verified live:** `worker-gvisor` → `host_supported_runtimes=[docker gvisor wasm]`;
+leader saw it via gossip; `runtime:"gvisor"` create returned `status=started`.
+
+**PR call-out:** cluster-correctness — gVisor nodes were silently unschedulable;
+single-node unaffected. No FSM/placement code change.
+
+**B7 folds in here:** UC-74 (`CreateWithImage` "no placement target") is the same
+error class. After B1, re-run UC-74. If it still fails, the create-placement
+path differs from plain create — and note there are **two** create-placement
+implementations (`pkg/api/v1/cluster_handler.go` and
+`pkg/api/clustercreate/clustercreate.go`); fix both or confirm one delegates to
+the other, so native / Daytona / E2B don't split.
+
+---
+
+### B2 — Firecracker driver doesn't create the jailer chroot before rootfs staging
+
+**Symptom:** UC-24 fails
+`oci: mkfs.ext4 ... /srv/jailer/firecracker/sb-XXX/root/rootfs.ext4 ...:
+mkfs.ext4: No such file or directory while trying to determine filesystem size`.
+On the host, `/srv/jailer/firecracker/` did not exist (only an empty
+`/srv/jailer/`).
+
+**Root cause:** in `internal/runtime/firecracker/driver.go`, Step 3 stages the
+rootfs at `rootfsPath := filepath.Join(handle.RunDir(), rootfsFileName)`
+(driver.go:553). The Step 2 comment claims "spawn ... creates the runDir we need
+before staging" (driver.go:515) — but with `UseJailer=true` (the fc node's
+config), `RunDir()` returns the **jailer chroot root**, which the jailer binary
+creates only when it execs firecracker, *after* staging. So the directory
+doesn't exist when mkfs runs.
+
+**Fix (review decision: driver, not the OCI builder):** in the driver, after
+`d.spawn(...)` and before Step 3, `os.MkdirAll(handle.RunDir(), 0o755)`. This
+keeps chroot-lifecycle ownership in the driver/jailer layer (the OCI builder
+stays a generic "write to OutPath" tool) and also covers the overlay path, which
+uses the same `RunDir()` (driver.go:668, :683). Confirm the pre-created dir
+doesn't conflict with the jailer's own chroot setup (ownership/chown); if the
+jailer chowns the chroot to the jailed UID after the fact, a root-created empty
+dir is fine.
+
+**Files:** `internal/runtime/firecracker/driver.go` (MkdirAll after spawn);
+driver test asserting `handle.RunDir()` exists before `rootfs.Build` is invoked
+(table-driven, matching the package's existing style). Note: the plan's earlier
+`pkg/oci/builder.go` location is **rejected** — fix is in the driver.
+
+**PR call-out:** boot-path — firecracker cold boot only; one `MkdirAll` before
+the seconds-scale skopeo/umoci/mkfs pipeline (no latency concern).
+
+---
+
+### B4 — SSH gateway runs only on workers; public `:2220` (ingress) has none
+
+**Symptom:** UC-43 `dial tcp <ingress>:2220: connection refused`; UC-67 observes
+no auth failure. Live: nothing on `:2220` (only `sshd` on `:22`).
+
+**Root cause:** `pkg/daemon/daemon.go:683` gates the gateway on
+`cfg.EnableSSHGateway && cfg.IsWorker()`. Public DNS → ingress, which is not a
+worker. (Pre-cluster-join boots logged "listening" because the role defaulted to
+worker before the cluster drop-in set `ingress` — masking the gap.)
+
+**Fix (review decision: Option B — run on ingress too):** relax the gate to
+`cfg.EnableSSHGateway && (cfg.IsWorker() || cfg.IsIngress())`. Verified safe:
+`sshgateway.New` takes a `DockerExec` **interface** (`pkg/sshgateway/gateway.go:90`),
+and when `RemoteAPIBaseURL` is set (cluster mode, daemon.go:694) the remote
+bridge path is used and the local docker client is bypassed
+(`gateway.go:81`); the ingress has docker installed, so `New` gets a non-nil
+client regardless. **No sshgateway change needed.** L4-proxy (Option A) rejected
+as redundant — Terraform already opens `:2220` on ingress-bearing nodes.
+
+**Host-key call-out (Codex):** a multi-ingress cluster needs **shared** SSH host
+key material or clients see host-key churn between ingress nodes. Terraform has a
+host-key variable; tie the daemon change to it (provision the same
+`SB_SSH_HOST_KEY_PATH` material across ingress nodes). For single-ingress
+(this scenario) it's a no-op, but the PR must state the multi-ingress
+requirement so it isn't discovered in production.
+
+**Files:** `pkg/daemon/daemon.go` (gate); a wiring test asserting the gate
+returns true for the ingress role; Terraform/bootstrap note for shared host key.
+
+**PR call-out:** cluster — SSH reachability in cluster mode; a connection landing
+on a non-owner node bridges to the owner via the existing `RemoteAPIBaseURL`
+path; single-node unchanged.
+
+---
+
+## 3. Investigate-first lane (reproduce → locate → test → fix)
+
+### B5 — Session-attach websocket EOF when forwarded to a non-owner node
+
+**Symptom:** UC-45 `attach ... /sessions/<id>/attach: unexpected EOF`. UC-44
+partly downstream. exec/stream **does** upgrade (status 101) when owned locally.
+
+**What's known:** both exec/stream and sessions/attach go through the same
+`proxyToToolbox` → `ServeToolboxReverseProxy` (`pkg/api/v1/proxy.go:31`). The
+working case was local-owner; the failing case was cross-node forwarded. The
+drop point is **not located**.
+
+**Investigate (step 1, no fix yet):** reproduce by forcing a sessions/attach to a
+non-owner node; capture where the upgrade drops. Codex's steer: the likely cause
+is the **two-hop** sessions/toolbox path, request-context lifetime, or session
+close semantics — *not* generic `httputil.ReverseProxy` upgrade stripping (the
+repo already relies on ReverseProxy for upgrades). A `forward.go` unit test can
+pass while UC-45 still fails.
+
+**Test requirement once located:** an **end-to-end v1 route test** through
+`clusterForwardWrap → sessionsProxy → ServeToolboxReverseProxy`, not just a
+`forward.go` unit test. Add a `forward_test.go` upgrade case only if the located
+cause is actually in the forward layer.
+
+**Files (TBD after repro):** likely `pkg/api/v1` (sessionsProxy / toolbox proxy),
+possibly `internal/cluster/forward.go`; tests at the v1 route level.
+
+---
+
+### B6 — S3 platform-volume mount never completes (mount-s3, not rclone)
+
+**Symptom:** UC-81..84 `mount external storage: mount 0 (s3): timed out waiting
+for mount at .../0`. Also `cleanup platform volume lookup failed ... GET
+.../v1/cluster/internal/volume: context deadline exceeded`.
+
+**Correction (Codex):** S3 platform volumes use AWS **`mount-s3`** (mountpoint-s3),
+NOT rclone — `pkg/mounts/adapters/s3.go:29` shells out to `mount-s3`. (rclone is
+installed for a *different* mount type.) The earlier plan's "capture rclone
+stderr" was wrong and would not explain these failures.
+
+**Investigate (step 1, instrument):**
+1. Capture `mount-s3` stderr on failure in `pkg/mounts/adapters/s3.go` /
+   `pkg/mounts/manager.go` and surface it in the returned error (today it's
+   swallowed behind a bare "timed out waiting for mount").
+2. Audit the mount-process race: `mountOne` starts the FUSE process without
+   stderr capture, and timeout cleanup can race the supervisor's `cmd.Wait`
+   (`pkg/mounts/manager.go:266`). Fix diagnostics around process ownership first.
+3. Cross-node volume metadata: the lookup's role matters — worker/agent reads go
+   through the agent control-plane endpoint; voters read local FSM. Identify
+   **which role timed out** before changing any timeout/retry; the "longer
+   timeout" idea is a guess until then.
+
+**Files (TBD after instrument):** `pkg/mounts/adapters/s3.go`,
+`pkg/mounts/manager.go`, the volume-lookup client; tests in `pkg/mounts`.
+
+**PR call-out:** mounts run host-side (pr-review §5); document the
+partially-mounted-volume rollback rule.
+
+---
+
+## 4. Tickets (separate from this plan's PRs)
+
+### B3 — Template ops are node-local; routing them is a real design problem (blocked on decision)
+
+**Symptom:** UC-47..50 (+ UC-80) `template create requires SB_ENABLE_FIRECRACKER`
+on a non-FC serving node; `worker-fc` advertises firecracker but never receives
+the request.
+
+**Why it's a ticket, not a quick fix (Codex):** templates are **per-host by
+design** (`pkg/api/v1/template.go:9`). Forwarding only `POST /templates` breaks
+`GET` / `LIST` / `DELETE` / rebuild unless there's template ownership, fanout, or
+a cluster template catalogue. And creates with `TemplateID` are filtered by
+**local template inventory** in placement (`internal/cluster/placement.go:220`) —
+so a routed template create must guarantee that later sandbox placement targets
+the same artifact-bearing node. This is cluster-FSM-adjacent work.
+
+**Decision needed before coding:** product routing + template catalogue
+(large, cluster-correctness work) vs. test-only (target a FC worker for
+UC-47..50 + return a clear "no firecracker-capable node, candidates: …" error).
+Recommend deciding via a focused design pass, not folding into this plan.
+
+### B8 — WASM ref (UC-26): triage scheduling-vs-resolution before touching fixtures
+
+**Symptom:** UC-26 `resolve module "aocr.aerol.ai/.../snapshots/python:latest--ttl-1h":
+wasm module not found`.
+
+**Why it's a ticket (Codex):** WASM placement has authoritative module-inventory
+filtering; a bad ref can fail at **scheduling** (no node advertises the module)
+or at **owner-local resolution** (scheduled, then resolver misses). Identify
+which before changing test fixtures — otherwise the "register the module" fix may
+not address the real path.
+
+---
+
+## 5. NOT in scope
+
+- **B3 product routing / template catalogue** — deferred to its own design pass;
+  blocked on the routing-vs-test decision.
+- **Multi-ingress shared host-key provisioning automation** — B4 ships the daemon
+  gate + the call-out; the Terraform automation for shared host keys is a
+  follow-up unless multi-ingress is being deployed now.
+- **B6 timeout/retry tuning** — explicitly NOT done until instrumentation proves
+  the failing role/hop.
+- **WASM reserved-module distribution to all roles** — the ingress "did not
+  resolve" warning is benign (ingress runs no WASM sandboxes); not touched.
+- **Rewriting the two create-placement paths into one** — B7 fixes behavior in
+  both; consolidating them is separate tech-debt.
+
+## 6. What already exists (reused, not rebuilt)
+
+- **Capacity advertising + gossip** (`pkg/capacity`, `internal/cluster`) — B1
+  reuses the existing `SupportedRuntimes` advertisement; no new mechanism.
+- **Cross-node SSH bridge** (`RemoteAPIBaseURL`, daemon.go:694) — B4 reuses it;
+  the ingress gateway forwards to the owner exactly like the worker path.
+- **Jailer chroot lifecycle** (`internal/runtime/firecracker/jailer.go`) — B2
+  fixes ordering within it, doesn't add a new path.
+- **Reverse-proxy upgrade forwarding** (`ServeToolboxReverseProxy`) — B5 keeps
+  it; the bug is in the two-hop/context path, not a new proxy.
+- **mount-s3 adapter** (`pkg/mounts/adapters/s3.go`) — B6 instruments it, doesn't
+  replace it.
+
+## 7. Failure modes (fix-now codepaths)
+
+| Codepath | Realistic failure | Test? | Error handling? | User sees |
+|---|---|---|---|---|
+| B1 daemon harden | `cfg.Runtime` empty → no gvisor advertised | yes (new case) | n/a (pure fn) | clear (placement error) |
+| B2 MkdirAll(RunDir) | jailer later chowns chroot, root-owned dir conflicts | driver test | spawn/Build error returned | clear (create fails with reason) |
+| B4 ingress gateway | multi-ingress host-key churn | wiring test (gate) | n/a | **host-key warning** — call-out, not silent |
+| B4 ingress gateway | ingress has no docker client (non-cluster) | wiring test | `New` error surfaced | clear |
+
+No fix-now failure mode is both untested and silent → **no critical gaps in the
+fix-now lane.** (B5/B6 silent-timeout failures are exactly why they're
+investigate-first: instrumentation removes the silence before any fix.)
+
+## 8. Parallelization
+
+| Step | Modules | Depends on |
+|---|---|---|
+| B1 daemon harden | `pkg/daemon` | — |
+| B2 driver mkdir | `internal/runtime/firecracker` | — |
+| B4 gateway gate | `pkg/daemon` | — |
+| B5 investigate | `pkg/api/v1`, `internal/cluster` | repro |
+| B6 investigate | `pkg/mounts` | instrument |
+
+```
+Lane A: B1 → B4 (sequential — both edit pkg/daemon)
+Lane B: B2 (independent — internal/runtime/firecracker)
+Lane C: B6 (independent — pkg/mounts)
+Lane D: B5 (independent — pkg/api/v1 + cluster)
+```
+
+Launch A, B, C, D in parallel worktrees. **Conflict flag:** B1 and B4 both touch
+`pkg/daemon/daemon.go` — keep them in one lane (sequential), not parallel.
+
+## 9. Implementation Tasks
+
+Synthesized from this review. P1 blocks the scenario; P2 same-branch; P3 follow-up.
+
+- [x] **T1 (P1)** — pkg/daemon — Harden `supportedRuntimesForConfig` to advertise gvisor when `cfg.Runtime == RuntimeGvisor` ✅ DONE
+  - Surfaced by: Code-quality review — B1 couples advertising to install flag (daemon.go:1397)
+  - Files: `pkg/daemon/daemon.go`, `pkg/daemon/daemon_test.go` (3 new cases)
+  - Verify: `go test -run TestSupportedRuntimesForConfig ./pkg/daemon/` ✅ pass. install.sh half shipped + verified live.
+- [x] **T2 (P1)** — firecracker driver — `MkdirAll(handle.RunDir())` after spawn, before Step 3 staging ✅ DONE
+  - Surfaced by: Architecture review — jailer chroot not created until firecracker exec (driver.go:515,553)
+  - Files: `internal/runtime/firecracker/driver.go`, `internal/runtime/firecracker/create_rundir_test.go` (new)
+  - Verify: `TestCreate_CreatesRunDirBeforeStaging` ✅ pass; integration UC-24 (live)
+- [x] **T3 (P1)** — pkg/daemon — Relax SSH gateway gate to `IsWorker() || IsIngress()` (extracted `shouldStartSSHGateway`) ✅ DONE
+  - Surfaced by: Architecture review — public :2220 → ingress has no gateway (daemon.go:683)
+  - Files: `pkg/daemon/daemon.go`, `pkg/daemon/daemon_test.go`; host-key call-out in code comment
+  - Verify: `TestShouldStartSSHGateway` ✅ pass; integration UC-43/67 (live)
+- [ ] **T4 (P2, human: ~2h / CC: ~30min)** — pkg/mounts — Capture mount-s3 stderr + audit timeout/cmd.Wait race
+  - Surfaced by: Performance/Code review + Codex — stderr swallowed, race at manager.go:266; tool is mount-s3 not rclone (s3.go:29)
+  - Files: `pkg/mounts/adapters/s3.go`, `pkg/mounts/manager.go`
+  - Verify: forced-failure test surfaces stderr; then re-triage UC-81..84
+- [ ] **T5 (P2, human: ~2h / CC: ~30min)** — pkg/api/v1 — Reproduce + locate session-attach forward drop; add end-to-end route test
+  - Surfaced by: Test review + Codex — root cause not located; forward unit test passes vacuously
+  - Files: TBD (`pkg/api/v1`, maybe `internal/cluster/forward.go`)
+  - Verify: e2e route test through clusterForwardWrap→sessionsProxy; integration UC-45
+- [ ] **T6 (P3, human: — / CC: —)** — verify — Re-run UC-74 after B1; if still failing, fix both create-placement paths
+  - Surfaced by: Codex — `cluster_handler.go` vs `clustercreate/` divergence
+  - Files: `pkg/api/v1/cluster_handler.go`, `pkg/api/clustercreate/clustercreate.go`
+- [ ] **T7 (P3 ticket)** — design — Decide B3 template routing (product catalogue vs test-only)
+- [ ] **T8 (P3 ticket)** — test — B8 triage WASM scheduling-vs-resolution before changing fixtures
+
+## 10. Landing order
+
+1. **B1 daemon harden** (T1) — install.sh already shipped + verified.
+2. **B2** (T2) — self-contained driver fix.
+3. **B4** (T3) — sequential after B1 (same file).
+4. **B6 instrument** (T4) — surface mount-s3 stderr, then re-triage.
+5. **B5 reproduce** (T5) — locate before fixing.
+6. **B7 verify** (T6); **B3/B8 tickets** (T7/T8).
+
+B5/B6 do **not** become normal fix PRs until the failing hop/process is proven.
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | — |
+| Codex Review | `/codex review` | Independent 2nd opinion | 4 | issues_found | 12 problems, all folded |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 4 | reviewed | 5 issues, 0 critical gaps |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | — |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | — |
+
+- **CODEX:** caught one factual error (B6 uses `mount-s3`, not rclone — verified at `s3.go:29`) plus 11 enrichments (B3 per-host template + placement.go:220 inventory filter, B7 dual create-placement paths, B4 multi-ingress host-key churn, B5 two-hop not generic-proxy). All folded with user approval.
+- **CROSS-MODEL:** No tension — Codex's points were corrections/enrichments, not conflicts. The B6 mount-s3 correction reversed a wrong assumption in the original plan.
+- **VERDICT:** ENG CLEARED — plan partitioned (fix-now B1/B2/B4 · investigate-first B5/B6 · tickets B3/B8), 5 decisions resolved, 0 critical gaps. Ready to implement the fix-now lane.
+
+Decisions resolved this review: scope partition (fix-now vs investigate); B2 fix site (firecracker driver, not OCI builder); B4 topology (Option B gate relax, no sshgateway change); B1 depth (also harden daemon `cfg.Runtime`); B5 reclassified investigate-first.
+
+NO UNRESOLVED DECISIONS


### PR DESCRIPTION
## Summary

- **B1 — gVisor cluster placement:** Harden `supportedRuntimesForConfig` so nodes with `SB_RUNTIME=gvisor` advertise `gvisor` in gossip capacity even when `SB_HOST_RUNTIMES` omits it; fixes "no worker placement target available" for gVisor creates in heterogeneous clusters.
- **B2 — Firecracker cold boot:** `MkdirAll(handle.RunDir())` after spawn and before OCI→ext4 staging so jailer-mode cold boots don't fail with `mkfs.ext4: No such file or directory` when the chroot root doesn't exist yet.
- **B4 — SSH gateway on ingress:** Relax the gateway gate to `IsWorker() || IsIngress()` so the public `:2220` endpoint (wildcard DNS → ingress) actually binds a listener; connections for sandboxes the ingress doesn't own bridge via the existing `RemoteAPIBaseURL` path.
- **B6 instrumentation:** Capture mount-tool (mount-s3) stdout+stderr in a capped buffer and append the tail to mount-timeout errors so S3 volume failures are diagnosable instead of a bare "timed out waiting for mount".
- **Regression guards:** Offline unit tests for each fix plus integration UCs UC-87/88/89 (`regression_fixes_test.go`) that pin the gossip-advertise, cold-boot, and ingress-SSH layers more tightly than the broad full-suite UCs.

## Sandbox boot impact

**Yes — firecracker cold-boot path only (B2).** One `os.MkdirAll(handle.RunDir(), 0o755)` after spawn and before rootfs staging. Expected latency: sub-millisecond (directory create or no-op when already present). Fires on every firecracker `Create` that reaches the staging step; bounded, idempotent, and only on the driver path — not on docker/wasm/gvisor creates. No new work on `CreateSandbox` service-layer hot path beyond what the firecracker driver already does.

## Idempotency

N/A — no API surface changed. All changes are daemon wiring (runtime advertisement, SSH gateway gate), firecracker driver directory prep, and mount error formatting. Retries/concurrent creates behave as before; `MkdirAll` is idempotent.

## Failure-path consistency

N/A — no multi-step write path touching both caddy and the store changed. Mount instrumentation only enriches the error returned on an already-failing mount probe; it does not change mount success/cleanup semantics.

## L4 / host-port-pool changes

N/A — neither touched.

## Cluster-correctness impact

- **B1:** gVisor-capable nodes that relied only on `SB_RUNTIME=gvisor` were invisible to placement; single-node mode unaffected (no gossip). No FSM/placement code change.
- **B4:** Ingress nodes now bind the SSH gateway. Multi-ingress deployments must share `SB_SSH_HOST_KEY_PATH` material or clients see host-key churn — called out in code comment; single-ingress (cluster-hetero scenario) is a no-op.

## Test plan

- [x] `go test -run TestSupportedRuntimesForConfig ./pkg/daemon/` — gVisor default-runtime advertise cases
- [x] `go test -run TestShouldStartSSHGateway ./pkg/daemon/` — ingress/worker/server gate matrix
- [x] `go test -run TestCreate_CreatesRunDirBeforeStaging ./internal/runtime/firecracker/`
- [x] `go test -run TestMountWaitErrorSurfacesToolOutput ./pkg/mounts/`
- [ ] `make integration-cluster-hetero` — UC-87/88/89 regression guards + re-verify UC-24/25/43/67/81–84 with new mount stderr
- [ ] Confirm UC-74 (`CreateWithImage` placement) passes after B1; if not, follow-up on dual create-placement paths (T6 in plan)


Made with [Cursor](https://cursor.com)