### PR TITLE
feat(cluster): route built images and templates to capable workers

### DIFF
--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -309,6 +309,10 @@ run_one() {
   # module by alias; default to python (override by exporting the env var).
   local wasm_ref=""
   [[ "$caps_wasm" == "true" ]] && wasm_ref="${AEROL_WASM_MODULE_REF:-python}"
+  if [[ "$caps_wasm" == "true" && "$wasm_ref" == aocr.aerol.ai/cluster/*/snapshots/* ]]; then
+    echo "scenario ${scenario}: ignoring stale snapshot image ref in AEROL_WASM_MODULE_REF=${wasm_ref}; using staged wasm module alias 'python'" >&2
+    wasm_ref="python"
+  fi
 
   mkdir -p "${HERE}/reports"
   # A successful run does not collect a failure-log artifact, so clear any

--- a/integration-tests/suite/harness/usecases.go
+++ b/integration-tests/suite/harness/usecases.go
@@ -208,6 +208,27 @@ var Registry = []UseCase{
 	// The bug gated it on IsWorker() only, so the public :2220 (which DNS points
 	// at the ingress) refused every connection.
 	{ID: "UC-89", Title: "SSH gateway listens on the ingress public host", Requires: []Capability{CapCluster, CapDomain}, Implemented: true},
+
+	// UC-90..93 guard the cluster-hetero ROUTING fix pass: a request that lands
+	// on a node which can't serve it locally (templates, locally-built images,
+	// a specialized runtime) must be routed to a capable worker rather than run
+	// in place and fail. The cheap offline guard is the SelectPlacement hetero
+	// matrix in internal/cluster/placement_test.go; these are the live
+	// end-to-end confirmations on the 8-node cluster-hetero scenario.
+	//
+	// UC-90: a runtime create must be PLACED on a worker that advertises that
+	// runtime in gossip (not merely "a create happened to succeed").
+	{ID: "UC-90", Title: "Runtime create places on a capability-matching worker", Requires: []Capability{CapCluster}, Implemented: true},
+	// UC-91: a create that omits runtime must resolve to one deterministic
+	// effective runtime cluster-wide — guards a silent default change (e.g. a
+	// gVisor-default deployment quietly downgraded to runc) across the router.
+	{ID: "UC-91", Title: "Unspecified-runtime create has a deterministic effective runtime", Requires: []Capability{CapCluster}, Implemented: true},
+	// UC-92: CreateWithImage through a non-worker ingress. The local
+	// aerolvm-build/* image must reach the worker the create is placed on.
+	{ID: "UC-92", Title: "CreateWithImage through a non-worker ingress reaches a docker worker", Requires: []Capability{CapCluster, CapDocker}, Implemented: true},
+	// UC-93: the firecracker template lifecycle must work when the API entry
+	// node is not the firecracker worker (templates are per-worker artifacts).
+	{ID: "UC-93", Title: "Firecracker template lifecycle works through a non-FC entry node", Requires: []Capability{CapCluster, CapFirecracker}, Implemented: true},
 }
 
 // byID is a lookup built once for the report generator.

--- a/integration-tests/suite/harness/usecases.go
+++ b/integration-tests/suite/harness/usecases.go
@@ -219,10 +219,10 @@ var Registry = []UseCase{
 	// UC-90: a runtime create must be PLACED on a worker that advertises that
 	// runtime in gossip (not merely "a create happened to succeed").
 	{ID: "UC-90", Title: "Runtime create places on a capability-matching worker", Requires: []Capability{CapCluster}, Implemented: true},
-	// UC-91: a create that omits runtime must resolve to one deterministic
-	// effective runtime cluster-wide — guards a silent default change (e.g. a
-	// gVisor-default deployment quietly downgraded to runc) across the router.
-	{ID: "UC-91", Title: "Unspecified-runtime create has a deterministic effective runtime", Requires: []Capability{CapCluster}, Implemented: true},
+	// UC-91: a create that omits runtime must run under the placement worker's
+	// own configured default (e.g. gvisor), never be silently forced to docker
+	// by the router. Guards the gvisor-by-default isolation contract.
+	{ID: "UC-91", Title: "Unspecified-runtime create is honored, not forced to docker", Requires: []Capability{CapCluster}, Implemented: true},
 	// UC-92: CreateWithImage through a non-worker ingress. The local
 	// aerolvm-build/* image must reach the worker the create is placed on.
 	{ID: "UC-92", Title: "CreateWithImage through a non-worker ingress reaches a docker worker", Requires: []Capability{CapCluster, CapDocker}, Implemented: true},

--- a/integration-tests/suite/regression_fixes_test.go
+++ b/integration-tests/suite/regression_fixes_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/aerol-ai/microvm/integration-tests/suite/harness"
+	microvm "github.com/aerol-ai/microvm/sdk/go/pkg/microvm"
 	sdktypes "github.com/aerol-ai/microvm/sdk/go/pkg/types"
 )
 
@@ -188,4 +189,274 @@ func TestSSHGatewayListensOnPublicHost(t *testing.T) {
 		return
 	}
 	t.Fatalf("SSH gateway never reachable on ingress public host %s: %v (regression: gateway not bound on the ingress role)", addr, lastErr)
+}
+
+// UC-90..93 guard the cluster-hetero ROUTING fix pass. The offline counterpart
+// is internal/cluster/placement_test.go (the SelectPlacement hetero matrix);
+// these confirm the same invariants end to end on the live 8-node cluster,
+// where the SDK only ever talks to the ingress URL.
+
+// placementOwnerView is the slice of /v1/cluster/placements/{id} we assert on:
+// which node currently owns the sandbox.
+type placementOwnerView struct {
+	Owner struct {
+		NodeID string `json:"node_id"`
+	} `json:"owner"`
+}
+
+// heteroRuntimeCaps maps a scenario runtime capability to the runtime string a
+// create requests and a node must advertise to host it. Docker is always
+// present and routed implicitly, so it is not listed here.
+var heteroRuntimeCaps = []struct {
+	cap     harness.Capability
+	runtime string
+}{
+	{harness.CapWasm, "wasm"},
+	{harness.CapFirecracker, "firecracker"},
+	{harness.CapGvisor, "gvisor"},
+}
+
+// wasmModuleRef is the staged WASM module alias a wasm create resolves against.
+// Defaults to the standard "python" alias; AEROL_WASM_MODULE_REF overrides it.
+func wasmModuleRef() string {
+	if v := os.Getenv("AEROL_WASM_MODULE_REF"); v != "" {
+		return v
+	}
+	return "python"
+}
+
+// resolvePlacementOwner polls /v1/cluster/placements/{id} until an owner node is
+// recorded (the FSM commit lands a moment after create returns).
+func resolvePlacementOwner(t *testing.T, c *harness.Client, sandboxID string) string {
+	t.Helper()
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		var pv placementOwnerView
+		err := c.GetJSON(ctx, "/v1/cluster/placements/"+sandboxID, &pv)
+		cancel()
+		if err == nil && pv.Owner.NodeID != "" {
+			return pv.Owner.NodeID
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return ""
+}
+
+// nodeAdvertisesRuntime reports whether nodeID's gossiped capacity lists runtime.
+func nodeAdvertisesRuntime(members capacityView, nodeID, runtime string) bool {
+	for _, m := range members.Members {
+		if m.NodeID != nodeID {
+			continue
+		}
+		for _, rt := range m.Capacity.SupportedRuntimes {
+			if rt == runtime {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// fetchMembers reads /v1/cluster/members with the capacity (supported_runtimes)
+// projection.
+func fetchMembers(t *testing.T, c *harness.Client) capacityView {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	var cv capacityView
+	if err := c.GetJSON(ctx, "/v1/cluster/members", &cv); err != nil {
+		t.Fatalf("get cluster members: %v", err)
+	}
+	return cv
+}
+
+// UC-90 — a create for a specialized runtime must be PLACED on a worker that
+// advertises that runtime in gossip. This is the live confirmation of the
+// offline SelectPlacement hetero matrix: the cluster-hetero failures were
+// creates that landed on a node which could not run the requested runtime (the
+// WASM create routed to a non-WASM worker; the create then failed instead of
+// being forwarded). For each specialized runtime the scenario has, create a
+// sandbox, resolve its owner node, and assert that node advertises the runtime.
+func TestClusterPlacesRuntimeOnCapableWorker(t *testing.T) {
+	harness.Require(t, sc, "UC-90")
+	c := client(t)
+	members := fetchMembers(t, c)
+
+	ran := false
+	for _, rc := range heteroRuntimeCaps {
+		if !sc.Has(rc.cap) {
+			continue
+		}
+		ran = true
+		t.Run(rc.runtime, func(t *testing.T) {
+			opts := sdktypes.CreateSandboxOptions{Name: harness.UniqueName(sc, t), Runtime: rc.runtime}
+			if rc.runtime == "wasm" {
+				// WASM resolves an image/module ref, not a container image.
+				opts.Image = wasmModuleRef()
+			}
+			sb := c.NewSandbox(t, opts)
+			waitRunning(t, sb)
+
+			owner := resolvePlacementOwner(t, c, sb.ID)
+			if owner == "" {
+				t.Fatalf("sandbox %s never got a placement owner", sb.ID)
+			}
+			if !nodeAdvertisesRuntime(members, owner, rc.runtime) {
+				t.Fatalf("%s sandbox placed on %q, which does not advertise runtime %q (regression: create routed to a worker that cannot run it)",
+					rc.runtime, owner, rc.runtime)
+			}
+			t.Logf("runtime %q placed on capable worker %s", rc.runtime, owner)
+		})
+	}
+	if !ran {
+		t.Skip("scenario advertises no specialized runtime capability")
+	}
+}
+
+// UC-91 — a create that omits runtime must resolve to a single, deterministic
+// effective runtime cluster-wide. The hetero routing layer normalizes an
+// omitted runtime before placement; this pins the result so it cannot silently
+// change — e.g. a gVisor-default deployment quietly downgraded to plain runc,
+// or an omitted create resolving as docker on one node and gvisor on another.
+// The expected value is docker unless AEROL_DEFAULT_RUNTIME overrides it; on a
+// deployment whose operator default is gVisor, set that env so this guards the
+// operator's isolation choice rather than masking a downgrade.
+func TestUnspecifiedRuntimeEffectiveRuntimeDeterministic(t *testing.T) {
+	harness.Require(t, sc, "UC-91")
+	c := client(t)
+
+	want := os.Getenv("AEROL_DEFAULT_RUNTIME")
+	if want == "" {
+		want = "docker"
+	}
+
+	// Two omitted-runtime creates must resolve to the same effective runtime and
+	// to the documented default — proving the result is deterministic and not a
+	// function of which worker placement happened to pick.
+	var got []string
+	for i := 0; i < 2; i++ {
+		sb := c.NewSandbox(t, sdktypes.CreateSandboxOptions{Name: harness.UniqueName(sc, t)})
+		waitRunning(t, sb)
+		rt := resolveEffectiveRuntime(t, c, sb.ID)
+		if rt == "" {
+			t.Fatalf("sandbox %s reported no effective runtime", sb.ID)
+		}
+		got = append(got, rt)
+	}
+	if got[0] != got[1] {
+		t.Fatalf("omitted-runtime creates resolved to different runtimes %q and %q (regression: effective runtime depends on placement)", got[0], got[1])
+	}
+	if got[0] != want {
+		t.Fatalf("omitted-runtime effective runtime = %q, want %q (set AEROL_DEFAULT_RUNTIME if the deployment default changed; regression: the cluster default-runtime decision changed silently)", got[0], want)
+	}
+}
+
+// resolveEffectiveRuntime reads the runtime the sandbox actually runs under.
+func resolveEffectiveRuntime(t *testing.T, c *harness.Client, sandboxID string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	var sb struct {
+		Runtime string `json:"runtime"`
+	}
+	if err := c.GetJSON(ctx, "/v1/sandboxes/"+sandboxID, &sb); err != nil {
+		t.Fatalf("get sandbox %s: %v", sandboxID, err)
+	}
+	return sb.Runtime
+}
+
+// UC-92 — CreateWithImage from a non-worker ingress. The SDK talks only to the
+// ingress URL; CreateWithImage builds a local aerolvm-build/* image and then
+// creates a sandbox from it. The cluster-hetero bug was the build landing on
+// the ingress (which can't host the sandbox) and the create then failing with
+// "no worker placement target available". This asserts the sandbox reaches
+// running, the built artifact is present, and the placement owner is a worker
+// that advertises docker.
+func TestCreateWithImageThroughIngress(t *testing.T) {
+	harness.Require(t, sc, "UC-92")
+	c := client(t)
+
+	img := microvm.BaseImage("alpine:3.20").
+		RunCommands("echo created-with-image-92 > /uc92.txt")
+	if err := img.Err(); err != nil {
+		t.Fatalf("build image spec: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
+	defer cancel()
+	sb, err := c.SDK().CreateWithImage(ctx, img, sdktypes.CreateSandboxOptions{
+		Name: harness.UniqueName(sc, t),
+	})
+	if err != nil {
+		t.Fatalf("create with image through ingress: %v (regression: built image not reachable from the placement worker)", err)
+	}
+	t.Cleanup(func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), time.Minute)
+		defer ccancel()
+		_ = c.SDK().Destroy(cctx, sb.ID)
+	})
+	waitRunning(t, sb)
+
+	res, err := sb.ExecCommand(ctx, "cat /uc92.txt")
+	if err != nil {
+		t.Fatalf("exec cat in built-image sandbox: %v", err)
+	}
+	if !strings.Contains(res.Stdout, "created-with-image-92") {
+		t.Fatalf("built artifact missing: stdout = %q", res.Stdout)
+	}
+
+	owner := resolvePlacementOwner(t, c, sb.ID)
+	if owner == "" {
+		t.Fatalf("sandbox %s never got a placement owner", sb.ID)
+	}
+	if !nodeAdvertisesRuntime(fetchMembers(t, c), owner, "docker") {
+		t.Fatalf("built-image sandbox placed on %q, which does not advertise docker (regression: built image created on a node that cannot host it)", owner)
+	}
+}
+
+// UC-93 — the firecracker template lifecycle must work when the API entry node
+// is not the firecracker worker. Templates are per-worker artifacts; the
+// cluster-hetero bug was POST /v1/templates running on the ingress/server node
+// (which has no firecracker) and rejecting with "requires SB_ENABLE_FIRECRACKER".
+// The SDK talks only to the ingress URL, so create -> ready -> list -> get -> delete
+// here exercises the template routing/fan-out path end to end.
+func TestFirecrackerTemplateLifecycleThroughIngress(t *testing.T) {
+	harness.Require(t, sc, "UC-93")
+	c := client(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
+	defer cancel()
+	tmpl, err := c.SDK().CreateTemplate(ctx, sdktypes.CreateTemplateOptions{
+		Image: "docker://alpine:3.20",
+	})
+	if err != nil {
+		t.Fatalf("create template through ingress: %v (regression: template create evaluated on a non-firecracker node)", err)
+	}
+	t.Cleanup(func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), time.Minute)
+		defer ccancel()
+		_ = c.SDK().DeleteTemplate(cctx, tmpl.ID)
+	})
+	waitTemplateReady(t, c, tmpl.ID)
+
+	// List is fanned out across firecracker workers; it must include the
+	// template regardless of which worker built the rootfs.
+	list, err := c.SDK().ListTemplates(ctx)
+	if err != nil {
+		t.Fatalf("list templates through ingress: %v", err)
+	}
+	found := false
+	for _, tl := range list {
+		if tl.ID == tmpl.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("template %s not in ingress-fanned list (regression: list not routed to the firecracker worker)", tmpl.ID)
+	}
+	if _, err := c.SDK().GetTemplate(ctx, tmpl.ID); err != nil {
+		t.Fatalf("get template through ingress: %v (regression: per-id template read not routed to the owning worker)", err)
+	}
 }

--- a/integration-tests/suite/regression_fixes_test.go
+++ b/integration-tests/suite/regression_fixes_test.go
@@ -314,42 +314,46 @@ func TestClusterPlacesRuntimeOnCapableWorker(t *testing.T) {
 	}
 }
 
-// UC-91 — a create that omits runtime must resolve to a single, deterministic
-// effective runtime cluster-wide. The hetero routing layer normalizes an
-// omitted runtime before placement; this pins the result so it cannot silently
-// change — e.g. a gVisor-default deployment quietly downgraded to plain runc,
-// or an omitted create resolving as docker on one node and gvisor on another.
-// The expected value is docker unless AEROL_DEFAULT_RUNTIME overrides it; on a
-// deployment whose operator default is gVisor, set that env so this guards the
-// operator's isolation choice rather than masking a downgrade.
-func TestUnspecifiedRuntimeEffectiveRuntimeDeterministic(t *testing.T) {
+// UC-91 — a create that omits runtime must run under the placement worker's own
+// configured default, never be silently forced to docker by the router. This is
+// the gvisor-by-default isolation contract: the router leaves an omitted runtime
+// empty so the selected worker applies its cfg.Runtime (e.g. gvisor). An omitted
+// runtime is therefore placement-dependent in a heterogeneous cluster (it may
+// run as docker on a docker worker or gvisor on a gvisor worker) — so this does
+// NOT assert a single cluster-wide value. It asserts (a) the effective runtime
+// is one the owner node actually runs, and (b) when the deployment pins a
+// default via AEROL_DEFAULT_RUNTIME (e.g. a gvisor-by-default cluster), the
+// omitted runtime equals it rather than being downgraded to docker.
+func TestUnspecifiedRuntimeHonoredNotForced(t *testing.T) {
 	harness.Require(t, sc, "UC-91")
 	c := client(t)
+	members := fetchMembers(t, c)
 
-	want := os.Getenv("AEROL_DEFAULT_RUNTIME")
-	if want == "" {
-		want = "docker"
-	}
+	sb := c.NewSandbox(t, sdktypes.CreateSandboxOptions{Name: harness.UniqueName(sc, t)})
+	waitRunning(t, sb)
 
-	// Two omitted-runtime creates must resolve to the same effective runtime and
-	// to the documented default — proving the result is deterministic and not a
-	// function of which worker placement happened to pick.
-	var got []string
-	for i := 0; i < 2; i++ {
-		sb := c.NewSandbox(t, sdktypes.CreateSandboxOptions{Name: harness.UniqueName(sc, t)})
-		waitRunning(t, sb)
-		rt := resolveEffectiveRuntime(t, c, sb.ID)
-		if rt == "" {
-			t.Fatalf("sandbox %s reported no effective runtime", sb.ID)
-		}
-		got = append(got, rt)
+	owner := resolvePlacementOwner(t, c, sb.ID)
+	if owner == "" {
+		t.Fatalf("sandbox %s never got a placement owner", sb.ID)
 	}
-	if got[0] != got[1] {
-		t.Fatalf("omitted-runtime creates resolved to different runtimes %q and %q (regression: effective runtime depends on placement)", got[0], got[1])
+	effective := resolveEffectiveRuntime(t, c, sb.ID)
+	if effective == "" {
+		t.Fatalf("sandbox %s reported no effective runtime", sb.ID)
 	}
-	if got[0] != want {
-		t.Fatalf("omitted-runtime effective runtime = %q, want %q (set AEROL_DEFAULT_RUNTIME if the deployment default changed; regression: the cluster default-runtime decision changed silently)", got[0], want)
+	// The effective runtime must be one the owner node actually runs — an omitted
+	// runtime resolves to the worker's own default, never to something the
+	// placement node isn't configured for.
+	if !nodeAdvertisesRuntime(members, owner, effective) {
+		t.Fatalf("omitted-runtime sandbox runs %q on %q, which advertises no such runtime (regression: runtime not honored by the placement node)", effective, owner)
 	}
+	// When the deployment pins a cluster-wide default (a gvisor-by-default
+	// cluster sets AEROL_DEFAULT_RUNTIME=gvisor), an omitted runtime MUST equal
+	// it — the guard that the operator's isolation default is not silently
+	// forced to docker by the router.
+	if want := os.Getenv("AEROL_DEFAULT_RUNTIME"); want != "" && effective != want {
+		t.Fatalf("omitted-runtime effective runtime = %q, want %q (regression: operator default-runtime silently overridden to docker)", effective, want)
+	}
+	t.Logf("omitted-runtime create ran as %q on %s (honored node default)", effective, owner)
 }
 
 // resolveEffectiveRuntime reads the runtime the sandbox actually runs under.

--- a/internal/cluster/placement.go
+++ b/internal/cluster/placement.go
@@ -39,6 +39,9 @@ func capacityRequestFromSpec(spec *models.CreateSandboxRequest) capacity.Request
 	if templateID != "" && runtimeName == "" {
 		runtimeName = models.RuntimeFirecracker
 	}
+	if runtimeName == "" {
+		runtimeName = models.RuntimeDocker
+	}
 	out := capacity.Request{
 		CPU:        cpu,
 		MemoryMB:   mem,

--- a/internal/cluster/placement_test.go
+++ b/internal/cluster/placement_test.go
@@ -536,3 +536,133 @@ func runtimeWorker(prefix string, i int, runtimes []string) Member {
 		},
 	}
 }
+
+// heteroPlacementCluster builds an offline *Cluster whose gossip view mirrors
+// the cluster-hetero integration topology: a dedicated control-plane server and
+// ingress (neither may own a sandbox) plus one worker per specialized runtime.
+// It is the offline guard for the routing bugs behind the cluster-hetero
+// failures (the WASM/template/built-image creates that landed on the wrong
+// node): a create for runtime X must be placed on a worker that advertises X,
+// never on a differently-specialized worker. Returns the cluster plus the
+// runtime->worker-node-id map so tests assert exact placement.
+func heteroPlacementCluster() (*Cluster, map[string]string) {
+	workers := map[string]string{
+		models.RuntimeDocker:      "docker-worker-0",
+		models.RuntimeWasm:        "wasm-worker-0",
+		models.RuntimeFirecracker: "fc-worker-0",
+		models.RuntimeGvisor:      "gvisor-worker-0",
+	}
+	members := []Member{
+		{NodeID: "server-a", APIURL: "http://server-a", Alive: true, Role: config.NodeRoleServer},
+		{NodeID: "ingress-a", APIURL: "http://ingress-a", Alive: true, Role: config.NodeRoleIngress},
+		runtimeWorker("docker-worker-", 0, []string{models.RuntimeDocker}),
+		runtimeWorker("wasm-worker-", 0, []string{models.RuntimeWasm}),
+		runtimeWorker("fc-worker-", 0, []string{models.RuntimeFirecracker}),
+		// A gVisor worker also runs the docker base runtime (mirrors
+		// supportedRuntimesForConfig), so it advertises both.
+		runtimeWorker("gvisor-worker-", 0, []string{models.RuntimeDocker, models.RuntimeGvisor}),
+	}
+	index := newGossipMemberIndex()
+	index.replace(members)
+	c := &Cluster{
+		nodeID: "server-a",
+		apiURL: "http://server-a",
+		fsm:    newPlacementFSM(),
+		gossip: &gossipNode{memberIndex: index},
+	}
+	return c, workers
+}
+
+// TestSelectPlacementHeteroRoutesSpecializedRuntimeToCapableWorker pins the core
+// hetero scheduler invariant: a create that names a specialized runtime is
+// placed only on the worker that runs it. With exactly one capable worker the
+// candidate set is a singleton, so every power-of-two draw must pick it; the
+// loop catches a regression that wrongly widened the candidate set (the failure
+// mode that sent WASM/Firecracker creates to the wrong node in cluster-hetero).
+func TestSelectPlacementHeteroRoutesSpecializedRuntimeToCapableWorker(t *testing.T) {
+	c, workers := heteroPlacementCluster()
+	for _, runtimeName := range []string{models.RuntimeWasm, models.RuntimeFirecracker, models.RuntimeGvisor} {
+		want := workers[runtimeName]
+		for i := 0; i < 100; i++ {
+			target, err := c.SelectPlacement(capacity.Request{CPU: 1, MemoryMB: 100, Runtime: runtimeName})
+			if err != nil {
+				t.Fatalf("runtime %q: SelectPlacement iter %d: %v", runtimeName, i, err)
+			}
+			if target.NodeID != want {
+				t.Fatalf("runtime %q placed on %q, want %q (regression: create routed to a worker that does not run this runtime)",
+					runtimeName, target.NodeID, want)
+			}
+		}
+	}
+}
+
+// TestSelectPlacementHeteroDockerStaysOffSpecializedWorkers asserts a docker
+// create only lands on a docker-capable worker, never on the wasm- or
+// firecracker-only worker.
+func TestSelectPlacementHeteroDockerStaysOffSpecializedWorkers(t *testing.T) {
+	c, workers := heteroPlacementCluster()
+	allowed := map[string]bool{
+		workers[models.RuntimeDocker]: true,
+		workers[models.RuntimeGvisor]: true, // gvisor worker also runs docker
+	}
+	for i := 0; i < 200; i++ {
+		target, err := c.SelectPlacement(capacity.Request{CPU: 1, MemoryMB: 100, Runtime: models.RuntimeDocker})
+		if err != nil {
+			t.Fatalf("SelectPlacement iter %d: %v", i, err)
+		}
+		if !allowed[target.NodeID] {
+			t.Fatalf("docker create placed on %q, want a docker-capable worker %v", target.NodeID, allowed)
+		}
+	}
+}
+
+// TestSelectPlacementHeteroUnspecifiedRuntimeStaysOffSpecializedWorkers is the
+// offline guard for the cluster-hetero default-runtime routing bug: a create
+// that omits runtime must not reach a wasm- or firecracker-only worker (neither
+// can run a plain container image). capacityRequestFromSpec defaults an empty
+// runtime to docker; this pins that default and the placement filter together,
+// end to end — the exact path that previously let an unspecified create land on
+// a specialized worker and fail.
+func TestSelectPlacementHeteroUnspecifiedRuntimeStaysOffSpecializedWorkers(t *testing.T) {
+	c, workers := heteroPlacementCluster()
+	forbidden := map[string]bool{
+		workers[models.RuntimeWasm]:        true,
+		workers[models.RuntimeFirecracker]: true,
+	}
+	req := capacityRequestFromSpec(&models.CreateSandboxRequest{CPU: 1, MemoryMB: 100})
+	if req.Runtime != models.RuntimeDocker {
+		t.Fatalf("capacityRequestFromSpec defaulted runtime to %q, want docker", req.Runtime)
+	}
+	for i := 0; i < 200; i++ {
+		target, err := c.SelectPlacement(req)
+		if err != nil {
+			t.Fatalf("SelectPlacement iter %d: %v", i, err)
+		}
+		if forbidden[target.NodeID] {
+			t.Fatalf("unspecified-runtime create placed on specialized worker %q (regression: an omitted runtime reached a wasm/firecracker-only node)", target.NodeID)
+		}
+	}
+}
+
+// TestSelectPlacementRejectsRuntimeWithNoCapableWorker pins the "503, don't
+// misplace" contract: when no live worker advertises the requested runtime,
+// SelectPlacement returns ErrNoPlacementTarget rather than silently forwarding
+// to an incapable node (which would 5xx at create time after a wasted hop).
+func TestSelectPlacementRejectsRuntimeWithNoCapableWorker(t *testing.T) {
+	members := []Member{
+		{NodeID: "server-a", APIURL: "http://server-a", Alive: true, Role: config.NodeRoleServer},
+		runtimeWorker("docker-worker-", 0, []string{models.RuntimeDocker}),
+	}
+	index := newGossipMemberIndex()
+	index.replace(members)
+	c := &Cluster{
+		nodeID: "server-a",
+		apiURL: "http://server-a",
+		fsm:    newPlacementFSM(),
+		gossip: &gossipNode{memberIndex: index},
+	}
+
+	if _, err := c.SelectPlacement(capacity.Request{CPU: 1, MemoryMB: 100, Runtime: models.RuntimeWasm}); !errors.Is(err, ErrNoPlacementTarget) {
+		t.Fatalf("SelectPlacement for wasm with no wasm worker = %v, want ErrNoPlacementTarget", err)
+	}
+}

--- a/internal/cluster/placement_test.go
+++ b/internal/cluster/placement_test.go
@@ -283,6 +283,13 @@ func TestCapacityRequestFromSpecPopulatesAllAxes(t *testing.T) {
 	}
 }
 
+func TestCapacityRequestFromSpecDefaultsRuntimeToDocker(t *testing.T) {
+	got := capacityRequestFromSpec(&models.CreateSandboxRequest{})
+	if got.Runtime != models.RuntimeDocker {
+		t.Fatalf("Runtime = %q, want docker", got.Runtime)
+	}
+}
+
 // TestCapacityRequestFromSpecGPUCountDefaults pins the documented GPU.Count
 // semantics: 0 means "default 1", -1 ("all") is normalized to 1 for
 // placement scoring (we can't gossip "all" cleanly, and any GPU host with

--- a/pkg/api/clustercreate/clustercreate.go
+++ b/pkg/api/clustercreate/clustercreate.go
@@ -52,6 +52,9 @@ func Prepare(w http.ResponseWriter, r *http.Request, svc *service.Service, req m
 			writeError(w, http.StatusMisdirectedRequest, "cluster: forwarded create reached wrong target")
 			return Decision{}, false
 		}
+		if service.ImageRequiresLocalPlacement(req) {
+			return Decision{}, true
+		}
 		sandboxID := strings.TrimSpace(r.Header.Get(HeaderID))
 		if sandboxID == "" {
 			writeError(w, http.StatusBadRequest, "cluster: forwarded create missing "+HeaderID)
@@ -69,11 +72,42 @@ func Prepare(w http.ResponseWriter, r *http.Request, svc *service.Service, req m
 		return Decision{}, false
 	}
 	if service.ImageRequiresLocalPlacement(req) {
-		if c.IsNodeDrained(c.SelfNodeID()) {
+		if clusterCreateSelfCanOwnSandbox(c) {
+			if c.IsNodeDrained(c.SelfNodeID()) {
+				writeError(w, http.StatusServiceUnavailable, cluster.ErrNoPlacementTarget.Error())
+				return Decision{}, false
+			}
+			return Decision{}, true
+		}
+		target, err := c.SelectPlacement(CapacityRequestFromCreate(req))
+		if err != nil {
+			if errors.Is(err, cluster.ErrNoPlacementTarget) || errors.Is(err, cluster.ErrInvalidTopology) {
+				if errors.Is(err, cluster.ErrInvalidTopology) {
+					w.Header().Set("Retry-After", "300")
+				} else {
+					w.Header().Set("Retry-After", strconv.Itoa(cluster.CapacityRetryAfterSeconds))
+				}
+				writeError(w, http.StatusServiceUnavailable, err.Error())
+				return Decision{}, false
+			}
+			writeError(w, http.StatusInternalServerError, "placement: "+err.Error())
+			return Decision{}, false
+		}
+		if target.IsSelf {
+			if c.IsNodeDrained(c.SelfNodeID()) {
+				writeError(w, http.StatusServiceUnavailable, cluster.ErrNoPlacementTarget.Error())
+				return Decision{}, false
+			}
+			return Decision{}, true
+		}
+		if target.APIURL == "" && target.InternalURL == "" {
 			writeError(w, http.StatusServiceUnavailable, cluster.ErrNoPlacementTarget.Error())
 			return Decision{}, false
 		}
-		return Decision{}, true
+		r.Header.Set(HeaderTarget, target.NodeID)
+		r.Header.Del(HeaderID)
+		c.ForwardHTTP(cluster.Endpoint{InternalURL: target.InternalURL, APIURL: target.APIURL}, w, r)
+		return Decision{}, false
 	}
 
 	target, err := c.SelectPlacement(CapacityRequestFromCreate(req))
@@ -266,7 +300,25 @@ func CapacityRequestFromCreate(req models.CreateSandboxRequest) capacity.Request
 	if disk <= 0 {
 		disk = models.DefaultDiskGB
 	}
-	out := capacity.Request{CPU: cpu, MemoryMB: mem, DiskGB: disk, Runtime: req.Runtime}
+	runtimeName := strings.TrimSpace(req.Runtime)
+	templateID := strings.TrimSpace(req.TemplateID)
+	if templateID != "" && runtimeName == "" {
+		runtimeName = models.RuntimeFirecracker
+	}
+	if runtimeName == "" {
+		runtimeName = models.RuntimeDocker
+	}
+	out := capacity.Request{
+		CPU:        cpu,
+		MemoryMB:   mem,
+		DiskGB:     diskGBForCapacity(disk, runtimeName, req.OverlaySizeGB),
+		Runtime:    runtimeName,
+		TemplateID: templateID,
+		ModuleRef:  models.ModuleRefForCreate(req),
+	}
+	if runtimeName == models.RuntimeWasm {
+		out.MemoryMB += 8
+	}
 	if req.GPUs != nil {
 		want := req.GPUs.Count
 		if want <= 0 {
@@ -276,6 +328,26 @@ func CapacityRequestFromCreate(req models.CreateSandboxRequest) capacity.Request
 		out.GPUVendor = string(req.GPUs.Vendor)
 	}
 	return out
+}
+
+func diskGBForCapacity(base int, runtimeName string, overlaySizeGB int) int {
+	if runtimeName == models.RuntimeFirecracker && overlaySizeGB > 0 {
+		return base + overlaySizeGB
+	}
+	return base
+}
+
+func clusterCreateSelfCanOwnSandbox(c cluster.Client) bool {
+	if c == nil {
+		return true
+	}
+	selfID := c.SelfNodeID()
+	for _, m := range c.Members() {
+		if m.NodeID == selfID {
+			return cluster.CanOwnSandboxRole(m.Role)
+		}
+	}
+	return true
 }
 
 func rollbackCreate(ctx context.Context, svc *service.Service, c cluster.Client, logger *slog.Logger, sandboxID, reservationID string) {

--- a/pkg/api/clustercreate/clustercreate_test.go
+++ b/pkg/api/clustercreate/clustercreate_test.go
@@ -576,6 +576,115 @@ func TestCapacityRequestFromCreateIncludesModuleAndBuiltImageRuntime(t *testing.
 	}
 }
 
+func TestDiskGBForCapacityClustercreate(t *testing.T) {
+	if got := diskGBForCapacity(10, models.RuntimeDocker, 5); got != 10 {
+		t.Fatalf("docker disk = %d, want 10", got)
+	}
+	if got := diskGBForCapacity(10, models.RuntimeFirecracker, 5); got != 15 {
+		t.Fatalf("firecracker overlay disk = %d, want 15", got)
+	}
+}
+
+func TestClusterCreateSelfCanOwnSandboxClustercreate(t *testing.T) {
+	if !clusterCreateSelfCanOwnSandbox(nil) {
+		t.Fatal("nil cluster should default true")
+	}
+	stub := &clusterStub{
+		Noop: cluster.NewNoop("server-a", "", ""),
+		members: []cluster.Member{
+			{NodeID: "server-a", Role: config.NodeRoleServer},
+		},
+	}
+	if clusterCreateSelfCanOwnSandbox(stub) {
+		t.Fatal("server should not own sandboxes")
+	}
+}
+
+func TestPrepareLocalImageCoverageBranches(t *testing.T) {
+	t.Run("forwarded_local_image_without_reservation", func(t *testing.T) {
+		stub := &clusterStub{Noop: cluster.NewNoop("worker-b", "http://worker-b", "")}
+		svc := testServiceWithCluster(stub)
+		r := httptest.NewRequest(http.MethodPost, "/v1/sandboxes", nil)
+		r.Header.Set(HeaderTarget, "worker-b")
+		decision, ok := Prepare(httptest.NewRecorder(), r, svc, models.CreateSandboxRequest{
+			Image: docker.BuiltImageNamespace + "/abc:latest",
+		}, nil, PrepareOptions{})
+		if !ok || decision.ReservationID != "" {
+			t.Fatalf("ok=%v reservation=%q, want local forward accept", ok, decision.ReservationID)
+		}
+	})
+
+	t.Run("non_worker_placement_self_drained", func(t *testing.T) {
+		stub := &clusterStub{
+			Noop:         cluster.NewNoop("server-a", "http://server-a", ""),
+			selectTarget: cluster.PlacementTarget{NodeID: "server-a", IsSelf: true},
+			members: []cluster.Member{
+				{NodeID: "server-a", Role: config.NodeRoleServer},
+			},
+			drained: true,
+		}
+		svc := testServiceWithCluster(stub)
+		var status int
+		_, ok := Prepare(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/v1/sandboxes", nil), svc, models.CreateSandboxRequest{
+			Image: docker.BuiltImageNamespace + "/abc:latest",
+		}, func(_ http.ResponseWriter, code int, _ string) { status = code }, PrepareOptions{})
+		if ok || status != http.StatusServiceUnavailable {
+			t.Fatalf("ok=%v status=%d, want 503", ok, status)
+		}
+	})
+
+	t.Run("non_worker_placement_empty_urls", func(t *testing.T) {
+		stub := &clusterStub{
+			Noop:         cluster.NewNoop("server-a", "http://server-a", ""),
+			selectTarget: cluster.PlacementTarget{NodeID: "worker-b", IsSelf: false},
+			members: []cluster.Member{
+				{NodeID: "server-a", Role: config.NodeRoleServer},
+				{NodeID: "worker-b", Role: config.NodeRoleWorker},
+			},
+		}
+		svc := testServiceWithCluster(stub)
+		var status int
+		_, ok := Prepare(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/v1/sandboxes", nil), svc, models.CreateSandboxRequest{
+			Image: docker.BuiltImageNamespace + "/abc:latest",
+		}, func(_ http.ResponseWriter, code int, _ string) { status = code }, PrepareOptions{})
+		if ok || status != http.StatusServiceUnavailable {
+			t.Fatalf("ok=%v status=%d, want 503", ok, status)
+		}
+	})
+
+	t.Run("non_worker_placement_generic_error", func(t *testing.T) {
+		stub := &clusterStub{
+			Noop:      cluster.NewNoop("server-a", "http://server-a", ""),
+			selectErr: errors.New("boom"),
+			members: []cluster.Member{
+				{NodeID: "server-a", Role: config.NodeRoleServer},
+			},
+		}
+		svc := testServiceWithCluster(stub)
+		var status int
+		_, ok := Prepare(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/v1/sandboxes", nil), svc, models.CreateSandboxRequest{
+			Image: docker.BuiltImageNamespace + "/abc:latest",
+		}, func(_ http.ResponseWriter, code int, _ string) { status = code }, PrepareOptions{})
+		if ok || status != http.StatusInternalServerError {
+			t.Fatalf("ok=%v status=%d, want 500", ok, status)
+		}
+	})
+
+	t.Run("non_worker_server_role_in_members", func(t *testing.T) {
+		stub := &clusterStub{
+			Noop: cluster.NewNoop("server-a", "http://server-a", ""),
+			members: []cluster.Member{
+				{NodeID: "server-a", Role: config.NodeRoleServer},
+			},
+		}
+		svc := testServiceWithCluster(stub)
+		if clusterCreateSelfCanOwnSandbox(stub) {
+			t.Fatal("expected server role to block self ownership")
+		}
+		_ = svc
+	})
+}
+
 func TestPrepare_ReservePaths(t *testing.T) {
 	baseReq := models.CreateSandboxRequest{
 		Image: "private.example.com/app:latest",

--- a/pkg/api/clustercreate/clustercreate_test.go
+++ b/pkg/api/clustercreate/clustercreate_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aerol-ai/microvm/internal/store"
 	"github.com/aerol-ai/microvm/pkg/caddy"
 	"github.com/aerol-ai/microvm/pkg/capacity"
+	"github.com/aerol-ai/microvm/pkg/docker"
 	"github.com/aerol-ai/microvm/pkg/models"
 	"github.com/aerol-ai/microvm/pkg/mounts"
 	"github.com/aerol-ai/microvm/pkg/secrets"
@@ -40,6 +41,7 @@ type clusterStub struct {
 	selectErr    error
 	selectReqs   []capacity.Request
 	drained      bool
+	members      []cluster.Member
 
 	reserveErr   error
 	reserveCalls []reserveCall
@@ -96,6 +98,13 @@ func (s *clusterStub) SelectPlacement(req capacity.Request) (cluster.PlacementTa
 
 func (s *clusterStub) IsNodeDrained(_ string) bool {
 	return s.drained
+}
+
+func (s *clusterStub) Members() []cluster.Member {
+	if s.members != nil {
+		return s.members
+	}
+	return s.Noop.Members()
 }
 
 func (s *clusterStub) ReserveOnTarget(_ context.Context, sandboxID string, target cluster.PlacementTarget, redacted *models.CreateSandboxRequest, secrets cluster.PlacementSecrets, ttl time.Duration) error {
@@ -481,6 +490,36 @@ func TestPrepare_GuardsAndPlacementBranches(t *testing.T) {
 		}
 	})
 
+	t.Run("local_only_image_routes_from_non_worker", func(t *testing.T) {
+		stub := &clusterStub{
+			Noop:         cluster.NewNoop("server-a", "http://server-a", ""),
+			selectTarget: cluster.PlacementTarget{NodeID: "worker-b", APIURL: "http://worker-b", IsSelf: false},
+			members: []cluster.Member{
+				{NodeID: "server-a", APIURL: "http://server-a", Alive: true, Role: config.NodeRoleServer},
+				{NodeID: "worker-b", APIURL: "http://worker-b", Alive: true, Role: config.NodeRoleWorker},
+			},
+		}
+		svc := testServiceWithCluster(stub)
+		decision, ok := Prepare(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/v1/sandboxes", nil), svc, models.CreateSandboxRequest{
+			Image: docker.BuiltImageNamespace + "/abc:latest",
+		}, nil, PrepareOptions{})
+		if ok {
+			t.Fatal("Prepare returned ok=true, want false after forwarding")
+		}
+		if decision.ReservationID != "" {
+			t.Fatalf("ReservationID = %q, want empty", decision.ReservationID)
+		}
+		if stub.forwards != 1 {
+			t.Fatalf("ForwardHTTP calls = %d, want 1", stub.forwards)
+		}
+		if len(stub.reserveCalls) != 0 {
+			t.Fatalf("ReserveOnTarget calls = %d, want 0 for local-only image", len(stub.reserveCalls))
+		}
+		if len(stub.selectReqs) != 1 || stub.selectReqs[0].Runtime != models.RuntimeDocker {
+			t.Fatalf("placement request = %+v, want docker runtime", stub.selectReqs)
+		}
+	})
+
 	t.Run("select_placement_error_shapes", func(t *testing.T) {
 		tests := []struct {
 			name           string
@@ -514,6 +553,27 @@ func TestPrepare_GuardsAndPlacementBranches(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestCapacityRequestFromCreateIncludesModuleAndBuiltImageRuntime(t *testing.T) {
+	def := CapacityRequestFromCreate(models.CreateSandboxRequest{})
+	if def.Runtime != models.RuntimeDocker {
+		t.Fatalf("default runtime = %q, want docker", def.Runtime)
+	}
+
+	wasm := CapacityRequestFromCreate(models.CreateSandboxRequest{
+		Runtime:   models.RuntimeWasm,
+		ModuleRef: "python",
+		MemoryMB:  128,
+	})
+	if wasm.ModuleRef != "python" || wasm.MemoryMB != 136 {
+		t.Fatalf("wasm capacity request = %+v, want module ref and overhead", wasm)
+	}
+
+	built := CapacityRequestFromCreate(models.CreateSandboxRequest{Image: docker.BuiltImageNamespace + "/abc:latest"})
+	if built.Runtime != models.RuntimeDocker {
+		t.Fatalf("built image runtime = %q, want docker", built.Runtime)
+	}
 }
 
 func TestPrepare_ReservePaths(t *testing.T) {

--- a/pkg/api/v1/build.go
+++ b/pkg/api/v1/build.go
@@ -1,17 +1,24 @@
 package v1
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"time"
 
+	"github.com/aerol-ai/microvm/internal/cluster"
 	"github.com/aerol-ai/microvm/pkg/api/apihttp"
 	"github.com/aerol-ai/microvm/pkg/docker"
 	"github.com/aerol-ai/microvm/pkg/models"
 )
+
+const clusterImageBuildFanoutHeader = "X-Cluster-Image-Build-Fanout"
 
 // buildContextWithTimeout returns a child context with the configured build
 // timeout. A timeout of zero falls back to plain cancel — the parent's
@@ -44,6 +51,135 @@ type buildImagePushSpec struct {
 type buildImageResponse struct {
 	Image  string `json:"image"`
 	Pushed string `json:"pushed,omitempty"`
+}
+
+func (h *handlers) clusterBuildImageWrap(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get(clusterImageBuildFanoutHeader) == "1" {
+		h.buildImage(w, r)
+		return
+	}
+	if h.deps.Service == nil {
+		h.buildImage(w, r)
+		return
+	}
+	c := h.deps.Service.Cluster()
+	if c == nil {
+		h.buildImage(w, r)
+		return
+	}
+
+	raw, err := io.ReadAll(r.Body)
+	_ = r.Body.Close()
+	if err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, "read body: "+err.Error())
+		return
+	}
+	var parsed buildImageRequest
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &parsed); err != nil {
+			apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
+			return
+		}
+	}
+	r.Body = io.NopCloser(bytes.NewReader(raw))
+	r.ContentLength = int64(len(raw))
+
+	// Explicit push/context builds have their own distribution semantics. The
+	// fanout is for the SDK CreateWithImage path, which returns a local-only
+	// aerolvm-build/* tag and immediately creates a Docker sandbox from it.
+	if parsed.Push != nil || len(parsed.ContextHashes) > 0 {
+		h.buildImage(w, r)
+		return
+	}
+	if clusterSelfCanOwnSandbox(c) {
+		h.buildImage(w, r)
+		return
+	}
+
+	type target struct {
+		member cluster.Member
+		self   bool
+	}
+	selfID := c.SelfNodeID()
+	targets := make([]target, 0)
+	for _, m := range c.Members() {
+		if !m.Alive || m.NodeID == "" || c.IsNodeDrained(m.NodeID) {
+			continue
+		}
+		if !clusterMemberCanOwnSandbox(m.Role) || !clusterMemberSupportsRuntime(m, models.RuntimeDocker) {
+			continue
+		}
+		isSelf := m.NodeID == selfID
+		if !isSelf && m.APIURL == "" {
+			continue
+		}
+		targets = append(targets, target{member: m, self: isSelf})
+	}
+	if len(targets) == 0 || (len(targets) == 1 && targets[0].self) {
+		h.buildImage(w, r)
+		return
+	}
+
+	var firstStatus int
+	var firstHeader http.Header
+	var firstBody []byte
+	for _, t := range targets {
+		status, header, body, err := h.runImageBuildOnTarget(r, raw, t.member, t.self)
+		if err != nil {
+			if h.deps.Logger != nil {
+				h.deps.Logger.Warn("cluster image build fanout failed", "node", t.member.NodeID, "err", err)
+			}
+			apihttp.WriteError(w, http.StatusBadGateway, "cluster image build failed on "+t.member.NodeID+": "+err.Error())
+			return
+		}
+		if status != http.StatusOK {
+			apihttp.WriteError(w, http.StatusBadGateway, "cluster image build failed on "+t.member.NodeID+": "+strings.TrimSpace(string(body)))
+			return
+		}
+		if firstStatus == 0 {
+			firstStatus = status
+			firstHeader = header
+			firstBody = body
+		}
+	}
+	copyHeaderValues(w.Header(), firstHeader)
+	w.WriteHeader(firstStatus)
+	_, _ = w.Write(firstBody)
+}
+
+func (h *handlers) runImageBuildOnTarget(parent *http.Request, raw []byte, m cluster.Member, self bool) (int, http.Header, []byte, error) {
+	if self {
+		req := parent.Clone(parent.Context())
+		req.Body = io.NopCloser(bytes.NewReader(raw))
+		req.ContentLength = int64(len(raw))
+		req.Header = parent.Header.Clone()
+		req.Header.Set(clusterImageBuildFanoutHeader, "1")
+		rr := httptest.NewRecorder()
+		h.buildImage(rr, req)
+		return rr.Code, rr.Header(), rr.Body.Bytes(), nil
+	}
+	req, err := http.NewRequestWithContext(parent.Context(), http.MethodPost,
+		clusterPeerURL(m.APIURL, PathPrefix+"/images/build"), bytes.NewReader(raw))
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	req.Header.Set(clusterImageBuildFanoutHeader, "1")
+	if auth := parent.Header.Get("Authorization"); auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+	if ct := parent.Header.Get("Content-Type"); ct != "" {
+		req.Header.Set("Content-Type", ct)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	return resp.StatusCode, resp.Header.Clone(), body, nil
 }
 
 func (h *handlers) buildImage(w http.ResponseWriter, r *http.Request) {

--- a/pkg/api/v1/build_test.go
+++ b/pkg/api/v1/build_test.go
@@ -4,13 +4,20 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/aerol-ai/microvm/internal/cluster"
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/internal/service"
+	"github.com/aerol-ai/microvm/pkg/capacity"
 	"github.com/aerol-ai/microvm/pkg/docker"
+	"github.com/aerol-ai/microvm/pkg/models"
 )
 
 type fakeImageBuilder struct {
@@ -101,6 +108,147 @@ func TestBuildImageReturnsContentAddressedTag(t *testing.T) {
 	}
 	if len(builder.builds) != 1 || builder.builds[0].Tag != wantTag {
 		t.Fatalf("unexpected build calls: %+v", builder.builds)
+	}
+}
+
+func TestClusterBuildImageWrapFansOutToDockerWorkers(t *testing.T) {
+	dockerfile := "FROM alpine\nRUN echo hi"
+	var remoteSeen bool
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		remoteSeen = true
+		if got := r.Header.Get(clusterImageBuildFanoutHeader); got != "1" {
+			t.Fatalf("%s = %q, want 1", clusterImageBuildFanoutHeader, got)
+		}
+		var req buildImageRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode remote request: %v", err)
+		}
+		apiResp := buildImageResponse{Image: docker.BuildTagFor(req.DockerfileContent, nil)}
+		_ = json.NewEncoder(w).Encode(apiResp)
+	}))
+	defer remote.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	svc := service.New(config.Config{EnableCluster: true, NodeRole: config.NodeRoleServer}, logger, nil, nil, nil, nil, nil, nil, nil)
+	svc.AttachCluster(&membersStubCluster{
+		Noop: cluster.NewNoop("ingress-a", "http://ingress-a", ""),
+		members: []cluster.Member{
+			{NodeID: "ingress-a", APIURL: "http://ingress-a", Alive: true, Role: config.NodeRoleServer},
+			{
+				NodeID: "worker-docker", APIURL: remote.URL, Alive: true, Role: config.NodeRoleWorker,
+				Capacity: capacity.Snapshot{SupportedRuntimes: []string{models.RuntimeDocker}},
+			},
+			{
+				NodeID: "worker-fc", APIURL: "http://fc.invalid", Alive: true, Role: config.NodeRoleWorker,
+				Capacity: capacity.Snapshot{SupportedRuntimes: []string{models.RuntimeFirecracker}},
+			},
+		},
+	})
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, Deps{
+		Service: svc,
+		Logger:  logger,
+		Auth:    func(h http.Handler) http.Handler { return h },
+	})
+
+	body, _ := json.Marshal(buildImageRequest{DockerfileContent: dockerfile})
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/v1/images/build", strings.NewReader(string(body))))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", rr.Code, rr.Body.String())
+	}
+	if !remoteSeen {
+		t.Fatal("remote docker worker did not receive build fanout")
+	}
+	var resp buildImageResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if want := docker.BuildTagFor(dockerfile, nil); resp.Image != want {
+		t.Fatalf("Image = %q, want %q", resp.Image, want)
+	}
+}
+
+func TestClusterBuildImageWrapSkipsFanoutWhenSelfCanOwn(t *testing.T) {
+	dockerfile := "FROM alpine\nRUN echo local"
+	var remoteSeen bool
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		remoteSeen = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer remote.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	svc := service.New(config.Config{EnableCluster: true, NodeRole: config.NodeRoleMixed}, logger, nil, nil, nil, nil, nil, nil, nil)
+	svc.AttachCluster(&membersStubCluster{
+		Noop: cluster.NewNoop("mixed-a", "http://mixed-a", ""),
+		members: []cluster.Member{
+			{NodeID: "mixed-a", APIURL: "http://mixed-a", Alive: true, Role: config.NodeRoleMixed},
+			{
+				NodeID: "worker-docker", APIURL: remote.URL, Alive: true, Role: config.NodeRoleWorker,
+				Capacity: capacity.Snapshot{SupportedRuntimes: []string{models.RuntimeDocker}},
+			},
+		},
+	})
+	builder := &fakeImageBuilder{}
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, Deps{
+		Service: svc,
+		Logger:  logger,
+		Builder: builder,
+		Auth:    func(h http.Handler) http.Handler { return h },
+	})
+
+	body, _ := json.Marshal(buildImageRequest{DockerfileContent: dockerfile})
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/v1/images/build", strings.NewReader(string(body))))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", rr.Code, rr.Body.String())
+	}
+	if remoteSeen {
+		t.Fatal("remote worker received build fanout even though this node can own the follow-up create")
+	}
+	if len(builder.builds) != 1 {
+		t.Fatalf("local build calls = %d, want 1", len(builder.builds))
+	}
+}
+
+func TestClusterBuildImageWrapReturnsBadGatewayWhenPeerBuildFails(t *testing.T) {
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "remote build failed", http.StatusInternalServerError)
+	}))
+	defer remote.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	svc := service.New(config.Config{EnableCluster: true, NodeRole: config.NodeRoleServer}, logger, nil, nil, nil, nil, nil, nil, nil)
+	svc.AttachCluster(&membersStubCluster{
+		Noop: cluster.NewNoop("ingress-a", "http://ingress-a", ""),
+		members: []cluster.Member{
+			{NodeID: "ingress-a", APIURL: "http://ingress-a", Alive: true, Role: config.NodeRoleServer},
+			{
+				NodeID: "worker-docker", APIURL: remote.URL, Alive: true, Role: config.NodeRoleWorker,
+				Capacity: capacity.Snapshot{SupportedRuntimes: []string{models.RuntimeDocker}},
+			},
+		},
+	})
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, Deps{
+		Service: svc,
+		Logger:  logger,
+		Auth:    func(h http.Handler) http.Handler { return h },
+	})
+
+	body, _ := json.Marshal(buildImageRequest{DockerfileContent: "FROM alpine"})
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/v1/images/build", strings.NewReader(string(body))))
+
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusBadGateway, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "worker-docker") || !strings.Contains(rr.Body.String(), "remote build failed") {
+		t.Fatalf("body = %q, want worker id and peer error", rr.Body.String())
 	}
 }
 

--- a/pkg/api/v1/cluster_handler.go
+++ b/pkg/api/v1/cluster_handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aerol-ai/microvm/internal/store"
 	"github.com/aerol-ai/microvm/pkg/api/apihttp"
 	"github.com/aerol-ai/microvm/pkg/capacity"
+	"github.com/aerol-ai/microvm/pkg/docker"
 	"github.com/aerol-ai/microvm/pkg/models"
 )
 
@@ -154,6 +155,14 @@ func (h *handlers) clusterCreateWrap(w http.ResponseWriter, r *http.Request) {
 			apihttp.WriteError(w, http.StatusMisdirectedRequest, "cluster: forwarded create reached wrong target")
 			return
 		}
+		// Local-only image creates cannot use the reservation-first flow: the
+		// image tag is expected to exist on the selected worker already. A
+		// cluster router may still forward these off an ingress/server node, so
+		// accept a target-pinned request without X-Cluster-Create-ID.
+		if service.ImageRequiresLocalPlacement(req) {
+			h.createSandboxOnSelectedNode(w, r, req, "")
+			return
+		}
 		// Reservation-first: a forwarded create MUST carry the ID the router
 		// minted before opReserve, so CreateSandboxWithID + RecordPlacement
 		// promote run against the same row. A missing header means the request
@@ -190,11 +199,43 @@ func (h *handlers) clusterCreateWrap(w http.ResponseWriter, r *http.Request) {
 	r.ContentLength = int64(len(normalizedRaw))
 
 	if service.ImageRequiresLocalPlacement(req) {
-		if c.IsNodeDrained(c.SelfNodeID()) {
-			apihttp.WriteError(w, http.StatusServiceUnavailable, cluster.ErrNoPlacementTarget.Error())
+		if clusterSelfCanOwnSandbox(c) {
+			if c.IsNodeDrained(c.SelfNodeID()) {
+				apihttp.WriteError(w, http.StatusServiceUnavailable, cluster.ErrNoPlacementTarget.Error())
+				return
+			}
+			h.createSandboxOnSelectedNode(w, r, req, "")
 			return
 		}
-		h.createSandboxOnSelectedNode(w, r, req, "")
+		target, err := c.SelectPlacement(capacityRequestFromCreate(req))
+		if err != nil {
+			if errors.Is(err, cluster.ErrNoPlacementTarget) || errors.Is(err, cluster.ErrInvalidTopology) {
+				if errors.Is(err, cluster.ErrInvalidTopology) {
+					w.Header().Set("Retry-After", "300")
+				} else {
+					w.Header().Set("Retry-After", strconv.Itoa(cluster.CapacityRetryAfterSeconds))
+				}
+				apihttp.WriteError(w, http.StatusServiceUnavailable, err.Error())
+				return
+			}
+			apihttp.WriteError(w, http.StatusInternalServerError, "placement: "+err.Error())
+			return
+		}
+		if target.IsSelf {
+			if c.IsNodeDrained(c.SelfNodeID()) {
+				apihttp.WriteError(w, http.StatusServiceUnavailable, cluster.ErrNoPlacementTarget.Error())
+				return
+			}
+			h.createSandboxOnSelectedNode(w, r, req, "")
+			return
+		}
+		if strings.HasPrefix(strings.TrimSpace(req.Image), docker.BuiltImageNamespace+"/") && h.deps.Logger != nil {
+			h.deps.Logger.Info("cluster create: forwarding built local image to selected worker",
+				"image", req.Image, "target", target.NodeID)
+		}
+		r.Header.Set(clusterCreateTargetHeader, target.NodeID)
+		r.Header.Del(clusterCreateIDHeader)
+		c.ForwardHTTP(cluster.Endpoint{InternalURL: target.InternalURL, APIURL: target.APIURL}, w, r)
 		return
 	}
 
@@ -1448,12 +1489,19 @@ func capacityRequestFromCreate(req models.CreateSandboxRequest) capacity.Request
 	if templateID != "" && runtimeName == "" {
 		runtimeName = models.RuntimeFirecracker
 	}
+	if runtimeName == "" {
+		runtimeName = models.RuntimeDocker
+	}
 	out := capacity.Request{
 		CPU:        cpu,
 		MemoryMB:   mem,
 		DiskGB:     diskGBForCapacity(disk, runtimeName, req.OverlaySizeGB),
 		Runtime:    runtimeName,
 		TemplateID: templateID,
+		ModuleRef:  models.ModuleRefForCreate(req),
+	}
+	if runtimeName == models.RuntimeWasm {
+		out.MemoryMB += 8
 	}
 	// GPUs == nil means "no GPU"; a non-nil GPURequest with Count <= 0 is
 	// the documented "default 1" path (see GPURequest.Count comment in

--- a/pkg/api/v1/cluster_handler_test.go
+++ b/pkg/api/v1/cluster_handler_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aerol-ai/microvm/internal/service"
 	storepkg "github.com/aerol-ai/microvm/internal/store"
 	"github.com/aerol-ai/microvm/pkg/capacity"
+	"github.com/aerol-ai/microvm/pkg/docker"
 	"github.com/aerol-ai/microvm/pkg/models"
 )
 
@@ -29,6 +30,7 @@ type createForwardCluster struct {
 	forwardedPeer      string
 	forwardedTarget    string
 	forwardedCreateID  string
+	forwardedBody      string
 	selectPlacementHit int
 	selectRequests     []capacity.Request
 	selectErr          error
@@ -36,6 +38,8 @@ type createForwardCluster struct {
 	reserveErr   error
 	reserveCalls []reserveCall
 	cancelCalls  []string
+	members      []cluster.Member
+	drained      map[string]bool
 }
 
 type reserveCall struct {
@@ -65,6 +69,17 @@ func (c *createForwardCluster) CancelReservation(_ context.Context, sandboxID st
 	return nil
 }
 
+func (c *createForwardCluster) Members() []cluster.Member {
+	if c.members != nil {
+		return c.members
+	}
+	return c.Noop.Members()
+}
+
+func (c *createForwardCluster) IsNodeDrained(nodeID string) bool {
+	return c.drained != nil && c.drained[nodeID]
+}
+
 func (c *createForwardCluster) ForwardHTTP(target cluster.Endpoint, w http.ResponseWriter, r *http.Request) {
 	// Prefer the internal channel for assertion purposes (matches the
 	// production preference order) so tests that exercise the mTLS path can
@@ -78,6 +93,9 @@ func (c *createForwardCluster) ForwardHTTP(target cluster.Endpoint, w http.Respo
 	}
 	c.forwardedTarget = r.Header.Get(clusterCreateTargetHeader)
 	c.forwardedCreateID = r.Header.Get(clusterCreateIDHeader)
+	if body, err := io.ReadAll(r.Body); err == nil {
+		c.forwardedBody = string(body)
+	}
 	w.WriteHeader(http.StatusAccepted)
 }
 
@@ -163,6 +181,38 @@ func TestClusterCreateWrapTemplateIDImpliesFirecrackerPlacement(t *testing.T) {
 	}
 }
 
+func TestCapacityRequestFromCreateIncludesWasmModuleRef(t *testing.T) {
+	got := capacityRequestFromCreate(models.CreateSandboxRequest{
+		Runtime:   models.RuntimeWasm,
+		ModuleRef: "python",
+		MemoryMB:  128,
+	})
+
+	if got.Runtime != models.RuntimeWasm || got.ModuleRef != "python" {
+		t.Fatalf("placement runtime/module = %q/%q, want wasm/python", got.Runtime, got.ModuleRef)
+	}
+	if got.MemoryMB != 136 {
+		t.Fatalf("placement MemoryMB = %d, want request memory plus wasm overhead", got.MemoryMB)
+	}
+}
+
+func TestCapacityRequestFromCreateTreatsBuiltImagesAsDocker(t *testing.T) {
+	got := capacityRequestFromCreate(models.CreateSandboxRequest{Image: docker.BuiltImageNamespace + "/abc:latest"})
+	if got.Runtime != models.RuntimeDocker {
+		t.Fatalf("placement Runtime = %q, want docker for built local image", got.Runtime)
+	}
+}
+
+func TestNormalizeCreateRuntimeForPlacementPreservesHostDefault(t *testing.T) {
+	req := models.CreateSandboxRequest{Image: "alpine:3.20"}
+	if err := normalizeCreateRuntimeForPlacement(&req); err != nil {
+		t.Fatalf("normalizeCreateRuntimeForPlacement: %v", err)
+	}
+	if req.Runtime != "" {
+		t.Fatalf("Runtime = %q, want empty so the selected worker applies its configured default", req.Runtime)
+	}
+}
+
 func TestClusterCreateWrapRejectsTemplateIDWithDockerRuntimeBeforePlacement(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	svc := service.New(config.Config{}, logger, nil, nil, nil, nil, nil, nil, nil)
@@ -188,6 +238,35 @@ func TestClusterCreateWrapRejectsTemplateIDWithDockerRuntimeBeforePlacement(t *t
 	}
 	if !strings.Contains(rr.Body.String(), "template_id requires runtime") {
 		t.Fatalf("body = %q, want template_id runtime validation", rr.Body.String())
+	}
+}
+
+func TestClusterCreateWrapForwardsUnspecifiedRuntimeUnchanged(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	svc := service.New(config.Config{}, logger, nil, nil, nil, nil, nil, nil, nil)
+	fakeCluster := &createForwardCluster{
+		Noop:   cluster.NewNoop("router", "http://router", ""),
+		target: cluster.PlacementTarget{NodeID: "worker-gvisor", APIURL: "http://worker-gvisor:21212", IsSelf: false},
+	}
+	svc.AttachCluster(fakeCluster)
+	h := &handlers{deps: Deps{Service: svc, Logger: logger}}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/sandboxes", strings.NewReader(`{"image":"alpine:3.20"}`))
+	rr := httptest.NewRecorder()
+	h.clusterCreateWrap(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d: %s", rr.Code, http.StatusAccepted, rr.Body.String())
+	}
+	if len(fakeCluster.selectRequests) != 1 || fakeCluster.selectRequests[0].Runtime != models.RuntimeDocker {
+		t.Fatalf("placement request = %+v, want docker filter for omitted runtime", fakeCluster.selectRequests)
+	}
+	var forwarded models.CreateSandboxRequest
+	if err := json.Unmarshal([]byte(fakeCluster.forwardedBody), &forwarded); err != nil {
+		t.Fatalf("decode forwarded body %q: %v", fakeCluster.forwardedBody, err)
+	}
+	if forwarded.Runtime != "" {
+		t.Fatalf("forwarded Runtime = %q, want empty so worker default is preserved", forwarded.Runtime)
 	}
 }
 
@@ -363,6 +442,48 @@ func TestClusterCreateWrapKeepsLocalOnlyImagesOnReceivingNode(t *testing.T) {
 	}
 	if fakeCluster.forwardedPeer != "" {
 		t.Fatalf("ForwardHTTP fired with peer %q; local-only image must not be forwarded", fakeCluster.forwardedPeer)
+	}
+}
+
+func TestClusterCreateWrapRoutesLocalOnlyImageOffNonWorkerNode(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	svc := service.New(config.Config{EnableCluster: true, NodeRole: config.NodeRoleServer}, logger, nil, nil, nil, nil, nil, nil, nil)
+	fakeCluster := &createForwardCluster{
+		Noop:   cluster.NewNoop("server-a", "http://server-a", ""),
+		target: cluster.PlacementTarget{NodeID: "worker-b", APIURL: "http://worker-b:21212", IsSelf: false},
+		members: []cluster.Member{
+			{NodeID: "server-a", APIURL: "http://server-a", Alive: true, Role: config.NodeRoleServer},
+			{NodeID: "worker-b", APIURL: "http://worker-b:21212", Alive: true, Role: config.NodeRoleWorker},
+		},
+	}
+	svc.AttachCluster(fakeCluster)
+	h := &handlers{deps: Deps{Service: svc, Logger: logger}}
+
+	body := `{"image":"` + docker.BuiltImageNamespace + `/abc:latest"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sandboxes", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.clusterCreateWrap(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d: %s", rr.Code, http.StatusAccepted, rr.Body.String())
+	}
+	if fakeCluster.selectPlacementHit != 1 {
+		t.Fatalf("SelectPlacement calls = %d, want 1", fakeCluster.selectPlacementHit)
+	}
+	if fakeCluster.forwardedPeer != "http://worker-b:21212" {
+		t.Fatalf("forwarded peer = %q, want worker-b", fakeCluster.forwardedPeer)
+	}
+	if fakeCluster.forwardedTarget != "worker-b" {
+		t.Fatalf("%s = %q, want worker-b", clusterCreateTargetHeader, fakeCluster.forwardedTarget)
+	}
+	if fakeCluster.forwardedCreateID != "" {
+		t.Fatalf("%s = %q, want empty for local-only image forward", clusterCreateIDHeader, fakeCluster.forwardedCreateID)
+	}
+	if len(fakeCluster.reserveCalls) != 0 {
+		t.Fatalf("ReserveOnTarget calls = %d, want 0 for local-only image", len(fakeCluster.reserveCalls))
+	}
+	if len(fakeCluster.selectRequests) != 1 || fakeCluster.selectRequests[0].Runtime != models.RuntimeDocker {
+		t.Fatalf("placement request = %+v, want docker runtime", fakeCluster.selectRequests)
 	}
 }
 

--- a/pkg/api/v1/cluster_handler_test.go
+++ b/pkg/api/v1/cluster_handler_test.go
@@ -211,6 +211,15 @@ func TestNormalizeCreateRuntimeForPlacementPreservesHostDefault(t *testing.T) {
 	if req.Runtime != "" {
 		t.Fatalf("Runtime = %q, want empty so the selected worker applies its configured default", req.Runtime)
 	}
+	// The two halves of the gvisor-by-default design must hold together: the
+	// forwarded runtime stays empty (above) AND placement still filters by docker
+	// (here). A "fix" that drops both defaults would reintroduce the misrouting
+	// bug — an omitted-runtime create scoring onto a wasm/firecracker-only
+	// worker. A gvisor node advertises "docker" too, so docker filtering keeps the
+	// create on a container-capable worker without forcing its runtime.
+	if got := capacityRequestFromCreate(req); got.Runtime != models.RuntimeDocker {
+		t.Fatalf("placement filter runtime = %q, want docker", got.Runtime)
+	}
 }
 
 func TestClusterCreateWrapRejectsTemplateIDWithDockerRuntimeBeforePlacement(t *testing.T) {

--- a/pkg/api/v1/cluster_helpers.go
+++ b/pkg/api/v1/cluster_helpers.go
@@ -1,0 +1,46 @@
+package v1
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/aerol-ai/microvm/internal/cluster"
+)
+
+func clusterMemberSupportsRuntime(m cluster.Member, runtimeName string) bool {
+	runtimeName = strings.TrimSpace(runtimeName)
+	if runtimeName == "" || len(m.Capacity.SupportedRuntimes) == 0 {
+		return true
+	}
+	for _, r := range m.Capacity.SupportedRuntimes {
+		if r == runtimeName {
+			return true
+		}
+	}
+	return false
+}
+
+func clusterSelfCanOwnSandbox(c cluster.Client) bool {
+	if c == nil {
+		return true
+	}
+	selfID := c.SelfNodeID()
+	for _, m := range c.Members() {
+		if m.NodeID == selfID {
+			return clusterMemberCanOwnSandbox(m.Role)
+		}
+	}
+	return true
+}
+
+func clusterPeerURL(apiURL, requestURI string) string {
+	return strings.TrimRight(apiURL, "/") + requestURI
+}
+
+func copyHeaderValues(dst, src http.Header) {
+	for key, values := range src {
+		for _, value := range values {
+			dst.Add(key, value)
+		}
+	}
+}

--- a/pkg/api/v1/cluster_routing_coverage_test.go
+++ b/pkg/api/v1/cluster_routing_coverage_test.go
@@ -1,0 +1,592 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aerol-ai/microvm/internal/cluster"
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/internal/service"
+	"github.com/aerol-ai/microvm/pkg/capacity"
+	"github.com/aerol-ai/microvm/pkg/docker"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+type errReadCloser struct{}
+
+func (errReadCloser) Read([]byte) (int, error) { return 0, errors.New("read failed") }
+func (errReadCloser) Close() error             { return nil }
+
+type drainableMembersCluster struct {
+	membersStubCluster
+	drained map[string]bool
+}
+
+func (c *drainableMembersCluster) IsNodeDrained(nodeID string) bool {
+	return c.drained != nil && c.drained[nodeID]
+}
+
+func TestClusterHelpersCoverage(t *testing.T) {
+	if !clusterMemberSupportsRuntime(cluster.Member{}, "") {
+		t.Fatal("empty runtime should match")
+	}
+	if !clusterMemberSupportsRuntime(cluster.Member{
+		Capacity: capacity.Snapshot{SupportedRuntimes: []string{models.RuntimeDocker}},
+	}, models.RuntimeDocker) {
+		t.Fatal("docker runtime should match")
+	}
+	if clusterMemberSupportsRuntime(cluster.Member{
+		Capacity: capacity.Snapshot{SupportedRuntimes: []string{models.RuntimeFirecracker}},
+	}, models.RuntimeDocker) {
+		t.Fatal("docker runtime should not match firecracker-only member")
+	}
+
+	if !clusterSelfCanOwnSandbox(nil) {
+		t.Fatal("nil cluster should allow self ownership")
+	}
+	serverCluster := &membersStubCluster{
+		Noop: cluster.NewNoop("server-a", "http://server-a", ""),
+		members: []cluster.Member{
+			{NodeID: "server-a", Role: config.NodeRoleServer},
+		},
+	}
+	if clusterSelfCanOwnSandbox(serverCluster) {
+		t.Fatal("server role should not own sandboxes")
+	}
+	workerCluster := &membersStubCluster{
+		Noop: cluster.NewNoop("worker-a", "http://worker-a", ""),
+		members: []cluster.Member{
+			{NodeID: "worker-a", Role: config.NodeRoleWorker},
+		},
+	}
+	if !clusterSelfCanOwnSandbox(workerCluster) {
+		t.Fatal("worker role should own sandboxes")
+	}
+	if !clusterSelfCanOwnSandbox(&membersStubCluster{Noop: cluster.NewNoop("orphan", "", "")}) {
+		t.Fatal("missing self member should default to true")
+	}
+}
+
+func TestClusterTemplatePeersFiltersMembers(t *testing.T) {
+	if clusterTemplatePeers(nil) != nil {
+		t.Fatal("nil cluster should return nil peers")
+	}
+	c := &drainableMembersCluster{
+		membersStubCluster: membersStubCluster{
+			Noop: cluster.NewNoop("server-a", "http://server-a", ""),
+			members: []cluster.Member{
+				{NodeID: "server-a", APIURL: "http://server-a", Alive: true, Role: config.NodeRoleServer},
+				{NodeID: "dead", APIURL: "http://dead", Alive: false, Role: config.NodeRoleWorker},
+				{NodeID: "drained", APIURL: "http://drained", Alive: true, Role: config.NodeRoleWorker, Capacity: capacity.Snapshot{SupportedRuntimes: []string{models.RuntimeFirecracker}}},
+				{NodeID: "docker-only", APIURL: "http://docker-only", Alive: true, Role: config.NodeRoleWorker, Capacity: capacity.Snapshot{SupportedRuntimes: []string{models.RuntimeDocker}}},
+				{NodeID: "fc-peer", APIURL: "http://fc-peer", Alive: true, Role: config.NodeRoleWorker, Capacity: capacity.Snapshot{SupportedRuntimes: []string{models.RuntimeFirecracker}}},
+			},
+		},
+		drained: map[string]bool{"drained": true},
+	}
+	peers := clusterTemplatePeers(c)
+	if len(peers) != 1 || peers[0].NodeID != "fc-peer" {
+		t.Fatalf("peers = %+v, want only fc-peer", peers)
+	}
+}
+
+func TestClusterBuildImageWrapCoverageBranches(t *testing.T) {
+	dockerfile := "FROM alpine\nRUN echo hi"
+	body, _ := json.Marshal(buildImageRequest{DockerfileContent: dockerfile})
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	builder := &fakeImageBuilder{}
+
+	t.Run("fanout_header_bypass", func(t *testing.T) {
+		h := &handlers{deps: Deps{Builder: builder, Logger: logger}}
+		req := httptest.NewRequest(http.MethodPost, "/v1/images/build", strings.NewReader(string(body)))
+		req.Header.Set(clusterImageBuildFanoutHeader, "1")
+		rr := httptest.NewRecorder()
+		h.clusterBuildImageWrap(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rr.Code)
+		}
+	})
+
+	t.Run("build_nil_cluster", func(t *testing.T) {
+		svc := service.New(config.Config{}, logger, nil, nil, nil, nil, nil, nil, nil)
+		svc.ClearClusterForTest()
+		h := &handlers{deps: Deps{Service: svc, Builder: builder, Logger: logger}}
+		rr := httptest.NewRecorder()
+		h.clusterBuildImageWrap(rr, httptest.NewRequest(http.MethodPost, "/v1/images/build", strings.NewReader(string(body))))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rr.Code)
+		}
+	})
+
+	t.Run("invalid_json", func(t *testing.T) {
+		svc := service.New(config.Config{EnableCluster: true}, logger, nil, nil, nil, nil, nil, nil, nil)
+		h := &handlers{deps: Deps{Service: svc, Logger: logger}}
+		rr := httptest.NewRecorder()
+		h.clusterBuildImageWrap(rr, httptest.NewRequest(http.MethodPost, "/v1/images/build", strings.NewReader("{")))
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", rr.Code)
+		}
+	})
+
+	t.Run("read_body_error", func(t *testing.T) {
+		svc := service.New(config.Config{EnableCluster: true}, logger, nil, nil, nil, nil, nil, nil, nil)
+		h := &handlers{deps: Deps{Service: svc, Logger: logger}}
+		req := httptest.NewRequest(http.MethodPost, "/v1/images/build", nil)
+		req.Body = errReadCloser{}
+		rr := httptest.NewRecorder()
+		h.clusterBuildImageWrap(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", rr.Code)
+		}
+	})
+
+	t.Run("push_skips_fanout", func(t *testing.T) {
+		svc := service.New(config.Config{EnableCluster: true, NodeRole: config.NodeRoleServer}, logger, nil, nil, nil, nil, nil, nil, nil)
+		svc.AttachCluster(dockerFanoutCluster("ingress-a", "http://worker.invalid"))
+		h := &handlers{deps: Deps{Service: svc, Builder: builder, Logger: logger}}
+		pushBody, _ := json.Marshal(buildImageRequest{
+			DockerfileContent: dockerfile,
+			Push:              &buildImagePushSpec{Registry: "registry.example.com", Username: "u", Password: "p"},
+		})
+		rr := httptest.NewRecorder()
+		h.clusterBuildImageWrap(rr, httptest.NewRequest(http.MethodPost, "/v1/images/build", strings.NewReader(string(pushBody))))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rr.Code)
+		}
+	})
+
+	t.Run("context_hashes_skip_fanout", func(t *testing.T) {
+		svc := service.New(config.Config{EnableCluster: true, NodeRole: config.NodeRoleServer}, logger, nil, nil, nil, nil, nil, nil, nil)
+		svc.AttachCluster(dockerFanoutCluster("ingress-a", "http://127.0.0.1:1"))
+		h := &handlers{deps: Deps{Service: svc, Builder: builder, Logger: logger}}
+		ctxBody, _ := json.Marshal(buildImageRequest{DockerfileContent: dockerfile, ContextHashes: []string{"abc"}})
+		rr := httptest.NewRecorder()
+		h.clusterBuildImageWrap(rr, httptest.NewRequest(http.MethodPost, "/v1/images/build", strings.NewReader(string(ctxBody))))
+		if rr.Code == http.StatusBadGateway {
+			t.Fatalf("context_hashes build should skip fanout; got 502")
+		}
+	})
+
+	t.Run("no_docker_workers_falls_back_local", func(t *testing.T) {
+		svc := service.New(config.Config{EnableCluster: true, NodeRole: config.NodeRoleServer}, logger, nil, nil, nil, nil, nil, nil, nil)
+		svc.AttachCluster(&membersStubCluster{
+			Noop: cluster.NewNoop("ingress-a", "http://ingress-a", ""),
+			members: []cluster.Member{
+				{NodeID: "ingress-a", APIURL: "http://ingress-a", Alive: true, Role: config.NodeRoleServer},
+			},
+		})
+		h := &handlers{deps: Deps{Service: svc, Builder: builder, Logger: logger}}
+		rr := httptest.NewRecorder()
+		h.clusterBuildImageWrap(rr, httptest.NewRequest(http.MethodPost, "/v1/images/build", strings.NewReader(string(body))))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rr.Code)
+		}
+	})
+
+	t.Run("peer_network_error", func(t *testing.T) {
+		svc := service.New(config.Config{EnableCluster: true, NodeRole: config.NodeRoleServer}, logger, nil, nil, nil, nil, nil, nil, nil)
+		svc.AttachCluster(dockerFanoutCluster("ingress-a", "http://127.0.0.1:1"))
+		h := &handlers{deps: Deps{Service: svc, Logger: logger}}
+		rr := httptest.NewRecorder()
+		h.clusterBuildImageWrap(rr, httptest.NewRequest(http.MethodPost, "/v1/images/build", strings.NewReader(string(body))))
+		if rr.Code != http.StatusBadGateway {
+			t.Fatalf("status = %d, want 502", rr.Code)
+		}
+	})
+
+	t.Run("peer_non_200_status", func(t *testing.T) {
+		remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "build failed", http.StatusInternalServerError)
+		}))
+		defer remote.Close()
+		svc := service.New(config.Config{EnableCluster: true, NodeRole: config.NodeRoleServer}, logger, nil, nil, nil, nil, nil, nil, nil)
+		svc.AttachCluster(dockerFanoutCluster("ingress-a", remote.URL))
+		h := &handlers{deps: Deps{Service: svc, Logger: logger}}
+		rr := httptest.NewRecorder()
+		h.clusterBuildImageWrap(rr, httptest.NewRequest(http.MethodPost, "/v1/images/build", strings.NewReader(string(body))))
+		if rr.Code != http.StatusBadGateway {
+			t.Fatalf("status = %d, want 502", rr.Code)
+		}
+	})
+}
+
+func TestRunImageBuildOnTargetCoverage(t *testing.T) {
+	dockerfile := "FROM alpine\nRUN echo local"
+	body, _ := json.Marshal(buildImageRequest{DockerfileContent: dockerfile})
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	builder := &fakeImageBuilder{}
+
+	t.Run("self_local_build", func(t *testing.T) {
+		h := &handlers{deps: Deps{Builder: builder, Logger: logger}}
+		parent := httptest.NewRequest(http.MethodPost, "/v1/images/build", strings.NewReader(string(body)))
+		parent.Header.Set("Content-Type", "application/json")
+		status, header, respBody, err := h.runImageBuildOnTarget(parent, body, cluster.Member{NodeID: "self"}, true)
+		if err != nil || status != http.StatusOK {
+			t.Fatalf("self build: status=%d err=%v body=%s", status, err, respBody)
+		}
+		if header.Get("Content-Type") == "" {
+			t.Fatal("expected response headers from local build")
+		}
+	})
+
+	t.Run("remote_forwards_auth_and_content_type", func(t *testing.T) {
+		var gotAuth, gotCT string
+		remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAuth = r.Header.Get("Authorization")
+			gotCT = r.Header.Get("Content-Type")
+			_ = json.NewEncoder(w).Encode(buildImageResponse{Image: docker.BuildTagFor(dockerfile, nil)})
+		}))
+		defer remote.Close()
+
+		h := &handlers{deps: Deps{Logger: logger}}
+		parent := httptest.NewRequest(http.MethodPost, "/v1/images/build", strings.NewReader(string(body)))
+		parent.Header.Set("Authorization", "Bearer tok")
+		parent.Header.Set("Content-Type", "application/json")
+		status, _, _, err := h.runImageBuildOnTarget(parent, body, cluster.Member{NodeID: "worker", APIURL: remote.URL}, false)
+		if err != nil || status != http.StatusOK {
+			t.Fatalf("remote build: status=%d err=%v", status, err)
+		}
+		if gotAuth != "Bearer tok" || gotCT != "application/json" {
+			t.Fatalf("auth/ct = %q/%q", gotAuth, gotCT)
+		}
+	})
+}
+
+func dockerFanoutCluster(selfID, workerURL string) cluster.Client {
+	return &membersStubCluster{
+		Noop: cluster.NewNoop(selfID, "http://"+selfID, ""),
+		members: []cluster.Member{
+			{NodeID: selfID, APIURL: "http://" + selfID, Alive: true, Role: config.NodeRoleServer},
+			{
+				NodeID: "worker-docker", APIURL: workerURL, Alive: true, Role: config.NodeRoleWorker,
+				Capacity: capacity.Snapshot{SupportedRuntimes: []string{models.RuntimeDocker}},
+			},
+		},
+	}
+}
+
+func TestClusterTemplateWrapCoverageBranches(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	t.Run("list_forwarded_header_hits_listTemplates", func(t *testing.T) {
+		env := newTemplateV1TestEnv(t)
+		req := httptest.NewRequest(http.MethodGet, "/v1/templates", nil)
+		req.Header.Set(clusterTemplateForwardedHeader, "1")
+		rr := httptest.NewRecorder()
+		env.handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rr.Code)
+		}
+	})
+
+	t.Run("list_forwarded_header_store_error", func(t *testing.T) {
+		env := newTemplateV1TestEnv(t)
+		_ = env.store.Close()
+		req := httptest.NewRequest(http.MethodGet, "/v1/templates", nil)
+		req.Header.Set(clusterTemplateForwardedHeader, "1")
+		rr := httptest.NewRecorder()
+		env.handler.ServeHTTP(rr, req)
+		if rr.Code == http.StatusOK {
+			t.Fatal("expected store error from listTemplates")
+		}
+	})
+
+	t.Run("create_forwarded_header_invalid_json", func(t *testing.T) {
+		env := newTemplateV1TestEnv(t)
+		req := httptest.NewRequest(http.MethodPost, "/v1/templates", strings.NewReader("{bad"))
+		req.Header.Set(clusterTemplateForwardedHeader, "1")
+		rr := httptest.NewRecorder()
+		env.handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", rr.Code)
+		}
+	})
+
+	t.Run("create_self_target", func(t *testing.T) {
+		env := newTemplateV1TestEnv(t)
+		env.svc.AttachCluster(&createForwardCluster{
+			Noop:   cluster.NewNoop("worker-fc", "http://worker-fc", ""),
+			target: cluster.PlacementTarget{NodeID: "worker-fc", IsSelf: true},
+			members: []cluster.Member{
+				{NodeID: "worker-fc", APIURL: "http://worker-fc", Alive: true, Role: config.NodeRoleWorker},
+			},
+		})
+		req := httptest.NewRequest(http.MethodPost, "/v1/templates", strings.NewReader(`{"image":"docker://alpine:3.20"}`))
+		rr := httptest.NewRecorder()
+		env.handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusAccepted {
+			t.Fatalf("status = %d, want 202: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("create_placement_errors", func(t *testing.T) {
+		env := newTemplateV1TestEnv(t)
+		tests := []struct {
+			name       string
+			err        error
+			wantStatus int
+		}{
+			{name: "no_target", err: cluster.ErrNoPlacementTarget, wantStatus: http.StatusServiceUnavailable},
+			{name: "invalid_topology", err: cluster.ErrInvalidTopology, wantStatus: http.StatusServiceUnavailable},
+			{name: "generic", err: errors.New("boom"), wantStatus: http.StatusInternalServerError},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				env.svc.AttachCluster(&createForwardCluster{
+					Noop:      cluster.NewNoop("server-a", "http://server-a", ""),
+					selectErr: tc.err,
+				})
+				req := httptest.NewRequest(http.MethodPost, "/v1/templates", strings.NewReader(`{"image":"docker://alpine:3.20"}`))
+				rr := httptest.NewRecorder()
+				env.handler.ServeHTTP(rr, req)
+				if rr.Code != tc.wantStatus {
+					t.Fatalf("status = %d, want %d: %s", rr.Code, tc.wantStatus, rr.Body.String())
+				}
+			})
+		}
+	})
+
+	t.Run("create_read_body_error", func(t *testing.T) {
+		env := newTemplateV1TestEnv(t)
+		env.svc.AttachCluster(templateMembersCluster("server-a", "http://fc.invalid"))
+		req := httptest.NewRequest(http.MethodPost, "/v1/templates", nil)
+		req.Body = errReadCloser{}
+		rr := httptest.NewRecorder()
+		(&handlers{deps: Deps{Service: env.svc, Logger: logger}}).clusterCreateTemplateWrap(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", rr.Code)
+		}
+	})
+
+	t.Run("list_peer_failures_still_return_local", func(t *testing.T) {
+		env := newTemplateV1TestEnv(t)
+		badPeer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "nope", http.StatusInternalServerError)
+		}))
+		defer badPeer.Close()
+		env.svc.AttachCluster(templateMembersCluster("server-a", badPeer.URL))
+		req := httptest.NewRequest(http.MethodGet, "/v1/templates", nil)
+		rr := httptest.NewRecorder()
+		env.handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("list_peer_network_error", func(t *testing.T) {
+		env := newTemplateV1TestEnv(t)
+		env.svc.AttachCluster(templateMembersCluster("server-a", "http://127.0.0.1:1"))
+		req := httptest.NewRequest(http.MethodGet, "/v1/templates", nil)
+		rr := httptest.NewRecorder()
+		env.handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rr.Code)
+		}
+	})
+
+	t.Run("list_fanout_cap_exceeded", func(t *testing.T) {
+		env := newTemplateV1TestEnv(t)
+		members := []cluster.Member{
+			{NodeID: "server-a", APIURL: "http://server-a", Alive: true, Role: config.NodeRoleServer},
+		}
+		for i := 0; i <= clusterListMaxFanoutPeers; i++ {
+			members = append(members, cluster.Member{
+				NodeID: fmt.Sprintf("fc-%d", i), APIURL: fmt.Sprintf("http://fc-%d", i), Alive: true,
+				Role: config.NodeRoleWorker, Capacity: capacity.Snapshot{SupportedRuntimes: []string{models.RuntimeFirecracker}},
+			})
+		}
+		env.svc.AttachCluster(&membersStubCluster{Noop: cluster.NewNoop("server-a", "http://server-a", ""), members: members})
+		rr := httptest.NewRecorder()
+		env.handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/v1/templates", nil))
+		if rr.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want 503", rr.Code)
+		}
+	})
+
+	t.Run("list_local_error_when_no_rows", func(t *testing.T) {
+		env := newTemplateV1TestEnv(t)
+		_ = env.store.Close()
+		env.svc.AttachCluster(templateMembersCluster("server-a", "http://fc.invalid"))
+		rr := httptest.NewRecorder()
+		env.handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/v1/templates", nil))
+		if rr.Code == http.StatusOK {
+			t.Fatal("expected store error when local list fails and merge is empty")
+		}
+	})
+
+	t.Run("item_peer_non_404_response", func(t *testing.T) {
+		env := newTemplateV1TestEnv(t)
+		peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "bad", http.StatusInternalServerError)
+		}))
+		defer peer.Close()
+		env.svc.AttachCluster(templateMembersCluster("server-a", peer.URL))
+		rr := httptest.NewRecorder()
+		env.handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/v1/templates/tpl-remote", nil))
+		if rr.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500", rr.Code)
+		}
+	})
+
+	t.Run("item_read_body_error", func(t *testing.T) {
+		env := newTemplateV1TestEnv(t)
+		env.svc.AttachCluster(templateMembersCluster("server-a", "http://fc.invalid"))
+		req := httptest.NewRequest(http.MethodPost, "/v1/templates/tpl-x/rebuild", nil)
+		req.Body = errReadCloser{}
+		rr := httptest.NewRecorder()
+		itemHandler := (&handlers{deps: Deps{Service: env.svc, Logger: logger}}).clusterTemplateItemWrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusAccepted)
+		}))
+		itemHandler(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", rr.Code)
+		}
+	})
+
+	t.Run("item_peer_request_error_falls_back_local", func(t *testing.T) {
+		env := newTemplateV1TestEnv(t)
+		env.svc.AttachCluster(templateMembersCluster("server-a", "http://127.0.0.1:1"))
+		rr := httptest.NewRecorder()
+		env.handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/v1/templates/missing-tpl", nil))
+		if rr.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404", rr.Code)
+		}
+	})
+}
+
+func TestClusterCreateWrapLocalImageCoverageBranches(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	builtBody := `{"image":"` + docker.BuiltImageNamespace + `/abc:latest"}`
+
+	t.Run("forwarded_local_image_without_reservation_id", func(t *testing.T) {
+		rt := &apiRecordingRuntime{}
+		fake := &createForwardCluster{Noop: cluster.NewNoop("worker-b", "http://worker-b", "")}
+		h, _ := newClusterCreateHarness(t, rt, fake)
+		req := httptest.NewRequest(http.MethodPost, "/v1/sandboxes", strings.NewReader(builtBody))
+		req.Header.Set(clusterCreateTargetHeader, "worker-b")
+		rr := httptest.NewRecorder()
+		h.clusterCreateWrap(rr, req)
+		if rr.Code == http.StatusBadRequest && strings.Contains(rr.Body.String(), clusterCreateIDHeader) {
+			t.Fatalf("local image forward should not require create id: %s", rr.Body.String())
+		}
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("status = %d, want 201: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("mixed_worker_drained", func(t *testing.T) {
+		svc := service.New(config.Config{EnableCluster: true, NodeRole: config.NodeRoleMixed}, logger, nil, nil, nil, nil, nil, nil, nil)
+		fake := &createForwardCluster{
+			Noop: cluster.NewNoop("mixed-a", "http://mixed-a", ""),
+			members: []cluster.Member{
+				{NodeID: "mixed-a", APIURL: "http://mixed-a", Alive: true, Role: config.NodeRoleMixed},
+			},
+			drained: map[string]bool{"mixed-a": true},
+		}
+		svc.AttachCluster(fake)
+		h := &handlers{deps: Deps{Service: svc, Logger: logger}}
+		rr := httptest.NewRecorder()
+		h.clusterCreateWrap(rr, httptest.NewRequest(http.MethodPost, "/v1/sandboxes", strings.NewReader(builtBody)))
+		if rr.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want 503", rr.Code)
+		}
+	})
+
+	t.Run("placement_self_drained", func(t *testing.T) {
+		svc := service.New(config.Config{EnableCluster: true, NodeRole: config.NodeRoleServer}, logger, nil, nil, nil, nil, nil, nil, nil)
+		fake := &createForwardCluster{
+			Noop:   cluster.NewNoop("server-a", "http://server-a", ""),
+			target: cluster.PlacementTarget{NodeID: "worker-b", APIURL: "http://worker-b", IsSelf: true},
+			members: []cluster.Member{
+				{NodeID: "server-a", APIURL: "http://server-a", Alive: true, Role: config.NodeRoleServer},
+			},
+			drained: map[string]bool{"server-a": true},
+		}
+		svc.AttachCluster(fake)
+		h := &handlers{deps: Deps{Service: svc, Logger: logger}}
+		rr := httptest.NewRecorder()
+		h.clusterCreateWrap(rr, httptest.NewRequest(http.MethodPost, "/v1/sandboxes", strings.NewReader(builtBody)))
+		if rr.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want 503", rr.Code)
+		}
+	})
+
+	t.Run("placement_empty_target_urls_still_forwards", func(t *testing.T) {
+		svc := service.New(config.Config{EnableCluster: true, NodeRole: config.NodeRoleServer}, logger, nil, nil, nil, nil, nil, nil, nil)
+		fake := &createForwardCluster{
+			Noop:   cluster.NewNoop("server-a", "http://server-a", ""),
+			target: cluster.PlacementTarget{NodeID: "worker-b", IsSelf: false},
+			members: []cluster.Member{
+				{NodeID: "server-a", APIURL: "http://server-a", Alive: true, Role: config.NodeRoleServer},
+				{NodeID: "worker-b", APIURL: "http://worker-b", Alive: true, Role: config.NodeRoleWorker},
+			},
+		}
+		svc.AttachCluster(fake)
+		h := &handlers{deps: Deps{Service: svc, Logger: logger}}
+		rr := httptest.NewRecorder()
+		h.clusterCreateWrap(rr, httptest.NewRequest(http.MethodPost, "/v1/sandboxes", strings.NewReader(builtBody)))
+		if rr.Code != http.StatusAccepted {
+			t.Fatalf("status = %d, want 202 forward", rr.Code)
+		}
+		if fake.forwardedTarget != "worker-b" {
+			t.Fatalf("forwarded target = %q", fake.forwardedTarget)
+		}
+	})
+
+	t.Run("placement_generic_error", func(t *testing.T) {
+		svc := service.New(config.Config{EnableCluster: true, NodeRole: config.NodeRoleServer}, logger, nil, nil, nil, nil, nil, nil, nil)
+		fake := &createForwardCluster{
+			Noop: cluster.NewNoop("server-a", "http://server-a", ""),
+			members: []cluster.Member{
+				{NodeID: "server-a", APIURL: "http://server-a", Alive: true, Role: config.NodeRoleServer},
+			},
+			selectErr: errors.New("placement boom"),
+		}
+		svc.AttachCluster(fake)
+		h := &handlers{deps: Deps{Service: svc, Logger: logger}}
+		rr := httptest.NewRecorder()
+		h.clusterCreateWrap(rr, httptest.NewRequest(http.MethodPost, "/v1/sandboxes", strings.NewReader(builtBody)))
+		if rr.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500", rr.Code)
+		}
+	})
+}
+
+func TestClusterListTemplatesPeerDecodeError(t *testing.T) {
+	env := newTemplateV1TestEnv(t)
+	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("not-json"))
+	}))
+	defer peer.Close()
+	env.svc.AttachCluster(templateMembersCluster("server-a", peer.URL))
+	rr := httptest.NewRecorder()
+	env.handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/v1/templates", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+}
+
+func TestClusterListTemplatesWithAuthHeader(t *testing.T) {
+	env := newTemplateV1TestEnv(t)
+	var gotAuth string
+	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_ = json.NewEncoder(w).Encode([]*models.Template{})
+	}))
+	defer peer.Close()
+	env.svc.AttachCluster(templateMembersCluster("server-a", peer.URL))
+	req := httptest.NewRequest(http.MethodGet, "/v1/templates", nil)
+	req.Header.Set("Authorization", "Bearer list-tok")
+	rr := httptest.NewRecorder()
+	env.handler.ServeHTTP(rr, req)
+	if gotAuth != "Bearer list-tok" {
+		t.Fatalf("Authorization = %q", gotAuth)
+	}
+}

--- a/pkg/api/v1/handlers_coverage_test.go
+++ b/pkg/api/v1/handlers_coverage_test.go
@@ -326,6 +326,9 @@ func TestCapacityRequestFromCreateDefaults(t *testing.T) {
 	if got.CPU != models.DefaultCPU || got.MemoryMB != models.DefaultMemoryMB || got.DiskGB != models.DefaultDiskGB {
 		t.Fatalf("defaults = %+v, want cpu/mem/disk defaults", got)
 	}
+	if got.Runtime != models.RuntimeDocker {
+		t.Fatalf("default runtime = %q, want docker", got.Runtime)
+	}
 	req := models.CreateSandboxRequest{
 		TemplateID: "tpl-1",
 		GPUs:       &models.GPURequest{Count: 0, Vendor: models.GPUVendorNVIDIA},

--- a/pkg/api/v1/routes.go
+++ b/pkg/api/v1/routes.go
@@ -60,7 +60,7 @@ func RegisterRoutes(mux *http.ServeMux, d Deps) {
 
 	mux.Handle("GET "+PathPrefix+"/capacity", d.Auth(http.HandlerFunc(h.capacity)))
 	mux.Handle("POST "+PathPrefix+"/admin/reconcile", d.Auth(http.HandlerFunc(h.reconcile)))
-	mux.Handle("POST "+PathPrefix+"/images/build", d.Auth(http.HandlerFunc(h.buildImage)))
+	mux.Handle("POST "+PathPrefix+"/images/build", d.Auth(http.HandlerFunc(h.clusterBuildImageWrap)))
 
 	// POST /sandboxes is special: placement happens in the wrapper before any
 	// local handler runs. The wrapper falls through to createSandbox when this
@@ -109,17 +109,16 @@ func RegisterRoutes(mux *http.ServeMux, d Deps) {
 	mux.Handle("POST "+PathPrefix+"/snapshots", d.Auth(http.HandlerFunc(h.registerSnapshot)))
 
 	// Firecracker template lifecycle (plans/snapshot-clone-fast-boot.md
-	// Phase 2). No clusterForwardWrap — templates are per-host artifacts;
-	// cross-node placement awareness is Phase 6 territory.
-	mux.Handle("POST "+PathPrefix+"/templates", d.Auth(http.HandlerFunc(h.createTemplate)))
-	mux.Handle("GET "+PathPrefix+"/templates", d.Auth(http.HandlerFunc(h.listTemplates)))
-	mux.Handle("GET "+PathPrefix+"/templates/{id}", d.Auth(http.HandlerFunc(h.getTemplate)))
-	mux.Handle("DELETE "+PathPrefix+"/templates/{id}", d.Auth(http.HandlerFunc(h.deleteTemplate)))
+	// Phase 2). Templates are per-worker artifacts, so the wrapper routes
+	// creates to a Firecracker-capable worker and fans per-id operations to
+	// those workers when the caller hits an ingress/server node.
+	mux.Handle("POST "+PathPrefix+"/templates", d.Auth(http.HandlerFunc(h.clusterCreateTemplateWrap)))
+	mux.Handle("GET "+PathPrefix+"/templates", d.Auth(http.HandlerFunc(h.clusterListTemplatesWrap)))
+	mux.Handle("GET "+PathPrefix+"/templates/{id}", d.Auth(h.clusterTemplateItemWrap(http.HandlerFunc(h.getTemplate))))
+	mux.Handle("DELETE "+PathPrefix+"/templates/{id}", d.Auth(h.clusterTemplateItemWrap(http.HandlerFunc(h.deleteTemplate))))
 	// Operator-triggered snapshot rebuild (Phase 6 follow-up). Idempotent
-	// under concurrent retry — see RequestTemplateRebuild for the CAS
-	// gate. No clusterForwardWrap: templates are per-host artifacts and
-	// a rebuild only makes sense on the node that owns the rootfs.
-	mux.Handle("POST "+PathPrefix+"/templates/{id}/rebuild", d.Auth(http.HandlerFunc(h.rebuildTemplate)))
+	// under concurrent retry — see RequestTemplateRebuild for the CAS gate.
+	mux.Handle("POST "+PathPrefix+"/templates/{id}/rebuild", d.Auth(h.clusterTemplateItemWrap(http.HandlerFunc(h.rebuildTemplate))))
 
 	// WASM module catalogue (plans/wasm-runtime.md). Per-host like templates.
 	mux.Handle("POST "+PathPrefix+"/wasm-modules", d.Auth(http.HandlerFunc(h.createWasmModule)))

--- a/pkg/api/v1/template.go
+++ b/pkg/api/v1/template.go
@@ -1,18 +1,249 @@
 package v1
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
+	"strings"
+	"time"
 
+	"github.com/aerol-ai/microvm/internal/cluster"
 	"github.com/aerol-ai/microvm/pkg/api/apihttp"
+	"github.com/aerol-ai/microvm/pkg/capacity"
 	"github.com/aerol-ai/microvm/pkg/models"
 )
 
+const clusterTemplateForwardedHeader = "X-Cluster-Template-Forwarded"
+
 // Template handlers — POST/GET/LIST/DELETE for the Firecracker template
-// pipeline (plans/snapshot-clone-fast-boot.md Phase 2). These routes are
-// per-host: a template's rootfs.ext4 lives on the node it was built on,
-// so we deliberately skip clusterForwardWrap. A Phase 6 follow-up will
-// add cross-node fan-out for list and ownership-based routing for the
-// per-id paths once template distribution is in scope.
+// pipeline (plans/snapshot-clone-fast-boot.md Phase 2). Template artifacts
+// live on the worker that built them, so cluster mode routes creates to a
+// Firecracker-capable worker and fans reads/mutations across those workers.
+
+func (h *handlers) clusterCreateTemplateWrap(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get(clusterTemplateForwardedHeader) == "1" {
+		h.createTemplate(w, r)
+		return
+	}
+	if h.deps.Service == nil {
+		h.createTemplate(w, r)
+		return
+	}
+	c := h.deps.Service.Cluster()
+	if c == nil {
+		h.createTemplate(w, r)
+		return
+	}
+	raw, err := io.ReadAll(r.Body)
+	_ = r.Body.Close()
+	if err != nil {
+		apihttp.WriteError(w, http.StatusBadRequest, "read body: "+err.Error())
+		return
+	}
+	r.Body = io.NopCloser(bytes.NewReader(raw))
+	r.ContentLength = int64(len(raw))
+
+	target, err := c.SelectPlacement(capacity.Request{
+		CPU:      models.DefaultCPU,
+		MemoryMB: models.DefaultMemoryMB,
+		DiskGB:   models.DefaultDiskGB,
+		Runtime:  models.RuntimeFirecracker,
+	})
+	if err != nil {
+		if errors.Is(err, cluster.ErrNoPlacementTarget) || errors.Is(err, cluster.ErrInvalidTopology) {
+			apihttp.WriteError(w, http.StatusServiceUnavailable, err.Error())
+			return
+		}
+		apihttp.WriteError(w, http.StatusInternalServerError, "placement: "+err.Error())
+		return
+	}
+	if target.IsSelf {
+		h.createTemplate(w, r)
+		return
+	}
+	r.Header.Set(clusterTemplateForwardedHeader, "1")
+	c.ForwardHTTP(cluster.Endpoint{InternalURL: target.InternalURL, APIURL: target.APIURL}, w, r)
+}
+
+func (h *handlers) clusterListTemplatesWrap(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get(clusterTemplateForwardedHeader) == "1" {
+		h.listTemplates(w, r)
+		return
+	}
+	if h.deps.Service == nil {
+		h.listTemplates(w, r)
+		return
+	}
+	c := h.deps.Service.Cluster()
+	if c == nil {
+		h.listTemplates(w, r)
+		return
+	}
+	peers := clusterTemplatePeers(c)
+	if len(peers) > clusterListMaxFanoutPeers {
+		apihttp.WriteError(w, http.StatusServiceUnavailable, "cluster template list fanout exceeds safe peer cap")
+		return
+	}
+
+	local, localErr := h.deps.Service.ListTemplates(r.Context())
+	if localErr != nil && h.deps.Logger != nil {
+		h.deps.Logger.Warn("cluster templates: local list failed", "err", localErr)
+	}
+	merged := make([]*models.Template, 0, len(local))
+	seen := map[string]struct{}{}
+	for _, tpl := range local {
+		if tpl == nil {
+			continue
+		}
+		seen[tpl.ID] = struct{}{}
+		merged = append(merged, tpl)
+	}
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	for _, peer := range peers {
+		req, err := http.NewRequestWithContext(r.Context(), http.MethodGet,
+			clusterPeerURL(peer.APIURL, r.URL.RequestURI()), nil)
+		if err != nil {
+			continue
+		}
+		req.Header.Set(clusterTemplateForwardedHeader, "1")
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			req.Header.Set("Authorization", auth)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			if h.deps.Logger != nil {
+				h.deps.Logger.Warn("cluster templates: peer list failed", "peer", peer.NodeID, "err", err)
+			}
+			continue
+		}
+		func() {
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+				if h.deps.Logger != nil {
+					h.deps.Logger.Warn("cluster templates: peer list returned error",
+						"peer", peer.NodeID, "status", resp.StatusCode, "body", strings.TrimSpace(string(body)))
+				}
+				return
+			}
+			var rows []*models.Template
+			if err := json.NewDecoder(resp.Body).Decode(&rows); err != nil {
+				if h.deps.Logger != nil {
+					h.deps.Logger.Warn("cluster templates: decode peer list failed", "peer", peer.NodeID, "err", err)
+				}
+				return
+			}
+			for _, tpl := range rows {
+				if tpl == nil {
+					continue
+				}
+				if _, ok := seen[tpl.ID]; ok {
+					continue
+				}
+				seen[tpl.ID] = struct{}{}
+				merged = append(merged, tpl)
+			}
+		}()
+	}
+	if localErr != nil && len(merged) == 0 {
+		apihttp.WriteStoreAwareError(h.deps.Logger, w, localErr)
+		return
+	}
+	apihttp.WriteJSON(w, http.StatusOK, merged)
+}
+
+func (h *handlers) clusterTemplateItemWrap(local http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get(clusterTemplateForwardedHeader) == "1" {
+			local.ServeHTTP(w, r)
+			return
+		}
+		if h.deps.Service == nil {
+			local.ServeHTTP(w, r)
+			return
+		}
+		c := h.deps.Service.Cluster()
+		if c == nil {
+			local.ServeHTTP(w, r)
+			return
+		}
+		raw, err := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		if err != nil {
+			apihttp.WriteError(w, http.StatusBadRequest, "read body: "+err.Error())
+			return
+		}
+		for _, peer := range clusterTemplatePeers(c) {
+			status, header, body, err := templatePeerRequest(r, raw, peer)
+			if err != nil {
+				if h.deps.Logger != nil {
+					h.deps.Logger.Warn("cluster templates: peer request failed",
+						"peer", peer.NodeID, "method", r.Method, "path", r.URL.Path, "err", err)
+				}
+				continue
+			}
+			if status == http.StatusNotFound {
+				continue
+			}
+			copyHeaderValues(w.Header(), header)
+			w.WriteHeader(status)
+			_, _ = w.Write(body)
+			return
+		}
+		r.Body = io.NopCloser(bytes.NewReader(raw))
+		r.ContentLength = int64(len(raw))
+		local.ServeHTTP(w, r)
+	}
+}
+
+func clusterTemplatePeers(c cluster.Client) []cluster.Member {
+	if c == nil {
+		return nil
+	}
+	selfID := c.SelfNodeID()
+	out := make([]cluster.Member, 0)
+	for _, m := range c.Members() {
+		if !m.Alive || m.NodeID == "" || m.NodeID == selfID || m.APIURL == "" {
+			continue
+		}
+		if !clusterMemberCanOwnSandbox(m.Role) || !clusterMemberSupportsRuntime(m, models.RuntimeFirecracker) {
+			continue
+		}
+		if c.IsNodeDrained(m.NodeID) {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func templatePeerRequest(parent *http.Request, raw []byte, peer cluster.Member) (int, http.Header, []byte, error) {
+	req, err := http.NewRequestWithContext(parent.Context(), parent.Method,
+		clusterPeerURL(peer.APIURL, parent.URL.RequestURI()), bytes.NewReader(raw))
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	req.Header.Set(clusterTemplateForwardedHeader, "1")
+	if auth := parent.Header.Get("Authorization"); auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+	if ct := parent.Header.Get("Content-Type"); ct != "" {
+		req.Header.Set("Content-Type", ct)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	return resp.StatusCode, resp.Header.Clone(), body, nil
+}
 
 // createTemplate accepts an OCI image reference and persists a PENDING
 // row, returning 202. The actual skopeo+umoci+mkfs.ext4 pipeline runs

--- a/pkg/api/v1/template_test.go
+++ b/pkg/api/v1/template_test.go
@@ -14,9 +14,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aerol-ai/microvm/internal/cluster"
 	"github.com/aerol-ai/microvm/internal/config"
 	"github.com/aerol-ai/microvm/internal/service"
 	"github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/capacity"
 	"github.com/aerol-ai/microvm/pkg/models"
 )
 
@@ -84,6 +86,178 @@ func newTemplateV1TestEnv(t *testing.T) *templateV1Env {
 		Auth:    func(h http.Handler) http.Handler { return h },
 	})
 	return &templateV1Env{svc: svc, store: st, builder: builder, handler: mux}
+}
+
+func TestClusterCreateTemplateWrapRoutesToFirecrackerWorker(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	svc := service.New(config.Config{EnableCluster: true, NodeRole: config.NodeRoleServer}, logger, nil, nil, nil, nil, nil, nil, nil)
+	fakeCluster := &createForwardCluster{
+		Noop:   cluster.NewNoop("server-a", "http://server-a", ""),
+		target: cluster.PlacementTarget{NodeID: "worker-fc", APIURL: "http://worker-fc:21212", IsSelf: false},
+	}
+	svc.AttachCluster(fakeCluster)
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, Deps{
+		Service: svc,
+		Logger:  logger,
+		Auth:    func(h http.Handler) http.Handler { return h },
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/templates", strings.NewReader(`{"image":"docker://alpine:3.20"}`))
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d: %s", rr.Code, http.StatusAccepted, rr.Body.String())
+	}
+	if fakeCluster.forwardedPeer != "http://worker-fc:21212" {
+		t.Fatalf("forwarded peer = %q, want firecracker worker", fakeCluster.forwardedPeer)
+	}
+	if len(fakeCluster.selectRequests) != 1 || fakeCluster.selectRequests[0].Runtime != models.RuntimeFirecracker {
+		t.Fatalf("placement request = %+v, want firecracker runtime", fakeCluster.selectRequests)
+	}
+}
+
+func TestClusterListTemplatesWrapMergesAndDedupesPeers(t *testing.T) {
+	env := newTemplateV1TestEnv(t)
+	now := time.Now().UTC()
+	local := &models.Template{
+		ID: "tpl-shared", Image: "docker://local",
+		Status: models.TemplateStatusReady, RootfsPath: filepath.Join(t.TempDir(), "rootfs.ext4"),
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := env.store.CreateTemplate(context.Background(), local); err != nil {
+		t.Fatalf("CreateTemplate local: %v", err)
+	}
+	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get(clusterTemplateForwardedHeader); got != "1" {
+			t.Fatalf("%s = %q, want 1", clusterTemplateForwardedHeader, got)
+		}
+		rows := []*models.Template{
+			{ID: "tpl-shared", Image: "docker://peer-dupe", Status: models.TemplateStatusReady, CreatedAt: now, UpdatedAt: now},
+			{ID: "tpl-peer", Image: "docker://peer", Status: models.TemplateStatusReady, CreatedAt: now, UpdatedAt: now},
+		}
+		_ = json.NewEncoder(w).Encode(rows)
+	}))
+	defer peer.Close()
+	env.svc.AttachCluster(templateMembersCluster("server-a", peer.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/templates", nil)
+	rr := httptest.NewRecorder()
+	env.handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	var rows []*models.Template
+	if err := json.NewDecoder(rr.Body).Decode(&rows); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("templates = %+v, want local duplicate plus one peer row", rows)
+	}
+	byID := map[string]*models.Template{}
+	for _, row := range rows {
+		byID[row.ID] = row
+	}
+	if byID["tpl-shared"].Image != "docker://local" {
+		t.Fatalf("dedupe kept image %q, want local row", byID["tpl-shared"].Image)
+	}
+	if byID["tpl-peer"] == nil {
+		t.Fatalf("merged rows missing peer template: %+v", rows)
+	}
+}
+
+func TestClusterTemplateItemWrapRoutesPeerGetDeleteAndRebuild(t *testing.T) {
+	env := newTemplateV1TestEnv(t)
+	now := time.Now().UTC()
+	seen := map[string]bool{}
+	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get(clusterTemplateForwardedHeader); got != "1" {
+			t.Fatalf("%s = %q, want 1", clusterTemplateForwardedHeader, got)
+		}
+		seen[r.Method+" "+r.URL.Path] = true
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/templates/tpl-remote":
+			_ = json.NewEncoder(w).Encode(&models.Template{ID: "tpl-remote", Image: "docker://peer", Status: models.TemplateStatusReady, CreatedAt: now, UpdatedAt: now})
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/templates/tpl-remote":
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/templates/tpl-remote/rebuild":
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(&models.Template{ID: "tpl-remote", Status: models.TemplateStatusPending, CreatedAt: now, UpdatedAt: now})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer peer.Close()
+	env.svc.AttachCluster(templateMembersCluster("server-a", peer.URL))
+
+	cases := []struct {
+		method string
+		path   string
+		want   int
+	}{
+		{method: http.MethodGet, path: "/v1/templates/tpl-remote", want: http.StatusOK},
+		{method: http.MethodDelete, path: "/v1/templates/tpl-remote", want: http.StatusNoContent},
+		{method: http.MethodPost, path: "/v1/templates/tpl-remote/rebuild", want: http.StatusAccepted},
+	}
+	for _, tc := range cases {
+		req := httptest.NewRequest(tc.method, tc.path, nil)
+		rr := httptest.NewRecorder()
+		env.handler.ServeHTTP(rr, req)
+		if rr.Code != tc.want {
+			t.Fatalf("%s %s status = %d, want %d: %s", tc.method, tc.path, rr.Code, tc.want, rr.Body.String())
+		}
+		if !seen[tc.method+" "+tc.path] {
+			t.Fatalf("peer did not see %s %s", tc.method, tc.path)
+		}
+	}
+}
+
+func TestClusterTemplateItemWrapFallsBackLocalAfterPeer404(t *testing.T) {
+	env := newTemplateV1TestEnv(t)
+	now := time.Now().UTC()
+	tpl := &models.Template{
+		ID: "tpl-local", Image: "docker://local",
+		Status: models.TemplateStatusReady, RootfsPath: filepath.Join(t.TempDir(), "rootfs.ext4"),
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := env.store.CreateTemplate(context.Background(), tpl); err != nil {
+		t.Fatalf("CreateTemplate local: %v", err)
+	}
+	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer peer.Close()
+	env.svc.AttachCluster(templateMembersCluster("server-a", peer.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/templates/tpl-local", nil)
+	rr := httptest.NewRecorder()
+	env.handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	var got models.Template
+	if err := json.NewDecoder(rr.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.ID != "tpl-local" {
+		t.Fatalf("template ID = %q, want tpl-local", got.ID)
+	}
+}
+
+func templateMembersCluster(selfID, peerURL string) cluster.Client {
+	return &membersStubCluster{
+		Noop: cluster.NewNoop(selfID, "http://"+selfID, ""),
+		members: []cluster.Member{
+			{NodeID: selfID, APIURL: "http://" + selfID, Alive: true, Role: config.NodeRoleServer},
+			{
+				NodeID: "worker-fc", APIURL: peerURL, Alive: true, Role: config.NodeRoleWorker,
+				Capacity: capacity.Snapshot{SupportedRuntimes: []string{models.RuntimeFirecracker}},
+			},
+		},
+	}
 }
 
 // TestV1CreateTemplate_Returns202 is the canonical happy path: POST

--- a/plans/b7-built-image-placement.md
+++ b/plans/b7-built-image-placement.md
@@ -1,9 +1,16 @@
 # B7 — Local-only built images can't be placed in a cluster (UC-74)
 
-Status: ticketed · Severity: P2 (feature broken in cluster mode, no data risk) ·
+Status: **implemented (Option A fanout)** in PR [#253](https://github.com/aerol-ai/microvm/pull/253)
+(`self-node-placement`) · documented in [`pr-review.md` §7.1](../pr-review.md) ·
+Severity: P2 (feature broken in cluster mode, no data risk) ·
 Area: `internal/cluster` placement + `internal/service` image distribution +
 `pkg/api/v1` build · Source: cluster-hetero integration scenario, UC-74
 ("Create with built image graph"). Parent: `plans/cluster-hetero-failures-fix.md`.
+
+> **Shipped vs recommended:** Option B (AOCR distribution) remains the long-term
+> recommendation below. PR #253 shipped Option A extended with
+> replicate-to-all-Docker-workers build fanout plus placement-forward create —
+> see `pr-review.md` §7.1 for rationale.
 
 ## 1. Symptom
 

--- a/pr-review.md
+++ b/pr-review.md
@@ -69,6 +69,227 @@ These two areas are particularly fragile and have produced live incidents (PR #1
 - Any change to `EnsureLayer4` / `EnsureLayer4Ready` / the `l4Ready` latch requires a regression test in `internal/service/layer4_bootstrap_test.go` AND a call-out.
 - Do not collapse the three-state `ReserveHostPortResult` (`Reserved` / `Existing` / neither) back into a `bool`. The middle state is what prevents pool walks on PK collisions.
 
+## 7. Cluster placement, forwarding & per-host artifacts
+
+Cluster mode runs Raft placement state, SWIM gossip, and cross-node HTTP forwarding.
+This area is as fragile as the TCP host-port pool (see `CLAUDE.md` Hard rules §6).
+
+**Reviewer asks:** does this PR change who runs a sandbox, where an artifact is
+built, or how a request is forwarded? If yes, document split-brain / misdirect
+behavior, single-node no-op, and leader-change replay safety.
+
+### Rules (all cluster-touching PRs)
+
+- **Role gate.** Only `worker` and `mixed` nodes may own sandboxes
+  (`cluster.CanOwnSandboxRole`). Ingress/server nodes may route but must not
+  assume they can execute creates locally.
+- **Per-host artifacts.** Built images (`aerolvm-build/*`), Firecracker template
+  rootfs, and similar node-local blobs must be built or probed on nodes that can
+  run them. API entrypoints that cannot own sandboxes must forward or fan out —
+  not pin work to self.
+- **Local-only create contract.** When `service.ImageRequiresLocalPlacement` is
+  true, create skips the reservation-first flow: forward with
+  `X-Cluster-Create-Target` only (no `X-Cluster-Create-ID`). The target worker
+  runs `createSandboxOnSelectedNode` directly.
+- **Loop guards.** Cross-node wrappers MUST set a private header
+  (`X-Cluster-Image-Build-Fanout`, `X-Cluster-Template-Forwarded`, etc.) on
+  forwarded requests so the receiver executes locally and does not re-fanout.
+- **Runtime in placement vs body.** Placement scoring may infer a default
+  runtime (e.g. `docker` for built images) for `SelectPlacement` filters, but
+  must not rewrite an omitted `runtime` on the forwarded create body — the
+  selected worker applies its configured default (e.g. gVisor).
+- **Regression tests.** Changes to placement selection, create forwarding,
+  build/template fanout, or `capacityRequestFromCreate` need a test next to the
+  file changed (`placement_test.go`, `clustercreate_test.go`,
+  `cluster_handler_test.go`, `build_test.go`, `template_test.go`).
+- **Single-node / cluster-off.** All wrappers must no-op when `EnableCluster` is
+  false or `cluster.Client` is nil (`cluster.NewNoop`).
+
+### 7.1 Reference implementation — B7 local-only built images & per-host routing (PR #253)
+
+**Plan:** [`plans/b7-built-image-placement.md`](plans/b7-built-image-placement.md)
+(parent: [`plans/cluster-hetero-failures-fix.md`](plans/cluster-hetero-failures-fix.md),
+integration UC-74). **Branch:** `self-node-placement`.
+
+#### What was solved
+
+| Symptom | Root cause | Fix |
+|---------|------------|-----|
+| UC-74 `CreateWithImage` → `cluster: no worker placement target available` on role-separated clusters | `POST /v1/images/build` ran on ingress/server; image existed only there; `ImageRequiresLocalPlacement` pinned create to self; `CanOwnSandboxRole(server)` is false | Build fans out to Docker workers; local-image create uses placement + forward to a worker |
+| Template API unusable from ingress (B3 ticket) | Templates are per-worker rootfs; routes had no cluster wrappers | Create routes via Firecracker placement; list merges peers; get/delete/rebuild probe peers then fall back local |
+| Placement under-filtered for built images / WASM | `capacityRequestFromCreate` omitted runtime, module ref, WASM overhead | Align scoring with `internal/cluster/placement.go` (default `docker`, `ModuleRef`, +8MB WASM, overlay disk) |
+
+Before (broken on ingress/server):
+
+```
+CreateWithImage
+  → build on ingress (image only on non-worker)
+  → create pinned to self (ImageRequiresLocalPlacement)
+  → CanOwnSandboxRole(server) == false
+  → ErrNoPlacementTarget
+```
+
+After:
+
+```
+CreateWithImage
+  → build fans out to all Docker-capable workers (content-addressed tag on each)
+  → create: SelectPlacement(runtime=docker) → forward to worker
+  → worker creates without reservation ID
+```
+
+#### Decisions taken
+
+The B7 plan evaluated three options. **What shipped is Option A (build on
+workers), extended with replicate-to-all-workers fanout** — not Option B (AOCR
+push after build), which remains the long-term recommendation in the plan for
+durable, reusable images.
+
+| Decision | Rationale |
+|----------|-----------|
+| **Fan out build to every alive Docker worker** (not single placement pick) | `CreateWithImage` is two independent SDK calls with no sticky worker field. Replicating the content-addressed tag to all Docker workers lets the second call's `SelectPlacement` succeed on any worker without threading build-node metadata through the API. |
+| **Skip fanout when self can own sandboxes** (`clusterSelfCanOwnSandbox`) | Single-node and mixed-role clusters keep the old local build path; no extra HTTP on the hot path. |
+| **Skip fanout for `push` / `context_hashes` builds** | Those paths have explicit distribution semantics; fanout would be wrong. |
+| **Local-image create: no reservation ID** | Image must already exist on the target; reservation-first would reserve on router then forward to a node that cannot see the router's local image. |
+| **Template cluster wrappers in same PR** | Same class of bug (per-host artifact on ingress); unblocks B3 without AOCR. List is best-effort merge (peer failures warn + continue); item routes probe peers then local fallback. |
+| **Do not inject `runtime` into forwarded create body** | Preserves worker-specific defaults (gVisor cluster-hetero fix); placement filter uses inferred `docker` only for scoring. |
+
+Option B (AOCR distribution after build) is **not** superseded — it remains the
+better fix for image durability and cross-create reuse. Option A fanout is the
+minimal cluster-correctness fix that unblocks UC-74 without AOCR dependency.
+
+#### Impact
+
+| Surface | Who is affected | Behavior change |
+|---------|-----------------|-----------------|
+| `POST /v1/images/build` | Clients hitting ingress/server in role-separated clusters | Extra N−1 peer HTTP builds (N = Docker-capable workers) before response; 502 on first peer failure |
+| `POST /v1/sandboxes` with `aerolvm-build/*` | Same | Router does `SelectPlacement` + forward instead of local create; worker path unchanged |
+| `POST /v1/sandboxes` (normal) | Unchanged | Still reservation-first |
+| Template CRUD from ingress | Operators / SDKs using templates in cluster mode | Create forwarded to FC worker; list is union of peers; get/delete/rebuild hit peers first |
+| Worker `CreateSandbox` | No added work on worker boot path | Forwarded local-image create uses existing `createSandboxOnSelectedNode` |
+| Single-node / `EnableCluster=false` | No impact | Wrappers no-op |
+| Integration harness | WASM scenarios | Ignores stale `AEROL_WASM_MODULE_REF=aocr.aerol.ai/cluster/*/snapshots/*` |
+
+**Latency:** ingress-only overhead on `CreateWithImage` — O(workers) build
+fanout (bounded by cluster size) plus one placement + forward on create. Worker
+boot path itself is unchanged.
+
+#### Implementation map
+
+| Component | File(s) | Mechanism |
+|-----------|---------|-----------|
+| Image build fanout | `pkg/api/v1/build.go`, `routes.go` | `clusterBuildImageWrap`; header `X-Cluster-Image-Build-Fanout: 1` |
+| Local-image create (facade) | `pkg/api/clustercreate/clustercreate.go` | `clusterCreateSelfCanOwnSandbox`; placement + `ForwardHTTP` without `HeaderID` |
+| Local-image create (v1) | `pkg/api/v1/cluster_handler.go` | Mirror of clustercreate branch; accepts target-pinned forward without `X-Cluster-Create-ID` |
+| Shared helpers | `pkg/api/v1/cluster_helpers.go` | `clusterSelfCanOwnSandbox`, `clusterMemberSupportsRuntime`, `clusterPeerURL` |
+| Placement scoring | `pkg/api/clustercreate/clustercreate.go`, `pkg/api/v1/cluster_handler.go`, `internal/cluster/placement.go` | `CapacityRequestFromCreate` / `capacityRequestFromSpec` defaults |
+| Template cluster | `pkg/api/v1/template.go`, `routes.go` | `clusterCreateTemplateWrap`, `clusterListTemplatesWrap`, `clusterTemplateItemWrap`; header `X-Cluster-Template-Forwarded: 1` |
+| Classification (unchanged) | `internal/service/image_distribution.go` | `ImageRequiresLocalPlacement` still true for `aerolvm-build/*` |
+
+Key invariant preserved: **`ImageRequiresLocalPlacement` still means the image
+must exist on the node that runs the sandbox** — we changed *which* node that
+is, not the local-only contract.
+
+#### End-to-end flow (operator / SDK view)
+
+```mermaid
+flowchart TB
+    subgraph sdk["SDK CreateWithImage"]
+        S1["1. BuildImage"]
+        S2["2. Create sandbox"]
+    end
+
+    subgraph ingress["Ingress or server node"]
+        BW["clusterBuildImageWrap"]
+        CP["clustercreate.Prepare"]
+    end
+
+    subgraph workers["Docker workers"]
+        W1["worker-docker A"]
+        W2["worker-docker B"]
+    end
+
+    S1 --> BW
+    BW --> RoleQ{"Can this node own sandboxes?"}
+    RoleQ -->|yes mixed or worker| LocalB["buildImage locally"]
+    RoleQ -->|no server or ingress| Fanout["Fan out build to all Docker workers"]
+    Fanout --> W1
+    Fanout --> W2
+    Fanout --> Tag["Same aerolvm-build tag on each worker"]
+
+    S2 --> CP
+    CP --> LocalQ{"local-only built image?"}
+    LocalQ -->|no| Normal["Reservation-first placement unchanged"]
+    LocalQ -->|yes| OwnQ{"Can this node own sandboxes?"}
+    OwnQ -->|yes| SelfC["Create on self"]
+    OwnQ -->|no| Place["SelectPlacement with runtime docker"]
+    Place --> Fwd["Forward with X-Cluster-Create-Target"]
+    Fwd --> WorkerC["Worker creates without reservation ID"]
+    Tag -.-> WorkerC
+```
+
+#### Template API flow (cluster mode)
+
+```mermaid
+flowchart LR
+    TC["POST /templates"] --> PFC["SelectPlacement firecracker"]
+    PFC --> TF["Forward to FC worker"]
+
+    TL["GET /templates"] --> LM["List local"]
+    LM --> PM["Fan out to FC peers"]
+    PM --> MD["Merge and dedupe by template ID"]
+
+    TI["GET, DELETE, rebuild /templates/id"] --> PR["Probe FC peers"]
+    PR -->|found| Ret["Return peer response"]
+    PR -->|404 on all peers| FB["Fallback to local handler"]
+```
+
+#### pr-review axes for this change
+
+**Idempotency (§1)**
+
+- Build: content-addressed tag is deterministic; fanout replays the same tag on
+  each worker. `X-Cluster-Image-Build-Fanout: 1` prevents re-fanout loops.
+- Local-image create: no reservation on forward; worker create idempotency is
+  unchanged (name conflict, etc.). Misdirect guard: `X-Cluster-Create-Target` must
+  match self → 421.
+- Template list: read-only merge; duplicate IDs deduped (local row wins).
+
+**Sandbox boot / `CreateSandbox` latency (§2)**
+
+- **Worker path:** N/A — no new work on `CreateSandbox` at the worker.
+- **Ingress path (documented):** build fanout adds O(Docker workers) HTTP
+  round-trips before create; create adds one `SelectPlacement` + one forward
+  (no `ReserveOnTarget`). Fires only when self cannot own sandboxes.
+
+**Bootstrap (§3)**
+
+- N/A — no daemon-start lazy bootstrap added.
+
+**Failure-path consistency (§4)**
+
+- N/A — no new multi-step caddy + store write. Partial build fanout failure
+  returns 502; client retries build. Template list tolerates peer failures.
+
+**Mount inputs (§5)**
+
+- N/A.
+
+**TCP host-port pool & L4 (§6)**
+
+- N/A.
+
+**Cluster correctness**
+
+- Split-brain / wrong target: forwarded creates require target header == self.
+- FSM unchanged; no new Raft ops for local-image path.
+- Single-node: all wrappers no-op when cluster disabled or self can own.
+- Regression tests: `clustercreate_test.go`, `build_test.go`,
+  `cluster_handler_test.go`, `template_test.go`, `placement_test.go`.
+
+**Live verification:** `make integration-cluster-hetero` — UC-74
+(CreateWithImage built-image graph).
+
 ## PR description template
 
 Lives at [`.github/pull_request_template.md`](./.github/pull_request_template.md). GitHub auto-fills new PRs with it. Authors must answer every section; "N/A — <one-line reason>" is valid, empty is not.


### PR DESCRIPTION
## Summary

Fixes **UC-74** (`CreateWithImage` failing on role-separated clusters) and related per-host artifact routing. Reference: [`pr-review.md` §7.1](https://github.com/aerol-ai/microvm/blob/self-node-placement/pr-review.md#71-reference-implementation--b7-local-only-built-images--per-host-routing-pr-253) · Plan: [`plans/b7-built-image-placement.md`](plans/b7-built-image-placement.md) (parent: [`plans/cluster-hetero-failures-fix.md`](plans/cluster-hetero-failures-fix.md)).

- **Image build fanout** — `POST /v1/images/build` fans out to all alive, non-drained Docker-capable workers when the receiving node cannot own sandboxes (server/ingress). Mixed/worker nodes build locally. `push` / `context_hashes` builds unchanged.
- **Local-only image create routing** — `aerolvm-build/*` creates use `SelectPlacement` + forward with `X-Cluster-Create-Target` only (no reservation ID). Forwarded creates accept target-pinned local-image requests without `X-Cluster-Create-ID`.
- **Firecracker template cluster wrappers** — create routes via FC placement; list merges/dedupes peers; get/delete/rebuild probe peers then fall back local.
- **Placement scoring** — `CapacityRequestFromCreate` / `capacityRequestFromSpec` default omitted runtime to `docker`, include `ModuleRef`, WASM +8MB overhead, Firecracker overlay disk. Omitted `runtime` is **not** rewritten on forwarded create body (worker defaults preserved).

**Decision:** shipped **Option A (build on workers)** with replicate-to-all-Docker-workers fanout — not Option B (AOCR push), which remains the long-term recommendation in the B7 plan for durable/reusable images.

### What was solved

| Symptom | Root cause | Fix |
|---------|------------|-----|
| UC-74 `CreateWithImage` → `no worker placement target` | Build on ingress; image only there; `ImageRequiresLocalPlacement` pinned create to self; `CanOwnSandboxRole(server)` false | Build fanout + placement-forward create |
| Template API from ingress (B3) | Per-worker rootfs; no cluster wrappers | FC placement create; list merge; item probe + local fallback |
| Placement under-filtered | Missing runtime/module/WASM scoring | Align with `internal/cluster/placement.go` |

### End-to-end flow (`CreateWithImage`)

```mermaid
flowchart TB
    subgraph sdk["SDK CreateWithImage"]
        S1["1. BuildImage"]
        S2["2. Create sandbox"]
    end

    subgraph ingress["Ingress or server node"]
        BW["clusterBuildImageWrap"]
        CP["clustercreate.Prepare"]
    end

    subgraph workers["Docker workers"]
        W1["worker-docker A"]
        W2["worker-docker B"]
    end

    S1 --> BW
    BW --> RoleQ{"Can this node own sandboxes?"}
    RoleQ -->|yes mixed or worker| LocalB["buildImage locally"]
    RoleQ -->|no server or ingress| Fanout["Fan out build to all Docker workers"]
    Fanout --> W1
    Fanout --> W2
    Fanout --> Tag["Same aerolvm-build tag on each worker"]

    S2 --> CP
    CP --> LocalQ{"local-only built image?"}
    LocalQ -->|no| Normal["Reservation-first placement unchanged"]
    LocalQ -->|yes| OwnQ{"Can this node own sandboxes?"}
    OwnQ -->|yes| SelfC["Create on self"]
    OwnQ -->|no| Place["SelectPlacement with runtime docker"]
    Place --> Fwd["Forward with X-Cluster-Create-Target"]
    Fwd --> WorkerC["Worker creates without reservation ID"]
    Tag -.-> WorkerC
```

### Template API flow (cluster mode)

```mermaid
flowchart LR
    TC["POST /templates"] --> PFC["SelectPlacement firecracker"]
    PFC --> TF["Forward to FC worker"]

    TL["GET /templates"] --> LM["List local"]
    LM --> PM["Fan out to FC peers"]
    PM --> MD["Merge and dedupe by template ID"]

    TI["GET, DELETE, rebuild /templates/id"] --> PR["Probe FC peers"]
    PR -->|found| Ret["Return peer response"]
    PR -->|404 on all peers| FB["Fallback to local handler"]
```

### Implementation map

| Component | File(s) | Mechanism |
|-----------|---------|-----------|
| Image build fanout | `pkg/api/v1/build.go`, `routes.go` | `clusterBuildImageWrap`; `X-Cluster-Image-Build-Fanout: 1` |
| Local-image create | `pkg/api/clustercreate/clustercreate.go`, `pkg/api/v1/cluster_handler.go` | `clusterSelfCanOwnSandbox`; forward without reservation ID |
| Shared helpers | `pkg/api/v1/cluster_helpers.go` | `clusterMemberSupportsRuntime`, `clusterPeerURL` |
| Placement scoring | `clustercreate`, `cluster_handler`, `internal/cluster/placement.go` | Runtime/module/WASM defaults |
| Template cluster | `pkg/api/v1/template.go`, `routes.go` | `X-Cluster-Template-Forwarded: 1` |

Key invariant: `ImageRequiresLocalPlacement` still means the image must exist on the node that runs the sandbox — we changed *which* node that is, not the local-only contract.

## Sandbox boot impact

**Worker path:** N/A — no new work on `CreateSandbox` or its callees at the worker. Forwarded local-image create uses existing `createSandboxOnSelectedNode`.

**Ingress/server path (new, bounded):** fires only when `clusterSelfCanOwnSandbox` is false.

| Step | Added work | Latency | Bounded by |
|------|------------|---------|------------|
| `POST /v1/images/build` | O(Docker workers) peer HTTP builds (fanout) | One round-trip per worker | Alive Docker-capable peer count |
| `POST /v1/sandboxes` (`aerolvm-build/*`) | One `SelectPlacement` + one HTTP forward (no `ReserveOnTarget`) | Single placement + forward | Cluster size |

Single-node / `EnableCluster=false`: wrappers no-op — no added latency.

## Idempotency

| Surface | Retry / concurrent behavior |
|---------|----------------------------|
| `POST /v1/images/build` | Content-addressed tag is deterministic per dockerfile. Fanout replays same tag on each worker. `X-Cluster-Image-Build-Fanout: 1` prevents re-fanout loops. `push` / `context_hashes` skip fanout (unchanged). |
| `POST /v1/sandboxes` (`aerolvm-build/*`) | No reservation ID on forward — worker create idempotency unchanged (name conflict, etc.). Misdirect guard: `X-Cluster-Create-Target` must match self → 421. |
| `POST /v1/sandboxes` (normal) | Unchanged reservation-first flow. |
| Template list | Read-only merge; duplicate IDs deduped (local row wins). |
| Template get/delete/rebuild | Probe peers; 404 continues; local fallback. Rebuild CAS unchanged on owning worker. |

## Failure-path consistency

N/A — no new multi-step caddy + store write path. Image build fanout: partial failure returns 502; client retries build. Template list tolerates peer failures (warn + continue). No reconcile dependency introduced.

## L4 / host-port-pool changes

N/A — neither touched.

## Cluster correctness (`pr-review.md` §7)

| Concern | Mitigation |
|---------|------------|
| Split-brain / wrong target | Forwarded creates require `X-Cluster-Create-Target == self`; misdirect → 421 |
| Leader-change / replay | FSM unchanged; no new Raft ops for local-image path |
| Single-node regression | All wrappers no-op when cluster disabled or self can own sandboxes |
| Role-separated topology | Server/ingress no longer assumes it can run `aerolvm-build/*` or host template rootfs |
| Heterogeneous runtimes | Build fanout filters `SupportedRuntimes`; templates filter Firecracker; placement uses `docker` for built images but does not inject `runtime` into forwarded body |
| Loop guards | `X-Cluster-Image-Build-Fanout`, `X-Cluster-Template-Forwarded` prevent re-fanout |

Regression tests: `clustercreate_test.go`, `build_test.go`, `cluster_handler_test.go`, `template_test.go`, `placement_test.go`.

## Test plan

- [x] `go test ./pkg/api/v1/... ./pkg/api/clustercreate/... ./internal/cluster/...`
- [ ] `make integration-cluster-hetero` — UC-74 (CreateWithImage built-image graph)
- [ ] Manual: `CreateWithImage` from SDK against ingress URL in 8-node hetero cluster
- [ ] Manual: `POST /v1/templates` from ingress → FC worker; `GET /v1/templates` returns union
- [ ] Single-node / cluster-disabled smoke: build + create still work locally