### PR TITLE
fix(firecracker): stage overlay before snapshot load under jailer

### DIFF
--- a/internal/pool/vmm/refill.go
+++ b/internal/pool/vmm/refill.go
@@ -72,6 +72,7 @@ type TemplateWarmInput struct {
 	SnapshotStatePath  string
 	SnapshotChecksum   string
 	VsockCID           uint32
+	HasOverlay         bool
 }
 
 // RefillConfig is the timing knobs the refill loop reads on
@@ -271,6 +272,7 @@ func (p *Pool) spawnOne(parentCtx context.Context, tpl TemplateWarmInput, spawne
 		SnapshotStatePath:  tpl.SnapshotStatePath,
 		SnapshotChecksum:   tpl.SnapshotChecksum,
 		VsockCID:           tpl.VsockCID,
+		HasOverlay:         tpl.HasOverlay,
 	})
 	recordSpawnLatency(time.Since(spawnStart))
 	if err != nil {

--- a/internal/pool/vmm/spawner.go
+++ b/internal/pool/vmm/spawner.go
@@ -39,6 +39,7 @@ type SnapshotInputs struct {
 	SnapshotStatePath  string
 	SnapshotChecksum   string
 	VsockCID           uint32
+	HasOverlay         bool
 }
 
 // SpawnedHandle is the subset of a *firecracker.vmm the pool consumes

--- a/internal/runtime/firecracker/create_rundir_test.go
+++ b/internal/runtime/firecracker/create_rundir_test.go
@@ -229,3 +229,39 @@ func TestCreate_SnapshotLoadPath_JailerStagesAPIPaths(t *testing.T) {
 		}
 	}
 }
+
+func TestConfigureVMMForLoad_JailerStagesOverlayBeforeLoadSnapshot(t *testing.T) {
+	f := newDriverFixture(t)
+	f.driver.cfg.UseJailer = true
+
+	runDir := t.TempDir()
+	rootfsPath := filepath.Join(runDir, rootfsFileName)
+	if err := os.WriteFile(rootfsPath, []byte("rootfs"), 0o644); err != nil {
+		t.Fatalf("write rootfs: %v", err)
+	}
+	tplDir := t.TempDir()
+	snapMem := filepath.Join(tplDir, sandboxSnapshotMemoryFileName)
+	snapState := filepath.Join(tplDir, sandboxSnapshotStateFileName)
+	overlayPath := filepath.Join(tplDir, overlayFileName)
+	for _, path := range []string{snapMem, snapState, overlayPath} {
+		if err := os.WriteFile(path, []byte("artifact-"+filepath.Base(path)), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	client := newFakeClient()
+	client.loadSnapshotHook = func() error {
+		_, err := os.Stat(filepath.Join(runDir, overlayFileName))
+		return err
+	}
+	err := f.driver.configureVMMForLoad(context.Background(), client, &TemplateResolution{
+		SnapshotMemoryPath: snapMem,
+		SnapshotStatePath:  snapState,
+	}, rootfsPath, &TapSlot{TapName: "fctap0"}, overlayPath)
+	if err != nil {
+		t.Fatalf("configureVMMForLoad: %v", err)
+	}
+	if patch := client.drivePatches[overlayDriveID]; patch.PathOnHost != overlayFileName {
+		t.Fatalf("overlay drive patch path = %q, want %q", patch.PathOnHost, overlayFileName)
+	}
+}

--- a/internal/runtime/firecracker/create_test.go
+++ b/internal/runtime/firecracker/create_test.go
@@ -317,9 +317,10 @@ type fakeClient struct {
 	vmStates []string
 	instance *firecracker.InstanceInfo
 
-	snapshotCreate *firecracker.SnapshotCreate
-	snapshotLoad   *firecracker.SnapshotLoad
-	snapshotBase   string
+	snapshotCreate   *firecracker.SnapshotCreate
+	snapshotLoad     *firecracker.SnapshotLoad
+	snapshotBase     string
+	loadSnapshotHook func() error
 
 	// drivePatches records each PatchDrive call (snapshot-load + overlay
 	// path swap). Keyed by drive_id so a test can assert the post-load
@@ -447,10 +448,17 @@ func (c *fakeClient) CreateSnapshot(_ context.Context, req firecracker.SnapshotC
 
 func (c *fakeClient) LoadSnapshot(_ context.Context, req firecracker.SnapshotLoad) error {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	c.snapshotLoad = &req
 	c.restOrder = append(c.restOrder, "LoadSnapshot")
-	return c.snapshotLoadErr
+	err := c.snapshotLoadErr
+	hook := c.loadSnapshotHook
+	c.mu.Unlock()
+	if hook != nil {
+		if hErr := hook(); hErr != nil {
+			return hErr
+		}
+	}
+	return err
 }
 
 func (c *fakeClient) PatchDrive(_ context.Context, id string, patch firecracker.DrivePatch) error {

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -977,6 +977,13 @@ func (d *Driver) configureVMMForLoad(ctx context.Context, client VMMClient, snap
 	if err != nil {
 		return fmt.Errorf("firecracker runtime: stage snapshot load artifacts: %w", err)
 	}
+	var overlayAPIPath string
+	if overlayPath != "" {
+		overlayAPIPath, err = d.chrootFilePath(runDir, overlayPath, overlayFileName)
+		if err != nil {
+			return fmt.Errorf("firecracker runtime: stage snapshot overlay: %w", err)
+		}
+	}
 	if err := client.LoadSnapshot(ctx, firecracker.SnapshotLoad{
 		SnapshotPath: snapshotStatePath,
 		MemBackend: &firecracker.MemoryBackend{
@@ -1014,10 +1021,6 @@ func (d *Driver) configureVMMForLoad(ctx context.Context, client VMMClient, snap
 	// request when snap.HasOverlay=false, so a missing placeholder
 	// here is a corrupted template, not a user error.
 	if overlayPath != "" {
-		overlayAPIPath, err := d.chrootFilePath(runDir, overlayPath, overlayFileName)
-		if err != nil {
-			return fmt.Errorf("firecracker runtime: stage snapshot overlay: %w", err)
-		}
 		if err := client.PatchDrive(ctx, overlayDriveID, firecracker.DrivePatch{
 			DriveID:    overlayDriveID,
 			PathOnHost: overlayAPIPath,
@@ -1442,9 +1445,11 @@ func (d *Driver) ListManaged(ctx context.Context) (map[string]*models.SandboxRun
 	d.mu.Lock()
 	ids := make([]string, 0, len(d.clients))
 	clients := make([]VMMClient, 0, len(d.clients))
+	handles := make([]VMMHandle, 0, len(d.clients))
 	for id, c := range d.clients {
 		ids = append(ids, id)
 		clients = append(clients, c)
+		handles = append(handles, d.vmms[id])
 	}
 	d.mu.Unlock()
 
@@ -1456,7 +1461,11 @@ func (d *Driver) ListManaged(ctx context.Context) (map[string]*models.SandboxRun
 			// reconcile uses this as a snapshot, and a transient API
 			// blip shouldn't mark every sandbox as unknown.
 			d.logger.Warn("firecracker list_managed: inspect failed",
-				"sandbox_id", id, "error", err)
+				"sandbox_id", id,
+				"error", err,
+				"vmm_pid", handlePID(handles[i]),
+				"run_dir", handleRunDir(handles[i]),
+				"stderr_tail", handleStderrTail(handles[i]))
 			continue
 		}
 		out[id] = &models.SandboxRuntimeState{
@@ -1465,6 +1474,27 @@ func (d *Driver) ListManaged(ctx context.Context) (map[string]*models.SandboxRun
 		}
 	}
 	return out, nil
+}
+
+func handlePID(handle VMMHandle) int {
+	if handle == nil {
+		return 0
+	}
+	return handle.Pid()
+}
+
+func handleRunDir(handle VMMHandle) string {
+	if handle == nil {
+		return ""
+	}
+	return handle.RunDir()
+}
+
+func handleStderrTail(handle VMMHandle) string {
+	if handle == nil {
+		return ""
+	}
+	return handle.StderrTail()
 }
 
 // statusFromInstanceState maps Firecracker's self-reported VMM state

--- a/internal/runtime/firecracker/poolspawner.go
+++ b/internal/runtime/firecracker/poolspawner.go
@@ -55,6 +55,7 @@ func (s *PoolSpawner) Spawn(ctx context.Context, slotID string, inputs vmmpool.S
 		SnapshotStatePath:  inputs.SnapshotStatePath,
 		SnapshotChecksum:   inputs.SnapshotChecksum,
 		VsockCID:           inputs.VsockCID,
+		HasOverlay:         inputs.HasOverlay,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/runtime/firecracker/sandbox_snapshot.go
+++ b/internal/runtime/firecracker/sandbox_snapshot.go
@@ -462,6 +462,13 @@ func (d *Driver) configureSandboxSnapshotRestore(ctx context.Context, client VMM
 	if err != nil {
 		return fmt.Errorf("firecracker runtime: stage snapshot load artifacts: %w", err)
 	}
+	var overlayAPIPath string
+	if manifest.HasOverlay {
+		overlayAPIPath, err = d.chrootFilePath(runDir, overlayPath, overlayFileName)
+		if err != nil {
+			return fmt.Errorf("firecracker runtime: stage snapshot overlay: %w", err)
+		}
+	}
 	if err := client.LoadSnapshot(ctx, firecracker.SnapshotLoad{
 		SnapshotPath: snapshotStatePath,
 		MemBackend: &firecracker.MemoryBackend{
@@ -484,10 +491,6 @@ func (d *Driver) configureSandboxSnapshotRestore(ctx context.Context, client VMM
 		return fmt.Errorf("firecracker runtime: PatchDrive rootfs: %w", err)
 	}
 	if manifest.HasOverlay {
-		overlayAPIPath, err := d.chrootFilePath(runDir, overlayPath, overlayFileName)
-		if err != nil {
-			return fmt.Errorf("firecracker runtime: stage snapshot overlay: %w", err)
-		}
 		if err := client.PatchDrive(ctx, overlayDriveID, firecracker.DrivePatch{
 			DriveID:    overlayDriveID,
 			PathOnHost: overlayAPIPath,

--- a/internal/runtime/firecracker/sandbox_snapshot_test.go
+++ b/internal/runtime/firecracker/sandbox_snapshot_test.go
@@ -95,11 +95,15 @@ func TestConfigureSandboxSnapshotRestore_JailerStagesAPIPaths(t *testing.T) {
 		}
 	}
 	rootfsPath := filepath.Join(runDir, rootfsFileName)
-	overlayPath := filepath.Join(runDir, overlayFileName)
+	overlayPath := filepath.Join(t.TempDir(), overlayFileName)
 	for _, path := range []string{rootfsPath, overlayPath} {
 		if err := os.WriteFile(path, []byte("drive-"+filepath.Base(path)), 0o600); err != nil {
 			t.Fatalf("write %s: %v", path, err)
 		}
+	}
+	client.loadSnapshotHook = func() error {
+		_, err := os.Stat(filepath.Join(runDir, overlayFileName))
+		return err
 	}
 
 	err := d.configureSandboxSnapshotRestore(context.Background(), client, &sandboxSnapshotManifest{
@@ -125,7 +129,7 @@ func TestConfigureSandboxSnapshotRestore_JailerStagesAPIPaths(t *testing.T) {
 	if patch := client.drivePatches[overlayDriveID]; patch.PathOnHost != overlayFileName {
 		t.Fatalf("overlay drive patch path = %q, want %q", patch.PathOnHost, overlayFileName)
 	}
-	for _, name := range []string{sandboxSnapshotMemoryFileName, sandboxSnapshotStateFileName} {
+	for _, name := range []string{sandboxSnapshotMemoryFileName, sandboxSnapshotStateFileName, overlayFileName} {
 		if _, err := os.Stat(filepath.Join(runDir, name)); err != nil {
 			t.Fatalf("%s not staged into restore chroot: %v", name, err)
 		}

--- a/internal/runtime/firecracker/vmm.go
+++ b/internal/runtime/firecracker/vmm.go
@@ -196,6 +196,25 @@ func (v *vmm) Start(ctx context.Context) error {
 
 	go func() {
 		v.waitErr = cmd.Wait()
+		attrs := []any{
+			"sandbox_id", v.sandboxID,
+			"pid", cmd.Process.Pid,
+			"run_dir", v.runDir,
+			"stderr_tail", v.stderr.String(),
+		}
+		if v.waitErr != nil {
+			logger := v.logger
+			if logger == nil {
+				logger = slog.Default()
+			}
+			logger.Warn("firecracker vmm process exited", append(attrs, "error", v.waitErr)...)
+		} else {
+			logger := v.logger
+			if logger == nil {
+				logger = slog.Default()
+			}
+			logger.Info("firecracker vmm process exited", attrs...)
+		}
 		close(v.waitCh)
 	}()
 	return nil

--- a/internal/runtime/firecracker/warmspawn.go
+++ b/internal/runtime/firecracker/warmspawn.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"github.com/aerol-ai/microvm/pkg/firecracker"
@@ -47,6 +48,7 @@ type WarmSpawnRequest struct {
 	SnapshotStatePath  string
 	SnapshotChecksum   string
 	VsockCID           uint32
+	HasOverlay         bool
 }
 
 // WarmHandle is the runtime-side handle the pool stores after a
@@ -187,6 +189,15 @@ func (d *Driver) WarmSpawn(ctx context.Context, req WarmSpawnRequest) (WarmHandl
 	snapshotMemoryPath, snapshotStatePath, err := d.stageSnapshotLoadPaths(handle.RunDir(), req.SnapshotMemoryPath, req.SnapshotStatePath)
 	if err != nil {
 		return nil, fmt.Errorf("firecracker warm-spawn: stage snapshot load artifacts: %w", err)
+	}
+	if req.HasOverlay {
+		overlayPath := filepath.Join(handle.RunDir(), overlayFileName)
+		if err := allocateSparse(overlayPath, overlayPlaceholderBytes); err != nil {
+			return nil, fmt.Errorf("firecracker warm-spawn: overlay placeholder alloc: %w", err)
+		}
+		if _, err := d.chrootFilePath(handle.RunDir(), overlayPath, overlayFileName); err != nil {
+			return nil, fmt.Errorf("firecracker warm-spawn: stage overlay placeholder: %w", err)
+		}
 	}
 	if err := client.LoadSnapshot(ctx, firecracker.SnapshotLoad{
 		SnapshotPath: snapshotStatePath,

--- a/internal/runtime/firecracker/warmspawn_test.go
+++ b/internal/runtime/firecracker/warmspawn_test.go
@@ -118,6 +118,10 @@ func TestWarmSpawn_JailerStagesSnapshotLoadPaths(t *testing.T) {
 			t.Fatalf("write %s: %v", path, err)
 		}
 	}
+	f.client.loadSnapshotHook = func() error {
+		_, err := os.Stat(filepath.Join(chrootRoot, overlayFileName))
+		return err
+	}
 
 	if _, err := f.driver.WarmSpawn(context.Background(), WarmSpawnRequest{
 		SlotID:             "vmms-warm-jail",
@@ -125,6 +129,7 @@ func TestWarmSpawn_JailerStagesSnapshotLoadPaths(t *testing.T) {
 		SnapshotMemoryPath: snapMem,
 		SnapshotStatePath:  snapState,
 		VsockCID:           200,
+		HasOverlay:         true,
 	}); err != nil {
 		t.Fatalf("WarmSpawn (jailer): %v", err)
 	}
@@ -139,7 +144,7 @@ func TestWarmSpawn_JailerStagesSnapshotLoadPaths(t *testing.T) {
 		f.client.snapshotLoad.MemBackend.BackendPath != sandboxSnapshotMemoryFileName {
 		t.Fatalf("LoadSnapshot.MemBackend = %+v, want chroot-relative snapshot memory", f.client.snapshotLoad.MemBackend)
 	}
-	for _, name := range []string{sandboxSnapshotMemoryFileName, sandboxSnapshotStateFileName} {
+	for _, name := range []string{sandboxSnapshotMemoryFileName, sandboxSnapshotStateFileName, overlayFileName} {
 		if _, err := os.Stat(filepath.Join(chrootRoot, name)); err != nil {
 			t.Fatalf("%s not staged into warm chroot: %v", name, err)
 		}
@@ -245,6 +250,10 @@ func TestPoolSpawner_DelegatesToWarmSpawn(t *testing.T) {
 	// is the single source of truth that adding a method to
 	// vmm.Spawner breaks the build here, not at main.go wiring time.
 	var _ vmmpool.Spawner = NewPoolSpawner(f.driver)
+	f.client.loadSnapshotHook = func() error {
+		_, err := os.Stat(filepath.Join(f.vmm.runDir, overlayFileName))
+		return err
+	}
 
 	adapter := NewPoolSpawner(f.driver)
 	handle, err := adapter.Spawn(context.Background(), "vmms-adapt-001", vmmpool.SnapshotInputs{
@@ -252,6 +261,7 @@ func TestPoolSpawner_DelegatesToWarmSpawn(t *testing.T) {
 		SnapshotMemoryPath: snapMem,
 		SnapshotStatePath:  snapState,
 		VsockCID:           200,
+		HasOverlay:         true,
 	})
 	if err != nil {
 		t.Fatalf("Spawn: %v", err)

--- a/internal/service/toolbox_proxy.go
+++ b/internal/service/toolbox_proxy.go
@@ -65,7 +65,12 @@ func (s *Service) ServeToolboxReverseProxy(ctx context.Context, sandboxID string
 	}
 	proxy.ErrorHandler = func(w http.ResponseWriter, _ *http.Request, err error) {
 		if s.logger != nil {
-			s.logger.Warn("toolbox proxy failed", "error", err, "sandbox_id", sandboxID, "path", path)
+			s.logger.Warn("toolbox proxy failed",
+				"error", err,
+				"sandbox_id", sandboxID,
+				"runtime", sandbox.Runtime,
+				"target", endpoint.URL,
+				"path", path)
 		}
 		http.Error(w, "toolbox unavailable", http.StatusBadGateway)
 	}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1741,6 +1741,7 @@ func (a *vmmTemplateListerAdapter) ListWarmableTemplates(ctx context.Context) ([
 			SnapshotStatePath:  t.SnapshotStatePath,
 			SnapshotChecksum:   t.SnapshotChecksum,
 			VsockCID:           t.SnapshotVsockCID,
+			HasOverlay:         t.HasOverlay,
 		})
 	}
 	return out, nil

--- a/pkg/daemon/daemon_adapters_test.go
+++ b/pkg/daemon/daemon_adapters_test.go
@@ -190,7 +190,7 @@ func TestVMMTemplateListerAdapter_ListWarmableTemplates(t *testing.T) {
 	mustCreateTemplate(&models.Template{
 		ID: "tpl-warm", Image: "alpine", Status: models.TemplateStatusReady,
 		RootfsPath: "/tmp/rootfs.ext4", CreatedAt: now, UpdatedAt: now,
-		HasSnapshot: true, SnapshotMemoryPath: "/tmp/snap.mem", SnapshotStatePath: "/tmp/snap.state", SnapshotChecksum: "abc", SnapshotVsockCID: 200,
+		HasSnapshot: true, HasOverlay: true, SnapshotMemoryPath: "/tmp/snap.mem", SnapshotStatePath: "/tmp/snap.state", SnapshotChecksum: "abc", SnapshotVsockCID: 200,
 	})
 	mustCreateTemplate(&models.Template{ID: "tpl-no-path", Image: "alpine", Status: models.TemplateStatusReady, CreatedAt: now, UpdatedAt: now, HasSnapshot: true})
 	mustCreateTemplate(&models.Template{ID: "tpl-no-snap", Image: "alpine", Status: models.TemplateStatusReadyNoSnapshot, CreatedAt: now, UpdatedAt: now, HasSnapshot: false})
@@ -203,7 +203,7 @@ func TestVMMTemplateListerAdapter_ListWarmableTemplates(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("len(ListWarmableTemplates) = %d, want 1 (%+v)", len(got), got)
 	}
-	if got[0].TemplateID != "tpl-warm" || got[0].SnapshotMemoryPath == "" || got[0].SnapshotStatePath == "" || got[0].VsockCID != 200 {
+	if got[0].TemplateID != "tpl-warm" || got[0].SnapshotMemoryPath == "" || got[0].SnapshotStatePath == "" || got[0].VsockCID != 200 || !got[0].HasOverlay {
 		t.Fatalf("unexpected warmable template: %+v", got[0])
 	}
 }


### PR DESCRIPTION
## Summary

- Stage overlay placeholder into the jailer chroot **before** `LoadSnapshot` on cold create, sandbox restore, and warm spawn paths.
- Propagate `HasOverlay` through the VMM warm pool (`TemplateWarmInput` → `WarmSpawnRequest`).
- Add VMM process-exit logging and richer `ListManaged` / toolbox-proxy failure diagnostics.

## Sandbox boot impact

Warm-pool refill may allocate and stage an overlay placeholder when `HasOverlay=true` before snapshot load. Bounded file I/O on pool refill only; create path unchanged for non-overlay templates.

## Idempotency

N/A - no API surface changed.

## Failure-path consistency

N/A - no multi-step write path changed.

## L4 / host-port-pool changes

N/A - neither touched.

## Test plan

- [x] `go test ./internal/runtime/firecracker/...`
- [x] `go test ./internal/pool/vmm/...`
- [x] `go test ./pkg/daemon/...`

Made with [Cursor](https://cursor.com)