### PR TITLE
fix(integration): set ModuleRef for WASM tests and harden stale snapshot ref guard

### DIFF
--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -129,6 +129,14 @@ on_demand_tfvar() {
   [[ "$METAL_ON_DEMAND" == "1" ]] && echo "true" || echo "false"
 }
 
+is_stale_wasm_snapshot_ref() {
+  local ref="${1:-}"
+  # WASM runtime tests use a staged module alias such as "python". A snapshot
+  # image ref from the Docker snapshot UCs is not a WASM module and always fails
+  # module resolution if it leaks in from the operator's shell environment.
+  [[ "$ref" == *"/cluster/"*"/snapshots"* || "$ref" == "cluster/"*"/snapshots"* ]]
+}
+
 run_one() {
   local scenario="$1"
   local sdir="${REPO_ROOT}/integration-tests/.tf/${scenario}"
@@ -309,7 +317,7 @@ run_one() {
   # module by alias; default to python (override by exporting the env var).
   local wasm_ref=""
   [[ "$caps_wasm" == "true" ]] && wasm_ref="${AEROL_WASM_MODULE_REF:-python}"
-  if [[ "$caps_wasm" == "true" && "$wasm_ref" == aocr.aerol.ai/cluster/*/snapshots/* ]]; then
+  if [[ "$caps_wasm" == "true" ]] && is_stale_wasm_snapshot_ref "$wasm_ref"; then
     echo "scenario ${scenario}: ignoring stale snapshot image ref in AEROL_WASM_MODULE_REF=${wasm_ref}; using staged wasm module alias 'python'" >&2
     wasm_ref="python"
   fi

--- a/integration-tests/suite/benchmark_test.go
+++ b/integration-tests/suite/benchmark_test.go
@@ -260,6 +260,7 @@ func TestBenchCreateLatency(t *testing.T) {
 			}
 			if br.runtime == "wasm" {
 				opts.Image = wasmRef
+				opts.ModuleRef = wasmRef
 			} else {
 				opts.Image = harness.DefaultImage
 			}

--- a/integration-tests/suite/platform_volumes_test.go
+++ b/integration-tests/suite/platform_volumes_test.go
@@ -170,7 +170,7 @@ func expectPlatformVolumeRuntimeRejected(t *testing.T, runtime, image string) {
 	c := client(t)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
-	sb, err := c.SDK().Create(ctx, sdktypes.CreateSandboxOptions{
+	opts := sdktypes.CreateSandboxOptions{
 		Image:   image,
 		Name:    harness.UniqueName(sc, t),
 		Runtime: runtime,
@@ -178,7 +178,11 @@ func expectPlatformVolumeRuntimeRejected(t *testing.T, runtime, image string) {
 			Name: volumeName(t),
 			Path: "/vol",
 		}},
-	})
+	}
+	if runtime == sdktypes.RuntimeWasm {
+		opts.ModuleRef = image
+	}
+	sb, err := c.SDK().Create(ctx, opts)
 	if err == nil {
 		_ = c.SDK().Destroy(ctx, sb.ID)
 		t.Fatalf("create with runtime=%s and platform volume succeeded; expected rejection", runtime)

--- a/integration-tests/suite/regression_fixes_test.go
+++ b/integration-tests/suite/regression_fixes_test.go
@@ -284,7 +284,8 @@ func TestClusterPlacesRuntimeOnCapableWorker(t *testing.T) {
 			opts := sdktypes.CreateSandboxOptions{Name: harness.UniqueName(sc, t), Runtime: rc.runtime}
 			if rc.runtime == "wasm" {
 				// WASM resolves an image/module ref, not a container image.
-				opts.Image = stagedWasmModuleRefOrDefault(t)
+				opts.ModuleRef = stagedWasmModuleRefOrDefault(t)
+				opts.Image = opts.ModuleRef
 			}
 			sb := c.NewSandbox(t, opts)
 			waitRunning(t, sb)

--- a/integration-tests/suite/runtimes_test.go
+++ b/integration-tests/suite/runtimes_test.go
@@ -58,9 +58,10 @@ func TestRuntimeWasm(t *testing.T) {
 	}
 	c := client(t)
 	sb := c.NewSandbox(t, sdktypes.CreateSandboxOptions{
-		Name:    harness.UniqueName(sc, t),
-		Runtime: "wasm",
-		Image:   ref,
+		Name:      harness.UniqueName(sc, t),
+		Runtime:   "wasm",
+		Image:     ref,
+		ModuleRef: ref,
 	})
 	waitRunning(t, sb)
 }

--- a/integration-tests/suite/wasm_ref_test.go
+++ b/integration-tests/suite/wasm_ref_test.go
@@ -33,5 +33,25 @@ func stagedWasmModuleRefOrDefault(t testing.TB) string {
 
 func staleSnapshotModuleRef(ref string) bool {
 	ref = strings.TrimSpace(ref)
-	return strings.Contains(ref, "/cluster/") && strings.Contains(ref, "/snapshots/")
+	return (strings.Contains(ref, "/cluster/") || strings.HasPrefix(ref, "cluster/")) &&
+		strings.Contains(ref, "/snapshots")
+}
+
+func TestStaleSnapshotModuleRef(t *testing.T) {
+	cases := []string{
+		"aocr.aerol.ai/cluster/prod-aerolvm-us-east-1/snapshots/python:latest--ttl-1h",
+		"oci://aocr.aerol.ai/cluster/prod-aerolvm-us-east-1/snapshots/python:latest--ttl-1h",
+		"cluster/prod-aerolvm-us-east-1/snapshots/python:latest--ttl-1h",
+	}
+	for _, ref := range cases {
+		if !staleSnapshotModuleRef(ref) {
+			t.Fatalf("staleSnapshotModuleRef(%q) = false, want true", ref)
+		}
+	}
+
+	for _, ref := range []string{"python", "aocr.aerol.ai/wasm/std/python:3.12"} {
+		if staleSnapshotModuleRef(ref) {
+			t.Fatalf("staleSnapshotModuleRef(%q) = true, want false", ref)
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- Set `ModuleRef` on WASM sandbox creates across integration suite (benchmark, platform volumes, runtimes, cluster placement).
- Replace broken glob in `run.sh` with `is_stale_wasm_snapshot_ref` shell predicate for leaked Docker snapshot refs in `AEROL_WASM_MODULE_REF`.
- Add unit test for `staleSnapshotModuleRef` covering registry-prefixed and bare `cluster/.../snapshots` paths.

## Test plan
- [x] `go test -run TestStaleSnapshotModuleRef ./integration-tests/suite/...` (integration tag not required for unit test)
- [ ] `make integration-cluster-hetero keep` (operator-run)


Made with [Cursor](https://cursor.com)