### PR TITLE
fix(docker): ready-socket race fallback + cluster-gated gVisor --host-uds

### DIFF
--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -1152,14 +1152,13 @@ func (c *Client) waitForToolboxReady(ctx context.Context, containerIP string, li
 		source string
 		err    error
 	}
+	// Buffered for exactly two senders, and both goroutines send exactly once,
+	// so a send never blocks even after we stop reading on the first success —
+	// the loser drains into the buffer and exits. No leak, no drain goroutine.
 	ch := make(chan result, 2)
 
 	go func() {
-		err := listener.Wait(raceCtx)
-		select {
-		case ch <- result{source: "socket", err: err}:
-		case <-raceCtx.Done():
-		}
+		ch <- result{source: "socket", err: listener.Wait(raceCtx)}
 	}()
 
 	go func() {
@@ -1167,36 +1166,43 @@ func (c *Client) waitForToolboxReady(ctx context.Context, containerIP string, li
 		defer timer.Stop()
 		select {
 		case <-timer.C:
+			ch <- result{source: "health", err: c.pollToolboxHealth(raceCtx, containerIP)}
 		case <-raceCtx.Done():
-			return
-		}
-		err := c.pollToolboxHealth(raceCtx, containerIP)
-		select {
-		case ch <- result{source: "health", err: err}:
-		case <-raceCtx.Done():
+			ch <- result{source: "health", err: raceCtx.Err()}
 		}
 	}()
 
-	res := <-ch
-	cancel()
-	// Drain the loser so its goroutine can exit without leaking a dial.
-	go func() {
-		select {
-		case <-ch:
-		case <-time.After(c.toolboxWaitTimeout):
+	// Take the first path that SUCCEEDS; a failure on one path is not fatal
+	// while the other may still win. This is what makes the health poll a true
+	// safety net: it backstops not just a silent socket (old toolbox image, or
+	// gVisor without --host-uds=open) but also an *erroring* one — an
+	// in-container process tripping maxInvalidReadyAttempts (or any other
+	// listener error) must not be able to fail the create of a healthy sandbox.
+	var socketErr, healthErr error
+	for i := 0; i < 2; i++ {
+		res := <-ch
+		if res.err == nil {
+			cancel() // stop the loser; its buffered send still completes.
+			waitMS := time.Since(start).Milliseconds()
+			if res.source == "socket" {
+				recordReadySocketHit(waitMS)
+			} else {
+				recordReadySocketFallback(waitMS)
+			}
+			return res.source, nil
 		}
-	}()
-
-	if res.err != nil {
-		return "", res.err
+		if res.source == "socket" {
+			socketErr = res.err
+		} else {
+			healthErr = res.err
+		}
 	}
-	waitMS := time.Since(start).Milliseconds()
-	if res.source == "socket" {
-		recordReadySocketHit(waitMS)
-	} else {
-		recordReadySocketFallback(waitMS)
+	// Both paths failed. Prefer the health error: it reflects the actual
+	// readiness probe rather than socket-channel noise.
+	if healthErr != nil {
+		return "", healthErr
 	}
-	return res.source, nil
+	return "", socketErr
 }
 
 func (c *Client) pollToolboxHealth(ctx context.Context, containerIP string) error {

--- a/pkg/docker/ready_create_test.go
+++ b/pkg/docker/ready_create_test.go
@@ -159,6 +159,84 @@ func TestCreate_SocketPushWinsOverHealthPoll(t *testing.T) {
 	}
 }
 
+// TestCreate_SocketErrorFallsBackToHealth is the regression guard for the race
+// fix: an in-container process spamming the ready socket with invalid frames
+// trips listener.Wait's maxInvalidReadyAttempts and returns an error. That
+// error must NOT win the race and fail the create — the health poll is the
+// safety net and the (healthy) sandbox must still come up via "health".
+// Pre-fix, the socket error short-circuited the create.
+func TestCreate_SocketErrorFallsBackToHealth(t *testing.T) {
+	requireLinuxUnix(t)
+	readyDir := t.TempDir()
+
+	// Slow-but-eventually-ready health endpoint: 503 until a few polls in, then
+	// 200. This guarantees the socket error (fast invalid spam) lands before
+	// the health success, so we exercise the "socket errored first" path.
+	var mu sync.Mutex
+	var hits int
+	ip, port, closeFn := toolboxServer(t, func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		hits++
+		n := hits
+		mu.Unlock()
+		if n >= 3 {
+			w.WriteHeader(http.StatusOK)
+		} else {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+	})
+	t.Cleanup(closeFn)
+
+	d := fakeCreateDaemon(t)
+	c := newCreateClient(t, d, false, func(c *Client) {
+		c.readyEnabled = true
+		c.readyDir = readyDir
+		c.toolboxPort = port
+		c.readinessPollInit = 5 * time.Millisecond
+		c.readinessPollMax = 10 * time.Millisecond
+		c.toolboxWaitTimeout = 2 * time.Second
+	})
+	d.containerGet = func() *http.Response {
+		return textResponse(http.StatusOK, inspectBody("cid", "/sb-err", ip, true, "running", 7))
+	}
+
+	// Spam invalid frames (wrong nonce) until the listener trips its invalid cap.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		deadline := time.Now().Add(time.Second)
+		for time.Now().Before(deadline) {
+			matches, _ := filepath.Glob(filepath.Join(readyDir, "sb-err.*.sock"))
+			if len(matches) == 0 {
+				time.Sleep(2 * time.Millisecond)
+				continue
+			}
+			for i := 0; i < maxInvalidReadyAttempts+2; i++ {
+				conn, err := net.Dial("unix", matches[0])
+				if err != nil {
+					return
+				}
+				_ = readyproto.Encode(conn, readyproto.ReadySignal{
+					Event: readyproto.EventReady, SandboxID: "sb-err", Token: "tok", Nonce: "wrong-nonce",
+				})
+				_ = conn.Close()
+			}
+			return
+		}
+	}()
+
+	ctx, timing := WithCreateTiming(context.Background())
+	_, err := c.Create(ctx, models.CreateSandboxRequest{Image: "img"}, "sb-err", "tok", nil)
+	wg.Wait()
+	if err != nil {
+		t.Fatalf("create must survive a socket error via health fallback: %v", err)
+	}
+	if timing.Source != "health" {
+		t.Fatalf("source = %q, want health (socket errored, health backstopped)", timing.Source)
+	}
+}
+
 func TestCreate_FallbackWhenPushDisabled(t *testing.T) {
 	d := fakeCreateDaemon(t)
 	c := newCreateClient(t, d, true, func(c *Client) {

--- a/plans/docker-readiness-unix-socket-push.md
+++ b/plans/docker-readiness-unix-socket-push.md
@@ -10,7 +10,7 @@ Status: **Implemented** — landed in [PR #271](https://github.com/aerol-ai/micr
 | Unit tests | ✅ Shipped (`go test ./pkg/readyproto/... ./pkg/docker/... ./cmd/toolboxd/... ./internal/config/...`) |
 | Integration tests (UC-96 / 96b / 96c written) | ⏳ Not yet run on live AWS |
 | UC-97 fallback | ✅ Unit test (`TestCreate_FallbackWhenPushDisabled`) + non-cluster integration (`TestDockerReadinessFallbackOnNonCluster`) |
-| gVisor `install.sh` `--host-uds=open` | ✅ Code shipped; ⏳ UC-96c + security sign-off pending |
+| gVisor `--host-uds=open` (cluster-init/join) | ✅ Code shipped (cluster-only gate; off on standalone hosts); ⏳ UC-96c + security sign-off pending |
 | Docs (`integration-tests/README.md`, `packaging/`, gVisor operator docs) | ⏳ Pending (T11) |
 | `readyproto` fuzz | ⏳ Pending (T9, P2) |
 | Benchmark `toolbox_wait` regression | ⏳ Optional, not done |
@@ -202,7 +202,7 @@ the outer deadline, unchanged.
 | `pkg/api/v1/cluster_handler.go` | Pass `nil` timing on cluster placement path (worker returns timing when hit directly). |
 | `integration-tests/suite/harness/usecases.go` | UC-96, UC-96b, UC-96c registered. |
 | `integration-tests/suite/harness/timing.go` | `parseServerTimingReadinessSource`, `LastCreateReadinessSource`. |
-| `scripts/install.sh` | gVisor `runtimeArgs: ["--host-uds=open"]` (all three `register_gvisor_runtime` branches). |
+| `scripts/cluster-init.sh`, `scripts/cluster-join.sh` | `ensure_gvisor_host_uds` appends gVisor `runtimeArgs: ["--host-uds=open"]` on cluster nodes only (idempotent; no-op without gVisor). `install.sh` deliberately leaves runsc at `--host-uds=none`. |
 | `integration-tests/README.md` | ⏳ Document UC-96* and env knobs (T11). |
 | `packaging/` env table | ⏳ Document knobs (T11). |
 | `integration-tests/suite/benchmark_test.go` | Optional: `toolbox_wait` regression — not implemented. |
@@ -440,10 +440,16 @@ attribution comes from the per-phase timing even though bundled.
    regression hidden behind a faster metric.
 
 5. **gVisor — needs `--host-uds=open`.** `runsc` gates host UDS passthrough
-   behind `--host-uds` (default `none`). **Shipped:** `scripts/install.sh`
-   `register_gvisor_runtime` sets `"runtimeArgs":["--host-uds=open"]` in all
-   three merge branches. **Pending:** UC-96c on live `cluster-hetero` + security
-   sign-off (isolation relaxation is fleet-wide).
+   behind `--host-uds` (default `none`). The relaxation is fleet-wide (every
+   runsc sandbox on the host), so it is enabled **only on cluster nodes**, by
+   `scripts/cluster-init.sh` / `scripts/cluster-join.sh` (`ensure_gvisor_host_uds`)
+   rather than `install.sh` — install.sh runs before the node is in a cluster
+   and must not relax isolation on standalone gVisor hosts that never run the
+   socket. The cluster scripts append `--host-uds=open` to the registered
+   `runsc` runtimeArgs idempotently (no-op when gVisor isn't installed or the
+   arg is already present), so the relaxation is scoped to cluster+gVisor.
+   Without it the push path degrades to health polling (UC-97). **Pending:**
+   UC-96c on live `cluster-hetero` + security sign-off.
 
 6. **Bind-mount topology — scope to local Linux runc dockerd.** Rootless Docker,
    strict SELinux/AppArmor (:z/:Z), userns-remap, Docker Desktop, and remote
@@ -545,7 +551,7 @@ attribution comes from the per-phase timing even though bundled.
 | Codepath | Realistic failure | Test? | Error handling | User-visible? |
 |---|---|---|---|---|
 | `readyListener.Accept` | malicious in-container connect floods bad tokens | yes (cap test) | invalid-attempt cap + deadline | no (push just degrades to poll) |
-| `readyListener.Accept` | gVisor blocks the connect (runsc `--host-uds` defaults to `none`) | yes (UC-96c) | grace-delayed poll wins | no (slower create only, until install adds `--host-uds=open`) |
+| `readyListener.Accept` | gVisor blocks the connect (runsc `--host-uds` defaults to `none`) | yes (UC-96c) | grace-delayed poll wins | no (slower create only, until cluster-init/join adds `--host-uds=open`) |
 | `announceReady` dial | dial blocks during PID1 boot | yes (unit) | goroutine + bounded timeout, never fatal | no |
 | socket bind | stale socket from crashed sandbox blocks `Listen` | yes (unit) | unlink-before-listen + gen-keyed sweep | no |
 | boot sweep | sweep races a live create's socket | **must test** | generation/nonce-keyed paths | **CRITICAL if unkeyed — would kill a live create** |
@@ -591,7 +597,7 @@ Status as of 2026-06-30 ([PR #271](https://github.com/aerol-ai/microvm/pull/271)
 - [x] **T10** — expvar counters; per-create attribution via Server-Timing
 - [ ] **T11** — operator docs (`integration-tests/README.md`, `packaging/`, gVisor docs)
 - [x] **T12** — `readyclient_linux.go` / `readyclient_other.go`
-- [x] **T13 code** — `install.sh` all three `register_gvisor_runtime` branches
+- [x] **T13 code** — `ensure_gvisor_host_uds` in `cluster-init.sh` + `cluster-join.sh` (cluster-only gate; `install.sh` left at `--host-uds=none`)
 - [ ] **T13 verify** — UC-96c green + security sign-off on `--host-uds=open`
 
 ## Propagation map (where each change actually lands)
@@ -601,7 +607,7 @@ place it must reach so nothing is updated in one path and missed in another.
 
 | Change | Single source? | Reaches Terraform | Reaches Ansible | Reaches integration tests | Status |
 |---|---|---|---|---|---|
-| gVisor `--host-uds=open` | **Yes** — `install.sh register_gvisor_runtime` | ✅ via `--with-gvisor` | ✅ via install.sh | UC-96c on cluster-hetero | Code ✅; live verify ⏳ |
+| gVisor `--host-uds=open` | **Yes** — `ensure_gvisor_host_uds` in `cluster-init.sh`/`cluster-join.sh` (cluster-only) | ✅ Terraform bootstrap always runs cluster-init/join | ✅ same scripts | UC-96c on cluster-hetero | Code ✅; live verify ⏳ |
 | Ready-socket knobs + `EnableCluster` gate | **config.go** | ✅ cluster bootstraps | ✅ same | non-cluster → fallback | ✅ |
 | `SB_READY_SOCKET` / `SB_READY_NONCE` env | per-create in `client.go` | n/a | n/a | n/a | ✅ |
 | UC-96 / 96b / 96c | `usecases.go` + `docker_readiness_test.go` | n/a | n/a | cluster-hetero | Written ✅; run ⏳ |

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -470,6 +470,57 @@ cat > /etc/systemd/system/sandboxd.service.d/cluster.conf <<'EOF'
 EnvironmentFile=/etc/sandboxd/cluster.env
 EOF
 
+# gVisor host-UDS: prerequisite for the cluster Docker push-readiness socket
+# (toolboxd dials a host unix socket bind-mounted into the sandbox; under runsc
+# that connect is blocked unless --host-uds=open is set). We enable it HERE, not
+# in install.sh, on purpose: install.sh runs before the node is in a cluster and
+# must not relax gVisor isolation on standalone hosts that never run the socket.
+# By the time cluster-init runs we KNOW this is a cluster node, so the relaxation
+# is correctly scoped to cluster+gVisor. No-op when gVisor isn't registered, and
+# idempotent (we check for the arg semantically, so a re-run never bounces
+# docker). Best-effort: a failure degrades the socket to health polling, it must
+# not fail the cluster join.
+ensure_gvisor_host_uds() {
+	local daemon_json="/etc/docker/daemon.json"
+	command -v docker >/dev/null 2>&1 || return 0
+	[[ -s "$daemon_json" ]] || return 0
+
+	local merged=""
+	if command -v jq >/dev/null 2>&1; then
+		# Only rewrite when runsc is registered AND host-uds is absent. index()
+		# returns null when missing; this keeps re-runs idempotent regardless of
+		# how the existing daemon.json happens to be formatted.
+		if [[ "$(jq -r '((.runtimes.runsc | type) == "object") and (((.runtimes.runsc.runtimeArgs // []) | index("--host-uds=open")) == null)' "$daemon_json" 2>/dev/null)" != "true" ]]; then
+			return 0
+		fi
+		merged="$(jq '.runtimes.runsc.runtimeArgs = ((.runtimes.runsc.runtimeArgs // []) + ["--host-uds=open"])' "$daemon_json")" || return 0
+	elif command -v python3 >/dev/null 2>&1; then
+		merged="$(python3 - "$daemon_json" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    cfg = json.load(f)
+rs = cfg.get("runtimes", {}).get("runsc")
+if not isinstance(rs, dict):
+    sys.exit(3)  # gVisor not registered -> no-op
+args = rs.get("runtimeArgs", [])
+if "--host-uds=open" in args:
+    sys.exit(3)  # already enabled -> idempotent no-op
+args.append("--host-uds=open")
+rs["runtimeArgs"] = args
+print(json.dumps(cfg, indent=2))
+PY
+)" || return 0  # exit 3 (no-op) or any error -> leave daemon.json untouched
+	else
+		echo "[cluster-init] no jq/python3 to enable runsc --host-uds=open; readiness socket will fall back to health polling" >&2
+		return 0
+	fi
+
+	[[ -n "$merged" ]] || return 0
+	printf '%s\n' "$merged" > "$daemon_json"
+	echo "[cluster-init] enabled runsc --host-uds=open for the cluster readiness socket; restarting docker"
+	systemctl restart docker || echo "[cluster-init] docker restart failed; readiness socket will fall back to health polling" >&2
+}
+
 restart_sandboxd_with_diagnostics() {
 	echo "[cluster-init] restarting sandboxd with cluster mode enabled"
 	if ! systemctl restart sandboxd; then
@@ -505,6 +556,7 @@ restart_sandboxd_with_diagnostics() {
 	fi
 }
 
+ensure_gvisor_host_uds
 systemctl daemon-reload
 restart_sandboxd_with_diagnostics
 

--- a/scripts/cluster-join.sh
+++ b/scripts/cluster-join.sh
@@ -446,6 +446,57 @@ cat > /etc/systemd/system/sandboxd.service.d/cluster.conf <<'EOF'
 EnvironmentFile=/etc/sandboxd/cluster.env
 EOF
 
+# gVisor host-UDS: prerequisite for the cluster Docker push-readiness socket
+# (toolboxd dials a host unix socket bind-mounted into the sandbox; under runsc
+# that connect is blocked unless --host-uds=open is set). We enable it HERE, not
+# in install.sh, on purpose: install.sh runs before the node is in a cluster and
+# must not relax gVisor isolation on standalone hosts that never run the socket.
+# By the time cluster-join runs we KNOW this is a cluster node, so the relaxation
+# is correctly scoped to cluster+gVisor. No-op when gVisor isn't registered, and
+# idempotent (we check for the arg semantically, so a re-run never bounces
+# docker). Best-effort: a failure degrades the socket to health polling, it must
+# not fail the cluster join.
+ensure_gvisor_host_uds() {
+	local daemon_json="/etc/docker/daemon.json"
+	command -v docker >/dev/null 2>&1 || return 0
+	[[ -s "$daemon_json" ]] || return 0
+
+	local merged=""
+	if command -v jq >/dev/null 2>&1; then
+		# Only rewrite when runsc is registered AND host-uds is absent. index()
+		# returns null when missing; this keeps re-runs idempotent regardless of
+		# how the existing daemon.json happens to be formatted.
+		if [[ "$(jq -r '((.runtimes.runsc | type) == "object") and (((.runtimes.runsc.runtimeArgs // []) | index("--host-uds=open")) == null)' "$daemon_json" 2>/dev/null)" != "true" ]]; then
+			return 0
+		fi
+		merged="$(jq '.runtimes.runsc.runtimeArgs = ((.runtimes.runsc.runtimeArgs // []) + ["--host-uds=open"])' "$daemon_json")" || return 0
+	elif command -v python3 >/dev/null 2>&1; then
+		merged="$(python3 - "$daemon_json" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    cfg = json.load(f)
+rs = cfg.get("runtimes", {}).get("runsc")
+if not isinstance(rs, dict):
+    sys.exit(3)  # gVisor not registered -> no-op
+args = rs.get("runtimeArgs", [])
+if "--host-uds=open" in args:
+    sys.exit(3)  # already enabled -> idempotent no-op
+args.append("--host-uds=open")
+rs["runtimeArgs"] = args
+print(json.dumps(cfg, indent=2))
+PY
+)" || return 0  # exit 3 (no-op) or any error -> leave daemon.json untouched
+	else
+		echo "[cluster-join] no jq/python3 to enable runsc --host-uds=open; readiness socket will fall back to health polling" >&2
+		return 0
+	fi
+
+	[[ -n "$merged" ]] || return 0
+	printf '%s\n' "$merged" > "$daemon_json"
+	echo "[cluster-join] enabled runsc --host-uds=open for the cluster readiness socket; restarting docker"
+	systemctl restart docker || echo "[cluster-join] docker restart failed; readiness socket will fall back to health polling" >&2
+}
+
 restart_sandboxd_with_diagnostics() {
 	echo "[cluster-join] restarting sandboxd with cluster mode enabled"
 	if ! systemctl restart sandboxd; then
@@ -481,6 +532,7 @@ restart_sandboxd_with_diagnostics() {
 	fi
 }
 
+ensure_gvisor_host_uds
 systemctl daemon-reload
 restart_sandboxd_with_diagnostics
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1203,7 +1203,7 @@ register_gvisor_runtime() {
 	mkdir -p /etc/docker
 	local daemon_json="/etc/docker/daemon.json"
 	local desired
-	desired="$(printf '{"runtimes":{"runsc":{"path":"%s","runtimeArgs":["--host-uds=open"]}}}' "$runsc_bin")"
+	desired="$(printf '{"runtimes":{"runsc":{"path":"%s"}}}' "$runsc_bin")"
 
 	# Merge our runtimes.runsc entry into any existing daemon.json instead of
 	# replacing the file. jq does this cleanly when present; a Python fallback
@@ -1211,7 +1211,7 @@ register_gvisor_runtime() {
 	local merged
 	if [[ -s "$daemon_json" ]]; then
 		if command -v jq >/dev/null 2>&1; then
-			merged="$(jq --arg path "$runsc_bin" '.runtimes = (.runtimes // {}) | .runtimes.runsc = {"path": $path, "runtimeArgs": ["--host-uds=open"]}' "$daemon_json")"
+			merged="$(jq --arg path "$runsc_bin" '.runtimes = (.runtimes // {}) | .runtimes.runsc = {"path": $path}' "$daemon_json")"
 		elif command -v python3 >/dev/null 2>&1; then
 			merged="$(RUNSC_PATH="$runsc_bin" python3 - <<'PY'
 import json, os, sys
@@ -1219,7 +1219,7 @@ path = "/etc/docker/daemon.json"
 with open(path) as f:
     cfg = json.load(f)
 cfg.setdefault("runtimes", {})
-cfg["runtimes"]["runsc"] = {"path": os.environ["RUNSC_PATH"], "runtimeArgs": ["--host-uds=open"]}
+cfg["runtimes"]["runsc"] = {"path": os.environ["RUNSC_PATH"]}
 print(json.dumps(cfg, indent=2))
 PY
 )"


### PR DESCRIPTION
## Summary

Two follow-ups to the #271 Docker push-readiness socket — a real race-fallback
bug, plus correctly scoping the gVisor isolation relaxation #271 introduced.

- **Race robustness (`pkg/docker/client.go`).** `waitForToolboxReady` took the
  *first* race result including errors, so a socket-path error — e.g. an
  in-container process tripping `maxInvalidReadyAttempts`, or any listener
  error — won the race and failed an otherwise-healthy create. It now takes the
  first path that **succeeds**, so the health poll is a true backstop for a
  *silent* **or** *erroring* socket; the health error (the actual readiness
  probe) is surfaced when both fail.
- **gVisor `--host-uds=open` is now scoped to cluster nodes.** #271 added it to
  *every* `--with-gvisor` install, including standalone / non-cluster hosts
  where the cluster-only ready socket never runs (`DockerReadySocketEffective()
  = enabled && EnableCluster`) — relaxing gVisor host-UDS isolation fleet-wide
  with zero benefit there. `install.sh` runs **before** the node is in a
  cluster and can't self-gate (`SB_ENABLE_CLUSTER` is set later by
  `cluster-init.sh` / `cluster-join.sh`), so the relaxation moves into those
  scripts via `ensure_gvisor_host_uds` — the one place that authoritatively
  knows the host is a cluster node. `install.sh` reverts to plain `runsc`.

### Why cluster-init/join, not an install.sh flag

The only signal that "this host is in a cluster" is `SB_ENABLE_CLUSTER=true`,
which is written by `cluster-init.sh` / `cluster-join.sh`, **after** `install.sh`
has already registered the runsc runtime. The Terraform bootstrap always runs
`install.sh` → then `cluster-init`/`cluster-join`, so every cluster node passes
through one of those scripts. `ensure_gvisor_host_uds`:

- appends `--host-uds=open` to the **registered** `runsc` `runtimeArgs`,
  preserving `path` and any existing args (e.g. `--platform=systrap`);
- is a **no-op** when gVisor isn't registered (firecracker/wasm-only nodes) and
  **idempotent** — it checks for the arg *semantically* (not by byte-diffing
  reformatted JSON), so a re-run never bounces Docker;
- is **best-effort**: a jq/python3-absent host or a failed docker restart logs a
  warning and degrades the socket to health polling (UC-97) rather than failing
  the cluster join.

Net effect: host-UDS isolation is relaxed **iff** (cluster mode) **and**
(gVisor present) — exactly where the readiness socket runs. Standalone gVisor
hosts keep runsc at the safe `--host-uds=none`. No new Terraform variable is
needed (the bootstrap already runs cluster-init/join on every node).

## Sandbox boot impact

Touches the create path (`waitForToolboxReady`), but adds **no** new DB query,
HTTP round-trip, file I/O, or lock acquisition.

- **Normal case — no change.** The first *success* still wins immediately
  (socket push, or socket-silent + health). Same latency as before.
- **Pathological case — bounded increase, intentional.** When the socket path
  *errors*, the create previously failed instantly; it now waits for the health
  poll to resolve (success or the existing `toolboxWaitTimeout`, default 30s —
  the same bound the health poll already used). This is the fix: a
  socket-channel error must not fail a healthy sandbox.
- `cluster-init.sh` / `cluster-join.sh` changes are provisioning-time only, not
  boot path.

## Idempotency

- The race fix doesn't alter the per-create nonce-keyed socket path or its
  retry/cleanup semantics; it only changes which race result is authoritative.
- `ensure_gvisor_host_uds` is idempotent by a semantic presence check
  (`--host-uds=open` already in `runtimeArgs` → no write, no docker restart), so
  re-running cluster-init/join is safe and won't kick running containers.

## Failure-path consistency

N/A — no multi-step caddy+store write path changed. The only added create-path
teardown is the ready-listener `Close()`, already covered by the existing
`defer` on every create error path. `ensure_gvisor_host_uds` leaves
`daemon.json` untouched on any error.

## Cluster-correctness impact

`ensure_gvisor_host_uds` lives in the cluster bootstrap scripts but is a host
docker-config concern, not the Raft/gossip/placement path — no FSM, replication,
owner-watcher, or capacity-lease behavior changes. It runs once at init/join,
before sandboxd is (re)started into cluster mode. No split-brain / replay /
leader-change surface. Single-node (`EnableCluster=false`) is unaffected:
install.sh leaves runsc at `--host-uds=none` and the socket path stays off.

## L4 / host-port-pool changes

N/A — neither touched.

## Test plan

- Added `TestCreate_SocketErrorFallsBackToHealth`: spams invalid frames to trip
  the listener's error path while the container is healthy-but-slow, asserts the
  create still succeeds via `health`. **Verified it fails against the pre-fix
  (#271) `client.go`** with `ready socket: too many invalid attempts`, and
  passes post-fix.
- `pkg/docker` socket suite (incl. the new test) green on **real Linux** under
  `-race` (`-count` repeated); deterministic, no flake. `go build ./...`,
  `gofmt`, full `TestCreate*` run clean on darwin.
- `ensure_gvisor_host_uds` logic exercised against six `daemon.json` fixtures
  (no runsc / runsc-no-args / runsc-with-other-arg / already-has-host-uds /
  no-runtimes-key / extra-top-keys) on **both** the jq and python3 paths —
  identical, correct output; path + existing args preserved; idempotent no-op
  when already present or gVisor absent. `bash -n` clean on all three scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
