### PR TITLE
fix(firecracker): stage jailer snapshot-load paths and harden guest networking

### DIFF
--- a/cmd/toolboxd/quiesce_linux.go
+++ b/cmd/toolboxd/quiesce_linux.go
@@ -127,7 +127,7 @@ func (linuxQuiesceOps) ConfigureNetwork(cfg guestNetworkConfig) error {
 		_ = runNetworkCmd(ipBin, "link", "set", "lo", "up")
 		_ = runNetworkCmd(ipBin, "link", "set", iface, "up")
 		addr := fmt.Sprintf("%s/%d", cfg.GuestIP, cfg.PrefixLen)
-		if err := runNetworkCmdIgnoreExists(ipBin, "addr", "add", addr, "dev", iface); err != nil {
+		if err := runNetworkCmd(ipBin, "addr", "replace", addr, "dev", iface); err != nil {
 			return err
 		}
 		_ = runNetworkCmd(ipBin, "route", "replace", "default", "via", cfg.GatewayIP, "dev", iface)

--- a/cmd/toolboxd/vsock.go
+++ b/cmd/toolboxd/vsock.go
@@ -257,9 +257,16 @@ func (h *quiesceHandler) OnPostResume(ctx context.Context, raw json.RawMessage) 
 			h.logger.Warn("vsock post_resume: clock resync failed", "error", err)
 		}
 	}
+	networkConfigured := false
 	if data.Network != nil {
 		if err := h.quiesce.ConfigureNetwork(*data.Network); err != nil {
-			h.logger.Warn("vsock post_resume: network reconfigure failed", "error", err)
+			h.logger.Warn("vsock post_resume: network reconfigure failed",
+				"guest_ip", data.Network.GuestIP,
+				"gateway_ip", data.Network.GatewayIP,
+				"prefix_len", data.Network.PrefixLen,
+				"error", err)
+		} else {
+			networkConfigured = true
 		}
 	}
 	if err := h.quiesce.ReseedRandom(); err != nil {
@@ -279,7 +286,17 @@ func (h *quiesceHandler) OnPostResume(ctx context.Context, raw json.RawMessage) 
 	if h.cloneGen != nil {
 		h.cloneGen.Bump(data.WallclockUnixNs)
 	}
-	h.logger.Info("vsock: post_resume complete",
-		"wallclock_set", data.WallclockUnixNs > 0)
+	logFields := []any{
+		"wallclock_set", data.WallclockUnixNs > 0,
+		"network_requested", data.Network != nil,
+		"network_configured", networkConfigured,
+	}
+	if data.Network != nil {
+		logFields = append(logFields,
+			"guest_ip", data.Network.GuestIP,
+			"gateway_ip", data.Network.GatewayIP,
+			"prefix_len", data.Network.PrefixLen)
+	}
+	h.logger.Info("vsock: post_resume complete", logFields...)
 	return nil
 }

--- a/integration-tests/suite/templates_test.go
+++ b/integration-tests/suite/templates_test.go
@@ -55,6 +55,7 @@ func TestTemplateLifecycle(t *testing.T) {
 		defer ccancel()
 		_ = c.SDK().DeleteTemplate(cctx, tmpl.ID)
 	})
+	waitTemplateReady(t, c, tmpl.ID)
 
 	// UC-48 — list includes it and get returns it.
 	t.Run("UC-48-list-get", func(t *testing.T) {
@@ -83,6 +84,7 @@ func TestTemplateLifecycle(t *testing.T) {
 		if _, err := c.SDK().RebuildTemplate(ctx, tmpl.ID); err != nil {
 			t.Fatalf("rebuild template: %v", err)
 		}
+		waitTemplateReady(t, c, tmpl.ID)
 	})
 
 	// UC-50 — delete; a subsequent get fails.

--- a/internal/runtime/firecracker/assets/toolboxd-init.sh
+++ b/internal/runtime/firecracker/assets/toolboxd-init.sh
@@ -51,7 +51,7 @@ configure_network() {
 	[ -n "${SB_TOOLBOX_PREFIX_LEN:-}" ] || return 0
 
 	iface=""
-	for _ in 1 2 3 4 5 6 7 8 9 10; do
+	for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
 		for dev in /sys/class/net/*; do
 			[ -e "$dev" ] || continue
 			name=${dev##*/}
@@ -71,7 +71,7 @@ configure_network() {
 	if [ -n "$ip_cmd" ]; then
 		"$ip_cmd" link set lo up 2>/dev/null || true
 		"$ip_cmd" link set "$iface" up 2>/dev/null || true
-		"$ip_cmd" addr add "$SB_TOOLBOX_GUEST_IP/$SB_TOOLBOX_PREFIX_LEN" dev "$iface" 2>/dev/null || true
+		"$ip_cmd" addr replace "$SB_TOOLBOX_GUEST_IP/$SB_TOOLBOX_PREFIX_LEN" dev "$iface" 2>/dev/null || true
 		"$ip_cmd" route replace default via "$SB_TOOLBOX_GATEWAY_IP" dev "$iface" 2>/dev/null || true
 	elif [ -n "$ifconfig_cmd" ]; then
 		"$ifconfig_cmd" lo up 2>/dev/null || true

--- a/internal/runtime/firecracker/create_rundir_test.go
+++ b/internal/runtime/firecracker/create_rundir_test.go
@@ -168,3 +168,64 @@ func TestSnapshotTemplate_JailerStagesAPIPaths(t *testing.T) {
 		}
 	}
 }
+
+func TestCreate_SnapshotLoadPath_JailerStagesAPIPaths(t *testing.T) {
+	f := newDriverFixture(t)
+	f.driver.cfg.UseJailer = true
+
+	chrootRoot := filepath.Join(t.TempDir(), "jailer", "firecracker", "sb-snap-load-jail", "root")
+	f.driver.SetSpawner(func(_ Config, sandboxID string) (VMMHandle, error) {
+		f.vmm.id = sandboxID
+		f.vmm.runDir = chrootRoot
+		f.vmm.apiSocket = filepath.Join(chrootRoot, "api.sock")
+		return f.vmm, nil
+	})
+
+	tplDir := t.TempDir()
+	templateRootfs := filepath.Join(tplDir, rootfsFileName)
+	if err := os.WriteFile(templateRootfs, []byte("template-rootfs"), 0o644); err != nil {
+		t.Fatalf("write template rootfs: %v", err)
+	}
+	snapMem := filepath.Join(tplDir, sandboxSnapshotMemoryFileName)
+	snapState := filepath.Join(tplDir, sandboxSnapshotStateFileName)
+	for _, path := range []string{snapMem, snapState} {
+		if err := os.WriteFile(path, []byte("snapshot-"+filepath.Base(path)), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	f.driver.SetTemplateResolver(&fakeTemplateResolver{
+		rootfsPath:         templateRootfs,
+		hasSnapshot:        true,
+		snapshotMemoryPath: snapMem,
+		snapshotStatePath:  snapState,
+		snapshotVsockCID:   200,
+	})
+
+	if _, err := f.driver.Create(context.Background(), models.CreateSandboxRequest{
+		TemplateID: "tpl-snap-jail",
+		CPU:        1,
+		MemoryMB:   128,
+		DiskGB:     1,
+	}, "sb-snap-load-jail", "tok", nil); err != nil {
+		t.Fatalf("Create snapshot-load (jailer): %v", err)
+	}
+
+	if f.client.snapshotLoad == nil {
+		t.Fatal("LoadSnapshot was not called")
+	}
+	if f.client.snapshotLoad.SnapshotPath != sandboxSnapshotStateFileName {
+		t.Fatalf("LoadSnapshot.SnapshotPath = %q, want %q", f.client.snapshotLoad.SnapshotPath, sandboxSnapshotStateFileName)
+	}
+	if f.client.snapshotLoad.MemBackend == nil ||
+		f.client.snapshotLoad.MemBackend.BackendPath != sandboxSnapshotMemoryFileName {
+		t.Fatalf("LoadSnapshot.MemBackend = %+v, want chroot-relative snapshot memory", f.client.snapshotLoad.MemBackend)
+	}
+	if patch := f.client.drivePatches[rootDriveID]; patch.PathOnHost != rootfsFileName {
+		t.Fatalf("root drive patch path = %q, want %q", patch.PathOnHost, rootfsFileName)
+	}
+	for _, name := range []string{rootfsFileName, sandboxSnapshotMemoryFileName, sandboxSnapshotStateFileName} {
+		if _, err := os.Stat(filepath.Join(chrootRoot, name)); err != nil {
+			t.Fatalf("%s not staged into chroot: %v", name, err)
+		}
+	}
+}

--- a/internal/runtime/firecracker/create_test.go
+++ b/internal/runtime/firecracker/create_test.go
@@ -175,9 +175,9 @@ type fakeVsockDialer struct {
 	// writes records every line written through any returned conn, so
 	// post_resume payload-shape assertions can grep the captured JSON.
 	writes [][]byte
-	// errOnDialIdx >0 makes Dial fail on the Nth call (1-based) only —
-	// the snapshot-load post_resume test uses this to assert Create
-	// does not fail when the post_resume send fails.
+	// errOnDialIdx >0 makes Dial fail on the Nth call (1-based) only.
+	// Post-boot/post-resume sends are best-effort, so tests use this
+	// to assert Create does not fail when that follow-up dial fails.
 	errOnDialIdx int
 }
 
@@ -507,7 +507,7 @@ func newDriverFixture(t *testing.T) *driverFixture {
 		KernelImage:       kernel,
 		RunDir:            runDir,
 		OverlayEnabled:    true,
-		PostResumeTimeout: 2 * time.Second,
+		PostResumeTimeout: 20 * time.Millisecond,
 	}, nil)
 	d.SetPool(pool)
 	d.SetRootfsBuilder(rootfs)
@@ -577,9 +577,9 @@ func TestCreate_HappyPath(t *testing.T) {
 	if !f.vmm.started || !f.vmm.waited || f.vmm.shutdown {
 		t.Errorf("vmm started=%v waited=%v shutdown=%v; want true/true/false", f.vmm.started, f.vmm.waited, f.vmm.shutdown)
 	}
-	// Vsock handshake ran exactly once.
-	if f.vsock.dials != 1 {
-		t.Errorf("vsock dials = %d, want 1", f.vsock.dials)
+	// Vsock handshake plus best-effort post-boot network reconfigure.
+	if f.vsock.dials != 2 {
+		t.Errorf("vsock dials = %d, want 2", f.vsock.dials)
 	}
 	// REST: machine config, boot source, drive, nic, vsock, action all set.
 	if f.client.mc == nil || f.client.mc.VcpuCount != 2 || f.client.mc.MemSizeMib != 256 {

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -32,6 +32,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -772,25 +773,36 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 	if err := d.vsockHandshake(ctx, vsockPath, handshakeCID); err != nil {
 		return nil, fmt.Errorf("firecracker runtime: vsock handshake: %w", err)
 	}
+	d.logger.Info("firecracker create: vsock handshake complete",
+		"sandbox_id", allocID,
+		"snapshot_load", snapshotLoadPath,
+		"vsock_cid", handshakeCID,
+		"guest_ip", slot.GuestIP,
+		"tap", slot.TapName)
 
-	// Step 8b: post-resume quiesce signal (snapshot-load path only).
-	// The clone resumed with the template's RNG entropy pool and
-	// wall clock — both observably wrong (two clones would draw the
-	// same getrandom bytes; logs and TLS handshakes show a backwards
-	// time jump). Tell the in-guest toolboxd to reseed the kernel
-	// RNG and set CLOCK_REALTIME from the host now. Best-effort:
-	// a failed ack here means the guest is using stale entropy/clock,
-	// not that the clone is broken, so we log-and-continue. Cold-boot
-	// has nothing to resync (kernel just initialized) so skip.
-	if snapshotLoadPath {
-		postCtx, cancel := context.WithTimeout(ctx, d.cfg.PostResumeTimeout)
-		err := d.sendVsockOp(postCtx, vsockPath, handshakeCID, "post_resume", postResumeData(slot))
-		cancel()
-		if err != nil {
-			d.logger.Warn("firecracker create: post_resume send failed (continuing)",
-				"sandbox_id", allocID, "error", err)
-		}
+	// Step 8b: post-boot/post-resume quiesce signal. Snapshot clones
+	// resumed with the template's RNG entropy pool and wall clock, so
+	// toolboxd reseeds and sets CLOCK_REALTIME. Cold boots do not need
+	// the entropy fix, but the same message also re-applies the static
+	// TAP address after toolboxd is definitely running, which closes
+	// the boot-time race where PID 1 starts before the virtio-net
+	// device is fully visible.
+	postCtx, cancel := context.WithTimeout(ctx, d.cfg.PostResumeTimeout)
+	postErr := d.sendVsockOp(postCtx, vsockPath, handshakeCID, "post_resume", postResumeData(slot))
+	cancel()
+	if postErr != nil {
+		d.logger.Warn("firecracker create: post_resume send failed (continuing)",
+			"sandbox_id", allocID, "snapshot_load", snapshotLoadPath, "error", postErr)
+	} else {
+		d.logger.Info("firecracker create: post_resume acked",
+			"sandbox_id", allocID,
+			"snapshot_load", snapshotLoadPath,
+			"vsock_cid", handshakeCID,
+			"guest_ip", slot.GuestIP,
+			"gateway_ip", slot.HostIP,
+			"tap", slot.TapName)
 	}
+	d.probeToolboxTCP(ctx, "create", allocID, slot, snapshotLoadPath)
 
 	// All steps succeeded. Register the client + handle so Destroy can
 	// find them. Order matters: the map writes happen AFTER we flip
@@ -960,20 +972,29 @@ func (d *Driver) configureVMMForLoad(ctx context.Context, client VMMClient, snap
 			return fmt.Errorf("firecracker runtime: snapshot integrity: %w", err)
 		}
 	}
+	runDir := filepath.Dir(rootfsPath)
+	snapshotMemoryPath, snapshotStatePath, err := d.stageSnapshotLoadPaths(runDir, snap.SnapshotMemoryPath, snap.SnapshotStatePath)
+	if err != nil {
+		return fmt.Errorf("firecracker runtime: stage snapshot load artifacts: %w", err)
+	}
 	if err := client.LoadSnapshot(ctx, firecracker.SnapshotLoad{
-		SnapshotPath: snap.SnapshotStatePath,
+		SnapshotPath: snapshotStatePath,
 		MemBackend: &firecracker.MemoryBackend{
 			BackendType: "File",
-			BackendPath: snap.SnapshotMemoryPath,
+			BackendPath: snapshotMemoryPath,
 		},
 		EnableDiffSnapshots: true,
 		ResumeVM:            false,
 	}); err != nil {
 		return fmt.Errorf("firecracker runtime: LoadSnapshot: %w", err)
 	}
+	rootfsAPIPath, err := d.chrootFilePath(runDir, rootfsPath, rootfsFileName)
+	if err != nil {
+		return fmt.Errorf("firecracker runtime: stage snapshot rootfs: %w", err)
+	}
 	if err := client.PatchDrive(ctx, rootDriveID, firecracker.DrivePatch{
 		DriveID:    rootDriveID,
-		PathOnHost: rootfsPath,
+		PathOnHost: rootfsAPIPath,
 	}); err != nil {
 		return fmt.Errorf("firecracker runtime: PatchDrive rootfs: %w", err)
 	}
@@ -993,14 +1014,77 @@ func (d *Driver) configureVMMForLoad(ctx context.Context, client VMMClient, snap
 	// request when snap.HasOverlay=false, so a missing placeholder
 	// here is a corrupted template, not a user error.
 	if overlayPath != "" {
+		overlayAPIPath, err := d.chrootFilePath(runDir, overlayPath, overlayFileName)
+		if err != nil {
+			return fmt.Errorf("firecracker runtime: stage snapshot overlay: %w", err)
+		}
 		if err := client.PatchDrive(ctx, overlayDriveID, firecracker.DrivePatch{
 			DriveID:    overlayDriveID,
-			PathOnHost: overlayPath,
+			PathOnHost: overlayAPIPath,
 		}); err != nil {
 			return fmt.Errorf("firecracker runtime: PatchDrive overlay: %w", err)
 		}
 	}
 	return nil
+}
+
+func (d *Driver) stageSnapshotLoadPaths(runDir, memoryPath, statePath string) (memoryAPIPath, stateAPIPath string, err error) {
+	memoryAPIPath, err = d.chrootFilePath(runDir, memoryPath, sandboxSnapshotMemoryFileName)
+	if err != nil {
+		return "", "", fmt.Errorf("stage snapshot memory: %w", err)
+	}
+	stateAPIPath, err = d.chrootFilePath(runDir, statePath, sandboxSnapshotStateFileName)
+	if err != nil {
+		return "", "", fmt.Errorf("stage snapshot state: %w", err)
+	}
+	return memoryAPIPath, stateAPIPath, nil
+}
+
+func (d *Driver) probeToolboxTCP(ctx context.Context, operation, sandboxID string, slot *TapSlot, snapshotLoad bool) {
+	if slot == nil || slot.GuestIP == "" {
+		return
+	}
+	timeout := d.cfg.PostResumeTimeout
+	if timeout <= 0 {
+		return
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	addr := net.JoinHostPort(slot.GuestIP, strconv.Itoa(guestToolboxPort))
+	attempts := 0
+	var lastErr error
+	for {
+		attempts++
+		dialCtx, dialCancel := context.WithTimeout(probeCtx, 200*time.Millisecond)
+		conn, err := (&net.Dialer{}).DialContext(dialCtx, "tcp", addr)
+		dialCancel()
+		if err == nil {
+			_ = conn.Close()
+			d.logger.Info("firecracker: toolbox tcp reachable after vsock readiness",
+				"operation", operation,
+				"sandbox_id", sandboxID,
+				"snapshot_load", snapshotLoad,
+				"addr", addr,
+				"attempts", attempts,
+				"tap", slot.TapName)
+			return
+		}
+		lastErr = err
+		select {
+		case <-probeCtx.Done():
+			d.logger.Warn("firecracker: toolbox tcp not reachable after vsock readiness",
+				"operation", operation,
+				"sandbox_id", sandboxID,
+				"snapshot_load", snapshotLoad,
+				"addr", addr,
+				"attempts", attempts,
+				"tap", slot.TapName,
+				"error", lastErr)
+			return
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
 }
 
 // vsockHandshake dials the in-guest toolbox through Firecracker's host-side

--- a/internal/runtime/firecracker/sandbox_snapshot.go
+++ b/internal/runtime/firecracker/sandbox_snapshot.go
@@ -419,12 +419,25 @@ func (d *Driver) startFromSandboxSnapshot(ctx context.Context, sandboxID string)
 	if err := d.vsockHandshake(ctx, vsockPath, manifest.VsockCID); err != nil {
 		return nil, fmt.Errorf("firecracker runtime: start %s: vsock handshake: %w", sandboxID, err)
 	}
+	d.logger.Info("firecracker start: vsock handshake complete",
+		"sandbox_id", sandboxID,
+		"vsock_cid", manifest.VsockCID,
+		"guest_ip", slot.GuestIP,
+		"tap", slot.TapName)
 	postCtx, cancel := context.WithTimeout(ctx, d.cfg.PostResumeTimeout)
 	if err := d.sendVsockOp(postCtx, vsockPath, manifest.VsockCID, "post_resume", postResumeData(slot)); err != nil {
 		d.logger.Warn("firecracker start: post_resume send failed (continuing)",
 			"sandbox_id", sandboxID, "error", err)
+	} else {
+		d.logger.Info("firecracker start: post_resume acked",
+			"sandbox_id", sandboxID,
+			"vsock_cid", manifest.VsockCID,
+			"guest_ip", slot.GuestIP,
+			"gateway_ip", slot.HostIP,
+			"tap", slot.TapName)
 	}
 	cancel()
+	d.probeToolboxTCP(ctx, "start", sandboxID, slot, true)
 
 	d.mu.Lock()
 	d.clients[sandboxID] = client
@@ -444,27 +457,40 @@ func (d *Driver) startFromSandboxSnapshot(ctx context.Context, sandboxID string)
 }
 
 func (d *Driver) configureSandboxSnapshotRestore(ctx context.Context, client VMMClient, manifest *sandboxSnapshotManifest, memPath, statePath, rootfsPath string, slot *TapSlot, overlayPath string) error {
+	runDir := filepath.Dir(rootfsPath)
+	snapshotMemoryPath, snapshotStatePath, err := d.stageSnapshotLoadPaths(runDir, memPath, statePath)
+	if err != nil {
+		return fmt.Errorf("firecracker runtime: stage snapshot load artifacts: %w", err)
+	}
 	if err := client.LoadSnapshot(ctx, firecracker.SnapshotLoad{
-		SnapshotPath: statePath,
+		SnapshotPath: snapshotStatePath,
 		MemBackend: &firecracker.MemoryBackend{
 			BackendType: "File",
-			BackendPath: memPath,
+			BackendPath: snapshotMemoryPath,
 		},
 		EnableDiffSnapshots: true,
 		ResumeVM:            false,
 	}); err != nil {
 		return fmt.Errorf("firecracker runtime: LoadSnapshot: %w", err)
 	}
+	rootfsAPIPath, err := d.chrootFilePath(runDir, rootfsPath, rootfsFileName)
+	if err != nil {
+		return fmt.Errorf("firecracker runtime: stage snapshot rootfs: %w", err)
+	}
 	if err := client.PatchDrive(ctx, rootDriveID, firecracker.DrivePatch{
 		DriveID:    rootDriveID,
-		PathOnHost: rootfsPath,
+		PathOnHost: rootfsAPIPath,
 	}); err != nil {
 		return fmt.Errorf("firecracker runtime: PatchDrive rootfs: %w", err)
 	}
 	if manifest.HasOverlay {
+		overlayAPIPath, err := d.chrootFilePath(runDir, overlayPath, overlayFileName)
+		if err != nil {
+			return fmt.Errorf("firecracker runtime: stage snapshot overlay: %w", err)
+		}
 		if err := client.PatchDrive(ctx, overlayDriveID, firecracker.DrivePatch{
 			DriveID:    overlayDriveID,
-			PathOnHost: overlayPath,
+			PathOnHost: overlayAPIPath,
 		}); err != nil {
 			return fmt.Errorf("firecracker runtime: PatchDrive overlay: %w", err)
 		}

--- a/internal/runtime/firecracker/sandbox_snapshot_test.go
+++ b/internal/runtime/firecracker/sandbox_snapshot_test.go
@@ -81,6 +81,57 @@ func TestStopStartSnapshotLifecycle(t *testing.T) {
 	}
 }
 
+func TestConfigureSandboxSnapshotRestore_JailerStagesAPIPaths(t *testing.T) {
+	d := &Driver{cfg: Config{UseJailer: true}}
+	client := newFakeClient()
+	runDir := t.TempDir()
+
+	srcDir := t.TempDir()
+	memPath := filepath.Join(srcDir, sandboxSnapshotMemoryFileName)
+	statePath := filepath.Join(srcDir, sandboxSnapshotStateFileName)
+	for _, path := range []string{memPath, statePath} {
+		if err := os.WriteFile(path, []byte("snapshot-"+filepath.Base(path)), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	rootfsPath := filepath.Join(runDir, rootfsFileName)
+	overlayPath := filepath.Join(runDir, overlayFileName)
+	for _, path := range []string{rootfsPath, overlayPath} {
+		if err := os.WriteFile(path, []byte("drive-"+filepath.Base(path)), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	err := d.configureSandboxSnapshotRestore(context.Background(), client, &sandboxSnapshotManifest{
+		HasOverlay: true,
+	}, memPath, statePath, rootfsPath, &TapSlot{TapName: "fctap0"}, overlayPath)
+	if err != nil {
+		t.Fatalf("configureSandboxSnapshotRestore: %v", err)
+	}
+
+	if client.snapshotLoad == nil {
+		t.Fatal("LoadSnapshot was not called")
+	}
+	if client.snapshotLoad.SnapshotPath != sandboxSnapshotStateFileName {
+		t.Fatalf("LoadSnapshot.SnapshotPath = %q, want %q", client.snapshotLoad.SnapshotPath, sandboxSnapshotStateFileName)
+	}
+	if client.snapshotLoad.MemBackend == nil ||
+		client.snapshotLoad.MemBackend.BackendPath != sandboxSnapshotMemoryFileName {
+		t.Fatalf("LoadSnapshot.MemBackend = %+v, want chroot-relative snapshot memory", client.snapshotLoad.MemBackend)
+	}
+	if patch := client.drivePatches[rootDriveID]; patch.PathOnHost != rootfsFileName {
+		t.Fatalf("root drive patch path = %q, want %q", patch.PathOnHost, rootfsFileName)
+	}
+	if patch := client.drivePatches[overlayDriveID]; patch.PathOnHost != overlayFileName {
+		t.Fatalf("overlay drive patch path = %q, want %q", patch.PathOnHost, overlayFileName)
+	}
+	for _, name := range []string{sandboxSnapshotMemoryFileName, sandboxSnapshotStateFileName} {
+		if _, err := os.Stat(filepath.Join(runDir, name)); err != nil {
+			t.Fatalf("%s not staged into restore chroot: %v", name, err)
+		}
+	}
+}
+
 func TestStopSnapshotFailureResumesRunningVMM(t *testing.T) {
 	f := newDriverFixture(t)
 	ctx := context.Background()

--- a/internal/runtime/firecracker/warmacquire.go
+++ b/internal/runtime/firecracker/warmacquire.go
@@ -193,9 +193,13 @@ func (d *Driver) tryAcquireWarm(
 	if err := linkOrCopyRootfs(snap.RootfsPath, warmRootfsPath); err != nil {
 		return nil, false, fmt.Errorf("firecracker runtime: warm stage rootfs: %w", err)
 	}
+	warmRootfsAPIPath, err := d.chrootFilePath(slot.RunDir, warmRootfsPath, rootfsFileName)
+	if err != nil {
+		return nil, false, fmt.Errorf("firecracker runtime: warm stage rootfs for API: %w", err)
+	}
 	if err := client.PatchDrive(ctx, rootDriveID, firecracker.DrivePatch{
 		DriveID:    rootDriveID,
-		PathOnHost: warmRootfsPath,
+		PathOnHost: warmRootfsAPIPath,
 	}); err != nil {
 		return nil, false, fmt.Errorf("firecracker runtime: warm patch rootfs drive: %w", err)
 	}
@@ -230,9 +234,13 @@ func (d *Driver) tryAcquireWarm(
 	// The snapshot baked in the template's placeholder overlay; we
 	// swap to this sandbox's per-sandbox file before Resume.
 	if warmOverlayPath != "" {
+		warmOverlayAPIPath, err := d.chrootFilePath(slot.RunDir, warmOverlayPath, overlayFileName)
+		if err != nil {
+			return nil, false, fmt.Errorf("firecracker runtime: warm stage overlay for API: %w", err)
+		}
 		if err := client.PatchDrive(ctx, overlayDriveID, firecracker.DrivePatch{
 			DriveID:    overlayDriveID,
-			PathOnHost: warmOverlayPath,
+			PathOnHost: warmOverlayAPIPath,
 		}); err != nil {
 			return nil, false, fmt.Errorf("firecracker runtime: warm patch overlay drive: %w", err)
 		}
@@ -254,6 +262,11 @@ func (d *Driver) tryAcquireWarm(
 	if err := d.vsockHandshake(ctx, vsockPath, slot.VsockCID); err != nil {
 		return nil, false, fmt.Errorf("firecracker runtime: warm vsock handshake: %w", err)
 	}
+	d.logger.Info("firecracker create: warm vsock handshake complete",
+		"sandbox_id", sandboxID,
+		"vsock_cid", slot.VsockCID,
+		"guest_ip", tapSlot.GuestIP,
+		"tap", tapSlot.TapName)
 
 	// post_resume reseed (RNG + wallclock). Best-effort; same shape
 	// as the cold snapshot-load path.
@@ -261,8 +274,16 @@ func (d *Driver) tryAcquireWarm(
 	if err := d.sendVsockOp(postCtx, vsockPath, slot.VsockCID, "post_resume", postResumeData(tapSlot)); err != nil {
 		d.logger.Warn("firecracker create: warm post_resume send failed (continuing)",
 			"sandbox_id", sandboxID, "error", err)
+	} else {
+		d.logger.Info("firecracker create: warm post_resume acked",
+			"sandbox_id", sandboxID,
+			"vsock_cid", slot.VsockCID,
+			"guest_ip", tapSlot.GuestIP,
+			"gateway_ip", tapSlot.HostIP,
+			"tap", tapSlot.TapName)
 	}
 	cancel()
+	d.probeToolboxTCP(ctx, "warm_acquire", sandboxID, tapSlot, true)
 
 	// Register the warm handle + client into the driver's map so
 	// Destroy finds them. The handle is the SpawnedHandle from the

--- a/internal/runtime/firecracker/warmacquire_test.go
+++ b/internal/runtime/firecracker/warmacquire_test.go
@@ -224,6 +224,31 @@ func TestCreate_WarmHit(t *testing.T) {
 	}
 }
 
+func TestCreate_WarmHit_JailerUsesRelativeDrivePatchPaths(t *testing.T) {
+	f := newDriverFixture(t)
+	f.driver.cfg.UseJailer = true
+	stageWarmFixture(t, f)
+	stageWarmTemplate(t, f, true)
+
+	if _, err := f.driver.Create(context.Background(), models.CreateSandboxRequest{
+		Image:         "alpine:3.20",
+		CPU:           1,
+		MemoryMB:      128,
+		DiskGB:        1,
+		TemplateID:    "tpl-warm",
+		OverlaySizeGB: 1,
+	}, "sb-warm-jail", "tok", nil); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if patch := f.client.drivePatches[rootDriveID]; patch.PathOnHost != rootfsFileName {
+		t.Fatalf("root drive patch path = %q, want %q", patch.PathOnHost, rootfsFileName)
+	}
+	if patch := f.client.drivePatches[overlayDriveID]; patch.PathOnHost != overlayFileName {
+		t.Fatalf("overlay drive patch path = %q, want %q", patch.PathOnHost, overlayFileName)
+	}
+}
+
 // TestCreate_WarmMissFallsBackToColdSpawn asserts the contract: when
 // the pool returns ErrNoLoadedSlot, Create proceeds with the existing
 // snapshot-load path and the user-visible outcome is unchanged. A

--- a/internal/runtime/firecracker/warmspawn.go
+++ b/internal/runtime/firecracker/warmspawn.go
@@ -184,11 +184,15 @@ func (d *Driver) WarmSpawn(ctx context.Context, req WarmSpawnRequest) (WarmHandl
 	// paused so the Acquire code can PATCH per-sandbox state on top
 	// of the snapshot's references before issuing Resume.
 	client := d.newClient(handle.APISocket())
+	snapshotMemoryPath, snapshotStatePath, err := d.stageSnapshotLoadPaths(handle.RunDir(), req.SnapshotMemoryPath, req.SnapshotStatePath)
+	if err != nil {
+		return nil, fmt.Errorf("firecracker warm-spawn: stage snapshot load artifacts: %w", err)
+	}
 	if err := client.LoadSnapshot(ctx, firecracker.SnapshotLoad{
-		SnapshotPath: req.SnapshotStatePath,
+		SnapshotPath: snapshotStatePath,
 		MemBackend: &firecracker.MemoryBackend{
 			BackendType: "File",
-			BackendPath: req.SnapshotMemoryPath,
+			BackendPath: snapshotMemoryPath,
 		},
 		EnableDiffSnapshots: true,
 		ResumeVM:            false,

--- a/internal/runtime/firecracker/warmspawn_test.go
+++ b/internal/runtime/firecracker/warmspawn_test.go
@@ -95,6 +95,57 @@ func TestWarmSpawn_HappyPath(t *testing.T) {
 	}
 }
 
+func TestWarmSpawn_JailerStagesSnapshotLoadPaths(t *testing.T) {
+	f := newDriverFixture(t)
+	f.driver.cfg.UseJailer = true
+
+	chrootRoot := filepath.Join(t.TempDir(), "jailer", "firecracker", "vmms-warm-jail", "root")
+	if err := os.MkdirAll(chrootRoot, 0o755); err != nil {
+		t.Fatalf("mkdir chroot: %v", err)
+	}
+	f.driver.SetSpawner(func(_ Config, slotID string) (VMMHandle, error) {
+		f.vmm.id = slotID
+		f.vmm.runDir = chrootRoot
+		f.vmm.apiSocket = filepath.Join(chrootRoot, "api.sock")
+		return f.vmm, nil
+	})
+
+	tplDir := t.TempDir()
+	snapMem := filepath.Join(tplDir, sandboxSnapshotMemoryFileName)
+	snapState := filepath.Join(tplDir, sandboxSnapshotStateFileName)
+	for _, path := range []string{snapMem, snapState} {
+		if err := os.WriteFile(path, []byte("snapshot-"+filepath.Base(path)), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	if _, err := f.driver.WarmSpawn(context.Background(), WarmSpawnRequest{
+		SlotID:             "vmms-warm-jail",
+		TemplateID:         "tpl-snap",
+		SnapshotMemoryPath: snapMem,
+		SnapshotStatePath:  snapState,
+		VsockCID:           200,
+	}); err != nil {
+		t.Fatalf("WarmSpawn (jailer): %v", err)
+	}
+
+	if f.client.snapshotLoad == nil {
+		t.Fatal("LoadSnapshot was not called")
+	}
+	if f.client.snapshotLoad.SnapshotPath != sandboxSnapshotStateFileName {
+		t.Fatalf("LoadSnapshot.SnapshotPath = %q, want %q", f.client.snapshotLoad.SnapshotPath, sandboxSnapshotStateFileName)
+	}
+	if f.client.snapshotLoad.MemBackend == nil ||
+		f.client.snapshotLoad.MemBackend.BackendPath != sandboxSnapshotMemoryFileName {
+		t.Fatalf("LoadSnapshot.MemBackend = %+v, want chroot-relative snapshot memory", f.client.snapshotLoad.MemBackend)
+	}
+	for _, name := range []string{sandboxSnapshotMemoryFileName, sandboxSnapshotStateFileName} {
+		if _, err := os.Stat(filepath.Join(chrootRoot, name)); err != nil {
+			t.Fatalf("%s not staged into warm chroot: %v", name, err)
+		}
+	}
+}
+
 // TestWarmSpawn_CleansUpOnLoadFailure asserts the cleanup contract
 // spawner.go promises the pool: a failed WarmSpawn leaks no
 // firecracker process and no rundir. The pool's GC sweep depends on


### PR DESCRIPTION
## Summary

- Stage chroot-relative snapshot load paths for cold create, warm spawn, sandbox restore, and warm-acquire drive patches under the jailer.
- Reapply guest IPs with `ip addr replace` on resume (toolboxd + init) and extend NIC discovery retries.
- Add post_resume / warm-path logging, toolbox TCP probes, and integration-test template readiness waits.

## Sandbox boot impact

Minor: warm-acquire and cold snapshot-load paths may send an extra best-effort post_resume vsock op and run a short toolbox TCP probe after warm acquire. Both are bounded and best-effort; failures do not block create.

## Idempotency

N/A - no API surface changed.

## Failure-path consistency

N/A - no multi-step write path changed.

## L4 / host-port-pool changes

N/A - neither touched.

## Test plan

- [x] `go test ./internal/runtime/firecracker/...`
- [x] `go test ./cmd/toolboxd/...`

Made with [Cursor](https://cursor.com)