### PR TITLE
fix(integration): wait for cluster readiness before benchmarks

### DIFF
--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -401,7 +401,7 @@ run_one() {
     AEROL_BENCH="${AEROL_BENCH:-}" \
     AEROL_BENCH_OUT="${bench_out}" \
     AEROL_WASM_MODULE_REF="${wasm_ref}" \
-    go test -tags=integration -count=1 -json ./integration-tests/suite/... > "$json_out"
+    go test -tags=integration -count=1 -timeout=60m -json ./integration-tests/suite/... > "$json_out"
   local test_rc=$?
   set -e
 
@@ -533,8 +533,9 @@ run_bench_only() {
     exit 2
   fi
 
-  local caps_wasm
+  local caps_wasm expected_members
   caps_wasm=$(yq -r '.capabilities | contains(["wasm"])' "$caps_file")
+  expected_members=$(yq -r '.expected_members // ""' "$caps_file")
   local wasm_ref=""
   [[ "$caps_wasm" == "true" ]] && wasm_ref="${AEROL_WASM_MODULE_REF:-python}"
   if [[ "$caps_wasm" == "true" ]] && is_stale_wasm_snapshot_ref "$wasm_ref"; then
@@ -561,6 +562,7 @@ run_bench_only() {
   AEROL_SCENARIO="$scenario" \
   AEROL_CAPS="${caps_file}" \
   AEROL_DOMAIN="${leased}" \
+  AEROL_EXPECTED_MEMBERS="${expected_members}" \
   AEROL_WASM_MODULE_REF="${wasm_ref}" \
     go test -tags=integration -count=1 -timeout=60m -v \
       -run 'TestBench' \

--- a/integration-tests/suite/benchmark_test.go
+++ b/integration-tests/suite/benchmark_test.go
@@ -5,6 +5,7 @@ package suite
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -43,6 +44,11 @@ var benchRuntimes = []struct {
 	{"firecracker", harness.CapFirecracker},
 	{"gvisor", harness.CapGvisor},
 	{"wasm", harness.CapWasm},
+}
+
+type benchRuntimeSpec struct {
+	runtime string
+	wasmRef string
 }
 
 // requireBenchEnabled is a second gate on top of the CapBenchmark capability.
@@ -84,6 +90,173 @@ func benchEnvInt(key string, def int) int {
 		}
 	}
 	return def
+}
+
+func selectedBenchRuntimes(t *testing.T) []benchRuntimeSpec {
+	t.Helper()
+	var selected []benchRuntimeSpec
+	for _, br := range benchRuntimes {
+		if !sc.Has(br.cap) || !benchRuntimeAllowed(br.runtime) {
+			continue
+		}
+		spec := benchRuntimeSpec{runtime: br.runtime}
+		if br.runtime == "wasm" {
+			spec.wasmRef = stagedWasmModuleRef(t)
+			if spec.wasmRef == "" {
+				t.Logf("bench: skipping wasm latency (AEROL_WASM_MODULE_REF unset)")
+				continue
+			}
+		}
+		selected = append(selected, spec)
+	}
+	return selected
+}
+
+func benchCreateOptions(t *testing.T, spec benchRuntimeSpec) sdktypes.CreateSandboxOptions {
+	t.Helper()
+	opts := sdktypes.CreateSandboxOptions{
+		Name:    harness.UniqueName(sc, t),
+		Runtime: spec.runtime,
+	}
+	if spec.runtime == "wasm" {
+		opts.Image = spec.wasmRef
+		opts.ModuleRef = spec.wasmRef
+	} else {
+		opts.Image = harness.DefaultImage
+	}
+	return opts
+}
+
+func waitBenchmarkReady(t *testing.T, c *harness.Client, runtimes []benchRuntimeSpec) {
+	t.Helper()
+	if !sc.Has(harness.CapCluster) {
+		return
+	}
+	want, exact := expectedMembers()
+	timeout := time.Duration(benchEnvInt("AEROL_BENCH_READY_SECONDS", 300)) * time.Second
+	deadline := time.Now().Add(timeout)
+	var last string
+	for time.Now().Before(deadline) {
+		leader, leaderErr := benchClusterLeader(c)
+		members, err := benchClusterMembers(c)
+		if err != nil {
+			last = err.Error()
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		if leaderErr != nil {
+			last = "leader: " + leaderErr.Error()
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		if leader == "" {
+			last = "leader not elected"
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		if exact && len(members.Members) != want {
+			last = fmt.Sprintf("members=%d want=%d", len(members.Members), want)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		if !exact && len(members.Members) < want {
+			last = fmt.Sprintf("members=%d want>=%d", len(members.Members), want)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		if missing := missingBenchRuntimeTargets(members, runtimes); len(missing) > 0 {
+			last = "runtime targets not ready: " + strings.Join(missing, ",")
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		return
+	}
+	t.Fatalf("benchmark prerequisites not ready within %s: %s", timeout, last)
+}
+
+func benchClusterLeader(c *harness.Client) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	var resp struct {
+		Leader string `json:"leader"`
+	}
+	if err := c.GetJSON(ctx, "/v1/cluster/leader", &resp); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(resp.Leader), nil
+}
+
+func benchClusterMembers(c *harness.Client) (capacityView, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	var members capacityView
+	if err := c.GetJSON(ctx, "/v1/cluster/members", &members); err != nil {
+		return capacityView{}, err
+	}
+	return members, nil
+}
+
+func missingBenchRuntimeTargets(members capacityView, runtimes []benchRuntimeSpec) []string {
+	var missing []string
+	for _, spec := range runtimes {
+		if !benchHasRuntimeTarget(members, spec.runtime) {
+			missing = append(missing, spec.runtime)
+		}
+	}
+	return missing
+}
+
+func benchHasRuntimeTarget(members capacityView, runtime string) bool {
+	for _, m := range members.Members {
+		if !m.Alive || m.Drained || m.CapacityStale || !benchCanOwnSandbox(m.Role) || !m.Capacity.CanAdmit {
+			continue
+		}
+		for _, rt := range m.Capacity.SupportedRuntimes {
+			if rt == runtime {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func benchCanOwnSandbox(role string) bool {
+	role = strings.TrimSpace(role)
+	if role == "" {
+		return true
+	}
+	for _, part := range strings.Split(role, ",") {
+		switch strings.ToLower(strings.TrimSpace(part)) {
+		case "worker", "mixed":
+			return true
+		}
+	}
+	return false
+}
+
+func warmBenchmarkRuntimes(t *testing.T, c *harness.Client, runtimes []benchRuntimeSpec) {
+	t.Helper()
+	for _, spec := range runtimes {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+		sb, err := c.SDK().Create(ctx, benchCreateOptions(t, spec))
+		cancel()
+		if err != nil {
+			t.Fatalf("bench[%s] warmup create failed after readiness: %v", spec.runtime, err)
+		}
+		destroy := true
+		id := sb.ID
+		defer func() {
+			if destroy {
+				destroyBest(c, id)
+			}
+		}()
+		if !waitRunningTimed(t, sb) {
+			t.Fatalf("bench[%s] warmup sandbox %s did not reach started", spec.runtime, id)
+		}
+		destroyBest(c, id)
+		destroy = false
+		_, _ = c.LastServerCreateMS()
+	}
 }
 
 // percentile returns the p-th percentile (0..100) of durs using nearest-rank.
@@ -266,37 +439,19 @@ func TestBenchCreateLatency(t *testing.T) {
 	requireBenchEnabled(t)
 	c := client(t)
 	samples := benchEnvInt("AEROL_BENCH_SAMPLES", 10)
+	runtimes := selectedBenchRuntimes(t)
+	if len(runtimes) == 0 {
+		t.Skip("no benchmark runtimes selected")
+	}
+	waitBenchmarkReady(t, c, runtimes)
+	warmBenchmarkRuntimes(t, c, runtimes)
 
 	var report benchReport
-	for _, br := range benchRuntimes {
-		if !sc.Has(br.cap) {
-			continue // scenario lacks this runtime; nothing to time
-		}
-		if !benchRuntimeAllowed(br.runtime) {
-			continue // narrowed out by AEROL_BENCH_RUNTIMES
-		}
-		wasmRef := ""
-		if br.runtime == "wasm" {
-			wasmRef = stagedWasmModuleRef(t)
-			if wasmRef == "" {
-				t.Logf("bench: skipping wasm latency (AEROL_WASM_MODULE_REF unset)")
-				continue
-			}
-		}
-
+	for _, br := range runtimes {
 		var apiD, runD, serverD []time.Duration
 		failures := 0
 		for i := 0; i < samples; i++ {
-			opts := sdktypes.CreateSandboxOptions{
-				Name:    harness.UniqueName(sc, t),
-				Runtime: br.runtime,
-			}
-			if br.runtime == "wasm" {
-				opts.Image = wasmRef
-				opts.ModuleRef = wasmRef
-			} else {
-				opts.Image = harness.DefaultImage
-			}
+			opts := benchCreateOptions(t, br)
 
 			start := time.Now()
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
@@ -383,6 +538,9 @@ func TestBenchDensity(t *testing.T) {
 		t.Skip("AEROL_BENCH_RUNTIMES excludes docker; density probe is docker-only")
 	}
 	c := client(t)
+	dockerBench := []benchRuntimeSpec{{runtime: "docker"}}
+	waitBenchmarkReady(t, c, dockerBench)
+	warmBenchmarkRuntimes(t, c, dockerBench)
 	maxSandboxes := benchEnvInt("AEROL_BENCH_MAX", 200)
 
 	ds := densityStats{Runtime: "docker"}

--- a/integration-tests/suite/regression_fixes_test.go
+++ b/integration-tests/suite/regression_fixes_test.go
@@ -37,10 +37,14 @@ import (
 // that depends on it.
 type capacityView struct {
 	Members []struct {
-		NodeID   string `json:"node_id"`
-		NodeName string `json:"node_name"`
-		Role     string `json:"role"`
-		Capacity struct {
+		NodeID        string `json:"node_id"`
+		NodeName      string `json:"node_name"`
+		Role          string `json:"role"`
+		Alive         bool   `json:"alive"`
+		Drained       bool   `json:"drained"`
+		CapacityStale bool   `json:"capacity_stale"`
+		Capacity      struct {
+			CanAdmit          bool     `json:"can_admit"`
 			SupportedRuntimes []string `json:"supported_runtimes"`
 		} `json:"capacity"`
 	} `json:"members"`

--- a/internal/pool/wasm/spawner_test.go
+++ b/internal/pool/wasm/spawner_test.go
@@ -159,6 +159,37 @@ func TestSupervisorSpawnerWarmSuccess(t *testing.T) {
 	_ = sup.Stop("slot-ok")
 }
 
+func TestSupervisorSpawnerWarmContextCancelDoesNotRespawnLoadedSlot(t *testing.T) {
+	wasmBytes := []byte{
+		0x00, 0x61, 0x73, 0x6d,
+		0x01, 0x00, 0x00, 0x00,
+	}
+	modFile := filepath.Join(t.TempDir(), "noop.wasm")
+	if err := os.WriteFile(modFile, wasmBytes, 0o600); err != nil {
+		t.Fatalf("write wasm: %v", err)
+	}
+
+	socketPath := filepath.Join(os.TempDir(), "pool_warm_cancel.sock")
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	sup := worker.NewSupervisor(spawnInProcessServer(t))
+	ss := NewSupervisorSpawner(sup)
+	ss.PingWait = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := ss.Warm(ctx, "slot-cancel", socketPath, modFile); err != nil {
+		cancel()
+		t.Fatalf("Warm: %v", err)
+	}
+	cancel()
+	t.Cleanup(func() { _ = sup.Stop("slot-cancel") })
+
+	time.Sleep(100 * time.Millisecond)
+	if got := sup.SpawnCount("slot-cancel"); got != 1 {
+		t.Fatalf("spawn count after warm context cancel = %d, want 1", got)
+	}
+}
+
 // TestSupervisorSpawnerShutdownWithSupervisor verifies the happy-path Shutdown
 // via a real Supervisor.
 func TestSupervisorSpawnerShutdownWithSupervisor(t *testing.T) {

--- a/pkg/api/v1/cluster_create_coverage_test.go
+++ b/pkg/api/v1/cluster_create_coverage_test.go
@@ -194,6 +194,9 @@ func TestCreateSandboxOnSelectedNode_PromoteSuccess(t *testing.T) {
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("status = %d, want 201; body=%s", rr.Code, rr.Body.String())
 	}
+	if st := rr.Header().Get("Server-Timing"); !strings.Contains(st, "create;dur=") {
+		t.Fatalf("Server-Timing = %q, want create duration", st)
+	}
 	if rt.lastCreateID != "sb-reserved" {
 		t.Fatalf("create id = %q, want sb-reserved", rt.lastCreateID)
 	}

--- a/pkg/api/v1/cluster_handler.go
+++ b/pkg/api/v1/cluster_handler.go
@@ -316,6 +316,7 @@ func (h *handlers) clusterCreateWrap(w http.ResponseWriter, r *http.Request) {
 //     opPlace transitions State=Reserved → Placed atomically while keeping
 //     secret material out of Raft.
 func (h *handlers) createSandboxOnSelectedNode(w http.ResponseWriter, r *http.Request, req models.CreateSandboxRequest, reservationID string) {
+	createStart := time.Now()
 	if err := h.deps.Service.NormalizeCreateImageDistribution(r.Context(), &req); err != nil {
 		apihttp.WriteError(w, http.StatusBadRequest, err.Error())
 		return
@@ -357,6 +358,7 @@ func (h *handlers) createSandboxOnSelectedNode(w http.ResponseWriter, r *http.Re
 			}
 			rbCancel()
 		}
+		setCreateServerTiming(w, createStart)
 		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
 		return
 	}
@@ -386,6 +388,7 @@ func (h *handlers) createSandboxOnSelectedNode(w http.ResponseWriter, r *http.Re
 			}
 		}
 		rbCancel()
+		setCreateServerTiming(w, createStart)
 		apihttp.WriteError(w, http.StatusInternalServerError, "cluster: store secret ref: "+sealErr.Error())
 		return
 	}
@@ -416,13 +419,16 @@ func (h *handlers) createSandboxOnSelectedNode(w http.ResponseWriter, r *http.Re
 		// this should only fire on the self-wins path (the reserve step
 		// already validated name uniqueness for the forward path).
 		if errors.Is(promoteErr, cluster.ErrNameConflict) {
+			setCreateServerTiming(w, createStart)
 			apihttp.WriteError(w, http.StatusConflict, "sandbox name already in use cluster-wide")
 			return
 		}
+		setCreateServerTiming(w, createStart)
 		apihttp.WriteError(w, http.StatusServiceUnavailable, "cluster: placement commit failed: "+promoteErr.Error())
 		return
 	}
 
+	setCreateServerTiming(w, createStart)
 	apihttp.WriteJSON(w, http.StatusCreated, resp)
 }
 

--- a/pkg/api/v1/handlers.go
+++ b/pkg/api/v1/handlers.go
@@ -34,6 +34,10 @@ func (h *handlers) capacity(w http.ResponseWriter, r *http.Request) {
 	apihttp.WriteJSON(w, http.StatusOK, h.deps.Service.Capacity())
 }
 
+func setCreateServerTiming(w http.ResponseWriter, start time.Time) {
+	w.Header().Set("Server-Timing", "create;dur="+strconv.FormatFloat(float64(time.Since(start).Microseconds())/1000, 'f', 1, 64))
+}
+
 func (h *handlers) createSandbox(w http.ResponseWriter, r *http.Request) {
 	var req models.CreateSandboxRequest
 	if err := apihttp.DecodeJSON(w, r, &req); err != nil {
@@ -46,7 +50,7 @@ func (h *handlers) createSandbox(w http.ResponseWriter, r *http.Request) {
 	// WriteJSON/WriteError — response headers must land before the status line.
 	createStart := time.Now()
 	response, err := h.deps.Service.CreateSandbox(r.Context(), req)
-	w.Header().Set("Server-Timing", "create;dur="+strconv.FormatFloat(float64(time.Since(createStart).Microseconds())/1000, 'f', 1, 64))
+	setCreateServerTiming(w, createStart)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			apihttp.WriteError(w, http.StatusGatewayTimeout, "sandbox create exceeded timeout")

--- a/pkg/wasm/worker/supervisor.go
+++ b/pkg/wasm/worker/supervisor.go
@@ -79,8 +79,16 @@ func (s *Supervisor) Ensure(ctx context.Context, sandboxID, socketPath string) e
 }
 
 func (s *Supervisor) startLocked(ctx context.Context, sandboxID, socketPath string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
 	_ = os.Remove(socketPath)
-	cmd, err := s.spawn(ctx, socketPath)
+	cmd, err := s.spawn(context.WithoutCancel(ctx), socketPath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- Add benchmark prerequisite polling (cluster leader, member count, runtime targets) plus warmup creates before latency/density runs
- Propagate `Server-Timing` on cluster-mode create paths so server-side create latency is measurable end-to-end
- Fix WASM warm-pool supervisor so a cancelled parent context does not respawn an already-loaded slot
- Extend integration test timeout to 60m and pass `AEROL_EXPECTED_MEMBERS` in bench-only runs

## Test plan
- [x] `go test ./pkg/api/v1/... ./internal/pool/wasm/...`
- [ ] `make integration-benchmark-only` on cluster-hetero (operator-run)


Made with [Cursor](https://cursor.com)