### PR TITLE
fix(oci): always pass explicit ext4 size to mkfs.ext4 (template builds)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BIN_DIR ?= bin
 
 .PHONY: fmt install-git-hooks test test-acme-e2e build build-sandboxd build-toolboxd docs-install docs-dev docs-build clean \
 	integration-local integration-single integration-single-wasm integration-cluster-mixed integration-cluster-mixed-wasm \
-	integration-cluster-hetero integration-arm64 integration-arm64-single integration-arm64-cluster integration-all integration-collect-logs integration-destroy integration-reap
+	integration-cluster-hetero integration-single-fc integration-arm64 integration-arm64-single integration-arm64-cluster integration-all integration-collect-logs integration-destroy integration-reap
 
 fmt:
 	$(GO) fmt ./...
@@ -93,6 +93,12 @@ integration-cluster-hetero:
 	# the bare-metal Firecracker box alone exceeds the account Spot vCPU quota,
 	# so --metal-on-demand is unnecessary here. Pass FLAGS=--keep to debug.
 	integration-tests/run.sh cluster-hetero $(RUN_FLAGS)
+
+# Single-node x86 Firecracker on bare metal (c5.metal). Smallest scenario that
+# exercises the firecracker use cases (UC-24/47-50) without the full hetero
+# cluster. On-Demand only (the metal box exceeds the Spot vCPU quota).
+integration-single-fc:
+	integration-tests/run.sh single-node-fc $(RUN_FLAGS)
 
 integration-arm64-single:
 	integration-tests/run.sh single-node-fc-arm64 $(RUN_FLAGS)

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -32,6 +32,7 @@ make integration-local                  # local-mode (--local install on a throw
 integration-tests/run.sh single-node --keep        # leave infra up for debugging
 integration-tests/run.sh single-node --prod-tls    # use real Let's Encrypt instead of staging
 make integration-cluster-hetero           # 8-node heterogeneous cluster (x86 fc)
+make integration-single-fc                # single-node-fc (x86 firecracker, c5.metal)
 make integration-arm64                    # arm64 firecracker single + cluster scenarios
 make integration-arm64-single             # single-node-fc-arm64 (Graviton metal)
 make integration-arm64-cluster            # cluster-arm64 (homogeneous arm64)

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -7,7 +7,7 @@
 #   integration-tests/run.sh all       [flags]
 #
 # Scenarios: single-node | local-mode | cluster-3-mixed | cluster-hetero |
-#            single-node-fc-arm64 | cluster-arm64
+#            single-node-fc | single-node-fc-arm64 | cluster-arm64
 #
 # Safety: every dangerous input is gated by provision.sh check-safety BEFORE any
 # apply. Teardown runs on EXIT/INT/TERM (trap) so a crash can't leak EC2; the
@@ -443,7 +443,7 @@ if [[ "$DESTROY_ONLY" == "1" ]]; then
 elif [[ "$COLLECT_LOGS_ONLY" == "1" ]]; then
   collect_logs_only "$SCENARIO"
 elif [[ "$SCENARIO" == "all" ]]; then
-  for s in local-mode single-node single-node-wasm cluster-3-mixed cluster-3-mixed-wasm cluster-hetero single-node-fc-arm64 cluster-arm64; do
+  for s in local-mode single-node single-node-wasm cluster-3-mixed cluster-3-mixed-wasm cluster-hetero single-node-fc single-node-fc-arm64 cluster-arm64; do
     ( run_one "$s" )
   done
 else

--- a/integration-tests/scenarios/single-node-fc.caps.yml
+++ b/integration-tests/scenarios/single-node-fc.caps.yml
@@ -1,0 +1,10 @@
+# Capabilities the single-node x86 Firecracker scenario can satisfy. The suite
+# skips any use case whose required capabilities aren't all present here. Mirror
+# of single-node-fc-arm64 but on an x86 bare-metal host.
+name: single-node-fc
+capabilities:
+  - docker
+  - platform-volumes
+  - firecracker
+  - domain
+  - custom-domains

--- a/integration-tests/scenarios/single-node-fc.tfvars
+++ b/integration-tests/scenarios/single-node-fc.tfvars
@@ -1,0 +1,43 @@
+# Single-node x86 Firecracker integration scenario: one mixed bare-metal worker
+# with Firecracker enabled. The lowest-cost way to exercise the firecracker
+# use cases (UC-24/47-50) in isolation — i.e. without standing up the full
+# 8-node cluster-hetero just to reach its single worker-fc node. arm64 parity
+# lives in single-node-fc-arm64.tfvars.
+#
+# Firecracker needs /dev/kvm, so this must be a bare-metal instance (c5.metal).
+# On-Demand only (spot = false): the bare-metal box alone exceeds the account
+# Spot vCPU quota (MaxSpotInstanceCountExceeded), matching cluster-hetero's
+# worker-fc reasoning.
+#
+# AWS access (aws_profile, aws_region, ssh_key_name, ...) is inherited from the
+# operator's config/terraform.tfvars, which run.sh chains as the first
+# -var-file.
+cluster_name = "aerolvm-itest-single-node-fc"
+
+extra_tags = {
+  itest = "true"
+  ttl   = "4"
+}
+
+default_instance_type    = "c5.metal"
+default_volume_size_gb   = 80
+default_with_firecracker = true
+
+# A single node has nothing to share certs WITH; disable the prod-inherited
+# managed S3 cert bucket so the run doesn't create one.
+caddy_shared_cert_storage = {
+  enabled = false
+}
+
+firecracker = {
+  # Empty *_url + auto_install_artifacts (default true) pulls arch-matched
+  # upstream firecracker/jailer/vmlinux on first boot — no custom staging needed.
+}
+
+nodes = {
+  node1 = {
+    role = "mixed"
+    seed = true
+    spot = false
+  }
+}

--- a/pkg/oci/builder.go
+++ b/pkg/oci/builder.go
@@ -16,12 +16,12 @@
 //     read the OCI config from the staging dir directly so layer ordering
 //     is unambiguous.
 //
-//  3. mkfs.ext4 -d <bundle-dir>/rootfs/ -F <out.ext4>
+//  3. mkfs.ext4 -d <bundle-dir>/rootfs/ -F <out.ext4> <size>
 //     Build a single-file ext4 filesystem from the materialized rootfs.
-//     Size is auto-sized by mkfs.ext4 (the -d flag computes minimum
-//     necessary blocks plus the journal); the caller can set MinSizeMiB
-//     to round up so guest writes have headroom before the filesystem
-//     fills.
+//     The size is ALWAYS passed explicitly (mke2fs refuses to size a new
+//     file from -d alone); it is derived from the unpacked rootfs plus
+//     metadata/journal + guest headroom, floored by MinSizeMiB. See
+//     ext4SizeMiB / runMkfs.
 //
 // What does NOT live here: the per-sandbox overlay file (that's the
 // runtime driver's job; the overlay is a sparse file plus a writeback
@@ -223,23 +223,75 @@ func (b *Builder) runUmoci(ctx context.Context, ociDir, tag, bundleDir string) e
 }
 
 // runMkfs wraps stage 3. -d copies a directory in as the initial
-// contents; -F overwrites without prompting; we pass an explicit size in
-// MiB only when MinSizeMiB > 0 (mkfs.ext4's -d alone would size the
-// filesystem to the minimum needed, leaving zero room for guest writes).
+// contents; -F overwrites without prompting.
+//
+// We ALWAYS pass an explicit size. Contrary to the older assumption that
+// "mkfs.ext4 -d auto-sizes to the minimum", mke2fs (1.43+, including the
+// 1.46.5 that ships on the production hosts) refuses to size a new file
+// from -d alone — it exits with "The file <out> does not exist and no
+// size was specified." That is exactly the template-build failure seen in
+// single-node-fc (UC-47..50, UC-80) when MinSizeMiB came through as 0.
+//
+// The size is the larger of (a) a floor derived from the unpacked rootfs
+// plus ext4 metadata/journal + guest write headroom, and (b) the caller's
+// MinSizeMiB request. Computing (a) keeps zero-config template builds
+// working without forcing every caller to pick a disk size.
 func (b *Builder) runMkfs(ctx context.Context, rootfsSrc, outPath string, minSizeMiB int) error {
+	sizeMiB, err := ext4SizeMiB(rootfsSrc, minSizeMiB)
+	if err != nil {
+		return fmt.Errorf("oci: size rootfs %s: %w", rootfsSrc, err)
+	}
 	args := []string{
 		"-d", rootfsSrc,
 		"-F",
-	}
-	// Pinning the UUID would make build output deterministic, but mkfs
-	// doesn't accept a "-U <uuid>" option universally and the runtime
-	// driver doesn't rely on the UUID — skip it.
-	if minSizeMiB > 0 {
-		args = append(args, outPath, strconv.Itoa(minSizeMiB)+"M")
-	} else {
-		args = append(args, outPath)
+		// Pinning the UUID would make build output deterministic, but mkfs
+		// doesn't accept a "-U <uuid>" option universally and the runtime
+		// driver doesn't rely on the UUID — skip it.
+		outPath,
+		strconv.Itoa(sizeMiB) + "M",
 	}
 	return runStage(ctx, "mkfs.ext4", b.cfg.Mkfs4Bin, args)
+}
+
+// ext4 overhead constants used to turn the apparent size of the unpacked
+// rootfs into an ext4 image size that (a) actually fits the files plus
+// filesystem metadata + journal and (b) leaves the guest some room to
+// write before it hits ENOSPC on first boot.
+const (
+	// ext4MetadataNumer/ext4MetadataDenom grow the payload by 50% to cover
+	// inode tables, block bitmaps, the journal, and rounding slack. ext4 on
+	// a directory-seeded image needs noticeably more than the apparent file
+	// bytes; 1.5x is the conservative floor mke2fs itself trends toward.
+	ext4MetadataNumer = 3
+	ext4MetadataDenom = 2
+	// ext4HeadroomMiB is a fixed floor added on top so even a tiny rootfs
+	// (e.g. a scratch/alpine template) boots with writable space rather
+	// than a filesystem sized to the byte.
+	ext4HeadroomMiB = 128
+)
+
+// ext4SizeMiB computes the ext4 image size in MiB for the unpacked rootfs
+// at src, never returning less than minSizeMiB. It walks the tree summing
+// apparent file sizes, applies the metadata multiplier and fixed
+// headroom, and rounds up to whole MiB. A symlink or special file
+// contributes nothing (we follow nothing; only regular files hold bytes).
+func ext4SizeMiB(src string, minSizeMiB int) (int, error) {
+	var total int64
+	err := filepath.Walk(src, func(_ string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.Mode().IsRegular() {
+			total += info.Size()
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	const miB = 1 << 20
+	payloadMiB := int((total*ext4MetadataNumer/ext4MetadataDenom + miB - 1) / miB)
+	return max(payloadMiB+ext4HeadroomMiB, minSizeMiB), nil
 }
 
 // runStage executes one subprocess with bounded stderr capture, returning

--- a/pkg/oci/builder_test.go
+++ b/pkg/oci/builder_test.go
@@ -192,6 +192,59 @@ func TestBuild_PassesMinSizeMiB(t *testing.T) {
 	}
 }
 
+// TestBuild_AlwaysPassesSize is the regression guard for the single-node-fc
+// template-build failure (UC-47..50, UC-80):
+//
+//	mkfs.ext4 -d <bundle>/rootfs -F <out>: The file <out> does not exist
+//	and no size was specified.
+//
+// A zero MinSizeMiB (the default for a template create that didn't pick a
+// disk size) must NOT reach mke2fs without a size — mke2fs 1.46.5 refuses
+// to size a new file from -d alone. Build must compute a floor from the
+// unpacked rootfs and always pass an explicit "<n>M".
+func TestBuild_AlwaysPassesSize(t *testing.T) {
+	cfg, _ := happyConfig(t)
+	b, _ := New(cfg)
+	out := filepath.Join(t.TempDir(), "rootfs.ext4")
+	res, err := b.Build(context.Background(), BuildRequest{
+		ImageRef: "docker://alpine:3.20",
+		OutPath:  out,
+		// MinSizeMiB intentionally left 0 — the failure case.
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer res.CleanupDir()
+	contents, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if strings.Contains(string(contents), "no-size") {
+		t.Error("mkfs called WITHOUT a size for MinSizeMiB=0 — would EPERM/abort on mke2fs 1.46.5")
+	}
+}
+
+// TestExt4SizeMiB checks the size math directly: it must honor MinSizeMiB
+// as a floor, add headroom over a tiny rootfs, and round up to whole MiB.
+func TestExt4SizeMiB(t *testing.T) {
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "f"), make([]byte, 1<<20), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Tiny rootfs, no floor: payload (1MiB*1.5=2MiB) + headroom.
+	got, err := ext4SizeMiB(src, 0)
+	if err != nil {
+		t.Fatalf("ext4SizeMiB: %v", err)
+	}
+	if want := 2 + ext4HeadroomMiB; got != want {
+		t.Errorf("size = %d MiB, want %d", got, want)
+	}
+	// A larger MinSizeMiB wins as the floor.
+	if got, _ := ext4SizeMiB(src, 4096); got != 4096 {
+		t.Errorf("floor not honored: got %d, want 4096", got)
+	}
+}
+
 // TestBuild_StageFailure_SurfacesTail confirms a non-zero exit from any
 // stage carries the binary's stderr in the returned error. Operators
 // staring at a failed sandbox create need this; without it the only


### PR DESCRIPTION
## What

Template builds fail at the rootfs stage on production firecracker hosts:

```
mkfs.ext4 -d <bundle>/rootfs -F <out>/rootfs.ext4: exit status 1
(stderr: mke2fs 1.46.5 (30-Dec-2021)
The file .../rootfs.ext4 does not exist and no size was specified.)
```

The OCI builder assumed `mkfs.ext4 -d <dir>` auto-sizes the image. It does not on e2fsprogs 1.43+ (1.46.5 ships on the hosts): with a non-existent output file and no size, mke2fs aborts. So any template create with `MinSizeMiB=0` (the default) failed.

## Symptom (single-node-fc integration run)

- UC-47 Create template, UC-48 List+get, UC-50 Delete — fail at build
- UC-49 Rebuild — "template not eligible for rebuild: status=failed" (downstream of the failed build)
- UC-80 Firecracker clone RNG entropy — builds a template first, same failure

## Fix

`runMkfs` now **always** passes an explicit size. `ext4SizeMiB` derives it from the unpacked rootfs (apparent bytes × 1.5 for ext4 metadata + journal, plus a 128 MiB guest-write headroom floor), then takes the max with the caller's `MinSizeMiB`. Zero-config template builds size themselves; explicit disk requests still win as a floor.

## Boot-path / fragile-area call-outs

- This is the **cold-boot rootfs build** path (`pkg/oci`), shared by template builds and firecracker cold-boot from a plain OCI image. The cold-boot driver already passed `DiskGB*1024` (non-zero), so it was unaffected and stays unaffected — the size is now `max(computed-floor, request)`, never smaller than before.
- No cluster/placement/store surface touched. No-op for non-firecracker builds.
- Idempotent: `-F` overwrites; recompute is deterministic for a given rootfs.

## Tests

- `TestBuild_AlwaysPassesSize` — `MinSizeMiB=0` reaches mkfs **with** a size (the regression).
- `TestExt4SizeMiB` — headroom + rounding + MinSizeMiB floor math.
- `TestBuild_PassesMinSizeMiB` / `TestBuild_HappyPath` still green.
- `go test ./pkg/oci/...` passes.

Re-run `make integration-single-fc` after deploy to confirm UC-47..50 + UC-80 flip green. (UC-24/44/88 drive EPERM is the separate, already-merged #238.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)