### PR TITLE
fix(service): delete custom-domain leaf routes on create rollback + destroy

### DIFF
--- a/internal/service/public_traffic_create_rollback_test.go
+++ b/internal/service/public_traffic_create_rollback_test.go
@@ -1,0 +1,161 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	storepkg "github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/caddy"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// statefulCaddyFake emulates the slice of the Caddy admin API that the create
+// path exercises: PATCH /id/<id> (update-in-place; 404 forces the PUT insert),
+// PUT /config/.../routes/0 (fresh insert, body carries the @id), and
+// DELETE /id/<id>. Unlike the all-500 fake in TestCreateSandboxRollbackAndCustomDomainBranches,
+// this one tracks which route IDs are actually live, so a test can assert that
+// the rollback chain deleted every route it installed — main toolbox route AND
+// the per-custom-domain leaf routes UpsertSandboxRoute installs in domain mode.
+type statefulCaddyFake struct {
+	mu     sync.Mutex
+	routes map[string]struct{}
+}
+
+func newStatefulCaddyFake() *statefulCaddyFake {
+	return &statefulCaddyFake{routes: map[string]struct{}{}}
+}
+
+func (f *statefulCaddyFake) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPatch && strings.HasPrefix(r.URL.Path, "/id/"):
+			id := strings.TrimPrefix(r.URL.Path, "/id/")
+			f.mu.Lock()
+			_, ok := f.routes[id]
+			f.mu.Unlock()
+			if ok {
+				w.WriteHeader(http.StatusOK) // updated in place
+				return
+			}
+			// Unknown @id: 404 makes the client fall through to PUT-insert,
+			// mirroring real Caddy on a fresh route.
+			http.Error(w, "not found", http.StatusNotFound)
+		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/routes/0"):
+			var route map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&route)
+			id, _ := route["@id"].(string)
+			f.mu.Lock()
+			if id != "" {
+				f.routes[id] = struct{}{}
+			}
+			f.mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/id/"):
+			id := strings.TrimPrefix(r.URL.Path, "/id/")
+			f.mu.Lock()
+			_, ok := f.routes[id]
+			delete(f.routes, id)
+			f.mu.Unlock()
+			if ok {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			http.Error(w, "not found", http.StatusNotFound) // 404 is a no-op for the client
+		default:
+			// Any other admin call (config GETs etc.) is irrelevant to this
+			// test; succeed so it doesn't mask the assertion below.
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+}
+
+func (f *statefulCaddyFake) has(id string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.routes[id]
+	return ok
+}
+
+func (f *statefulCaddyFake) ids() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, 0, len(f.routes))
+	for id := range f.routes {
+		out = append(out, id)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestCreateSandboxRollbackDeletesCustomDomainLeafRoutes is the regression test
+// for the caddy custom-domain leaf-route leak: UpsertSandboxRoute installs a
+// main route PLUS one HTTP leaf route per custom domain (domain mode), but the
+// create rollback used to call DeleteSandboxRoute, which only removes the main
+// route — leaving each leaf route orphaned in caddy. The fix routes rollback
+// through deleteSandboxPublicRoutes, which deletes the main route and every
+// leaf. This test installs both kinds of route, forces a post-route create
+// failure, and asserts no route bearing the failed sandbox's id survives.
+func TestCreateSandboxRollbackDeletesCustomDomainLeafRoutes(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, _, _ := newServiceRuntimeHarness(t, rt)
+
+	fake := newStatefulCaddyFake()
+	server := httptest.NewServer(fake.handler())
+	t.Cleanup(server.Close)
+
+	svc.cfg.EnableCaddy = true
+	svc.cfg.CaddyAdminURL = server.URL
+	svc.cfg.CaddyServerID = "srv0"
+	svc.cfg.Domain = "sandbox.test"
+	svc.cfg.EnableCustomDomains = true
+	svc.caddy = caddy.New(svc.cfg)
+	svc.admitter = nil
+
+	const host = "api.external.test"
+
+	// Seed sandbox claims the custom domain and installs its main + leaf routes.
+	if _, err := svc.CreateSandboxWithID(ctx, models.CreateSandboxRequest{
+		Image:         "alpine:3.20",
+		CustomDomains: []string{host},
+	}, "sb-keep"); err != nil {
+		t.Fatalf("seed create: %v", err)
+	}
+	keepLeaf := caddy.IngressCustomDomainHTTPRouteID("sb-keep", host)
+	// Guard against a false negative: if leaf routes weren't installed at all,
+	// the leak assertion below would pass vacuously.
+	if !fake.has(keepLeaf) {
+		t.Fatalf("seed sandbox leaf route %q was never installed; test setup is wrong (have %v)", keepLeaf, fake.ids())
+	}
+
+	// Second sandbox installs its OWN main + leaf routes via syncSandboxPublicRoute,
+	// then trips the custom-domain conflict at persistCustomDomainsOnCreate, which
+	// runs the post-route rollback chain.
+	_, err := svc.CreateSandboxWithID(ctx, models.CreateSandboxRequest{
+		Image:         "alpine:3.20",
+		CustomDomains: []string{host},
+	}, "sb-roll")
+	if err == nil || !errors.Is(err, storepkg.ErrCustomDomainConflict) {
+		t.Fatalf("CreateSandboxWithID() error = %v, want custom domain conflict", err)
+	}
+
+	mainID := caddy.SandboxRouteID("sb-roll")
+	leafID := caddy.IngressCustomDomainHTTPRouteID("sb-roll", host)
+	if fake.has(leafID) {
+		t.Errorf("custom-domain leaf route %q leaked after rollback; live routes=%v", leafID, fake.ids())
+	}
+	if fake.has(mainID) {
+		t.Errorf("main route %q leaked after rollback; live routes=%v", mainID, fake.ids())
+	}
+	// Rollback of sb-roll must not over-delete the kept sandbox's routes.
+	if !fake.has(keepLeaf) {
+		t.Errorf("kept sandbox leaf route %q was removed by sb-roll rollback; live routes=%v", keepLeaf, fake.ids())
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1227,6 +1227,13 @@ func (s *Service) createSandbox(ctx context.Context, req models.CreateSandboxReq
 	}
 
 	if err := s.syncSandboxPublicRoute(ctx, sandbox); err != nil {
+		// UpsertSandboxRoute is non-atomic in domain mode: it installs the
+		// main route and then a per-custom-domain leaf route in a loop, so a
+		// failure on a later leaf can leave the main route + earlier leaves
+		// installed. deleteSandboxPublicRoutes (not DeleteSandboxRoute) tears
+		// down the main route AND every custom-domain leaf — 404 per leaf is
+		// a no-op, so it's safe on a partial install.
+		_ = s.deleteSandboxPublicRoutes(cleanupCtx, sandbox)
 		_ = s.docker.Destroy(cleanupCtx, sandbox)
 		cleanupMounts()
 		releaseAdmission()
@@ -1235,7 +1242,7 @@ func (s *Service) createSandbox(ctx context.Context, req models.CreateSandboxReq
 
 	sandbox.OwnerRef = ownerRef
 	if err := s.store.Create(ctx, sandbox); err != nil {
-		_ = s.caddy.DeleteSandboxRoute(cleanupCtx, sandbox.ID)
+		_ = s.deleteSandboxPublicRoutes(cleanupCtx, sandbox)
 		_ = s.docker.Destroy(cleanupCtx, sandbox)
 		cleanupMounts()
 		releaseAdmission()
@@ -1248,7 +1255,7 @@ func (s *Service) createSandbox(ctx context.Context, req models.CreateSandboxReq
 		}
 		if err := s.volumeMeta().PutAttachments(ctx, platformAttachments); err != nil {
 			_ = s.store.Delete(ctx, sandbox.ID)
-			_ = s.caddy.DeleteSandboxRoute(cleanupCtx, sandbox.ID)
+			_ = s.deleteSandboxPublicRoutes(cleanupCtx, sandbox)
 			_ = s.docker.Destroy(cleanupCtx, sandbox)
 			cleanupMounts()
 			releaseAdmission()
@@ -1267,7 +1274,7 @@ func (s *Service) createSandbox(ctx context.Context, req models.CreateSandboxReq
 	if len(sealedMounts) > 0 {
 		if err := s.store.PutMounts(ctx, sandbox.ID, sealedMounts); err != nil {
 			_ = s.store.Delete(ctx, sandbox.ID)
-			_ = s.caddy.DeleteSandboxRoute(cleanupCtx, sandbox.ID)
+			_ = s.deleteSandboxPublicRoutes(cleanupCtx, sandbox)
 			_ = s.docker.Destroy(cleanupCtx, sandbox)
 			cleanupMounts()
 			releaseAdmission()
@@ -1279,7 +1286,7 @@ func (s *Service) createSandbox(ctx context.Context, req models.CreateSandboxReq
 		// Same rollback chain as a mount-persist failure. ErrCustomDomainConflict
 		// flows through unchanged so the API layer can map it to 409.
 		_ = s.store.Delete(ctx, sandbox.ID)
-		_ = s.caddy.DeleteSandboxRoute(cleanupCtx, sandbox.ID)
+		_ = s.deleteSandboxPublicRoutes(cleanupCtx, sandbox)
 		_ = s.docker.Destroy(cleanupCtx, sandbox)
 		cleanupMounts()
 		releaseAdmission()
@@ -1487,6 +1494,10 @@ func (s *Service) createFirecrackerSandbox(ctx context.Context, req models.Creat
 	}
 
 	if err := s.syncSandboxPublicRoute(ctx, sandbox); err != nil {
+		// deleteSandboxPublicRoutes (not DeleteSandboxRoute) so a non-atomic
+		// partial UpsertSandboxRoute — main route + per-custom-domain leaves —
+		// is fully torn down. See the docker path for the rationale.
+		_ = s.deleteSandboxPublicRoutes(cleanupCtx, sandbox)
 		_ = s.firecracker.Destroy(cleanupCtx, sandbox)
 		releaseAdmission()
 		return nil, err
@@ -1496,7 +1507,7 @@ func (s *Service) createFirecrackerSandbox(ctx context.Context, req models.Creat
 	// refreshed the account mapping before dispatching here.
 	sandbox.OwnerRef = ownerRefForCreate(ctx)
 	if err := s.store.Create(ctx, sandbox); err != nil {
-		_ = s.caddy.DeleteSandboxRoute(cleanupCtx, sandbox.ID)
+		_ = s.deleteSandboxPublicRoutes(cleanupCtx, sandbox)
 		_ = s.firecracker.Destroy(cleanupCtx, sandbox)
 		releaseAdmission()
 		return nil, err
@@ -1504,7 +1515,7 @@ func (s *Service) createFirecrackerSandbox(ctx context.Context, req models.Creat
 
 	if err := s.persistCustomDomainsOnCreate(ctx, sandbox.ID, req.CustomDomains); err != nil {
 		_ = s.store.Delete(ctx, sandbox.ID)
-		_ = s.caddy.DeleteSandboxRoute(cleanupCtx, sandbox.ID)
+		_ = s.deleteSandboxPublicRoutes(cleanupCtx, sandbox)
 		_ = s.firecracker.Destroy(cleanupCtx, sandbox)
 		releaseAdmission()
 		return nil, err
@@ -1877,9 +1888,11 @@ func (s *Service) DestroySandbox(ctx context.Context, id string) error {
 	for _, port := range sandbox.ExposedPorts {
 		_ = s.deleteExposedPortRoute(ctx, sandbox, port)
 	}
-	if s.caddy != nil {
-		_ = s.caddy.DeleteSandboxRoute(ctx, sandbox.ID)
-	}
+	// deleteSandboxPublicRoutes (not DeleteSandboxRoute) so the per-custom-domain
+	// leaf routes installed by UpsertSandboxRoute are torn down too. store.Delete
+	// below cascades the custom_domain DB rows, but the caddy routes are separate
+	// state and would otherwise be orphaned on every destroy. nil-caddy safe.
+	_ = s.deleteSandboxPublicRoutes(ctx, sandbox)
 	rt, err := s.runtimeForSandbox(sandbox)
 	if err != nil {
 		return err

--- a/internal/service/wasm.go
+++ b/internal/service/wasm.go
@@ -196,13 +196,20 @@ func (s *Service) createWasmSandbox(ctx context.Context, req models.CreateSandbo
 	sandbox.OwnerRef = ownerRefForCreate(ctx)
 
 	if err := s.syncSandboxPublicRoute(ctx, sandbox); err != nil {
+		// deleteSandboxPublicRoutes (not DeleteSandboxRoute) tears down the
+		// main route AND every per-custom-domain leaf. WASM is doubly exposed
+		// here: routes get installed both via syncSandboxPublicRoute's
+		// UpsertSandboxRoute loop and via syncWasmCustomDomainRoutes below,
+		// and both key on IngressCustomDomainHTTPRouteID — so the leaf delete
+		// covers both. 404 per leaf is a no-op, safe on a partial install.
+		_ = s.deleteSandboxPublicRoutes(ctx, sandbox)
 		_ = s.wasm.Destroy(ctx, sandbox)
 		cleanupMounts()
 		releaseAdmission()
 		return nil, err
 	}
 	if err := s.store.Create(ctx, sandbox); err != nil {
-		_ = s.caddy.DeleteSandboxRoute(ctx, sandbox.ID)
+		_ = s.deleteSandboxPublicRoutes(ctx, sandbox)
 		_ = s.wasm.Destroy(ctx, sandbox)
 		cleanupMounts()
 		releaseAdmission()
@@ -211,7 +218,7 @@ func (s *Service) createWasmSandbox(ctx context.Context, req models.CreateSandbo
 	if len(sealedMounts) > 0 {
 		if err := s.store.PutMounts(ctx, sandbox.ID, sealedMounts); err != nil {
 			_ = s.store.Delete(ctx, sandbox.ID)
-			_ = s.caddy.DeleteSandboxRoute(ctx, sandbox.ID)
+			_ = s.deleteSandboxPublicRoutes(ctx, sandbox)
 			_ = s.wasm.Destroy(ctx, sandbox)
 			cleanupMounts()
 			releaseAdmission()
@@ -220,7 +227,7 @@ func (s *Service) createWasmSandbox(ctx context.Context, req models.CreateSandbo
 	}
 	if err := s.persistCustomDomainsOnCreate(ctx, sandbox.ID, req.CustomDomains); err != nil {
 		_ = s.store.Delete(ctx, sandbox.ID)
-		_ = s.caddy.DeleteSandboxRoute(ctx, sandbox.ID)
+		_ = s.deleteSandboxPublicRoutes(ctx, sandbox)
 		_ = s.wasm.Destroy(ctx, sandbox)
 		cleanupMounts()
 		releaseAdmission()
@@ -230,7 +237,7 @@ func (s *Service) createWasmSandbox(ctx context.Context, req models.CreateSandbo
 		storedCD, getErr := s.store.Get(ctx, sandbox.ID)
 		if getErr != nil {
 			_ = s.store.Delete(ctx, sandbox.ID)
-			_ = s.caddy.DeleteSandboxRoute(ctx, sandbox.ID)
+			_ = s.deleteSandboxPublicRoutes(ctx, sandbox)
 			_ = s.wasm.Destroy(ctx, sandbox)
 			cleanupMounts()
 			releaseAdmission()
@@ -238,7 +245,7 @@ func (s *Service) createWasmSandbox(ctx context.Context, req models.CreateSandbo
 		}
 		if err := s.syncWasmCustomDomainRoutes(ctx, storedCD); err != nil {
 			_ = s.store.Delete(ctx, sandbox.ID)
-			_ = s.caddy.DeleteSandboxRoute(ctx, sandbox.ID)
+			_ = s.deleteSandboxPublicRoutes(ctx, storedCD)
 			_ = s.wasm.Destroy(ctx, sandbox)
 			cleanupMounts()
 			releaseAdmission()


### PR DESCRIPTION
## Summary

- `caddy.UpsertSandboxRoute` installs a main toolbox route **plus one HTTP leaf route per custom domain** (domain mode), but every teardown path called `DeleteSandboxRoute`, which removes only the main route — so the per-hostname leaf routes (`IngressCustomDomainHTTPRouteID`) were orphaned in caddy.
- Leaked on **create rollback** (docker/firecracker/wasm: post-route failures tore down only the main route; the `syncSandboxPublicRoute`-failure path did no caddy cleanup at all despite `UpsertSandboxRoute` being non-atomic) and on the **normal `DestroySandbox` path** (fires on every destroy of a custom-domain sandbox).
- Fix routes all teardown through the existing `deleteSandboxPublicRoutes` helper (main route + every leaf; `DeleteCustomDomainHTTPRoute` is 404-safe, so correct on partial installs).

## Sandbox boot impact

N/A on the success path — `deleteSandboxPublicRoutes` only runs on rollback or destroy, never on a successful create. On those paths it adds N extra caddy DELETE calls (one per attached custom domain), bounded by the custom-domain count per sandbox. No new work or latency on the create success path.

## Idempotency

No API surface or wire contract changed. The teardown itself is idempotent: `DeleteCustomDomainHTTPRoute` / `DeleteSandboxRoute` treat 404 as success, so a retried create rollback or a repeated destroy re-deletes the same routes as a no-op. Safe on the cluster recreate path (`CreateSandboxWithID` with an `idOverride`).

## Failure-path consistency

This PR **is** a failure-path fix. The rollback rule for the create path is unchanged in shape (LIFO: `store.Delete` → caddy teardown → driver `Destroy` → `cleanupMounts` → `releaseAdmission`); the only change is that the caddy step now tears down the custom-domain leaf routes in addition to the main route, via `deleteSandboxPublicRoutes` instead of `DeleteSandboxRoute`. The previously-uncovered `syncSandboxPublicRoute`-failure path now also runs caddy teardown to cover `UpsertSandboxRoute`'s non-atomic partial install (main route up, a later leaf fails). `DestroySandbox` gets the same superset teardown so it no longer relies on the reconcile sweep to reclaim leaf routes (pr-review.md §4).

## L4 / host-port-pool changes

N/A - neither touched.

## Test plan

- New regression test `TestCreateSandboxRollbackDeletesCustomDomainLeafRoutes` (`internal/service/public_traffic_create_rollback_test.go`): stateful caddy admin fake records live route IDs; installs main + leaf routes, forces a post-route create failure (custom-domain conflict), asserts no route bearing the failed sandbox's id survives while the seed sandbox's routes are untouched.
- Verified the test **fails on the pre-fix code** (`sandbox-sb-roll-custom-…-http leaked`) and passes after the fix.
- `go test ./internal/service/...` — pass; full offline suite `go test ./cmd/... ./internal/... ./pkg/...` — pass.
- `go vet ./internal/service/...` and `gofmt -l` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)