### PR TITLE
fix(firecracker): realize host TAP on warm-pool create path

### DIFF
--- a/internal/runtime/firecracker/warmacquire.go
+++ b/internal/runtime/firecracker/warmacquire.go
@@ -123,6 +123,12 @@ func (d *Driver) tryAcquireWarm(
 	// flag-and-defer pattern mirrors the cold-spawn path's pool/tap/vmm
 	// cleanup.
 	committed := false
+	// tapEnsured gates the host-TAP rollback below: we only `ip link
+	// delete` a device this path actually brought up. The host TAP is
+	// realized lazily (just before the network PATCH), so an error in the
+	// overlay/rootfs staging above it must not Remove a device that was
+	// never Ensured.
+	tapEnsured := false
 	defer func() {
 		if committed {
 			return
@@ -138,6 +144,16 @@ func (d *Driver) tryAcquireWarm(
 		if sErr := handle.Shutdown(context.Background(), 3*time.Second); sErr != nil {
 			d.logger.Warn("firecracker create: warm acquire rollback (handle shutdown)",
 				"sandbox_id", sandboxID, "slot_id", slot.ID, "error", sErr)
+		}
+		// Drop the host TAP last — after handle.Shutdown has brought the
+		// firecracker process down. `ip link delete` on a TAP still
+		// owned by a running VMM fails EBUSY (the same ordering Destroy
+		// relies on in driver.go).
+		if tapEnsured {
+			if rmErr := d.tapHost.Remove(context.Background(), tapSlot.TapName); rmErr != nil {
+				d.logger.Warn("firecracker create: warm acquire rollback (tap remove)",
+					"sandbox_id", sandboxID, "tap", tapSlot.TapName, "error", rmErr)
+			}
 		}
 	}()
 
@@ -183,6 +199,20 @@ func (d *Driver) tryAcquireWarm(
 	}); err != nil {
 		return nil, false, fmt.Errorf("firecracker runtime: warm patch rootfs drive: %w", err)
 	}
+
+	// Bring this sandbox's host TAP up before pointing the guest's eth0
+	// at it. WarmSpawn deliberately skips host-TAP realization: the
+	// snapshot's eth0 references the defunct template-build TAP, and
+	// firecracker only validates the device at Resume, not at snapshot
+	// load (see warmspawn.go). The cold path realizes the TAP at its
+	// Step 4 in driver.go; the warm path returns before reaching that
+	// step, so without this Ensure the Action(Resume) below points
+	// host_dev_name at a device that was never created and the create
+	// fails. Idempotent — a retried create re-Ensures the same slot.
+	if err := d.tapHost.Ensure(ctx, *tapSlot); err != nil {
+		return nil, false, fmt.Errorf("firecracker runtime: warm tap host ensure %s: %w", tapSlot.TapName, err)
+	}
+	tapEnsured = true
 
 	// PATCH NetworkInterface: the snapshot's eth0 references the
 	// defunct template-build TAP. Swap it for this sandbox's TAP.

--- a/internal/runtime/firecracker/warmacquire_test.go
+++ b/internal/runtime/firecracker/warmacquire_test.go
@@ -195,6 +195,15 @@ func TestCreate_WarmHit(t *testing.T) {
 		t.Errorf("LoadSnapshot was called on warm-hit Create path: %+v", f.client.snapshotLoad)
 	}
 
+	// The per-sandbox host TAP MUST have been realized on the warm-hit
+	// path — WarmSpawn skips it, so the Acquire side owns it. Without
+	// this Ensure, Action(Resume) would point the guest's eth0 at a
+	// host_dev_name that does not exist. Exactly one Ensure, no Remove
+	// (the sandbox now owns the device; Destroy removes it later).
+	if f.tapHost.ensureCalls != 1 || f.tapHost.removeCalls != 0 {
+		t.Errorf("warm-hit tap ensure=%d remove=%d, want 1/0", f.tapHost.ensureCalls, f.tapHost.removeCalls)
+	}
+
 	// PATCH NetworkInterface MUST have been called with the per-sandbox
 	// TAP name (mapped from the pool's preloaded slot.TapName via the
 	// fake tap pool's Allocate).
@@ -291,6 +300,53 @@ func TestCreate_WarmRollbackOnPatchFailure(t *testing.T) {
 		t.Error("warm handle Shutdown was not called on PATCH failure; firecracker process would leak")
 	}
 	handle.mu.Unlock()
+
+	// The host TAP was Ensured just before the PATCH, so the rollback
+	// MUST Remove it — otherwise a `ip link` device leaks on every
+	// failed warm create. ensure=1/remove=1 is the matched pair.
+	if f.tapHost.ensureCalls != 1 || f.tapHost.removeCalls != 1 {
+		t.Errorf("warm rollback tap ensure=%d remove=%d, want 1/1", f.tapHost.ensureCalls, f.tapHost.removeCalls)
+	}
+}
+
+// TestCreate_WarmRollbackOnTapEnsureFailure asserts the rollback when
+// the host-TAP realization itself fails on the warm path: the create
+// must surface the error, tear down the warm handle + pool slot, and
+// MUST NOT call Remove (there is no device to delete — mirrors the
+// cold path's "no Remove when Ensure failed" discipline).
+func TestCreate_WarmRollbackOnTapEnsureFailure(t *testing.T) {
+	f := newDriverFixture(t)
+	pool, handle := stageWarmFixture(t, f)
+	stageWarmTemplate(t, f, false)
+	f.tapHost.ensureErr = errors.New("synthetic tap ensure failure")
+
+	_, err := f.driver.Create(context.Background(), models.CreateSandboxRequest{
+		Image:      "alpine:3.20",
+		CPU:        1,
+		MemoryMB:   128,
+		DiskGB:     1,
+		TemplateID: "tpl-warm",
+	}, "sb-warm-tap-fail", "tok", nil)
+	if err == nil {
+		t.Fatal("Create returned nil on injected tap Ensure failure")
+	}
+
+	// Pool slot released + handle shut down so the warm VMM doesn't leak.
+	pool.mu.Lock()
+	if len(pool.releaseCalls) == 0 {
+		t.Error("warm pool Release was not called on tap Ensure failure; slot would leak as 'allocated'")
+	}
+	pool.mu.Unlock()
+	handle.mu.Lock()
+	if handle.shutdowns == 0 {
+		t.Error("warm handle Shutdown was not called on tap Ensure failure; firecracker process would leak")
+	}
+	handle.mu.Unlock()
+
+	// Ensure was attempted once and failed; Remove MUST be skipped.
+	if f.tapHost.ensureCalls != 1 || f.tapHost.removeCalls != 0 {
+		t.Errorf("warm tap-ensure-failure ensure=%d remove=%d, want 1/0", f.tapHost.ensureCalls, f.tapHost.removeCalls)
+	}
 }
 
 // TestCreate_WarmEligibilityNoTemplate asserts the warm path is


### PR DESCRIPTION
## Summary

- **Bug:** the warm-VMM pool fast path (`tryAcquireWarm`) PATCHed the guest's `eth0` to the per-sandbox TAP and issued `Action(Resume)`, but **never called `tapHost.Ensure`** to bring that device up on the host. The cold path realizes the TAP at its Step 4 (`driver.go`); the warm path returns before reaching it.
- **Impact (when `SB_FIRECRACKER_VMM_POOL_ENABLED` is on):** every warm-pool hit pointed `host_dev_name` at a device that was never created → `Resume` opens a missing TAP and the create fails (or returns a network-dead sandbox). A warm-path error has no cold fallback, so the pool degraded into guaranteed create failures **plus** self-inflicted pool drain — each failed hit shuts down a pre-booted VMM.
- **Fix:** `Ensure` the host TAP just before the network PATCH, gated by a `tapEnsured` latch, with a matching `Remove` in the rollback defer.

## Sandbox boot impact

Adds one `ip` invocation set (`tuntap add` / `addr add` / `link set up`) to the **warm-hit** create path only. This is not new net work — it restores the host-TAP realization the warm path was missing; the warm path remains strictly cheaper than the cold path it replaces (still skips process spawn, `WaitSocket`, and `LoadSnapshot`). Cold path and warm-miss fall-through are unchanged. Fires only when the VMM pool is enabled and a create hits a warm slot. Bounded (single device bring-up).

## Idempotency

No wire/API surface changed. The added `tapHost.Ensure`/`Remove` are idempotent by contract (`internal/network/tap/host.go`): `Ensure` on an existing device with the right address is a no-op; `Remove` on a missing device returns nil. A retried `CreateSandbox` re-`Ensure`s the same slot safely.

## Failure-path consistency

The host TAP is added to the warm path's existing `committed`-latch rollback. On any failure after Ensure, teardown order is: `handle.Shutdown` → `tapHost.Remove` → `warmPool.Release`. `Remove` runs **after** `Shutdown` because `ip link delete` on a TAP still owned by a running VMM fails EBUSY — the same ordering `Destroy` relies on. The `tapEnsured` latch ensures the rollback only deletes a device this path actually brought up (a failure in overlay/rootfs staging above the Ensure call does not call `Remove`). No caddy/store multi-step write involved.

## L4 / host-port-pool changes

N/A - neither touched. This is the TAP allocator's host-realization seam, not the TCP host-port pool / L4 latch.

## Test plan

- [x] `go build ./internal/runtime/firecracker/...`
- [x] `TestCreate_WarmHit` now asserts host TAP `ensure=1, remove=0` (locks in the fix)
- [x] `TestCreate_WarmRollbackOnPatchFailure` now asserts `ensure=1, remove=1` (matched pair on failure)
- [x] New `TestCreate_WarmRollbackOnTapEnsureFailure` asserts `ensure=1, remove=0` + handle shutdown + pool release when Ensure itself fails
- [x] `go test ./internal/runtime/firecracker/ ./internal/network/tap/ ./internal/pool/vmm/` — all pass
- [x] `gofmt` clean
- [ ] Live integration suite not run (provisions real AWS; out of scope for an offline allocator fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)