### PR TITLE
fix(firecracker): pin host neighbor to snapshot guest MAC

### DIFF
--- a/internal/network/tap/host.go
+++ b/internal/network/tap/host.go
@@ -186,11 +186,15 @@ func (h *Host) Ensure(ctx context.Context, slot Slot) error {
 	}
 
 	// Step 4: pin host -> guest L2 resolution when the slot carries a
-	// guest endpoint. The runtime gives Firecracker the same deterministic
-	// MAC, so this turns the first toolbox proxy dial into a direct route
-	// instead of waiting for ARP to discover a quiet guest.
-	if slot.GuestIP != "" && slot.VsockCID >= 3 {
-		mac := guestMACFromSlot(slot)
+	// guest endpoint. Cold boots derive the deterministic MAC from the
+	// slot CID. Snapshot restores can override GuestMAC because the
+	// guest NIC MAC is frozen in the snapshot while the host TAP/IP slot
+	// changes per clone.
+	if slot.GuestIP != "" && (slot.VsockCID >= 3 || slot.GuestMAC != "") {
+		mac := slot.GuestMAC
+		if mac == "" {
+			mac = guestMACFromSlot(slot)
+		}
 		if out, err := h.exec(ctx, "neigh", "replace", slot.GuestIP, "lladdr", mac, "dev", slot.TapName, "nud", "permanent"); err != nil {
 			return fmt.Errorf("tap host: neigh replace %s dev %s: %w (%s)", slot.GuestIP, slot.TapName, err, strings.TrimSpace(string(out)))
 		}

--- a/internal/network/tap/host_test.go
+++ b/internal/network/tap/host_test.go
@@ -130,6 +130,27 @@ func TestEnsure_NeighborFailureBubbles(t *testing.T) {
 	}
 }
 
+func TestEnsure_UsesExplicitGuestMACForNeighbor(t *testing.T) {
+	r := &recordingRun{}
+	h := newHostWithRun(r)
+	slot := Slot{
+		TapName:  "fctap-snap",
+		CIDR:     "172.16.0.40/30",
+		HostIP:   "172.16.0.41",
+		GuestIP:  "172.16.0.42",
+		VsockCID: 13,
+		GuestMAC: "02:00:00:00:00:03",
+	}
+	if err := h.Ensure(context.Background(), slot); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	got := r.calls[len(r.calls)-1].args
+	want := []string{"neigh", "replace", "172.16.0.42", "lladdr", "02:00:00:00:00:03", "dev", "fctap-snap", "nud", "permanent"}
+	if !equalStrings(got, want) {
+		t.Fatalf("neighbor argv = %v, want %v", got, want)
+	}
+}
+
 // TestEnsure_AddrAddFailureBubbles confirms a non-idempotent addr-add
 // failure surfaces verbatim — operator needs the `ip` output to diagnose
 // (most commonly: missing CAP_NET_ADMIN on the daemon).

--- a/internal/network/tap/pool.go
+++ b/internal/network/tap/pool.go
@@ -148,13 +148,15 @@ func addOffset(base net.IP, delta uint32) net.IP {
 // store.FirecrackerTapSlot but lives in this package so callers (the
 // Firecracker driver) depend on the policy layer's type, not the
 // store's. SandboxID is always non-empty here — a Slot returned by the
-// pool is always claimed.
+// pool is always claimed. GuestMAC is an optional host-neighbor override
+// used by snapshot restores whose guest NIC MAC is frozen in snapshot state.
 type Slot struct {
 	TapName  string
 	CIDR     string
 	HostIP   string
 	GuestIP  string
 	VsockCID uint32
+	GuestMAC string
 }
 
 // Allocate claims a slot for sandboxID. Idempotent (re-Allocate for the

--- a/internal/runtime/firecracker/create_test.go
+++ b/internal/runtime/firecracker/create_test.go
@@ -125,6 +125,7 @@ type fakeTapHost struct {
 	ensureErr   error
 	removeErr   error
 	lastTap     string
+	lastSlot    TapSlot
 }
 
 func (h *fakeTapHost) Ensure(_ context.Context, slot TapSlot) error {
@@ -132,6 +133,7 @@ func (h *fakeTapHost) Ensure(_ context.Context, slot TapSlot) error {
 	defer h.mu.Unlock()
 	h.ensureCalls++
 	h.lastTap = slot.TapName
+	h.lastSlot = slot
 	if h.ensureErr != nil {
 		err := h.ensureErr
 		h.ensureErr = nil
@@ -1108,6 +1110,9 @@ func TestCreate_SnapshotLoadPath(t *testing.T) {
 	}
 	if f.tapHost.ensureCalls != 1 || f.tapHost.removeCalls != 0 {
 		t.Errorf("tap ensure=%d remove=%d, want 1/0 on success", f.tapHost.ensureCalls, f.tapHost.removeCalls)
+	}
+	if f.tapHost.lastSlot.GuestMAC != macFromCID(templateCID) {
+		t.Errorf("tap ensure GuestMAC = %q, want template MAC %q", f.tapHost.lastSlot.GuestMAC, macFromCID(templateCID))
 	}
 	if !f.vmm.started || f.vmm.shutdown {
 		t.Errorf("vmm started=%v shutdown=%v, want true/false", f.vmm.started, f.vmm.shutdown)

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -145,13 +145,15 @@ type TapPool interface {
 
 // TapSlot mirrors internal/network/tap.Slot. Re-declared here to keep
 // the import-cycle wall up; main.go's adapter converts between the two
-// shapes.
+// shapes. GuestMAC is optional and is set only when snapshot restore needs
+// the host neighbor entry to match a MAC frozen in snapshot state.
 type TapSlot struct {
 	TapName  string
 	CIDR     string
 	HostIP   string
 	GuestIP  string
 	VsockCID uint32
+	GuestMAC string
 }
 
 // Config is the subset of internal/config.Config the driver actually uses.
@@ -663,7 +665,16 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 	// Step 4: bring the host-side TAP up. After this point, error
 	// returns must call tapHost.Remove. The flag-and-defer pattern
 	// mirrors the pool-release one above.
-	if err := d.tapHost.Ensure(ctx, *slot); err != nil {
+	hostSlot := *slot
+	if snapshotLoadPath && snapshotInfo != nil && snapshotInfo.SnapshotVsockCID >= 3 {
+		// Snapshot restore preserves the guest NIC MAC captured in the
+		// template. network_overrides moves that NIC to this clone's TAP,
+		// but it does not rewrite guest_mac, so the host neighbor entry
+		// must target the frozen template MAC rather than this clone's
+		// allocated slot MAC.
+		hostSlot.GuestMAC = macFromCID(snapshotInfo.SnapshotVsockCID)
+	}
+	if err := d.tapHost.Ensure(ctx, hostSlot); err != nil {
 		return nil, fmt.Errorf("firecracker runtime: tap host ensure %s: %w", slot.TapName, err)
 	}
 	tapRemoved := false
@@ -1233,10 +1244,14 @@ func defaultBootArgs() string {
 // final 4 bytes gives stable, collision-free MACs. The first byte
 // (0x02) sets the locally-administered bit per IEEE 802.
 func macFromSlot(slot *TapSlot) string {
+	return macFromCID(slot.VsockCID)
+}
+
+func macFromCID(cid uint32) string {
 	return fmt.Sprintf("02:00:00:%02x:%02x:%02x",
-		byte(slot.VsockCID>>16),
-		byte(slot.VsockCID>>8),
-		byte(slot.VsockCID))
+		byte(cid>>16),
+		byte(cid>>8),
+		byte(cid))
 }
 
 func postResumeData(slot *TapSlot) map[string]any {

--- a/internal/runtime/firecracker/sandbox_snapshot.go
+++ b/internal/runtime/firecracker/sandbox_snapshot.go
@@ -387,7 +387,11 @@ func (d *Driver) startFromSandboxSnapshot(ctx context.Context, sandboxID string)
 		}
 	}
 
-	if err := d.tapHost.Ensure(ctx, *slot); err != nil {
+	hostSlot := *slot
+	if manifest.VsockCID >= 3 {
+		hostSlot.GuestMAC = macFromCID(manifest.VsockCID)
+	}
+	if err := d.tapHost.Ensure(ctx, hostSlot); err != nil {
 		return nil, fmt.Errorf("firecracker runtime: start %s: tap host ensure %s: %w", sandboxID, slot.TapName, err)
 	}
 	tapCommitted := false

--- a/internal/runtime/firecracker/snapshot.go
+++ b/internal/runtime/firecracker/snapshot.go
@@ -172,8 +172,12 @@ func (d *Driver) SnapshotTemplate(ctx context.Context, req TemplateSnapshotReque
 	}
 
 	// Step 4: bring up the host-side TAP. Same flag-and-defer release
-	// pattern as Create's tap step.
-	if err := d.tapHost.Ensure(ctx, *slot); err != nil {
+	// pattern as Create's tap step. The template snapshot's NIC MAC is
+	// derived from the reserved snapshot CID, not the temporary build
+	// slot CID, because clones restore this NIC identity unchanged.
+	templateSlot := *slot
+	templateSlot.GuestMAC = macFromCID(req.GuestCID)
+	if err := d.tapHost.Ensure(ctx, templateSlot); err != nil {
 		return nil, fmt.Errorf("firecracker snapshot: tap ensure %s: %w", slot.TapName, err)
 	}
 	tapRemoved := false
@@ -271,7 +275,7 @@ func (d *Driver) SnapshotTemplate(ctx context.Context, req TemplateSnapshotReque
 	if err := client.PutNetworkInterface(ctx, primaryIfaceID, firecracker.NetworkInterface{
 		IfaceID:     primaryIfaceID,
 		HostDevName: slot.TapName,
-		GuestMAC:    macFromSlot(slot),
+		GuestMAC:    macFromCID(req.GuestCID),
 	}); err != nil {
 		return nil, fmt.Errorf("firecracker snapshot: PutNetworkInterface: %w", err)
 	}

--- a/internal/runtime/firecracker/snapshot_test.go
+++ b/internal/runtime/firecracker/snapshot_test.go
@@ -99,6 +99,12 @@ func TestSnapshotTemplate_HappyPath(t *testing.T) {
 	if f.client.vsock == nil || uint32(f.client.vsock.GuestCID) != guestCID {
 		t.Errorf("PutVsock.GuestCID = %v, want %d", f.client.vsock, guestCID)
 	}
+	if nic, ok := f.client.nics[primaryIfaceID]; !ok || nic.GuestMAC != macFromCID(guestCID) {
+		t.Errorf("PutNetworkInterface.GuestMAC = %+v, want %q", nic, macFromCID(guestCID))
+	}
+	if f.tapHost.lastSlot.GuestMAC != macFromCID(guestCID) {
+		t.Errorf("tap ensure GuestMAC = %q, want template MAC %q", f.tapHost.lastSlot.GuestMAC, macFromCID(guestCID))
+	}
 
 	// CreateSnapshot request shape.
 	if f.client.snapshotCreate == nil {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1541,6 +1541,7 @@ func (a *firecrackerTapHostAdapter) Ensure(ctx context.Context, slot fcruntime.T
 		HostIP:   slot.HostIP,
 		GuestIP:  slot.GuestIP,
 		VsockCID: slot.VsockCID,
+		GuestMAC: slot.GuestMAC,
 	})
 }
 
@@ -1558,6 +1559,7 @@ func adaptTapSlot(s *tap.Slot) *fcruntime.TapSlot {
 		HostIP:   s.HostIP,
 		GuestIP:  s.GuestIP,
 		VsockCID: s.VsockCID,
+		GuestMAC: s.GuestMAC,
 	}
 }
 

--- a/pkg/daemon/daemon_adapters_test.go
+++ b/pkg/daemon/daemon_adapters_test.go
@@ -86,9 +86,9 @@ func TestAdaptTapSlot(t *testing.T) {
 		t.Fatalf("adaptTapSlot(nil) = %+v, want nil", got)
 	}
 
-	in := &tap.Slot{TapName: "fctap1", CIDR: "172.16.0.0/30", HostIP: "172.16.0.1", GuestIP: "172.16.0.2", VsockCID: 33}
+	in := &tap.Slot{TapName: "fctap1", CIDR: "172.16.0.0/30", HostIP: "172.16.0.1", GuestIP: "172.16.0.2", VsockCID: 33, GuestMAC: "02:00:00:00:00:03"}
 	got := adaptTapSlot(in)
-	if got == nil || got.TapName != in.TapName || got.CIDR != in.CIDR || got.HostIP != in.HostIP || got.GuestIP != in.GuestIP || got.VsockCID != in.VsockCID {
+	if got == nil || got.TapName != in.TapName || got.CIDR != in.CIDR || got.HostIP != in.HostIP || got.GuestIP != in.GuestIP || got.VsockCID != in.VsockCID || got.GuestMAC != in.GuestMAC {
 		t.Fatalf("adaptTapSlot mismatch: got=%+v in=%+v", got, in)
 	}
 }


### PR DESCRIPTION
## Summary

- Add optional `GuestMAC` to TAP slots so host `neigh replace` can target the MAC frozen in snapshot state.
- Template builds and snapshot restores pin neighbors to the template/snapshot CID MAC instead of the per-clone slot MAC.
- Align `PutNetworkInterface.GuestMAC` on template capture with the reserved snapshot CID.

## Sandbox boot impact

N/A - same TAP ensure call; neighbor MAC selection uses snapshot CID when on the snapshot-load path.

## Idempotency

N/A - no API surface changed.

## Failure-path consistency

N/A - no multi-step write path changed.

## L4 / host-port-pool changes

N/A - neither touched.

## Test plan

- [x] `go test ./internal/network/tap/...`
- [x] `go test ./internal/runtime/firecracker/...`
- [x] `go test ./pkg/daemon/...`

Made with [Cursor](https://cursor.com)