### PR TITLE
feat(docker): unix-socket push readiness for cluster creates

### DIFF
--- a/cmd/toolboxd/main.go
+++ b/cmd/toolboxd/main.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -45,7 +46,8 @@ var (
 	startReaperFn            = startReaper
 	startUserCommandFn       = startUserCommand
 	forwardShutdownSignalsFn = forwardShutdownSignals
-	serveHTTPFn              = func(srv *http.Server) error { return srv.ListenAndServe() }
+	serveHTTPFn              = func(srv *http.Server, ln net.Listener) error { return srv.Serve(ln) }
+	netListenFn              = func(network, addr string) (net.Listener, error) { return net.Listen(network, addr) }
 	newVsockServerFn         = func(port uint32, handler VsockHandler, logger *slog.Logger) (vsockServerAPI, error) {
 		return newVsockServer(port, handler, logger)
 	}
@@ -113,9 +115,12 @@ func main() {
 		envd:         newEnvdCompat(),
 		cloneGen:     clonegen.New(envString("SB_CLONE_GEN_PATH", clonegen.DefaultPath), logger),
 	}
+	readySocket := strings.TrimSpace(os.Getenv("SB_READY_SOCKET"))
+	readyNonce := strings.TrimSpace(os.Getenv("SB_READY_NONCE"))
 	// Evict the token from the process env table so child processes spawned
 	// for the user command and /exec endpoints don't inherit it via os.Environ().
 	os.Unsetenv("SB_TOOLBOX_TOKEN")
+	scrubReadyEnv()
 
 	startReaperFn(logger)
 
@@ -138,10 +143,19 @@ func main() {
 
 	addr := fmt.Sprintf(":%d", srv.port)
 	httpServer := &http.Server{
-		Addr:              addr,
 		Handler:           srv.routes(),
 		ReadHeaderTimeout: 10 * time.Second,
 	}
+
+	ln, err := netListenFn("tcp", addr)
+	if err != nil {
+		logger.Error("toolboxd listen failed", "error", err)
+		os.Exit(1)
+	}
+
+	// Push readiness only after the HTTP listener is accepting — same contract
+	// as /health 200 when create returns started.
+	announceReady(logger, srv.sandboxID, srv.authToken, readyNonce, readySocket)
 
 	go forwardShutdownSignalsFn(logger, httpServer)
 
@@ -169,7 +183,7 @@ func main() {
 	}
 
 	logger.Info("toolboxd listening", "addr", addr, "sandbox_id", srv.sandboxID, "version", version.Version)
-	if err := serveHTTPFn(httpServer); err != nil && !errors.Is(err, http.ErrServerClosed) {
+	if err := serveHTTPFn(httpServer, ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		logger.Error("toolboxd failed", "error", err)
 		os.Exit(1)
 	}

--- a/cmd/toolboxd/main_more_test.go
+++ b/cmd/toolboxd/main_more_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -123,6 +124,7 @@ func TestMainStartupBranchesWithStubs(t *testing.T) {
 	oldStartUserCommandFn := startUserCommandFn
 	oldForwardShutdownSignalsFn := forwardShutdownSignalsFn
 	oldServeHTTPFn := serveHTTPFn
+	oldNetListenFn := netListenFn
 	oldNewVsockServerFn := newVsockServerFn
 	t.Cleanup(func() {
 		os.Args = oldArgs
@@ -131,6 +133,7 @@ func TestMainStartupBranchesWithStubs(t *testing.T) {
 		startUserCommandFn = oldStartUserCommandFn
 		forwardShutdownSignalsFn = oldForwardShutdownSignalsFn
 		serveHTTPFn = oldServeHTTPFn
+		netListenFn = oldNetListenFn
 		newVsockServerFn = oldNewVsockServerFn
 	})
 
@@ -146,7 +149,10 @@ func TestMainStartupBranchesWithStubs(t *testing.T) {
 		}
 	}
 	forwardShutdownSignalsFn = func(*slog.Logger, *http.Server) {}
-	serveHTTPFn = func(*http.Server) error { return http.ErrServerClosed }
+	netListenFn = func(network, addr string) (net.Listener, error) {
+		return net.Listen(network, addr)
+	}
+	serveHTTPFn = func(*http.Server, net.Listener) error { return http.ErrServerClosed }
 	fakeVsock := &fakeVsockServer{served: make(chan struct{}), closed: make(chan struct{})}
 	newVsockServerFn = func(uint32, VsockHandler, *slog.Logger) (vsockServerAPI, error) {
 		return fakeVsock, nil

--- a/cmd/toolboxd/readyclient_linux.go
+++ b/cmd/toolboxd/readyclient_linux.go
@@ -1,0 +1,65 @@
+//go:build linux
+
+package main
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/version"
+	"github.com/aerol-ai/microvm/pkg/readyproto"
+)
+
+const readyDialTimeout = 3 * time.Second
+
+func dialReadySocket(logger *slog.Logger, socketPath, sandboxID, token, nonce string) {
+	socketPath = strings.TrimSpace(socketPath)
+	if socketPath == "" {
+		return
+	}
+	token = strings.TrimSpace(token)
+	nonce = strings.TrimSpace(nonce)
+	sandboxID = strings.TrimSpace(sandboxID)
+	if token == "" || nonce == "" || sandboxID == "" {
+		logger.Warn("ready socket dial skipped: missing handshake fields")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), readyDialTimeout)
+	defer cancel()
+
+	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+	if err != nil {
+		logger.Warn("ready socket dial failed", "error", err)
+		return
+	}
+	defer conn.Close()
+
+	sig := readyproto.ReadySignal{
+		Event:        readyproto.EventReady,
+		SandboxID:    sandboxID,
+		Token:        token,
+		Nonce:        nonce,
+		AgentVersion: version.Version,
+	}
+	if err := readyproto.Encode(conn, sig); err != nil {
+		logger.Warn("ready socket write failed", "error", err)
+	}
+}
+
+func announceReady(logger *slog.Logger, sandboxID, token, nonce, socketPath string) {
+	if strings.TrimSpace(socketPath) == "" {
+		return
+	}
+	go dialReadySocket(logger, socketPath, sandboxID, token, nonce)
+}
+
+// scrubReadyEnv removes readiness env vars so user commands never inherit them.
+func scrubReadyEnv() {
+	os.Unsetenv("SB_READY_SOCKET")
+	os.Unsetenv("SB_READY_NONCE")
+}

--- a/cmd/toolboxd/readyclient_other.go
+++ b/cmd/toolboxd/readyclient_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package main
+
+import "log/slog"
+
+func announceReady(_ *slog.Logger, _, _, _, _ string) {}
+
+func scrubReadyEnv() {}

--- a/cmd/toolboxd/readyclient_test.go
+++ b/cmd/toolboxd/readyclient_test.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"net"
 	"os"
-	"strings"
 	"sync"
 	"testing"
 	"time"

--- a/cmd/toolboxd/readyclient_test.go
+++ b/cmd/toolboxd/readyclient_test.go
@@ -1,0 +1,70 @@
+//go:build linux
+
+package main
+
+import (
+	"bufio"
+	"log/slog"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/readyproto"
+)
+
+func TestAnnounceReadyWritesValidSignal(t *testing.T) {
+	dir := t.TempDir()
+	sockPath := dir + "/ready.sock"
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		conn, err := ln.Accept()
+		if err != nil {
+			t.Errorf("accept: %v", err)
+			return
+		}
+		defer conn.Close()
+		sig, err := readyproto.Decode(bufio.NewReader(conn))
+		if err != nil {
+			t.Errorf("decode: %v", err)
+			return
+		}
+		if sig.SandboxID != "sb-1" || sig.Token != "tok" || sig.Nonce != "nonce-1" {
+			t.Errorf("signal = %+v", sig)
+		}
+	}()
+
+	dialReadySocket(slog.Default(), sockPath, "sb-1", "tok", "nonce-1")
+	wg.Wait()
+}
+
+func TestAnnounceReadyNoopWhenUnset(t *testing.T) {
+	announceReady(slog.Default(), "sb", "tok", "nonce", "")
+}
+
+func TestScrubReadyEnv(t *testing.T) {
+	t.Setenv("SB_READY_SOCKET", "/run/aerol/ready.sock")
+	t.Setenv("SB_READY_NONCE", "n")
+	scrubReadyEnv()
+	if os.Getenv("SB_READY_SOCKET") != "" || os.Getenv("SB_READY_NONCE") != "" {
+		t.Fatal("expected env scrubbed")
+	}
+}
+
+func TestDialReadySocketBounded(t *testing.T) {
+	start := time.Now()
+	dialReadySocket(slog.Default(), "/nonexistent/path.sock", "sb", "tok", "nonce")
+	if time.Since(start) > readyDialTimeout+time.Second {
+		t.Fatal("dial exceeded bounded timeout")
+	}
+}

--- a/integration-tests/suite/docker_readiness_test.go
+++ b/integration-tests/suite/docker_readiness_test.go
@@ -1,0 +1,121 @@
+//go:build integration
+
+package suite
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/integration-tests/suite/harness"
+	sdktypes "github.com/aerol-ai/microvm/sdk/go/pkg/types"
+)
+
+// UC-96 — on cluster deployments the docker create path should attribute
+// readiness to the unix-socket push channel.
+func TestDockerReadinessSocketPush(t *testing.T) {
+	harness.Require(t, sc, "UC-96")
+	c := client(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	sb, err := c.SDK().Create(ctx, sdktypes.CreateSandboxOptions{
+		Image: harness.DefaultImage,
+		Name:  harness.UniqueName(sc, t),
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = c.SDK().Destroy(context.Background(), sb.ID)
+	})
+	waitRunning(t, sb)
+
+	source, ok := c.LastCreateReadinessSource()
+	if !ok {
+		t.Fatal("create response missing readiness Server-Timing source")
+	}
+	if source != "socket" {
+		t.Fatalf("readiness source = %q, want socket (push path inactive?)", source)
+	}
+}
+
+// UC-96b — non-root images must still complete the socket push (0666 + token).
+func TestDockerReadinessSocketPushNonRoot(t *testing.T) {
+	harness.Require(t, sc, "UC-96b")
+	c := client(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	sb, err := c.SDK().Create(ctx, sdktypes.CreateSandboxOptions{
+		Image: "node:22-slim",
+		Name:  harness.UniqueName(sc, t),
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = c.SDK().Destroy(context.Background(), sb.ID)
+	})
+	waitRunning(t, sb)
+
+	source, ok := c.LastCreateReadinessSource()
+	if !ok || source != "socket" {
+		t.Fatalf("readiness source = %q ok=%v, want socket", source, ok)
+	}
+}
+
+// UC-96c — gVisor sandboxes must deliver readiness via the socket when runsc
+// is configured with --host-uds=open.
+func TestDockerReadinessSocketPushGvisor(t *testing.T) {
+	harness.Require(t, sc, "UC-96c")
+	c := client(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	sb, err := c.SDK().Create(ctx, sdktypes.CreateSandboxOptions{
+		Image:   harness.DefaultImage,
+		Name:    harness.UniqueName(sc, t),
+		Runtime: "gvisor",
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = c.SDK().Destroy(context.Background(), sb.ID)
+	})
+	waitRunning(t, sb)
+
+	source, ok := c.LastCreateReadinessSource()
+	if !ok || source != "socket" {
+		t.Fatalf("readiness source = %q ok=%v, want socket on gvisor", source, ok)
+	}
+}
+
+// UC-97 is covered by pkg/docker unit tests (push disabled → health poll).
+// Non-cluster scenarios (local-mode, single-node) exercise the fallback on
+// live infra because EnableCluster=false keeps the push path off.
+func TestDockerReadinessFallbackOnNonCluster(t *testing.T) {
+	if sc.Satisfies(harness.UseCase{Requires: []harness.Capability{harness.CapCluster}}) {
+		t.Skip("cluster scenario uses socket push; fallback covered elsewhere")
+	}
+	harness.Require(t, sc, "UC-11")
+	c := client(t)
+	sb := c.NewSandbox(t, sdktypes.CreateSandboxOptions{
+		Image: harness.DefaultImage,
+		Name:  harness.UniqueName(sc, t),
+	})
+	waitRunning(t, sb)
+
+	source, ok := c.LastCreateReadinessSource()
+	if !ok {
+		t.Fatal("missing Server-Timing readiness source")
+	}
+	if source != "health" {
+		t.Fatalf("readiness source = %q, want health on non-cluster host", source)
+	}
+	if strings.Contains(source, "socket") {
+		t.Fatal("socket push must be off outside cluster mode")
+	}
+}

--- a/integration-tests/suite/docker_readiness_test.go
+++ b/integration-tests/suite/docker_readiness_test.go
@@ -93,6 +93,46 @@ func TestDockerReadinessSocketPushGvisor(t *testing.T) {
 	}
 }
 
+// UC-96d — a socket-attributed create must mean the agent is genuinely
+// serving, not merely that toolboxd dialed the socket. toolboxd announces only
+// after its HTTP listener is bound (dial-after-listener contract), so an exec
+// issued immediately after create returns must succeed without a readiness
+// race. This guards against a false-ready regression where the push fires
+// before the agent can answer.
+func TestDockerReadinessSocketImpliesServingAgent(t *testing.T) {
+	harness.Require(t, sc, "UC-96d")
+	c := client(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	sb, err := c.SDK().Create(ctx, sdktypes.CreateSandboxOptions{
+		Image: harness.DefaultImage,
+		Name:  harness.UniqueName(sc, t),
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = c.SDK().Destroy(context.Background(), sb.ID)
+	})
+
+	source, ok := c.LastCreateReadinessSource()
+	if !ok || source != "socket" {
+		t.Fatalf("readiness source = %q ok=%v, want socket", source, ok)
+	}
+
+	// No waitRunning: the socket-ready signal must already imply a serving
+	// agent. Exec straight away — a false-ready push would surface here as a
+	// connection refused / 503 from the toolbox proxy.
+	res, err := sb.Exec(ctx, sdktypes.ExecRequest{Command: "echo uc96d-ready"})
+	if err != nil {
+		t.Fatalf("exec right after socket-ready create: %v", err)
+	}
+	if !strings.Contains(res.Stdout, "uc96d-ready") {
+		t.Fatalf("exec stdout = %q, want uc96d-ready", res.Stdout)
+	}
+}
+
 // UC-97 is covered by pkg/docker unit tests (push disabled → health poll).
 // Non-cluster scenarios (local-mode, single-node) exercise the fallback on
 // live infra because EnableCluster=false keeps the push path off.

--- a/integration-tests/suite/harness/client.go
+++ b/integration-tests/suite/harness/client.go
@@ -52,6 +52,11 @@ func (c *Client) LastServerCreateMS() (float64, bool) {
 	return c.timing.takeCreateMS()
 }
 
+// LastCreateReadinessSource returns readiness;desc= from the latest create.
+func (c *Client) LastCreateReadinessSource() (string, bool) {
+	return c.timing.takeCreateReadinessSource()
+}
+
 // SDK exposes the underlying client for use cases that need a method this
 // wrapper doesn't surface yet.
 func (c *Client) SDK() *microvm.Client { return c.sdk }

--- a/integration-tests/suite/harness/timing.go
+++ b/integration-tests/suite/harness/timing.go
@@ -15,9 +15,11 @@ import (
 type serverTimingTransport struct {
 	base http.RoundTripper
 
-	mu     sync.Mutex
-	lastMS float64
-	have   bool
+	mu            sync.Mutex
+	lastMS        float64
+	have          bool
+	lastReadiness string
+	haveReadiness bool
 }
 
 func (t *serverTimingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -29,6 +31,11 @@ func (t *serverTimingTransport) RoundTrip(req *http.Request) (*http.Response, er
 		if ms, ok := parseServerTimingCreate(resp.Header.Get("Server-Timing")); ok {
 			t.mu.Lock()
 			t.lastMS, t.have = ms, true
+			t.mu.Unlock()
+		}
+		if src, ok := parseServerTimingReadinessSource(resp.Header.Get("Server-Timing")); ok {
+			t.mu.Lock()
+			t.lastReadiness, t.haveReadiness = src, true
 			t.mu.Unlock()
 		}
 	}
@@ -44,6 +51,35 @@ func (t *serverTimingTransport) takeCreateMS() (float64, bool) {
 	ms, ok := t.lastMS, t.have
 	t.have = false
 	return ms, ok
+}
+
+// takeCreateReadinessSource returns the readiness source from the most recent
+// create's Server-Timing header (readiness;desc=socket|health).
+func (t *serverTimingTransport) takeCreateReadinessSource() (string, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	src, ok := t.lastReadiness, t.haveReadiness
+	t.haveReadiness = false
+	return src, ok
+}
+
+// parseServerTimingReadinessSource extracts readiness;desc=<source>.
+func parseServerTimingReadinessSource(header string) (string, bool) {
+	for _, metric := range strings.Split(header, ",") {
+		fields := strings.Split(metric, ";")
+		if strings.TrimSpace(fields[0]) != "readiness" {
+			continue
+		}
+		for _, attr := range fields[1:] {
+			if v, ok := strings.CutPrefix(strings.TrimSpace(attr), "desc="); ok {
+				v = strings.TrimSpace(v)
+				if v != "" {
+					return v, true
+				}
+			}
+		}
+	}
+	return "", false
 }
 
 // parseServerTimingCreate pulls the "create" metric's dur (milliseconds) out of

--- a/integration-tests/suite/harness/timing_test.go
+++ b/integration-tests/suite/harness/timing_test.go
@@ -106,3 +106,10 @@ func TestServerTimingTransportIgnoresNonCreate(t *testing.T) {
 		})
 	}
 }
+
+func TestParseServerTimingReadinessSource(t *testing.T) {
+	src, ok := parseServerTimingReadinessSource(`create;dur=1, readiness;desc=socket, runtime_wait;dur=2`)
+	if !ok || src != "socket" {
+		t.Fatalf("got (%q, %v)", src, ok)
+	}
+}

--- a/integration-tests/suite/harness/usecases.go
+++ b/integration-tests/suite/harness/usecases.go
@@ -244,6 +244,9 @@ var Registry = []UseCase{
 	// then tears them all down. Both reuse the hetero cluster substrate.
 	{ID: "UC-94", Title: "Benchmark: per-runtime sandbox create latency", Requires: []Capability{CapCluster, CapBenchmark}, Implemented: true},
 	{ID: "UC-95", Title: "Benchmark: fleet density to capacity rejection", Requires: []Capability{CapCluster, CapBenchmark}, Implemented: true},
+	{ID: "UC-96", Title: "Docker create readiness delivered via unix-socket push", Requires: []Capability{CapCluster, CapDocker}, Implemented: true},
+	{ID: "UC-96b", Title: "Docker socket push works for non-root container images", Requires: []Capability{CapCluster, CapDocker}, Implemented: true},
+	{ID: "UC-96c", Title: "Docker socket push works under gVisor runtime", Requires: []Capability{CapCluster, CapDocker, CapGvisor}, Implemented: true},
 }
 
 // byID is a lookup built once for the report generator.

--- a/integration-tests/suite/harness/usecases.go
+++ b/integration-tests/suite/harness/usecases.go
@@ -247,6 +247,7 @@ var Registry = []UseCase{
 	{ID: "UC-96", Title: "Docker create readiness delivered via unix-socket push", Requires: []Capability{CapCluster, CapDocker}, Implemented: true},
 	{ID: "UC-96b", Title: "Docker socket push works for non-root container images", Requires: []Capability{CapCluster, CapDocker}, Implemented: true},
 	{ID: "UC-96c", Title: "Docker socket push works under gVisor runtime", Requires: []Capability{CapCluster, CapDocker, CapGvisor}, Implemented: true},
+	{ID: "UC-96d", Title: "Socket-ready signal implies a genuinely serving agent (exec succeeds)", Requires: []Capability{CapCluster, CapDocker}, Implemented: true},
 }
 
 // byID is a lookup built once for the report generator.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -307,6 +307,9 @@ type Config struct {
 	HTTPClientTimeout           time.Duration
 	DockerRuntimeWaitTimeout    time.Duration
 	ToolboxWaitTimeout          time.Duration
+	DockerReadySocketEnabled    bool
+	DockerReadinessPollInitial  time.Duration
+	DockerReadinessPollMax      time.Duration
 	ReconcileInterval           time.Duration
 	NetstatsPollInterval        time.Duration
 	UploadMaxBytes              int64
@@ -1245,21 +1248,24 @@ func Load() (Config, error) {
 			NFSExport:          strings.TrimSpace(os.Getenv("SB_PLATFORM_VOLUMES_NFS_EXPORT")),
 			NFSOptions:         strings.TrimSpace(os.Getenv("SB_PLATFORM_VOLUMES_NFS_OPTIONS")),
 		},
-		LogLevel:                 strings.ToLower(getEnv("SB_LOG_LEVEL", "info")),
-		ShutdownTimeout:          getEnvDuration("SB_SHUTDOWN_TIMEOUT", 10*time.Second),
-		HTTPClientTimeout:        getEnvDuration("SB_HTTP_CLIENT_TIMEOUT", 180*time.Second),
-		DockerRuntimeWaitTimeout: getEnvDuration("SB_DOCKER_WAIT_TIMEOUT", 30*time.Second),
-		ToolboxWaitTimeout:       getEnvDuration("SB_TOOLBOX_WAIT_TIMEOUT", 30*time.Second),
-		ReconcileInterval:        getEnvDuration("SB_RECONCILE_INTERVAL", 5*time.Minute),
-		NetstatsPollInterval:     getEnvDuration("SB_NETSTATS_POLL_INTERVAL", 10*time.Second),
-		UploadMaxBytes:           int64(getEnvInt("SB_UPLOAD_MAX_BYTES", 256*1024*1024)),
-		OTELMetricsEnabled:       getEnvBool("SB_OTEL_METRICS_ENABLED", false),
-		OTELMetricsEndpoint:      firstNonEmpty(os.Getenv("SB_OTEL_METRICS_ENDPOINT"), os.Getenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT")),
-		OTELMetricsInterval:      getEnvDuration("SB_OTEL_METRICS_INTERVAL", 30*time.Second),
-		OTELTracesEnabled:        getEnvBool("SB_OTEL_TRACES_ENABLED", false),
-		OTELTracesEndpoint:       firstNonEmpty(os.Getenv("SB_OTEL_TRACES_ENDPOINT"), os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")),
-		OTELTracesSampleRatio:    getEnvFloat("SB_OTEL_TRACES_SAMPLE_RATIO", 0.05),
-		OTELServiceName:          getEnv("OTEL_SERVICE_NAME", "sandboxd"),
+		LogLevel:                   strings.ToLower(getEnv("SB_LOG_LEVEL", "info")),
+		ShutdownTimeout:            getEnvDuration("SB_SHUTDOWN_TIMEOUT", 10*time.Second),
+		HTTPClientTimeout:          getEnvDuration("SB_HTTP_CLIENT_TIMEOUT", 180*time.Second),
+		DockerRuntimeWaitTimeout:   getEnvDuration("SB_DOCKER_WAIT_TIMEOUT", 30*time.Second),
+		ToolboxWaitTimeout:         getEnvDuration("SB_TOOLBOX_WAIT_TIMEOUT", 30*time.Second),
+		DockerReadySocketEnabled:   getEnvBool("SB_DOCKER_READY_SOCKET_ENABLED", true),
+		DockerReadinessPollInitial: getEnvDuration("SB_DOCKER_READINESS_POLL_INITIAL", 20*time.Millisecond),
+		DockerReadinessPollMax:     getEnvDuration("SB_DOCKER_READINESS_POLL_MAX", 300*time.Millisecond),
+		ReconcileInterval:          getEnvDuration("SB_RECONCILE_INTERVAL", 5*time.Minute),
+		NetstatsPollInterval:       getEnvDuration("SB_NETSTATS_POLL_INTERVAL", 10*time.Second),
+		UploadMaxBytes:             int64(getEnvInt("SB_UPLOAD_MAX_BYTES", 256*1024*1024)),
+		OTELMetricsEnabled:         getEnvBool("SB_OTEL_METRICS_ENABLED", false),
+		OTELMetricsEndpoint:        firstNonEmpty(os.Getenv("SB_OTEL_METRICS_ENDPOINT"), os.Getenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT")),
+		OTELMetricsInterval:        getEnvDuration("SB_OTEL_METRICS_INTERVAL", 30*time.Second),
+		OTELTracesEnabled:          getEnvBool("SB_OTEL_TRACES_ENABLED", false),
+		OTELTracesEndpoint:         firstNonEmpty(os.Getenv("SB_OTEL_TRACES_ENDPOINT"), os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")),
+		OTELTracesSampleRatio:      getEnvFloat("SB_OTEL_TRACES_SAMPLE_RATIO", 0.05),
+		OTELServiceName:            getEnv("OTEL_SERVICE_NAME", "sandboxd"),
 
 		CPUReservationRatio:       getEnvFloat("SB_CPU_RESERVATION_RATIO", 0.9),
 		MemoryReservationRatio:    getEnvFloat("SB_MEMORY_RESERVATION_RATIO", 0.85),
@@ -1507,6 +1513,12 @@ func Load() (Config, error) {
 
 	if cfg.ToolboxMountPath == "" || !strings.HasPrefix(cfg.ToolboxMountPath, "/") {
 		return Config{}, fmt.Errorf("SB_TOOLBOX_MOUNT_PATH must be an absolute path")
+	}
+	if cfg.DockerReadinessPollInitial <= 0 {
+		return Config{}, errors.New("SB_DOCKER_READINESS_POLL_INITIAL must be > 0")
+	}
+	if cfg.DockerReadinessPollMax < cfg.DockerReadinessPollInitial {
+		return Config{}, errors.New("SB_DOCKER_READINESS_POLL_MAX must be >= SB_DOCKER_READINESS_POLL_INITIAL")
 	}
 
 	if cfg.Domain == "" && cfg.PublicHost == "" {
@@ -1916,6 +1928,22 @@ func (c Config) CreateSandboxTimeout() time.Duration {
 		return 0
 	}
 	return time.Duration(c.CreateSandboxTimeoutSeconds) * time.Second
+}
+
+// DockerReadySocketEffective is true only on cluster deployments where sandboxd
+// controls the host layout. Self-install and single-node hosts keep the safer
+// health-poll path even when SB_DOCKER_READY_SOCKET_ENABLED defaults true.
+func (c Config) DockerReadySocketEffective() bool {
+	return c.DockerReadySocketEnabled && c.EnableCluster
+}
+
+// DockerReadySocketDir is the host directory for per-create readiness sockets.
+func (c Config) DockerReadySocketDir() string {
+	base := strings.TrimSpace(c.MountsCredentialsRuntimeDir)
+	if base == "" {
+		base = "/run/sandboxd"
+	}
+	return filepath.Join(base, "docker", "ready")
 }
 
 func getEnv(key, fallback string) string {

--- a/internal/config/docker_ready_socket_test.go
+++ b/internal/config/docker_ready_socket_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestDockerReadySocketEffectiveGating(t *testing.T) {
+	t.Setenv("SB_PAT_TOKEN", "tok")
+	t.Setenv("SB_PUBLIC_HOST", "127.0.0.1")
+	t.Setenv("SB_DB_PATH", t.TempDir()+"/db.sqlite")
+	t.Setenv("SB_CONTAINER_RUNTIME", "docker")
+	t.Setenv("SB_TOOLBOX_BINARY_PATH", t.TempDir()+"/toolboxd")
+
+	t.Run("non_cluster_disabled_even_when_knob_true", func(t *testing.T) {
+		t.Setenv("SB_ENABLE_CLUSTER", "false")
+		t.Setenv("SB_DOCKER_READY_SOCKET_ENABLED", "true")
+		cfg, err := Load()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.DockerReadySocketEffective() {
+			t.Fatal("expected push disabled on non-cluster host")
+		}
+	})
+
+	t.Run("cluster_enabled_by_default", func(t *testing.T) {
+		t.Setenv("SB_ENABLE_CLUSTER", "true")
+		t.Setenv("SB_CLUSTER_BOOTSTRAP", "true")
+		t.Setenv("SB_CLUSTER_INSECURE_GOSSIP", "true")
+		t.Setenv("SB_CLUSTER_INSECURE_CREDENTIALS", "true")
+		t.Setenv("SB_DOCKER_READY_SOCKET_ENABLED", "true")
+		cfg, err := Load()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !cfg.DockerReadySocketEffective() {
+			t.Fatal("expected push enabled on cluster host")
+		}
+	})
+
+	t.Run("cluster_knob_false_disables", func(t *testing.T) {
+		t.Setenv("SB_ENABLE_CLUSTER", "true")
+		t.Setenv("SB_CLUSTER_BOOTSTRAP", "true")
+		t.Setenv("SB_CLUSTER_INSECURE_GOSSIP", "true")
+		t.Setenv("SB_CLUSTER_INSECURE_CREDENTIALS", "true")
+		t.Setenv("SB_DOCKER_READY_SOCKET_ENABLED", "false")
+		cfg, err := Load()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.DockerReadySocketEffective() {
+			t.Fatal("expected kill switch to disable push")
+		}
+	})
+}
+
+func TestDockerReadySocketDirDerived(t *testing.T) {
+	cfg := Config{MountsCredentialsRuntimeDir: "/run/sandboxd/creds"}
+	if got := cfg.DockerReadySocketDir(); got != "/run/sandboxd/creds/docker/ready" {
+		t.Fatalf("dir = %q", got)
+	}
+}

--- a/pkg/api/v1/cluster_create_coverage_test.go
+++ b/pkg/api/v1/cluster_create_coverage_test.go
@@ -19,6 +19,7 @@ import (
 	storepkg "github.com/aerol-ai/microvm/internal/store"
 	"github.com/aerol-ai/microvm/pkg/caddy"
 	"github.com/aerol-ai/microvm/pkg/capacity"
+	"github.com/aerol-ai/microvm/pkg/docker"
 	"github.com/aerol-ai/microvm/pkg/models"
 	"github.com/aerol-ai/microvm/pkg/mounts"
 	"github.com/aerol-ai/microvm/pkg/secrets"
@@ -33,11 +34,23 @@ type apiRecordingRuntime struct {
 	destroyErr   error
 	createCalls  int
 	lastCreateID string
+	// timingSource, when set, makes Create populate the docker.CreateTiming
+	// recorder carried on ctx — mimicking what the real docker runtime does so
+	// handler tests can assert the create→readiness Server-Timing attribution
+	// is threaded through service.CreateSandbox.
+	timingSource string
 }
 
-func (r *apiRecordingRuntime) Create(_ context.Context, _ models.CreateSandboxRequest, sandboxID, _ string, _ []mounts.ContainerBind) (*models.SandboxRuntimeState, error) {
+func (r *apiRecordingRuntime) Create(ctx context.Context, _ models.CreateSandboxRequest, sandboxID, _ string, _ []mounts.ContainerBind) (*models.SandboxRuntimeState, error) {
 	r.createCalls++
 	r.lastCreateID = sandboxID
+	if r.timingSource != "" {
+		if tm := docker.CreateTimingFrom(ctx); tm != nil {
+			tm.RuntimeWaitMS = 12.5
+			tm.ToolboxWaitMS = 34.0
+			tm.Source = r.timingSource
+		}
+	}
 	if r.createErr != nil {
 		return nil, r.createErr
 	}

--- a/pkg/api/v1/cluster_create_timing_test.go
+++ b/pkg/api/v1/cluster_create_timing_test.go
@@ -1,0 +1,75 @@
+package v1
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aerol-ai/microvm/internal/cluster"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// TestCreateSandboxOnSelectedNode_ThreadsReadinessTiming is the regression for
+// the cluster-path attribution gap: createSandboxOnSelectedNode is the *only*
+// path the readiness socket runs on (the feature is gated on EnableCluster), so
+// if it doesn't wrap the request context with docker.WithCreateTiming and pass
+// the recorder to setCreateServerTiming, the create response carries only
+// create;dur= and the UC-96 integration assertions (readiness;desc=socket) can
+// never pass. This drives both create entry points (promote + self-local).
+func TestCreateSandboxOnSelectedNode_ThreadsReadinessTiming(t *testing.T) {
+	cases := []struct {
+		name          string
+		reservationID string
+	}{
+		{name: "promote_local", reservationID: "sb-timing-promote"},
+		{name: "self_local", reservationID: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := &apiRecordingRuntime{timingSource: "socket"}
+			stub := &promoteStubCluster{Noop: cluster.NewNoop("node-a", "http://node-a", "")}
+			h, _ := newClusterCreateHarness(t, rt, stub)
+
+			req := models.CreateSandboxRequest{Image: "alpine:3.20"}
+			rr := httptest.NewRecorder()
+			httpReq := httptest.NewRequest(http.MethodPost, "/v1/sandboxes", nil)
+			h.createSandboxOnSelectedNode(rr, httpReq, req, tc.reservationID)
+
+			if rr.Code != http.StatusCreated {
+				t.Fatalf("status = %d, want 201; body=%s", rr.Code, rr.Body.String())
+			}
+			st := rr.Header().Get("Server-Timing")
+			for _, want := range []string{"create;dur=", "runtime_wait;dur=", "toolbox_wait;dur=", "readiness;desc=socket"} {
+				if !strings.Contains(st, want) {
+					t.Fatalf("Server-Timing = %q, missing %q (timing not threaded?)", st, want)
+				}
+			}
+		})
+	}
+}
+
+// TestCreateSandboxOnSelectedNode_TimingOnErrorPath asserts the attribution is
+// also emitted on the failure path, so a create that fails late still reports
+// whatever readiness phase it reached rather than dropping the header.
+func TestCreateSandboxOnSelectedNode_TimingOnErrorPath(t *testing.T) {
+	rt := &apiRecordingRuntime{timingSource: "health"}
+	stub := &promoteStubCluster{
+		Noop:      cluster.NewNoop("node-a", "http://node-a", ""),
+		recordErr: errors.New("raft commit failed"),
+	}
+	h, _ := newClusterCreateHarness(t, rt, stub)
+
+	req := models.CreateSandboxRequest{Image: "alpine:3.20"}
+	rr := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/sandboxes", nil)
+	h.createSandboxOnSelectedNode(rr, httpReq, req, "sb-timing-fail")
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body=%s", rr.Code, rr.Body.String())
+	}
+	if st := rr.Header().Get("Server-Timing"); !strings.Contains(st, "readiness;desc=health") {
+		t.Fatalf("Server-Timing = %q, want readiness attribution on error path", st)
+	}
+}

--- a/pkg/api/v1/cluster_handler.go
+++ b/pkg/api/v1/cluster_handler.go
@@ -335,16 +335,23 @@ func (h *handlers) createSandboxOnSelectedNode(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	// Thread a CreateTiming recorder so the docker create path can attribute
+	// readiness (socket vs health) on this — the only path where the readiness
+	// socket runs, since the feature is gated on EnableCluster. The plain
+	// createSandbox handler does the same; without it the cluster create
+	// response carries only create;dur= and UC-96 attribution is lost.
+	createCtx, createTiming := docker.WithCreateTiming(r.Context())
+
 	var (
 		resp *models.CreateSandboxResponse
 		err  error
 	)
 	if reservationID != "" {
 		service.RecordCreateReservationState("promote_local")
-		resp, err = h.deps.Service.CreateSandboxWithID(r.Context(), req, reservationID)
+		resp, err = h.deps.Service.CreateSandboxWithID(createCtx, req, reservationID)
 	} else {
 		service.RecordCreateReservationState("self_local")
-		resp, err = h.deps.Service.CreateSandbox(r.Context(), req)
+		resp, err = h.deps.Service.CreateSandbox(createCtx, req)
 	}
 	if err != nil {
 		// Local create failed — release the reservation so the leader's GC
@@ -358,7 +365,7 @@ func (h *handlers) createSandboxOnSelectedNode(w http.ResponseWriter, r *http.Re
 			}
 			rbCancel()
 		}
-		setCreateServerTiming(w, createStart, nil)
+		setCreateServerTiming(w, createStart, createTiming)
 		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
 		return
 	}
@@ -388,7 +395,7 @@ func (h *handlers) createSandboxOnSelectedNode(w http.ResponseWriter, r *http.Re
 			}
 		}
 		rbCancel()
-		setCreateServerTiming(w, createStart, nil)
+		setCreateServerTiming(w, createStart, createTiming)
 		apihttp.WriteError(w, http.StatusInternalServerError, "cluster: store secret ref: "+sealErr.Error())
 		return
 	}
@@ -419,16 +426,16 @@ func (h *handlers) createSandboxOnSelectedNode(w http.ResponseWriter, r *http.Re
 		// this should only fire on the self-wins path (the reserve step
 		// already validated name uniqueness for the forward path).
 		if errors.Is(promoteErr, cluster.ErrNameConflict) {
-			setCreateServerTiming(w, createStart, nil)
+			setCreateServerTiming(w, createStart, createTiming)
 			apihttp.WriteError(w, http.StatusConflict, "sandbox name already in use cluster-wide")
 			return
 		}
-		setCreateServerTiming(w, createStart, nil)
+		setCreateServerTiming(w, createStart, createTiming)
 		apihttp.WriteError(w, http.StatusServiceUnavailable, "cluster: placement commit failed: "+promoteErr.Error())
 		return
 	}
 
-	setCreateServerTiming(w, createStart, nil)
+	setCreateServerTiming(w, createStart, createTiming)
 	apihttp.WriteJSON(w, http.StatusCreated, resp)
 }
 

--- a/pkg/api/v1/cluster_handler.go
+++ b/pkg/api/v1/cluster_handler.go
@@ -358,7 +358,7 @@ func (h *handlers) createSandboxOnSelectedNode(w http.ResponseWriter, r *http.Re
 			}
 			rbCancel()
 		}
-		setCreateServerTiming(w, createStart)
+		setCreateServerTiming(w, createStart, nil)
 		apihttp.WriteStoreAwareError(h.deps.Logger, w, err)
 		return
 	}
@@ -388,7 +388,7 @@ func (h *handlers) createSandboxOnSelectedNode(w http.ResponseWriter, r *http.Re
 			}
 		}
 		rbCancel()
-		setCreateServerTiming(w, createStart)
+		setCreateServerTiming(w, createStart, nil)
 		apihttp.WriteError(w, http.StatusInternalServerError, "cluster: store secret ref: "+sealErr.Error())
 		return
 	}
@@ -419,16 +419,16 @@ func (h *handlers) createSandboxOnSelectedNode(w http.ResponseWriter, r *http.Re
 		// this should only fire on the self-wins path (the reserve step
 		// already validated name uniqueness for the forward path).
 		if errors.Is(promoteErr, cluster.ErrNameConflict) {
-			setCreateServerTiming(w, createStart)
+			setCreateServerTiming(w, createStart, nil)
 			apihttp.WriteError(w, http.StatusConflict, "sandbox name already in use cluster-wide")
 			return
 		}
-		setCreateServerTiming(w, createStart)
+		setCreateServerTiming(w, createStart, nil)
 		apihttp.WriteError(w, http.StatusServiceUnavailable, "cluster: placement commit failed: "+promoteErr.Error())
 		return
 	}
 
-	setCreateServerTiming(w, createStart)
+	setCreateServerTiming(w, createStart, nil)
 	apihttp.WriteJSON(w, http.StatusCreated, resp)
 }
 

--- a/pkg/api/v1/handlers.go
+++ b/pkg/api/v1/handlers.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aerol-ai/microvm/internal/cluster"
 	"github.com/aerol-ai/microvm/pkg/api/apihttp"
+	"github.com/aerol-ai/microvm/pkg/docker"
 	"github.com/aerol-ai/microvm/pkg/models"
 )
 
@@ -34,8 +35,22 @@ func (h *handlers) capacity(w http.ResponseWriter, r *http.Request) {
 	apihttp.WriteJSON(w, http.StatusOK, h.deps.Service.Capacity())
 }
 
-func setCreateServerTiming(w http.ResponseWriter, start time.Time) {
-	w.Header().Set("Server-Timing", "create;dur="+strconv.FormatFloat(float64(time.Since(start).Microseconds())/1000, 'f', 1, 64))
+func setCreateServerTiming(w http.ResponseWriter, start time.Time, timing *docker.CreateTiming) {
+	parts := []string{
+		"create;dur=" + strconv.FormatFloat(float64(time.Since(start).Microseconds())/1000, 'f', 1, 64),
+	}
+	if timing != nil {
+		if timing.RuntimeWaitMS > 0 || timing.Source != "" {
+			parts = append(parts, "runtime_wait;dur="+strconv.FormatFloat(timing.RuntimeWaitMS, 'f', 1, 64))
+		}
+		if timing.ToolboxWaitMS > 0 || timing.Source != "" {
+			parts = append(parts, "toolbox_wait;dur="+strconv.FormatFloat(timing.ToolboxWaitMS, 'f', 1, 64))
+		}
+		if timing.Source != "" {
+			parts = append(parts, "readiness;desc="+timing.Source)
+		}
+	}
+	w.Header().Set("Server-Timing", strings.Join(parts, ", "))
 }
 
 func (h *handlers) createSandbox(w http.ResponseWriter, r *http.Request) {
@@ -49,8 +64,9 @@ func (h *handlers) createSandbox(w http.ResponseWriter, r *http.Request) {
 	// the client<->cluster network round-trip. Set the header before
 	// WriteJSON/WriteError — response headers must land before the status line.
 	createStart := time.Now()
-	response, err := h.deps.Service.CreateSandbox(r.Context(), req)
-	setCreateServerTiming(w, createStart)
+	ctx, createTiming := docker.WithCreateTiming(r.Context())
+	response, err := h.deps.Service.CreateSandbox(ctx, req)
+	setCreateServerTiming(w, createStart, createTiming)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			apihttp.WriteError(w, http.StatusGatewayTimeout, "sandbox create exceeded timeout")

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -155,6 +155,15 @@ func Run(ctx context.Context, logger *slog.Logger, makeProvider ProviderFactory)
 	if err != nil {
 		return fmt.Errorf("create docker client: %w", err)
 	}
+	if cfg.DockerReadySocketEffective() {
+		readyDir := cfg.DockerReadySocketDir()
+		if err := docker.EnsureReadyDir(readyDir); err != nil {
+			return fmt.Errorf("ready socket dir: %w", err)
+		}
+		if err := docker.SweepOrphanReadySockets(readyDir); err != nil {
+			logger.Warn("ready socket sweep failed", "error", err)
+		}
+	}
 	configureMirror(logger, cfg, dockerClient)
 	configureAOCRPullAuth(logger, cfg, dockerClient)
 

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -436,6 +436,12 @@ func (c *Client) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 		binds = append(binds, readyListener.BindSpec())
 		envValues = append(envValues, readyListener.EnvVars()...)
 		sort.Strings(envValues)
+		// envValues was sized to len(req.Env)+3, so appending the two ready
+		// vars reallocates the backing array — the slice already stored under
+		// createRequest["Env"] still points at the pre-append array. Re-store
+		// the grown slice or toolboxd never sees SB_READY_SOCKET/NONCE and the
+		// push silently degrades to health-poll on every create.
+		createRequest["Env"] = envValues
 	}
 
 	for _, m := range hostMounts {
@@ -1127,14 +1133,18 @@ func (c *Client) waitForContainerRunning(ctx context.Context, containerRef strin
 
 func (c *Client) waitForToolboxReady(ctx context.Context, containerIP string, listener *ReadyListener) (string, error) {
 	if listener == nil {
-		err := c.pollToolboxHealth(ctx, containerIP)
-		if err != nil {
+		// Push disabled (non-cluster) — plain health poll. Deliberately do not
+		// touch readySocketFallbackHealth: there was no socket to fall back
+		// from, and counting disabled-path creates here would make the metric
+		// useless for spotting real socket losses (old toolbox image, gVisor
+		// without host-uds) in cluster mode.
+		if err := c.pollToolboxHealth(ctx, containerIP); err != nil {
 			return "", err
 		}
-		recordReadySocketFallback(0)
 		return "health", nil
 	}
 
+	start := time.Now()
 	raceCtx, cancel := context.WithTimeout(ctx, c.toolboxWaitTimeout)
 	defer cancel()
 
@@ -1180,7 +1190,7 @@ func (c *Client) waitForToolboxReady(ctx context.Context, containerIP string, li
 	if res.err != nil {
 		return "", res.err
 	}
-	waitMS := int64(0)
+	waitMS := time.Since(start).Milliseconds()
 	if res.source == "socket" {
 		recordReadySocketHit(waitMS)
 	} else {

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -60,6 +60,10 @@ type Client struct {
 	networkRules       *netrules.Manager
 	waitTimeout        time.Duration
 	toolboxWaitTimeout time.Duration
+	readyEnabled       bool
+	readyDir           string
+	readinessPollInit  time.Duration
+	readinessPollMax   time.Duration
 	pullMu             sync.Mutex
 	pulls              map[string]*imagePull
 	pullSlots          chan struct{}
@@ -126,6 +130,10 @@ func New(logger *slog.Logger, cfg config.Config, rules *netrules.Manager) (*Clie
 		networkRules:       rules,
 		waitTimeout:        cfg.DockerRuntimeWaitTimeout,
 		toolboxWaitTimeout: cfg.ToolboxWaitTimeout,
+		readyEnabled:       cfg.DockerReadySocketEffective(),
+		readyDir:           cfg.DockerReadySocketDir(),
+		readinessPollInit:  cfg.DockerReadinessPollInitial,
+		readinessPollMax:   cfg.DockerReadinessPollMax,
 		pulls:              make(map[string]*imagePull),
 		pullSlots:          pullSlots,
 		pullBackoff:        cfg.ImagePullFailureBackoff,
@@ -407,6 +415,29 @@ func (c *Client) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 	binds := []string{
 		fmt.Sprintf("%s:%s:ro", c.toolboxBinaryPath, c.toolboxMountPath),
 	}
+
+	var readyListener *ReadyListener
+	var readyListenerClosed bool
+	defer func() {
+		if readyListener != nil && !readyListenerClosed {
+			_ = readyListener.Close()
+		}
+	}()
+
+	if c.readyEnabled {
+		readyNonce, err := mintReadyNonce()
+		if err != nil {
+			return nil, fmt.Errorf("mint ready nonce: %w", err)
+		}
+		readyListener, err = NewReadyListener(c.readyDir, sandboxID, toolboxToken, readyNonce)
+		if err != nil {
+			return nil, fmt.Errorf("ready listener: %w", err)
+		}
+		binds = append(binds, readyListener.BindSpec())
+		envValues = append(envValues, readyListener.EnvVars()...)
+		sort.Strings(envValues)
+	}
+
 	for _, m := range hostMounts {
 		entry := fmt.Sprintf("%s:%s", m.HostPath, m.ContainerPath)
 		if m.ReadOnly {
@@ -520,10 +551,35 @@ func (c *Client) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 		return nil, fmt.Errorf("start container: %w", err)
 	}
 
-	runtime, err := c.waitForRuntime(ctx, created.ID)
+	runtimeWaitStart := time.Now()
+	containerIP, inspect, err := c.waitForContainerRunning(ctx, created.ID)
+	runtimeWait := time.Since(runtimeWaitStart)
 	if err != nil {
 		_ = c.removeContainer(ctx, created.ID, true)
 		return nil, err
+	}
+
+	toolboxWaitStart := time.Now()
+	toolboxSource, err := c.waitForToolboxReady(ctx, containerIP, readyListener)
+	toolboxWait := time.Since(toolboxWaitStart)
+	if timing := CreateTimingFrom(ctx); timing != nil {
+		timing.record(runtimeWait, toolboxWait, toolboxSource)
+	}
+	if err != nil {
+		_ = c.removeContainer(ctx, created.ID, true)
+		return nil, err
+	}
+	if readyListener != nil {
+		readyListenerClosed = true
+		_ = readyListener.Close()
+		readyListener = nil
+	}
+
+	runtime := &SandboxRuntime{
+		SandboxID:   sandboxIDFromContainerName(inspect.Name),
+		ContainerID: inspect.ID,
+		ContainerIP: containerIP,
+		Status:      models.SandboxStatusStarted,
 	}
 
 	if req.NetworkBlockAll {
@@ -578,6 +634,7 @@ func (c *Client) Destroy(ctx context.Context, sandbox *models.Sandbox) error {
 	if sandbox == nil {
 		return nil
 	}
+	RemoveReadySocketsForSandbox(c.readyDir, sandbox.ID)
 	containerRef := strings.TrimSpace(sandbox.ContainerID)
 	if containerRef == "" {
 		return errors.New("sandbox container ID is not available")
@@ -1033,36 +1090,113 @@ func IsLocalOnlyImageRef(imageRef string) bool {
 }
 
 func (c *Client) waitForRuntime(ctx context.Context, containerRef string) (*SandboxRuntime, error) {
-	deadline := time.Now().Add(c.waitTimeout)
-	for time.Now().Before(deadline) {
-		inspect, err := c.inspectContainer(ctx, containerRef)
-		if err != nil {
-			return nil, fmt.Errorf("inspect container: %w", err)
-		}
-
-		containerIP := getContainerIP(inspect, c.network)
-		if inspect.State != nil && inspect.State.Running && containerIP != "" {
-			if err := c.waitForToolbox(ctx, containerIP); err != nil {
-				return nil, err
-			}
-			return &SandboxRuntime{
-				SandboxID:   sandboxIDFromContainerName(inspect.Name),
-				ContainerID: inspect.ID,
-				ContainerIP: containerIP,
-				Status:      models.SandboxStatusStarted,
-			}, nil
-		}
-
-		time.Sleep(300 * time.Millisecond)
+	containerIP, inspect, err := c.waitForContainerRunning(ctx, containerRef)
+	if err != nil {
+		return nil, err
 	}
-
-	return nil, fmt.Errorf("timed out waiting for sandbox runtime: %s", containerRef)
+	if _, err := c.waitForToolboxReady(ctx, containerIP, nil); err != nil {
+		return nil, err
+	}
+	return &SandboxRuntime{
+		SandboxID:   sandboxIDFromContainerName(inspect.Name),
+		ContainerID: inspect.ID,
+		ContainerIP: containerIP,
+		Status:      models.SandboxStatusStarted,
+	}, nil
 }
 
-func (c *Client) waitForToolbox(ctx context.Context, containerIP string) error {
+func (c *Client) waitForContainerRunning(ctx context.Context, containerRef string) (string, containerInspect, error) {
+	deadline := time.Now().Add(c.waitTimeout)
+	sleep := c.readinessPollInterval()
+	for time.Now().Before(deadline) {
+		if err := ctx.Err(); err != nil {
+			return "", containerInspect{}, err
+		}
+		inspect, err := c.inspectContainer(ctx, containerRef)
+		if err != nil {
+			return "", containerInspect{}, fmt.Errorf("inspect container: %w", err)
+		}
+		containerIP := getContainerIP(inspect, c.network)
+		if inspect.State != nil && inspect.State.Running && containerIP != "" {
+			return containerIP, inspect, nil
+		}
+		time.Sleep(sleep())
+	}
+	return "", containerInspect{}, fmt.Errorf("timed out waiting for sandbox runtime: %s", containerRef)
+}
+
+func (c *Client) waitForToolboxReady(ctx context.Context, containerIP string, listener *ReadyListener) (string, error) {
+	if listener == nil {
+		err := c.pollToolboxHealth(ctx, containerIP)
+		if err != nil {
+			return "", err
+		}
+		recordReadySocketFallback(0)
+		return "health", nil
+	}
+
+	raceCtx, cancel := context.WithTimeout(ctx, c.toolboxWaitTimeout)
+	defer cancel()
+
+	type result struct {
+		source string
+		err    error
+	}
+	ch := make(chan result, 2)
+
+	go func() {
+		err := listener.Wait(raceCtx)
+		select {
+		case ch <- result{source: "socket", err: err}:
+		case <-raceCtx.Done():
+		}
+	}()
+
+	go func() {
+		timer := time.NewTimer(readyHealthPollGrace)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+		case <-raceCtx.Done():
+			return
+		}
+		err := c.pollToolboxHealth(raceCtx, containerIP)
+		select {
+		case ch <- result{source: "health", err: err}:
+		case <-raceCtx.Done():
+		}
+	}()
+
+	res := <-ch
+	cancel()
+	// Drain the loser so its goroutine can exit without leaking a dial.
+	go func() {
+		select {
+		case <-ch:
+		case <-time.After(c.toolboxWaitTimeout):
+		}
+	}()
+
+	if res.err != nil {
+		return "", res.err
+	}
+	waitMS := int64(0)
+	if res.source == "socket" {
+		recordReadySocketHit(waitMS)
+	} else {
+		recordReadySocketFallback(waitMS)
+	}
+	return res.source, nil
+}
+
+func (c *Client) pollToolboxHealth(ctx context.Context, containerIP string) error {
 	target := fmt.Sprintf("http://%s:%d/health", containerIP, c.toolboxPort)
 	deadline := time.Now().Add(c.toolboxWaitTimeout)
+	sleep := c.readinessPollInterval()
 	for time.Now().Before(deadline) {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
 		if err != nil {
 			return err
@@ -1074,9 +1208,36 @@ func (c *Client) waitForToolbox(ctx context.Context, containerIP string) error {
 				return nil
 			}
 		}
-		time.Sleep(300 * time.Millisecond)
+		time.Sleep(sleep())
 	}
 	return fmt.Errorf("toolbox did not become healthy on %s", target)
+}
+
+func (c *Client) readinessPollInterval() func() time.Duration {
+	initial := c.readinessPollInit
+	if initial <= 0 {
+		initial = 20 * time.Millisecond
+	}
+	maximum := c.readinessPollMax
+	if maximum < initial {
+		maximum = 300 * time.Millisecond
+	}
+	cur := initial
+	return func() time.Duration {
+		d := cur
+		if cur < maximum {
+			cur *= 2
+			if cur > maximum {
+				cur = maximum
+			}
+		}
+		return d
+	}
+}
+
+func (c *Client) waitForToolbox(ctx context.Context, containerIP string) error {
+	_, err := c.waitForToolboxReady(ctx, containerIP, nil)
+	return err
 }
 
 func (c *Client) inspectContainer(ctx context.Context, id string) (containerInspect, error) {

--- a/pkg/docker/create_timing.go
+++ b/pkg/docker/create_timing.go
@@ -1,0 +1,45 @@
+package docker
+
+import (
+	"context"
+	"time"
+)
+
+type createTimingKey struct{}
+
+// CreateTiming captures per-phase create latency for Server-Timing attribution.
+type CreateTiming struct {
+	RuntimeWaitMS float64
+	ToolboxWaitMS float64
+	Source        string // "socket" or "health"; empty when not recorded
+}
+
+// WithCreateTiming returns a child context that carries a CreateTiming recorder.
+func WithCreateTiming(parent context.Context) (context.Context, *CreateTiming) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	if existing, ok := parent.Value(createTimingKey{}).(*CreateTiming); ok && existing != nil {
+		return parent, existing
+	}
+	timing := &CreateTiming{}
+	return context.WithValue(parent, createTimingKey{}, timing), timing
+}
+
+// CreateTimingFrom returns the recorder stashed on ctx, if any.
+func CreateTimingFrom(ctx context.Context) *CreateTiming {
+	if ctx == nil {
+		return nil
+	}
+	timing, _ := ctx.Value(createTimingKey{}).(*CreateTiming)
+	return timing
+}
+
+func (t *CreateTiming) record(runtimeWait, toolboxWait time.Duration, source string) {
+	if t == nil {
+		return
+	}
+	t.RuntimeWaitMS = float64(runtimeWait.Microseconds()) / 1000
+	t.ToolboxWaitMS = float64(toolboxWait.Microseconds()) / 1000
+	t.Source = source
+}

--- a/pkg/docker/ready_create_more_test.go
+++ b/pkg/docker/ready_create_more_test.go
@@ -1,0 +1,127 @@
+package docker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// captureCreateEnv runs a Create against fakeCreateDaemon and returns the Env
+// slice the daemon actually received in the /containers/create body.
+func captureCreateEnv(t *testing.T, mutate func(*Client), req models.CreateSandboxRequest, id string) []string {
+	t.Helper()
+	var captured map[string]any
+	d := fakeCreateDaemon(t)
+	base := d.transport()
+	wrapped := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodPost && r.URL.Path == "/containers/create" && r.Body != nil {
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &captured)
+			r.Body = io.NopCloser(bytes.NewReader(body))
+		}
+		return base(r)
+	})
+
+	c := newCreateClient(t, d, true, func(c *Client) {
+		c.httpClient = &http.Client{Transport: wrapped, Timeout: c.httpClient.Timeout}
+		c.streamClient = &http.Client{Transport: wrapped}
+		if mutate != nil {
+			mutate(c)
+		}
+	})
+
+	if _, err := c.Create(context.Background(), req, id, "tok", nil); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	out := []string{}
+	for _, e := range captured["Env"].([]any) {
+		s, _ := e.(string)
+		out = append(out, s)
+	}
+	return out
+}
+
+func hasEnvPrefix(env []string, prefix string) bool {
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestCreate_ReadyEnvSurvivesUserEnv is the regression for the slice-aliasing
+// bug: envValues is sized to len(req.Env)+3, so appending the two ready vars
+// reallocates the backing array. If createRequest["Env"] is not re-stored
+// after the append, toolboxd never receives SB_READY_SOCKET/NONCE and the
+// push silently degrades to health-poll on every create. User env present
+// here exercises the same overflow with a non-trivial base length so the bug
+// can't hide behind a lucky capacity.
+func TestCreate_ReadyEnvSurvivesUserEnv(t *testing.T) {
+	requireLinuxUnix(t)
+	readyDir := t.TempDir()
+	env := captureCreateEnv(t, func(c *Client) {
+		c.readyEnabled = true
+		c.readyDir = readyDir
+	}, models.CreateSandboxRequest{
+		Image: "img",
+		Env:   map[string]string{"USER_A": "1", "USER_B": "2"},
+	}, "sb-env")
+
+	// All three categories must coexist in the slice the daemon received.
+	for _, want := range []string{
+		"SB_TOOLBOX_PORT=", "SB_TOOLBOX_TOKEN=", // base
+		"USER_A=", "USER_B=", // user
+		readySocketEnv + "=", readyNonceEnv + "=", // ready
+	} {
+		if !hasEnvPrefix(env, want) {
+			t.Fatalf("create Env missing %q; got %v", want, env)
+		}
+	}
+}
+
+// TestCreate_DisabledOmitsReadyEnv asserts the inverse: with the push disabled
+// no readiness vars leak into the container, and the base/user env is intact.
+func TestCreate_DisabledOmitsReadyEnv(t *testing.T) {
+	env := captureCreateEnv(t, func(c *Client) {
+		c.readyEnabled = false
+	}, models.CreateSandboxRequest{
+		Image: "img",
+		Env:   map[string]string{"USER_A": "1"},
+	}, "sb-env-off")
+
+	if hasEnvPrefix(env, readySocketEnv+"=") || hasEnvPrefix(env, readyNonceEnv+"=") {
+		t.Fatalf("disabled create leaked ready env: %v", env)
+	}
+	if !hasEnvPrefix(env, "USER_A=") || !hasEnvPrefix(env, "SB_TOOLBOX_TOKEN=") {
+		t.Fatalf("disabled create dropped base/user env: %v", env)
+	}
+}
+
+// TestCreate_DisabledDoesNotRecordFallbackMetric guards the metric cleanup:
+// docker_ready_socket_fallback_health must count only *real* socket losses
+// (old toolbox image, gVisor without host-uds) so it stays usable as a
+// cluster-mode signal. A non-cluster create (listener == nil) must not bump it.
+func TestCreate_DisabledDoesNotRecordFallbackMetric(t *testing.T) {
+	before := readySocketFallbackHealth.Value()
+	d := fakeCreateDaemon(t)
+	c := newCreateClient(t, d, true, func(c *Client) {
+		c.readyEnabled = false
+	})
+	ctx, timing := WithCreateTiming(context.Background())
+	if _, err := c.Create(ctx, models.CreateSandboxRequest{Image: "img"}, "sb-nofb", "tok", nil); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if timing.Source != "health" {
+		t.Fatalf("source = %q, want health", timing.Source)
+	}
+	if delta := readySocketFallbackHealth.Value() - before; delta != 0 {
+		t.Fatalf("fallback metric moved by %d on disabled path, want 0", delta)
+	}
+}

--- a/pkg/docker/ready_create_test.go
+++ b/pkg/docker/ready_create_test.go
@@ -1,0 +1,206 @@
+package docker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+	"github.com/aerol-ai/microvm/pkg/readyproto"
+)
+
+func requireLinuxUnix(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "linux" {
+		t.Skip("unix ready socket tests require linux")
+	}
+}
+
+func fakeCreateDaemon(t *testing.T) *fakeDaemon {
+	t.Helper()
+	return &fakeDaemon{
+		t: t,
+		imageInspect: func() *http.Response {
+			return jsonResponse(http.StatusOK, map[string]any{
+				"Config": map[string]any{"WorkingDir": "/", "Entrypoint": []string{}, "Cmd": []string{}},
+			})
+		},
+		create: func() *http.Response { return jsonResponse(http.StatusCreated, map[string]string{"Id": "cid"}) },
+		start:  func() *http.Response { return textResponse(http.StatusNoContent, "") },
+	}
+}
+
+func TestCreate_WiresReadySocketWhenEnabled(t *testing.T) {
+	requireLinuxUnix(t)
+	readyDir := t.TempDir()
+	var captured map[string]any
+	d := fakeCreateDaemon(t)
+	base := d.transport()
+	wrapped := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodPost && r.URL.Path == "/containers/create" && r.Body != nil {
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &captured)
+			r.Body = io.NopCloser(bytes.NewReader(body))
+		}
+		return base(r)
+	})
+
+	c := newCreateClient(t, d, true, func(c *Client) {
+		c.readyEnabled = true
+		c.readyDir = readyDir
+		c.httpClient = &http.Client{Transport: wrapped, Timeout: c.httpClient.Timeout}
+		c.streamClient = &http.Client{Transport: wrapped}
+	})
+
+	_, err := c.Create(context.Background(), models.CreateSandboxRequest{Image: "img"}, "sb-create", "tok", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	hostCfg, _ := captured["HostConfig"].(map[string]any)
+	binds, _ := hostCfg["Binds"].([]any)
+	foundBind := false
+	for _, b := range binds {
+		s, _ := b.(string)
+		if strings.Contains(s, GuestReadySocketPath) {
+			foundBind = true
+		}
+	}
+	if !foundBind {
+		t.Fatalf("binds missing ready socket: %v", binds)
+	}
+	envs, _ := captured["Env"].([]any)
+	var hasSocket, hasNonce bool
+	for _, e := range envs {
+		s, _ := e.(string)
+		if strings.HasPrefix(s, readySocketEnv+"=") {
+			hasSocket = true
+		}
+		if strings.HasPrefix(s, readyNonceEnv+"=") {
+			hasNonce = true
+		}
+	}
+	if !hasSocket || !hasNonce {
+		t.Fatalf("env missing ready vars: socket=%v nonce=%v env=%v", hasSocket, hasNonce, envs)
+	}
+}
+
+func TestCreate_SocketPushWinsOverHealthPoll(t *testing.T) {
+	requireLinuxUnix(t)
+	readyDir := t.TempDir()
+	healthHits := 0
+	ip, port, closeFn := toolboxServer(t, func(w http.ResponseWriter, r *http.Request) {
+		healthHits++
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	t.Cleanup(closeFn)
+
+	d := fakeCreateDaemon(t)
+	c := newCreateClient(t, d, false, func(c *Client) {
+		c.readyEnabled = true
+		c.readyDir = readyDir
+		c.toolboxPort = port
+		c.readinessPollInit = 5 * time.Millisecond
+		c.readinessPollMax = 10 * time.Millisecond
+		c.toolboxWaitTimeout = 2 * time.Second
+	})
+	d.containerGet = func() *http.Response {
+		return textResponse(http.StatusOK, inspectBody("cid", "/sb-race", ip, true, "running", 7))
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		deadline := time.Now().Add(time.Second)
+		for time.Now().Before(deadline) {
+			matches, _ := filepath.Glob(filepath.Join(readyDir, "sb-race.*.sock"))
+			if len(matches) == 0 {
+				time.Sleep(5 * time.Millisecond)
+				continue
+			}
+			conn, err := net.Dial("unix", matches[0])
+			if err != nil {
+				return
+			}
+			defer conn.Close()
+			base := filepath.Base(matches[0])
+			parts := strings.Split(strings.TrimSuffix(base, ".sock"), ".")
+			if len(parts) < 2 {
+				return
+			}
+			nonce := parts[1]
+			_ = readyproto.Encode(conn, readyproto.ReadySignal{
+				Event: readyproto.EventReady, SandboxID: "sb-race", Token: "tok", Nonce: nonce,
+			})
+			return
+		}
+	}()
+
+	ctx, timing := WithCreateTiming(context.Background())
+	_, err := c.Create(ctx, models.CreateSandboxRequest{Image: "img"}, "sb-race", "tok", nil)
+	wg.Wait()
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if timing.Source != "socket" {
+		t.Fatalf("source = %q, want socket", timing.Source)
+	}
+	if healthHits > 0 {
+		t.Fatalf("health poll ran %d times on socket win", healthHits)
+	}
+}
+
+func TestCreate_FallbackWhenPushDisabled(t *testing.T) {
+	d := fakeCreateDaemon(t)
+	c := newCreateClient(t, d, true, func(c *Client) {
+		c.readyEnabled = false
+	})
+	ctx, timing := WithCreateTiming(context.Background())
+	_, err := c.Create(ctx, models.CreateSandboxRequest{Image: "img"}, "sb-fb", "tok", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if timing.Source != "health" {
+		t.Fatalf("source = %q, want health", timing.Source)
+	}
+}
+
+func TestPollToolboxHealth_SlowReadyStillSucceeds(t *testing.T) {
+	var hits int
+	var mu sync.Mutex
+	_, port, closeFn := toolboxServer(t, func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		hits++
+		n := hits
+		mu.Unlock()
+		if n >= 3 {
+			w.WriteHeader(http.StatusOK)
+		} else {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+	})
+	t.Cleanup(closeFn)
+
+	c := newCreateClient(t, &fakeDaemon{t: t}, true, func(c *Client) {
+		c.readyEnabled = false
+		c.toolboxPort = port
+		c.readinessPollInit = 10 * time.Millisecond
+		c.readinessPollMax = 20 * time.Millisecond
+		c.toolboxWaitTimeout = 2 * time.Second
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := c.pollToolboxHealth(ctx, "127.0.0.1"); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+}

--- a/pkg/docker/readysock.go
+++ b/pkg/docker/readysock.go
@@ -1,0 +1,291 @@
+package docker
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/readyproto"
+)
+
+const (
+	// GuestReadySocketPath is the in-container path toolboxd dials.
+	GuestReadySocketPath = "/run/aerol/ready.sock"
+	readySocketEnv       = "SB_READY_SOCKET"
+	readyNonceEnv        = "SB_READY_NONCE"
+
+	readyHealthPollGrace    = 50 * time.Millisecond
+	readyConnReadTimeout    = 2 * time.Second
+	maxInvalidReadyAttempts = 16
+)
+
+var activeReadySockets sync.Map // path -> struct{}
+
+// validateReadySandboxID mirrors the daemon's sandbox ID charset because the
+// ID is embedded in a host filesystem path.
+func validateReadySandboxID(id string) error {
+	if id == "" {
+		return errors.New("sandbox ID is empty")
+	}
+	if len(id) > 128 {
+		return fmt.Errorf("sandbox ID exceeds 128 chars (%d)", len(id))
+	}
+	for _, r := range id {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '-' || r == '_':
+		default:
+			return fmt.Errorf("invalid character %q in sandbox ID %q", r, id)
+		}
+	}
+	return nil
+}
+
+func mintReadyNonce() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// ReadyListener accepts a single valid readiness push from toolboxd.
+type ReadyListener struct {
+	hostPath   string
+	sandboxID  string
+	token      string
+	nonce      string
+	listener   net.Listener
+	closed     bool
+	closeMu    sync.Mutex
+	registered bool
+}
+
+// NewReadyListener creates and listens on a per-create unix socket under dir.
+// The socket file is nonce-keyed so boot sweeps and retries cannot collide.
+func NewReadyListener(dir, sandboxID, token, nonce string) (*ReadyListener, error) {
+	sandboxID = strings.TrimSpace(sandboxID)
+	token = strings.TrimSpace(token)
+	nonce = strings.TrimSpace(nonce)
+	if err := validateReadySandboxID(sandboxID); err != nil {
+		return nil, err
+	}
+	if token == "" {
+		return nil, errors.New("toolbox token is required")
+	}
+	if nonce == "" {
+		return nil, errors.New("ready nonce is required")
+	}
+	if strings.TrimSpace(dir) == "" {
+		return nil, errors.New("ready socket dir is required")
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("mkdir ready dir: %w", err)
+	}
+
+	hostPath := filepath.Join(dir, sandboxID+"."+nonce+".sock")
+	if err := os.Remove(hostPath); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("unlink stale ready socket: %w", err)
+	}
+
+	ln, err := net.Listen("unix", hostPath)
+	if err != nil {
+		return nil, fmt.Errorf("listen ready socket: %w", err)
+	}
+	if err := os.Chmod(hostPath, 0o666); err != nil {
+		_ = ln.Close()
+		_ = os.Remove(hostPath)
+		return nil, fmt.Errorf("chmod ready socket: %w", err)
+	}
+
+	rl := &ReadyListener{
+		hostPath:  hostPath,
+		sandboxID: sandboxID,
+		token:     token,
+		nonce:     nonce,
+		listener:  ln,
+	}
+	activeReadySockets.Store(hostPath, struct{}{})
+	rl.registered = true
+	return rl, nil
+}
+
+// HostSocketPath returns the host-side socket path.
+func (l *ReadyListener) HostSocketPath() string {
+	if l == nil {
+		return ""
+	}
+	return l.hostPath
+}
+
+// BindSpec returns the docker bind mount for this socket.
+func (l *ReadyListener) BindSpec() string {
+	return fmt.Sprintf("%s:%s:rw", l.hostPath, GuestReadySocketPath)
+}
+
+// EnvVars returns the env vars toolboxd needs to dial the socket.
+func (l *ReadyListener) EnvVars() []string {
+	return []string{
+		readySocketEnv + "=" + GuestReadySocketPath,
+		readyNonceEnv + "=" + l.nonce,
+	}
+}
+
+// Wait accepts connections until a valid ready signal arrives or ctx expires.
+func (l *ReadyListener) Wait(ctx context.Context) error {
+	if l == nil || l.listener == nil {
+		return errors.New("ready listener is not configured")
+	}
+	invalid := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			recordReadySocketTimeout()
+			return fmt.Errorf("ready socket wait: %w", err)
+		}
+		if invalid >= maxInvalidReadyAttempts {
+			recordReadySocketInvalid()
+			return errors.New("ready socket: too many invalid attempts")
+		}
+
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			deadline = time.Now().Add(30 * time.Second)
+		}
+		_ = l.listener.(*net.UnixListener).SetDeadline(deadline)
+
+		conn, err := l.listener.Accept()
+		if err != nil {
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				if ctx.Err() != nil {
+					recordReadySocketTimeout()
+					return fmt.Errorf("ready socket wait: %w", ctx.Err())
+				}
+				continue
+			}
+			if ctx.Err() != nil {
+				recordReadySocketTimeout()
+				return fmt.Errorf("ready socket wait: %w", ctx.Err())
+			}
+			return fmt.Errorf("ready socket accept: %w", err)
+		}
+
+		if err := l.readAndVerify(conn); err != nil {
+			invalid++
+			recordReadySocketInvalid()
+			_ = conn.Close()
+			continue
+		}
+		_ = conn.Close()
+		return nil
+	}
+}
+
+func (l *ReadyListener) readAndVerify(conn net.Conn) error {
+	_ = conn.SetDeadline(time.Now().Add(readyConnReadTimeout))
+	sig, err := readyproto.Decode(bufio.NewReader(conn))
+	if err != nil {
+		return err
+	}
+	if sig.SandboxID != l.sandboxID {
+		return errors.New("sandbox_id mismatch")
+	}
+	if sig.Nonce != l.nonce {
+		return errors.New("nonce mismatch")
+	}
+	if subtle.ConstantTimeCompare([]byte(sig.Token), []byte(l.token)) != 1 {
+		return errors.New("token mismatch")
+	}
+	return nil
+}
+
+// Close shuts down the listener and unlinks the socket file.
+func (l *ReadyListener) Close() error {
+	if l == nil {
+		return nil
+	}
+	l.closeMu.Lock()
+	defer l.closeMu.Unlock()
+	if l.closed {
+		return nil
+	}
+	l.closed = true
+	if l.registered {
+		activeReadySockets.Delete(l.hostPath)
+		l.registered = false
+	}
+	var err error
+	if l.listener != nil {
+		err = l.listener.Close()
+		l.listener = nil
+	}
+	if l.hostPath != "" {
+		if rmErr := os.Remove(l.hostPath); rmErr != nil && !os.IsNotExist(rmErr) {
+			if err == nil {
+				err = rmErr
+			}
+		}
+	}
+	return err
+}
+
+// EnsureReadyDir creates the sandboxd-owned ready-socket parent directory.
+func EnsureReadyDir(dir string) error {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return errors.New("ready socket dir is required")
+	}
+	return os.MkdirAll(dir, 0o700)
+}
+
+// SweepOrphanReadySockets removes stale socket files from a prior crash.
+// Paths registered by live creates (activeReadySockets) are skipped.
+func SweepOrphanReadySockets(dir string) error {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	for _, ent := range entries {
+		if ent.IsDir() || !strings.HasSuffix(ent.Name(), ".sock") {
+			continue
+		}
+		path := filepath.Join(dir, ent.Name())
+		if _, active := activeReadySockets.Load(path); active {
+			continue
+		}
+		_ = os.Remove(path)
+	}
+	return nil
+}
+
+// RemoveReadySocketsForSandbox unlinks any ready sockets keyed to sandboxID.
+func RemoveReadySocketsForSandbox(dir, sandboxID string) {
+	if strings.TrimSpace(dir) == "" || strings.TrimSpace(sandboxID) == "" {
+		return
+	}
+	matches, _ := filepath.Glob(filepath.Join(dir, sandboxID+".*.sock"))
+	for _, path := range matches {
+		if _, active := activeReadySockets.Load(path); active {
+			continue
+		}
+		_ = os.Remove(path)
+	}
+}

--- a/pkg/docker/readysock_metrics.go
+++ b/pkg/docker/readysock_metrics.go
@@ -1,0 +1,42 @@
+package docker
+
+import (
+	"expvar"
+	"sync/atomic"
+)
+
+var (
+	readySocketHit             = expvar.NewInt("docker_ready_socket_hit")
+	readySocketFallbackHealth  = expvar.NewInt("docker_ready_socket_fallback_health")
+	readySocketTimeout         = expvar.NewInt("docker_ready_socket_timeout")
+	readySocketInvalidAttempts = expvar.NewInt("docker_ready_socket_invalid_attempts")
+)
+
+// readyWaitMS tracks the last successful readiness wait in milliseconds.
+// A histogram would be nicer but expvar has no built-in one; this matches
+// the pool-metrics simplicity bar for the first cut.
+var readyWaitMS atomic.Int64
+
+func recordReadySocketHit(waitMS int64) {
+	readySocketHit.Add(1)
+	readyWaitMS.Store(waitMS)
+}
+
+func recordReadySocketFallback(waitMS int64) {
+	readySocketFallbackHealth.Add(1)
+	readyWaitMS.Store(waitMS)
+}
+
+func recordReadySocketTimeout() {
+	readySocketTimeout.Add(1)
+}
+
+func recordReadySocketInvalid() {
+	readySocketInvalidAttempts.Add(1)
+}
+
+// ReadyWaitMS returns the most recent successful readiness wait (ms). Exported
+// for tests; production dashboards read the expvar counters above.
+func ReadyWaitMS() int64 {
+	return readyWaitMS.Load()
+}

--- a/pkg/docker/readysock_test.go
+++ b/pkg/docker/readysock_test.go
@@ -1,0 +1,176 @@
+//go:build linux
+
+package docker
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/readyproto"
+)
+
+func TestReadyListenerHappyPath(t *testing.T) {
+	dir := t.TempDir()
+	const (
+		sandboxID = "sb"
+		token     = "secret-token"
+		nonce     = "n1"
+	)
+	ln, err := NewReadyListener(dir, sandboxID, token, nonce)
+	if err != nil {
+		t.Fatalf("new listener: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		conn, err := net.Dial("unix", ln.HostSocketPath())
+		if err != nil {
+			t.Errorf("dial: %v", err)
+			return
+		}
+		defer conn.Close()
+		_ = readyproto.Encode(conn, readyproto.ReadySignal{
+			Event:     readyproto.EventReady,
+			SandboxID: sandboxID,
+			Token:     token,
+			Nonce:     nonce,
+		})
+	}()
+
+	if err := ln.Wait(ctx); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	wg.Wait()
+}
+
+func TestReadyListenerTokenMismatch(t *testing.T) {
+	dir := t.TempDir()
+	ln, err := NewReadyListener(dir, "sb", "good", "nonce1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	go func() {
+		conn, err := net.Dial("unix", ln.HostSocketPath())
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_ = readyproto.Encode(conn, readyproto.ReadySignal{
+			Event: readyproto.EventReady, SandboxID: "sb", Token: "bad", Nonce: "nonce1",
+		})
+	}()
+
+	if err := ln.Wait(ctx); err == nil {
+		t.Fatal("expected timeout or invalid cap error")
+	}
+}
+
+func TestReadyListenerNeverConnectTimesOut(t *testing.T) {
+	dir := t.TempDir()
+	ln, err := NewReadyListener(dir, "sb", "tok", "n1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	if err := ln.Wait(ctx); err == nil {
+		t.Fatal("expected timeout")
+	}
+}
+
+func TestReadyListenerCloseUnlinks(t *testing.T) {
+	dir := t.TempDir()
+	ln, err := NewReadyListener(dir, "sb", "tok", "n1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := ln.HostSocketPath()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("socket still present after close: %v", err)
+	}
+	if err := ln.Close(); err != nil {
+		t.Fatalf("double close: %v", err)
+	}
+}
+
+func TestSweepOrphanReadySocketsSkipsActive(t *testing.T) {
+	dir := t.TempDir()
+	ln, err := NewReadyListener(dir, "sb-active", "tok", "n1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	orphan := filepath.Join(dir, "sb-dead.old.sock")
+	if err := os.WriteFile(orphan, nil, 0o666); err != nil {
+		t.Fatal(err)
+	}
+	if err := SweepOrphanReadySockets(dir); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Fatalf("orphan not removed")
+	}
+	if _, err := os.Stat(ln.HostSocketPath()); err != nil {
+		t.Fatalf("active socket removed: %v", err)
+	}
+}
+
+func TestValidateReadySandboxID(t *testing.T) {
+	if err := validateReadySandboxID("ok-id_1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateReadySandboxID("../evil"); err == nil {
+		t.Fatal("expected rejection")
+	}
+}
+
+func TestReadyMetricsHit(t *testing.T) {
+	before := readySocketHit.Value()
+	dir := t.TempDir()
+	ln, err := NewReadyListener(dir, "sb", "tok", "n1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	go func() {
+		conn, err := net.Dial("unix", ln.HostSocketPath())
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_ = readyproto.Encode(conn, readyproto.ReadySignal{
+			Event: readyproto.EventReady, SandboxID: "sb", Token: "tok", Nonce: "n1",
+		})
+	}()
+	// Wait is exercised by waitForToolboxReady in integration; here we only
+	// verify the listener accepts a valid line.
+	if err := ln.Wait(ctx); err != nil {
+		t.Fatal(err)
+	}
+	_ = before
+}

--- a/pkg/readyproto/readyproto.go
+++ b/pkg/readyproto/readyproto.go
@@ -1,0 +1,78 @@
+// Package readyproto defines the newline-delimited JSON handshake toolboxd
+// sends to sandboxd when a Docker sandbox's agent is ready to serve.
+package readyproto
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	// EventReady is the only event type accepted on the readiness channel.
+	EventReady = "ready"
+	// MaxLineBytes caps attacker-controlled read size on the host listener.
+	MaxLineBytes = 4 << 10
+)
+
+// ReadySignal is the guest→host readiness announcement.
+type ReadySignal struct {
+	Event        string `json:"event"`
+	SandboxID    string `json:"sandbox_id"`
+	Token        string `json:"token"`
+	Nonce        string `json:"nonce"`
+	AgentVersion string `json:"agent_version,omitempty"`
+}
+
+// Encode writes one newline-terminated JSON line.
+func Encode(w io.Writer, sig ReadySignal) error {
+	if strings.TrimSpace(sig.Event) == "" {
+		sig.Event = EventReady
+	}
+	data, err := json.Marshal(sig)
+	if err != nil {
+		return err
+	}
+	if len(data) > MaxLineBytes {
+		return fmt.Errorf("readyproto: encoded line exceeds %d bytes", MaxLineBytes)
+	}
+	data = append(data, '\n')
+	_, err = w.Write(data)
+	return err
+}
+
+// Decode reads one bounded newline-delimited JSON line from r.
+func Decode(r io.Reader) (ReadySignal, error) {
+	limited := io.LimitReader(r, MaxLineBytes+1)
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(limited); err != nil {
+		return ReadySignal{}, err
+	}
+	line := strings.TrimSpace(buf.String())
+	if line == "" {
+		return ReadySignal{}, errors.New("readyproto: empty line")
+	}
+	if len(line) > MaxLineBytes {
+		return ReadySignal{}, fmt.Errorf("readyproto: line exceeds %d bytes", MaxLineBytes)
+	}
+	var sig ReadySignal
+	if err := json.Unmarshal([]byte(line), &sig); err != nil {
+		return ReadySignal{}, fmt.Errorf("readyproto: decode: %w", err)
+	}
+	if sig.Event != EventReady {
+		return ReadySignal{}, fmt.Errorf("readyproto: unexpected event %q", sig.Event)
+	}
+	if strings.TrimSpace(sig.SandboxID) == "" {
+		return ReadySignal{}, errors.New("readyproto: sandbox_id is required")
+	}
+	if strings.TrimSpace(sig.Token) == "" {
+		return ReadySignal{}, errors.New("readyproto: token is required")
+	}
+	if strings.TrimSpace(sig.Nonce) == "" {
+		return ReadySignal{}, errors.New("readyproto: nonce is required")
+	}
+	return sig, nil
+}

--- a/pkg/readyproto/readyproto_test.go
+++ b/pkg/readyproto/readyproto_test.go
@@ -1,0 +1,68 @@
+package readyproto
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	want := ReadySignal{
+		Event:        EventReady,
+		SandboxID:    "sb-abc123",
+		Token:        "tok-secret",
+		Nonce:        "nonce-1",
+		AgentVersion: "1.2.3",
+	}
+	var buf bytes.Buffer
+	if err := Encode(&buf, want); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	got, err := Decode(&buf)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got != want {
+		t.Fatalf("round-trip = %+v, want %+v", got, want)
+	}
+}
+
+func TestDecodeOversizeLine(t *testing.T) {
+	line := strings.Repeat("a", MaxLineBytes+1)
+	_, err := Decode(strings.NewReader(line))
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("expected oversize error, got %v", err)
+	}
+}
+
+func TestDecodeMalformedJSON(t *testing.T) {
+	_, err := Decode(strings.NewReader("{not json}\n"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestDecodeUnknownFieldsTolerated(t *testing.T) {
+	line := `{"event":"ready","sandbox_id":"sb","token":"t","nonce":"n","extra":1}` + "\n"
+	got, err := Decode(strings.NewReader(line))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.SandboxID != "sb" || got.Nonce != "n" {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestDecodeRejectsEmptyValues(t *testing.T) {
+	cases := []string{
+		`{"event":"ready","sandbox_id":"","token":"t","nonce":"n"}`,
+		`{"event":"ready","sandbox_id":"sb","token":"","nonce":"n"}`,
+		`{"event":"ready","sandbox_id":"sb","token":"t","nonce":""}`,
+		`{"event":"ping","sandbox_id":"sb","token":"t","nonce":"n"}`,
+	}
+	for _, line := range cases {
+		if _, err := Decode(strings.NewReader(line + "\n")); err == nil {
+			t.Fatalf("expected error for %q", line)
+		}
+	}
+}

--- a/plans/docker-readiness-unix-socket-push.md
+++ b/plans/docker-readiness-unix-socket-push.md
@@ -1,0 +1,696 @@
+# Docker readiness via Unix-socket push ("vsock for Docker")
+
+Status: **Proposed** — design plan, not yet implemented.
+Owner: TBD. Boot-path change → must follow `/touch-create-sandbox` + `pr-review.md`.
+
+## Problem
+
+Today a Docker (and gVisor) sandbox create blocks on two **pull-based**
+readiness loops at the tail of `pkg/docker/client.go`:
+
+- `waitForRuntime` — polls `inspect` until the container is `Running` with an
+  IP (300ms granularity).
+- `waitForToolbox` — polls `http://<containerIP>:<toolboxPort>/health` until
+  `200` (300ms granularity).
+
+Both loops *round the true readiness time up to the next 300ms tick*, and
+because they run back-to-back the quanta **stack** — a sandbox whose agent is
+genuinely ready at ~350ms is reported at ~600ms+. Measured Docker server-side
+create is ~628ms; the rounding is the dominant avoidable cost.
+
+Firecracker already avoids this: its in-guest `toolboxd` exposes an
+out-of-band **vsock** channel and the host handshakes over it
+(`internal/runtime/firecracker/driver.go`), independent of the user network.
+WASM waits on a local unix-socket `Ping`. **Docker is the only runtime that
+polls the user data-plane network.**
+
+This plan gives Docker an out-of-band, **push-based** readiness channel — a
+per-sandbox **Unix domain socket** the host listens on and the in-container
+`toolboxd` connects to the instant it is up. It is the "vsock for Docker": same
+trust model as vsock (point-to-point host↔container, no network), without the
+security and network-coupling problems of an HTTP webhook to sandboxd.
+
+---
+
+## 20 use cases this solves
+
+Latency / performance
+1. Removes the ~300ms toolbox-health rounding from every Docker create (push
+   fires the instant the agent is up).
+2. Collapses the p99 create tail caused by *multiple* missed 300ms polls on a
+   slightly-slow boot.
+3. Eliminates the `dockerd` inspect/`/health` request storm during
+   high-concurrency bursts (e.g. the 200-at-once density probe), where tight
+   polling otherwise fights the very create/start calls it waits on.
+4. Removes ephemeral-port / TIME_WAIT churn from repeated *refused* health
+   dials while the agent is still booting.
+5. Makes create latency essentially independent of host CPU / instance type —
+   kills the "provision a bigger box to go faster" misconception.
+6. Cuts sandboxd CPU + goroutine pressure from many concurrent tight poll loops.
+
+Correctness / robustness
+7. Readiness no longer depends on having polled the *right* container IP yet
+   (push is immune to IP-assignment lag after `/containers/start`).
+8. Removes false-"healthy" flaps where `/health` returns 200 before the agent
+   has finished initialising — the agent itself decides when to announce ready.
+9. Detects a wedged / never-ready toolbox more cleanly: a single-shot accept
+   with a deadline instead of an ambiguous repeated poll.
+10. Provides a precise, attributable readiness timestamp for Server-Timing and
+    metrics (the agent reports exactly when it came up).
+11. Fences stale readiness on snapshot-clone / recreate paths via a
+    per-create nonce + clone-generation in the handshake.
+12. Reduces log noise from repeated "connection refused" health attempts on a
+    normal boot.
+
+Network / isolation
+13. Readiness works when the sandbox is created with `NetworkBlockAll` — no
+    data-plane network is required.
+14. Readiness works under restrictive egress (`NetworkDenyOut`) without
+    special-casing the boot window or ordering rule application around it.
+15. Decouples the control signal from the user-controllable data plane entirely.
+
+Architecture / security / ops
+16. Unifies the readiness model across runtimes (Docker now out-of-band push,
+    like Firecracker vsock and WASM socket) — one mental model, less special-casing.
+17. Gives gVisor sandboxes the same fast readiness for free (they ride the
+    docker client path).
+18. Avoids exposing any host-facing readiness *network* endpoint to untrusted
+    sandboxes (the failure mode of a webhook approach).
+19. Backward compatible: toolbox images built before this change still come up
+    via the existing `/health` poll fallback (no flag-day).
+20. Establishes a reusable per-sandbox host↔container control channel that
+    future features can extend (push quiesce/shutdown to Docker sandboxes,
+    capability advertisement, agent-version negotiation) with **no** new
+    network surface.
+
+---
+
+## Design / how it is solved
+
+### Channel topology (host listens, guest connects = true push)
+
+```
+HOST (sandboxd)                                  CONTAINER (toolboxd, PID 1)
+──────────────                                   ──────────────────────────
+1. create  <dir>/<sandboxID>.sock, listen()
+2. bind-mount that ONE socket file ──────────►   /run/aerol/ready.sock  (rw)
+   set env SB_READY_SOCKET=/run/aerol/ready.sock
+3. /containers/create, /containers/start
+4. inspect once → container IP (tight retry
+   only if not Running yet)                      5. on boot, FIRST action:
+6. Accept() blocks (deadline = toolboxWaitTimeout)   dial unix:/run/aerol/ready.sock
+7. read 1 JSON line, verify token+nonce ◄────────    write {ready, token, nonce, ...}
+8. close listener, unlink socket → ready             then continue (HTTP/vsock listen)
+```
+
+Host **listens** (not the guest) so there is nothing for the host to poll: the
+socket exists before the container starts, and `Accept()` returns the moment
+`toolboxd` connects. The guest dial is a single best-effort connect; it never
+blocks the agent's own startup.
+
+### Readiness handshake (newline-delimited JSON, mirrors `vsock.go`)
+
+```json
+{"event":"ready","sandbox_id":"<id>","token":"<SB_TOOLBOX_TOKEN>","nonce":"<per-create>","agent_version":"<v>"}
+```
+
+Host validates: `sandbox_id` matches, `token` matches (constant-time), `nonce`
+matches the value it minted for *this* create. Then the create returns
+`status=started`.
+
+### Graceful degradation (race, don't replace)
+
+The host runs the socket-accept **and** the existing `/health` poll
+(now with adaptive backoff) **concurrently**, first-ready-wins:
+
+- New toolbox image → socket fires first (~immediately).
+- Old toolbox image (no dialer) → socket never connects; the health poll wins
+  as it does today. No flag-day, fully backward compatible (use case #19).
+- Container never becomes ready → both lose; the existing
+  `toolboxWaitTimeout` deadline still applies and Create fails as today.
+
+### Metrics (expvar, mirroring pool metrics convention)
+
+`docker_ready_socket_hit`, `docker_ready_socket_fallback_health`,
+`docker_ready_socket_timeout`, plus a `ready_wait_ms` histogram — gives the
+integration assertion hook and dashboards.
+
+### Config knobs (`internal/config`)
+
+- `SB_DOCKER_READY_SOCKET_ENABLED` (default `true`) — master switch; off =
+  pure legacy behavior.
+- `SB_DOCKER_READY_SOCKET_DIR` (default `<runtime-dir>/docker/ready`).
+- Plus the fallback poll's backoff knobs (`SB_DOCKER_READINESS_POLL_INITIAL`,
+  `_MAX`) carried over from the tight-poll plan.
+
+The existing `SB_DOCKER_WAIT_TIMEOUT` / `SB_TOOLBOX_WAIT_TIMEOUT` (30s) stay as
+the outer deadline, unchanged.
+
+---
+
+## Files CREATED
+
+| File | Purpose |
+|---|---|
+| `pkg/readyproto/readyproto.go` | Shared wire shape (`ReadySignal` struct, `Event` constant, a bounded newline-JSON `Encode`/`Decode`). Imported by **both** the host (`pkg/docker`) and the guest (`cmd/toolboxd`), mirroring how the vsock protocol shape is isolated from its socket layer. |
+| `pkg/readyproto/readyproto_test.go` | Encode/decode round-trip, oversize-line rejection, malformed-JSON rejection, unknown-field tolerance. |
+| `pkg/docker/readysock.go` | Host side: `readyListener` — create+listen (unlink-before-bind), `Accept` with deadline, token/nonce verification (constant-time), bounded reader, single-shot, cleanup (`Close`+unlink). Plus `bindSpec()`/`envFor()` helpers the Create path uses to wire the bind and env. |
+| `pkg/docker/readysock_test.go` | Unit tests (see test section). |
+| `pkg/docker/readysock_metrics.go` | expvar counters/histogram for the readiness channel. |
+| `cmd/toolboxd/readyclient.go` | Guest side: `announceReady()` — read `SB_READY_SOCKET`/`SB_TOOLBOX_TOKEN`/nonce env, dial the unix socket with a short deadline, write one `ReadySignal` line, close. Best-effort; never fatal. Portable (plain unix socket; no AF_VSOCK, builds on all platforms). |
+| `cmd/toolboxd/readyclient_test.go` | Unit tests for the dialer. |
+| `integration-tests/suite/docker_readiness_test.go` | New UC tests (UC-96/UC-97) — see integration section. |
+| `plans/docker-readiness-unix-socket-push.md` | This document. |
+
+## Files MODIFIED
+
+| File | Change |
+|---|---|
+| `pkg/docker/client.go` | `Create`: (a) before `/containers/create`, construct the `readyListener` and append its bind to `binds` + its env to `envValues`; (b) after `/containers/start`, keep one `inspect` for the container IP, then **race** `readyListener.Accept()` against the (backoff) `waitForToolbox`; (c) on every failure path, `readyListener.Close()` + unlink (LIFO with the existing cleanup); (d) `Destroy`/`removeContainer` also unlink any stale socket. New struct fields (`readyDir`, `readyEnabled`) + `New()` wiring. `waitForToolbox`/`waitForRuntime` get the adaptive backoff. |
+| `cmd/toolboxd/main.go` | Call `announceReady(logger)` early in boot — after env is read, *before* `serveHTTPFn` blocks (it can run in a goroutine so it never delays the HTTP/vsock listeners). |
+| `internal/config/config.go` | Add `DockerReadySocketEnabled`, `DockerReadySocketDir`, `DockerReadinessPollInitial`, `DockerReadinessPollMax` with `getEnv*` defaults and validation (`initial>0`, `max>=initial`, dir non-empty when enabled). |
+| `pkg/daemon/` (boot wiring) | Pass the resolved ready-socket dir/enable into the docker client constructor; ensure the dir is created (0700, sandboxd-owned) at boot and swept on startup for orphans. |
+| `pkg/docker/client_test.go` | Extend the existing `roundTripFunc` fake + `newTestClient` so create-path tests assert the new bind + `SB_READY_SOCKET` env are present, and inject a temp ready dir. |
+| `integration-tests/suite/harness/usecases.go` | Register `UC-96` (push readiness) and `UC-97` (legacy fallback) in `Registry`. |
+| `integration-tests/suite/benchmark_test.go` | Optional: assert the Server-Timing `toolbox_wait` phase is near-zero when the push path is active, so a regression to polling is caught by the bench. |
+| `pkg/api/v1/handlers.go` | (From the tight-poll plan) extend `setCreateServerTiming` to emit the `runtime_wait` / `toolbox_wait` sub-phases used by the assertion above. |
+| `packaging/` + docs env table | Document the new `SB_DOCKER_READY_SOCKET_*` vars. |
+
+> Note on the runtime seam: `pkg/docker/client.go` is the Docker
+> `runtime.Runtime` implementation, so no `internal/runtime/docker` driver
+> changes are needed beyond what flows through the client. If a thin wrapper
+> exists there, only its constructor passthrough changes.
+
+---
+
+## Security issues & mitigations (≥10)
+
+A host-owned socket bind-mounted into an **untrusted** container is sensitive
+(cf. `docker.sock` escapes). Each risk and how this design closes it:
+
+1. **Cross-sandbox access (confused deputy).** Could container A reach
+   container B's readiness socket? → **Only the single socket file** is
+   bind-mounted, into its own container, at a fixed guest path. The host
+   parent directory (mode `0700`, sandboxd-owned) is **never** mounted. A
+   container sees only its own socket inode.
+
+2. **Readiness spoofing / premature ready.** Anything that can write to the
+   socket could announce ready early or for another sandbox. → The handshake
+   carries the per-sandbox `SB_TOOLBOX_TOKEN` (already injected, high-entropy);
+   the host verifies it with `subtle.ConstantTimeCompare` and rejects mismatches.
+
+3. **Socket file permissions vs. non-root container user.** The container's
+   `toolboxd` (entrypoint, runs first) must be able to connect, but nothing
+   else on the host should. → Socket created `0660`, sandboxd-owned, inside a
+   `0700` dir; the host-side confidentiality rests on the dir mode + mount
+   isolation, integrity on the token. Where userns/UID-mapping prevents connect,
+   fall to `0666` *on the bind-mounted node only* — safe because the node is
+   reachable solely from inside that one container. Documented explicitly; no
+   silent world-writable host path.
+
+4. **Connection-flood DoS (fd/goroutine exhaustion).** Untrusted code could
+   open many connections. → The listener is **single-shot**: after the first
+   *valid* ready (or the deadline) it `Close()`s and stops accepting. Small
+   listen backlog; one accept goroutine per sandbox, bounded by the create's
+   own lifetime.
+
+5. **Slow-loris / connect-but-never-send.** → Every accepted conn gets a short
+   read deadline (e.g. 2s); single-shot accept means a stalled connection
+   cannot hold the channel open past the create deadline.
+
+6. **Oversized / malformed payload (parser OOM).** → `bufio` reader with a hard
+   line cap (e.g. 4 KiB) via `io.LimitReader`; one newline-delimited line; JSON
+   decode of a bounded buffer; reuse the already-tested vsock JSON-line shape
+   rather than new parsing code.
+
+7. **Stale socket reuse / bind failure.** A leftover socket from a crashed
+   sandbox could block `bind` or be reused. → Per-sandbox path keyed by
+   validated `sandboxID` + create nonce; `os.Remove` (unlink) before `Listen`;
+   cleanup on `Destroy` and a boot-time sweep of the ready dir for orphans.
+
+8. **Path traversal / symlink on the socket path.** → Path is built only from
+   `validateSandboxID`-checked IDs under a fixed sandboxd-owned dir; **no user
+   input** in the path; create the dir with restrictive perms and refuse to
+   follow symlinks for the parent.
+
+9. **Container escape via the bind mount.** Bind-mounting host paths into
+   untrusted containers is the classic escape vector. → Mount **only the socket
+   node**, never its directory; a unix *socket* file does not let the container
+   read/write arbitrary host files — connecting to it only yields the readiness
+   channel. The host never mounts anything writable beyond this one node.
+
+10. **Token leakage via logs/errors.** The ready line contains the token. →
+    Never log the token or the raw line; compare constant-time; the token is
+    already `os.Unsetenv`'d in `toolboxd` after read so user commands can't see
+    it.
+
+11. **Replay / cross-generation confusion (snapshot clones, recreate).** A
+    recreated sandbox could receive a stale ready from a prior generation. →
+    The host mints a fresh **nonce** per create and embeds the
+    clone-generation; it accepts only a handshake echoing *that* nonce.
+
+12. **Root-context parser hardening.** sandboxd may run as root; the socket
+    reader is a root-context parser of attacker-influenced bytes. → Minimal,
+    bounded, deadline-guarded parser reusing the vsock-proven shape; fuzz the
+    `readyproto.Decode` path; no allocation driven by attacker-supplied length.
+
+13. **Downgrade pressure to the fallback path.** Could an attacker force the
+    weaker channel? → The fallback *is* today's `/health` behavior (not weaker),
+    and both paths still require the agent to actually be up. There is no
+    privileged action gated only behind the socket path.
+
+14. **Listener lifetime leak.** A create that errors after listen but before
+    accept could leak the listener/socket. → `readyListener.Close()` is in the
+    same deferred-with-flag LIFO cleanup the Create path already uses for the
+    TAP/VMM/registry resources (`pr-review.md §4`).
+
+---
+
+## Unit tests
+
+### Created
+
+`pkg/readyproto/readyproto_test.go`
+- round-trip encode→decode of `ReadySignal`;
+- oversize line (> cap) → error, no over-allocation;
+- malformed JSON → error; unknown fields tolerated (forward-compat);
+- empty/zero-value rejected.
+
+`pkg/docker/readysock_test.go` (table-driven, matching `client_test.go` style)
+- happy path: guest connects + sends valid signal → `Accept` returns ready
+  before deadline;
+- token mismatch → rejected, channel reports not-ready (forces fallback);
+- nonce mismatch (replay) → rejected;
+- never-connect → `Accept` times out at the deadline, returns the
+  fallback-signal sentinel (not a hard error);
+- slow-loris (connect, no data) → read deadline trips, treated as not-ready;
+- oversize payload → rejected;
+- single-shot: a second connection after the first ready is refused/ignored;
+- cleanup: `Close()` unlinks the socket file; double-`Close` is safe;
+- stale socket present → unlink-before-listen succeeds.
+
+`pkg/docker/readysock_metrics.go` covered by `readysock_test.go` assertions on
+the expvar counters (hit / fallback / timeout increment correctly).
+
+`cmd/toolboxd/readyclient_test.go`
+- dials a test listener and writes a signal with the env-sourced
+  token/nonce/sandbox_id;
+- `SB_READY_SOCKET` unset → no-op, no error (so non-Docker runtimes are
+  unaffected);
+- socket path present but unconnectable → logs + returns, never blocks boot;
+- does not leak the token into the process env it passes to child commands.
+
+### Modified
+
+`pkg/docker/client_test.go`
+- the create-path tests assert the new **bind** (`<dir>/<id>.sock:/run/aerol/ready.sock`)
+  and **`SB_READY_SOCKET` env** are present in the `/containers/create` body;
+- a test that drives the **race**: fake the container as ready via the socket
+  and assert `waitForToolbox`'s health poll is *not* what completed the create
+  (i.e. push wins); and the inverse (socket silent → health poll completes it);
+- inject a `t.TempDir()` ready dir so tests never touch a real runtime dir.
+
+`pkg/docker` coverage: keep the package at the ~85% bar (`/maintain-coverage`).
+
+---
+
+## Integration test updates
+
+Register two UCs in `integration-tests/suite/harness/usecases.go`:
+
+```go
+{ID: "UC-96", Title: "Docker create readiness delivered via unix-socket push", Requires: []Capability{CapDocker}, Implemented: true},
+{ID: "UC-97", Title: "Docker create falls back to health poll when push absent", Requires: []Capability{CapDocker}, Implemented: true},
+```
+
+`integration-tests/suite/docker_readiness_test.go` (behind the existing
+`integration` build tag, run via the orchestrated suite):
+
+- **UC-96 (push path):** create a Docker sandbox against a live node; assert it
+  reaches `started`; then read the node's metrics/`Server-Timing` and assert the
+  readiness came through the **socket** channel (`docker_ready_socket_hit`
+  incremented and/or the `toolbox_wait` Server-Timing phase is near-zero). This
+  is the regression guard that proves push is actually active, not silently
+  falling back.
+- **UC-97 (fallback path):** create a sandbox from an image whose toolbox does
+  **not** dial (a pinned older toolbox, or a config toggle
+  `SB_DOCKER_READY_SOCKET_ENABLED=false`); assert it still reaches `started`
+  via the health poll (`docker_ready_socket_fallback_health` incremented). This
+  guarantees the backward-compatibility promise (use case #19) is exercised on
+  real infra.
+- **Latency tie-in:** the existing `TestBenchCreateLatency` (UC-94) already
+  measures docker server-side time; once this lands it should drop materially.
+  Optionally tighten the bench to assert `toolbox_wait` ≈ 0 on the push path so
+  a regression to polling shows up as a failing assertion, not just a slower
+  number.
+
+`integration-tests/README.md`: document the two new UCs and the
+`SB_DOCKER_READY_SOCKET_*` knobs in the env table.
+
+No live-AWS-specific wiring is required beyond the standard harness; these run
+on any scenario advertising `CapDocker`.
+
+---
+
+## Rollout & PR rules
+
+- **Boot-path change** → run `/touch-create-sandbox`, read `pr-review.md`, and
+  the PR description must call out the create-latency impact (improvement, with
+  before/after from the Server-Timing sub-phases), the idempotency story
+  (readiness is single-shot + retry-safe; a retried create re-mints a nonce and
+  re-listens), and the failure-path cleanup (listener `Close()`+unlink in LIFO).
+- **Security review** required (new host↔container channel) — the section above
+  is the checklist to walk in review.
+- **Default on** (`SB_DOCKER_READY_SOCKET_ENABLED=true`) with the health-poll
+  fallback always compiled in, so a problem can be disabled by config without a
+  redeploy of new code.
+- Ship behind the metrics so an operator can confirm hit-vs-fallback ratio in
+  production before trusting it.
+
+## Expected outcome
+
+Docker server-side create drops from ~628ms toward the **true** agent-ready
+time (push removes the double 300ms rounding and the fallback poll is only a
+safety net). Under burst load the `dockerd` inspect/health storm disappears.
+The readiness model converges with Firecracker/WASM, and a reusable per-sandbox
+control channel exists for future Docker-side push features — all without
+exposing any host network surface to untrusted sandbox code.
+
+---
+
+## Review decisions (locked 2026-06-30, /plan-eng-review + Codex outside voice)
+
+These supersede the as-written design above where they conflict. Each is a
+resolved decision; implementation follows these, not the earlier prose.
+
+**Scope:** Build the full socket-push subsystem now (not the backoff-only
+minimal version), bundled into ONE PR with the fallback backoff. The
+Server-Timing sub-phases still ship in the same PR, so socket-vs-backoff
+attribution comes from the per-phase timing even though bundled.
+
+1. **Accept model — accept-until-valid, NOT single-shot.** The container runs
+   untrusted code; a malicious in-container process can race `toolboxd` and
+   connect first with a bad token. A single-shot listener would close on that
+   first connection and silently suppress the real push (degrading that sandbox
+   to the slow poll and skewing metrics). The listener keeps accepting until a
+   connection carries a valid `token`+`nonce`, OR the deadline hits, OR a
+   bounded `max-invalid-attempts` cap trips. Each accepted conn still has a read
+   deadline + byte cap. (Replaces security items #4 and #5's single-shot.)
+
+2. **Socket permissions — `0666` + mandatory token.** Connecting to a unix
+   socket needs write permission on the node; sandboxd runs as root and many
+   images run as a non-root uid, so a tight 0660 root-owned socket would make
+   the push a silent no-op on those images. Create the socket `0666`; the
+   per-sandbox `token` (constant-time compared) is the integrity gate, since the
+   user's own code shares the container uid and file perms can never exclude it.
+   Confidentiality rests on per-container mount isolation (only the one socket
+   node is mounted) + the `0700` host dir. (Settles security item #3.)
+
+3. **Race design — shared context, grace-delayed poll.** Socket-accept and the
+   backoff health-poll run under ONE context bounded by `toolboxWaitTimeout`;
+   first success cancels the other (no goroutine leak dialing a returned
+   container). The health poll starts only after a short grace (~50ms) so a
+   normal socket hit issues ZERO health dials — this is what actually delivers
+   the dockerd-storm-elimination goal.
+
+4. **Ready semantics — dial AFTER the HTTP listener is accepting.** `toolboxd`
+   sends the ready signal once its HTTP server is bound and accepting, NOT as
+   its literal first action. This preserves the exact guarantee today's
+   `/health` 200 gives: when create returns `started`, the toolbox API
+   (exec/files/sessions) is reachable. Dialing earlier would return `started`
+   before the API serves and cause post-create connection-refused races — a
+   regression hidden behind a faster metric.
+
+5. **gVisor — needs `--host-uds=open`; NOT free, and off by default today.**
+   Root cause (not just "virtualized AF_UNIX"): `runsc` gates host unix-socket
+   passthrough behind `--host-uds` (default `none`). A gVisor sandbox can only
+   `connect()` to a bind-mounted host socket when runsc runs with
+   `--host-uds=open` (or `all`). **AerolVM's installer does not set it** —
+   `scripts/install.sh` `register_gvisor_runtime` writes
+   `{"runtimes":{"runsc":{"path":...}}}` with no `runtimeArgs`, so the default
+   `none` applies and the push would silently fall back to the poll on every
+   gVisor create. Sharing `pkg/docker/client.go` does **not** make it "free" —
+   same Go code, different runtime *policy*. Resolution:
+   - Drop use case #17's "for free" claim.
+   - Add **UC-96c on cluster-hetero** (which has a gVisor-capable node): create
+     under `runsc`, assert the push channel actually delivered (per-sandbox
+     `Server-Timing source`), not fallback.
+   - **If UC-96c is green with the flag**, add `"runtimeArgs":["--host-uds=open"]`
+     to the runsc entry in `register_gvisor_runtime` (`scripts/install.sh`) +
+     the Terraform/Ansible install path, and document it. Use `open`
+     (connect-only), **not** `all` (which also permits the sandbox to *create*
+     host sockets — broader than we need).
+   - **Security note (review item):** `--host-uds=open` is a deliberate,
+     fleet-wide relaxation of gVisor isolation — every gVisor sandbox gains the
+     capability to connect to host UDSes that are bind-mounted into it. Exposure
+     is bounded to exactly what we mount (the one readiness socket node); we
+     mount nothing else host-UDS-wise. This must be an explicit security-review
+     decision, not a silent flip.
+   - Fallback guarantees correctness regardless of the flag, so this is a
+     latency/claim issue, never a correctness one. If the security team rejects
+     relaxing `host-uds`, gVisor stays fallback-only (still gets the backoff
+     win) and use case #17 is dropped, not deferred.
+
+6. **Bind-mount topology — scope to local Linux runc dockerd.** Rootless Docker,
+   strict SELinux/AppArmor (:z/:Z), userns-remap, Docker Desktop, and remote
+   daemons are **NOT in scope** (see below) — they're not AerolVM deployment
+   targets and the fallback + hit/fallback metric keep them correct and visible.
+
+7. **DRY — separate `pkg/readyproto`.** Do not unify with the Firecracker vsock
+   protocol (different direction/ops/lifecycle; unifying drags the fragile
+   snapshot path into this change). Accept the ~20-line wire-shape duplication.
+
+8. **Config — 3 knobs, and the push is gated on cluster mode.**
+   `SB_DOCKER_READY_SOCKET_ENABLED` + the two backoff knobs. Derive the socket
+   dir from the runtime dir (drop `SB_DOCKER_READY_SOCKET_DIR`).
+
+10. **Enablement gated on `EnableCluster` — OFF in local/self-install.** The
+    socket push must NOT run on hosts we don't control (the open-source
+    one-liner self-install on an arbitrary Docker setup). The effective gate is
+    `SB_DOCKER_READY_SOCKET_ENABLED` (default `true`) **AND** `cfg.EnableCluster`.
+    So:
+    - Cluster deploys (`SB_ENABLE_CLUSTER=true`, e.g. cluster-hetero) → push ON.
+    - Every self-install, `--local` install, and single-node deploy
+      (`EnableCluster=false`) → push OFF → the (backoff-improved) health poll
+      runs, which is safe on any topology.
+    - The `_ENABLED` knob stays a kill switch (set `false` disables even in
+      cluster) but can never force the push ON outside cluster mode.
+    This is one line in `config.go` (no installer/IaC edits), and it makes the
+    local-mode/single-node integration scenarios validate the OFF/fallback path
+    for free (they're non-cluster). The fallback guarantees correctness, so a
+    controlled single-node deploy simply uses the poll — not a regression.
+    Rationale: "default-on" applies *within the deployments we control*
+    (clusters); uncontrolled hosts get the safe poll.
+
+9. **Cleanup is NEW wiring, not reuse.** The Docker `Create` (`client.go:303`)
+   has no defer-flag stack (that's the *Firecracker* Create). Add an explicit
+   committed-flag deferred closure (close listener + unlink socket on any
+   pre-commit error) + `Destroy` unlink + a boot sweep. The sweep MUST be
+   generation/nonce-keyed so it cannot race-delete a live create's socket.
+
+**Folded hardening (from Codex, no separate decision needed):**
+- **Nonce lifecycle:** inject as its own env var (e.g. `SB_READY_NONCE`)
+  alongside the token; `toolboxd` reads both, dials, then the existing
+  `os.Unsetenv` scrub runs — the dial MUST happen before the scrub. Cover in
+  `readyclient_test.go` (token/nonce not leaked to child env).
+- **PID1 safety:** the dial runs in a goroutine with a concrete bounded timeout,
+  placed AFTER reaper setup and env scrubbing, never fatal — a blocked/crashed
+  dial cannot regress create.
+- **Test attribution:** integration UCs assert via the per-create `Server-Timing`
+  `source` field (push vs fallback) for THAT sandbox, NOT a global expvar
+  counter delta (counters are flaky under concurrent tests).
+- **Sandbox-ID boundary:** the socket path derives only from a
+  `validateSandboxID`-checked id; document the exact charset/length the path
+  relies on.
+- **Server-Timing assertion:** assert the readiness `source` is the socket, NOT
+  that `toolbox_wait ≈ 0` (a correct agent still takes real init time).
+- **Compat matrix collapses for Docker:** `toolboxd` is bind-mounted from the
+  host (`client.go` `c.toolboxBinaryPath`), so host and guest are ALWAYS the
+  same release — no old-toolbox/new-host skew. The fallback stays as
+  defense-in-depth, but use case #19's "old image" framing is rewritten.
+- **Claim corrections:** soften #13 (the create path's `/health` poll already
+  precedes egress-block application, so `NetworkBlockAll` survival is not a
+  differentiator); #17 (gVisor — verify); #20 (the listener closes after one
+  line — it is NOT a reusable bidirectional channel without a different
+  lifetime/auth/versioning model; state that honestly).
+
+## NOT in scope
+
+| Deferred | Rationale |
+|---|---|
+| Rootless Docker / Docker Desktop / remote daemon socket-push | Not AerolVM deployment targets; fallback keeps them correct, metric makes the slow path visible |
+| Strict SELinux/AppArmor relabel handling (:z/:Z) | Same; add a one-line doc note that push falls back unless the node is relabeled |
+| userns-remap chown of the socket | `0666` + token already works under remap; chown-to-uid (review option 1B) rejected as fragile |
+| Unifying vsock + readiness into one shared control protocol | Premature abstraction across the fragile snapshot path (review decision #7); revisit only if a 3rd host↔guest channel appears |
+| Bidirectional/reusable control channel (push shutdown/quiesce to Docker) | This design is one-shot readiness; a real control channel needs its own lifetime/auth/versioning design |
+| Push on local-mode / self-install / any non-cluster host | Decision #10 — gated on `EnableCluster`; we don't control self-install hosts, fallback poll is correct everywhere |
+| Push on a CONTROLLED single-node (non-cluster) deploy | Side effect of the `EnableCluster` gate; acceptable (poll fallback), revisit only if controlled single-node becomes a production shape |
+| Splitting backoff into a separate PR | Considered (Codex); user chose one bundled PR — attribution preserved via Server-Timing sub-phases |
+| Non-Linux runtime support for the dial | toolboxd runs in Linux containers; only a CI cross-compile build-tag guard is in scope, not real non-Linux behavior |
+
+## What already exists (reused, not rebuilt)
+
+- **Firecracker vsock readiness** (`internal/runtime/firecracker/driver.go`,
+  `cmd/toolboxd/vsock.go`) — the out-of-band push model this mirrors. Wire
+  *shape* is echoed in `readyproto`; code intentionally not shared (decision #7).
+- **`toolboxd` bind-mount + env injection** (`pkg/docker/client.go` `binds` +
+  `envValues`) — the readiness bind + `SB_READY_SOCKET`/`SB_READY_NONCE` ride
+  the existing mechanism; no new mount machinery.
+- **`SB_TOOLBOX_TOKEN`** (`cmd/toolboxd/main.go`) — reused as the handshake
+  integrity gate; already high-entropy, already env-scrubbed post-read.
+- **`waitForToolbox`/`waitForRuntime`** (`pkg/docker/client.go`) — the fallback
+  path; modified in place (backoff), not replaced.
+- **expvar pool-metrics convention** (`internal/pool/*/metrics.go`) — the
+  readiness counters follow it.
+- **`validateSandboxID`** — reused for the socket path boundary.
+- **Server-Timing** (`pkg/api/v1/handlers.go`) — extended with sub-phases, not
+  rebuilt.
+
+## Failure modes (per new codepath)
+
+| Codepath | Realistic failure | Test? | Error handling | User-visible? |
+|---|---|---|---|---|
+| `readyListener.Accept` | malicious in-container connect floods bad tokens | yes (cap test) | invalid-attempt cap + deadline | no (push just degrades to poll) |
+| `readyListener.Accept` | gVisor blocks the connect (runsc `--host-uds` defaults to `none`) | yes (UC-96c) | grace-delayed poll wins | no (slower create only, until install adds `--host-uds=open`) |
+| `announceReady` dial | dial blocks during PID1 boot | yes (unit) | goroutine + bounded timeout, never fatal | no |
+| socket bind | stale socket from crashed sandbox blocks `Listen` | yes (unit) | unlink-before-listen + gen-keyed sweep | no |
+| boot sweep | sweep races a live create's socket | **must test** | generation/nonce-keyed paths | **CRITICAL if unkeyed — would kill a live create** |
+| race cancel | loser goroutine leaks dialing dead container | yes (unit) | shared ctx cancel | no |
+| backoff poll (regression) | slow-ready container exceeds a too-tight cap | yes (regression, mandatory) | deadline unchanged at 30s | yes if it regressed (create fails) — guarded |
+
+The boot-sweep-vs-live-create race is the one **critical** gap: unkeyed cleanup
+could unlink a socket a concurrent create is mid-flight on. Generation/nonce-keyed
+paths + a test are mandatory.
+
+## Worktree parallelization strategy
+
+| Step | Modules touched | Depends on |
+|---|---|---|
+| S1 readyproto | `pkg/readyproto/` | — |
+| S2 host listener | `pkg/docker/` (readysock) | S1 |
+| S3 guest dialer | `cmd/toolboxd/` | S1 |
+| S4 config | `internal/config/` | — |
+| S5 Create wiring + backoff + Server-Timing | `pkg/docker/`, `pkg/api/v1/`, `pkg/daemon/` | S2, S4 |
+| S6 integration UCs | `integration-tests/` | S5, S3 |
+
+- **Lane A:** S1 → S2 → S5 (sequential, shared `pkg/docker/`)
+- **Lane B:** S3 (independent, `cmd/toolboxd/`, after S1)
+- **Lane C:** S4 (independent, `internal/config/`)
+
+Execution: S1 first (both lanes depend on it). Then A (S2→S5), B (S3), C (S4) in
+parallel worktrees. Merge all. Then S6. **Conflict flag:** S2 and S5 both touch
+`pkg/docker/` — keep them in one lane (sequential), do not parallelize.
+
+## Implementation Tasks
+Synthesized from this review's findings. Each derives from a specific finding.
+
+- [ ] **T1 (P1, human: ~3h / CC: ~25min)** — readysock — accept-until-valid listener
+  - Surfaced by: Codex tension #8 — single-shot is exploitable
+  - Files: `pkg/docker/readysock.go`, `pkg/readyproto/readyproto.go`
+  - Verify: `go test ./pkg/docker/ -run ReadySock`
+- [ ] **T2 (P1, human: ~2h / CC: ~15min)** — readysock/toolboxd — 0666 socket + mandatory token+nonce (constant-time)
+  - Surfaced by: Architecture #1 + Codex token/nonce
+  - Files: `pkg/docker/readysock.go`, `cmd/toolboxd/readyclient.go`
+  - Verify: `go test ./pkg/docker/... ./cmd/toolboxd/...`
+- [ ] **T3 (P1, human: ~4h / CC: ~30min)** — docker Create — race (grace-delayed poll, shared ctx) + explicit cleanup + gen-keyed sweep
+  - Surfaced by: Architecture #2, #3; Codex sweep-race
+  - Files: `pkg/docker/client.go`, `pkg/daemon/`
+  - Verify: `go test ./pkg/docker/ -run Create`
+- [ ] **T4 (P1, human: ~2h / CC: ~15min)** — toolboxd — dial after HTTP listener up, goroutine + bounded timeout, never fatal
+  - Surfaced by: Codex tension #10 + PID1 timing
+  - Files: `cmd/toolboxd/main.go`, `cmd/toolboxd/readyclient.go`
+  - Verify: `go test ./cmd/toolboxd/...`
+- [ ] **T5 (P1, human: ~2h / CC: ~15min)** — docker — adaptive backoff + REGRESSION test (slow-ready container still succeeds)
+  - Surfaced by: Test review IRON RULE (modifies path every create uses)
+  - Files: `pkg/docker/client.go`, `pkg/docker/client_test.go`
+  - Verify: `go test ./pkg/docker/ -run WaitFor`
+- [ ] **T6 (P1, human: ~45min / CC: ~8min)** — config — 3 knobs + validation, derive socket dir, gate effective-enable on `EnableCluster`
+  - Surfaced by: Code Quality #2 + decision #10 (off in local/self-install)
+  - Files: `internal/config/config.go`
+  - Detail: effective enable = `getEnvBool("SB_DOCKER_READY_SOCKET_ENABLED", true) && cfg.EnableCluster`; add a config test asserting non-cluster → disabled even with the knob true, and cluster+knob-false → disabled.
+  - Verify: `go test ./internal/config/...`
+- [ ] **T7 (P1, human: ~1h / CC: ~10min)** — api — Server-Timing sub-phases (runtime_wait/toolbox_wait/source)
+  - Surfaced by: Phase-1 measure-first (Codex "wrong bottleneck")
+  - Files: `pkg/api/v1/handlers.go`, `pkg/docker/client.go`
+  - Verify: `go test ./pkg/api/v1/...`
+- [ ] **T8 (P1, human: ~3h / CC: ~25min)** — integration — UC-96 / UC-96b (non-root) / UC-96c (gVisor) / UC-97 (fallback), assert per-sandbox Server-Timing source
+  - Surfaced by: Test review (silent-fallback) + Codex gVisor + metric-flakiness
+  - Files: `integration-tests/suite/docker_readiness_test.go`, `integration-tests/suite/harness/usecases.go`
+  - Verify: `go test -tags=integration ./integration-tests/suite/ -run Readiness`
+- [ ] **T9 (P2, human: ~1h / CC: ~10min)** — readyproto — bounded decode + fuzz
+  - Surfaced by: Security #6/#12
+  - Files: `pkg/readyproto/readyproto.go`, `pkg/readyproto/readyproto_test.go`
+  - Verify: `go test ./pkg/readyproto/...`
+- [ ] **T10 (P2, human: ~1h / CC: ~10min)** — metrics — expvar counters with per-sandbox attribution
+  - Surfaced by: Codex metric-flakiness
+  - Files: `pkg/docker/readysock_metrics.go`
+  - Verify: `go test ./pkg/docker/ -run Metrics`
+- [ ] **T11 (P2, human: ~1h / CC: ~10min)** — docs — env table, NOT-in-scope topologies, soften use-case claims #13/#17/#20
+  - Surfaced by: Codex claim corrections
+  - Files: `integration-tests/README.md`, `packaging/`, this plan
+  - Verify: manual
+- [ ] **T12 (P3, human: ~30min / CC: ~5min)** — toolboxd — build-tag guard if CI cross-compiles to non-Linux
+  - Surfaced by: Codex non-Linux builds
+  - Files: `cmd/toolboxd/readyclient_linux.go` / `_other.go`
+  - Verify: `GOOS=darwin go build ./cmd/toolboxd/`
+- [ ] **T13 (P2, human: ~1h / CC: ~15min, GATED on UC-96c green)** — install — add `runtimeArgs:["--host-uds=open"]` to the runsc daemon.json entry
+  - Surfaced by: user — gVisor connect needs runsc `--host-uds=open`; default install omits it
+  - Files: `scripts/install.sh` `register_gvisor_runtime` — **single source**; Terraform (`--with-gvisor` → install.sh) and Ansible (asserts install.sh ran) both route through it, so this one function is the only code change. BUT it has **three spots** that hard-set the runsc entry and ALL must add `runtimeArgs`: the `desired=` printf (~:1206), the `jq` merge (~:1214), and the `python3` fallback (~:1216) — miss the python branch and no-jq hosts silently omit the flag. Plus docs: `README.md` gVisor row, `docs/.../single-node-setup.md`, `setup/arch.md`.
+  - Verify: `UC-96c` push delivered under gVisor on cluster-hetero; `docker info` / `cat /etc/docker/daemon.json` shows runsc with the arg; re-run installer is idempotent (the diff-check at ~:1237 detects the new arg and restarts docker once).
+  - Note: security-review gate — `open` not `all`; isolation-relaxation decision must be signed off. Do NOT land before UC-96c proves it's needed and sufficient.
+
+## Propagation map (where each change actually lands)
+
+The repo has multiple install/provision paths; this maps each change to every
+place it must reach so nothing is updated in one path and missed in another.
+
+| Change | Single source? | Reaches Terraform | Reaches Ansible | Reaches integration tests | Action |
+|---|---|---|---|---|---|
+| gVisor `--host-uds=open` | **Yes** — `install.sh register_gvisor_runtime` (only `daemon.json` runsc writer) | ✅ via `--with-gvisor`→install.sh | ✅ relies on install.sh, no own registration | ✅ via the prod TF module | Edit the one function (3 spots: printf/jq/python) — T13 |
+| `SB_DOCKER_READY_SOCKET_ENABLED` (gated `AND EnableCluster`) + backoff knobs | **config.go**, effective = default `true` AND `cfg.EnableCluster` | ✅ on in cluster bootstraps (EnableCluster=true), off otherwise | ✅ same | ✅ on for cluster-* scenarios, off for local-mode/single-node | One config.go line; no template edits. Self-install/local/single-node are non-cluster → OFF automatically |
+| New `SB_READY_SOCKET` / `SB_READY_NONCE` env | host-side, set per-create by `pkg/docker/client.go` | n/a (not an operator env) | n/a | n/a | Injected by the daemon at create time, never in any `.env` template |
+| New UCs (96/96b/96c/97) | `harness/usecases.go` Registry | n/a | n/a | ✅ cluster-hetero already has docker + gVisor nodes | Register in usecases.go — T8 |
+| Docs (env table, gVisor flag, NOT-in-scope) | per-file | — | — | `integration-tests/README.md` | T11 + T13 |
+
+**UC-97 (fallback path) — make it a unit test, not an env-toggled integration
+test.** The plan originally suggested toggling `SB_DOCKER_READY_SOCKET_ENABLED=false`
+on a node. That env var is NOT surfaced through the IaC (default-on, config.go
+only), so toggling it per-scenario would require the full 4-place wasm-pool
+plumbing just for one test. Cheaper and more robust: cover the disabled/fallback
+path as a `pkg/docker` **unit test** (construct the client with the channel
+disabled, assert the health poll completes the create). Reserve integration for
+UC-96/96b/96c (proving the push *fires*), which run on cluster-hetero
+(`EnableCluster=true`) where the gate is on. (Also: the "old toolbox image"
+framing for UC-97 is moot for Docker — toolboxd is bind-mounted from the host,
+so it's always current.)
+
+**Bonus from decision #10:** because the push is gated on `EnableCluster`, the
+non-cluster integration scenarios (`local-mode`, `single-node`) now exercise the
+OFF/fallback path on real infra **for free** — a Docker create there must still
+reach `started` via the poll, with `docker_ready_socket_*` untouched. Add that
+assertion to the existing single-node lifecycle UC rather than a new scenario.
+
+**Kill-switch surfacing — deliberately deferred (YAGNI).** Keeping
+`SB_DOCKER_READY_SOCKET_ENABLED` config.go-default-on (not surfaced in
+Terraform/Ansible/`config/cluster.yml`/run.sh) means a managed-fleet operator
+who hand-edits `sandboxd.env` to disable it would have it overwritten on the
+next provision. That's acceptable because the fallback guarantees correctness
+and the switch is an emergency lever, not a routine knob. If ops ever needs it
+first-class, surface it via the 4-place wasm-pool pattern as a fast-follow —
+listed in NOT in scope.
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | not run (infra change) |
+| Codex Review | `/codex review` | Independent 2nd opinion | 1 | issues_found | 21 challenges; 5 promoted to forks, rest folded as hardening |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | clean | 11 issues + 5 cross-model forks, all folded; 1 critical gap (boot-sweep race) fix mandated |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | not run (no UI) |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | not run |
+
+- **CODEX:** outside voice surfaced 5 issues the inside review missed — single-shot accept is exploitable, gVisor passthrough unverified, ready-semantics timing, bind-mount portability, backoff-bundling scope. All resolved via decisions #1, #5, #4, #6, scope-bundle. Remaining Codex points folded as hardening (nonce lifecycle, PID1 timeout, per-sandbox metric attribution, sweep generation-keying, claim corrections).
+- **CROSS-MODEL:** Claude + Codex converged on measure-first (Phase-1 instrumentation), 0666 caution, inspect/NetworkBlockAll claim weakness, and metric-as-assertion flakiness. Codex's single-shot-exploit catch was the highest-value addition; Claude's "toolboxd is bind-mounted from host" context collapsed Codex's compat-matrix concern.
+- **VERDICT:** ENG CLEARED — ready to implement. All 11 findings + 5 cross-model forks folded into the plan; the one critical gap (boot-sweep racing a live create) has a mandated fix (generation/nonce-keyed paths + test). Scope confirmed: full socket-push, one bundled PR.
+
+NO UNRESOLVED DECISIONS

--- a/plans/docker-readiness-unix-socket-push.md
+++ b/plans/docker-readiness-unix-socket-push.md
@@ -1,7 +1,21 @@
 # Docker readiness via Unix-socket push ("vsock for Docker")
 
-Status: **Proposed** — design plan, not yet implemented.
-Owner: TBD. Boot-path change → must follow `/touch-create-sandbox` + `pr-review.md`.
+Status: **Implemented** — landed in [PR #271](https://github.com/aerol-ai/microvm/pull/271) (`docker-socket` branch). Live integration verification (UC-96/96b/96c on `cluster-hetero`) and operator docs are still pending before merge.
+
+## Implementation status (2026-06-30)
+
+| Area | State |
+|------|--------|
+| Core code (`readyproto`, `readysock`, Create race, toolboxd dial, config gate, Server-Timing) | ✅ Shipped |
+| Unit tests | ✅ Shipped (`go test ./pkg/readyproto/... ./pkg/docker/... ./cmd/toolboxd/... ./internal/config/...`) |
+| Integration tests (UC-96 / 96b / 96c written) | ⏳ Not yet run on live AWS |
+| UC-97 fallback | ✅ Unit test (`TestCreate_FallbackWhenPushDisabled`) + non-cluster integration (`TestDockerReadinessFallbackOnNonCluster`) |
+| gVisor `install.sh` `--host-uds=open` | ✅ Code shipped; ⏳ UC-96c + security sign-off pending |
+| Docs (`integration-tests/README.md`, `packaging/`, gVisor operator docs) | ⏳ Pending (T11) |
+| `readyproto` fuzz | ⏳ Pending (T9, P2) |
+| Benchmark `toolbox_wait` regression | ⏳ Optional, not done |
+
+Boot-path change → followed `/touch-create-sandbox` + `pr-review.md` in PR description.
 
 ## Problem
 
@@ -53,8 +67,8 @@ Correctness / robustness
    (push is immune to IP-assignment lag after `/containers/start`).
 8. Removes false-"healthy" flaps where `/health` returns 200 before the agent
    has finished initialising — the agent itself decides when to announce ready.
-9. Detects a wedged / never-ready toolbox more cleanly: a single-shot accept
-   with a deadline instead of an ambiguous repeated poll.
+9. Detects a wedged / never-ready toolbox via accept-until-valid deadline
+   (invalid connects rejected; valid handshake or timeout).
 10. Provides a precise, attributable readiness timestamp for Server-Timing and
     metrics (the agent reports exactly when it came up).
 11. Fences stale readiness on snapshot-clone / recreate paths via a
@@ -72,16 +86,25 @@ Network / isolation
 Architecture / security / ops
 16. Unifies the readiness model across runtimes (Docker now out-of-band push,
     like Firecracker vsock and WASM socket) — one mental model, less special-casing.
-17. Gives gVisor sandboxes the same fast readiness for free (they ride the
-    docker client path).
+17. gVisor can use the same push path when `runsc` runs with `--host-uds=open`
+    (`install.sh`); otherwise fallback poll only (same backoff win).
 18. Avoids exposing any host-facing readiness *network* endpoint to untrusted
     sandboxes (the failure mode of a webhook approach).
 19. Backward compatible: toolbox images built before this change still come up
     via the existing `/health` poll fallback (no flag-day).
-20. Establishes a reusable per-sandbox host↔container control channel that
-    future features can extend (push quiesce/shutdown to Docker sandboxes,
-    capability advertisement, agent-version negotiation) with **no** new
-    network surface.
+20. Establishes a **one-shot** per-create host↔container readiness channel (not a
+    reusable bidirectional control plane without further auth/lifetime design).
+
+### As-implemented claim notes
+
+Eng review softened several bullets above; shipped behavior matches the locked
+decisions section:
+
+- **#9** — accept-until-valid (invalid connects are rejected, channel stays open).
+- **#13** — not a unique win: health poll already completed before egress rules apply.
+- **#17** — gVisor needs `runsc --host-uds=open`; otherwise fallback poll only.
+- **#19** — toolboxd is bind-mounted from the host; fallback is defense-in-depth.
+- **#20** — one-shot readiness only; listener closes after success or create ends.
 
 ---
 
@@ -92,16 +115,18 @@ Architecture / security / ops
 ```
 HOST (sandboxd)                                  CONTAINER (toolboxd, PID 1)
 ──────────────                                   ──────────────────────────
-1. create  <dir>/<sandboxID>.sock, listen()
+1. create <dir>/<sandboxID>.<nonce>.sock, listen()
 2. bind-mount that ONE socket file ──────────►   /run/aerol/ready.sock  (rw)
-   set env SB_READY_SOCKET=/run/aerol/ready.sock
+   set env SB_READY_SOCKET=/run/aerol/ready.sock, SB_READY_NONCE=<nonce>
 3. /containers/create, /containers/start
-4. inspect once → container IP (tight retry
-   only if not Running yet)                      5. on boot, FIRST action:
-6. Accept() blocks (deadline = toolboxWaitTimeout)   dial unix:/run/aerol/ready.sock
-7. read 1 JSON line, verify token+nonce ◄────────    write {ready, token, nonce, ...}
-8. close listener, unlink socket → ready             then continue (HTTP/vsock listen)
+4. inspect (backoff) until Running + IP         5. HTTP listener binds (tcp)
+6. race: Accept() vs grace-delayed /health       6. goroutine dials ready.sock
+7. read JSON line, verify token+nonce ◄────────    write {ready, token, nonce, ...}
+8. close listener, unlink socket → ready
 ```
+
+**Ready semantics (decision #4):** toolboxd dials **after** its HTTP listener is
+accepting — same guarantee as `/health` 200 when create returns `started`.
 
 Host **listens** (not the guest) so there is nothing for the host to poll: the
 socket exists before the container starts, and `Accept()` returns the moment
@@ -132,16 +157,16 @@ The host runs the socket-accept **and** the existing `/health` poll
 ### Metrics (expvar, mirroring pool metrics convention)
 
 `docker_ready_socket_hit`, `docker_ready_socket_fallback_health`,
-`docker_ready_socket_timeout`, plus a `ready_wait_ms` histogram — gives the
-integration assertion hook and dashboards.
+`docker_ready_socket_timeout`, `docker_ready_socket_invalid_attempts`, plus
+`ready_wait_ms` (atomic last successful wait — not a histogram). Integration
+assertions use per-create `Server-Timing` (`readiness;desc=socket|health`), not
+global expvar deltas (flaky under concurrency).
 
 ### Config knobs (`internal/config`)
 
-- `SB_DOCKER_READY_SOCKET_ENABLED` (default `true`) — master switch; off =
-  pure legacy behavior.
-- `SB_DOCKER_READY_SOCKET_DIR` (default `<runtime-dir>/docker/ready`).
-- Plus the fallback poll's backoff knobs (`SB_DOCKER_READINESS_POLL_INITIAL`,
-  `_MAX`) carried over from the tight-poll plan.
+- `SB_DOCKER_READY_SOCKET_ENABLED` (default `true`) — kill switch; effective only when `EnableCluster=true`.
+- Socket dir **derived** at runtime: `{MountsCredentialsRuntimeDir}/docker/ready` via `Config.DockerReadySocketDir()` (no separate `SB_DOCKER_READY_SOCKET_DIR` env).
+- Fallback poll backoff: `SB_DOCKER_READINESS_POLL_INITIAL` (default `20ms`), `SB_DOCKER_READINESS_POLL_MAX` (default `300ms`).
 
 The existing `SB_DOCKER_WAIT_TIMEOUT` / `SB_TOOLBOX_WAIT_TIMEOUT` (30s) stay as
 the outer deadline, unchanged.
@@ -154,12 +179,15 @@ the outer deadline, unchanged.
 |---|---|
 | `pkg/readyproto/readyproto.go` | Shared wire shape (`ReadySignal` struct, `Event` constant, a bounded newline-JSON `Encode`/`Decode`). Imported by **both** the host (`pkg/docker`) and the guest (`cmd/toolboxd`), mirroring how the vsock protocol shape is isolated from its socket layer. |
 | `pkg/readyproto/readyproto_test.go` | Encode/decode round-trip, oversize-line rejection, malformed-JSON rejection, unknown-field tolerance. |
-| `pkg/docker/readysock.go` | Host side: `readyListener` — create+listen (unlink-before-bind), `Accept` with deadline, token/nonce verification (constant-time), bounded reader, single-shot, cleanup (`Close`+unlink). Plus `bindSpec()`/`envFor()` helpers the Create path uses to wire the bind and env. |
-| `pkg/docker/readysock_test.go` | Unit tests (see test section). |
-| `pkg/docker/readysock_metrics.go` | expvar counters/histogram for the readiness channel. |
-| `cmd/toolboxd/readyclient.go` | Guest side: `announceReady()` — read `SB_READY_SOCKET`/`SB_TOOLBOX_TOKEN`/nonce env, dial the unix socket with a short deadline, write one `ReadySignal` line, close. Best-effort; never fatal. Portable (plain unix socket; no AF_VSOCK, builds on all platforms). |
-| `cmd/toolboxd/readyclient_test.go` | Unit tests for the dialer. |
-| `integration-tests/suite/docker_readiness_test.go` | New UC tests (UC-96/UC-97) — see integration section. |
+| `pkg/docker/readysock.go` | Host side: `ReadyListener` — accept-until-valid, `0666` socket, token/nonce verification, bounded reader, cleanup. |
+| `pkg/docker/readysock_test.go` | Unit tests (`//go:build linux` — unix socket bind requires Linux). |
+| `pkg/docker/readysock_metrics.go` | expvar counters + `ready_wait_ms` atomic. |
+| `pkg/docker/create_timing.go` | `CreateTiming` context recorder for Server-Timing sub-phases. |
+| `pkg/docker/ready_create_test.go` | Create-path wiring, socket-wins race, fallback-disabled, slow-ready backoff. |
+| `cmd/toolboxd/readyclient_linux.go` | Guest dialer (`announceReady`, `dialReadySocket`). |
+| `cmd/toolboxd/readyclient_other.go` | No-op stub for non-Linux builds. |
+| `cmd/toolboxd/readyclient_test.go` | Dialer unit tests (`//go:build linux`). |
+| `integration-tests/suite/docker_readiness_test.go` | UC-96 / 96b / 96c + non-cluster fallback assertion. |
 | `plans/docker-readiness-unix-socket-push.md` | This document. |
 
 ## Files MODIFIED
@@ -167,14 +195,17 @@ the outer deadline, unchanged.
 | File | Change |
 |---|---|
 | `pkg/docker/client.go` | `Create`: (a) before `/containers/create`, construct the `readyListener` and append its bind to `binds` + its env to `envValues`; (b) after `/containers/start`, keep one `inspect` for the container IP, then **race** `readyListener.Accept()` against the (backoff) `waitForToolbox`; (c) on every failure path, `readyListener.Close()` + unlink (LIFO with the existing cleanup); (d) `Destroy`/`removeContainer` also unlink any stale socket. New struct fields (`readyDir`, `readyEnabled`) + `New()` wiring. `waitForToolbox`/`waitForRuntime` get the adaptive backoff. |
-| `cmd/toolboxd/main.go` | Call `announceReady(logger)` early in boot — after env is read, *before* `serveHTTPFn` blocks (it can run in a goroutine so it never delays the HTTP/vsock listeners). |
-| `internal/config/config.go` | Add `DockerReadySocketEnabled`, `DockerReadySocketDir`, `DockerReadinessPollInitial`, `DockerReadinessPollMax` with `getEnv*` defaults and validation (`initial>0`, `max>=initial`, dir non-empty when enabled). |
-| `pkg/daemon/` (boot wiring) | Pass the resolved ready-socket dir/enable into the docker client constructor; ensure the dir is created (0700, sandboxd-owned) at boot and swept on startup for orphans. |
-| `pkg/docker/client_test.go` | Extend the existing `roundTripFunc` fake + `newTestClient` so create-path tests assert the new bind + `SB_READY_SOCKET` env are present, and inject a temp ready dir. |
-| `integration-tests/suite/harness/usecases.go` | Register `UC-96` (push readiness) and `UC-97` (legacy fallback) in `Registry`. |
-| `integration-tests/suite/benchmark_test.go` | Optional: assert the Server-Timing `toolbox_wait` phase is near-zero when the push path is active, so a regression to polling is caught by the bench. |
-| `pkg/api/v1/handlers.go` | (From the tight-poll plan) extend `setCreateServerTiming` to emit the `runtime_wait` / `toolbox_wait` sub-phases used by the assertion above. |
-| `packaging/` + docs env table | Document the new `SB_DOCKER_READY_SOCKET_*` vars. |
+| `cmd/toolboxd/main.go` | `announceReady()` after HTTP `Listen`, before `Serve`; scrub `SB_READY_*` env. |
+| `internal/config/config.go` | `DockerReadySocketEnabled`, poll backoff knobs, `DockerReadySocketEffective()`, `DockerReadySocketDir()`. |
+| `pkg/daemon/daemon.go` | `EnsureReadyDir` + `SweepOrphanReadySockets` at boot when push enabled. |
+| `pkg/api/v1/handlers.go` | Server-Timing: `runtime_wait`, `toolbox_wait`, `readiness;desc=`. |
+| `pkg/api/v1/cluster_handler.go` | Pass `nil` timing on cluster placement path (worker returns timing when hit directly). |
+| `integration-tests/suite/harness/usecases.go` | UC-96, UC-96b, UC-96c registered. |
+| `integration-tests/suite/harness/timing.go` | `parseServerTimingReadinessSource`, `LastCreateReadinessSource`. |
+| `scripts/install.sh` | gVisor `runtimeArgs: ["--host-uds=open"]` (all three `register_gvisor_runtime` branches). |
+| `integration-tests/README.md` | ⏳ Document UC-96* and env knobs (T11). |
+| `packaging/` env table | ⏳ Document knobs (T11). |
+| `integration-tests/suite/benchmark_test.go` | Optional: `toolbox_wait` regression — not implemented. |
 
 > Note on the runtime seam: `pkg/docker/client.go` is the Docker
 > `runtime.Runtime` implementation, so no `internal/runtime/docker` driver
@@ -199,24 +230,19 @@ A host-owned socket bind-mounted into an **untrusted** container is sensitive
    carries the per-sandbox `SB_TOOLBOX_TOKEN` (already injected, high-entropy);
    the host verifies it with `subtle.ConstantTimeCompare` and rejects mismatches.
 
-3. **Socket file permissions vs. non-root container user.** The container's
-   `toolboxd` (entrypoint, runs first) must be able to connect, but nothing
-   else on the host should. → Socket created `0660`, sandboxd-owned, inside a
-   `0700` dir; the host-side confidentiality rests on the dir mode + mount
-   isolation, integrity on the token. Where userns/UID-mapping prevents connect,
-   fall to `0666` *on the bind-mounted node only* — safe because the node is
-   reachable solely from inside that one container. Documented explicitly; no
-   silent world-writable host path.
+3. **Socket file permissions vs. non-root container user.** → Socket created
+   **`0666`** on the bind-mounted node (decision #2); integrity gate is the
+   per-sandbox token. Parent dir stays `0700`, sandboxd-owned; only the socket
+   inode is mounted into the container.
 
-4. **Connection-flood DoS (fd/goroutine exhaustion).** Untrusted code could
-   open many connections. → The listener is **single-shot**: after the first
-   *valid* ready (or the deadline) it `Close()`s and stops accepting. Small
-   listen backlog; one accept goroutine per sandbox, bounded by the create's
-   own lifetime.
+4. **Connection-flood DoS (fd/goroutine exhaustion).** → **Accept-until-valid**
+   (decision #1) with a bounded `max-invalid-attempts` cap and per-conn read
+   deadline. Listener lifetime is bounded by the create's `toolboxWaitTimeout`;
+   one accept goroutine per in-flight create.
 
 5. **Slow-loris / connect-but-never-send.** → Every accepted conn gets a short
-   read deadline (e.g. 2s); single-shot accept means a stalled connection
-   cannot hold the channel open past the create deadline.
+   read deadline (2s); invalid/slow connects are dropped and the listener keeps
+   accepting until a valid handshake or the outer deadline.
 
 6. **Oversized / malformed payload (parser OOM).** → `bufio` reader with a hard
    line cap (e.g. 4 KiB) via `io.LimitReader`; one newline-delimited line; JSON
@@ -302,53 +328,44 @@ the expvar counters (hit / fallback / timeout increment correctly).
 
 ### Modified
 
-`pkg/docker/client_test.go`
-- the create-path tests assert the new **bind** (`<dir>/<id>.sock:/run/aerol/ready.sock`)
-  and **`SB_READY_SOCKET` env** are present in the `/containers/create` body;
-- a test that drives the **race**: fake the container as ready via the socket
-  and assert `waitForToolbox`'s health poll is *not* what completed the create
-  (i.e. push wins); and the inverse (socket silent → health poll completes it);
-- inject a `t.TempDir()` ready dir so tests never touch a real runtime dir.
+`pkg/docker/ready_create_test.go` (new file, not `client_test.go`):
+- create-path bind + `SB_READY_SOCKET` / `SB_READY_NONCE` env assertions;
+- socket-wins race (`TestCreate_SocketPushWinsOverHealthPoll`);
+- push-disabled fallback (`TestCreate_FallbackWhenPushDisabled`);
+- slow-ready backoff (`TestPollToolboxHealth_SlowReadyStillSucceeds`).
 
-`pkg/docker` coverage: keep the package at the ~85% bar (`/maintain-coverage`).
+`readysock_test.go` is `//go:build linux` (unix bind requires Linux hosts).
 
 ---
 
 ## Integration test updates
 
-Register two UCs in `integration-tests/suite/harness/usecases.go`:
+Registered in `integration-tests/suite/harness/usecases.go`:
 
 ```go
-{ID: "UC-96", Title: "Docker create readiness delivered via unix-socket push", Requires: []Capability{CapDocker}, Implemented: true},
-{ID: "UC-97", Title: "Docker create falls back to health poll when push absent", Requires: []Capability{CapDocker}, Implemented: true},
+{ID: "UC-96",  Title: "Docker create readiness delivered via unix-socket push", Requires: []Capability{CapCluster, CapDocker}, Implemented: true},
+{ID: "UC-96b", Title: "Docker socket push works for non-root container images", Requires: []Capability{CapCluster, CapDocker}, Implemented: true},
+{ID: "UC-96c", Title: "Docker socket push works under gVisor runtime",         Requires: []Capability{CapCluster, CapDocker, CapGvisor}, Implemented: true},
 ```
 
-`integration-tests/suite/docker_readiness_test.go` (behind the existing
-`integration` build tag, run via the orchestrated suite):
+`integration-tests/suite/docker_readiness_test.go` (behind `integration` build tag):
 
-- **UC-96 (push path):** create a Docker sandbox against a live node; assert it
-  reaches `started`; then read the node's metrics/`Server-Timing` and assert the
-  readiness came through the **socket** channel (`docker_ready_socket_hit`
-  incremented and/or the `toolbox_wait` Server-Timing phase is near-zero). This
-  is the regression guard that proves push is actually active, not silently
-  falling back.
-- **UC-97 (fallback path):** create a sandbox from an image whose toolbox does
-  **not** dial (a pinned older toolbox, or a config toggle
-  `SB_DOCKER_READY_SOCKET_ENABLED=false`); assert it still reaches `started`
-  via the health poll (`docker_ready_socket_fallback_health` incremented). This
-  guarantees the backward-compatibility promise (use case #19) is exercised on
-  real infra.
-- **Latency tie-in:** the existing `TestBenchCreateLatency` (UC-94) already
-  measures docker server-side time; once this lands it should drop materially.
-  Optionally tighten the bench to assert `toolbox_wait` ≈ 0 on the push path so
-  a regression to polling shows up as a failing assertion, not just a slower
-  number.
+- **UC-96 / 96b / 96c:** create on `cluster-hetero`; assert `readiness;desc=socket`
+  via `Client.LastCreateReadinessSource()` (per-create Server-Timing, not expvar).
+- **Fallback (UC-97 equivalent):** `TestDockerReadinessFallbackOnNonCluster` on
+  `local-mode` / `single-node` scenarios asserts `readiness;desc=health` (push
+  gated off by `EnableCluster=false`). Plus unit test `TestCreate_FallbackWhenPushDisabled`.
 
-`integration-tests/README.md`: document the two new UCs and the
-`SB_DOCKER_READY_SOCKET_*` knobs in the env table.
+**Not asserted:** `toolbox_wait ≈ 0` on push path — a correct agent still has real
+init time; only the *source* matters.
 
-No live-AWS-specific wiring is required beyond the standard harness; these run
-on any scenario advertising `CapDocker`.
+**Verify on live infra:**
+```bash
+make integration-cluster-hetero   # UC-96, 96b, 96c
+go test -tags=integration ./integration-tests/suite/ -run Readiness
+```
+
+`integration-tests/README.md`: ⏳ document UC-96* and env knobs (T11).
 
 ---
 
@@ -357,8 +374,9 @@ on any scenario advertising `CapDocker`.
 - **Boot-path change** → run `/touch-create-sandbox`, read `pr-review.md`, and
   the PR description must call out the create-latency impact (improvement, with
   before/after from the Server-Timing sub-phases), the idempotency story
-  (readiness is single-shot + retry-safe; a retried create re-mints a nonce and
-  re-listens), and the failure-path cleanup (listener `Close()`+unlink in LIFO).
+  (readiness is accept-until-valid + retry-safe; a retried create re-mints a
+  nonce and re-listens), and the failure-path cleanup (listener `Close()`+unlink
+  in deferred LIFO).
 - **Security review** required (new host↔container channel) — the section above
   is the checklist to walk in review.
 - **Default on** (`SB_DOCKER_READY_SOCKET_ENABLED=true`) with the health-poll
@@ -421,35 +439,11 @@ attribution comes from the per-phase timing even though bundled.
    before the API serves and cause post-create connection-refused races — a
    regression hidden behind a faster metric.
 
-5. **gVisor — needs `--host-uds=open`; NOT free, and off by default today.**
-   Root cause (not just "virtualized AF_UNIX"): `runsc` gates host unix-socket
-   passthrough behind `--host-uds` (default `none`). A gVisor sandbox can only
-   `connect()` to a bind-mounted host socket when runsc runs with
-   `--host-uds=open` (or `all`). **AerolVM's installer does not set it** —
-   `scripts/install.sh` `register_gvisor_runtime` writes
-   `{"runtimes":{"runsc":{"path":...}}}` with no `runtimeArgs`, so the default
-   `none` applies and the push would silently fall back to the poll on every
-   gVisor create. Sharing `pkg/docker/client.go` does **not** make it "free" —
-   same Go code, different runtime *policy*. Resolution:
-   - Drop use case #17's "for free" claim.
-   - Add **UC-96c on cluster-hetero** (which has a gVisor-capable node): create
-     under `runsc`, assert the push channel actually delivered (per-sandbox
-     `Server-Timing source`), not fallback.
-   - **If UC-96c is green with the flag**, add `"runtimeArgs":["--host-uds=open"]`
-     to the runsc entry in `register_gvisor_runtime` (`scripts/install.sh`) +
-     the Terraform/Ansible install path, and document it. Use `open`
-     (connect-only), **not** `all` (which also permits the sandbox to *create*
-     host sockets — broader than we need).
-   - **Security note (review item):** `--host-uds=open` is a deliberate,
-     fleet-wide relaxation of gVisor isolation — every gVisor sandbox gains the
-     capability to connect to host UDSes that are bind-mounted into it. Exposure
-     is bounded to exactly what we mount (the one readiness socket node); we
-     mount nothing else host-UDS-wise. This must be an explicit security-review
-     decision, not a silent flip.
-   - Fallback guarantees correctness regardless of the flag, so this is a
-     latency/claim issue, never a correctness one. If the security team rejects
-     relaxing `host-uds`, gVisor stays fallback-only (still gets the backoff
-     win) and use case #17 is dropped, not deferred.
+5. **gVisor — needs `--host-uds=open`.** `runsc` gates host UDS passthrough
+   behind `--host-uds` (default `none`). **Shipped:** `scripts/install.sh`
+   `register_gvisor_runtime` sets `"runtimeArgs":["--host-uds=open"]` in all
+   three merge branches. **Pending:** UC-96c on live `cluster-hetero` + security
+   sign-off (isolation relaxation is fleet-wide).
 
 6. **Bind-mount topology — scope to local Linux runc dockerd.** Rootless Docker,
    strict SELinux/AppArmor (:z/:Z), userns-remap, Docker Desktop, and remote
@@ -582,75 +576,36 @@ parallel worktrees. Merge all. Then S6. **Conflict flag:** S2 and S5 both touch
 `pkg/docker/` — keep them in one lane (sequential), do not parallelize.
 
 ## Implementation Tasks
-Synthesized from this review's findings. Each derives from a specific finding.
 
-- [ ] **T1 (P1, human: ~3h / CC: ~25min)** — readysock — accept-until-valid listener
-  - Surfaced by: Codex tension #8 — single-shot is exploitable
-  - Files: `pkg/docker/readysock.go`, `pkg/readyproto/readyproto.go`
-  - Verify: `go test ./pkg/docker/ -run ReadySock`
-- [ ] **T2 (P1, human: ~2h / CC: ~15min)** — readysock/toolboxd — 0666 socket + mandatory token+nonce (constant-time)
-  - Surfaced by: Architecture #1 + Codex token/nonce
-  - Files: `pkg/docker/readysock.go`, `cmd/toolboxd/readyclient.go`
-  - Verify: `go test ./pkg/docker/... ./cmd/toolboxd/...`
-- [ ] **T3 (P1, human: ~4h / CC: ~30min)** — docker Create — race (grace-delayed poll, shared ctx) + explicit cleanup + gen-keyed sweep
-  - Surfaced by: Architecture #2, #3; Codex sweep-race
-  - Files: `pkg/docker/client.go`, `pkg/daemon/`
-  - Verify: `go test ./pkg/docker/ -run Create`
-- [ ] **T4 (P1, human: ~2h / CC: ~15min)** — toolboxd — dial after HTTP listener up, goroutine + bounded timeout, never fatal
-  - Surfaced by: Codex tension #10 + PID1 timing
-  - Files: `cmd/toolboxd/main.go`, `cmd/toolboxd/readyclient.go`
-  - Verify: `go test ./cmd/toolboxd/...`
-- [ ] **T5 (P1, human: ~2h / CC: ~15min)** — docker — adaptive backoff + REGRESSION test (slow-ready container still succeeds)
-  - Surfaced by: Test review IRON RULE (modifies path every create uses)
-  - Files: `pkg/docker/client.go`, `pkg/docker/client_test.go`
-  - Verify: `go test ./pkg/docker/ -run WaitFor`
-- [ ] **T6 (P1, human: ~45min / CC: ~8min)** — config — 3 knobs + validation, derive socket dir, gate effective-enable on `EnableCluster`
-  - Surfaced by: Code Quality #2 + decision #10 (off in local/self-install)
-  - Files: `internal/config/config.go`
-  - Detail: effective enable = `getEnvBool("SB_DOCKER_READY_SOCKET_ENABLED", true) && cfg.EnableCluster`; add a config test asserting non-cluster → disabled even with the knob true, and cluster+knob-false → disabled.
-  - Verify: `go test ./internal/config/...`
-- [ ] **T7 (P1, human: ~1h / CC: ~10min)** — api — Server-Timing sub-phases (runtime_wait/toolbox_wait/source)
-  - Surfaced by: Phase-1 measure-first (Codex "wrong bottleneck")
-  - Files: `pkg/api/v1/handlers.go`, `pkg/docker/client.go`
-  - Verify: `go test ./pkg/api/v1/...`
-- [ ] **T8 (P1, human: ~3h / CC: ~25min)** — integration — UC-96 / UC-96b (non-root) / UC-96c (gVisor) / UC-97 (fallback), assert per-sandbox Server-Timing source
-  - Surfaced by: Test review (silent-fallback) + Codex gVisor + metric-flakiness
-  - Files: `integration-tests/suite/docker_readiness_test.go`, `integration-tests/suite/harness/usecases.go`
-  - Verify: `go test -tags=integration ./integration-tests/suite/ -run Readiness`
-- [ ] **T9 (P2, human: ~1h / CC: ~10min)** — readyproto — bounded decode + fuzz
-  - Surfaced by: Security #6/#12
-  - Files: `pkg/readyproto/readyproto.go`, `pkg/readyproto/readyproto_test.go`
-  - Verify: `go test ./pkg/readyproto/...`
-- [ ] **T10 (P2, human: ~1h / CC: ~10min)** — metrics — expvar counters with per-sandbox attribution
-  - Surfaced by: Codex metric-flakiness
-  - Files: `pkg/docker/readysock_metrics.go`
-  - Verify: `go test ./pkg/docker/ -run Metrics`
-- [ ] **T11 (P2, human: ~1h / CC: ~10min)** — docs — env table, NOT-in-scope topologies, soften use-case claims #13/#17/#20
-  - Surfaced by: Codex claim corrections
-  - Files: `integration-tests/README.md`, `packaging/`, this plan
-  - Verify: manual
-- [ ] **T12 (P3, human: ~30min / CC: ~5min)** — toolboxd — build-tag guard if CI cross-compiles to non-Linux
-  - Surfaced by: Codex non-Linux builds
-  - Files: `cmd/toolboxd/readyclient_linux.go` / `_other.go`
-  - Verify: `GOOS=darwin go build ./cmd/toolboxd/`
-- [ ] **T13 (P2, human: ~1h / CC: ~15min, GATED on UC-96c green)** — install — add `runtimeArgs:["--host-uds=open"]` to the runsc daemon.json entry
-  - Surfaced by: user — gVisor connect needs runsc `--host-uds=open`; default install omits it
-  - Files: `scripts/install.sh` `register_gvisor_runtime` — **single source**; Terraform (`--with-gvisor` → install.sh) and Ansible (asserts install.sh ran) both route through it, so this one function is the only code change. BUT it has **three spots** that hard-set the runsc entry and ALL must add `runtimeArgs`: the `desired=` printf (~:1206), the `jq` merge (~:1214), and the `python3` fallback (~:1216) — miss the python branch and no-jq hosts silently omit the flag. Plus docs: `README.md` gVisor row, `docs/.../single-node-setup.md`, `setup/arch.md`.
-  - Verify: `UC-96c` push delivered under gVisor on cluster-hetero; `docker info` / `cat /etc/docker/daemon.json` shows runsc with the arg; re-run installer is idempotent (the diff-check at ~:1237 detects the new arg and restarts docker once).
-  - Note: security-review gate — `open` not `all`; isolation-relaxation decision must be signed off. Do NOT land before UC-96c proves it's needed and sufficient.
+Status as of 2026-06-30 ([PR #271](https://github.com/aerol-ai/microvm/pull/271)).
+
+- [x] **T1** — accept-until-valid listener (`readysock.go`, `readyproto/`)
+- [x] **T2** — `0666` + token/nonce (`readysock.go`, `readyclient_linux.go`)
+- [x] **T3** — Create race + cleanup + nonce-keyed sweep (`client.go`, `daemon.go`)
+- [x] **T4** — dial after HTTP listen (`main.go`, `readyclient_linux.go`)
+- [x] **T5** — adaptive backoff + slow-ready test (`ready_create_test.go`)
+- [x] **T6** — config gate + validation (`config.go`, `docker_ready_socket_test.go`)
+- [x] **T7** — Server-Timing sub-phases (`handlers.go`, `create_timing.go`)
+- [ ] **T8** — integration **verified on live AWS** (tests written; run `make integration-cluster-hetero`)
+- [ ] **T9** — `FuzzDecode` (bounded unit tests ✅)
+- [x] **T10** — expvar counters; per-create attribution via Server-Timing
+- [ ] **T11** — operator docs (`integration-tests/README.md`, `packaging/`, gVisor docs)
+- [x] **T12** — `readyclient_linux.go` / `readyclient_other.go`
+- [x] **T13 code** — `install.sh` all three `register_gvisor_runtime` branches
+- [ ] **T13 verify** — UC-96c green + security sign-off on `--host-uds=open`
 
 ## Propagation map (where each change actually lands)
 
 The repo has multiple install/provision paths; this maps each change to every
 place it must reach so nothing is updated in one path and missed in another.
 
-| Change | Single source? | Reaches Terraform | Reaches Ansible | Reaches integration tests | Action |
+| Change | Single source? | Reaches Terraform | Reaches Ansible | Reaches integration tests | Status |
 |---|---|---|---|---|---|
-| gVisor `--host-uds=open` | **Yes** — `install.sh register_gvisor_runtime` (only `daemon.json` runsc writer) | ✅ via `--with-gvisor`→install.sh | ✅ relies on install.sh, no own registration | ✅ via the prod TF module | Edit the one function (3 spots: printf/jq/python) — T13 |
-| `SB_DOCKER_READY_SOCKET_ENABLED` (gated `AND EnableCluster`) + backoff knobs | **config.go**, effective = default `true` AND `cfg.EnableCluster` | ✅ on in cluster bootstraps (EnableCluster=true), off otherwise | ✅ same | ✅ on for cluster-* scenarios, off for local-mode/single-node | One config.go line; no template edits. Self-install/local/single-node are non-cluster → OFF automatically |
-| New `SB_READY_SOCKET` / `SB_READY_NONCE` env | host-side, set per-create by `pkg/docker/client.go` | n/a (not an operator env) | n/a | n/a | Injected by the daemon at create time, never in any `.env` template |
-| New UCs (96/96b/96c/97) | `harness/usecases.go` Registry | n/a | n/a | ✅ cluster-hetero already has docker + gVisor nodes | Register in usecases.go — T8 |
-| Docs (env table, gVisor flag, NOT-in-scope) | per-file | — | — | `integration-tests/README.md` | T11 + T13 |
+| gVisor `--host-uds=open` | **Yes** — `install.sh register_gvisor_runtime` | ✅ via `--with-gvisor` | ✅ via install.sh | UC-96c on cluster-hetero | Code ✅; live verify ⏳ |
+| Ready-socket knobs + `EnableCluster` gate | **config.go** | ✅ cluster bootstraps | ✅ same | non-cluster → fallback | ✅ |
+| `SB_READY_SOCKET` / `SB_READY_NONCE` env | per-create in `client.go` | n/a | n/a | n/a | ✅ |
+| UC-96 / 96b / 96c | `usecases.go` + `docker_readiness_test.go` | n/a | n/a | cluster-hetero | Written ✅; run ⏳ |
+| Operator docs | per-file | — | — | `integration-tests/README.md` | ⏳ T11 |
 
 **UC-97 (fallback path) — make it a unit test, not an env-toggled integration
 test.** The plan originally suggested toggling `SB_DOCKER_READY_SOCKET_ENABLED=false`
@@ -667,8 +622,8 @@ so it's always current.)
 **Bonus from decision #10:** because the push is gated on `EnableCluster`, the
 non-cluster integration scenarios (`local-mode`, `single-node`) now exercise the
 OFF/fallback path on real infra **for free** — a Docker create there must still
-reach `started` via the poll, with `docker_ready_socket_*` untouched. Add that
-assertion to the existing single-node lifecycle UC rather than a new scenario.
+reach `started` via the poll. **Shipped:** `TestDockerReadinessFallbackOnNonCluster`
+in `docker_readiness_test.go` asserts `readiness;desc=health` on non-cluster scenarios.
 
 **Kill-switch surfacing — deliberately deferred (YAGNI).** Keeping
 `SB_DOCKER_READY_SOCKET_ENABLED` config.go-default-on (not surfaced in
@@ -691,6 +646,6 @@ listed in NOT in scope.
 
 - **CODEX:** outside voice surfaced 5 issues the inside review missed — single-shot accept is exploitable, gVisor passthrough unverified, ready-semantics timing, bind-mount portability, backoff-bundling scope. All resolved via decisions #1, #5, #4, #6, scope-bundle. Remaining Codex points folded as hardening (nonce lifecycle, PID1 timeout, per-sandbox metric attribution, sweep generation-keying, claim corrections).
 - **CROSS-MODEL:** Claude + Codex converged on measure-first (Phase-1 instrumentation), 0666 caution, inspect/NetworkBlockAll claim weakness, and metric-as-assertion flakiness. Codex's single-shot-exploit catch was the highest-value addition; Claude's "toolboxd is bind-mounted from host" context collapsed Codex's compat-matrix concern.
-- **VERDICT:** ENG CLEARED — ready to implement. All 11 findings + 5 cross-model forks folded into the plan; the one critical gap (boot-sweep racing a live create) has a mandated fix (generation/nonce-keyed paths + test). Scope confirmed: full socket-push, one bundled PR.
+- **VERDICT:** ENG CLEARED → **implemented in PR #271**. Remaining before merge: live UC-96c (gVisor + `--host-uds=open`), security sign-off on gVisor UDS relaxation, operator docs (T11).
 
-NO UNRESOLVED DECISIONS
+**Open items (not unresolved design decisions):** T8 live run, T9 fuzz, T11 docs, T13 verify + security gate, optional benchmark assertion.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1203,7 +1203,7 @@ register_gvisor_runtime() {
 	mkdir -p /etc/docker
 	local daemon_json="/etc/docker/daemon.json"
 	local desired
-	desired="$(printf '{"runtimes":{"runsc":{"path":"%s"}}}' "$runsc_bin")"
+	desired="$(printf '{"runtimes":{"runsc":{"path":"%s","runtimeArgs":["--host-uds=open"]}}}' "$runsc_bin")"
 
 	# Merge our runtimes.runsc entry into any existing daemon.json instead of
 	# replacing the file. jq does this cleanly when present; a Python fallback
@@ -1211,7 +1211,7 @@ register_gvisor_runtime() {
 	local merged
 	if [[ -s "$daemon_json" ]]; then
 		if command -v jq >/dev/null 2>&1; then
-			merged="$(jq --arg path "$runsc_bin" '.runtimes = (.runtimes // {}) | .runtimes.runsc = {"path": $path}' "$daemon_json")"
+			merged="$(jq --arg path "$runsc_bin" '.runtimes = (.runtimes // {}) | .runtimes.runsc = {"path": $path, "runtimeArgs": ["--host-uds=open"]}' "$daemon_json")"
 		elif command -v python3 >/dev/null 2>&1; then
 			merged="$(RUNSC_PATH="$runsc_bin" python3 - <<'PY'
 import json, os, sys
@@ -1219,7 +1219,7 @@ path = "/etc/docker/daemon.json"
 with open(path) as f:
     cfg = json.load(f)
 cfg.setdefault("runtimes", {})
-cfg["runtimes"]["runsc"] = {"path": os.environ["RUNSC_PATH"]}
+cfg["runtimes"]["runsc"] = {"path": os.environ["RUNSC_PATH"], "runtimeArgs": ["--host-uds=open"]}
 print(json.dumps(cfg, indent=2))
 PY
 )"


### PR DESCRIPTION
## Summary

- Add a host-listened unix-socket readiness channel (`pkg/readyproto`, `pkg/docker/readysock`) that toolboxd dials after HTTP bind, replacing stacked 300ms inspect/health polling on the hot path.
- Race socket accept against a grace-delayed (50ms) adaptive health poll; first success wins. Effective only when `SB_DOCKER_READY_SOCKET_ENABLED=true` **and** `EnableCluster=true` (local/self-install stays on poll).
- Extend create `Server-Timing` with `runtime_wait`, `toolbox_wait`, and `readiness;desc=socket|health` for attribution. Add UC-96/96b/96c integration tests and gVisor `--host-uds=open` in `install.sh`.

## Sandbox boot impact

**Yes — intentional improvement on the Docker create path.**

- **Added (cluster only):** per-create unix socket bind-mount + listener accept goroutine, minted nonce env, and a 50ms-delayed health-poll racer. Fires on every Docker `Create` when `DockerReadySocketEffective()` is true.
- **Removed/reduced:** fixed 300ms sleeps in `waitForRuntime` / `waitForToolbox` replaced by adaptive backoff (20ms→300ms); socket hit avoids health dials entirely after grace.
- **Expected latency:** server-side docker create should drop from ~628ms toward true agent-ready time (minus poll rounding). Non-cluster hosts unchanged (push off, backoff-only win).
- **Bounded:** outer deadlines unchanged (`SB_DOCKER_WAIT_TIMEOUT` / `SB_TOOLBOX_WAIT_TIMEOUT`); listener uses accept-until-valid with per-conn read deadline and invalid-attempt cap.

## Idempotency

- **Create (retry):** each create mints a fresh nonce and socket path; stale listener cleaned via deferred `Close()` + unlink on failure. Retried create re-listens safely.
- **Create (concurrent duplicate):** unchanged — sandbox ID uniqueness still enforced at Docker name / store layer; readiness sockets are per-create nonce-keyed, no cross-sandbox confusion.
- **Readiness accept:** token+nonce constant-time validation; invalid connections rejected until valid or deadline.
- **Destroy:** unlinks `{sandboxID}.*.sock` orphans for that sandbox (skips active registrations).

## Failure-path consistency

- **Docker Create failure before commit:** deferred ready-listener `Close()` + socket unlink on all error paths after listen (LIFO with existing container teardown).
- **Partial readiness failure:** both socket and health poll lose → Create fails as today; container removed.
- **N/A for caddy+store** — no new multi-step caddy/store write path.

## L4 / host-port-pool changes

N/A - neither touched.

## Test plan

- [x] `go test ./pkg/readyproto/... ./pkg/docker/... ./cmd/toolboxd/... ./internal/config/... ./pkg/api/v1/...`
- [x] `go test ./internal/service/...`
- [x] Unit: accept-until-valid listener, token/nonce rejection, sweep skips active sockets, create wiring (bind+env), socket-wins race, disabled fallback (UC-97), slow-ready backoff regression
- [x] Config: `EnableCluster` gate + kill switch tests
- [x] Harness: `readiness;desc=` Server-Timing parser
- [ ] Integration (operator): `make integration-cluster-hetero` — UC-96/96b/96c assert `readiness;desc=socket`; non-cluster scenarios assert `health` fallback


Made with [Cursor](https://cursor.com)