### PR TITLE
feat(firecracker): inject toolboxd agent into cold-boot guests (fixes UC-44 vsock handshake)

### DIFF
--- a/internal/runtime/firecracker/assets/toolboxd-init.sh
+++ b/internal/runtime/firecracker/assets/toolboxd-init.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# toolboxd-init — PID 1 for cold-boot Firecracker guests booted from a
+# stock OCI image.
+#
+# A plain OCI image (alpine, ubuntu, ...) has no init that brings up the
+# AerolVM agent, so the host's Create handshake (vsock CID 3 port 1024)
+# and exec/files/sessions (HTTP on :2280) have nothing to talk to. The
+# cold-boot driver injects this script as init=/usr/local/bin/toolboxd-init
+# so the very first userspace process is us: mount the pseudo-filesystems
+# toolboxd needs, load the per-sandbox env, then exec the agent as PID 1.
+#
+# eth0 is already configured by the kernel `ip=` autoconf (CONFIG_IP_PNP)
+# the driver appends to the boot args, so there is no network setup here.
+#
+# This script must run under the guest's /bin/sh (busybox or bash). Keep
+# it POSIX and dependency-free. If toolboxd exits, PID 1 exits and the
+# kernel panics; boot args carry `panic=1` so the VMM exits cleanly and
+# the host's cleanup contract fires rather than leaving a hung guest.
+
+mount -t proc     proc /proc        2>/dev/null || true
+mount -t sysfs    sys  /sys         2>/dev/null || true
+mount -t devtmpfs dev  /dev         2>/dev/null || true
+mount -t tmpfs    tmp  /tmp         2>/dev/null || true
+
+# Per-sandbox environment (token, port) injected alongside this script.
+if [ -f /etc/toolboxd.env ]; then
+	# shellcheck disable=SC1091
+	. /etc/toolboxd.env
+	export SB_TOOLBOX_TOKEN SB_TOOLBOX_PORT
+fi
+
+exec /usr/local/bin/toolboxd

--- a/internal/runtime/firecracker/coldboot_agent.go
+++ b/internal/runtime/firecracker/coldboot_agent.go
@@ -1,0 +1,111 @@
+package firecracker
+
+import (
+	_ "embed"
+	"fmt"
+	"net"
+	"runtime"
+)
+
+// toolboxdInitScript is the PID-1 shim baked into every cold-boot rootfs.
+// See assets/toolboxd-init.sh for the rationale; embedding keeps it in the
+// binary so there's no runtime asset path to misconfigure.
+//
+//go:embed assets/toolboxd-init.sh
+var toolboxdInitScript []byte
+
+const (
+	// guestToolboxPath / guestInitPath / guestEnvPath are where the
+	// cold-boot injector places the agent, its init shim, and the
+	// per-sandbox env file inside the guest rootfs. guestInitPath must
+	// match the init= in coldBootArgs.
+	guestToolboxPath = "/usr/local/bin/toolboxd"
+	guestInitPath    = "/usr/local/bin/toolboxd-init"
+	guestEnvPath     = "/etc/toolboxd.env"
+
+	// guestToolboxPort is the in-guest HTTP port toolboxd listens on
+	// (toolboxd's SB_TOOLBOX_PORT default, cmd/toolboxd/main.go). The host
+	// reaches exec/files/sessions at GuestIP:guestToolboxPort over the TAP.
+	guestToolboxPort = 2280
+)
+
+// coldBootInjectFiles returns the files to bake into a cold-boot rootfs so
+// the guest comes up running the agent. Returns nil when no toolbox binary
+// is configured — the caller then cold-boots an agent-less guest (Create's
+// vsock handshake will time out, which is the honest failure for a
+// misconfigured daemon rather than a silently broken sandbox).
+//
+// The token is per-sandbox, so these files are regenerated on every
+// cold-boot Create (cold-boot already builds a fresh rootfs per sandbox).
+func coldBootInjectFiles(toolboxBinaryPath, toolboxToken string) []InjectFile {
+	if toolboxBinaryPath == "" {
+		return nil
+	}
+	// Single-quote the token defensively even though tokens are
+	// host-generated hex/base64 — keeps a future token format from
+	// breaking the `.`-sourced env file.
+	env := fmt.Sprintf("SB_TOOLBOX_TOKEN='%s'\nSB_TOOLBOX_PORT='%d'\n", toolboxToken, guestToolboxPort)
+	return []InjectFile{
+		{HostPath: toolboxBinaryPath, GuestPath: guestToolboxPath, Mode: 0o755},
+		{Content: toolboxdInitScript, GuestPath: guestInitPath, Mode: 0o755},
+		{Content: []byte(env), GuestPath: guestEnvPath, Mode: 0o600},
+	}
+}
+
+// coldBootArgs builds the kernel command line for a cold-boot guest that
+// runs the injected agent. It extends the base args with:
+//
+//   - ip=<guest>::<gw>:<mask>::eth0:off — kernel IP autoconfig (CONFIG_IP_PNP)
+//     so eth0 is up before userspace; the agent's HTTP server is then
+//     reachable at GuestIP:2280 over the TAP without an in-guest DHCP client.
+//   - init=/usr/local/bin/toolboxd-init — run our injected shim as PID 1
+//     instead of the stock image's (absent or unrelated) init.
+//
+// When slot is nil or carries no usable IP, the ip= clause is omitted (the
+// guest still boots; only host→guest networking is unconfigured). When
+// toolboxInjected is false the init= clause is omitted so an agent-less
+// cold-boot falls back to the image's own init.
+func coldBootArgs(slot *TapSlot, toolboxInjected bool) string {
+	args := baseBootArgsFor(runtime.GOARCH)
+	if ipClause := kernelIPArg(slot); ipClause != "" {
+		args += " " + ipClause
+	}
+	if toolboxInjected {
+		args += " init=" + guestInitPath
+	}
+	return args
+}
+
+// kernelIPArg renders the Linux `ip=` kernel-autoconfig clause from a TAP
+// slot, or "" if the slot lacks the data. Form:
+//
+//	ip=<client-ip>::<gateway-ip>:<netmask>::<device>:off
+//
+// gateway is the host side of the /30 (slot.HostIP); netmask is derived
+// from slot.CIDR. "off" disables any autoconfig protocol (we supply
+// everything statically).
+func kernelIPArg(slot *TapSlot) string {
+	if slot == nil || slot.GuestIP == "" || slot.HostIP == "" || slot.CIDR == "" {
+		return ""
+	}
+	mask := netmaskFromCIDR(slot.CIDR)
+	if mask == "" {
+		return ""
+	}
+	return fmt.Sprintf("ip=%s::%s:%s::%s:off", slot.GuestIP, slot.HostIP, mask, primaryIfaceID)
+}
+
+// netmaskFromCIDR turns "172.16.0.2/30" into dotted "255.255.255.252".
+// Returns "" on a malformed or non-IPv4 CIDR — the caller then drops the
+// ip= clause rather than booting with a bogus mask.
+func netmaskFromCIDR(cidr string) string {
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil || ipnet == nil {
+		return ""
+	}
+	m := ipnet.Mask
+	if len(m) != net.IPv4len {
+		return ""
+	}
+	return fmt.Sprintf("%d.%d.%d.%d", m[0], m[1], m[2], m[3])
+}

--- a/internal/runtime/firecracker/coldboot_agent.go
+++ b/internal/runtime/firecracker/coldboot_agent.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"runtime"
+	"strings"
 )
 
 // toolboxdInitScript is the PID-1 shim baked into every cold-boot rootfs.
@@ -41,15 +42,19 @@ func coldBootInjectFiles(toolboxBinaryPath, toolboxToken string) []InjectFile {
 	if toolboxBinaryPath == "" {
 		return nil
 	}
-	// Single-quote the token defensively even though tokens are
-	// host-generated hex/base64 — keeps a future token format from
+	// Shell-quote the token defensively even though tokens are
+	// host-generated hex today — keeps a future token format from
 	// breaking the `.`-sourced env file.
-	env := fmt.Sprintf("SB_TOOLBOX_TOKEN='%s'\nSB_TOOLBOX_PORT='%d'\n", toolboxToken, guestToolboxPort)
+	env := fmt.Sprintf("SB_TOOLBOX_TOKEN=%s\nSB_TOOLBOX_PORT='%d'\n", shellSingleQuote(toolboxToken), guestToolboxPort)
 	return []InjectFile{
 		{HostPath: toolboxBinaryPath, GuestPath: guestToolboxPath, Mode: 0o755},
 		{Content: toolboxdInitScript, GuestPath: guestInitPath, Mode: 0o755},
 		{Content: []byte(env), GuestPath: guestEnvPath, Mode: 0o600},
 	}
+}
+
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
 // coldBootArgs builds the kernel command line for a cold-boot guest that

--- a/internal/runtime/firecracker/coldboot_agent_test.go
+++ b/internal/runtime/firecracker/coldboot_agent_test.go
@@ -85,11 +85,31 @@ func TestNetmaskFromCIDR(t *testing.T) {
 		{"172.16.0.0/30", "255.255.255.252"},
 		{"10.0.0.0/24", "255.255.255.0"},
 		{"192.168.1.0/16", "255.255.0.0"},
+		{"2001:db8::/32", ""},
 		{"bogus", ""},
 		{"", ""},
 	} {
 		if got := netmaskFromCIDR(tc.cidr); got != tc.want {
 			t.Errorf("netmaskFromCIDR(%q) = %q, want %q", tc.cidr, got, tc.want)
+		}
+	}
+}
+
+func TestKernelIPArg(t *testing.T) {
+	full := &TapSlot{GuestIP: "172.16.0.2", HostIP: "172.16.0.1", CIDR: "172.16.0.0/30"}
+	want := "ip=172.16.0.2::172.16.0.1:255.255.255.252::eth0:off"
+	if got := kernelIPArg(full); got != want {
+		t.Fatalf("kernelIPArg(full) = %q, want %q", got, want)
+	}
+	for _, slot := range []*TapSlot{
+		nil,
+		{},
+		{GuestIP: "172.16.0.2"},
+		{GuestIP: "172.16.0.2", HostIP: "172.16.0.1"},
+		{GuestIP: "172.16.0.2", HostIP: "172.16.0.1", CIDR: "not-a-cidr"},
+	} {
+		if got := kernelIPArg(slot); got != "" {
+			t.Errorf("kernelIPArg(%+v) = %q, want empty", slot, got)
 		}
 	}
 }

--- a/internal/runtime/firecracker/coldboot_agent_test.go
+++ b/internal/runtime/firecracker/coldboot_agent_test.go
@@ -1,0 +1,89 @@
+package firecracker
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestColdBootInjectFiles_PutsAgentInGuest is the regression guard for the
+// cold-boot exec failure (single-node-fc UC-44): a plain OCI image has no
+// agent, so the guest must have toolboxd + its init shim + the per-sandbox
+// token baked in, or Create's vsock handshake has no peer.
+func TestColdBootInjectFiles_PutsAgentInGuest(t *testing.T) {
+	files := coldBootInjectFiles("/opt/aerolvm/toolboxd", "tok-123")
+	if len(files) != 3 {
+		t.Fatalf("want 3 injected files, got %d", len(files))
+	}
+	byPath := map[string]InjectFile{}
+	for _, f := range files {
+		byPath[f.GuestPath] = f
+	}
+
+	bin, ok := byPath[guestToolboxPath]
+	if !ok || bin.HostPath != "/opt/aerolvm/toolboxd" || bin.Mode != 0o755 {
+		t.Errorf("toolboxd inject wrong: %+v", bin)
+	}
+	init, ok := byPath[guestInitPath]
+	if !ok || len(init.Content) == 0 || init.Mode != 0o755 {
+		t.Errorf("init shim inject wrong: %+v", init)
+	}
+	if !strings.Contains(string(init.Content), "exec /usr/local/bin/toolboxd") {
+		t.Errorf("init shim does not exec the agent:\n%s", init.Content)
+	}
+	env, ok := byPath[guestEnvPath]
+	if !ok || env.Mode != 0o600 {
+		t.Errorf("env inject wrong mode: %+v", env)
+	}
+	if !strings.Contains(string(env.Content), "SB_TOOLBOX_TOKEN='tok-123'") {
+		t.Errorf("env file missing token: %q", env.Content)
+	}
+}
+
+// TestColdBootInjectFiles_NoBinaryIsNil: with no toolbox binary configured
+// the injector returns nil so the caller cold-boots an agent-less guest
+// (and warns) rather than panicking on an empty HostPath.
+func TestColdBootInjectFiles_NoBinaryIsNil(t *testing.T) {
+	if files := coldBootInjectFiles("", "tok"); files != nil {
+		t.Errorf("want nil with no binary, got %+v", files)
+	}
+}
+
+// TestColdBootArgs covers the boot-args contract: base args always present;
+// ip= autoconfig and init= override added only when their inputs are.
+func TestColdBootArgs(t *testing.T) {
+	slot := &TapSlot{GuestIP: "172.16.0.2", HostIP: "172.16.0.1", CIDR: "172.16.0.0/30"}
+
+	full := coldBootArgs(slot, true)
+	if !strings.Contains(full, "ip=172.16.0.2::172.16.0.1:255.255.255.252::eth0:off") {
+		t.Errorf("missing/wrong ip= clause: %q", full)
+	}
+	if !strings.Contains(full, "init="+guestInitPath) {
+		t.Errorf("missing init= clause: %q", full)
+	}
+	if !strings.Contains(full, "panic=1") {
+		t.Errorf("base args dropped: %q", full)
+	}
+
+	// No agent injected -> no init= (fall back to the image's own init).
+	if got := coldBootArgs(slot, false); strings.Contains(got, "init=") {
+		t.Errorf("init= must be absent when agent not injected: %q", got)
+	}
+	// No/blank slot -> no ip= clause, but still boots.
+	if got := coldBootArgs(nil, true); strings.Contains(got, "ip=") {
+		t.Errorf("ip= must be absent for nil slot: %q", got)
+	}
+}
+
+func TestNetmaskFromCIDR(t *testing.T) {
+	for _, tc := range []struct{ cidr, want string }{
+		{"172.16.0.0/30", "255.255.255.252"},
+		{"10.0.0.0/24", "255.255.255.0"},
+		{"192.168.1.0/16", "255.255.0.0"},
+		{"bogus", ""},
+		{"", ""},
+	} {
+		if got := netmaskFromCIDR(tc.cidr); got != tc.want {
+			t.Errorf("netmaskFromCIDR(%q) = %q, want %q", tc.cidr, got, tc.want)
+		}
+	}
+}

--- a/internal/runtime/firecracker/coldboot_agent_test.go
+++ b/internal/runtime/firecracker/coldboot_agent_test.go
@@ -39,6 +39,12 @@ func TestColdBootInjectFiles_PutsAgentInGuest(t *testing.T) {
 	}
 }
 
+func TestShellSingleQuote(t *testing.T) {
+	if got := shellSingleQuote("tok'123"); got != `'tok'\''123'` {
+		t.Fatalf("shellSingleQuote escaped token as %q", got)
+	}
+}
+
 // TestColdBootInjectFiles_NoBinaryIsNil: with no toolbox binary configured
 // the injector returns nil so the caller cold-boots an agent-less guest
 // (and warns) rather than panicking on an empty HostPath.

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -218,6 +218,15 @@ type Config struct {
 	// (carries host wall clock to the guest for clock+RNG resync).
 	// Mirrors internal/config.Config.FirecrackerSnapshotPostResumeTimeout.
 	PostResumeTimeout time.Duration
+	// ToolboxBinaryPath is the host path to the toolboxd agent binary,
+	// baked into every cold-boot rootfs so the guest has something
+	// listening on vsock (the Create readiness handshake) and HTTP (exec /
+	// files / sessions). Mirrors internal/config.Config.ToolboxBinaryPath.
+	// When empty, cold-boot still works but the guest comes up with no
+	// agent — Create's vsock handshake will then time out, so production
+	// daemons must set it. The template/snapshot path does NOT use this
+	// (those images carry their own init + agent).
+	ToolboxBinaryPath string
 }
 
 // FromDaemonConfig copies the Firecracker-relevant fields out of the full
@@ -240,6 +249,7 @@ func FromDaemonConfig(c config.Config) Config {
 		OverlayMkfs:          c.FirecrackerOverlayMkfs,
 		Mkfs4Bin:             c.FirecrackerMkfs4Bin,
 		PostResumeTimeout:    c.FirecrackerSnapshotPostResumeTimeout,
+		ToolboxBinaryPath:    c.ToolboxBinaryPath,
 	}
 }
 
@@ -613,6 +623,16 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 				"sandbox_id", allocID, "template_id", req.TemplateID, "src", src.RootfsPath)
 		}
 	} else {
+		// Bake the in-guest agent (toolboxd) + its PID-1 init shim + the
+		// per-sandbox token into the otherwise-stock OCI rootfs. Without
+		// this the guest boots with nothing on vsock and Create's readiness
+		// handshake times out (a plain image carries no agent). Empty when
+		// no toolbox binary is configured — see coldBootInjectFiles.
+		inject := coldBootInjectFiles(d.cfg.ToolboxBinaryPath, toolboxToken)
+		if inject == nil {
+			d.logger.Warn("firecracker cold-boot: no toolbox binary configured; guest will boot without an agent and the vsock handshake will fail",
+				"sandbox_id", allocID)
+		}
 		rootfsResult, err := d.rootfs.Build(ctx, RootfsBuildRequest{
 			ImageRef: ociImageRefFor(req.Image),
 			OutPath:  rootfsPath,
@@ -620,8 +640,9 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 			// the OCI builder rounds up to the larger of the image and
 			// this floor. Zero (the wire default) means "use whatever the
 			// unpacked rootfs needs".
-			MinSizeMiB: req.DiskGB * 1024,
-			Tag:        "latest",
+			MinSizeMiB:  req.DiskGB * 1024,
+			Tag:         "latest",
+			InjectFiles: inject,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("firecracker runtime: rootfs build: %w", err)
@@ -841,9 +862,14 @@ func (d *Driver) configureVMM(ctx context.Context, client VMMClient, req models.
 	if err != nil {
 		return fmt.Errorf("firecracker runtime: stage rootfs: %w", err)
 	}
+	// Cold-boot args: base + kernel IP autoconfig (so eth0 is up for the
+	// agent's HTTP server) + init=toolboxd-init when the agent was injected
+	// into the rootfs. The injection condition mirrors coldBootInjectFiles
+	// exactly (both key off a configured toolbox binary), so the init=
+	// override is present iff the shim is actually in the image.
 	if err := client.PutBootSource(ctx, firecracker.BootSource{
 		KernelImagePath: kernelAPIPath,
-		BootArgs:        defaultBootArgs(),
+		BootArgs:        coldBootArgs(slot, d.cfg.ToolboxBinaryPath != ""),
 	}); err != nil {
 		return fmt.Errorf("firecracker runtime: PutBootSource: %w", err)
 	}

--- a/internal/runtime/firecracker/seams.go
+++ b/internal/runtime/firecracker/seams.go
@@ -25,6 +25,7 @@ package firecracker
 import (
 	"context"
 	"io"
+	"os"
 	"time"
 
 	"github.com/aerol-ai/microvm/pkg/firecracker"
@@ -52,6 +53,19 @@ type RootfsBuildRequest struct {
 	OutPath    string
 	MinSizeMiB int
 	Tag        string
+	// InjectFiles mirrors pkg/oci.BuildRequest.InjectFiles. The cold-boot
+	// path uses it to bake the in-guest agent + init shim + per-sandbox
+	// token into a stock OCI image.
+	InjectFiles []InjectFile
+}
+
+// InjectFile mirrors pkg/oci.InjectFile. Exactly one of HostPath/Content
+// supplies the bytes; GuestPath is the absolute in-guest destination.
+type InjectFile struct {
+	HostPath  string
+	Content   []byte
+	GuestPath string
+	Mode      os.FileMode
 }
 
 // RootfsResult is the seam-side mirror of pkg/oci.Result. The driver

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1505,11 +1505,21 @@ type firecrackerRootfsAdapter struct {
 }
 
 func (a *firecrackerRootfsAdapter) Build(ctx context.Context, req fcruntime.RootfsBuildRequest) (*fcruntime.RootfsResult, error) {
+	inject := make([]oci.InjectFile, len(req.InjectFiles))
+	for i, f := range req.InjectFiles {
+		inject[i] = oci.InjectFile{
+			HostPath:  f.HostPath,
+			Content:   f.Content,
+			GuestPath: f.GuestPath,
+			Mode:      f.Mode,
+		}
+	}
 	res, err := a.inner.Build(ctx, oci.BuildRequest{
-		ImageRef:   req.ImageRef,
-		OutPath:    req.OutPath,
-		MinSizeMiB: req.MinSizeMiB,
-		Tag:        req.Tag,
+		ImageRef:    req.ImageRef,
+		OutPath:     req.OutPath,
+		MinSizeMiB:  req.MinSizeMiB,
+		Tag:         req.Tag,
+		InjectFiles: inject,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/daemon/daemon_adapters_test.go
+++ b/pkg/daemon/daemon_adapters_test.go
@@ -266,6 +266,37 @@ func TestFirecrackerRootfsAdapter_BuildSuccess(t *testing.T) {
 	}
 }
 
+func TestFirecrackerRootfsAdapter_BuildWithInjectFiles(t *testing.T) {
+	cfg, work := ociHappyConfig(t)
+	builder, err := oci.New(cfg)
+	if err != nil {
+		t.Fatalf("oci.New: %v", err)
+	}
+	hostBin := filepath.Join(t.TempDir(), "toolboxd")
+	if err := os.WriteFile(hostBin, []byte("ELF-ish"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	a := &firecrackerRootfsAdapter{inner: builder}
+	out := filepath.Join(work, "rootfs-inject.ext4")
+	res, err := a.Build(context.Background(), fcruntime.RootfsBuildRequest{
+		ImageRef: "docker://alpine:3.20",
+		OutPath:  out,
+		InjectFiles: []fcruntime.InjectFile{
+			{HostPath: hostBin, GuestPath: "/usr/local/bin/toolboxd", Mode: 0o755},
+			{Content: []byte("SB_TOOLBOX_TOKEN='tok'\n"), GuestPath: "/etc/toolboxd.env", Mode: 0o600},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if res == nil || res.RootfsPath != out {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	if err := res.Cleanup(); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+}
+
 func TestTemplateBuilderAdapter_BuildSuccess(t *testing.T) {
 	cfg, work := ociHappyConfig(t)
 	builder, err := oci.New(cfg)

--- a/pkg/daemon/daemon_run_test.go
+++ b/pkg/daemon/daemon_run_test.go
@@ -391,6 +391,97 @@ func TestRun_NetstatsBootstrapErrorIsNonFatal(t *testing.T) {
 	}
 }
 
+func TestRun_SSHGatewayWithCluster(t *testing.T) {
+	paths := setBaseRunEnv(t)
+	raftPort := pickFreeTCPPort(t)
+	gossipPort := pickFreeTCPPort(t)
+
+	t.Setenv("SB_ENABLE_SSH_GATEWAY", "true")
+	t.Setenv("SB_ENABLE_CLUSTER", "true")
+	t.Setenv("SB_CLUSTER_BOOTSTRAP", "true")
+	t.Setenv("SB_CLUSTER_INSECURE_GOSSIP", "true")
+	t.Setenv("SB_CLUSTER_INSECURE_CREDENTIALS", "true")
+	t.Setenv("SB_RAFT_BIND_ADDR", fmt.Sprintf("127.0.0.1:%d", raftPort))
+	t.Setenv("SB_RAFT_ADVERTISE_ADDR", fmt.Sprintf("127.0.0.1:%d", raftPort))
+	t.Setenv("SB_RAFT_DATA_DIR", filepath.Join(paths.rootDir, "raft"))
+	t.Setenv("SB_GOSSIP_BIND_ADDR", fmt.Sprintf("127.0.0.1:%d", gossipPort))
+	t.Setenv("SB_GOSSIP_ADVERTISE_ADDR", fmt.Sprintf("127.0.0.1:%d", gossipPort))
+	t.Setenv("SB_SELF_API_ADVERTISE_URL", "http://127.0.0.1:8080")
+
+	if err := runWithAutoCancel(t, 200*time.Millisecond, nil); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+}
+
+func TestRun_ClusterWorkerWithFirecracker(t *testing.T) {
+	paths := setBaseRunEnv(t)
+	raftPort := pickFreeTCPPort(t)
+	gossipPort := pickFreeTCPPort(t)
+
+	t.Setenv("SB_ENABLE_CLUSTER", "true")
+	t.Setenv("SB_CLUSTER_BOOTSTRAP", "true")
+	t.Setenv("SB_CLUSTER_INSECURE_GOSSIP", "true")
+	t.Setenv("SB_CLUSTER_INSECURE_CREDENTIALS", "true")
+	t.Setenv("SB_RAFT_BIND_ADDR", fmt.Sprintf("127.0.0.1:%d", raftPort))
+	t.Setenv("SB_RAFT_ADVERTISE_ADDR", fmt.Sprintf("127.0.0.1:%d", raftPort))
+	t.Setenv("SB_RAFT_DATA_DIR", filepath.Join(paths.rootDir, "raft"))
+	t.Setenv("SB_GOSSIP_BIND_ADDR", fmt.Sprintf("127.0.0.1:%d", gossipPort))
+	t.Setenv("SB_GOSSIP_ADVERTISE_ADDR", fmt.Sprintf("127.0.0.1:%d", gossipPort))
+	t.Setenv("SB_SELF_API_ADVERTISE_URL", "http://127.0.0.1:8080")
+	t.Setenv("SB_ENABLE_FIRECRACKER", "true")
+	t.Setenv("SB_FIRECRACKER_BINARY", "/bin/true")
+	t.Setenv("SB_JAILER_BINARY", "/bin/true")
+	t.Setenv("SB_FIRECRACKER_KERNEL", paths.firecrackerKernel)
+	t.Setenv("SB_FIRECRACKER_RUN_DIR", paths.firecrackerRunDir)
+	t.Setenv("SB_FIRECRACKER_TEMPLATES_DIR", paths.templatesDir)
+	t.Setenv("SB_FIRECRACKER_USE_JAILER", "false")
+	t.Setenv("SB_FIRECRACKER_TAP_BASE_CIDR", "172.19.0.0/30")
+	t.Setenv("SB_FIRECRACKER_TAP_POOL_SIZE", "1")
+	t.Setenv("SB_FIRECRACKER_SKOPEO_BIN", "/bin/true")
+	t.Setenv("SB_FIRECRACKER_UMOCI_BIN", "/bin/true")
+	t.Setenv("SB_FIRECRACKER_MKFS_BIN", "/bin/true")
+
+	if err := runWithAutoCancel(t, 200*time.Millisecond, nil); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+}
+
+func TestRun_PlatformVolumesS3(t *testing.T) {
+	paths := setBaseRunEnv(t)
+	t.Setenv("SB_PLATFORM_VOLUMES_ENABLED", "true")
+	t.Setenv("SB_PLATFORM_VOLUMES_BACKEND", "s3")
+	t.Setenv("SB_PLATFORM_VOLUMES_S3_BUCKET", "test-bucket")
+	t.Setenv("SB_PLATFORM_VOLUMES_RECLAIM_INTERVAL", "1h")
+	t.Setenv("SB_PLATFORM_VOLUMES_RECLAIM_MOUNT_ROOT", filepath.Join(paths.rootDir, "volume-reclaim"))
+
+	if err := runWithAutoCancel(t, 150*time.Millisecond, nil); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+}
+
+func TestRun_FirecrackerTapSeedFailure(t *testing.T) {
+	paths := setBaseRunEnv(t)
+	t.Setenv("SB_ENABLE_FIRECRACKER", "true")
+	t.Setenv("SB_FIRECRACKER_BINARY", "/bin/true")
+	t.Setenv("SB_JAILER_BINARY", "/bin/true")
+	t.Setenv("SB_FIRECRACKER_KERNEL", paths.firecrackerKernel)
+	t.Setenv("SB_FIRECRACKER_RUN_DIR", paths.firecrackerRunDir)
+	t.Setenv("SB_FIRECRACKER_USE_JAILER", "false")
+	t.Setenv("SB_FIRECRACKER_TAP_BASE_CIDR", "172.19.0.0/30")
+	t.Setenv("SB_FIRECRACKER_TAP_POOL_SIZE", "999999")
+	t.Setenv("SB_FIRECRACKER_SKOPEO_BIN", "/bin/true")
+	t.Setenv("SB_FIRECRACKER_UMOCI_BIN", "/bin/true")
+	t.Setenv("SB_FIRECRACKER_MKFS_BIN", "/bin/true")
+
+	err := Run(context.Background(), testLogger(), nil)
+	if err == nil {
+		t.Fatal("Run returned nil error, want firecracker tap pool seed failure")
+	}
+	if !strings.Contains(err.Error(), "firecracker tap pool seed") {
+		t.Fatalf("Run error = %v, want tap pool seed wrapper", err)
+	}
+}
+
 func TestStartAutoImportReconciler_ImporterBuildError(t *testing.T) {
 	st := openTestStore(t)
 	svc := service.New(config.Config{}, testLogger(), st, nil, nil, nil, nil, nil, nil)

--- a/pkg/oci/builder.go
+++ b/pkg/oci/builder.go
@@ -256,22 +256,18 @@ func (b *Builder) runUmoci(ctx context.Context, ociDir, tag, bundleDir string) e
 // injectFiles writes each requested file into the unpacked rootfs at
 // rootfsSrc. GuestPath is treated as absolute-in-guest, so it is joined
 // under rootfsSrc after trimming the leading slash; parent directories
-// are created. A GuestPath that escapes the rootfs (via .. or an
-// absolute symlink target) is rejected — these files are trusted host
-// inputs, but cheap path hygiene keeps a mistake from scribbling on the
-// host tree.
+// are created without following symlinks. A GuestPath that escapes the
+// rootfs via .. is clamped back under rootfs; existing symlinks in the
+// destination path are rejected so an untrusted image cannot redirect an
+// injected host file outside the unpacked rootfs tree.
 func injectFiles(rootfsSrc string, files []InjectFile) error {
 	for _, f := range files {
 		if f.GuestPath == "" {
 			return errors.New("oci: inject file with empty GuestPath")
 		}
-		rel := strings.TrimPrefix(filepath.Clean("/"+f.GuestPath), "/")
-		dst := filepath.Join(rootfsSrc, rel)
-		if !strings.HasPrefix(dst, filepath.Clean(rootfsSrc)+string(os.PathSeparator)) {
-			return fmt.Errorf("oci: inject path %q escapes rootfs", f.GuestPath)
-		}
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			return fmt.Errorf("oci: inject mkdir %s: %w", filepath.Dir(dst), err)
+		dst, err := prepareInjectDestination(rootfsSrc, f.GuestPath)
+		if err != nil {
+			return err
 		}
 		mode := f.Mode
 		if mode == 0 {
@@ -287,16 +283,67 @@ func injectFiles(rootfsSrc string, files []InjectFile) error {
 		} else {
 			data = f.Content
 		}
-		if err := os.WriteFile(dst, data, mode); err != nil {
+		if err := writeInjectFile(dst, data, mode); err != nil {
 			return fmt.Errorf("oci: inject write %s: %w", dst, err)
-		}
-		// WriteFile honors umask; force the requested mode (the agent must
-		// be executable regardless of the daemon's umask).
-		if err := os.Chmod(dst, mode); err != nil {
-			return fmt.Errorf("oci: inject chmod %s: %w", dst, err)
 		}
 	}
 	return nil
+}
+
+func prepareInjectDestination(rootfsSrc, guestPath string) (string, error) {
+	root, err := filepath.Abs(rootfsSrc)
+	if err != nil {
+		return "", fmt.Errorf("oci: inject rootfs path %s: %w", rootfsSrc, err)
+	}
+	rel := strings.TrimPrefix(filepath.Clean("/"+guestPath), "/")
+	if rel == "." || rel == "" {
+		return "", fmt.Errorf("oci: inject path %q resolves to rootfs root", guestPath)
+	}
+	parts := strings.Split(rel, string(os.PathSeparator))
+	dir := root
+	for _, part := range parts[:len(parts)-1] {
+		dir = filepath.Join(dir, part)
+		info, err := os.Lstat(dir)
+		switch {
+		case err == nil:
+			if info.Mode()&os.ModeSymlink != 0 {
+				return "", fmt.Errorf("oci: inject parent %s is a symlink", dir)
+			}
+			if !info.IsDir() {
+				return "", fmt.Errorf("oci: inject parent %s is not a directory", dir)
+			}
+		case os.IsNotExist(err):
+			if err := os.Mkdir(dir, 0o755); err != nil && !os.IsExist(err) {
+				return "", fmt.Errorf("oci: inject mkdir %s: %w", dir, err)
+			}
+		default:
+			return "", fmt.Errorf("oci: inject stat %s: %w", dir, err)
+		}
+	}
+	dst := filepath.Join(root, rel)
+	if info, err := os.Lstat(dst); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("oci: inject destination %s is a symlink", dst)
+	} else if err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("oci: inject stat %s: %w", dst, err)
+	}
+	return dst, nil
+}
+
+func writeInjectFile(dst string, data []byte, mode os.FileMode) error {
+	file, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	// OpenFile honors umask; force the requested mode (the agent must
+	// be executable regardless of the daemon's umask).
+	return os.Chmod(dst, mode)
 }
 
 // runMkfs wraps stage 3. -d copies a directory in as the initial

--- a/pkg/oci/builder.go
+++ b/pkg/oci/builder.go
@@ -117,6 +117,29 @@ type BuildRequest struct {
 	// transport sometimes needs the tag explicitly when the source ref
 	// doesn't carry one.
 	Tag string
+	// InjectFiles are host-provided files written into the unpacked rootfs
+	// AFTER umoci and BEFORE mkfs, so they become part of the ext4 image.
+	// The Firecracker cold-boot path uses this to bake the in-guest agent
+	// (toolboxd), its init shim, and the per-sandbox token into an
+	// otherwise-stock OCI image — a plain image has no agent, so without
+	// this the guest boots with nothing listening on vsock (see
+	// internal/runtime/firecracker cold-boot agent injection). Empty for
+	// template builds, which expect the operator's image to already carry
+	// an init that brings the agent up.
+	InjectFiles []InjectFile
+}
+
+// InjectFile is one file to write into the rootfs before mkfs. Exactly one
+// of HostPath or Content supplies the bytes: HostPath copies an existing
+// host file (e.g. the toolboxd binary), Content writes inline bytes (e.g. a
+// generated init script or a per-sandbox env file). GuestPath is the
+// absolute path inside the guest ("/usr/local/bin/toolboxd"); parent dirs
+// are created. Mode is the file mode applied to the written file.
+type InjectFile struct {
+	HostPath  string
+	Content   []byte
+	GuestPath string
+	Mode      os.FileMode
 }
 
 // Result reports a finished build. RootfsPath is OutPath echoed back for
@@ -175,8 +198,16 @@ func (b *Builder) Build(ctx context.Context, req BuildRequest) (*Result, error) 
 		_ = os.RemoveAll(staging)
 		return nil, err
 	}
-	// Stage 3: mkfs.ext4 -d <bundle>/rootfs -F <out>
+	// Stage 2.5: inject host-provided files (the in-guest agent + init)
+	// into the unpacked rootfs so they land inside the ext4 image. Must
+	// run after umoci (the tree exists) and before mkfs (the tree is
+	// snapshotted into the image).
 	rootfsSrc := filepath.Join(bundleDir, "rootfs")
+	if err := injectFiles(rootfsSrc, req.InjectFiles); err != nil {
+		_ = os.RemoveAll(staging)
+		return nil, err
+	}
+	// Stage 3: mkfs.ext4 -d <bundle>/rootfs -F <out>
 	if err := b.runMkfs(ctx, rootfsSrc, req.OutPath, req.MinSizeMiB); err != nil {
 		_ = os.RemoveAll(staging)
 		return nil, err
@@ -220,6 +251,52 @@ func (b *Builder) runUmoci(ctx context.Context, ociDir, tag, bundleDir string) e
 		bundleDir,
 	}
 	return runStage(ctx, "umoci", b.cfg.UmociBin, args)
+}
+
+// injectFiles writes each requested file into the unpacked rootfs at
+// rootfsSrc. GuestPath is treated as absolute-in-guest, so it is joined
+// under rootfsSrc after trimming the leading slash; parent directories
+// are created. A GuestPath that escapes the rootfs (via .. or an
+// absolute symlink target) is rejected — these files are trusted host
+// inputs, but cheap path hygiene keeps a mistake from scribbling on the
+// host tree.
+func injectFiles(rootfsSrc string, files []InjectFile) error {
+	for _, f := range files {
+		if f.GuestPath == "" {
+			return errors.New("oci: inject file with empty GuestPath")
+		}
+		rel := strings.TrimPrefix(filepath.Clean("/"+f.GuestPath), "/")
+		dst := filepath.Join(rootfsSrc, rel)
+		if !strings.HasPrefix(dst, filepath.Clean(rootfsSrc)+string(os.PathSeparator)) {
+			return fmt.Errorf("oci: inject path %q escapes rootfs", f.GuestPath)
+		}
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return fmt.Errorf("oci: inject mkdir %s: %w", filepath.Dir(dst), err)
+		}
+		mode := f.Mode
+		if mode == 0 {
+			mode = 0o644
+		}
+		var data []byte
+		if f.HostPath != "" {
+			b, err := os.ReadFile(f.HostPath)
+			if err != nil {
+				return fmt.Errorf("oci: inject read %s: %w", f.HostPath, err)
+			}
+			data = b
+		} else {
+			data = f.Content
+		}
+		if err := os.WriteFile(dst, data, mode); err != nil {
+			return fmt.Errorf("oci: inject write %s: %w", dst, err)
+		}
+		// WriteFile honors umask; force the requested mode (the agent must
+		// be executable regardless of the daemon's umask).
+		if err := os.Chmod(dst, mode); err != nil {
+			return fmt.Errorf("oci: inject chmod %s: %w", dst, err)
+		}
+	}
+	return nil
 }
 
 // runMkfs wraps stage 3. -d copies a directory in as the initial

--- a/pkg/oci/builder_test.go
+++ b/pkg/oci/builder_test.go
@@ -313,6 +313,57 @@ func TestInjectFiles_ClampsEscape(t *testing.T) {
 	}
 }
 
+// TestInjectFiles_RejectsSymlinkRedirect guards the critical boundary:
+// injected bytes are host-trusted data written into an untrusted image tree,
+// so the image must not be able to redirect the write through a symlink.
+func TestInjectFiles_RejectsSymlinkRedirect(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "rootfs")
+	outside := filepath.Join(base, "outside")
+	if err := os.MkdirAll(filepath.Join(root, "usr/local"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "usr/local/bin")); err != nil {
+		t.Fatal(err)
+	}
+	err := injectFiles(root, []InjectFile{
+		{Content: []byte("toolboxd"), GuestPath: "/usr/local/bin/toolboxd", Mode: 0o755},
+	})
+	if err == nil {
+		t.Fatal("expected symlink-parent rejection")
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "toolboxd")); statErr == nil {
+		t.Fatal("injected file followed symlink outside rootfs")
+	}
+}
+
+func TestInjectFiles_RejectsSymlinkDestination(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "rootfs")
+	outside := filepath.Join(base, "outside")
+	if err := os.MkdirAll(filepath.Join(root, "usr/local/bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(outside, "toolboxd"), filepath.Join(root, "usr/local/bin/toolboxd")); err != nil {
+		t.Fatal(err)
+	}
+	err := injectFiles(root, []InjectFile{
+		{Content: []byte("toolboxd"), GuestPath: "/usr/local/bin/toolboxd", Mode: 0o755},
+	})
+	if err == nil {
+		t.Fatal("expected symlink-destination rejection")
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "toolboxd")); statErr == nil {
+		t.Fatal("injected file followed symlink destination outside rootfs")
+	}
+}
+
 // TestBuild_StageFailure_SurfacesTail confirms a non-zero exit from any
 // stage carries the binary's stderr in the returned error. Operators
 // staring at a failed sandbox create need this; without it the only

--- a/pkg/oci/builder_test.go
+++ b/pkg/oci/builder_test.go
@@ -245,6 +245,74 @@ func TestExt4SizeMiB(t *testing.T) {
 	}
 }
 
+// TestBuild_InjectFiles bakes host-provided files into the rootfs before
+// mkfs — the mechanism the Firecracker cold-boot path uses to put the
+// agent + init shim into a stock OCI image. We assert the files land in
+// bundle/rootfs at the right path/mode/content (the fake mkfs's -d source
+// is exactly that tree, so this proves they'd be captured into the ext4).
+func TestBuild_InjectFiles(t *testing.T) {
+	cfg, _ := happyConfig(t)
+	b, _ := New(cfg)
+	hostBin := filepath.Join(t.TempDir(), "toolboxd")
+	if err := os.WriteFile(hostBin, []byte("ELF-ish"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(t.TempDir(), "rootfs.ext4")
+	res, err := b.Build(context.Background(), BuildRequest{
+		ImageRef: "docker://alpine:3.20",
+		OutPath:  out,
+		InjectFiles: []InjectFile{
+			{HostPath: hostBin, GuestPath: "/usr/local/bin/toolboxd", Mode: 0o755},
+			{Content: []byte("SB_TOOLBOX_TOKEN='abc'\n"), GuestPath: "/etc/toolboxd.env", Mode: 0o600},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer res.CleanupDir()
+	root := filepath.Join(res.StagingDir, "bundle", "rootfs")
+
+	bin := filepath.Join(root, "usr/local/bin/toolboxd")
+	gotBin, err := os.ReadFile(bin)
+	if err != nil || string(gotBin) != "ELF-ish" {
+		t.Fatalf("injected binary content=%q err=%v", gotBin, err)
+	}
+	if fi, _ := os.Stat(bin); fi.Mode().Perm() != 0o755 {
+		t.Errorf("injected binary mode = %v, want 0755", fi.Mode().Perm())
+	}
+	env := filepath.Join(root, "etc/toolboxd.env")
+	if gotEnv, _ := os.ReadFile(env); string(gotEnv) != "SB_TOOLBOX_TOKEN='abc'\n" {
+		t.Errorf("injected env content = %q", gotEnv)
+	}
+	if fi, _ := os.Stat(env); fi.Mode().Perm() != 0o600 {
+		t.Errorf("injected env mode = %v, want 0600", fi.Mode().Perm())
+	}
+}
+
+// TestInjectFiles_ClampsEscape guards path hygiene: a GuestPath that tries
+// to climb out of the rootfs (via ..) is clamped to the rootfs (absolute,
+// .. collapsed) and never scribbles on the host tree. The sibling temp dir
+// stands in for "the host filesystem above the rootfs".
+func TestInjectFiles_ClampsEscape(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "rootfs")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := injectFiles(root, []InjectFile{
+		{Content: []byte("x"), GuestPath: "../../etc/passwd", Mode: 0o644},
+	}); err != nil {
+		t.Fatalf("injectFiles: %v", err)
+	}
+	// Must land inside the rootfs (clamped), not above it.
+	if _, err := os.Stat(filepath.Join(root, "etc/passwd")); err != nil {
+		t.Errorf("clamped file not inside rootfs: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(base, "etc/passwd")); err == nil {
+		t.Error("escape NOT prevented: file written above rootfs")
+	}
+}
+
 // TestBuild_StageFailure_SurfacesTail confirms a non-zero exit from any
 // stage carries the binary's stderr in the returned error. Operators
 // staring at a failed sandbox create need this; without it the only

--- a/pkg/oci/builder_test.go
+++ b/pkg/oci/builder_test.go
@@ -479,3 +479,158 @@ func TestCappedBuffer_Overflow(t *testing.T) {
 		t.Errorf("head-keep broke: %q", got)
 	}
 }
+
+func TestInjectFiles_ValidationAndDefaults(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "rootfs")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := injectFiles(root, []InjectFile{{Content: []byte("x"), GuestPath: ""}}); err == nil {
+		t.Fatal("expected error for empty GuestPath")
+	}
+	if err := injectFiles(root, []InjectFile{{Content: []byte("x"), GuestPath: "/"}}); err == nil {
+		t.Fatal("expected error for root GuestPath")
+	}
+
+	if err := injectFiles(root, []InjectFile{{Content: []byte("plain"), GuestPath: "/etc/default-mode"}}); err != nil {
+		t.Fatalf("injectFiles default mode: %v", err)
+	}
+	fi, err := os.Stat(filepath.Join(root, "etc/default-mode"))
+	if err != nil || fi.Mode().Perm() != 0o644 {
+		t.Fatalf("default mode = %v err=%v, want 0644", fi.Mode().Perm(), err)
+	}
+
+	missing := filepath.Join(t.TempDir(), "missing-bin")
+	if err := injectFiles(root, []InjectFile{{HostPath: missing, GuestPath: "/bin/missing", Mode: 0o755}}); err == nil {
+		t.Fatal("expected error for unreadable HostPath")
+	}
+}
+
+func TestInjectFiles_ParentNotDirectory(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "rootfs")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "usr"), []byte("file"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := injectFiles(root, []InjectFile{
+		{Content: []byte("x"), GuestPath: "/usr/local/bin/toolboxd", Mode: 0o755},
+	})
+	if err == nil || !strings.Contains(err.Error(), "not a directory") {
+		t.Fatalf("injectFiles = %v, want parent-not-directory error", err)
+	}
+}
+
+func TestInjectFiles_DestinationIsDirectory(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "rootfs")
+	if err := os.MkdirAll(filepath.Join(root, "opt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	err := injectFiles(root, []InjectFile{
+		{Content: []byte("x"), GuestPath: "/opt", Mode: 0o644},
+	})
+	if err == nil {
+		t.Fatal("expected error when destination path is a directory")
+	}
+}
+
+func TestBuild_InjectFailureCleansStaging(t *testing.T) {
+	cfg, _ := happyConfig(t)
+	b, _ := New(cfg)
+	out := filepath.Join(t.TempDir(), "rootfs.ext4")
+	_, err := b.Build(context.Background(), BuildRequest{
+		ImageRef:    "docker://alpine:3.20",
+		OutPath:     out,
+		InjectFiles: []InjectFile{{Content: []byte("x"), GuestPath: ""}},
+	})
+	if err == nil {
+		t.Fatal("expected inject validation error")
+	}
+	entries, _ := os.ReadDir(cfg.WorkDir)
+	if len(entries) != 0 {
+		t.Fatalf("staging dir not cleaned up after inject failure: %d entries in %q", len(entries), cfg.WorkDir)
+	}
+}
+
+func TestBuild_WorkDirErrors(t *testing.T) {
+	cfg, _ := happyConfig(t)
+
+	t.Run("mkdir workdir fails", func(t *testing.T) {
+		base := t.TempDir()
+		cfg.WorkDir = filepath.Join(base, "blocked", "work")
+		if err := os.WriteFile(filepath.Join(base, "blocked"), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		b, _ := New(cfg)
+		_, err := b.Build(context.Background(), BuildRequest{ImageRef: "ref", OutPath: filepath.Join(t.TempDir(), "out.ext4")})
+		if err == nil || !strings.Contains(err.Error(), "mkdir workdir") {
+			t.Fatalf("Build = %v, want mkdir workdir error", err)
+		}
+	})
+
+	t.Run("mkdtemp fails", func(t *testing.T) {
+		work := filepath.Join(t.TempDir(), "nowrite")
+		if err := os.Mkdir(work, 0o555); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(work, 0o755) })
+		cfg.WorkDir = work
+		b, _ := New(cfg)
+		_, err := b.Build(context.Background(), BuildRequest{ImageRef: "ref", OutPath: filepath.Join(t.TempDir(), "out.ext4")})
+		if err == nil || !strings.Contains(err.Error(), "mkdtemp") {
+			t.Fatalf("Build = %v, want mkdtemp error", err)
+		}
+	})
+}
+
+func TestRunMkfs_MissingRootfs(t *testing.T) {
+	cfg, _ := happyConfig(t)
+	b, _ := New(cfg)
+	missing := filepath.Join(t.TempDir(), "missing-rootfs")
+	err := b.runMkfs(context.Background(), missing, filepath.Join(t.TempDir(), "out.ext4"), 0)
+	if err == nil || !strings.Contains(err.Error(), "size rootfs") {
+		t.Fatalf("runMkfs = %v, want size rootfs error", err)
+	}
+}
+
+func TestExt4SizeMiB_WalkError(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "root")
+	sub := filepath.Join(src, "blocked")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "f"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(sub, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(sub, 0o755) })
+
+	if _, err := ext4SizeMiB(src, 0); err == nil {
+		t.Fatal("expected walk error for unreadable subdirectory")
+	}
+}
+
+func TestBuild_DefaultTag(t *testing.T) {
+	cfg, _ := happyConfig(t)
+	b, _ := New(cfg)
+	out := filepath.Join(t.TempDir(), "rootfs.ext4")
+	res, err := b.Build(context.Background(), BuildRequest{
+		ImageRef: "docker://alpine:3.20",
+		OutPath:  out,
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer res.CleanupDir()
+	if _, err := os.Stat(filepath.Join(res.StagingDir, "bundle", "rootfs", "etc", "oci-meta")); err != nil {
+		t.Fatalf("umoci did not run with default latest tag: %v", err)
+	}
+	meta, _ := os.ReadFile(filepath.Join(res.StagingDir, "bundle", "rootfs", "etc", "oci-meta"))
+	if !strings.Contains(string(meta), "img=") {
+		t.Fatalf("unexpected oci-meta: %q", meta)
+	}
+}


### PR DESCRIPTION
## Problem

Cold-boot Firecracker sandboxes (created from a **plain OCI image**, not a template/snapshot) booted with **no in-guest agent**. The rootfs was the image bytes verbatim, boot args passed no `init=`, and there was no kernel network autoconfig — so nothing listened on **vsock CID 3 port 1024**, and `Create`'s readiness handshake failed:

```
vsock dial cid=3 port=1024: ... no such device    (single-node-fc UC-44)
```

This is the deferred **"Phase 2"** — agent injection was never built. The `init=/usr/local/bin/toolboxd-init` referenced in `pkg/firecracker/types.go:42` was only ever a doc comment; no script, no injection, no `ip=` autoconfig existed in the tree.

This is *not* a regression from the recent #238 (drive chown) / #239 (mkfs size) fixes — those got the VM as far as **booting**; this is the next layer down (guest agent).

## What this does — cold-boot path only

1. **`pkg/oci`**: `BuildRequest.InjectFiles` — host files (or inline content) written into the unpacked rootfs **after umoci, before mkfs**, so they land in the ext4 image. Path-clamped to the rootfs.
2. **firecracker driver**: bakes **toolboxd** + a PID-1 init shim (`assets/toolboxd-init.sh`, `go:embed`) + a per-sandbox `/etc/toolboxd.env` (carries `SB_TOOLBOX_TOKEN`) into the rootfs. The shim mounts the pseudo-filesystems, sources the env, and `exec`s the agent.
3. **boot args** (`coldBootArgs`): adds `ip=<guest>::<gw>:<mask>::eth0:off` kernel autoconfig (eth0 up before userspace → agent HTTP reachable at `GuestIP:2280` over the TAP) and `init=/usr/local/bin/toolboxd-init`.

## Fragile-area / boot-path call-outs (per CLAUDE.md)

- **Boot-path latency**: cold-boot rootfs build gains 3 small file writes (one binary copy, two tiny files) before mkfs — negligible next to the skopeo+umoci pull already on this path. **Snapshot / warm-pool / template paths are UNCHANGED** (they carry their own init+agent).
- **Cluster**: no placement / store / FSM surface touched; single-node and cluster behavior identical; no-op when `EnableCluster` is false.
- **Idempotency**: cold-boot already builds a fresh rootfs per `Create`; injection is regenerated each call (token is per-sandbox).
- **Failure path**: empty `ToolboxBinaryPath` → no injection, no `init=`, and a `WARN` — an agent-less guest that fails the handshake honestly, not a silently broken sandbox.

## Tests

- `pkg/oci`: `TestBuild_InjectFiles` (content/mode), `TestInjectFiles_ClampsEscape` (path hygiene).
- firecracker: `TestColdBootInjectFiles_*` (agent+shim+token present; nil when unconfigured), `TestColdBootArgs` (`ip=`/`init=` presence & absence), `TestNetmaskFromCIDR`.
- `go test ./pkg/oci/... ./internal/runtime/firecracker/... ./pkg/daemon/...` green.

## ⚠️ Validation gate

Host-side mechanics are fully unit-tested, but **the guest boot itself can't be tested in CI** (no Firecracker host). One live `make integration-single-fc` run is needed to confirm **UC-24 / UC-44 / UC-88** go green end-to-end (and that the chosen mount/`ip=`/init order actually brings the agent up inside the guest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)