### PR TITLE
fix(firecracker): use PATCH /vm for pause/resume and pin TAP neighbor

### DIFF
--- a/internal/network/tap/host.go
+++ b/internal/network/tap/host.go
@@ -111,8 +111,9 @@ func (h *Host) exec(ctx context.Context, args ...string) ([]byte, error) {
 	return cmd.CombinedOutput()
 }
 
-// Ensure creates the TAP device, assigns the host-side /30 IP, and
-// brings the link up. Each step is idempotent on its own; the
+// Ensure creates the TAP device, assigns the host-side /30 IP, brings
+// the link up, and pins the guest's L2 neighbor entry. Each step is
+// idempotent on its own; the
 // composition is idempotent overall because each step recognizes the
 // "already in desired state" output and treats it as success.
 //
@@ -123,8 +124,10 @@ func (h *Host) exec(ctx context.Context, args ...string) ([]byte, error) {
 //  2. `ip addr add` next — putting the IP on first means the link is
 //     usable the moment step 3 makes it up. Reverse order would race
 //     against the guest's DHCP/static-IP probe.
-//  3. `ip link set ... up` last — flipping IFF_UP is what the guest's
+//  3. `ip link set ... up` — flipping IFF_UP is what the guest's
 //     virtio-net device sees.
+//  4. `ip neigh replace` last — host-to-guest connects should not depend
+//     on ARP discovery during Firecracker's early boot window.
 //
 // Rollback on partial failure: if step 2 or 3 fails we DO NOT call
 // Remove. The caller is expected to call Remove from its
@@ -181,6 +184,17 @@ func (h *Host) Ensure(ctx context.Context, slot Slot) error {
 	if out, err := h.exec(ctx, "link", "set", slot.TapName, "up"); err != nil {
 		return fmt.Errorf("tap host: link set %s up: %w (%s)", slot.TapName, err, strings.TrimSpace(string(out)))
 	}
+
+	// Step 4: pin host -> guest L2 resolution when the slot carries a
+	// guest endpoint. The runtime gives Firecracker the same deterministic
+	// MAC, so this turns the first toolbox proxy dial into a direct route
+	// instead of waiting for ARP to discover a quiet guest.
+	if slot.GuestIP != "" && slot.VsockCID >= 3 {
+		mac := guestMACFromSlot(slot)
+		if out, err := h.exec(ctx, "neigh", "replace", slot.GuestIP, "lladdr", mac, "dev", slot.TapName, "nud", "permanent"); err != nil {
+			return fmt.Errorf("tap host: neigh replace %s dev %s: %w (%s)", slot.GuestIP, slot.TapName, err, strings.TrimSpace(string(out)))
+		}
+	}
 	return nil
 }
 
@@ -215,6 +229,12 @@ func hostAddrCIDR(hostIP, cidr string) (string, error) {
 		return "", fmt.Errorf("malformed CIDR %q", cidr)
 	}
 	return hostIP + cidr[slash:], nil
+}
+
+func guestMACFromSlot(slot Slot) string {
+	cid := slot.VsockCID
+	return fmt.Sprintf("02:00:00:%02x:%02x:%02x",
+		byte(cid>>16), byte(cid>>8), byte(cid))
 }
 
 // looksLikeExists matches the `ip` output for an idempotent "already

--- a/internal/network/tap/host_test.go
+++ b/internal/network/tap/host_test.go
@@ -44,10 +44,11 @@ func newHostWithRun(r *recordingRun) *Host {
 	return &Host{IPCmd: "/test/ip", run: r.fn}
 }
 
-// TestEnsure_HappyPath confirms the three-step sequence (tuntap add,
-// addr add, link set up) runs in order with the expected argv. The test
-// pins the argv shape because operators reading log lines rely on it;
-// reordering or changing the words breaks runbook copy-paste.
+// TestEnsure_HappyPath confirms the four-step sequence (tuntap add,
+// addr add, link set up, static neighbor) runs in order with the
+// expected argv. The test pins the argv shape because operators
+// reading log lines rely on it; reordering or changing the words
+// breaks runbook copy-paste.
 func TestEnsure_HappyPath(t *testing.T) {
 	r := &recordingRun{}
 	h := newHostWithRun(r)
@@ -62,13 +63,14 @@ func TestEnsure_HappyPath(t *testing.T) {
 	if err := h.Ensure(context.Background(), slot); err != nil {
 		t.Fatalf("Ensure: %v", err)
 	}
-	if len(r.calls) != 3 {
-		t.Fatalf("expected 3 ip calls, got %d (%+v)", len(r.calls), r.calls)
+	if len(r.calls) != 4 {
+		t.Fatalf("expected 4 ip calls, got %d (%+v)", len(r.calls), r.calls)
 	}
 	want := [][]string{
 		{"tuntap", "add", "fctap-1", "mode", "tap"},
 		{"addr", "add", "172.16.0.1/30", "dev", "fctap-1"},
 		{"link", "set", "fctap-1", "up"},
+		{"neigh", "replace", "172.16.0.2", "lladdr", "02:00:00:00:00:03", "dev", "fctap-1", "nud", "permanent"},
 	}
 	for i, w := range want {
 		if !equalStrings(r.calls[i].args, w) {
@@ -99,6 +101,32 @@ func TestEnsure_IdempotentOnAlreadyExists(t *testing.T) {
 	}
 	if len(r.calls) != 3 {
 		t.Errorf("expected 3 calls (idempotent steps still ran), got %d", len(r.calls))
+	}
+}
+
+func TestEnsure_NeighborFailureBubbles(t *testing.T) {
+	r := &recordingRun{
+		plan: []runReply{
+			{},
+			{},
+			{},
+			{out: []byte("RTNETLINK answers: Operation not permitted"), err: errors.New("exit 1")},
+		},
+	}
+	h := newHostWithRun(r)
+	slot := Slot{
+		TapName:  "fctap-neigh",
+		CIDR:     "172.16.0.0/30",
+		HostIP:   "172.16.0.1",
+		GuestIP:  "172.16.0.2",
+		VsockCID: 257,
+	}
+	err := h.Ensure(context.Background(), slot)
+	if err == nil {
+		t.Fatal("expected neighbor failure to bubble")
+	}
+	if !contains(err.Error(), "neigh replace 172.16.0.2 dev fctap-neigh") {
+		t.Errorf("error should mention neighbor command; got %v", err)
 	}
 }
 
@@ -176,6 +204,12 @@ func TestHostHelpers(t *testing.T) {
 		}
 		if len(r.calls) != 1 || r.calls[0].name != "/test/ip" {
 			t.Fatalf("calls = %+v, want one /test/ip invocation", r.calls)
+		}
+	})
+
+	t.Run("guest_mac_from_slot", func(t *testing.T) {
+		if got := guestMACFromSlot(Slot{VsockCID: 0x010203}); got != "02:00:00:01:02:03" {
+			t.Fatalf("guestMACFromSlot() = %q, want 02:00:00:01:02:03", got)
 		}
 	})
 }

--- a/internal/runtime/firecracker/bootargs_test.go
+++ b/internal/runtime/firecracker/bootargs_test.go
@@ -11,7 +11,7 @@ import (
 // on x86 and via FDT on aarch64; a guest kernel with CONFIG_VMGENID reseeds the
 // CRNG from it on snapshot restore *before userspace runs*, which is the only
 // mechanism that closes the entropy window the post_resume reseed cannot (the
-// guest is live between Action(Resume) and the post_resume ack — see Hazard 2 /
+// guest is live between PATCH /vm state=Resumed and the post_resume ack -- see Hazard 2 /
 // "Entropy window" in the Snapshot Clone Correctness doc). Passing acpi=off on
 // x86 would silently kill that pre-userspace reseed. This test fails loudly if
 // a future edit to baseBootArgs breaks the arch-appropriate vmgenid delivery path.

--- a/internal/runtime/firecracker/create_extra_test.go
+++ b/internal/runtime/firecracker/create_extra_test.go
@@ -49,7 +49,7 @@ func TestCreate_LoadSnapshot_ExtraRESTErrors(t *testing.T) {
 		{"LoadSnapshot", func(c *fakeClient) { c.snapshotLoadErr = os.ErrPermission }, "LoadSnapshot"},
 		{"PatchDrive root", func(c *fakeClient) { c.drivePatchErr = os.ErrPermission }, "PatchDrive rootfs"},
 		{"PatchNetworkInterface", func(c *fakeClient) { c.networkPatchErr = os.ErrPermission }, "PatchNetworkInterface"},
-		{"Action Resume", func(c *fakeClient) { c.actionErr = os.ErrPermission }, "action Resume"},
+		{"Patch VM Resumed", func(c *fakeClient) { c.patchVMErr = os.ErrPermission }, "patch VM Resumed"},
 	}
 
 	for _, tc := range testCases {

--- a/internal/runtime/firecracker/create_test.go
+++ b/internal/runtime/firecracker/create_test.go
@@ -314,6 +314,7 @@ type fakeClient struct {
 	nics     map[string]firecracker.NetworkInterface
 	vsock    *firecracker.Vsock
 	actions  []string
+	vmStates []string
 	instance *firecracker.InstanceInfo
 
 	snapshotCreate *firecracker.SnapshotCreate
@@ -326,10 +327,10 @@ type fakeClient struct {
 	drivePatches   map[string]firecracker.DrivePatch
 	networkPatches map[string]firecracker.NetworkInterfacePatch
 
-	// restOrder captures every PUT / Action / Snapshot call in the order
+	// restOrder captures every PUT / Action / PatchVM / Snapshot call in the order
 	// the driver issued them. Order is load-bearing for firecracker:
 	// machine-config + boot-source MUST land before drives + nics, and
-	// CreateSnapshot is only valid after Action(Pause). The snapshot
+	// CreateSnapshot is only valid after PATCH /vm Paused. The snapshot
 	// test asserts the full sequence; the cold-boot tests usually just
 	// assert end-state, but the slice is cheap and harmless to share.
 	restOrder []string
@@ -342,6 +343,7 @@ type fakeClient struct {
 	nicErr            error
 	vsockErr          error
 	actionErr         error
+	patchVMErr        error
 	snapshotCreateErr error
 	snapshotLoadErr   error
 }
@@ -402,6 +404,14 @@ func (c *fakeClient) Action(_ context.Context, a firecracker.Action) error {
 	c.actions = append(c.actions, a.ActionType)
 	c.restOrder = append(c.restOrder, "Action:"+a.ActionType)
 	return c.actionErr
+}
+
+func (c *fakeClient) PatchVM(_ context.Context, vm firecracker.VM) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.vmStates = append(c.vmStates, vm.State)
+	c.restOrder = append(c.restOrder, "PatchVM:"+vm.State)
+	return c.patchVMErr
 }
 
 func (c *fakeClient) InstanceInfo(_ context.Context) (*firecracker.InstanceInfo, error) {
@@ -950,7 +960,7 @@ func TestCreate_TemplateResolveErrorReleasesSlot(t *testing.T) {
 // resolver returns HasSnapshot=true, so the driver MUST skip
 // configureVMM (no PutMachineConfig, no PutBootSource, no PutDrive,
 // no PutNetworkInterface, no PutVsock) and instead issue LoadSnapshot
-// + PATCH rebinding + Action(Resume). The vsock handshake must dial the template's
+// + PATCH rebinding + PATCH /vm state=Resumed. The vsock handshake must dial the template's
 // reserved CID (baked into the snapshot at build time), NOT the
 // per-sandbox slot CID — a regression there silently hangs the
 // handshake until deadline because the guest is listening on the
@@ -1055,10 +1065,13 @@ func TestCreate_SnapshotLoadPath(t *testing.T) {
 		t.Errorf("PatchNetworkInterface = %+v, want fctap-test", f.client.networkPatches[primaryIfaceID])
 	}
 
-	// Resume only, never InstanceStart. The action list is the wire
-	// trace; assert ordering and content.
-	if len(f.client.actions) != 1 || f.client.actions[0] != firecracker.ActionResume {
-		t.Errorf("actions = %v, want [Resume] on snapshot-load path", f.client.actions)
+	// Resume only, never InstanceStart. PatchVM is the state-transition
+	// wire trace; assert ordering and content.
+	if len(f.client.vmStates) != 1 || f.client.vmStates[0] != firecracker.VMStateResumed {
+		t.Errorf("vmStates = %v, want [Resumed] on snapshot-load path", f.client.vmStates)
+	}
+	if len(f.client.actions) != 0 {
+		t.Errorf("actions = %v, want none on snapshot-load path", f.client.actions)
 	}
 
 	// The vsock handshake MUST dial the template's CID, not the
@@ -1233,7 +1246,7 @@ func TestCreate_ColdBoot_WithoutOverlay(t *testing.T) {
 // TestCreate_SnapshotLoadPath_WithOverlay asserts that the
 // snapshot-load path allocates a per-sandbox overlay file and
 // PATCHes the overlay drive to that path between LoadSnapshot and
-// Action(Resume). The PATCH order matters: Firecracker accepts
+// PATCH /vm state=Resumed. The PATCH order matters: Firecracker accepts
 // PathOnHost mutations on a loaded-but-paused VMM, but only before
 // Resume. A regression that PATCHed after Resume would either be
 // rejected by the API or be silently late (the guest's first write
@@ -1289,7 +1302,7 @@ func TestCreate_SnapshotLoadPath_WithOverlay(t *testing.T) {
 		t.Errorf("overlay file size = %d, want %d", info.Size(), int64(2)<<30)
 	}
 
-	// Order: LoadSnapshot → PatchDrive → Resume. Any rearrangement
+	// Order: LoadSnapshot -> PatchDrive -> Resume. Any rearrangement
 	// here is an outage (PATCH-after-Resume is rejected;
 	// Resume-before-PATCH silently corrupts).
 	var loadIdx, patchIdx, resumeIdx int = -1, -1, -1
@@ -1299,7 +1312,7 @@ func TestCreate_SnapshotLoadPath_WithOverlay(t *testing.T) {
 			loadIdx = i
 		case "PatchDrive:" + overlayDriveID:
 			patchIdx = i
-		case "Action:" + firecracker.ActionResume:
+		case "PatchVM:" + firecracker.VMStateResumed:
 			resumeIdx = i
 		}
 	}

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -406,7 +406,7 @@ func methodNotImplemented(method string) error {
 // in-VM toolbox to handshake over vsock, return the runtime state.
 //
 // Phase 3+ path (snapshot clone): pull a paused VMM from the warm pool,
-// PATCH the per-sandbox overlay and TAP onto it, issue Action Resume,
+// PATCH the per-sandbox overlay and TAP onto it, PATCH /vm state=Resumed,
 // return.
 //
 // Cleanup contract — pr-review.md §4: every failure path between an
@@ -743,8 +743,8 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 	// when execution actually begins — a Phase 4 (PR-B) hook to PATCH
 	// per-sandbox state before resume slots in here.
 	if snapshotLoadPath {
-		if err := client.Action(ctx, firecracker.Action{ActionType: firecracker.ActionResume}); err != nil {
-			return nil, fmt.Errorf("firecracker runtime: action Resume: %w", err)
+		if err := client.PatchVM(ctx, firecracker.VM{State: firecracker.VMStateResumed}); err != nil {
+			return nil, fmt.Errorf("firecracker runtime: patch VM Resumed: %w", err)
 		}
 	} else {
 		if err := client.Action(ctx, firecracker.Action{ActionType: firecracker.ActionInstanceStart}); err != nil {
@@ -1113,7 +1113,7 @@ func vcpuFromRequest(cpu float64) int {
 // (vmgenid) through ACPI, and a guest kernel built with CONFIG_VMGENID uses
 // that device to reseed its CRNG synchronously on snapshot restore — before
 // userspace runs — which is the only thing that closes the entropy window
-// between Action(Resume) and the post_resume reseed (see
+// between PATCH /vm state=Resumed and the post_resume reseed (see
 // plans/snapshot-clone-rng-userspace.md Phase C and Hazard 2 of the
 // Snapshot Clone Correctness doc). pci=off is fine — ACPI is a separate bus
 // — but acpi=off would silently disable that pre-userspace reseed. The

--- a/internal/runtime/firecracker/sandbox_snapshot.go
+++ b/internal/runtime/firecracker/sandbox_snapshot.go
@@ -141,13 +141,13 @@ func (d *Driver) stopToSandboxSnapshot(ctx context.Context, sandboxID string) er
 
 	paused := false
 	vmmStopped := false
-	if err := client.Action(ctx, firecracker.Action{ActionType: firecracker.ActionPause}); err != nil {
-		return fmt.Errorf("firecracker runtime: stop %s: action Pause: %w", sandboxID, err)
+	if err := client.PatchVM(ctx, firecracker.VM{State: firecracker.VMStatePaused}); err != nil {
+		return fmt.Errorf("firecracker runtime: stop %s: patch VM Paused: %w", sandboxID, err)
 	}
 	paused = true
 	defer func() {
 		if paused && !vmmStopped {
-			if err := client.Action(context.Background(), firecracker.Action{ActionType: firecracker.ActionResume}); err != nil {
+			if err := client.PatchVM(context.Background(), firecracker.VM{State: firecracker.VMStateResumed}); err != nil {
 				d.logger.Warn("firecracker stop: resume after failed snapshot failed",
 					"sandbox_id", sandboxID, "error", err)
 			}
@@ -416,8 +416,8 @@ func (d *Driver) startFromSandboxSnapshot(ctx context.Context, sandboxID string)
 	if err := d.configureSandboxSnapshotRestore(ctx, client, manifest, memPath, statePath, rootfsPath, slot, overlayPath); err != nil {
 		return nil, err
 	}
-	if err := client.Action(ctx, firecracker.Action{ActionType: firecracker.ActionResume}); err != nil {
-		return nil, fmt.Errorf("firecracker runtime: start %s: action Resume: %w", sandboxID, err)
+	if err := client.PatchVM(ctx, firecracker.VM{State: firecracker.VMStateResumed}); err != nil {
+		return nil, fmt.Errorf("firecracker runtime: start %s: patch VM Resumed: %w", sandboxID, err)
 	}
 	vsockPath := filepath.Join(handle.RunDir(), hostVsockUDSName)
 	if err := d.vsockHandshake(ctx, vsockPath, manifest.VsockCID); err != nil {

--- a/internal/runtime/firecracker/sandbox_snapshot_start_extra2_test.go
+++ b/internal/runtime/firecracker/sandbox_snapshot_start_extra2_test.go
@@ -173,12 +173,12 @@ func TestStartFromSandboxSnapshot_ExtraErrors(t *testing.T) {
 		t.Errorf("expected LoadSnapshot error, got %v", err)
 	}
 
-	// Action Resume fails
+	// Patch VM Resumed fails
 	client = newFakeClient()
-	client.actionErr = os.ErrPermission
+	client.patchVMErr = os.ErrPermission
 	d.SetClientFactory(func(_ string) VMMClient { return client })
-	if _, err := d.startFromSandboxSnapshot(context.Background(), sbID); err == nil || !strings.Contains(err.Error(), "action Resume") {
-		t.Errorf("expected action Resume error, got %v", err)
+	if _, err := d.startFromSandboxSnapshot(context.Background(), sbID); err == nil || !strings.Contains(err.Error(), "patch VM Resumed") {
+		t.Errorf("expected patch VM Resumed error, got %v", err)
 	}
 
 	// vsockHandshake fails

--- a/internal/runtime/firecracker/sandbox_snapshot_start_extra_test.go
+++ b/internal/runtime/firecracker/sandbox_snapshot_start_extra_test.go
@@ -98,15 +98,15 @@ func TestStartFromSandboxSnapshot_ExtraCoverage(t *testing.T) {
 		t.Errorf("expected tap ensure error, got %v", err)
 	}
 
-	// Action resume fail
+	// Patch VM Resumed fail
 	fakeTap.ensureErr = nil
 	client := newFakeClient()
-	client.actionErr = errors.New("resume error")
+	client.patchVMErr = errors.New("resume error")
 	d.SetClientFactory(func(socketPath string) VMMClient {
 		return client
 	})
-	if _, err := d.startFromSandboxSnapshot(context.Background(), sbID); err == nil || !strings.Contains(err.Error(), "action Resume") {
-		t.Errorf("expected action resume error, got %v", err)
+	if _, err := d.startFromSandboxSnapshot(context.Background(), sbID); err == nil || !strings.Contains(err.Error(), "patch VM Resumed") {
+		t.Errorf("expected patch VM Resumed error, got %v", err)
 	}
 }
 
@@ -136,14 +136,14 @@ func TestStopToSandboxSnapshot_ExtraCoverage(t *testing.T) {
 
 	d.pool.Allocate(context.Background(), sbID, time.Now())
 
-	// Action Pause fail
-	client.actionErr = errors.New("pause error")
-	if err := d.stopToSandboxSnapshot(context.Background(), sbID); err == nil || !strings.Contains(err.Error(), "action Pause") {
-		t.Errorf("expected pause error, got %v", err)
+	// Patch VM Paused fail
+	client.patchVMErr = errors.New("pause error")
+	if err := d.stopToSandboxSnapshot(context.Background(), sbID); err == nil || !strings.Contains(err.Error(), "patch VM Paused") {
+		t.Errorf("expected patch VM Paused error, got %v", err)
 	}
 
 	// writeSandboxSnapshot fail (CreateSnapshot error)
-	client.actionErr = nil
+	client.patchVMErr = nil
 	client.snapshotCreateErr = errors.New("snapshot create error")
 	if err := d.stopToSandboxSnapshot(context.Background(), sbID); err == nil || !strings.Contains(err.Error(), "CreateSnapshot") {
 		t.Errorf("expected snapshot create error, got %v", err)

--- a/internal/runtime/firecracker/sandbox_snapshot_test.go
+++ b/internal/runtime/firecracker/sandbox_snapshot_test.go
@@ -76,8 +76,8 @@ func TestStopStartSnapshotLifecycle(t *testing.T) {
 	if patch, ok := f.client.networkPatches[primaryIfaceID]; !ok || patch.HostDevName != "fctap-test" {
 		t.Fatalf("Start network patch = %+v, want fctap-test", f.client.networkPatches)
 	}
-	if got := f.client.actions[len(f.client.actions)-1]; got != firecracker.ActionResume {
-		t.Fatalf("last action = %q, want Resume", got)
+	if got := f.client.vmStates[len(f.client.vmStates)-1]; got != firecracker.VMStateResumed {
+		t.Fatalf("last VM state = %q, want Resumed", got)
 	}
 }
 
@@ -100,7 +100,7 @@ func TestStopSnapshotFailureResumesRunningVMM(t *testing.T) {
 	if f.vmm.shutdown {
 		t.Fatal("Stop shut down VMM after failed snapshot")
 	}
-	if got := f.client.actions[len(f.client.actions)-1]; got != firecracker.ActionResume {
-		t.Fatalf("last action after failed Stop = %q, want Resume rollback", got)
+	if got := f.client.vmStates[len(f.client.vmStates)-1]; got != firecracker.VMStateResumed {
+		t.Fatalf("last VM state after failed Stop = %q, want Resumed rollback", got)
 	}
 }

--- a/internal/runtime/firecracker/seams.go
+++ b/internal/runtime/firecracker/seams.go
@@ -172,12 +172,13 @@ type VMMClient interface {
 	PutNetworkInterface(ctx context.Context, ifaceID string, iface firecracker.NetworkInterface) error
 	PutVsock(ctx context.Context, v firecracker.Vsock) error
 	Action(ctx context.Context, a firecracker.Action) error
+	PatchVM(ctx context.Context, vm firecracker.VM) error
 	InstanceInfo(ctx context.Context) (*firecracker.InstanceInfo, error)
 	CreateSnapshot(ctx context.Context, req firecracker.SnapshotCreate) error
 	LoadSnapshot(ctx context.Context, req firecracker.SnapshotLoad) error
 	// PatchDrive is the snapshot-load + overlay seam (Phase 3 PR-B).
 	// Firecracker accepts a PATCH of `path_on_host` between LoadSnapshot
-	// and Action(Resume); the driver uses it to swap the template's
+	// and PATCH /vm state=Resumed; the driver uses it to swap the template's
 	// placeholder overlay (1 MiB scratch file from snapshot capture
 	// time) for the clone's own per-sandbox overlay.ext4 before the VM
 	// resumes. Drive geometry (read-only flag, cache type) is

--- a/internal/runtime/firecracker/snapshot.go
+++ b/internal/runtime/firecracker/snapshot.go
@@ -304,11 +304,11 @@ func (d *Driver) SnapshotTemplate(ctx context.Context, req TemplateSnapshotReque
 			"template_id", req.TemplateID, "error", err)
 	}
 
-	// Step 10: pause. Firecracker requires Pause before CreateSnapshot;
+	// Step 10: pause. Firecracker requires Paused before CreateSnapshot;
 	// resuming after a snapshot is the caller's choice (we don't —
 	// we shut the VMM down).
-	if err := client.Action(ctx, firecracker.Action{ActionType: firecracker.ActionPause}); err != nil {
-		return nil, fmt.Errorf("firecracker snapshot: action Pause: %w", err)
+	if err := client.PatchVM(ctx, firecracker.VM{State: firecracker.VMStatePaused}); err != nil {
+		return nil, fmt.Errorf("firecracker snapshot: patch VM Paused: %w", err)
 	}
 
 	// Step 11: write the snapshot. SnapshotType=Full because there is
@@ -328,7 +328,7 @@ func (d *Driver) SnapshotTemplate(ctx context.Context, req TemplateSnapshotReque
 	}
 
 	// Step 12: tear the transient VMM down. We Shutdown rather than
-	// Action(Resume) because the snapshot is captured — anything the
+	// PATCH /vm state=Resumed because the snapshot is captured -- anything the
 	// VMM does after this is wasted CPU. handle.Shutdown signals the
 	// firecracker process, which exits and releases its TAP grip;
 	// then tapHost.Remove can succeed.

--- a/internal/runtime/firecracker/snapshot_extra_test.go
+++ b/internal/runtime/firecracker/snapshot_extra_test.go
@@ -160,7 +160,7 @@ func TestSnapshotTemplate_Errors_Extra(t *testing.T) {
 	d.vsockDial = newFakeVsockDialer()
 
 	// CreateSnapshot fails
-	client.actionErr = nil // so Pause works
+	client.patchVMErr = nil // so Paused works
 
 	client.snapshotCreateErr = os.ErrPermission
 	if _, err := d.SnapshotTemplate(context.Background(), reqValid); err == nil || !strings.Contains(err.Error(), "CreateSnapshot") {

--- a/internal/runtime/firecracker/snapshot_rest_extra_test.go
+++ b/internal/runtime/firecracker/snapshot_rest_extra_test.go
@@ -29,21 +29,13 @@ func TestSnapshotTemplate_RESTErrors_Extra(t *testing.T) {
 		{"PutNetworkInterface", func(c *fakeClient) { c.nicErr = os.ErrPermission }, "PutNetworkInterface"},
 		{"PutVsock", func(c *fakeClient) { c.vsockErr = os.ErrPermission }, "PutVsock"},
 		{"Action InstanceStart", func(c *fakeClient) { c.actionErr = os.ErrPermission }, "action InstanceStart"},
-		{"Action Pause", func(c *fakeClient) {
-			c.actionErr = os.ErrPermission
-			// Wait, the client records actions. If we fail on Pause, it shouldn't fail on InstanceStart.
-			// Let's use a custom error or just not fail Action InstanceStart.
-		}, "action Pause"},
+		{"Patch VM Paused", func(c *fakeClient) { c.patchVMErr = os.ErrPermission }, "patch VM Paused"},
 		{"CreateSnapshot", func(c *fakeClient) { c.snapshotCreateErr = os.ErrPermission }, "CreateSnapshot"},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			client := newFakeClient()
-			if tc.name == "Action Pause" {
-				// fakeClient Action doesn't distinguish between start and pause for errors unless we do something hacky.
-				// Actually, we can skip Action Pause if it's too hard to mock specifically, or we can just mock it.
-			}
 			tc.setup(client)
 			d.SetClientFactory(func(_ string) VMMClient { return client })
 
@@ -57,22 +49,8 @@ func TestSnapshotTemplate_RESTErrors_Extra(t *testing.T) {
 			// Write dummy rootfs
 			os.WriteFile(req.RootfsPath, []byte("data"), 0644)
 
-			// For "Action Pause", Action InstanceStart comes first.
-			if tc.name == "Action Pause" {
-				d.SetClientFactory(func(_ string) VMMClient {
-					c := newFakeClient()
-					c.actionErr = os.ErrPermission
-					// We'll just let it fail at InstanceStart instead, or use a custom client
-					return c
-				})
-			}
-
 			_, err := d.SnapshotTemplate(context.Background(), req)
 			if err == nil || !strings.Contains(err.Error(), tc.errStr) {
-				if tc.name == "Action Pause" {
-					// It's ok if it fails at InstanceStart instead
-					return
-				}
 				t.Errorf("expected %q error, got %v", tc.errStr, err)
 			}
 		})

--- a/internal/runtime/firecracker/snapshot_test.go
+++ b/internal/runtime/firecracker/snapshot_test.go
@@ -16,8 +16,8 @@ import (
 // TestSnapshotTemplate_HappyPath is the Phase 3 capture-path regression
 // test: SnapshotTemplate must drive the transient VMM through the exact
 // REST sequence firecracker requires
-// (machine-config → boot-source → drive → nic → vsock → InstanceStart →
-// Pause → CreateSnapshot), then write artifacts whose checksum it
+// (machine-config -> boot-source -> drive -> nic -> vsock -> InstanceStart ->
+// Paused -> CreateSnapshot), then write artifacts whose checksum it
 // returns to the service layer. A change to the wire ordering would
 // hand firecracker a 400 on real hardware; the fakeClient is permissive
 // enough that only the recorded order catches it.
@@ -58,7 +58,7 @@ func TestSnapshotTemplate_HappyPath(t *testing.T) {
 		"PutNetworkInterface:" + primaryIfaceID,
 		"PutVsock",
 		"Action:" + firecracker.ActionInstanceStart,
-		"Action:" + firecracker.ActionPause,
+		"PatchVM:" + firecracker.VMStatePaused,
 		"CreateSnapshot",
 	}
 	if len(f.client.restOrder) != len(want) {

--- a/internal/runtime/firecracker/warmacquire.go
+++ b/internal/runtime/firecracker/warmacquire.go
@@ -17,7 +17,7 @@ package firecracker
 //   - PutNetworkInterface vs PatchDrive: the cold-boot path uses Put
 //     before InstanceStart; the snapshot-load path uses Patch between
 //     LoadSnapshot and Resume. The warm path is structurally the
-//     snapshot-load path with the Load step pre-done — same PATCH+Resume
+//     snapshot-load path with the Load step pre-done -- same PATCH+Resume
 //     contract.
 //
 // Failure-path consistency (pr-review.md §4): every resource acquired
@@ -185,8 +185,8 @@ func (d *Driver) tryAcquireWarm(
 	}
 
 	// Construct a REST client against the warm slot's live API socket.
-	// The pool already loaded the snapshot; this client only issues
-	// PATCH + Action(Resume).
+	// The pool already loaded the snapshot; this client only issues the
+	// per-sandbox rebind PATCHes and PATCH /vm state=Resumed.
 	client := d.newClient(slot.APISocket)
 
 	warmRootfsPath := filepath.Join(slot.RunDir, rootfsFileName)
@@ -206,7 +206,7 @@ func (d *Driver) tryAcquireWarm(
 	// firecracker only validates the device at Resume, not at snapshot
 	// load (see warmspawn.go). The cold path realizes the TAP at its
 	// Step 4 in driver.go; the warm path returns before reaching that
-	// step, so without this Ensure the Action(Resume) below points
+	// step, so without this Ensure the VM resume below points
 	// host_dev_name at a device that was never created and the create
 	// fails. Idempotent — a retried create re-Ensures the same slot.
 	if err := d.tapHost.Ensure(ctx, *tapSlot); err != nil {
@@ -241,8 +241,8 @@ func (d *Driver) tryAcquireWarm(
 	// Resume the VMM. From the guest's perspective this is the first
 	// instruction after the snapshot was taken — vCPUs start ticking
 	// against the new TAP+overlay.
-	if err := client.Action(ctx, firecracker.Action{ActionType: firecracker.ActionResume}); err != nil {
-		return nil, false, fmt.Errorf("firecracker runtime: warm action Resume: %w", err)
+	if err := client.PatchVM(ctx, firecracker.VM{State: firecracker.VMStateResumed}); err != nil {
+		return nil, false, fmt.Errorf("firecracker runtime: warm patch VM Resumed: %w", err)
 	}
 
 	// Vsock handshake — dial the snapshot's reserved CID. The pool

--- a/internal/runtime/firecracker/warmacquire_extra_coverage_test.go
+++ b/internal/runtime/firecracker/warmacquire_extra_coverage_test.go
@@ -126,12 +126,12 @@ func TestTryAcquireWarm_ExtraCoverage(t *testing.T) {
 		}
 	})
 
-	// Action Resume error
-	t.Run("ActionResumeErr", func(t *testing.T) {
+	// Patch VM Resumed error
+	t.Run("PatchVMResumedErr", func(t *testing.T) {
 		f := newDriverFixture(t)
 		stageWarmFixture(t, f)
 		stageWarmTemplate(t, f, false)
-		f.client.actionErr = errors.New("action resume error")
+		f.client.patchVMErr = errors.New("patch vm resumed error")
 
 		_, err := f.driver.Create(context.Background(), models.CreateSandboxRequest{
 			Image:      "alpine:3.20",

--- a/internal/runtime/firecracker/warmacquire_test.go
+++ b/internal/runtime/firecracker/warmacquire_test.go
@@ -135,7 +135,7 @@ func stageWarmTemplate(t *testing.T, f *driverFixture, hasOverlay bool) {
 // template with a warm pool slot ready skips cold-spawn entirely:
 // no spawn handle is allocated (the warm slot's API socket is used),
 // PatchNetworkInterface PATCHes the per-sandbox TAP onto the loaded
-// snapshot, and Action(Resume) is the only Action call (no
+// snapshot, and PatchVM(Resumed) is the only state transition (no
 // InstanceStart, which would mean the driver mistakenly cold-booted).
 //
 // This is the headline boot-path-latency win the Phase 4 plan calls
@@ -197,7 +197,7 @@ func TestCreate_WarmHit(t *testing.T) {
 
 	// The per-sandbox host TAP MUST have been realized on the warm-hit
 	// path — WarmSpawn skips it, so the Acquire side owns it. Without
-	// this Ensure, Action(Resume) would point the guest's eth0 at a
+	// this Ensure, VM resume would point the guest's eth0 at a
 	// host_dev_name that does not exist. Exactly one Ensure, no Remove
 	// (the sandbox now owns the device; Destroy removes it later).
 	if f.tapHost.ensureCalls != 1 || f.tapHost.removeCalls != 0 {
@@ -215,9 +215,12 @@ func TestCreate_WarmHit(t *testing.T) {
 		t.Errorf("PATCH NetworkInterface had empty HostDevName")
 	}
 
-	// Action(Resume) was the lone Action call — no InstanceStart.
-	if len(f.client.actions) != 1 || f.client.actions[0] != firecracker.ActionResume {
-		t.Errorf("actions = %v, want [Resume]", f.client.actions)
+	// PatchVM(Resumed) was the lone VM state transition -- no InstanceStart action.
+	if len(f.client.vmStates) != 1 || f.client.vmStates[0] != firecracker.VMStateResumed {
+		t.Errorf("vmStates = %v, want [Resumed]", f.client.vmStates)
+	}
+	if len(f.client.actions) != 0 {
+		t.Errorf("actions = %v, want none", f.client.actions)
 	}
 }
 

--- a/internal/runtime/firecracker/warmspawn.go
+++ b/internal/runtime/firecracker/warmspawn.go
@@ -5,7 +5,7 @@ package firecracker
 // snapshot artifacts, and leave the VMM paused (ResumeVM=false). The
 // returned handle is what the warm-VMM pool stores so a later sandbox
 // create can claim it, PATCH per-sandbox TAP+overlay onto it, and
-// issue Action(Resume) — that's where the <100ms boot-time win comes
+// PATCH /vm state=Resumed -- that's where the <100ms boot-time win comes
 // from.
 //
 // Cleanup contract: WarmSpawn is responsible for tearing down the
@@ -19,7 +19,7 @@ package firecracker
 // captures the network interface's host_dev_name pointing at the
 // template-build TAP (which was torn down at the end of
 // SnapshotTemplate). Firecracker's LoadSnapshot accepts the missing
-// TAP reference because device validation happens at Action(Resume),
+// TAP reference because device validation happens when the VM resumes,
 // not at load. The pool slot's per-sandbox TAP is allocated by the
 // Acquire-side code in Driver.Create just before the PATCH+Resume
 // hand-off.
@@ -100,7 +100,7 @@ type WarmHandle interface {
 //     references the 1 MiB placeholder used at capture time; the
 //     Acquire path PATCHes the drive's path_on_host before Resume.
 //
-//   - Issuing Action(Resume) and the vsock handshake.
+//   - Issuing PATCH /vm state=Resumed and the vsock handshake.
 func (d *Driver) WarmSpawn(ctx context.Context, req WarmSpawnRequest) (WarmHandle, error) {
 	if d.cfg.KernelImage == "" {
 		return nil, fmt.Errorf("firecracker warm-spawn: KernelImage not configured (SB_FIRECRACKER_KERNEL): %w",

--- a/internal/runtime/firecracker/warmspawn_test.go
+++ b/internal/runtime/firecracker/warmspawn_test.go
@@ -15,7 +15,7 @@ import (
 // TestWarmSpawn_HappyPath asserts the WarmSpawn primitive walks the
 // spawn → start → wait-socket → LoadSnapshot sequence and returns a
 // handle whose VMM is NOT resumed. The pool's Acquire path resumes the
-// slot — a regression where WarmSpawn issues Action(Resume) on its own
+// slot -- a regression where WarmSpawn resumes the VM on its own
 // would put the slot in 'Running' the moment it's loaded, defeating
 // the whole "pause and PATCH per-sandbox state before resume" model
 // PR-A built the snapshot capture path around.
@@ -68,7 +68,7 @@ func TestWarmSpawn_HappyPath(t *testing.T) {
 		t.Errorf("LoadSnapshot.MemBackend wrong: %+v", f.client.snapshotLoad.MemBackend)
 	}
 
-	// No Action(Resume): the pool will resume after PATCHing
+	// No VM resume: the pool will resume after PATCHing
 	// per-sandbox TAP+overlay. Anything in actions[] here that isn't a
 	// known warm-spawn step is a regression.
 	for _, a := range f.client.actions {

--- a/pkg/firecracker/client.go
+++ b/pkg/firecracker/client.go
@@ -2,7 +2,7 @@
 // HTTP-over-Unix-socket REST API. It is intentionally small: a *Client
 // owns a single VMM's API socket and exposes one Go method per Firecracker
 // resource (machine-config, boot-source, drives, net-ifaces, vsock,
-// actions, snapshot/{create,load}).
+// actions, vm state, snapshot/{create,load}).
 //
 // The package has no daemon-side state of its own. Lifecycle ownership —
 // spawning the `firecracker` (or `jailer`-wrapped) process, knowing where
@@ -160,18 +160,23 @@ func (c *Client) PutLogger(ctx context.Context, lg Logger) error {
 	return c.do(ctx, http.MethodPut, "/logger", lg, nil)
 }
 
-// Action issues a single action against the VMM. The action_type values
-// the daemon uses today are InstanceStart (cold boot), Resume (after
-// snapshot load with resume_vm=false), and Pause.
+// Action issues a single action against the VMM. Firecracker v1.15 keeps
+// InstanceStart on /actions; Paused/Resumed transitions use PatchVM instead.
 func (c *Client) Action(ctx context.Context, a Action) error {
 	return c.do(ctx, http.MethodPut, "/actions", a, nil)
 }
 
-// CreateSnapshot pauses the VMM (callers should issue Action Pause first if
-// the VM is running) and writes a memory file + state file to the paths in
-// req. SnapshotType=Full is the only option supported at template-build
-// time; Diff is taken automatically by enable_diff_snapshots on load and
-// does not flow through this call.
+// PatchVM updates the microVM running state. Firecracker accepts Paused and
+// Resumed here; sending those values to /actions is rejected by v1.15.
+func (c *Client) PatchVM(ctx context.Context, vm VM) error {
+	return c.do(ctx, http.MethodPatch, "/vm", vm, nil)
+}
+
+// CreateSnapshot writes a memory file + state file to the paths in req.
+// Callers should put the VM in the Paused state first. SnapshotType=Full is
+// the only option supported at template-build time; Diff is taken
+// automatically by enable_diff_snapshots on load and does not flow through
+// this call.
 func (c *Client) CreateSnapshot(ctx context.Context, req SnapshotCreate) error {
 	return c.do(ctx, http.MethodPut, "/snapshot/create", req, nil)
 }
@@ -181,7 +186,7 @@ func (c *Client) CreateSnapshot(ctx context.Context, req SnapshotCreate) error {
 // base for the clone; per-clone writes land in a dirty bitmap and do not
 // disturb the base — the property the whole plan rests on. With
 // ResumeVM=true, the action implicitly resumes execution; otherwise the
-// caller must issue Action Resume after attaching per-clone drives/TAP.
+// caller must PATCH /vm state=Resumed after attaching per-clone drives/TAP.
 func (c *Client) LoadSnapshot(ctx context.Context, req SnapshotLoad) error {
 	return c.do(ctx, http.MethodPut, "/snapshot/load", req, nil)
 }

--- a/pkg/firecracker/client_test.go
+++ b/pkg/firecracker/client_test.go
@@ -239,9 +239,18 @@ func TestWrapperMethods_RequestShape(t *testing.T) {
 			name:   "action",
 			method: http.MethodPut,
 			path:   "/actions",
-			body:   Action{ActionType: ActionPause},
+			body:   Action{ActionType: ActionInstanceStart},
 			invoke: func(ctx context.Context, c *Client) error {
-				return c.Action(ctx, Action{ActionType: ActionPause})
+				return c.Action(ctx, Action{ActionType: ActionInstanceStart})
+			},
+		},
+		{
+			name:   "patch-vm",
+			method: http.MethodPatch,
+			path:   "/vm",
+			body:   VM{State: VMStatePaused},
+			invoke: func(ctx context.Context, c *Client) error {
+				return c.PatchVM(ctx, VM{State: VMStatePaused})
 			},
 		},
 		{

--- a/pkg/firecracker/types.go
+++ b/pkg/firecracker/types.go
@@ -8,7 +8,7 @@ package firecracker
 
 // InstanceInfo is the GET / response. The runtime driver uses State to
 // distinguish "Not started" / "Running" / "Paused" without re-deriving from
-// process signals — useful as a sanity check before issuing Action Resume.
+// process signals -- useful as a sanity check before issuing VMStateResumed.
 type InstanceInfo struct {
 	ID    string `json:"id"`
 	State string `json:"state"`
@@ -111,19 +111,29 @@ type Logger struct {
 	// production runs. Surface them in tests if needed.
 }
 
-// Action types Firecracker accepts on PUT /actions. We intentionally
-// declare only the ones the daemon issues; the swagger lists a few more
-// (FlushMetrics, SendCtrlAltDel) that we don't drive today.
+// Action types Firecracker accepts on PUT /actions. Pause and Resume are
+// intentionally not here: Firecracker v1.15 exposes those through PATCH /vm,
+// not the action endpoint.
 const (
 	ActionInstanceStart = "InstanceStart"
-	ActionResume        = "Resume"
-	ActionPause         = "Pause"
 )
 
 // Action is the PUT /actions body. ActionType is one of the constants
 // above.
 type Action struct {
 	ActionType string `json:"action_type"`
+}
+
+// VM states accepted by PATCH /vm. Firecracker uses this endpoint for
+// Paused/Resumed transitions, especially around snapshot create/load.
+const (
+	VMStatePaused  = "Paused"
+	VMStateResumed = "Resumed"
+)
+
+// VM is the PATCH /vm body.
+type VM struct {
+	State string `json:"state"`
 }
 
 // SnapshotCreate is the PUT /snapshot/create body. SnapshotType=Full is
@@ -142,7 +152,7 @@ type SnapshotCreate struct {
 // the load-time flag that gives us per-clone CoW: the memory file stays
 // mmap'd read-only and per-VMM writes go to a dirty bitmap. ResumeVM=false
 // keeps the clone paused so the daemon can rebind the per-sandbox overlay
-// and TAP before issuing Action Resume.
+// and TAP before issuing PATCH /vm state=Resumed.
 type SnapshotLoad struct {
 	SnapshotPath        string         `json:"snapshot_path"`
 	MemBackend          *MemoryBackend `json:"mem_backend,omitempty"`


### PR DESCRIPTION
## Summary

- Migrate Firecracker pause/resume transitions from `PUT /actions` (`Pause`/`Resume`) to `PATCH /vm` (`Paused`/`Resumed`), matching Firecracker v1.15 API behavior. `InstanceStart` remains on `/actions`.
- Pin a static host→guest L2 neighbor entry during TAP `Ensure` so the first toolbox proxy dial routes directly instead of waiting on ARP during early boot.

## Sandbox boot impact

Adds one `ip neigh replace` call to TAP `Ensure`, which runs on every Firecracker create path (cold boot, snapshot load, warm acquire). Expected added latency is sub-millisecond (single local `ip` invocation). No new DB queries, HTTP round-trips, or lock acquisitions on `CreateSandbox`.

## Idempotency

N/A - no API surface changed.

## Failure-path consistency

N/A - no multi-step write path changed.

## L4 / host-port-pool changes

N/A - neither touched.

## Test plan

- [x] `go test ./internal/network/tap/...`
- [x] `go test ./internal/runtime/firecracker/...`
- [x] `go test ./pkg/firecracker/...`


Made with [Cursor](https://cursor.com)