### PR TITLE
fix(firecracker): write jailer snapshots via chroot-relative paths

### DIFF
--- a/internal/runtime/firecracker/assets/toolboxd-init.sh
+++ b/internal/runtime/firecracker/assets/toolboxd-init.sh
@@ -51,12 +51,16 @@ configure_network() {
 	[ -n "${SB_TOOLBOX_PREFIX_LEN:-}" ] || return 0
 
 	iface=""
-	for dev in /sys/class/net/*; do
-		[ -e "$dev" ] || continue
-		name=${dev##*/}
-		[ "$name" = "lo" ] && continue
-		iface=$name
-		break
+	for _ in 1 2 3 4 5 6 7 8 9 10; do
+		for dev in /sys/class/net/*; do
+			[ -e "$dev" ] || continue
+			name=${dev##*/}
+			[ "$name" = "lo" ] && continue
+			iface=$name
+			break
+		done
+		[ -n "$iface" ] && break
+		sleep 0.1
 	done
 	[ -n "$iface" ] || return 0
 

--- a/internal/runtime/firecracker/create_rundir_test.go
+++ b/internal/runtime/firecracker/create_rundir_test.go
@@ -112,6 +112,7 @@ func TestSnapshotTemplate_JailerStagesAPIPaths(t *testing.T) {
 		f.vmm.id = sandboxID
 		f.vmm.runDir = chrootRoot
 		f.vmm.apiSocket = filepath.Join(chrootRoot, "api.sock")
+		f.client.snapshotBase = chrootRoot
 		return f.vmm, nil
 	})
 
@@ -121,11 +122,13 @@ func TestSnapshotTemplate_JailerStagesAPIPaths(t *testing.T) {
 		t.Fatalf("write rootfs: %v", err)
 	}
 
+	memOut := filepath.Join(tplDir, "snapshot.memory")
+	stateOut := filepath.Join(tplDir, "snapshot.state")
 	_, err := f.driver.SnapshotTemplate(context.Background(), TemplateSnapshotRequest{
 		TemplateID:    "tpl-jail",
 		RootfsPath:    rootfs,
-		OutMemoryPath: filepath.Join(tplDir, "snapshot.memory"),
-		OutStatePath:  filepath.Join(tplDir, "snapshot.state"),
+		OutMemoryPath: memOut,
+		OutStatePath:  stateOut,
 		GuestCID:      200,
 		MemoryMB:      512,
 		VCPU:          1,
@@ -151,5 +154,17 @@ func TestSnapshotTemplate_JailerStagesAPIPaths(t *testing.T) {
 	}
 	if overlay := f.client.drives[overlayDriveID]; overlay.PathOnHost != overlayFileName {
 		t.Fatalf("overlay drive path = %q, want %q", overlay.PathOnHost, overlayFileName)
+	}
+	if f.client.snapshotCreate == nil {
+		t.Fatal("CreateSnapshot was not called")
+	}
+	if f.client.snapshotCreate.MemFilePath != sandboxSnapshotMemoryFileName ||
+		f.client.snapshotCreate.SnapshotPath != sandboxSnapshotStateFileName {
+		t.Fatalf("snapshot create paths = %+v, want chroot-relative snapshot files", f.client.snapshotCreate)
+	}
+	for _, path := range []string{memOut, stateOut} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("snapshot artifact %s was not copied out of chroot: %v", path, err)
+		}
 	}
 }

--- a/internal/runtime/firecracker/create_test.go
+++ b/internal/runtime/firecracker/create_test.go
@@ -319,6 +319,7 @@ type fakeClient struct {
 
 	snapshotCreate *firecracker.SnapshotCreate
 	snapshotLoad   *firecracker.SnapshotLoad
+	snapshotBase   string
 
 	// drivePatches records each PatchDrive call (snapshot-load + overlay
 	// path swap). Keyed by drive_id so a test can assert the post-load
@@ -433,6 +434,9 @@ func (c *fakeClient) CreateSnapshot(_ context.Context, req firecracker.SnapshotC
 			if path == "" {
 				continue
 			}
+			if !filepath.IsAbs(path) && c.snapshotBase != "" {
+				path = filepath.Join(c.snapshotBase, path)
+			}
 			if err := os.WriteFile(path, []byte("fake-snapshot-"+filepath.Base(path)), 0o600); err != nil {
 				return err
 			}
@@ -515,6 +519,7 @@ func newDriverFixture(t *testing.T) *driverFixture {
 		vmm.id = sandboxID
 		vmm.runDir = sandboxRun
 		vmm.apiSocket = filepath.Join(sandboxRun, "api.sock")
+		client.snapshotBase = sandboxRun
 		return vmm, nil
 	})
 	d.SetClientFactory(func(_ string) VMMClient { return client })

--- a/internal/runtime/firecracker/sandbox_snapshot.go
+++ b/internal/runtime/firecracker/sandbox_snapshot.go
@@ -211,12 +211,8 @@ func (d *Driver) writeSandboxSnapshot(ctx context.Context, sandboxID string, han
 
 	tmpMem := filepath.Join(tmpDir, sandboxSnapshotMemoryFileName)
 	tmpState := filepath.Join(tmpDir, sandboxSnapshotStateFileName)
-	if err := client.CreateSnapshot(ctx, firecracker.SnapshotCreate{
-		SnapshotType: "Full",
-		SnapshotPath: tmpState,
-		MemFilePath:  tmpMem,
-	}); err != nil {
-		return fmt.Errorf("firecracker runtime: stop %s: CreateSnapshot: %w", sandboxID, err)
+	if err := d.createSnapshotArtifacts(ctx, client, handle.RunDir(), tmpMem, tmpState); err != nil {
+		return fmt.Errorf("firecracker runtime: stop %s: %w", sandboxID, err)
 	}
 
 	srcRootfs := filepath.Join(handle.RunDir(), rootfsFileName)

--- a/internal/runtime/firecracker/snapshot.go
+++ b/internal/runtime/firecracker/snapshot.go
@@ -314,17 +314,13 @@ func (d *Driver) SnapshotTemplate(ctx context.Context, req TemplateSnapshotReque
 	// Step 11: write the snapshot. SnapshotType=Full because there is
 	// no base snapshot to diff against. Diff snapshots are a Phase 4+
 	// optimization (per-clone deltas above the shared template state).
-	if err := client.CreateSnapshot(ctx, firecracker.SnapshotCreate{
-		SnapshotType: "Full",
-		SnapshotPath: req.OutStatePath,
-		MemFilePath:  req.OutMemoryPath,
-	}); err != nil {
+	if err := d.createSnapshotArtifacts(ctx, client, handle.RunDir(), req.OutMemoryPath, req.OutStatePath); err != nil {
 		// On failure, drop any partial artifact files — better to have
 		// no snapshot.memory than a half-written one that integrity
 		// verification would reject hours later.
 		_ = os.Remove(req.OutMemoryPath)
 		_ = os.Remove(req.OutStatePath)
-		return nil, fmt.Errorf("firecracker snapshot: CreateSnapshot: %w", err)
+		return nil, fmt.Errorf("firecracker snapshot: %w", err)
 	}
 
 	// Step 12: tear the transient VMM down. We Shutdown rather than
@@ -417,6 +413,40 @@ func (d *Driver) sendVsockOp(ctx context.Context, socketPath string, guestCID ui
 	// Discard the ack. A short read budget keeps a hung guest from
 	// pinning the snapshot pipeline.
 	_, _ = io.CopyN(io.Discard, conn, 256)
+	return nil
+}
+
+func (d *Driver) createSnapshotArtifacts(ctx context.Context, client VMMClient, runDir, outMemPath, outStatePath string) error {
+	memAPIPath := outMemPath
+	stateAPIPath := outStatePath
+	memHostPath := outMemPath
+	stateHostPath := outStatePath
+
+	if d.cfg.UseJailer {
+		memHostPath = filepath.Join(runDir, sandboxSnapshotMemoryFileName)
+		stateHostPath = filepath.Join(runDir, sandboxSnapshotStateFileName)
+		memAPIPath = sandboxSnapshotMemoryFileName
+		stateAPIPath = sandboxSnapshotStateFileName
+		_ = os.Remove(memHostPath)
+		_ = os.Remove(stateHostPath)
+	}
+
+	if err := client.CreateSnapshot(ctx, firecracker.SnapshotCreate{
+		SnapshotType: "Full",
+		SnapshotPath: stateAPIPath,
+		MemFilePath:  memAPIPath,
+	}); err != nil {
+		return fmt.Errorf("CreateSnapshot: %w", err)
+	}
+	if !d.cfg.UseJailer {
+		return nil
+	}
+	if err := copyFile(memHostPath, outMemPath); err != nil {
+		return fmt.Errorf("copy snapshot memory out of jailer chroot: %w", err)
+	}
+	if err := copyFile(stateHostPath, outStatePath); err != nil {
+		return fmt.Errorf("copy snapshot state out of jailer chroot: %w", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Fix Firecracker snapshot creation under the jailer by passing chroot-relative paths to `CreateSnapshot` and copying `snapshot.memory` / `snapshot.state` out of the jailer chroot afterward.
- Retry guest NIC discovery in `toolboxd-init.sh` (up to 1s) so slow udev bring-up no longer leaves the guest without an IP after resume.

## Sandbox boot impact

N/A - no work added to sandbox boot path. Snapshot artifact path handling runs only on `SnapshotTemplate` and sandbox stop/snapshot writes.

## Idempotency

N/A - no API surface changed.

## Failure-path consistency

N/A - no multi-step write path changed.

## L4 / host-port-pool changes

N/A - neither touched.

## Test plan

- [x] `go test ./internal/runtime/firecracker/...`
- [x] `TestSnapshotTemplate_JailerStagesAPIPaths` asserts chroot-relative snapshot paths and post-copy artifacts

Made with [Cursor](https://cursor.com)