### PR TITLE
fix(cluster): tolerate transient gossip bootstrap join failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,15 +103,16 @@ integration-cluster-hetero-safe:
 # Create benchmark (UC-94 create latency + UC-95 fleet density). Provisions
 # cluster-hetero, runs the suite WITH the benchmark turned on (AEROL_BENCH=1 is
 # the master switch — the bench is dormant otherwise), writes the JSON artifact,
-# and tears down. Override the artifact path with BENCH_OUT=, or pass `keep` to
-# leave the cluster up for repeat runs. See integration-tests/README.md.
+# and tears down. Benchmark runs skip disruptive failover tests by default so
+# `keep` leaves a usable cluster for repeat bench-only runs. Override the artifact
+# path with BENCH_OUT=. See integration-tests/README.md.
 #   make integration-benchmark
 #   make integration-benchmark keep
 #   make integration-benchmark BENCH_OUT=/tmp/bench.json
 BENCH_OUT ?= integration-tests/reports/cluster-hetero-bench.json
 integration-benchmark:
 	AEROL_BENCH=1 AEROL_BENCH_OUT=$(BENCH_OUT) \
-		integration-tests/run.sh cluster-hetero $(RUN_FLAGS)
+		integration-tests/run.sh cluster-hetero --no-disruptive $(RUN_FLAGS)
 
 # Re-run UC-94/UC-95 only against a cluster left up with `keep` (no reprovision).
 #   make integration-benchmark-only
@@ -144,7 +145,7 @@ integration-all:
 #   make integration-collect-logs                       # cluster-hetero
 #   make integration-collect-logs SCENARIO=cluster-3-mixed
 integration-collect-logs:
-	integration-tests/run.sh $(or $(SCENARIO),cluster-hetero) --collect-logs-only
+	integration-tests/run.sh --collect-logs-only '$(or $(SCENARIO),cluster-hetero)'
 
 # Full teardown of a scenario brought up with `keep` — runs terraform destroy
 # (VPC, S3, IAM, instances) and clears the isolated state. This is the REAL
@@ -153,7 +154,7 @@ integration-collect-logs:
 #   make integration-destroy
 #   make integration-destroy SCENARIO=cluster-3-mixed
 integration-destroy:
-	integration-tests/run.sh $(or $(SCENARIO),cluster-hetero) --destroy-only
+	integration-tests/run.sh --destroy-only '$(or $(SCENARIO),cluster-hetero)'
 
 # Cost safety net: terminate leaked itest instances past their ttl. Faster than
 # integration-destroy but instance-only — leaves VPC/S3/IAM + TF state behind.

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -63,6 +63,12 @@ for arg in "$@"; do
   esac
 done
 [[ -n "$SCENARIO" ]] || { echo "usage: run.sh <scenario|all> [--keep] [--prod-tls] [--metal-on-demand] [--no-disruptive] [--collect-logs-only] [--bench-only] [--destroy-only]" >&2; exit 2; }
+# Reject shell metacharacters so a polluted SCENARIO env (or make injection)
+# cannot turn one run.sh invocation into multiple shell commands.
+if [[ "$SCENARIO" == *[$';#&|<>']* ]] || [[ "$SCENARIO" == *$'\n'* ]]; then
+  echo "scenario name contains unsafe shell characters (refusing: ${SCENARIO})" >&2
+  exit 2
+fi
 
 DOMAINS_FILE="${HERE}/scenarios/domains.yml"
 CONFIG_CLUSTER="${REPO_ROOT}/config/cluster.yml"
@@ -77,6 +83,12 @@ PROD_TFVARS="${REPO_ROOT}/config/terraform.tfvars"
 tf_varfile_args() {
   local scenario="$1"
   printf -- '-var-file=%s -var-file=%s' "$PROD_TFVARS" "${HERE}/scenarios/${scenario}.tfvars"
+}
+
+# on_demand_tfvar maps the --metal-on-demand flag to the force_on_demand TF var
+# (flips firecracker bare-metal nodes off spot; cheap t3 spot nodes unaffected).
+on_demand_tfvar() {
+  [[ "$METAL_ON_DEMAND" == "1" ]] && echo "true" || echo "false"
 }
 
 teardown() {
@@ -101,6 +113,13 @@ teardown() {
     -var="force_on_demand=$(on_demand_tfvar)" || \
     echo "teardown: destroy returned non-zero for ${scenario} — run 'make integration-reap'" >&2
 }
+
+if [[ "$DESTROY_ONLY" == "1" ]]; then
+  # Fast path: teardown() returns early when KEEP=1; force a real destroy here.
+  KEEP=0
+  teardown "$SCENARIO"
+  exit 0
+fi
 
 # lease_domain picks a RANDOM test domain from the pool, never repeating the
 # previous run's pick. Reusing one name re-requests the same cert set and trips
@@ -128,12 +147,6 @@ lease_domain() {
   mkdir -p "$(dirname "$lease_file")"
   echo "$idx" > "$lease_file"
   yq -r ".itest.domains[$idx]" "$DOMAINS_FILE"
-}
-
-# on_demand_tfvar maps the --metal-on-demand flag to the force_on_demand TF var
-# (flips firecracker bare-metal nodes off spot; cheap t3 spot nodes unaffected).
-on_demand_tfvar() {
-  [[ "$METAL_ON_DEMAND" == "1" ]] && echo "true" || echo "false"
 }
 
 # allow_disruptive_for decides AEROL_ALLOW_DISRUPTIVE for the suite. cluster-hetero
@@ -390,6 +403,10 @@ run_one() {
   fi
   if [[ "${AEROL_BENCH:-}" == "1" ]]; then
     echo "benchmark enabled (UC-94/UC-95); artifact=${bench_out:-logs only}" >&2
+    if [[ -n "$bench_out" ]]; then
+      mkdir -p "$(dirname "$bench_out")"
+      rm -f "$bench_out"
+    fi
   fi
   set +e
   AEROL_BASE_URL="$base_url" AEROL_PAT="$pat" AEROL_SCENARIO="$scenario" \
@@ -547,6 +564,7 @@ run_bench_only() {
     bench_out="${REPO_ROOT}/${bench_out}"
   fi
   mkdir -p "$(dirname "$bench_out")" "${HERE}/reports"
+  rm -f "$bench_out"
 
   echo "=== bench-only against ${base_url} (artifact=${bench_out}) ===" >&2
   if ! wait_for_health "$base_url" "$pat"; then
@@ -580,11 +598,7 @@ run_bench_only() {
   fi
 }
 
-if [[ "$DESTROY_ONLY" == "1" ]]; then
-  # teardown() returns early when KEEP=1; force a real destroy here.
-  KEEP=0
-  teardown "$SCENARIO"
-elif [[ "$COLLECT_LOGS_ONLY" == "1" ]]; then
+if [[ "$COLLECT_LOGS_ONLY" == "1" ]]; then
   collect_logs_only "$SCENARIO"
 elif [[ "$BENCH_ONLY" == "1" ]]; then
   run_bench_only "$SCENARIO"

--- a/internal/cluster/gossip.go
+++ b/internal/cluster/gossip.go
@@ -450,10 +450,13 @@ func setupGossip(cfg gossipSetupConfig, admitter *capacity.Admitter, logger *slo
 	if len(cfg.BootstrapPeers) > 0 {
 		joined, err := ml.Join(cfg.BootstrapPeers)
 		if err != nil {
-			_ = ml.Shutdown()
-			return nil, fmt.Errorf("gossip setup: join %v: %w", cfg.BootstrapPeers, err)
-		}
-		if logger != nil {
+			if logger != nil {
+				logger.Warn("cluster gossip initial bootstrap join failed; will retry in background",
+					"peers", cfg.BootstrapPeers,
+					"error", err,
+				)
+			}
+		} else if logger != nil {
 			logger.Info("cluster gossip joined peers", "joined", joined, "peers", cfg.BootstrapPeers)
 		}
 	} else if logger != nil {

--- a/internal/cluster/gossip_additional_test.go
+++ b/internal/cluster/gossip_additional_test.go
@@ -67,6 +67,37 @@ func TestSetupGossipInvalidSecretKey(t *testing.T) {
 	}
 }
 
+func TestSetupGossipContinuesWhenInitialBootstrapJoinFails(t *testing.T) {
+	cfg := gossipSetupConfig{
+		NodeID:         "join-retry-node",
+		BindAddr:       "127.0.0.1:0",
+		BootstrapPeers: []string{"127.0.0.1:1"},
+		GossipInterval: time.Hour,
+		APIURL:         "http://127.0.0.1:21212",
+		Role:           config.NodeRoleWorker,
+		AdvertiseAddr:  "",
+		DataPlaneHost:  "127.0.0.1",
+		RaftAddr:       "",
+		InternalURL:    "",
+		PublicHost:     "",
+		Events:         nil,
+	}
+
+	gn, err := setupGossip(cfg, nil, slog.Default())
+	if err != nil {
+		t.Fatalf("setupGossip returned fatal error for transient bootstrap join failure: %v", err)
+	}
+	defer gn.Close()
+
+	members := gn.members()
+	if len(members) != 1 || members[0].NodeID != "join-retry-node" || !members[0].Alive {
+		t.Fatalf("members after failed initial join = %+v, want live self member", members)
+	}
+	if len(gn.bootstrapPeers) != 1 || gn.bootstrapPeers[0] != "127.0.0.1:1" {
+		t.Fatalf("bootstrap peers = %v, want retained peer for background retry", gn.bootstrapPeers)
+	}
+}
+
 func TestGossipRefreshLoopExitsOnCancel(t *testing.T) {
 	// We just want to ensure runRefreshLoop doesn't block forever and handles context correctly
 	gn := &gossipNode{


### PR DESCRIPTION
## Summary
- Gossip setup no longer fails fatally when the initial bootstrap join is transiently unavailable; background retry continues as before.
- Integration benchmark runs skip disruptive failover tests by default (`--no-disruptive`) so `keep` leaves a usable cluster for repeat bench-only runs.
- Harden `run.sh` scenario validation and fix `--destroy-only` / `--collect-logs-only` flag ordering in the Makefile.

## Test plan
- [x] `go test ./internal/cluster/... -run TestSetupGossipContinuesWhenInitialBootstrapJoinFails`
- [ ] `make integration-benchmark` (operator-run, AWS)

Made with [Cursor](https://cursor.com)