### PR TITLE
feat(release): ship prebuilt custom Caddy binaries in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,6 +186,26 @@ jobs:
           go build -trimpath -ldflags "$LDFLAGS" -o dist/toolboxd_${{ matrix.suffix }} ./cmd/toolboxd
           chmod 0755 dist/toolboxd_${{ matrix.suffix }}
 
+      - name: Build custom Caddy (Linux only)
+        if: matrix.goos == 'linux'
+        shell: bash
+        run: |
+          mkdir -p dist
+          go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+          CGO_ENABLED=0 GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }} \
+            "$(go env GOPATH)/bin/xcaddy" build \
+            --output dist/caddy_${{ matrix.suffix }} \
+            --with github.com/mholt/caddy-l4 \
+            --with github.com/caddy-dns/cloudflare \
+            --with github.com/ss098/certmagic-s3
+          chmod 0755 dist/caddy_${{ matrix.suffix }}
+          if [[ "${{ matrix.goarch }}" == "amd64" ]]; then
+            dist/caddy_${{ matrix.suffix }} list-modules | grep -qx 'layer4'
+            dist/caddy_${{ matrix.suffix }} list-modules | grep -qx 'layer4.handlers.proxy'
+            dist/caddy_${{ matrix.suffix }} list-modules | grep -qx 'dns.providers.cloudflare'
+            dist/caddy_${{ matrix.suffix }} list-modules | grep -qx 'caddy.storage.s3'
+          fi
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/Terraform/nodes.tf
+++ b/Terraform/nodes.tf
@@ -126,6 +126,7 @@ resource "aws_instance" "seed" {
     aws_region                               = var.aws_region
     seed_private_ip                          = ""
     install_script_url                       = var.install_script_url
+    caddy_binary_url                         = var.caddy_binary_url
     cluster_init_script_url                  = var.cluster_init_script_url
     cluster_join_script_url                  = var.cluster_join_script_url
     seed_wait_max_seconds                    = var.seed_wait_max_seconds
@@ -304,6 +305,7 @@ resource "aws_instance" "joiner" {
     aws_region                               = var.aws_region
     seed_private_ip                          = aws_instance.seed.private_ip
     install_script_url                       = var.install_script_url
+    caddy_binary_url                         = var.caddy_binary_url
     cluster_init_script_url                  = var.cluster_init_script_url
     cluster_join_script_url                  = var.cluster_join_script_url
     seed_wait_max_seconds                    = var.seed_wait_max_seconds

--- a/Terraform/templates/bootstrap.sh.tftpl
+++ b/Terraform/templates/bootstrap.sh.tftpl
@@ -29,7 +29,8 @@
 #   firecracker_vmm_pool_refill_interval, firecracker_rss_sampler_interval,
 #   firecracker_rss_watermark_ratio,
 #   bundle_bucket, aws_region, seed_private_ip,
-#   install_script_url, cluster_init_script_url, cluster_join_script_url,
+#   install_script_url, caddy_binary_url,
+#   cluster_init_script_url, cluster_join_script_url,
 #   seed_wait_max_seconds, extra_user_data
 #
 # Order of operations matches the scripts' contracts:
@@ -46,6 +47,20 @@ echo "[bootstrap] node=${node_name} role=${role} seed=${is_seed}"
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
 apt-get install -y curl jq awscli openssl ca-certificates
+
+curl_download() {
+  local url="$1"
+  shift
+  curl -fsSL \
+    --retry 5 \
+    --retry-delay 2 \
+    --retry-connrefused \
+    --connect-timeout 20 \
+    --max-time 300 \
+    --speed-limit 1024 \
+    --speed-time 30 \
+    "$url" "$@"
+}
 
 %{ if aocr_enabled && aocr_mirror_host != "" ~}
 ###############################################################################
@@ -93,7 +108,7 @@ fi
 # install.sh runs in IP/path mode with no TLS, and the cluster's public URLs
 # fall back to http://<ip>/<id>/.
 ###############################################################################
-curl -fsSL '${install_script_url}' -o /tmp/install.sh
+curl_download '${install_script_url}' -o /tmp/install.sh
 chmod +x /tmp/install.sh
 
 INSTALL_ARGS=(--pat-token '${pat_token}' --node-name '${node_name}')
@@ -116,6 +131,9 @@ fi
 if [ -n '${acme_email}' ]; then
   INSTALL_ARGS+=(--acme-email '${acme_email}')
 fi
+%{ if caddy_binary_url != "" ~}
+INSTALL_ARGS+=(--caddy-binary-url '${caddy_binary_url}')
+%{ endif ~}
 %{ if with_gvisor ~}
 INSTALL_ARGS+=(--with-gvisor)
 %{ endif ~}
@@ -165,7 +183,7 @@ sudo /tmp/install.sh "$${INSTALL_ARGS[@]}"
 ###############################################################################
 GOSSIP_KEY="$(openssl rand -base64 32)"
 
-curl -fsSL '${cluster_init_script_url}' -o /tmp/cluster-init.sh
+curl_download '${cluster_init_script_url}' -o /tmp/cluster-init.sh
 chmod +x /tmp/cluster-init.sh
 sudo /tmp/cluster-init.sh \
   --role '${role}' \
@@ -213,7 +231,7 @@ aws --region '${aws_region}' s3 cp \
     "s3://${bundle_bucket}/aerolvm-tls-bundle.tar.gz" /tmp/aerolvm-tls-bundle.tar.gz
 GOSSIP_KEY="$(cat /tmp/gossip-key.txt)"
 
-curl -fsSL '${cluster_join_script_url}' -o /tmp/cluster-join.sh
+curl_download '${cluster_join_script_url}' -o /tmp/cluster-join.sh
 chmod +x /tmp/cluster-join.sh
 sudo /tmp/cluster-join.sh \
   --role '${role}' \
@@ -321,10 +339,8 @@ if [ '${firecracker_auto_install}' = 'true' ] && [ -z '${firecracker_binary_url}
   FC_TARBALL="firecracker-$${FC_VERSION}-$${FC_ARCH}.tgz"
   FC_WORKDIR="$(mktemp -d)"
   trap 'rm -rf "$${FC_WORKDIR}"' EXIT
-  curl -fL --retry 5 --retry-delay 2 --retry-connrefused \
-    "$${FC_RELEASE_BASE}/$${FC_TARBALL}" -o "$${FC_WORKDIR}/$${FC_TARBALL}"
-  curl -fL --retry 5 --retry-delay 2 --retry-connrefused \
-    "$${FC_RELEASE_BASE}/$${FC_TARBALL}.sha256.txt" -o "$${FC_WORKDIR}/$${FC_TARBALL}.sha256.txt"
+  curl_download "$${FC_RELEASE_BASE}/$${FC_TARBALL}" -o "$${FC_WORKDIR}/$${FC_TARBALL}"
+  curl_download "$${FC_RELEASE_BASE}/$${FC_TARBALL}.sha256.txt" -o "$${FC_WORKDIR}/$${FC_TARBALL}.sha256.txt"
   (cd "$${FC_WORKDIR}" && sha256sum -c "$${FC_TARBALL}.sha256.txt")
   tar -xzf "$${FC_WORKDIR}/$${FC_TARBALL}" -C "$${FC_WORKDIR}"
   install -m 0755 \
@@ -344,34 +360,32 @@ if [ '${firecracker_auto_install}' = 'true' ] && [ -z '${firecracker_kernel_url}
   KERNEL_CI='${firecracker_kernel_ci_version}'
   KERNEL_VER='${firecracker_kernel_version}'
   KERNEL_BASE="https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/$${KERNEL_CI}/$${FC_ARCH}"
-  curl -fL --retry 5 --retry-delay 2 --retry-connrefused \
-    "$${KERNEL_BASE}/vmlinux-$${KERNEL_VER}" -o /tmp/vmlinux
+  curl_download "$${KERNEL_BASE}/vmlinux-$${KERNEL_VER}" -o /tmp/vmlinux
   install -m 0644 /tmp/vmlinux '${firecracker_kernel_path}'
-  curl -fL --retry 5 --retry-delay 2 --retry-connrefused \
-    "$${KERNEL_BASE}/vmlinux-$${KERNEL_VER}.config" -o /tmp/vmlinux.config
+  curl_download "$${KERNEL_BASE}/vmlinux-$${KERNEL_VER}.config" -o /tmp/vmlinux.config
   install -m 0644 /tmp/vmlinux.config '${firecracker_kernel_path}.config'
 fi
 
 if [ -n '${firecracker_binary_url}' ]; then
-  curl -fL --retry 5 --retry-delay 2 --retry-connrefused '${firecracker_binary_url}' -o /tmp/firecracker.bin
+  curl_download '${firecracker_binary_url}' -o /tmp/firecracker.bin
   install -m 0755 /tmp/firecracker.bin '${firecracker_binary_path}'
 fi
 
 if [ -n '${firecracker_jailer_url}' ]; then
-  curl -fL --retry 5 --retry-delay 2 --retry-connrefused '${firecracker_jailer_url}' -o /tmp/jailer.bin
+  curl_download '${firecracker_jailer_url}' -o /tmp/jailer.bin
   install -m 0755 /tmp/jailer.bin '${firecracker_jailer_path}'
 fi
 
 if [ -n '${firecracker_kernel_url}' ]; then
-  curl -fL --retry 5 --retry-delay 2 --retry-connrefused '${firecracker_kernel_url}' -o /tmp/vmlinux
+  curl_download '${firecracker_kernel_url}' -o /tmp/vmlinux
   install -m 0644 /tmp/vmlinux '${firecracker_kernel_path}'
 fi
 
 if [ -n '${firecracker_kernel_config_url}' ]; then
-  curl -fL --retry 5 --retry-delay 2 --retry-connrefused '${firecracker_kernel_config_url}' -o /tmp/vmlinux.config
+  curl_download '${firecracker_kernel_config_url}' -o /tmp/vmlinux.config
   install -m 0644 /tmp/vmlinux.config '${firecracker_kernel_path}.config'
 elif [ -n '${firecracker_kernel_url}' ]; then
-  curl -fL --retry 5 --retry-delay 2 --retry-connrefused '${firecracker_kernel_url}.config' -o /tmp/vmlinux.config
+  curl_download '${firecracker_kernel_url}.config' -o /tmp/vmlinux.config
   install -m 0644 /tmp/vmlinux.config '${firecracker_kernel_path}.config'
 fi
 

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -498,6 +498,12 @@ variable "install_script_url" {
   default     = "https://github.com/aerol-ai/microvm/releases/latest/download/install.sh"
 }
 
+variable "caddy_binary_url" {
+  description = "Optional URL of a prebuilt custom Caddy binary containing caddy-l4, caddy-dns/cloudflare, and certmagic-s3. When empty, install.sh uses the matching release asset if present and then falls back to Caddy's build service."
+  type        = string
+  default     = ""
+}
+
 variable "cluster_init_script_url" {
   description = "URL of cluster-init.sh."
   type        = string

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,12 +17,22 @@ DNS_PROVIDER=""
 DNS_API_TOKEN=""
 ACME_EMAIL=""
 CADDY_BUILD_URL_BASE="https://caddyserver.com/api/download"
+CADDY_BINARY_URL=""
+CADDY_BINARY_URL_EXPLICIT="false"
 WITH_GVISOR="false"
 RUNSC_PATH=""
 WITH_NVIDIA_GPU="false"
 WITH_AMD_GPU="false"
 LOCAL_MODE="false"
 NODE_NAME=""
+
+# Bound every bootstrap download. Without low-speed and total timeouts, a dead
+# CDN/GitHub connection can sit at 0 bytes forever and leave cloud-init running
+# with no sandboxd.service installed.
+DOWNLOAD_CONNECT_TIMEOUT="${AEROL_DOWNLOAD_CONNECT_TIMEOUT:-20}"
+DOWNLOAD_MAX_TIME="${AEROL_DOWNLOAD_MAX_TIME:-300}"
+DOWNLOAD_LOW_SPEED_LIMIT="${AEROL_DOWNLOAD_LOW_SPEED_LIMIT:-1024}"
+DOWNLOAD_LOW_SPEED_TIME="${AEROL_DOWNLOAD_LOW_SPEED_TIME:-30}"
 
 # Shared Caddy cert storage (S3). All default empty / off; the feature is
 # off unless --caddy-storage-s3 is passed. When enabled, every node points
@@ -51,6 +61,11 @@ Options:
   --sandboxd-url <url>         Download URL for sandboxd binary
   --toolboxd-url <url>         Download URL for toolboxd binary
   --checksums-url <url>        Download URL for release checksums file
+  --caddy-binary-url <url>     Download URL for a prebuilt custom Caddy binary
+                               containing caddy-l4, caddy-dns/cloudflare, and
+                               certmagic-s3. Defaults to the matching GitHub
+                               release asset when available, then falls back to
+                               Caddy's build service.
   --install-prefix <dir>       Binary install directory (default: /usr/local/bin)
   --idle-timeout-min <minutes> Idle auto-stop timeout in minutes
   --build-from-source          Build binaries from the current checkout
@@ -207,10 +222,12 @@ resolve_release_urls() {
 		SANDBOXD_URL="${SANDBOXD_URL:-${release_base}/latest/download/sandboxd_${platform}}"
 		TOOLBOXD_URL="${TOOLBOXD_URL:-${release_base}/latest/download/toolboxd_${platform}}"
 		CHECKSUMS_URL="${CHECKSUMS_URL:-${release_base}/latest/download/checksums.txt}"
+		CADDY_BINARY_URL="${CADDY_BINARY_URL:-${release_base}/latest/download/caddy_${platform}}"
 	else
 		SANDBOXD_URL="${SANDBOXD_URL:-${release_base}/download/${VERSION}/sandboxd_${platform}}"
 		TOOLBOXD_URL="${TOOLBOXD_URL:-${release_base}/download/${VERSION}/toolboxd_${platform}}"
 		CHECKSUMS_URL="${CHECKSUMS_URL:-${release_base}/download/${VERSION}/checksums.txt}"
+		CADDY_BINARY_URL="${CADDY_BINARY_URL:-${release_base}/download/${VERSION}/caddy_${platform}}"
 	fi
 }
 
@@ -218,7 +235,22 @@ download_asset() {
 	local url="$1"
 	local output="$2"
 
-	curl -fL --retry 5 --retry-delay 2 --retry-connrefused "$url" -o "$output"
+	curl_download "$url" -o "$output"
+}
+
+curl_download() {
+	local url="$1"
+	shift
+
+	curl -fL \
+		--retry 5 \
+		--retry-delay 2 \
+		--retry-connrefused \
+		--connect-timeout "$DOWNLOAD_CONNECT_TIMEOUT" \
+		--max-time "$DOWNLOAD_MAX_TIME" \
+		--speed-limit "$DOWNLOAD_LOW_SPEED_LIMIT" \
+		--speed-time "$DOWNLOAD_LOW_SPEED_TIME" \
+		"$url" "$@"
 }
 
 verify_downloads() {
@@ -281,6 +313,11 @@ while [[ $# -gt 0 ]]; do
 		--checksums-url)
 			CHECKSUMS_URL="$2"
 			BUILD_FROM_SOURCE="false"
+			shift 2
+			;;
+		--caddy-binary-url)
+			CADDY_BINARY_URL="$2"
+			CADDY_BINARY_URL_EXPLICIT="true"
 			shift 2
 			;;
 		--install-prefix)
@@ -520,7 +557,7 @@ install_packages() {
 			if [[ -n "$arch_suffix" ]]; then
 				local tmp_deb
 				tmp_deb="$(mktemp --suffix=.deb)"
-				if curl -fsSL "https://s3.amazonaws.com/mountpoint-s3-release/latest/${arch_suffix}/mount-s3.deb" -o "$tmp_deb"; then
+				if curl_download "https://s3.amazonaws.com/mountpoint-s3-release/latest/${arch_suffix}/mount-s3.deb" -o "$tmp_deb"; then
 					apt-get install -y "$tmp_deb" || \
 						echo "Warning: mountpoint-s3 install failed; s3 mounts will be unavailable until installed manually" >&2
 				else
@@ -532,8 +569,8 @@ install_packages() {
 		ensure_docker
 		if ! command -v caddy >/dev/null 2>&1; then
 			apt-get install -y debian-keyring debian-archive-keyring apt-transport-https
-			curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
-			curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' > /etc/apt/sources.list.d/caddy-stable.list
+			curl_download 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+			curl_download 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' -o /etc/apt/sources.list.d/caddy-stable.list
 			apt-get update
 			apt-get install -y caddy
 		fi
@@ -546,6 +583,42 @@ install_packages() {
 	fi
 }
 
+verify_custom_caddy_binary() {
+	local tmp_binary="$1"
+	local source_label="$2"
+	shift 2
+	local required_modules=("$@")
+
+	if [[ ! -s "$tmp_binary" ]]; then
+		echo "${source_label} returned an empty binary" >&2
+		return 1
+	fi
+
+	if ! file "$tmp_binary" 2>/dev/null | grep -q ELF; then
+		echo "${source_label} did not return an ELF binary; first bytes:" >&2
+		head -c 200 "$tmp_binary" >&2 || true
+		echo "" >&2
+		return 1
+	fi
+
+	chmod +x "$tmp_binary"
+
+	# Verify every requested module is actually compiled in. Without this the
+	# Caddyfile / admin API calls we make later would fail at runtime with a
+	# cryptic "loading module 'X'" error long after install.sh exits.
+	local module
+	local present
+	present="$("$tmp_binary" list-modules 2>/dev/null || true)"
+	for module in "${required_modules[@]}"; do
+		if ! grep -q "^${module}\$" <<<"$present"; then
+			echo "${source_label} does not include required module: ${module}" >&2
+			echo "Modules present (filtered):" >&2
+			grep -E "^(layer4|dns\.providers|caddy\.storage)" <<<"$present" >&2 || true
+			return 1
+		fi
+	done
+}
+
 install_custom_caddy() {
 	# Replace the apt-installed Caddy binary with a custom build that includes
 	# every plugin AerolVM needs. caddy-l4 is always required so sandboxes can
@@ -553,8 +626,9 @@ install_custom_caddy() {
 	# layer4 admin API. caddy-dns/$DNS_PROVIDER is added when --dns-provider
 	# is set so DNS-01 wildcard TLS works.
 	#
-	# Caddy's official build server returns a single static binary with the
-	# requested modules baked in; no Go toolchain needed on the host.
+	# Prefer the pinned release artifact. The live Caddy build service is a
+	# fallback only; if it stalls at 0 bytes, bounded curl timeouts fail
+	# bootstrap cleanly instead of leaving cloud-init running forever.
 	local provider="${1:-}"
 	local arch_tag
 	local arch_extra=""
@@ -577,6 +651,34 @@ install_custom_caddy() {
 		caddy_path="/usr/bin/caddy"
 	fi
 
+	local required_modules=("layer4" "layer4.handlers.proxy")
+	if [[ -n "$provider" ]]; then
+		required_modules+=("dns.providers.${provider}")
+	fi
+	if [[ "$CADDY_STORAGE_S3" == "true" ]]; then
+		# The ss098 module registers under caddy.storage.s3.
+		required_modules+=("caddy.storage.s3")
+	fi
+
+	local tmp_binary
+	if [[ -n "$CADDY_BINARY_URL" ]]; then
+		tmp_binary="$(mktemp)"
+		echo "Downloading prebuilt custom Caddy from ${CADDY_BINARY_URL}"
+		if curl_download "$CADDY_BINARY_URL" -o "$tmp_binary" \
+			&& verify_custom_caddy_binary "$tmp_binary" "Prebuilt custom Caddy binary" "${required_modules[@]}"; then
+			systemctl stop caddy >/dev/null 2>&1 || true
+			install -m 0755 "$tmp_binary" "$caddy_path"
+			rm -f "$tmp_binary"
+			return
+		fi
+		rm -f "$tmp_binary"
+		if [[ "$CADDY_BINARY_URL_EXPLICIT" == "true" ]]; then
+			echo "Failed to install custom Caddy from explicit --caddy-binary-url: ${CADDY_BINARY_URL}" >&2
+			exit 1
+		fi
+		echo "Prebuilt custom Caddy release asset unavailable; falling back to Caddy build service" >&2
+	fi
+
 	# Caddy build server accepts repeated &p= for additional modules.
 	local download_url="${CADDY_BUILD_URL_BASE}?os=linux&arch=${arch_tag}${arch_extra}&p=github.com/mholt/caddy-l4"
 	if [[ -n "$provider" ]]; then
@@ -590,54 +692,18 @@ install_custom_caddy() {
 		download_url="${download_url}&p=github.com/ss098/certmagic-s3"
 	fi
 
-	local tmp_binary
 	tmp_binary="$(mktemp)"
 
-	if ! curl -fL --retry 5 --retry-delay 2 --retry-connrefused "$download_url" -o "$tmp_binary"; then
+	if ! curl_download "$download_url" -o "$tmp_binary"; then
 		rm -f "$tmp_binary"
 		echo "Failed to download custom Caddy build from ${download_url}" >&2
 		exit 1
 	fi
 
-	if [[ ! -s "$tmp_binary" ]]; then
-		rm -f "$tmp_binary"
-		echo "Caddy build server returned an empty binary" >&2
-		exit 1
-	fi
-
-	if ! file "$tmp_binary" 2>/dev/null | grep -q ELF; then
-		echo "Caddy build server did not return an ELF binary; first bytes:" >&2
-		head -c 200 "$tmp_binary" >&2 || true
-		echo "" >&2
+	if ! verify_custom_caddy_binary "$tmp_binary" "Caddy build server" "${required_modules[@]}"; then
 		rm -f "$tmp_binary"
 		exit 1
 	fi
-
-	chmod +x "$tmp_binary"
-
-	# Verify every requested module is actually compiled in. Without this the
-	# Caddyfile / admin API calls we make later would fail at runtime with a
-	# cryptic "loading module 'X'" error long after install.sh exits.
-	local required_modules=("layer4" "layer4.handlers.proxy")
-	if [[ -n "$provider" ]]; then
-		required_modules+=("dns.providers.${provider}")
-	fi
-	if [[ "$CADDY_STORAGE_S3" == "true" ]]; then
-		# The ss098 module registers under caddy.storage.s3.
-		required_modules+=("caddy.storage.s3")
-	fi
-	local module
-	local present
-	present="$("$tmp_binary" list-modules 2>/dev/null || true)"
-	for module in "${required_modules[@]}"; do
-		if ! grep -q "^${module}\$" <<<"$present"; then
-			echo "Downloaded Caddy does not include required module: ${module}" >&2
-			echo "Modules present (filtered):" >&2
-			grep -E "^(layer4|dns\.providers|caddy\.storage)" <<<"$present" >&2 || true
-			rm -f "$tmp_binary"
-			exit 1
-		fi
-	done
 
 	systemctl stop caddy >/dev/null 2>&1 || true
 	install -m 0755 "$tmp_binary" "$caddy_path"
@@ -989,14 +1055,14 @@ install_nvidia_gpu() {
 
 	local keyring="/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg"
 	if [[ ! -f "$keyring" ]]; then
-		curl -fsSL "https://nvidia.github.io/libnvidia-container/gpgkey" \
+		curl_download "https://nvidia.github.io/libnvidia-container/gpgkey" \
 			| gpg --dearmor -o "$keyring"
 	fi
 
 	# nvidia-container-toolkit.list uses plain https:// refs; rewrite to
 	# include the signed-by pointer so apt can verify the packages.
 	if [[ ! -f /etc/apt/sources.list.d/nvidia-container-toolkit.list ]]; then
-		curl -fsSL "https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list" \
+		curl_download "https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list" \
 			| sed "s#deb https://#deb [signed-by=${keyring}] https://#g" \
 			> /etc/apt/sources.list.d/nvidia-container-toolkit.list
 		apt-get update
@@ -1040,7 +1106,7 @@ install_amd_gpu() {
 	# documents and handles kernel module + ROCm library installation together.
 	local tmp_deb
 	tmp_deb="$(mktemp --suffix=.deb)"
-	if curl -fsSL \
+	if curl_download \
 		"https://repo.radeon.com/amdgpu-install/latest/ubuntu/${dist_codename}/amdgpu-install_latest_all.deb" \
 		-o "$tmp_deb" 2>/dev/null; then
 		apt-get install -y "$tmp_deb"
@@ -1052,7 +1118,7 @@ install_amd_gpu() {
 		rm -f "$tmp_deb"
 		echo "amdgpu-install package unavailable for '${dist_codename}'; falling back to direct ROCm apt repo" >&2
 		local keyring="/usr/share/keyrings/rocm-archive-keyring.gpg"
-		curl -fsSL "https://repo.radeon.com/rocm/rocm.gpg.key" | gpg --dearmor -o "$keyring"
+		curl_download "https://repo.radeon.com/rocm/rocm.gpg.key" | gpg --dearmor -o "$keyring"
 		echo "deb [arch=amd64 signed-by=${keyring}] https://repo.radeon.com/rocm/apt/latest ${dist_codename} main" \
 			> /etc/apt/sources.list.d/rocm.list
 		apt-get update
@@ -1091,11 +1157,11 @@ install_runsc_binary() {
 	trap "rm -rf '$tmp_dir'" RETURN
 
 	echo "Downloading runsc for ${arch} from ${base}"
-	if ! curl -fL --retry 5 --retry-delay 2 "${base}/runsc" -o "${tmp_dir}/runsc"; then
+	if ! curl_download "${base}/runsc" -o "${tmp_dir}/runsc"; then
 		echo "--with-gvisor: failed to download runsc from ${base}/runsc" >&2
 		exit 1
 	fi
-	if ! curl -fL --retry 5 --retry-delay 2 "${base}/runsc.sha512" -o "${tmp_dir}/runsc.sha512"; then
+	if ! curl_download "${base}/runsc.sha512" -o "${tmp_dir}/runsc.sha512"; then
 		echo "--with-gvisor: failed to download runsc.sha512 from ${base}/runsc.sha512" >&2
 		exit 1
 	fi


### PR DESCRIPTION
## Summary
- Build custom Caddy (caddy-l4, cloudflare DNS, certmagic-s3) for all Linux arches in the release workflow.
- `install.sh` prefers the pinned release Caddy artifact and falls back to the Caddy build service with bounded curl timeouts.
- Terraform bootstrap passes optional `caddy_binary_url` and uses resilient `curl_download` for all remote fetches.

## Test plan
- [ ] Release workflow builds and verifies `caddy_linux_amd64` modules
- [ ] `install.sh --caddy-binary-url <url>` on a fresh Ubuntu host
- [ ] Cluster Terraform apply with default (empty) `caddy_binary_url` picks up release asset

Made with [Cursor](https://cursor.com)