### PR TITLE
fix(firecracker): restore guest networking after snapshot resume

### DIFF
--- a/cmd/toolboxd/quiesce_linux.go
+++ b/cmd/toolboxd/quiesce_linux.go
@@ -24,6 +24,8 @@ import (
 	"crypto/rand"
 	"fmt"
 	"os"
+	"os/exec"
+	"strings"
 	"syscall"
 	"unsafe"
 
@@ -110,6 +112,91 @@ func (linuxQuiesceOps) SetWallclock(unixNs int64) error {
 		return fmt.Errorf("clock_settime: %w", err)
 	}
 	return nil
+}
+
+func (linuxQuiesceOps) ConfigureNetwork(cfg guestNetworkConfig) error {
+	if cfg.GuestIP == "" || cfg.GatewayIP == "" || cfg.PrefixLen <= 0 {
+		return fmt.Errorf("incomplete network config: %+v", cfg)
+	}
+	iface, err := firstNonLoopbackInterface()
+	if err != nil {
+		return err
+	}
+
+	if ipBin, err := lookNetworkBinary("ip"); err == nil {
+		_ = runNetworkCmd(ipBin, "link", "set", "lo", "up")
+		_ = runNetworkCmd(ipBin, "link", "set", iface, "up")
+		addr := fmt.Sprintf("%s/%d", cfg.GuestIP, cfg.PrefixLen)
+		if err := runNetworkCmdIgnoreExists(ipBin, "addr", "add", addr, "dev", iface); err != nil {
+			return err
+		}
+		_ = runNetworkCmd(ipBin, "route", "replace", "default", "via", cfg.GatewayIP, "dev", iface)
+		return nil
+	}
+
+	ifconfigBin, err := lookNetworkBinary("ifconfig")
+	if err != nil {
+		return fmt.Errorf("no ip or ifconfig binary found")
+	}
+	_ = runNetworkCmd(ifconfigBin, "lo", "up")
+	if cfg.Netmask != "" {
+		if err := runNetworkCmd(ifconfigBin, iface, cfg.GuestIP, "netmask", cfg.Netmask, "up"); err != nil {
+			return err
+		}
+	} else if err := runNetworkCmd(ifconfigBin, iface, cfg.GuestIP, "up"); err != nil {
+		return err
+	}
+	if routeBin, err := lookNetworkBinary("route"); err == nil {
+		_ = runNetworkCmdIgnoreExists(routeBin, "add", "default", "gw", cfg.GatewayIP, iface)
+	}
+	return nil
+}
+
+func firstNonLoopbackInterface() (string, error) {
+	entries, err := os.ReadDir("/sys/class/net")
+	if err != nil {
+		return "", fmt.Errorf("read /sys/class/net: %w", err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if name != "" && name != "lo" {
+			return name, nil
+		}
+	}
+	return "", fmt.Errorf("no non-loopback interface found")
+}
+
+func runNetworkCmd(name string, args ...string) error {
+	out, err := exec.Command(name, args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s %s: %w (%s)", name, strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func runNetworkCmdIgnoreExists(name string, args ...string) error {
+	out, err := exec.Command(name, args...).CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	text := strings.TrimSpace(string(out))
+	if strings.Contains(strings.ToLower(text), "exists") {
+		return nil
+	}
+	return fmt.Errorf("%s %s: %w (%s)", name, strings.Join(args, " "), err, text)
+}
+
+func lookNetworkBinary(name string) (string, error) {
+	if p, err := exec.LookPath(name); err == nil {
+		return p, nil
+	}
+	for _, dir := range []string{"/sbin", "/bin", "/usr/sbin", "/usr/bin"} {
+		p := dir + "/" + name
+		if st, err := os.Stat(p); err == nil && !st.IsDir() && st.Mode()&0o111 != 0 {
+			return p, nil
+		}
+	}
+	return "", fmt.Errorf("%s not found", name)
 }
 
 // newQuiesceOps returns the platform-specific quiesce implementation.

--- a/cmd/toolboxd/quiesce_other.go
+++ b/cmd/toolboxd/quiesce_other.go
@@ -24,6 +24,10 @@ func (otherQuiesceOps) SetWallclock(int64) error {
 	return errors.New("quiesce: linux-only (build tag !linux)")
 }
 
+func (otherQuiesceOps) ConfigureNetwork(guestNetworkConfig) error {
+	return errors.New("quiesce: linux-only (build tag !linux)")
+}
+
 // newQuiesceOps returns the platform-specific quiesce implementation.
 // Non-Linux gets the stub above; Linux gets real syscalls from
 // quiesce_linux.go.

--- a/cmd/toolboxd/stubs_nonlinux_test.go
+++ b/cmd/toolboxd/stubs_nonlinux_test.go
@@ -17,6 +17,9 @@ func TestNonLinuxStubs(t *testing.T) {
 	if err := q.SetWallclock(123); err == nil {
 		t.Fatal("SetWallclock expected error on non-linux stub")
 	}
+	if err := q.ConfigureNetwork(guestNetworkConfig{GuestIP: "172.16.0.2", GatewayIP: "172.16.0.1", PrefixLen: 30}); err == nil {
+		t.Fatal("ConfigureNetwork expected error on non-linux stub")
+	}
 
 	vs, err := newVsockServer(1024, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err == nil || vs != nil {

--- a/cmd/toolboxd/vsock.go
+++ b/cmd/toolboxd/vsock.go
@@ -174,6 +174,14 @@ func dispatchVsock(ctx context.Context, msg VsockMessage, handler VsockHandler) 
 type quiesceOps interface {
 	ReseedRandom() error
 	SetWallclock(unixNs int64) error
+	ConfigureNetwork(guestNetworkConfig) error
+}
+
+type guestNetworkConfig struct {
+	GuestIP   string `json:"guest_ip"`
+	GatewayIP string `json:"gateway_ip"`
+	Netmask   string `json:"netmask"`
+	PrefixLen int    `json:"prefix_len"`
 }
 
 // sessionFlusher is the subset of behaviour the quiesce handler needs
@@ -236,7 +244,8 @@ func (h *quiesceHandler) OnPreSnapshot(ctx context.Context, _ json.RawMessage) e
 
 func (h *quiesceHandler) OnPostResume(ctx context.Context, raw json.RawMessage) error {
 	var data struct {
-		WallclockUnixNs int64 `json:"wallclock_unix_ns"`
+		WallclockUnixNs int64               `json:"wallclock_unix_ns"`
+		Network         *guestNetworkConfig `json:"network,omitempty"`
 	}
 	if len(raw) > 0 {
 		// Tolerate a missing/malformed payload — the RNG reseed is
@@ -246,6 +255,11 @@ func (h *quiesceHandler) OnPostResume(ctx context.Context, raw json.RawMessage) 
 	if data.WallclockUnixNs > 0 {
 		if err := h.quiesce.SetWallclock(data.WallclockUnixNs); err != nil {
 			h.logger.Warn("vsock post_resume: clock resync failed", "error", err)
+		}
+	}
+	if data.Network != nil {
+		if err := h.quiesce.ConfigureNetwork(*data.Network); err != nil {
+			h.logger.Warn("vsock post_resume: network reconfigure failed", "error", err)
 		}
 	}
 	if err := h.quiesce.ReseedRandom(); err != nil {

--- a/cmd/toolboxd/vsock_test.go
+++ b/cmd/toolboxd/vsock_test.go
@@ -243,8 +243,10 @@ type fakeQuiesceOps struct {
 	mu            sync.Mutex
 	reseedCalls   int
 	wallclockArgs []int64
+	networkArgs   []guestNetworkConfig
 	reseedErr     error
 	wallclockErr  error
+	networkErr    error
 }
 
 func (f *fakeQuiesceOps) ReseedRandom() error {
@@ -259,6 +261,13 @@ func (f *fakeQuiesceOps) SetWallclock(ns int64) error {
 	defer f.mu.Unlock()
 	f.wallclockArgs = append(f.wallclockArgs, ns)
 	return f.wallclockErr
+}
+
+func (f *fakeQuiesceOps) ConfigureNetwork(cfg guestNetworkConfig) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.networkArgs = append(f.networkArgs, cfg)
+	return f.networkErr
 }
 
 // fakeSessionFlusher records FlushRecording calls; List returns
@@ -320,17 +329,17 @@ func TestQuiesceHandler_PreSnapshot_FlushesEverySession(t *testing.T) {
 	}
 }
 
-// TestQuiesceHandler_PostResume_ResyncsClockAndRNG asserts that a
-// well-formed post_resume payload with wallclock_unix_ns calls
-// SetWallclock then ReseedRandom. The RNG reseed is unconditional —
-// every clone resumes with the template's entropy pool, so reseed is
-// not gated on the wallclock field's presence.
-func TestQuiesceHandler_PostResume_ResyncsClockAndRNG(t *testing.T) {
+// TestQuiesceHandler_PostResume_ResyncsClockRNGAndNetwork asserts that a
+// well-formed post_resume payload with wallclock_unix_ns and network data calls
+// SetWallclock, ConfigureNetwork, then ReseedRandom. The RNG reseed is
+// unconditional — every clone resumes with the template's entropy pool, so
+// reseed is not gated on the wallclock field's presence.
+func TestQuiesceHandler_PostResume_ResyncsClockRNGAndNetwork(t *testing.T) {
 	q := &fakeQuiesceOps{}
 	h := newQuiesceHandler(nil, nil, nil)
 	h.quiesce = q
 
-	raw := json.RawMessage(`{"wallclock_unix_ns":1700000000000000000}`)
+	raw := json.RawMessage(`{"wallclock_unix_ns":1700000000000000000,"network":{"guest_ip":"172.16.0.6","gateway_ip":"172.16.0.5","netmask":"255.255.255.252","prefix_len":30}}`)
 	if err := h.OnPostResume(context.Background(), raw); err != nil {
 		t.Fatalf("OnPostResume: %v", err)
 	}
@@ -341,6 +350,9 @@ func TestQuiesceHandler_PostResume_ResyncsClockAndRNG(t *testing.T) {
 	}
 	if len(q.wallclockArgs) != 1 || q.wallclockArgs[0] != 1700000000000000000 {
 		t.Errorf("wallclockArgs = %v, want [1700000000000000000]", q.wallclockArgs)
+	}
+	if len(q.networkArgs) != 1 || q.networkArgs[0].GuestIP != "172.16.0.6" || q.networkArgs[0].GatewayIP != "172.16.0.5" || q.networkArgs[0].PrefixLen != 30 {
+		t.Errorf("networkArgs = %+v, want guest/gateway/prefix from payload", q.networkArgs)
 	}
 }
 
@@ -386,11 +398,12 @@ func TestQuiesceHandler_PostResume_QuiesceErrorIsNonFatal(t *testing.T) {
 	q := &fakeQuiesceOps{
 		reseedErr:    errors.New("entropy pool unavailable"),
 		wallclockErr: errors.New("CAP_SYS_TIME denied"),
+		networkErr:   errors.New("ip tool unavailable"),
 	}
 	h := newQuiesceHandler(nil, nil, nil)
 	h.quiesce = q
 	if err := h.OnPostResume(context.Background(),
-		json.RawMessage(`{"wallclock_unix_ns":12345}`)); err != nil {
+		json.RawMessage(`{"wallclock_unix_ns":12345,"network":{"guest_ip":"172.16.0.6","gateway_ip":"172.16.0.5","prefix_len":30}}`)); err != nil {
 		t.Errorf("OnPostResume returned %v; want nil despite quiesce errors", err)
 	}
 }

--- a/internal/runtime/firecracker/assets/toolboxd-init.sh
+++ b/internal/runtime/firecracker/assets/toolboxd-init.sh
@@ -9,8 +9,10 @@
 # so the very first userspace process is us: mount the pseudo-filesystems
 # toolboxd needs, load the per-sandbox env, then exec the agent as PID 1.
 #
-# eth0 is already configured by the kernel `ip=` autoconf (CONFIG_IP_PNP)
-# the driver appends to the boot args, so there is no network setup here.
+# The kernel `ip=` autoconf should configure the interface before userspace,
+# but not every host kernel/image combination has CONFIG_IP_PNP wired the way
+# we need. Re-apply the same static address from userspace as a fallback before
+# toolboxd starts accepting host HTTP traffic on :2280.
 #
 # This script must run under the guest's /bin/sh (busybox or bash). Keep
 # it POSIX and dependency-free. If toolboxd exits, PID 1 exits and the
@@ -22,11 +24,64 @@ mount -t sysfs    sys  /sys         2>/dev/null || true
 mount -t devtmpfs dev  /dev         2>/dev/null || true
 mount -t tmpfs    tmp  /tmp         2>/dev/null || true
 
+find_cmd() {
+	if command -v "$1" >/dev/null 2>&1; then
+		command -v "$1"
+		return 0
+	fi
+	for dir in /sbin /bin /usr/sbin /usr/bin; do
+		if [ -x "$dir/$1" ]; then
+			printf '%s\n' "$dir/$1"
+			return 0
+		fi
+	done
+	return 1
+}
+
 # Per-sandbox environment (token, port) injected alongside this script.
 if [ -f /etc/toolboxd.env ]; then
 	# shellcheck disable=SC1091
 	. /etc/toolboxd.env
-	export SB_TOOLBOX_TOKEN SB_TOOLBOX_PORT
+	export SB_TOOLBOX_TOKEN SB_TOOLBOX_PORT SB_TOOLBOX_GUEST_IP SB_TOOLBOX_GATEWAY_IP SB_TOOLBOX_NETMASK SB_TOOLBOX_PREFIX_LEN
 fi
+
+configure_network() {
+	[ -n "${SB_TOOLBOX_GUEST_IP:-}" ] || return 0
+	[ -n "${SB_TOOLBOX_GATEWAY_IP:-}" ] || return 0
+	[ -n "${SB_TOOLBOX_PREFIX_LEN:-}" ] || return 0
+
+	iface=""
+	for dev in /sys/class/net/*; do
+		[ -e "$dev" ] || continue
+		name=${dev##*/}
+		[ "$name" = "lo" ] && continue
+		iface=$name
+		break
+	done
+	[ -n "$iface" ] || return 0
+
+	ip_cmd=$(find_cmd ip || true)
+	ifconfig_cmd=$(find_cmd ifconfig || true)
+	route_cmd=$(find_cmd route || true)
+
+	if [ -n "$ip_cmd" ]; then
+		"$ip_cmd" link set lo up 2>/dev/null || true
+		"$ip_cmd" link set "$iface" up 2>/dev/null || true
+		"$ip_cmd" addr add "$SB_TOOLBOX_GUEST_IP/$SB_TOOLBOX_PREFIX_LEN" dev "$iface" 2>/dev/null || true
+		"$ip_cmd" route replace default via "$SB_TOOLBOX_GATEWAY_IP" dev "$iface" 2>/dev/null || true
+	elif [ -n "$ifconfig_cmd" ]; then
+		"$ifconfig_cmd" lo up 2>/dev/null || true
+		if [ -n "${SB_TOOLBOX_NETMASK:-}" ]; then
+			"$ifconfig_cmd" "$iface" "$SB_TOOLBOX_GUEST_IP" netmask "$SB_TOOLBOX_NETMASK" up 2>/dev/null || true
+		else
+			"$ifconfig_cmd" "$iface" "$SB_TOOLBOX_GUEST_IP" up 2>/dev/null || true
+		fi
+		if [ -n "$route_cmd" ]; then
+			"$route_cmd" add default gw "$SB_TOOLBOX_GATEWAY_IP" "$iface" 2>/dev/null || true
+		fi
+	fi
+}
+
+configure_network
 
 exec /usr/local/bin/toolboxd

--- a/internal/runtime/firecracker/coldboot_agent.go
+++ b/internal/runtime/firecracker/coldboot_agent.go
@@ -30,6 +30,15 @@ const (
 	guestToolboxPort = 2280
 )
 
+// ColdBootInjectFiles returns the files to bake into a Firecracker rootfs so
+// the guest comes up running the agent. It is exported for the daemon's
+// template builder adapter: templates built from stock OCI images need the
+// same injected agent/init as one-off cold boots before SnapshotTemplate can
+// capture a ready guest.
+func ColdBootInjectFiles(toolboxBinaryPath, toolboxToken string, slot *TapSlot) []InjectFile {
+	return coldBootInjectFiles(toolboxBinaryPath, toolboxToken, slot)
+}
+
 // coldBootInjectFiles returns the files to bake into a cold-boot rootfs so
 // the guest comes up running the agent. Returns nil when no toolbox binary
 // is configured — the caller then cold-boots an agent-less guest (Create's
@@ -38,7 +47,7 @@ const (
 //
 // The token is per-sandbox, so these files are regenerated on every
 // cold-boot Create (cold-boot already builds a fresh rootfs per sandbox).
-func coldBootInjectFiles(toolboxBinaryPath, toolboxToken string) []InjectFile {
+func coldBootInjectFiles(toolboxBinaryPath, toolboxToken string, slot *TapSlot) []InjectFile {
 	if toolboxBinaryPath == "" {
 		return nil
 	}
@@ -46,6 +55,7 @@ func coldBootInjectFiles(toolboxBinaryPath, toolboxToken string) []InjectFile {
 	// host-generated hex today — keeps a future token format from
 	// breaking the `.`-sourced env file.
 	env := fmt.Sprintf("SB_TOOLBOX_TOKEN=%s\nSB_TOOLBOX_PORT='%d'\n", shellSingleQuote(toolboxToken), guestToolboxPort)
+	env += toolboxNetworkEnv(slot)
 	return []InjectFile{
 		{HostPath: toolboxBinaryPath, GuestPath: guestToolboxPath, Mode: 0o755},
 		{Content: toolboxdInitScript, GuestPath: guestInitPath, Mode: 0o755},
@@ -100,6 +110,57 @@ func kernelIPArg(slot *TapSlot) string {
 	return fmt.Sprintf("ip=%s::%s:%s::%s:off", slot.GuestIP, slot.HostIP, mask, primaryIfaceID)
 }
 
+func toolboxNetworkEnv(slot *TapSlot) string {
+	cfg, ok := guestNetworkConfig(slot)
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf(
+		"SB_TOOLBOX_GUEST_IP=%s\nSB_TOOLBOX_GATEWAY_IP=%s\nSB_TOOLBOX_NETMASK=%s\nSB_TOOLBOX_PREFIX_LEN='%d'\n",
+		shellSingleQuote(cfg.GuestIP),
+		shellSingleQuote(cfg.GatewayIP),
+		shellSingleQuote(cfg.Netmask),
+		cfg.PrefixLen,
+	)
+}
+
+func toolboxNetworkPayload(slot *TapSlot) map[string]any {
+	cfg, ok := guestNetworkConfig(slot)
+	if !ok {
+		return nil
+	}
+	return map[string]any{
+		"guest_ip":   cfg.GuestIP,
+		"gateway_ip": cfg.GatewayIP,
+		"netmask":    cfg.Netmask,
+		"prefix_len": cfg.PrefixLen,
+	}
+}
+
+type guestNetworkDetails struct {
+	GuestIP   string
+	GatewayIP string
+	Netmask   string
+	PrefixLen int
+}
+
+func guestNetworkConfig(slot *TapSlot) (guestNetworkDetails, bool) {
+	if slot == nil || slot.GuestIP == "" || slot.HostIP == "" || slot.CIDR == "" {
+		return guestNetworkDetails{}, false
+	}
+	mask := netmaskFromCIDR(slot.CIDR)
+	prefix := prefixLenFromCIDR(slot.CIDR)
+	if mask == "" || prefix < 0 {
+		return guestNetworkDetails{}, false
+	}
+	return guestNetworkDetails{
+		GuestIP:   slot.GuestIP,
+		GatewayIP: slot.HostIP,
+		Netmask:   mask,
+		PrefixLen: prefix,
+	}, true
+}
+
 // netmaskFromCIDR turns "172.16.0.2/30" into dotted "255.255.255.252".
 // Returns "" on a malformed or non-IPv4 CIDR — the caller then drops the
 // ip= clause rather than booting with a bogus mask.
@@ -113,4 +174,16 @@ func netmaskFromCIDR(cidr string) string {
 		return ""
 	}
 	return fmt.Sprintf("%d.%d.%d.%d", m[0], m[1], m[2], m[3])
+}
+
+func prefixLenFromCIDR(cidr string) int {
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil || ipnet == nil {
+		return -1
+	}
+	ones, bits := ipnet.Mask.Size()
+	if bits != 32 {
+		return -1
+	}
+	return ones
 }

--- a/internal/runtime/firecracker/coldboot_agent_test.go
+++ b/internal/runtime/firecracker/coldboot_agent_test.go
@@ -10,7 +10,8 @@ import (
 // agent, so the guest must have toolboxd + its init shim + the per-sandbox
 // token baked in, or Create's vsock handshake has no peer.
 func TestColdBootInjectFiles_PutsAgentInGuest(t *testing.T) {
-	files := coldBootInjectFiles("/opt/aerolvm/toolboxd", "tok-123")
+	slot := &TapSlot{GuestIP: "172.16.0.2", HostIP: "172.16.0.1", CIDR: "172.16.0.0/30"}
+	files := coldBootInjectFiles("/opt/aerolvm/toolboxd", "tok-123", slot)
 	if len(files) != 3 {
 		t.Fatalf("want 3 injected files, got %d", len(files))
 	}
@@ -30,12 +31,25 @@ func TestColdBootInjectFiles_PutsAgentInGuest(t *testing.T) {
 	if !strings.Contains(string(init.Content), "exec /usr/local/bin/toolboxd") {
 		t.Errorf("init shim does not exec the agent:\n%s", init.Content)
 	}
+	if !strings.Contains(string(init.Content), "configure_network") {
+		t.Errorf("init shim does not configure guest networking:\n%s", init.Content)
+	}
 	env, ok := byPath[guestEnvPath]
 	if !ok || env.Mode != 0o600 {
 		t.Errorf("env inject wrong mode: %+v", env)
 	}
 	if !strings.Contains(string(env.Content), "SB_TOOLBOX_TOKEN='tok-123'") {
 		t.Errorf("env file missing token: %q", env.Content)
+	}
+	for _, want := range []string{
+		"SB_TOOLBOX_GUEST_IP='172.16.0.2'",
+		"SB_TOOLBOX_GATEWAY_IP='172.16.0.1'",
+		"SB_TOOLBOX_NETMASK='255.255.255.252'",
+		"SB_TOOLBOX_PREFIX_LEN='30'",
+	} {
+		if !strings.Contains(string(env.Content), want) {
+			t.Errorf("env file missing %s: %q", want, env.Content)
+		}
 	}
 }
 
@@ -49,7 +63,7 @@ func TestShellSingleQuote(t *testing.T) {
 // the injector returns nil so the caller cold-boots an agent-less guest
 // (and warns) rather than panicking on an empty HostPath.
 func TestColdBootInjectFiles_NoBinaryIsNil(t *testing.T) {
-	if files := coldBootInjectFiles("", "tok"); files != nil {
+	if files := coldBootInjectFiles("", "tok", nil); files != nil {
 		t.Errorf("want nil with no binary, got %+v", files)
 	}
 }
@@ -95,6 +109,22 @@ func TestNetmaskFromCIDR(t *testing.T) {
 	}
 }
 
+func TestPrefixLenFromCIDR(t *testing.T) {
+	for _, tc := range []struct {
+		cidr string
+		want int
+	}{
+		{"172.16.0.0/30", 30},
+		{"10.0.0.0/24", 24},
+		{"2001:db8::/32", -1},
+		{"bogus", -1},
+	} {
+		if got := prefixLenFromCIDR(tc.cidr); got != tc.want {
+			t.Errorf("prefixLenFromCIDR(%q) = %d, want %d", tc.cidr, got, tc.want)
+		}
+	}
+}
+
 func TestKernelIPArg(t *testing.T) {
 	full := &TapSlot{GuestIP: "172.16.0.2", HostIP: "172.16.0.1", CIDR: "172.16.0.0/30"}
 	want := "ip=172.16.0.2::172.16.0.1:255.255.255.252::eth0:off"
@@ -111,5 +141,13 @@ func TestKernelIPArg(t *testing.T) {
 		if got := kernelIPArg(slot); got != "" {
 			t.Errorf("kernelIPArg(%+v) = %q, want empty", slot, got)
 		}
+	}
+}
+
+func TestToolboxNetworkPayload(t *testing.T) {
+	slot := &TapSlot{GuestIP: "172.16.0.6", HostIP: "172.16.0.5", CIDR: "172.16.0.4/30"}
+	payload := toolboxNetworkPayload(slot)
+	if payload["guest_ip"] != "172.16.0.6" || payload["gateway_ip"] != "172.16.0.5" || payload["netmask"] != "255.255.255.252" || payload["prefix_len"] != 30 {
+		t.Fatalf("toolboxNetworkPayload = %+v", payload)
 	}
 }

--- a/internal/runtime/firecracker/create_rundir_test.go
+++ b/internal/runtime/firecracker/create_rundir_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/aerol-ai/microvm/pkg/models"
@@ -98,5 +99,57 @@ func TestSnapshotTemplate_CreatesRunDirBeforeStaging(t *testing.T) {
 	}
 	if got, err := os.ReadFile(filepath.Join(chrootRoot, rootfsFileName)); err != nil || string(got) != "rootfs" {
 		t.Fatalf("staged rootfs = %q, %v", got, err)
+	}
+}
+
+func TestSnapshotTemplate_JailerStagesAPIPaths(t *testing.T) {
+	f := newDriverFixture(t)
+	f.driver.cfg.UseJailer = true
+	f.driver.cfg.ToolboxBinaryPath = "/opt/aerolvm/toolboxd"
+
+	chrootRoot := filepath.Join(t.TempDir(), "jailer", "firecracker", "tpl-snap-tpl-jail", "root")
+	f.driver.SetSpawner(func(_ Config, sandboxID string) (VMMHandle, error) {
+		f.vmm.id = sandboxID
+		f.vmm.runDir = chrootRoot
+		f.vmm.apiSocket = filepath.Join(chrootRoot, "api.sock")
+		return f.vmm, nil
+	})
+
+	tplDir := t.TempDir()
+	rootfs := filepath.Join(tplDir, rootfsFileName)
+	if err := os.WriteFile(rootfs, []byte("rootfs"), 0o644); err != nil {
+		t.Fatalf("write rootfs: %v", err)
+	}
+
+	_, err := f.driver.SnapshotTemplate(context.Background(), TemplateSnapshotRequest{
+		TemplateID:    "tpl-jail",
+		RootfsPath:    rootfs,
+		OutMemoryPath: filepath.Join(tplDir, "snapshot.memory"),
+		OutStatePath:  filepath.Join(tplDir, "snapshot.state"),
+		GuestCID:      200,
+		MemoryMB:      512,
+		VCPU:          1,
+	})
+	if err != nil {
+		t.Fatalf("SnapshotTemplate (jailer): %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(chrootRoot, kernelFileName)); err != nil {
+		t.Fatalf("kernel not staged into chroot: %v", err)
+	}
+	if f.client.bs == nil || f.client.bs.KernelImagePath != kernelFileName {
+		t.Fatalf("boot source kernel path = %+v, want %q", f.client.bs, kernelFileName)
+	}
+	if !strings.Contains(f.client.bs.BootArgs, "init="+guestInitPath) {
+		t.Fatalf("snapshot boot args missing toolbox init: %q", f.client.bs.BootArgs)
+	}
+	if !strings.Contains(f.client.bs.BootArgs, "ip=172.16.0.2::172.16.0.1:255.255.255.252::eth0:off") {
+		t.Fatalf("snapshot boot args missing TAP ip config: %q", f.client.bs.BootArgs)
+	}
+	if root := f.client.drives[rootDriveID]; root.PathOnHost != rootfsFileName {
+		t.Fatalf("root drive path = %q, want %q", root.PathOnHost, rootfsFileName)
+	}
+	if overlay := f.client.drives[overlayDriveID]; overlay.PathOnHost != overlayFileName {
+		t.Fatalf("overlay drive path = %q, want %q", overlay.PathOnHost, overlayFileName)
 	}
 }

--- a/internal/runtime/firecracker/create_test.go
+++ b/internal/runtime/firecracker/create_test.go
@@ -1443,6 +1443,12 @@ func TestCreate_SnapshotLoadPath_SendsPostResume(t *testing.T) {
 		Op   string `json:"op"`
 		Data struct {
 			WallclockUnixNs int64 `json:"wallclock_unix_ns"`
+			Network         struct {
+				GuestIP   string `json:"guest_ip"`
+				GatewayIP string `json:"gateway_ip"`
+				Netmask   string `json:"netmask"`
+				PrefixLen int    `json:"prefix_len"`
+			} `json:"network"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(postLine, &decoded); err != nil {
@@ -1453,6 +1459,12 @@ func TestCreate_SnapshotLoadPath_SendsPostResume(t *testing.T) {
 	}
 	if decoded.Data.WallclockUnixNs <= 0 {
 		t.Errorf("WallclockUnixNs = %d, want > 0", decoded.Data.WallclockUnixNs)
+	}
+	if decoded.Data.Network.GuestIP != "172.16.0.2" ||
+		decoded.Data.Network.GatewayIP != "172.16.0.1" ||
+		decoded.Data.Network.Netmask != "255.255.255.252" ||
+		decoded.Data.Network.PrefixLen != 30 {
+		t.Errorf("post_resume network = %+v, want slot network", decoded.Data.Network)
 	}
 }
 

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -224,8 +224,9 @@ type Config struct {
 	// files / sessions). Mirrors internal/config.Config.ToolboxBinaryPath.
 	// When empty, cold-boot still works but the guest comes up with no
 	// agent — Create's vsock handshake will then time out, so production
-	// daemons must set it. The template/snapshot path does NOT use this
-	// (those images carry their own init + agent).
+	// daemons must set it. The template builder adapter also uses this
+	// binary so templates built from stock OCI images can be snapshotted
+	// after the same toolbox readiness handshake.
 	ToolboxBinaryPath string
 }
 
@@ -628,7 +629,7 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 		// this the guest boots with nothing on vsock and Create's readiness
 		// handshake times out (a plain image carries no agent). Empty when
 		// no toolbox binary is configured — see coldBootInjectFiles.
-		inject := coldBootInjectFiles(d.cfg.ToolboxBinaryPath, toolboxToken)
+		inject := coldBootInjectFiles(d.cfg.ToolboxBinaryPath, toolboxToken, slot)
 		if inject == nil {
 			d.logger.Warn("firecracker cold-boot: no toolbox binary configured; guest will boot without an agent and the vsock handshake will fail",
 				"sandbox_id", allocID)
@@ -783,9 +784,7 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 	// has nothing to resync (kernel just initialized) so skip.
 	if snapshotLoadPath {
 		postCtx, cancel := context.WithTimeout(ctx, d.cfg.PostResumeTimeout)
-		err := d.sendVsockOp(postCtx, vsockPath, handshakeCID, "post_resume", map[string]any{
-			"wallclock_unix_ns": time.Now().UnixNano(),
-		})
+		err := d.sendVsockOp(postCtx, vsockPath, handshakeCID, "post_resume", postResumeData(slot))
 		cancel()
 		if err != nil {
 			d.logger.Warn("firecracker create: post_resume send failed (continuing)",
@@ -1151,6 +1150,16 @@ func macFromSlot(slot *TapSlot) string {
 		byte(slot.VsockCID>>16),
 		byte(slot.VsockCID>>8),
 		byte(slot.VsockCID))
+}
+
+func postResumeData(slot *TapSlot) map[string]any {
+	data := map[string]any{
+		"wallclock_unix_ns": time.Now().UnixNano(),
+	}
+	if network := toolboxNetworkPayload(slot); network != nil {
+		data["network"] = network
+	}
+	return data
 }
 
 // ociImageRefFor expands a bare Docker-style image reference into a

--- a/internal/runtime/firecracker/sandbox_snapshot.go
+++ b/internal/runtime/firecracker/sandbox_snapshot.go
@@ -424,9 +424,7 @@ func (d *Driver) startFromSandboxSnapshot(ctx context.Context, sandboxID string)
 		return nil, fmt.Errorf("firecracker runtime: start %s: vsock handshake: %w", sandboxID, err)
 	}
 	postCtx, cancel := context.WithTimeout(ctx, d.cfg.PostResumeTimeout)
-	if err := d.sendVsockOp(postCtx, vsockPath, manifest.VsockCID, "post_resume", map[string]any{
-		"wallclock_unix_ns": time.Now().UnixNano(),
-	}); err != nil {
+	if err := d.sendVsockOp(postCtx, vsockPath, manifest.VsockCID, "post_resume", postResumeData(slot)); err != nil {
 		d.logger.Warn("firecracker start: post_resume send failed (continuing)",
 			"sandbox_id", sandboxID, "error", err)
 	}

--- a/internal/runtime/firecracker/snapshot.go
+++ b/internal/runtime/firecracker/snapshot.go
@@ -215,9 +215,17 @@ func (d *Driver) SnapshotTemplate(ctx context.Context, req TemplateSnapshotReque
 	}); err != nil {
 		return nil, fmt.Errorf("firecracker snapshot: PutMachineConfig: %w", err)
 	}
+	kernelAPIPath, err := d.chrootFilePath(handle.RunDir(), d.cfg.KernelImage, kernelFileName)
+	if err != nil {
+		return nil, fmt.Errorf("firecracker snapshot: stage kernel: %w", err)
+	}
+	rootfsAPIPath, err := d.chrootFilePath(handle.RunDir(), rootfsPath, rootfsFileName)
+	if err != nil {
+		return nil, fmt.Errorf("firecracker snapshot: stage rootfs for API: %w", err)
+	}
 	if err := client.PutBootSource(ctx, firecracker.BootSource{
-		KernelImagePath: d.cfg.KernelImage,
-		BootArgs:        defaultBootArgs(),
+		KernelImagePath: kernelAPIPath,
+		BootArgs:        coldBootArgs(slot, d.cfg.ToolboxBinaryPath != ""),
 	}); err != nil {
 		return nil, fmt.Errorf("firecracker snapshot: PutBootSource: %w", err)
 	}
@@ -230,7 +238,7 @@ func (d *Driver) SnapshotTemplate(ctx context.Context, req TemplateSnapshotReque
 	// with toolboxd, so it doesn't need to write to rootfs either.
 	if err := client.PutDrive(ctx, rootDriveID, firecracker.Drive{
 		DriveID:      rootDriveID,
-		PathOnHost:   rootfsPath,
+		PathOnHost:   rootfsAPIPath,
 		IsRootDevice: true,
 		IsReadOnly:   true,
 		CacheType:    "Writeback",
@@ -248,9 +256,13 @@ func (d *Driver) SnapshotTemplate(ctx context.Context, req TemplateSnapshotReque
 	if err := allocateSparse(placeholderPath, overlayPlaceholderBytes); err != nil {
 		return nil, fmt.Errorf("firecracker snapshot: overlay placeholder: %w", err)
 	}
+	placeholderAPIPath, err := d.chrootFilePath(handle.RunDir(), placeholderPath, overlayFileName)
+	if err != nil {
+		return nil, fmt.Errorf("firecracker snapshot: stage overlay placeholder for API: %w", err)
+	}
 	if err := client.PutDrive(ctx, overlayDriveID, firecracker.Drive{
 		DriveID:    overlayDriveID,
-		PathOnHost: placeholderPath,
+		PathOnHost: placeholderAPIPath,
 		IsReadOnly: false,
 		CacheType:  "Writeback",
 	}); err != nil {

--- a/internal/runtime/firecracker/warmacquire.go
+++ b/internal/runtime/firecracker/warmacquire.go
@@ -258,9 +258,7 @@ func (d *Driver) tryAcquireWarm(
 	// post_resume reseed (RNG + wallclock). Best-effort; same shape
 	// as the cold snapshot-load path.
 	postCtx, cancel := context.WithTimeout(ctx, d.cfg.PostResumeTimeout)
-	if err := d.sendVsockOp(postCtx, vsockPath, slot.VsockCID, "post_resume", map[string]any{
-		"wallclock_unix_ns": time.Now().UnixNano(),
-	}); err != nil {
+	if err := d.sendVsockOp(postCtx, vsockPath, slot.VsockCID, "post_resume", postResumeData(tapSlot)); err != nil {
 		d.logger.Warn("firecracker create: warm post_resume send failed (continuing)",
 			"sandbox_id", sandboxID, "error", err)
 	}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -339,7 +339,7 @@ func Run(ctx context.Context, logger *slog.Logger, makeProvider ProviderFactory)
 		// constraints. templateResolverAdapter lets the driver look up
 		// the template's rootfs path through the service layer without
 		// the runtime package importing internal/service.
-		svc.SetTemplateBuilder(&templateBuilderAdapter{inner: ociBuilder})
+		svc.SetTemplateBuilder(&templateBuilderAdapter{inner: ociBuilder, toolboxBinaryPath: cfg.ToolboxBinaryPath})
 		fcDriver.SetTemplateResolver(&templateResolverAdapter{svc: svc})
 		// Phase 3 snapshot pipeline: the snapshotter is the driver
 		// itself (it owns the transient VMM seams); the CID allocator
@@ -1567,15 +1567,26 @@ func adaptTapSlot(s *tap.Slot) *fcruntime.TapSlot {
 // the translation lives at the wiring layer where both packages are
 // already in scope.
 type templateBuilderAdapter struct {
-	inner *oci.Builder
+	inner             *oci.Builder
+	toolboxBinaryPath string
 }
 
 func (a *templateBuilderAdapter) Build(ctx context.Context, req service.TemplateBuildRequest) (*service.TemplateBuildResult, error) {
+	var inject []oci.InjectFile
+	for _, f := range fcruntime.ColdBootInjectFiles(a.toolboxBinaryPath, "", nil) {
+		inject = append(inject, oci.InjectFile{
+			HostPath:  f.HostPath,
+			Content:   f.Content,
+			GuestPath: f.GuestPath,
+			Mode:      f.Mode,
+		})
+	}
 	res, err := a.inner.Build(ctx, oci.BuildRequest{
-		ImageRef:   req.ImageRef,
-		OutPath:    req.OutPath,
-		MinSizeMiB: req.MinSizeMiB,
-		Tag:        req.Tag,
+		ImageRef:    req.ImageRef,
+		OutPath:     req.OutPath,
+		MinSizeMiB:  req.MinSizeMiB,
+		Tag:         req.Tag,
+		InjectFiles: inject,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- Send TAP slot network details in the `post_resume` vsock payload on snapshot-load, warm-pool, and sandbox-snapshot start paths; toolboxd applies the address from userspace via `ConfigureNetwork`.
- Add a userspace network fallback to `toolboxd-init.sh` and inject network env vars during cold boot so guests without reliable kernel `ip=` autoconf still get connectivity.
- Inject toolboxd into OCI-built templates (daemon template builder adapter) and fix `SnapshotTemplate` to stage kernel/rootfs/overlay paths relative to the jailer chroot.

## Test plan

- [x] `go test ./cmd/toolboxd/... ./internal/runtime/firecracker/... ./pkg/daemon/...`
- [ ] `make integration-single` (single-node-fc scenario) — verify snapshot/warm-pool boots reach toolboxd on :2280


Made with [Cursor](https://cursor.com)