### PR TITLE
feat(integration): benchmark harness improvements + server-side create timing

### DIFF
--- a/Ansible/playbooks/configure-ops.yml
+++ b/Ansible/playbooks/configure-ops.yml
@@ -116,6 +116,8 @@
       SB_ENABLE_WASM: "{{ wasm.enabled | default(false) | bool | string | lower }}"
       SB_WASM_MODULES_DIR: "{{ wasm.modules_dir | default('/var/lib/sandboxd/wasm/modules') }}"
       SB_WASM_CACHE_DIR: "{{ wasm.cache_dir | default('') }}"
+      SB_WASM_POOL_ENABLED: "{{ wasm.pool.enabled | default(false) | bool | string | lower }}"
+      SB_WASM_POOL_DEPTH_DEFAULT: "{{ wasm.pool.depth_default | default(0) | int }}"
       SB_WASM_REGISTRY_ALLOWLIST: "{{ wasm.registry_allowlist | default('') }}"
       SB_WASM_PULL_TIMEOUT: "{{ wasm.pull_timeout | default('60s') }}"
       SB_WASM_REGISTRY_PUSH_HOST: "{{ wasm.push_host | default('') }}"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BIN_DIR ?= bin
 
 .PHONY: fmt install-git-hooks test test-acme-e2e build build-sandboxd build-toolboxd docs-install docs-dev docs-build clean \
 	integration-local integration-single integration-single-wasm integration-cluster-mixed integration-cluster-mixed-wasm \
-	integration-cluster-hetero integration-cluster-hetero-safe integration-benchmark integration-single-fc integration-arm64 integration-arm64-single integration-arm64-cluster integration-all integration-collect-logs integration-destroy integration-reap
+	integration-cluster-hetero integration-cluster-hetero-safe integration-benchmark integration-benchmark-only integration-single-fc integration-arm64 integration-arm64-single integration-arm64-cluster integration-all integration-collect-logs integration-destroy integration-reap
 
 fmt:
 	$(GO) fmt ./...
@@ -112,6 +112,13 @@ BENCH_OUT ?= integration-tests/reports/cluster-hetero-bench.json
 integration-benchmark:
 	AEROL_BENCH=1 AEROL_BENCH_OUT=$(BENCH_OUT) \
 		integration-tests/run.sh cluster-hetero $(RUN_FLAGS)
+
+# Re-run UC-94/UC-95 only against a cluster left up with `keep` (no reprovision).
+#   make integration-benchmark-only
+#   make integration-benchmark-only BENCH_OUT=/tmp/bench.json
+integration-benchmark-only:
+	AEROL_BENCH_OUT=$(BENCH_OUT) \
+		integration-tests/run.sh cluster-hetero --bench-only
 
 # Single-node x86 Firecracker on bare metal (c5.metal). Smallest scenario that
 # exercises the firecracker use cases (UC-24/47-50) without the full hetero

--- a/Terraform/locals.tf
+++ b/Terraform/locals.tf
@@ -244,6 +244,8 @@ locals {
     enabled            = try(local.cluster_ops.wasm.enabled, false) ? "true" : "false"
     modules_dir        = try(local.cluster_ops.wasm.modules_dir, "/var/lib/sandboxd/wasm/modules")
     cache_dir          = try(local.cluster_ops.wasm.cache_dir, "")
+    pool_enabled       = try(local.cluster_ops.wasm.pool.enabled, false) ? "true" : "false"
+    pool_depth_default = tostring(try(local.cluster_ops.wasm.pool.depth_default, 0))
     registry_allowlist = try(local.cluster_ops.wasm.registry_allowlist, "")
     pull_timeout       = try(local.cluster_ops.wasm.pull_timeout, "60s")
     push_host          = try(local.cluster_ops.wasm.push_host, "")

--- a/Terraform/templates/bootstrap.sh.tftpl
+++ b/Terraform/templates/bootstrap.sh.tftpl
@@ -591,6 +591,8 @@ cat >> /tmp/aerolvm-ops.env <<'EOF'
 SB_ENABLE_WASM=${wasm_cfg.enabled}
 SB_WASM_MODULES_DIR=${wasm_cfg.modules_dir}
 SB_WASM_CACHE_DIR=${wasm_cfg.cache_dir}
+SB_WASM_POOL_ENABLED=${wasm_cfg.pool_enabled}
+SB_WASM_POOL_DEPTH_DEFAULT=${wasm_cfg.pool_depth_default}
 SB_WASM_REGISTRY_ALLOWLIST=${wasm_cfg.registry_allowlist}
 SB_WASM_PULL_TIMEOUT=${wasm_cfg.pull_timeout}
 SB_WASM_REGISTRY_PUSH_HOST=${wasm_cfg.push_host}

--- a/config/cluster.yml
+++ b/config/cluster.yml
@@ -120,6 +120,14 @@ wasm:
   enabled: false
   modules_dir: "/var/lib/sandboxd/wasm/modules"
   cache_dir: "/var/lib/sandboxd/wasm/cache"
+  # Warm-worker pool (Phase 5): pre-spawns workers with the standard modules
+  # already loaded + compiled, so a create acquires a ready worker instead of
+  # paying the cold compile — which for CPython-on-wasm is ~10s on a small node.
+  # Off by default: warm workers hold RAM. Turn on for perf/benchmark fleets.
+  # depth_default = warm slots kept per module digest.
+  pool:
+    enabled: false
+    depth_default: 0
   registry_allowlist: "aocr.aerol.ai"
   pull_timeout: "60s"
   push_host: ""

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -77,18 +77,17 @@ AEROL_BENCH_OUT=integration-tests/reports/cluster-hetero-bench.json \
 ```
 
 To iterate without re-provisioning, bring the cluster up once with `keep`, then
-re-run only the bench against it (the env that `run.sh` set for the suite —
-`AEROL_BASE_URL`, `AEROL_PAT`, `AEROL_CAPS`, `AEROL_WASM_MODULE_REF` — must be
-exported in your shell):
+re-run only UC-94/UC-95 with `make integration-benchmark-only` — it reads the API
+URL + PAT from TF state and forces `AEROL_BENCH=1`, so nothing to export:
 
 ```bash
-make integration-cluster-hetero keep        # provision, leave it up
+make integration-cluster-hetero keep         # provision, leave it up
+make integration-benchmark-only              # re-run just the bench against it
 
-AEROL_BENCH=1 \
-AEROL_BENCH_OUT=integration-tests/reports/cluster-hetero-bench.json \
-  go test -tags=integration -v -timeout 60m \
-    -run 'TestBenchCreateLatency|TestBenchDensity' \
-    ./integration-tests/suite/...
+# Narrow the UC-94 sweep — firecracker cold-boots are slow; skip them to finish:
+AEROL_BENCH_RUNTIMES=docker,gvisor,wasm make integration-benchmark-only
+# …or isolate one runtime:
+AEROL_BENCH_RUNTIMES=firecracker make integration-benchmark-only
 
 make integration-destroy                     # tear the kept cluster down
 ```
@@ -96,14 +95,26 @@ make integration-destroy                     # tear the kept cluster down
 Percentiles + the density ceiling also print as `bench[...]` log lines (captured
 by `go test -json`); the `AEROL_BENCH_OUT` JSON adds the machine block.
 
+**WASM warm pool.** wasm scenarios boot with the warm-worker pool on
+(`wasm.pool.enabled`, depth `AEROL_WASM_POOL_DEPTH`, default `2`) so creates skip
+the cold module compile — CPython-on-wasm is ~10s cold on a t3. Depth is baked
+into **node boot env**, so a cluster brought up before this change shows cold
+numbers until re-provisioned. The bench's serial burst drains a shallow pool, so
+for an all-warm wasm reading keep `AEROL_BENCH_SAMPLES` ≤ depth (e.g.
+`AEROL_BENCH_RUNTIMES=wasm AEROL_BENCH_SAMPLES=2`). Raise the depth only on
+`cluster-hetero` (worker-z is bare metal) — `depth × standard-modules` warm
+workers won't fit on a t3.medium.
+
 | Env var | Default | Purpose |
 |---------|---------|---------|
 | `AEROL_BENCH` | *(unset)* | **master switch** — must be `1` or the bench skips |
+| `AEROL_BENCH_RUNTIMES` | *(all advertised)* | comma list narrowing the UC-94 sweep, e.g. `docker,gvisor,wasm` (skip firecracker) or `firecracker` (isolate) |
 | `AEROL_BENCH_SAMPLES` | `10` | sandboxes timed per runtime (UC-94) |
 | `AEROL_BENCH_MAX` | `200` | safety cap on the density probe (UC-95) |
 | `AEROL_BENCH_OUT` | *(unset)* | path to write the JSON artifact; logs only if unset |
 | `AEROL_BENCH_TFVARS` | `../scenarios/<scenario>.tfvars` | override the machine-config source |
 | `AEROL_WASM_MODULE_REF` | *(unset)* | staged `.wasm` ref; wasm latency skips without it |
+| `AEROL_WASM_POOL_DEPTH` | `2` | warm wasm workers per module digest (provision-time; `0` when wasm off) |
 
 ## What runs where
 

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -52,8 +52,11 @@ sandboxes. Everywhere else UC-94/UC-95 skip (not-applicable).
 
 - **UC-94 — create latency:** for each runtime the scenario has (docker,
   firecracker, gvisor, wasm) it creates `AEROL_BENCH_SAMPLES` sandboxes
-  serially, timing the `Create()` round-trip and the full create→`started`
-  time, and reports p50/p90/p99 + mean.
+  serially, reporting p50/p90/p99 + mean for three timings: **api** (the
+  `Create()` client round-trip), **server** (the API's own `Server-Timing`
+  header for the create — client↔cluster network excluded), and **running**
+  (create→`started`). `api − server` is that network overhead, so you can tell a
+  slow create from a slow link.
 - **UC-95 — fleet density:** creates docker sandboxes until the fleet rejects on
   capacity (HTTP 503 `capacity exceeded`), reports how many landed, then tears
   them all down. `AEROL_BENCH_MAX` bounds cost if admission never trips.

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -205,11 +205,22 @@ run_one() {
   # wasm.enabled follows the scenario's wasm capability so the wasm worker can
   # actually run modules (the wasm-runtime UCs still gate on a staged module
   # ref via AEROL_WASM_MODULE_REF; this just turns the runtime on).
+  # When wasm runs we also turn on the warm-worker pool so creates skip the cold
+  # module compile (CPython-on-wasm is ~10s cold on a t3). depth_default is per
+  # module digest; AEROL_WASM_POOL_DEPTH raises it to cover a benchmark's serial
+  # sample burst. Pool stays off (depth 0) when wasm is off.
+  local wasm_pool_enabled="false" wasm_pool_depth=0
+  if [[ "$caps_wasm" == "true" ]]; then
+    wasm_pool_enabled="true"
+    wasm_pool_depth="${AEROL_WASM_POOL_DEPTH:-2}"
+  fi
   # Upstream auto-import (pulling private prod images through AOCR hooks) and
   # the fleet control plane are prod-only side effects we always neutralize.
   yq '.auto_import.enabled = false
       | .fleet_control_plane.enabled = false
       | .wasm.enabled = '"$caps_wasm"'
+      | .wasm.pool.enabled = '"$wasm_pool_enabled"'
+      | .wasm.pool.depth_default = '"$wasm_pool_depth"'
       | .platform_volumes.enabled = '"$caps_platform_volumes"'
       | .platform_volumes.backend = "s3"
       | .platform_volumes.s3_bucket = ""

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -29,6 +29,7 @@ PROD_TLS=0
 METAL_ON_DEMAND=0
 NO_DISRUPTIVE=0
 COLLECT_LOGS_ONLY=0
+BENCH_ONLY=0
 DESTROY_ONLY=0
 SCENARIO=""
 # PID of the local-mode SSH port-forward, so teardown can reap it. Without this
@@ -50,6 +51,9 @@ for arg in "$@"; do
     # forensics into reports/<scenario>-failure-logs.txt. Use this to iterate on
     # a stuck cluster without paying another bring-up.
     --collect-logs-only) COLLECT_LOGS_ONLY=1 ;;
+    # Re-run UC-94/UC-95 against a cluster already provisioned with --keep.
+    # Reads integration_targets from TF state; does not apply or destroy.
+    --bench-only) BENCH_ONLY=1 ;;
     # Full terraform destroy of a scenario kept up with --keep (VPC, S3, IAM,
     # instances — everything, and clears the TF state). Unlike integration-reap
     # (which only terminates EC2 instances), this is the real cleanup.
@@ -58,7 +62,7 @@ for arg in "$@"; do
     *) SCENARIO="$arg" ;;
   esac
 done
-[[ -n "$SCENARIO" ]] || { echo "usage: run.sh <scenario|all> [--keep] [--prod-tls] [--metal-on-demand] [--collect-logs-only] [--destroy-only]" >&2; exit 2; }
+[[ -n "$SCENARIO" ]] || { echo "usage: run.sh <scenario|all> [--keep] [--prod-tls] [--metal-on-demand] [--no-disruptive] [--collect-logs-only] [--bench-only] [--destroy-only]" >&2; exit 2; }
 
 DOMAINS_FILE="${HERE}/scenarios/domains.yml"
 CONFIG_CLUSTER="${REPO_ROOT}/config/cluster.yml"
@@ -366,6 +370,16 @@ run_one() {
   if [[ "$allow_disruptive" == "1" ]]; then
     echo "disruptive fault-injection tests enabled (UC-58b on cluster-hetero)" >&2
   fi
+  # go test runs with cwd = the package dir (integration-tests/suite), so bench
+  # artifact paths from the Makefile must be absolute or WriteFile lands under
+  # suite/integration-tests/reports/... and fails with ENOENT.
+  local bench_out="${AEROL_BENCH_OUT:-}"
+  if [[ -n "$bench_out" && "$bench_out" != /* ]]; then
+    bench_out="${REPO_ROOT}/${bench_out}"
+  fi
+  if [[ "${AEROL_BENCH:-}" == "1" ]]; then
+    echo "benchmark enabled (UC-94/UC-95); artifact=${bench_out:-logs only}" >&2
+  fi
   set +e
   AEROL_BASE_URL="$base_url" AEROL_PAT="$pat" AEROL_SCENARIO="$scenario" \
     AEROL_CAPS="${caps_file}" \
@@ -373,6 +387,8 @@ run_one() {
     AEROL_EXPECTED_MEMBERS="${expected_members}" \
     AEROL_INTEGRATION_TARGETS="${targets}" \
     AEROL_ALLOW_DISRUPTIVE="${allow_disruptive}" \
+    AEROL_BENCH="${AEROL_BENCH:-}" \
+    AEROL_BENCH_OUT="${bench_out}" \
     AEROL_WASM_MODULE_REF="${wasm_ref}" \
     go test -tags=integration -count=1 -json ./integration-tests/suite/... > "$json_out"
   local test_rc=$?
@@ -479,12 +495,86 @@ collect_logs_only() {
   echo "logs written to ${HERE}/reports/${scenario}-failure-logs.txt" >&2
 }
 
+# run_bench_only re-runs UC-94/UC-95 against an already-provisioned scenario
+# (brought up with --keep). Loads API URL + domain from TF state so the operator
+# does not have to hand-export AEROL_BASE_URL / AEROL_CAPS / AEROL_PAT.
+run_bench_only() {
+  local scenario="$1"
+  local sdir="${REPO_ROOT}/integration-tests/.tf/${scenario}"
+  local caps_file="${HERE}/scenarios/${scenario}.caps.yml"
+  if [[ ! -d "$sdir" ]]; then
+    echo "no TF state at ${sdir} — run 'make integration-${scenario} keep' (or integration-benchmark keep) first" >&2
+    exit 2
+  fi
+  if [[ ! -f "$caps_file" ]]; then
+    echo "scenario ${scenario}: missing ${caps_file}" >&2
+    exit 2
+  fi
+
+  local targets pat base_url leased
+  targets=$(TF_DATA_DIR="$sdir" terraform -chdir="${REPO_ROOT}/Terraform" output -json integration_targets 2>/dev/null) \
+    || { echo "could not read integration_targets from ${sdir} — is the cluster still up?" >&2; exit 2; }
+  pat=$(yq -r '.cluster.pat_token' "${REPO_ROOT}/config/secrets.yml")
+  base_url=$(echo "$targets" | jq -r '.base_url // empty')
+  leased=$(echo "$targets" | jq -r '.domain // empty')
+  if [[ -z "$base_url" ]]; then
+    echo "integration_targets has no base_url — is this a local-mode scenario?" >&2
+    exit 2
+  fi
+
+  local caps_wasm
+  caps_wasm=$(yq -r '.capabilities | contains(["wasm"])' "$caps_file")
+  local wasm_ref=""
+  [[ "$caps_wasm" == "true" ]] && wasm_ref="${AEROL_WASM_MODULE_REF:-python}"
+  if [[ "$caps_wasm" == "true" ]] && is_stale_wasm_snapshot_ref "$wasm_ref"; then
+    wasm_ref="python"
+  fi
+
+  local bench_out="${AEROL_BENCH_OUT:-integration-tests/reports/${scenario}-bench.json}"
+  if [[ "$bench_out" != /* ]]; then
+    bench_out="${REPO_ROOT}/${bench_out}"
+  fi
+  mkdir -p "$(dirname "$bench_out")" "${HERE}/reports"
+
+  echo "=== bench-only against ${base_url} (artifact=${bench_out}) ===" >&2
+  if ! wait_for_health "$base_url" "$pat"; then
+    echo "scenario ${scenario}: API not healthy at ${base_url}" >&2
+    exit 2
+  fi
+
+  set +e
+  AEROL_BENCH=1 \
+  AEROL_BENCH_OUT="${bench_out}" \
+  AEROL_BASE_URL="$base_url" \
+  AEROL_PAT="$pat" \
+  AEROL_SCENARIO="$scenario" \
+  AEROL_CAPS="${caps_file}" \
+  AEROL_DOMAIN="${leased}" \
+  AEROL_WASM_MODULE_REF="${wasm_ref}" \
+    go test -tags=integration -count=1 -timeout=60m -v \
+      -run 'TestBench' \
+      ./integration-tests/suite/...
+  local test_rc=$?
+  set -e
+  if [[ "$test_rc" != "0" ]]; then
+    exit "$test_rc"
+  fi
+  if [[ -f "$bench_out" ]]; then
+    echo "bench artifact: ${bench_out}" >&2
+  else
+    echo "bench tests finished but artifact missing at ${bench_out}" >&2
+    exit 2
+  fi
+}
+
 if [[ "$DESTROY_ONLY" == "1" ]]; then
   # teardown() returns early when KEEP=1; force a real destroy here.
   KEEP=0
   teardown "$SCENARIO"
 elif [[ "$COLLECT_LOGS_ONLY" == "1" ]]; then
   collect_logs_only "$SCENARIO"
+elif [[ "$BENCH_ONLY" == "1" ]]; then
+  run_bench_only "$SCENARIO"
 elif [[ "$SCENARIO" == "all" ]]; then
   for s in local-mode single-node single-node-wasm cluster-3-mixed cluster-3-mixed-wasm cluster-hetero single-node-fc single-node-fc-arm64 cluster-arm64; do
     ( run_one "$s" )

--- a/integration-tests/scenarios/cluster-hetero.caps.yml
+++ b/integration-tests/scenarios/cluster-hetero.caps.yml
@@ -1,11 +1,17 @@
 # Heterogeneous 8-node cluster: dedicated server/ingress roles plus four
-# multi-runtime workers (docker + gVisor + WASM on x/y/w; z also has FC host
-# wiring). Firecracker create UCs are skipped here — live FC coverage is in
-# single-node-fc, single-node-fc-arm64, and cluster-arm64.
+# multi-runtime workers — docker + gVisor + WASM on worker-x/y/w, and worker-z
+# (c5.metal) additionally runs Firecracker. FC create/template/exec UCs and the
+# Firecracker benchmark row exercise worker-z. Firecracker is the only runtime
+# with a single host here (worker-z is the lone bare-metal box; a second x86
+# *.metal is blocked on the metal vCPU quota), so it has no failover peer — the
+# disruptive recreate-via-failover UC (UC-58b) deliberately stays on docker, and
+# live FC *failover* coverage is deferred to cluster-arm64 (see
+# plans/arm64-firecracker-hosts.md).
 name: cluster-hetero
 capabilities:
   - docker
   - platform-volumes
+  - firecracker
   - gvisor
   - wasm
   - domain

--- a/integration-tests/scenarios/cluster-hetero.tfvars
+++ b/integration-tests/scenarios/cluster-hetero.tfvars
@@ -9,9 +9,11 @@
 #       worker-z     — docker + gVisor + WASM + Firecracker (KVM bare metal)
 #
 # Failover/disruptive tests kill worker-x and expect recreate-policy sandboxes
-# to land on worker-y or worker-z (worker-w is an extra placement peer). Firecracker create UCs are skipped
-# here (caps.yml omits the firecracker capability) — see single-node-fc and
-# cluster-arm64 for live FC coverage.
+# to land on worker-y or worker-z (worker-w is an extra placement peer). FC
+# create/template/exec UCs run against worker-z, but firecracker has no failover
+# peer here — worker-z is the only bare-metal host and a second x86 *.metal is
+# blocked on the metal vCPU quota — so the recreate-via-failover UC (UC-58b)
+# stays on docker. FC failover coverage is deferred to cluster-arm64.
 #
 # Cost control is by instance sizing (servers/ingress are t3.small). Every node
 # runs On-Demand (spot = false): the bare-metal firecracker box alone exceeds the

--- a/integration-tests/suite/benchmark_test.go
+++ b/integration-tests/suite/benchmark_test.go
@@ -114,6 +114,15 @@ type latencyStats struct {
 	Runp50MS  int64  `json:"run_p50_ms"`
 	Runp90MS  int64  `json:"run_p90_ms"`
 	Runp99MS  int64  `json:"run_p99_ms"`
+	// Server-side create time from the API's Server-Timing header — the create
+	// cost with the client<->cluster network round-trip excluded. The gap
+	// (api - server) is that network overhead. Zero when the server sends no
+	// header (older build); ServerSamples counts the creates that carried one.
+	ServerSamples int   `json:"server_samples"`
+	ServerMeanMS  int64 `json:"server_mean_ms"`
+	Serverp50MS   int64 `json:"server_p50_ms"`
+	Serverp90MS   int64 `json:"server_p90_ms"`
+	Serverp99MS   int64 `json:"server_p99_ms"`
 }
 
 // benchReport is the full JSON artifact (UC-94 + UC-95 combined).
@@ -275,7 +284,7 @@ func TestBenchCreateLatency(t *testing.T) {
 			}
 		}
 
-		var apiD, runD []time.Duration
+		var apiD, runD, serverD []time.Duration
 		failures := 0
 		for i := 0; i < samples; i++ {
 			opts := sdktypes.CreateSandboxOptions{
@@ -309,23 +318,29 @@ func TestBenchCreateLatency(t *testing.T) {
 				failures++
 			}
 			apiD = append(apiD, apiElapsed)
+			// Server-reported create time (Server-Timing header) — same create,
+			// minus the client<->cluster network. Absent on an older server.
+			if ms, ok := c.LastServerCreateMS(); ok {
+				serverD = append(serverD, time.Duration(ms*float64(time.Millisecond)))
+			}
 		}
 
 		if len(apiD) == 0 {
 			t.Errorf("bench[%s]: every create sample failed", br.runtime)
 			continue
 		}
-		ls := summarize(br.runtime, samples, failures, apiD, runD)
+		ls := summarize(br.runtime, samples, failures, apiD, runD, serverD)
 		report.Latency = append(report.Latency, ls)
-		t.Logf("bench[%s] api p50=%dms p90=%dms p99=%dms | running p50=%dms p90=%dms p99=%dms (%d ok, %d fail)",
+		t.Logf("bench[%s] api p50=%dms p90=%dms p99=%dms | server p50=%dms p90=%dms p99=%dms | running p50=%dms p90=%dms p99=%dms (%d ok, %d fail)",
 			br.runtime, ls.APIp50MS, ls.APIp90MS, ls.APIp99MS,
+			ls.Serverp50MS, ls.Serverp90MS, ls.Serverp99MS,
 			ls.Runp50MS, ls.Runp90MS, ls.Runp99MS, len(apiD), failures)
 	}
 	writeBenchArtifact(t, report)
 }
 
 // summarize folds raw samples into a latencyStats row.
-func summarize(rt string, samples, failures int, apiD, runD []time.Duration) latencyStats {
+func summarize(rt string, samples, failures int, apiD, runD, serverD []time.Duration) latencyStats {
 	ls := latencyStats{Runtime: rt, Samples: samples, Failures: failures}
 	if len(apiD) > 0 {
 		ls.APIMeanMS = meanMS(apiD)
@@ -338,6 +353,13 @@ func summarize(rt string, samples, failures int, apiD, runD []time.Duration) lat
 		ls.Runp50MS = percentile(runD, 50).Milliseconds()
 		ls.Runp90MS = percentile(runD, 90).Milliseconds()
 		ls.Runp99MS = percentile(runD, 99).Milliseconds()
+	}
+	if len(serverD) > 0 {
+		ls.ServerSamples = len(serverD)
+		ls.ServerMeanMS = meanMS(serverD)
+		ls.Serverp50MS = percentile(serverD, 50).Milliseconds()
+		ls.Serverp90MS = percentile(serverD, 90).Milliseconds()
+		ls.Serverp99MS = percentile(serverD, 99).Milliseconds()
 	}
 	return ls
 }

--- a/integration-tests/suite/benchmark_test.go
+++ b/integration-tests/suite/benchmark_test.go
@@ -223,6 +223,10 @@ func writeBenchArtifact(t *testing.T, rep benchReport) {
 		t.Logf("bench: marshal artifact: %v", err)
 		return
 	}
+	if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+		t.Logf("bench: mkdir %s: %v", filepath.Dir(out), err)
+		return
+	}
 	if err := os.WriteFile(out, blob, 0o644); err != nil {
 		t.Logf("bench: write artifact %s: %v", out, err)
 	}

--- a/integration-tests/suite/benchmark_test.go
+++ b/integration-tests/suite/benchmark_test.go
@@ -59,6 +59,23 @@ func requireBenchEnabled(t *testing.T) {
 	}
 }
 
+// benchRuntimeAllowed reports whether rt should be swept. AEROL_BENCH_RUNTIMES
+// (comma-separated, e.g. "docker,wasm") narrows the sweep — to isolate one
+// runtime or skip firecracker's slow cold-boots so a run actually finishes.
+// Empty = every runtime the scenario advertises.
+func benchRuntimeAllowed(rt string) bool {
+	filter := strings.TrimSpace(os.Getenv("AEROL_BENCH_RUNTIMES"))
+	if filter == "" {
+		return true
+	}
+	for _, want := range strings.Split(filter, ",") {
+		if strings.EqualFold(strings.TrimSpace(want), rt) {
+			return true
+		}
+	}
+	return false
+}
+
 // benchEnvInt reads a positive integer tunable from env, falling back to def.
 func benchEnvInt(key string, def int) int {
 	if v := os.Getenv(key); v != "" {
@@ -246,6 +263,9 @@ func TestBenchCreateLatency(t *testing.T) {
 		if !sc.Has(br.cap) {
 			continue // scenario lacks this runtime; nothing to time
 		}
+		if !benchRuntimeAllowed(br.runtime) {
+			continue // narrowed out by AEROL_BENCH_RUNTIMES
+		}
 		wasmRef := ""
 		if br.runtime == "wasm" {
 			wasmRef = stagedWasmModuleRef(t)
@@ -337,6 +357,9 @@ func meanMS(durs []time.Duration) int64 {
 func TestBenchDensity(t *testing.T) {
 	harness.Require(t, sc, "UC-95")
 	requireBenchEnabled(t)
+	if !benchRuntimeAllowed("docker") {
+		t.Skip("AEROL_BENCH_RUNTIMES excludes docker; density probe is docker-only")
+	}
 	c := client(t)
 	maxSandboxes := benchEnvInt("AEROL_BENCH_MAX", 200)
 

--- a/integration-tests/suite/harness/client.go
+++ b/integration-tests/suite/harness/client.go
@@ -3,6 +3,7 @@ package harness
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -19,22 +20,36 @@ const DefaultImage = "alpine:3.20"
 // resource-hygiene helpers (unique naming + guaranteed cleanup). Using the
 // real SDK is deliberate: the suite doubles as Go-SDK integration coverage.
 type Client struct {
-	sc  *Scenario
-	sdk *microvm.Client
+	sc     *Scenario
+	sdk    *microvm.Client
+	timing *serverTimingTransport
 }
 
 // NewClient builds a Client for the scenario. Fails the test immediately if the
 // SDK can't be constructed — there's no point continuing without an API client.
 func NewClient(t *testing.T, sc *Scenario) *Client {
 	t.Helper()
+	// Wrap the SDK's transport so we can read the server's self-reported create
+	// duration (Server-Timing) without touching any create call. Transparent: it
+	// only observes the response header, never alters the request or response.
+	timing := &serverTimingTransport{base: http.DefaultTransport}
 	sdk, err := microvm.NewClientWithConfig(&sdktypes.MicroVMConfig{
-		APIUrl:   sc.BaseURL,
-		PATToken: sc.PAT,
+		APIUrl:     sc.BaseURL,
+		PATToken:   sc.PAT,
+		HTTPClient: &http.Client{Transport: timing},
 	})
 	if err != nil {
 		t.Fatalf("build SDK client: %v", err)
 	}
-	return &Client{sc: sc, sdk: sdk}
+	return &Client{sc: sc, sdk: sdk, timing: timing}
+}
+
+// LastServerCreateMS returns the server-reported create duration (ms) from the
+// most recent create's Server-Timing header, then clears it. ok is false when
+// the last create carried no such header (e.g. an older server). This lets a
+// benchmark measure server-side create time, excluding client<->cluster network.
+func (c *Client) LastServerCreateMS() (float64, bool) {
+	return c.timing.takeCreateMS()
 }
 
 // SDK exposes the underlying client for use cases that need a method this

--- a/integration-tests/suite/harness/timing.go
+++ b/integration-tests/suite/harness/timing.go
@@ -1,0 +1,66 @@
+package harness
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// serverTimingTransport is a transparent http.RoundTripper that records the
+// server-reported create duration from the Server-Timing response header of a
+// create (POST .../sandboxes). It lets a benchmark read how long the server
+// spent creating a sandbox, independent of the client<->cluster network time.
+// It never alters the request or response — it only observes the header.
+type serverTimingTransport struct {
+	base http.RoundTripper
+
+	mu     sync.Mutex
+	lastMS float64
+	have   bool
+}
+
+func (t *serverTimingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	// A create is the only POST whose path ends in "/sandboxes" (stop/start/etc.
+	// have a longer suffix; list is a GET), so this uniquely tags create calls.
+	if err == nil && resp != nil && req.Method == http.MethodPost &&
+		strings.HasSuffix(req.URL.Path, "/sandboxes") && resp.StatusCode/100 == 2 {
+		if ms, ok := parseServerTimingCreate(resp.Header.Get("Server-Timing")); ok {
+			t.mu.Lock()
+			t.lastMS, t.have = ms, true
+			t.mu.Unlock()
+		}
+	}
+	return resp, err
+}
+
+// takeCreateMS returns the most recent create duration (ms) and clears it, so a
+// missing header on the next create reads as absent rather than reusing a stale
+// value. Callers are serial (one create at a time), so last-write wins cleanly.
+func (t *serverTimingTransport) takeCreateMS() (float64, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	ms, ok := t.lastMS, t.have
+	t.have = false
+	return ms, ok
+}
+
+// parseServerTimingCreate pulls the "create" metric's dur (milliseconds) out of
+// a Server-Timing header value like "create;dur=1234.5".
+func parseServerTimingCreate(header string) (float64, bool) {
+	for _, metric := range strings.Split(header, ",") {
+		fields := strings.Split(metric, ";")
+		if strings.TrimSpace(fields[0]) != "create" {
+			continue // a different Server-Timing metric (db, total, …)
+		}
+		for _, attr := range fields[1:] {
+			if v, ok := strings.CutPrefix(strings.TrimSpace(attr), "dur="); ok {
+				if ms, err := strconv.ParseFloat(strings.TrimSpace(v), 64); err == nil {
+					return ms, true
+				}
+			}
+		}
+	}
+	return 0, false
+}

--- a/integration-tests/suite/harness/timing_test.go
+++ b/integration-tests/suite/harness/timing_test.go
@@ -1,0 +1,108 @@
+package harness
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestParseServerTimingCreate(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		wantMS float64
+		wantOK bool
+	}{
+		{"simple float", "create;dur=1234.5", 1234.5, true},
+		{"integer dur", "create;dur=42", 42, true},
+		{"among other metrics", "db;dur=3, create;dur=900.25, total;dur=950", 900.25, true},
+		{"desc before dur", `create;desc="sandbox";dur=12`, 12, true},
+		{"surrounding spaces", "  create ; dur=7.5 ", 7.5, true},
+		{"no create metric", "db;dur=3, total;dur=10", 0, false},
+		{"create without dur", "create;desc=x", 0, false},
+		{"name prefix is not a match", "created;dur=5", 0, false},
+		{"empty header", "", 0, false},
+		{"unparseable dur", "create;dur=abc", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ms, ok := parseServerTimingCreate(tt.header)
+			if ok != tt.wantOK {
+				t.Fatalf("parseServerTimingCreate(%q) ok = %v, want %v", tt.header, ok, tt.wantOK)
+			}
+			if ok && ms != tt.wantMS {
+				t.Fatalf("parseServerTimingCreate(%q) ms = %v, want %v", tt.header, ms, tt.wantMS)
+			}
+		})
+	}
+}
+
+// stubRoundTripper returns a canned response (status code + optional
+// Server-Timing header) so the transport can be exercised without a server.
+type stubRoundTripper struct {
+	header string
+	code   int
+}
+
+func (s stubRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	h := make(http.Header)
+	if s.header != "" {
+		h.Set("Server-Timing", s.header)
+	}
+	return &http.Response{
+		StatusCode: s.code,
+		Header:     h,
+		Body:       io.NopCloser(strings.NewReader("")),
+		Request:    req,
+	}, nil
+}
+
+func newReq(t *testing.T, method, url string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	return req
+}
+
+// TestServerTimingTransportRecordsCreate verifies the transport captures the
+// create duration from a 2xx POST .../sandboxes and that takeCreateMS consumes
+// it (so a later create with no header reads absent, not stale).
+func TestServerTimingTransportRecordsCreate(t *testing.T) {
+	tr := &serverTimingTransport{base: stubRoundTripper{header: "create;dur=321.5", code: 201}}
+	if _, err := tr.RoundTrip(newReq(t, http.MethodPost, "https://x/v1/sandboxes")); err != nil {
+		t.Fatalf("round trip: %v", err)
+	}
+	ms, ok := tr.takeCreateMS()
+	if !ok || ms != 321.5 {
+		t.Fatalf("takeCreateMS() = (%v, %v), want (321.5, true)", ms, ok)
+	}
+	if _, ok := tr.takeCreateMS(); ok {
+		t.Fatal("takeCreateMS() should be empty after consumption")
+	}
+}
+
+// TestServerTimingTransportIgnoresNonCreate confirms a GET (list) and a non-2xx
+// response never record, even with a Server-Timing header present.
+func TestServerTimingTransportIgnoresNonCreate(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		method string
+		code   int
+	}{
+		{"list GET", http.MethodGet, 200},
+		{"failed create", http.MethodPost, 500},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := &serverTimingTransport{base: stubRoundTripper{header: "create;dur=99", code: tc.code}}
+			if _, err := tr.RoundTrip(newReq(t, tc.method, "https://x/v1/sandboxes")); err != nil {
+				t.Fatalf("round trip: %v", err)
+			}
+			if _, ok := tr.takeCreateMS(); ok {
+				t.Fatalf("%s: should not have recorded a create time", tc.name)
+			}
+		})
+	}
+}

--- a/integration-tests/suite/z_disruptive_cluster_test.go
+++ b/integration-tests/suite/z_disruptive_cluster_test.go
@@ -81,6 +81,12 @@ func TestRecreateViaFailover(t *testing.T) {
 		t.Fatalf("drain worker-w (%s): %v", extraDrainedNodeID, err)
 	}
 
+	// Must stay on docker. Recreate-via-failover needs >=2 workers advertising
+	// the runtime so the sandbox can land on a peer after worker-x dies; docker
+	// runs on all four workers. Do NOT switch this to firecracker: only worker-z
+	// is bare metal, so an FC sandbox has no failover peer on hetero (a second
+	// x86 *.metal is blocked on the metal vCPU quota). FC failover lives in
+	// cluster-arm64 instead.
 	sb := c.NewSandbox(t, sdktypes.CreateSandboxOptions{
 		Name:     harness.UniqueName(sc, t),
 		Runtime:  "docker",

--- a/pkg/api/v1/handlers.go
+++ b/pkg/api/v1/handlers.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aerol-ai/microvm/internal/cluster"
 	"github.com/aerol-ai/microvm/pkg/api/apihttp"
@@ -39,7 +40,13 @@ func (h *handlers) createSandbox(w http.ResponseWriter, r *http.Request) {
 		apihttp.WriteError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
+	// Time the create server-side and report it as a Server-Timing metric so a
+	// client (e.g. the create benchmark) can separate the real create cost from
+	// the client<->cluster network round-trip. Set the header before
+	// WriteJSON/WriteError — response headers must land before the status line.
+	createStart := time.Now()
 	response, err := h.deps.Service.CreateSandbox(r.Context(), req)
+	w.Header().Set("Server-Timing", "create;dur="+strconv.FormatFloat(float64(time.Since(createStart).Microseconds())/1000, 'f', 1, 64))
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			apihttp.WriteError(w, http.StatusGatewayTimeout, "sandbox create exceeded timeout")

--- a/pkg/api/v1/handlers_coverage_test.go
+++ b/pkg/api/v1/handlers_coverage_test.go
@@ -33,6 +33,11 @@ func TestHandlers_CreateSandbox_Success(t *testing.T) {
 	if rt.createCalls != 1 {
 		t.Fatalf("createCalls = %d, want 1", rt.createCalls)
 	}
+	// The create handler reports its server-side duration as a Server-Timing
+	// metric so a client can subtract network time (used by the create benchmark).
+	if st := rr.Header().Get("Server-Timing"); !strings.Contains(st, "create;dur=") {
+		t.Fatalf("Server-Timing = %q, want a create;dur= metric", st)
+	}
 }
 
 func TestHandlers_ListSandboxes_StoreError(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix integration benchmark artifact path resolution so `AEROL_BENCH_OUT` writes to the intended repo-root path instead of silently failing under `suite/`.
- Add `integration-benchmark-only` Makefile target and `AEROL_BENCH_RUNTIMES` filter for focused performance sweeps without full reprovision.
- Warm the WASM worker pool during integration benchmark runs and thread `SB_WASM_POOL_*` through Terraform/Ansible config for cluster-hetero.
- Enable Firecracker in cluster-hetero scenario config while keeping disruptive failover tests on Docker.
- Expose server-side `CreateSandbox` latency via `Server-Timing: create;dur=<ms>` on the create handler; harness records it alongside client round-trip for network-overhead separation.

## Test plan

- [x] `go test ./integration-tests/suite/harness/...` (timing parser + transport)
- [x] `go test ./pkg/api/v1/...` (Server-Timing header on create)
- [ ] Operator-run `make integration-benchmark-only SCENARIO=cluster-hetero` against a live cluster


Made with [Cursor](https://cursor.com)