### PR TITLE
fix(firecracker): chown staged jailer chroot files to fix cold-boot drive EPERM

### DIFF
--- a/internal/runtime/firecracker/chroot_path_test.go
+++ b/internal/runtime/firecracker/chroot_path_test.go
@@ -3,6 +3,7 @@ package firecracker
 import (
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 )
 
@@ -79,6 +80,44 @@ func TestChrootFilePath_JailerInPlaceIsNoop(t *testing.T) {
 	// The file must be untouched (same bytes, still present).
 	if b, err := os.ReadFile(inPlace); err != nil || string(b) != "rootfs" {
 		t.Errorf("in-place file disturbed: bytes=%q err=%v", string(b), err)
+	}
+}
+
+// TestChrootFilePath_JailerChownsToJailerIdentity is the regression guard for
+// the cold-boot drive failure (cluster-hetero UC-24/88):
+//
+//	PUT /drives/rootfs -> 400: ... Error manipulating the backing file:
+//	Permission denied (os error 13) rootfs.ext4
+//
+// The jailer drops firecracker to JailerUID:JailerGID before it opens the root
+// drive read-write, but the rootfs is built into the chroot as root, so the
+// jailed process can't open it. The staged file must be chowned to the jailer
+// identity. A non-root test can only chown to its own uid/gid, so we set the
+// jailer identity to exactly that and assert ownership lands on the staged file.
+func TestChrootFilePath_JailerChownsToJailerIdentity(t *testing.T) {
+	uid, gid := os.Getuid(), os.Getgid()
+	if uid == 0 {
+		t.Skip("running as root: the uid!=0 chown guard is exercised by the non-root CI path")
+	}
+	d := &Driver{cfg: Config{UseJailer: true, JailerUID: uid, JailerGID: gid}}
+	runDir := t.TempDir()
+	src := filepath.Join(t.TempDir(), "rootfs-src")
+	if err := os.WriteFile(src, []byte("rootfs"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.chrootFilePath(runDir, src, rootfsFileName); err != nil {
+		t.Fatalf("chrootFilePath: %v", err)
+	}
+	fi, err := os.Stat(filepath.Join(runDir, rootfsFileName))
+	if err != nil {
+		t.Fatalf("stat staged rootfs: %v", err)
+	}
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Skip("no syscall.Stat_t on this platform")
+	}
+	if int(st.Uid) != uid || int(st.Gid) != gid {
+		t.Errorf("staged rootfs owned by %d:%d, want jailer identity %d:%d", st.Uid, st.Gid, uid, gid)
 	}
 }
 

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -1569,6 +1569,16 @@ func (d *Driver) ClearNetworkBlockEgress(_ string) error {
 // runDir/destName (the rootfs and overlay are built in place) staging is a
 // no-op. In direct mode there is no chroot, so srcAbs is returned unchanged and
 // nothing is staged.
+//
+// The staged file is then chowned to JailerUID:JailerGID. The jailer drops
+// privilege to that uid/gid before firecracker opens the drives, and the root
+// drive is opened read-write (not read_only), so a root-owned rootfs.ext4 — the
+// shape mkfs/the OCI builder produces — fails with "Permission denied (os error
+// 13)". The kernel happens to work without this because boot-source opens it
+// read-only, but we chown uniformly so every chroot file is owned by the
+// process that will open it. All sandboxes share one jailer uid/gid, so
+// chowning a hardlinked shared template/kernel inode to that uid is consistent
+// across sandboxes.
 func (d *Driver) chrootFilePath(runDir, srcAbs, destName string) (string, error) {
 	if !d.cfg.UseJailer {
 		return srcAbs, nil
@@ -1580,6 +1590,17 @@ func (d *Driver) chrootFilePath(runDir, srcAbs, destName string) (string, error)
 		_ = os.Remove(dst)
 		if err := linkOrCopyRootfs(srcAbs, dst); err != nil {
 			return "", err
+		}
+	}
+	// Only chown when the jailer actually drops to a non-root identity.
+	// JailerUID/GID of 0 means no privilege drop (root opens the drives as
+	// root, no EPERM possible), so the chown is both unnecessary and — for the
+	// non-root unit-test process — itself a guaranteed EPERM. Skipping it on 0
+	// keeps the direct-spawn-shaped tests green while still chowning on every
+	// real production host (which runs the jailer as a dedicated uid/gid).
+	if d.cfg.JailerUID != 0 || d.cfg.JailerGID != 0 {
+		if err := os.Chown(dst, d.cfg.JailerUID, d.cfg.JailerGID); err != nil {
+			return "", fmt.Errorf("chown %s to jailer %d:%d: %w", destName, d.cfg.JailerUID, d.cfg.JailerGID, err)
 		}
 	}
 	return destName, nil


### PR DESCRIPTION
## Summary

Follow-up to #237. That PR fixed kernel staging and chroot-relative paths,
which let cold-boot progress past `boot-source` to the **drive** stage —
surfacing the next failure live on cluster-hetero UC-24/44/88:

```
PUT /drives/rootfs -> 400: Drive config error: Unable to create the virtio
block device: ... Error manipulating the backing file:
Permission denied (os error 13) rootfs.ext4
```

### Root cause (verified live on worker-fc)

The jailer drops firecracker to `JailerUID:JailerGID` (default **1000**, not
overridden in the cluster env) before it opens the drives, but `rootfs.ext4`
is built into the chroot as **root**. The kernel masked this because
`boot-source` opens **read-only** — a root-owned `0644` file is still readable
by uid 1000. The **root drive opens read-write**, so uid 1000 hits EPERM.

### Fix

`chrootFilePath` now chowns every staged chroot file to the jailer identity
after staging, covering the cold-boot rootfs, the overlay, and the kernel.
Guarded on a non-zero uid/gid so the direct-spawn and unit-test paths (which
run as the current user with `JailerUID` 0) are untouched — chowning to 0:0
is both meaningless (no privilege drop) and an EPERM for a non-root test
process.

## Cluster-correctness / fragile-area call-out

Touches the firecracker driver (a fragile area per CLAUDE.md). No cluster
state, placement, or store change. Single-node and non-jailer (dev/CI) paths
are a no-op: the `JailerUID != 0 || JailerGID != 0` guard means only real
jailer hosts chown. Idempotent across Create retries (chown of an already-
owned file is a no-op).

## Test plan

- [x] `go test ./internal/runtime/firecracker/...` — incl. new
  `TestChrootFilePath_JailerChownsToJailerIdentity` (chowns to the current
  uid/gid, the only chown a non-root test can perform; skips under root).
- [ ] `make integration-cluster-hetero keep` — verify UC-24/44/88 green after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)