### PR TITLE
fix(cluster-hetero): S3 prefix, firecracker jailer paths, and regression tests

### DIFF
--- a/internal/runtime/firecracker/chroot_path_test.go
+++ b/internal/runtime/firecracker/chroot_path_test.go
@@ -1,0 +1,104 @@
+package firecracker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestChrootFilePath_DirectMode: with UseJailer=false there is no chroot, so the
+// helper must return the absolute source path unchanged and stage nothing. This
+// is the property that keeps the dev/CI direct-spawn path (and every existing
+// fakeVMM test) behaving exactly as before the jailer fix.
+func TestChrootFilePath_DirectMode(t *testing.T) {
+	d := &Driver{cfg: Config{UseJailer: false}}
+	runDir := t.TempDir()
+	src := filepath.Join(t.TempDir(), "vmlinux-host")
+	if err := os.WriteFile(src, []byte("k"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := d.chrootFilePath(runDir, src, kernelFileName)
+	if err != nil {
+		t.Fatalf("chrootFilePath: %v", err)
+	}
+	if got != src {
+		t.Errorf("direct mode path = %q, want absolute src %q", got, src)
+	}
+	if _, err := os.Stat(filepath.Join(runDir, kernelFileName)); !os.IsNotExist(err) {
+		t.Errorf("direct mode must not stage into runDir (stat err = %v)", err)
+	}
+}
+
+// TestChrootFilePath_JailerStagesAndReturnsRelative: a source that lives outside
+// the chroot (the shared kernel) must be hardlinked/copied in and referenced by
+// its bare relative name — the exact failure that produced "kernel file cannot
+// be opened" once the OCI rootfs build started succeeding (UC-24/88).
+func TestChrootFilePath_JailerStagesAndReturnsRelative(t *testing.T) {
+	d := &Driver{cfg: Config{UseJailer: true}}
+	runDir := t.TempDir()
+	src := filepath.Join(t.TempDir(), "vmlinux-host")
+	if err := os.WriteFile(src, []byte("kernel-bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := d.chrootFilePath(runDir, src, kernelFileName)
+	if err != nil {
+		t.Fatalf("chrootFilePath: %v", err)
+	}
+	if got != kernelFileName {
+		t.Errorf("jailer path = %q, want relative %q", got, kernelFileName)
+	}
+	staged := filepath.Join(runDir, kernelFileName)
+	b, err := os.ReadFile(staged)
+	if err != nil {
+		t.Fatalf("kernel not staged into chroot: %v", err)
+	}
+	if string(b) != "kernel-bytes" {
+		t.Errorf("staged kernel content = %q, want original bytes", string(b))
+	}
+}
+
+// TestChrootFilePath_JailerInPlaceIsNoop: the rootfs and overlay are built
+// directly into runDir, so src already equals runDir/destName. The helper must
+// NOT try to link a file onto itself (which would fail EEXIST) — it just returns
+// the basename.
+func TestChrootFilePath_JailerInPlaceIsNoop(t *testing.T) {
+	d := &Driver{cfg: Config{UseJailer: true}}
+	runDir := t.TempDir()
+	inPlace := filepath.Join(runDir, rootfsFileName)
+	if err := os.WriteFile(inPlace, []byte("rootfs"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := d.chrootFilePath(runDir, inPlace, rootfsFileName)
+	if err != nil {
+		t.Fatalf("chrootFilePath in-place: %v", err)
+	}
+	if got != rootfsFileName {
+		t.Errorf("in-place path = %q, want %q", got, rootfsFileName)
+	}
+	// The file must be untouched (same bytes, still present).
+	if b, err := os.ReadFile(inPlace); err != nil || string(b) != "rootfs" {
+		t.Errorf("in-place file disturbed: bytes=%q err=%v", string(b), err)
+	}
+}
+
+// TestChrootFilePath_JailerOverwritesStaleStage: a leftover file from a previous
+// attempt must not make staging fail with EEXIST — the helper removes it first
+// so a retried Create is idempotent.
+func TestChrootFilePath_JailerOverwritesStaleStage(t *testing.T) {
+	d := &Driver{cfg: Config{UseJailer: true}}
+	runDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(runDir, kernelFileName), []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(t.TempDir(), "vmlinux-host")
+	if err := os.WriteFile(src, []byte("fresh"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.chrootFilePath(runDir, src, kernelFileName); err != nil {
+		t.Fatalf("chrootFilePath over stale: %v", err)
+	}
+	if b, _ := os.ReadFile(filepath.Join(runDir, kernelFileName)); string(b) != "fresh" {
+		t.Errorf("stale stage not replaced: %q", string(b))
+	}
+}

--- a/internal/runtime/firecracker/create_jailer_paths_test.go
+++ b/internal/runtime/firecracker/create_jailer_paths_test.go
@@ -1,0 +1,87 @@
+package firecracker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// TestCreate_JailerStagesKernelAndUsesRelativePaths is the regression guard for
+// the firecracker cold-boot failure that surfaced once the OCI rootfs build
+// started succeeding (cluster-hetero UC-24/UC-88):
+//
+//	PUT /boot-source -> 400: Boot source error: The kernel file cannot be
+//	opened: No such file or directory
+//
+// In jailer mode firecracker is chrooted into the runDir, so the kernel must be
+// staged inside it and every path handed to the firecracker API must be
+// chroot-relative. The driver previously passed the absolute host kernel path
+// (and absolute rootfs/overlay paths), which the jailed firecracker cannot
+// open. This test drives the cold-boot path with UseJailer=true and asserts the
+// kernel is hardlinked into the chroot and the API receives bare relative names.
+func TestCreate_JailerStagesKernelAndUsesRelativePaths(t *testing.T) {
+	tmp := t.TempDir()
+	// A real kernel file the driver stat-checks and then stages into the chroot.
+	hostKernel := filepath.Join(tmp, "vmlinux-host")
+	if err := os.WriteFile(hostKernel, []byte("fake-kernel"), 0o644); err != nil {
+		t.Fatalf("write kernel: %v", err)
+	}
+	// The chroot root the fake spawner reports as the VMM runDir. Not created
+	// here on purpose — the driver's MkdirAll(runDir) (the UC-24 mkfs fix) makes
+	// it, then the kernel/rootfs land inside it.
+	chroot := filepath.Join(tmp, "jailer", "firecracker", "sb-jail", "root")
+
+	pool := newFakePool()
+	rootfs := &fakeRootfs{}
+	tap := &fakeTapHost{}
+	vsock := newFakeVsockDialer()
+	client := newFakeClient()
+	vmm := &fakeVMM{}
+
+	d := New(Config{
+		KernelImage: hostKernel,
+		RunDir:      tmp,
+		UseJailer:   true,
+	}, nil)
+	d.SetPool(pool)
+	d.SetRootfsBuilder(rootfs)
+	d.SetTapHost(tap)
+	d.SetVsockDialer(vsock)
+	d.SetSpawner(func(_ Config, id string) (VMMHandle, error) {
+		vmm.id = id
+		vmm.runDir = chroot
+		vmm.apiSocket = filepath.Join(chroot, "api.sock")
+		return vmm, nil
+	})
+	d.SetClientFactory(func(_ string) VMMClient { return client })
+
+	if _, err := d.Create(context.Background(), models.CreateSandboxRequest{
+		Image:    "alpine:3.20",
+		CPU:      1,
+		MemoryMB: 256,
+		DiskGB:   1,
+	}, "sb-jail", "tok", nil); err != nil {
+		t.Fatalf("Create (jailer): %v", err)
+	}
+
+	// The kernel must now exist inside the chroot under its relative name.
+	if _, err := os.Stat(filepath.Join(chroot, kernelFileName)); err != nil {
+		t.Fatalf("kernel not staged into chroot: %v", err)
+	}
+	// The firecracker API must have received chroot-relative paths, never the
+	// absolute host paths the jailed process cannot open.
+	if client.bs == nil {
+		t.Fatal("PutBootSource never called")
+	}
+	if client.bs.KernelImagePath != kernelFileName {
+		t.Errorf("boot source kernel path = %q, want relative %q", client.bs.KernelImagePath, kernelFileName)
+	}
+	if dr, ok := client.drives[rootDriveID]; !ok {
+		t.Error("root drive never set")
+	} else if dr.PathOnHost != rootfsFileName {
+		t.Errorf("root drive path = %q, want relative %q", dr.PathOnHost, rootfsFileName)
+	}
+}

--- a/internal/runtime/firecracker/create_jailer_paths_test.go
+++ b/internal/runtime/firecracker/create_jailer_paths_test.go
@@ -42,9 +42,10 @@ func TestCreate_JailerStagesKernelAndUsesRelativePaths(t *testing.T) {
 	vmm := &fakeVMM{}
 
 	d := New(Config{
-		KernelImage: hostKernel,
-		RunDir:      tmp,
-		UseJailer:   true,
+		KernelImage:    hostKernel,
+		RunDir:         tmp,
+		UseJailer:      true,
+		OverlayEnabled: true, // exercise the overlay PutDrive path too
 	}, nil)
 	d.SetPool(pool)
 	d.SetRootfsBuilder(rootfs)
@@ -59,10 +60,11 @@ func TestCreate_JailerStagesKernelAndUsesRelativePaths(t *testing.T) {
 	d.SetClientFactory(func(_ string) VMMClient { return client })
 
 	if _, err := d.Create(context.Background(), models.CreateSandboxRequest{
-		Image:    "alpine:3.20",
-		CPU:      1,
-		MemoryMB: 256,
-		DiskGB:   1,
+		Image:         "alpine:3.20",
+		CPU:           1,
+		MemoryMB:      256,
+		DiskGB:        1,
+		OverlaySizeGB: 1,
 	}, "sb-jail", "tok", nil); err != nil {
 		t.Fatalf("Create (jailer): %v", err)
 	}
@@ -83,5 +85,10 @@ func TestCreate_JailerStagesKernelAndUsesRelativePaths(t *testing.T) {
 		t.Error("root drive never set")
 	} else if dr.PathOnHost != rootfsFileName {
 		t.Errorf("root drive path = %q, want relative %q", dr.PathOnHost, rootfsFileName)
+	}
+	if dr, ok := client.drives[overlayDriveID]; !ok {
+		t.Error("overlay drive never set")
+	} else if dr.PathOnHost != overlayFileName {
+		t.Errorf("overlay drive path = %q, want relative %q", dr.PathOnHost, overlayFileName)
 	}
 }

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -824,15 +824,32 @@ func (d *Driver) configureVMM(ctx context.Context, client VMMClient, req models.
 	}); err != nil {
 		return fmt.Errorf("firecracker runtime: PutMachineConfig: %w", err)
 	}
+	// In jailer mode firecracker is chrooted into the runDir, so every file
+	// path handed to its API must be chroot-relative and the file must live
+	// inside the chroot. The kernel lives elsewhere on the host, so stage it in;
+	// the rootfs/overlay were already built into the runDir, so staging is a
+	// no-op that just yields their basenames. In direct mode these return the
+	// original absolute paths unchanged. (Before this, the absolute kernel path
+	// failed with "kernel file cannot be opened: No such file or directory" the
+	// moment the OCI rootfs build started succeeding.)
+	runDir := filepath.Dir(rootfsPath)
+	kernelAPIPath, err := d.chrootFilePath(runDir, d.cfg.KernelImage, kernelFileName)
+	if err != nil {
+		return fmt.Errorf("firecracker runtime: stage kernel: %w", err)
+	}
+	rootfsAPIPath, err := d.chrootFilePath(runDir, rootfsPath, rootfsFileName)
+	if err != nil {
+		return fmt.Errorf("firecracker runtime: stage rootfs: %w", err)
+	}
 	if err := client.PutBootSource(ctx, firecracker.BootSource{
-		KernelImagePath: d.cfg.KernelImage,
+		KernelImagePath: kernelAPIPath,
 		BootArgs:        defaultBootArgs(),
 	}); err != nil {
 		return fmt.Errorf("firecracker runtime: PutBootSource: %w", err)
 	}
 	if err := client.PutDrive(ctx, rootDriveID, firecracker.Drive{
 		DriveID:      rootDriveID,
-		PathOnHost:   rootfsPath,
+		PathOnHost:   rootfsAPIPath,
 		IsRootDevice: true,
 		// Read-write rootfs in Phase 1 — the ext4 was created
 		// per-sandbox and dies with it. Read-only rootfs + per-
@@ -850,9 +867,13 @@ func (d *Driver) configureVMM(ctx context.Context, client VMMClient, req models.
 	// file directly — no PATCH needed because the VMM hasn't booted
 	// yet and no snapshot state pins a placeholder path.
 	if overlayPath != "" {
+		overlayAPIPath, err := d.chrootFilePath(runDir, overlayPath, overlayFileName)
+		if err != nil {
+			return fmt.Errorf("firecracker runtime: stage overlay: %w", err)
+		}
 		if err := client.PutDrive(ctx, overlayDriveID, firecracker.Drive{
 			DriveID:    overlayDriveID,
-			PathOnHost: overlayPath,
+			PathOnHost: overlayAPIPath,
 			IsReadOnly: false,
 			CacheType:  "Writeback",
 		}); err != nil {
@@ -1536,6 +1557,32 @@ func (d *Driver) ClearNetworkBlockIngress(_ string) error {
 
 func (d *Driver) ClearNetworkBlockEgress(_ string) error {
 	return methodNotImplemented("ClearNetworkBlockEgress")
+}
+
+// chrootFilePath returns the path to hand to the firecracker API for a host
+// file, staging it into the jailer chroot when needed.
+//
+// In jailer mode firecracker is chrooted into runDir, so it can only open files
+// that live there, referenced by a path relative to the chroot root (the jailer
+// docs in jailer.go spell this out). srcAbs is hardlinked — or copied across
+// devices — to runDir/destName and destName is returned. When srcAbs already IS
+// runDir/destName (the rootfs and overlay are built in place) staging is a
+// no-op. In direct mode there is no chroot, so srcAbs is returned unchanged and
+// nothing is staged.
+func (d *Driver) chrootFilePath(runDir, srcAbs, destName string) (string, error) {
+	if !d.cfg.UseJailer {
+		return srcAbs, nil
+	}
+	dst := filepath.Join(runDir, destName)
+	if srcAbs != dst {
+		// A leftover file from a previous attempt would make os.Link fail with
+		// EEXIST; clear it first so staging is idempotent across retries.
+		_ = os.Remove(dst)
+		if err := linkOrCopyRootfs(srcAbs, dst); err != nil {
+			return "", err
+		}
+	}
+	return destName, nil
 }
 
 // linkOrCopyRootfs makes dst point at the same bytes as src. Hard-link

--- a/internal/runtime/firecracker/seams.go
+++ b/internal/runtime/firecracker/seams.go
@@ -189,6 +189,13 @@ const hostVsockUDSName = "vsock.sock"
 // debug runbook ("look in /srv/firecracker/<id>/rootfs.ext4") accurate.
 const rootfsFileName = "rootfs.ext4"
 
+// kernelFileName is the filename the guest kernel is staged under inside the
+// per-sandbox jailer chroot. In jailer mode firecracker is chrooted into the
+// runDir, so the kernel (which lives elsewhere on the host) must be hardlinked
+// in and referenced by this relative name; in direct mode the kernel is passed
+// by its original absolute path and this is unused.
+const kernelFileName = "vmlinux"
+
 // rootDriveID is the drive_id firecracker uses for the rootfs drive.
 // Mirrored from the firecracker example configs; the guest kernel boots
 // from this drive id.

--- a/pkg/mounts/adapters/adapters_test.go
+++ b/pkg/mounts/adapters/adapters_test.go
@@ -132,6 +132,16 @@ func TestS3Build_PrefixTrailingSlash(t *testing.T) {
 			t.Errorf("Build(%q): --prefix = %q, want %q", source, got, want)
 		}
 	}
+
+	// A bucket-only source has no prefix, so mount-s3 must receive NO --prefix
+	// flag at all — emitting an empty "--prefix ''" would itself be rejected.
+	plan, err := (S3{}).Build("sb-x", 0, models.MountSpec{Source: "s3://bucket-only"}, "/mnt/t", "/creds")
+	if err != nil {
+		t.Fatalf("Build(bucket-only): %v", err)
+	}
+	if contains(plan.Argv, "--prefix") {
+		t.Errorf("bucket-only source emitted a --prefix flag: %v", plan.Argv)
+	}
 }
 
 func TestParseS3Source(t *testing.T) {

--- a/pkg/mounts/adapters/adapters_test.go
+++ b/pkg/mounts/adapters/adapters_test.go
@@ -45,7 +45,8 @@ func TestS3Build(t *testing.T) {
 	if err != nil {
 		t.Fatalf("S3.Build: %v", err)
 	}
-	wantPrefix := []string{"mount-s3", "bucket", "/mnt/target", "--foreground", "--profile", "sandbox", "--prefix", "prefix/sub"}
+	// mountpoint-s3 requires --prefix to end in '/', so the adapter appends one.
+	wantPrefix := []string{"mount-s3", "bucket", "/mnt/target", "--foreground", "--profile", "sandbox", "--prefix", "prefix/sub/"}
 	if !reflect.DeepEqual(plan.Argv[:len(wantPrefix)], wantPrefix) {
 		t.Fatalf("argv prefix mismatch: got=%v want=%v", plan.Argv[:len(wantPrefix)], wantPrefix)
 	}
@@ -100,6 +101,36 @@ func TestS3Build_InstanceRole(t *testing.T) {
 func TestS3Build_MissingBucket(t *testing.T) {
 	if _, err := (S3{}).Build("sb", 0, models.MountSpec{Source: "s3://"}, "/mnt", "/creds"); err == nil {
 		t.Fatal("expected error for missing bucket")
+	}
+}
+
+// TestS3Build_PrefixTrailingSlash is the regression guard for cluster-hetero
+// UC-81..84: mountpoint-s3 rejects a --prefix that doesn't end in '/'
+// ("error: invalid value '…' for '--prefix': prefix must end in '/'"), so the
+// adapter must normalize a non-empty prefix to end in exactly one slash and
+// carry no leading slash — whatever shape the volume key arrives in.
+func TestS3Build_PrefixTrailingSlash(t *testing.T) {
+	cases := map[string]string{
+		"s3://bucket/team/data":  "team/data/", // no trailing slash -> add one
+		"s3://bucket/team/data/": "team/data/", // already has one -> unchanged
+	}
+	for source, want := range cases {
+		plan, err := (S3{}).Build("sb-x", 0, models.MountSpec{Source: source}, "/mnt/t", "/creds")
+		if err != nil {
+			t.Fatalf("Build(%q): %v", source, err)
+		}
+		got := ""
+		for i, a := range plan.Argv {
+			if a == "--prefix" && i+1 < len(plan.Argv) {
+				got = plan.Argv[i+1]
+			}
+		}
+		if !strings.HasSuffix(got, "/") {
+			t.Errorf("Build(%q): --prefix %q does not end in '/'", source, got)
+		}
+		if got != want {
+			t.Errorf("Build(%q): --prefix = %q, want %q", source, got, want)
+		}
 	}
 }
 

--- a/pkg/mounts/adapters/s3.go
+++ b/pkg/mounts/adapters/s3.go
@@ -31,7 +31,15 @@ func (S3) Build(sandboxID string, index int, spec models.MountSpec, hostTarget, 
 		argv = append(argv, "--profile", "sandbox")
 	}
 	if prefix != "" {
-		argv = append(argv, "--prefix", strings.TrimPrefix(prefix, "/"))
+		// mountpoint-s3 requires --prefix to be a "directory" key: no leading
+		// slash and it MUST end in '/', else it rejects with
+		// "prefix must end in '/'". We normalize both ends so a caller passing
+		// "team/data" or "/team/data" mounts the same key space.
+		p := strings.TrimPrefix(prefix, "/")
+		if !strings.HasSuffix(p, "/") {
+			p += "/"
+		}
+		argv = append(argv, "--prefix", p)
 	}
 	if region := spec.Options["region"]; region != "" {
 		argv = append(argv, "--region", region)

--- a/plans/b7-built-image-placement.md
+++ b/plans/b7-built-image-placement.md
@@ -1,0 +1,174 @@
+# B7 — Local-only built images can't be placed in a cluster (UC-74)
+
+Status: ticketed · Severity: P2 (feature broken in cluster mode, no data risk) ·
+Area: `internal/cluster` placement + `internal/service` image distribution +
+`pkg/api/v1` build · Source: cluster-hetero integration scenario, UC-74
+("Create with built image graph"). Parent: `plans/cluster-hetero-failures-fix.md`.
+
+## 1. Symptom
+
+```
+UC-74 | Create with built image graph (CreateWithImage)
+     ❌ lifecycle_extra_test.go:99: create with image:
+        cluster: no worker placement target available
+```
+
+Plain docker creates place fine in the same cluster (UC-11, UC-53 pass), so this
+is specific to the **built-image** path, not placement in general.
+
+## 2. Reproduction (live, 8-node cluster-hetero)
+
+```
+# build returns a node-local content-addressed tag
+POST /v1/images/build  {"dockerfile_content":"FROM alpine:3.20\nRUN echo uc74 > /uc74.txt"}
+  -> 200 {"image":"aerolvm-build/7222513189e4820d:latest"}
+
+# create from that tag
+POST /v1/sandboxes     {"image":"aerolvm-build/7222513189e4820d:latest","name":"uc74-repro"}
+  -> {"error":"cluster: no worker placement target available"}
+```
+
+`CreateWithImage` in every SDK is two server calls
+(`sdk/go/pkg/microvm/client.go:148`): `BuildImage` then `Create` with the
+returned tag.
+
+## 3. Root cause (code-traced)
+
+```
+client.CreateWithImage(img, opts)
+  │
+  ├─ POST /v1/images/build         pkg/api/v1/build.go:49  buildImage()
+  │     • builds on WHICHEVER NODE RECEIVES THE REQUEST (not placement-routed)
+  │     • in cluster-hetero that node is the ingress/server (the API entrypoint)
+  │     • returns tag  aerolvm-build/<hash>:latest   (BuiltImageNamespace, build.go:51)
+  │     • the image now exists ONLY on that one non-worker node
+  │
+  └─ POST /v1/sandboxes            pkg/api/clustercreate/clustercreate.go
+        ├─ NormalizeCreateImageDistribution → classifies as local_only       (image_distribution.go)
+        ├─ if service.ImageRequiresLocalPlacement(req):                       (clustercreate.go:71)
+        │       → returns true for aerolvm-build/* (IsLocalOnlyImageRef)      (image_distribution.go:190)
+        │       → create is PINNED to self (the building node)
+        │       → but self is ingress/server, and...
+        └─ CanOwnSandboxRole("server"/"ingress") == false                    (placement.go:355)
+              → the only node with the image cannot run sandboxes
+              → no worker has the image
+              → ErrNoPlacementTarget
+```
+
+The two design rules collide:
+
+1. **A local-only image can only run where it physically exists** — so the
+   create is pinned to the build node (`ImageRequiresLocalPlacement`).
+2. **Only worker/mixed nodes run sandboxes** (`CanOwnSandboxRole`).
+
+The build endpoint is **not placement-aware**, so in a role-separated cluster
+the build lands on the API-terminating node (ingress/server), which violates
+rule 2. Single-node and all-mixed clusters work because the build node is also a
+worker; role-separated clusters (the production topology) are where it breaks.
+
+### Key code references
+
+| What | Where |
+|------|-------|
+| Build endpoint (not routed) | `pkg/api/v1/build.go:49` |
+| Built-image namespace `aerolvm-build` | `pkg/docker/build.go:51` |
+| `IsLocalOnlyImageRef` | `pkg/docker/...` (matches `aerolvm-build/*`) |
+| Pin-to-self for local images | `pkg/api/clustercreate/clustercreate.go:71` |
+| `ImageRequiresLocalPlacement` | `internal/service/image_distribution.go:190` |
+| Role gate | `internal/cluster/placement.go:355` (`CanOwnSandboxRole`) |
+| AOCR distribution mode (exists) | `pkg/models/types.go:401` (`ImageDistributionAOCR`) |
+| Snapshot/image pusher (exists) | `internal/service` (`snapshotPusher`, `DestRefFor`) |
+
+## 4. Fix options
+
+### Option A — Build on a worker (route the build through placement)
+
+`buildImage` selects a worker via placement and builds there (locally or by
+forwarding the build request), then `CreateWithImage`'s create is pinned to that
+same worker.
+
+- ✅ Image lands where it can run; `ImageRequiresLocalPlacement` then resolves correctly.
+- ✅ No image bytes cross the network beyond the build context.
+- ❌ Build and create are two independent calls — must thread the chosen worker
+  from build → create (a new response field / sticky placement) so they agree.
+- ❌ A worker chosen at build time may be full/drained at create time → re-pin churn.
+- ❌ Concentrates build load on workers (CPU/disk) instead of control-plane nodes.
+- Effort: human ~2-3 days / CC ~3-4h. Touches `pkg/api/v1/build.go`,
+  `internal/cluster` (build placement + forward), SDK (carry build node), tests.
+
+### Option B — Distribute the built image via AOCR (recommended)
+
+After building, push the image to the cluster registry (AOCR) so it's
+pullable on any worker; the create then uses the normal (non-local) placement
+path and the consumer-side puller fetches it.
+
+- ✅ Reuses machinery that already exists: `ImageDistributionAOCR`
+  (`models/types.go:401`), the snapshot/image pusher (`DestRefFor`,
+  `normalizeSnapshotImageDistribution`), and the consumer-side puller that
+  template/snapshot creates already rely on.
+- ✅ Build can stay on any node; create uses standard power-of-two placement.
+- ✅ Image is durable + reusable across creates, not pinned to one node's lifetime.
+- ❌ Adds a push (and a first-create pull) to the build→create latency — the same
+  cost snapshot/AOCR images already pay; acceptable for a build-then-run flow.
+- ❌ Requires AOCR to be configured for the cluster (it is, in cluster-hetero).
+  Need a graceful fallback for clusters without AOCR (keep local_only + pin, but
+  emit a clear "build node is not a worker; configure AOCR or build on a worker"
+  error instead of a bare `ErrNoPlacementTarget`).
+- Effort: human ~2-3 days / CC ~3-4h. Touches `pkg/api/v1/build.go` (push after
+  build), `internal/service/image_distribution.go` (classify the pushed ref as
+  AOCR, not local_only), tests.
+
+### Option C — Atomic build-on-placement-target
+
+Merge build+create into one server operation: select placement first, then build
+on the chosen target, then create. Requires a new combined endpoint.
+
+- ✅ Build and run are guaranteed co-located; no cross-call state.
+- ❌ Largest change: new endpoint + SDK method across all 5 SDKs; breaks the
+  clean "build returns a reusable tag" contract; the built image isn't reusable
+  by a second create without rebuilding.
+- Effort: human ~1-2 weeks / CC ~1-2 days. Not recommended.
+
+## 5. Recommendation
+
+**Option B (AOCR distribution).** It reuses the existing AOCR + pusher + puller
+path that template and snapshot creates already depend on, keeps the two-call
+build/create contract, and makes built images durable and reusable. Option A is
+the fallback if AOCR can't be assumed; ship the clear-error improvement (below)
+regardless of which option lands.
+
+### Independent quick win (do first, ~30 min)
+
+Whatever the chosen option, replace the bare `ErrNoPlacementTarget` for a
+local-only image whose build node can't own sandboxes with an actionable error,
+e.g. *"image is local-only and was built on a non-worker node; enable AOCR image
+distribution or build on a worker."* This turns a confusing scheduler error into
+a diagnosable one and is safe to ship on its own. Site:
+`pkg/api/clustercreate/clustercreate.go:71` (the `ImageRequiresLocalPlacement`
+branch) — detect `!CanOwnSandboxRole(self.Role)` and return the specific message.
+
+## 6. Test plan
+
+Unit:
+- `image_distribution_test.go` — a pushed built image classifies as
+  `ImageDistributionAOCR` (Option B), so `ImageRequiresLocalPlacement` is false.
+- `clustercreate_test.go` — local-only image + non-worker self → the new
+  actionable error (the quick win), not `ErrNoPlacementTarget`.
+- placement test — a create for an AOCR-distributed built image selects a worker.
+
+Integration (cluster-hetero, UC-74 already exists):
+- UC-74 goes green once the image is distributable/placeable.
+- Add UC-74b: build an image, then create TWO sandboxes from the same tag on
+  different workers (proves distribution, not just co-location). Register in
+  `harness/usecases.go` with `CapCluster`.
+
+## 7. Risks / call-outs (per CLAUDE.md + pr-review.md)
+
+- Cluster-correctness: changes touch placement + image distribution. Document
+  split-brain/leader-change behavior and keep single-node a no-op.
+- Boot-path latency: Option B adds a push + first-pull; call it out in the PR
+  with the first-create number, same axis as snapshot/AOCR creates.
+- Idempotency: build is content-addressed (idempotent by hash); the AOCR push
+  must be safe under retry (re-push of an existing tag is a no-op).
+- Failure-path: if the AOCR push fails, the create must fail cleanly with a clear
+  error and not leave a half-distributed image or a dangling reservation.

--- a/plans/cluster-hetero-failures-fix.md
+++ b/plans/cluster-hetero-failures-fix.md
@@ -143,6 +143,11 @@ the image → `ErrNoPlacementTarget`. Fix options (need design + live validation
 (3) atomic build-on-placement-target. Recommend (2) — the AOCR push path already
 exists (snapshotPusher / ImageDistributionAOCR). NOT a quick fix; ticket it.
 
+**Full ticket: [`plans/b7-built-image-placement.md`](./b7-built-image-placement.md)** —
+code-traced root cause, the three options with tradeoffs/effort, recommended
+Option B, a ~30-min independent quick win (replace the bare `ErrNoPlacementTarget`
+with an actionable error), test plan (incl. a new UC-74b), and PR call-outs.
+
 After B1, re-run UC-74. If it still fails, the create-placement
 path differs from plain create — and note there are **two** create-placement
 implementations (`pkg/api/v1/cluster_handler.go` and

--- a/plans/cluster-hetero-failures-fix.md
+++ b/plans/cluster-hetero-failures-fix.md
@@ -132,8 +132,18 @@ leader saw it via gossip; `runtime:"gvisor"` create returned `status=started`.
 **PR call-out:** cluster-correctness — gVisor nodes were silently unschedulable;
 single-node unaffected. No FSM/placement code change.
 
-**B7 folds in here:** UC-74 (`CreateWithImage` "no placement target") is the same
-error class. After B1, re-run UC-74. If it still fails, the create-placement
+**B7 — UC-74 is NOT the same bug as B1 (confirmed live).** It's the local-only
+built-image placement gap: `CreateWithImage` = BuildImage (builds on the
+receiving ingress/server node, returns `aerolvm-build/<hash>`) then Create.
+`ImageRequiresLocalPlacement` pins the local-only tag to the building node, but
+ingress/server can't own sandboxes (`CanOwnSandboxRole` false) and no worker has
+the image → `ErrNoPlacementTarget`. Fix options (need design + live validation):
+(1) build on a worker via placement so the image lives where it can run;
+(2) push the build to AOCR so it's distributable and normal placement applies;
+(3) atomic build-on-placement-target. Recommend (2) — the AOCR push path already
+exists (snapshotPusher / ImageDistributionAOCR). NOT a quick fix; ticket it.
+
+After B1, re-run UC-74. If it still fails, the create-placement
 path differs from plain create — and note there are **two** create-placement
 implementations (`pkg/api/v1/cluster_handler.go` and
 `pkg/api/clustercreate/clustercreate.go`); fix both or confirm one delegates to
@@ -303,6 +313,32 @@ stderr" was wrong and would not explain these failures.
 partially-mounted-volume rollback rule.
 
 ---
+
+## 3b. Live re-run findings (2026-06-23, commit 1380f63 + fixes)
+
+Re-ran `make integration-cluster-hetero keep`: **60→65 pass**. B1/B4/B5 confirmed
+green live (UC-25, UC-43, UC-67, UC-45). Three further fixes landed from the
+fresh logs:
+
+- **B6 S3 mount — ROOT CAUSE FOUND + FIXED (committed 7f16c8c).** The
+  instrumentation surfaced the real error: `mount-s3: invalid value '…' for
+  '--prefix': prefix must end in '/'`. The adapter stripped the leading slash
+  but never added a trailing one. Fixed in `pkg/mounts/adapters/s3.go` +
+  regression test. Fixes UC-81..84 (needs redeploy to verify live).
+- **B2 firecracker — fixed the next layer (committed df42238).** The mkfs error
+  is gone; cold boot then failed at `PutBootSource: kernel file cannot be
+  opened`. Jailer mode requires chroot-relative paths to files staged inside the
+  chroot; the driver passed the absolute host kernel path (and absolute
+  rootfs/overlay). Added `chrootFilePath` to stage the kernel in and return bare
+  relative names. Fixes UC-24/44/88. **Follow-up:** `configureVMMForLoad`
+  (snapshot-load) needs the same path translation PLUS staging the snapshot
+  state/memory into the chroot — deferred (that path is skipped in this scenario).
+- **UC-74 (B7) — root cause confirmed live.** Reproduced: build returns a
+  `aerolvm-build/<hash>` tag; `ImageRequiresLocalPlacement` (image_distribution.go:190)
+  pins a local-only image to the building node; but the build runs on the
+  ingress/server that received the request, and `CanOwnSandboxRole`
+  (placement.go:355) is false for ingress/server → the image lives only where no
+  sandbox can run → `ErrNoPlacementTarget`. See B7 below.
 
 ## 4. Tickets (separate from this plan's PRs)
 


### PR DESCRIPTION
## Summary

- Fix `mountpoint-s3` `--prefix` handling: normalize non-empty prefixes to end with exactly one trailing `/`, and omit `--prefix` entirely for bucket-only sources (UC-81..84).
- Fix Firecracker jailer cold-boot: stage the kernel into the chroot and pass chroot-relative paths for kernel, rootfs, and overlay drives (UC-24/44/88).
- Add unit regression tests locking in both fixes (`chrootFilePath` direct/jailer/in-place/stale-stage paths; S3 bucket-only no-prefix behavior; jailer Create overlay drive path).
- Document B7 (UC-74 built-image cluster placement) as a separate ticket with root cause, fix options, and test plan; update the parent cluster-hetero fix plan with live re-run findings.

## Test plan

- [x] `go test ./internal/runtime/firecracker/...`
- [x] `go test ./pkg/mounts/adapters/...`
- [ ] `make integration-cluster-hetero keep` (verify UC-24/44/81..84 green after deploy)


Made with [Cursor](https://cursor.com)