### PR TITLE
fix(docker): preserve ready-socket bind sources across container restart

### DIFF
--- a/Terraform/templates/bootstrap.sh.tftpl
+++ b/Terraform/templates/bootstrap.sh.tftpl
@@ -52,8 +52,10 @@ curl_download() {
   local url="$1"
   shift
   curl -fsSL \
-    --retry 5 \
-    --retry-delay 2 \
+    --retry 60 \
+    --retry-delay 5 \
+    --retry-all-errors \
+    --retry-max-time 900 \
     --retry-connrefused \
     --connect-timeout 20 \
     --max-time 300 \

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -201,6 +201,64 @@ print_bench_artifact_summary() {
   fi
 }
 
+tfvar_string_from_files() {
+  local name="$1"
+  shift
+  local file value=""
+  for file in "$@"; do
+    [[ -f "$file" ]] || continue
+    local found
+    found=$(sed -nE 's/^[[:space:]]*'"${name}"'[[:space:]]*=[[:space:]]*"([^"]*)".*/\1/p' "$file" | tail -n 1)
+    if [[ -n "$found" ]]; then
+      value="$found"
+    fi
+  done
+  echo "$value"
+}
+
+wait_for_download_url() {
+  local url="$1" label="$2" timeout="${3:-900}"
+  local deadline=$(( $(date +%s) + timeout ))
+  local code="000"
+
+  while (( $(date +%s) < deadline )); do
+    code=$(curl -sSL -o /dev/null -w '%{http_code}' \
+      --connect-timeout 10 \
+      --max-time 30 \
+      "$url" 2>/dev/null || true)
+    code="${code:-000}"
+    if [[ "$code" =~ ^(2|3)[0-9][0-9]$ ]]; then
+      echo "bootstrap asset ready: ${label}"
+      return 0
+    fi
+    echo "waiting for bootstrap asset ${label} (${code})" >&2
+    sleep 10
+  done
+
+  echo "bootstrap asset ${label} not ready after ${timeout}s: ${url} (last HTTP ${code})" >&2
+  return 1
+}
+
+wait_for_bootstrap_assets() {
+  local tfvars_file="$1"
+  local timeout="${AEROL_BOOTSTRAP_ASSET_WAIT_TIMEOUT:-900}"
+  local default_base="https://github.com/aerol-ai/microvm/releases/latest/download"
+  local install_url cluster_init_url cluster_join_url
+
+  install_url=$(tfvar_string_from_files install_script_url "$PROD_TFVARS" "$tfvars_file")
+  cluster_init_url=$(tfvar_string_from_files cluster_init_script_url "$PROD_TFVARS" "$tfvars_file")
+  cluster_join_url=$(tfvar_string_from_files cluster_join_script_url "$PROD_TFVARS" "$tfvars_file")
+
+  install_url="${install_url:-${default_base}/install.sh}"
+  cluster_init_url="${cluster_init_url:-${default_base}/cluster-init.sh}"
+  cluster_join_url="${cluster_join_url:-${default_base}/cluster-join.sh}"
+
+  echo "=== checking bootstrap assets ==="
+  wait_for_download_url "$install_url" "install.sh" "$timeout"
+  wait_for_download_url "$cluster_init_url" "cluster-init.sh" "$timeout"
+  wait_for_download_url "$cluster_join_url" "cluster-join.sh" "$timeout"
+}
+
 run_one() {
   local scenario="$1"
   local sdir="${REPO_ROOT}/integration-tests/.tf/${scenario}"
@@ -238,6 +296,7 @@ run_one() {
 
   # SAFETY GATE — before any apply.
   bash "$PROVISION" check-safety "$state_key" "${leased:-none.itest.invalid}" "$prod_domain" "$cluster_name"
+  wait_for_bootstrap_assets "$tfvars_file"
 
   # Config overlay: start from prod config, neutralize prod-only side effects,
   # set the leased domain. Secrets are symlinked (never copied).

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -160,7 +160,7 @@ func Run(ctx context.Context, logger *slog.Logger, makeProvider ProviderFactory)
 		if err := docker.EnsureReadyDir(readyDir); err != nil {
 			return fmt.Errorf("ready socket dir: %w", err)
 		}
-		if err := docker.SweepOrphanReadySockets(readyDir); err != nil {
+		if err := dockerClient.SweepOrphanReadySockets(ctx); err != nil {
 			logger.Warn("ready socket sweep failed", "error", err)
 		}
 	}

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -418,9 +418,14 @@ func (c *Client) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 
 	var readyListener *ReadyListener
 	var readyListenerClosed bool
+	var readySocketCreated bool
+	var keepReadySocket bool
 	defer func() {
 		if readyListener != nil && !readyListenerClosed {
 			_ = readyListener.Close()
+		}
+		if readySocketCreated && !keepReadySocket {
+			RemoveReadySocketsForSandbox(c.readyDir, sandboxID)
 		}
 	}()
 
@@ -433,6 +438,7 @@ func (c *Client) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 		if err != nil {
 			return nil, fmt.Errorf("ready listener: %w", err)
 		}
+		readySocketCreated = true
 		binds = append(binds, readyListener.BindSpec())
 		envValues = append(envValues, readyListener.EnvVars()...)
 		sort.Strings(envValues)
@@ -613,6 +619,7 @@ func (c *Client) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 	}
 
 	runtime.SandboxID = sandboxID
+	keepReadySocket = true
 	return runtime, nil
 }
 
@@ -646,6 +653,85 @@ func (c *Client) Destroy(ctx context.Context, sandbox *models.Sandbox) error {
 		return errors.New("sandbox container ID is not available")
 	}
 	return c.removeContainer(ctx, containerRef, true)
+}
+
+// SweepOrphanReadySockets removes ready sockets not referenced by existing
+// managed Docker containers. Docker persists bind mounts across stop/start, so
+// deleting a stopped container's ready-socket source would make docker start
+// fail before toolboxd can boot.
+func (c *Client) SweepOrphanReadySockets(ctx context.Context) error {
+	if strings.TrimSpace(c.readyDir) == "" {
+		return nil
+	}
+	keep, err := c.readySocketBindSources(ctx)
+	if err != nil {
+		return err
+	}
+	return SweepOrphanReadySocketsExcept(c.readyDir, keep)
+}
+
+func (c *Client) readySocketBindSources(ctx context.Context) (map[string]struct{}, error) {
+	query := queryValues(map[string]string{"all": "1"})
+	var containers []containerSummary
+	if err := c.doJSON(ctx, http.MethodGet, "/containers/json", query, nil, nil, &containers); err != nil {
+		return nil, fmt.Errorf("list managed containers for ready sockets: %w", err)
+	}
+	keep := map[string]struct{}{}
+	for _, summary := range containers {
+		if summary.Labels[managedLabelKey] != "true" {
+			continue
+		}
+		inspect, err := c.inspectContainer(ctx, summary.ID)
+		if err != nil {
+			return nil, fmt.Errorf("inspect managed container %s for ready sockets: %w", summary.ID, err)
+		}
+		for _, src := range readySocketBindSourcesFromInspect(inspect) {
+			if c.readySocketPathOwnedByDir(src) {
+				keep[src] = struct{}{}
+			}
+		}
+	}
+	return keep, nil
+}
+
+func (c *Client) readySocketPathOwnedByDir(path string) bool {
+	dir := filepath.Clean(strings.TrimSpace(c.readyDir))
+	path = filepath.Clean(strings.TrimSpace(path))
+	if dir == "." || path == "." {
+		return false
+	}
+	rel, err := filepath.Rel(dir, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != "" && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
+func readySocketBindSourcesFromInspect(inspect containerInspect) []string {
+	var out []string
+	for _, bind := range inspect.HostConfig.Binds {
+		if src, ok := readySocketSourceFromBind(bind); ok {
+			out = append(out, src)
+		}
+	}
+	for _, mount := range inspect.Mounts {
+		if mount.Destination == GuestReadySocketPath && strings.TrimSpace(mount.Source) != "" {
+			out = append(out, strings.TrimSpace(mount.Source))
+		}
+	}
+	return out
+}
+
+func readySocketSourceFromBind(bind string) (string, bool) {
+	parts := strings.Split(bind, ":")
+	if len(parts) < 2 || parts[1] != GuestReadySocketPath {
+		return "", false
+	}
+	src := strings.TrimSpace(parts[0])
+	if src == "" {
+		return "", false
+	}
+	return src, true
 }
 
 func (c *Client) CreateSnapshot(ctx context.Context, containerRef, imageRef string) (string, error) {
@@ -1370,6 +1456,13 @@ type containerInspect struct {
 			IPAddress string `json:"IPAddress"`
 		} `json:"Networks"`
 	} `json:"NetworkSettings"`
+	HostConfig struct {
+		Binds []string `json:"Binds"`
+	} `json:"HostConfig"`
+	Mounts []struct {
+		Source      string `json:"Source"`
+		Destination string `json:"Destination"`
+	} `json:"Mounts"`
 }
 
 type containerSummary struct {

--- a/pkg/docker/ready_create_more_test.go
+++ b/pkg/docker/ready_create_more_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -123,5 +124,31 @@ func TestCreate_DisabledDoesNotRecordFallbackMetric(t *testing.T) {
 	}
 	if delta := readySocketFallbackHealth.Value() - before; delta != 0 {
 		t.Fatalf("fallback metric moved by %d on disabled path, want 0", delta)
+	}
+}
+
+func TestReadySocketBindSourcesFromInspect(t *testing.T) {
+	dir := t.TempDir()
+	fromBind := filepath.Join(dir, "sb-bind.n.sock")
+	fromMount := filepath.Join(dir, "sb-mount.n.sock")
+	var inspect containerInspect
+	inspect.HostConfig.Binds = []string{
+		fromBind + ":" + GuestReadySocketPath + ":rw",
+		filepath.Join(dir, "other.sock") + ":/tmp/other.sock:rw",
+	}
+	inspect.Mounts = append(inspect.Mounts, struct {
+		Source      string "json:\"Source\""
+		Destination string "json:\"Destination\""
+	}{Source: fromMount, Destination: GuestReadySocketPath})
+
+	got := readySocketBindSourcesFromInspect(inspect)
+	want := map[string]bool{fromBind: true, fromMount: true}
+	if len(got) != len(want) {
+		t.Fatalf("sources = %v, want %v", got, want)
+	}
+	for _, src := range got {
+		if !want[src] {
+			t.Fatalf("unexpected source %q in %v", src, got)
+		}
 	}
 }

--- a/pkg/docker/ready_create_test.go
+++ b/pkg/docker/ready_create_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -90,6 +91,53 @@ func TestCreate_WiresReadySocketWhenEnabled(t *testing.T) {
 	}
 	if !hasSocket || !hasNonce {
 		t.Fatalf("env missing ready vars: socket=%v nonce=%v env=%v", hasSocket, hasNonce, envs)
+	}
+}
+
+func TestCreate_RetainsReadySocketBindSourceForRestart(t *testing.T) {
+	requireLinuxUnix(t)
+	readyDir := t.TempDir()
+	d := fakeCreateDaemon(t)
+	c := newCreateClient(t, d, true, func(c *Client) {
+		c.readyEnabled = true
+		c.readyDir = readyDir
+	})
+
+	if _, err := c.Create(context.Background(), models.CreateSandboxRequest{Image: "img"}, "sb-restart", "tok", nil); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	matches, err := filepath.Glob(filepath.Join(readyDir, "sb-restart.*.sock"))
+	if err != nil {
+		t.Fatalf("glob ready socket: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("ready socket bind source count = %d, want 1 (%v)", len(matches), matches)
+	}
+	RemoveReadySocketsForSandbox(readyDir, "sb-restart")
+	if _, err := os.Stat(matches[0]); !os.IsNotExist(err) {
+		t.Fatalf("ready socket survived sandbox cleanup: %v", err)
+	}
+}
+
+func TestCreate_RemovesReadySocketOnStartFailure(t *testing.T) {
+	requireLinuxUnix(t)
+	readyDir := t.TempDir()
+	d := fakeCreateDaemon(t)
+	d.start = func() *http.Response { return textResponse(http.StatusInternalServerError, "boom") }
+	c := newCreateClient(t, d, true, func(c *Client) {
+		c.readyEnabled = true
+		c.readyDir = readyDir
+	})
+
+	if _, err := c.Create(context.Background(), models.CreateSandboxRequest{Image: "img"}, "sb-fail", "tok", nil); err == nil {
+		t.Fatal("create expected start failure")
+	}
+	matches, err := filepath.Glob(filepath.Join(readyDir, "sb-fail.*.sock"))
+	if err != nil {
+		t.Fatalf("glob ready socket: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("failed create leaked ready socket bind source: %v", matches)
 	}
 }
 

--- a/pkg/docker/readysock.go
+++ b/pkg/docker/readysock.go
@@ -210,7 +210,10 @@ func (l *ReadyListener) readAndVerify(conn net.Conn) error {
 	return nil
 }
 
-// Close shuts down the listener and unlinks the socket file.
+// Close shuts down the listener but deliberately leaves the socket file in
+// place. Docker persists bind mounts across stop/start, so the host-side bind
+// source must remain present for the container lifetime. Destroy removes the
+// sandbox-keyed socket after the container is gone.
 func (l *ReadyListener) Close() error {
 	if l == nil {
 		return nil
@@ -230,13 +233,6 @@ func (l *ReadyListener) Close() error {
 		err = l.listener.Close()
 		l.listener = nil
 	}
-	if l.hostPath != "" {
-		if rmErr := os.Remove(l.hostPath); rmErr != nil && !os.IsNotExist(rmErr) {
-			if err == nil {
-				err = rmErr
-			}
-		}
-	}
 	return err
 }
 
@@ -252,6 +248,13 @@ func EnsureReadyDir(dir string) error {
 // SweepOrphanReadySockets removes stale socket files from a prior crash.
 // Paths registered by live creates (activeReadySockets) are skipped.
 func SweepOrphanReadySockets(dir string) error {
+	return SweepOrphanReadySocketsExcept(dir, nil)
+}
+
+// SweepOrphanReadySocketsExcept removes stale socket files while preserving
+// paths still referenced by Docker bind mounts. A stopped container cannot
+// restart if its persisted bind source disappears.
+func SweepOrphanReadySocketsExcept(dir string, keep map[string]struct{}) error {
 	dir = strings.TrimSpace(dir)
 	if dir == "" {
 		return nil
@@ -269,6 +272,9 @@ func SweepOrphanReadySockets(dir string) error {
 		}
 		path := filepath.Join(dir, ent.Name())
 		if _, active := activeReadySockets.Load(path); active {
+			continue
+		}
+		if _, ok := keep[path]; ok {
 			continue
 		}
 		_ = os.Remove(path)

--- a/pkg/docker/readysock_test.go
+++ b/pkg/docker/readysock_test.go
@@ -96,7 +96,7 @@ func TestReadyListenerNeverConnectTimesOut(t *testing.T) {
 	}
 }
 
-func TestReadyListenerCloseUnlinks(t *testing.T) {
+func TestReadyListenerCloseLeavesBindSourceForDockerRestart(t *testing.T) {
 	dir := t.TempDir()
 	ln, err := NewReadyListener(dir, "sb", "tok", "n1")
 	if err != nil {
@@ -106,11 +106,15 @@ func TestReadyListenerCloseUnlinks(t *testing.T) {
 	if err := ln.Close(); err != nil {
 		t.Fatalf("close: %v", err)
 	}
-	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		t.Fatalf("socket still present after close: %v", err)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("socket bind source missing after close: %v", err)
 	}
 	if err := ln.Close(); err != nil {
 		t.Fatalf("double close: %v", err)
+	}
+	RemoveReadySocketsForSandbox(dir, "sb")
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("socket still present after sandbox cleanup: %v", err)
 	}
 }
 
@@ -134,6 +138,27 @@ func TestSweepOrphanReadySocketsSkipsActive(t *testing.T) {
 	}
 	if _, err := os.Stat(ln.HostSocketPath()); err != nil {
 		t.Fatalf("active socket removed: %v", err)
+	}
+}
+
+func TestSweepOrphanReadySocketsPreservesDockerBindSources(t *testing.T) {
+	dir := t.TempDir()
+	kept := filepath.Join(dir, "sb-stopped.nonce.sock")
+	orphan := filepath.Join(dir, "sb-dead.old.sock")
+	for _, path := range []string{kept, orphan} {
+		if err := os.WriteFile(path, nil, 0o666); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := SweepOrphanReadySocketsExcept(dir, map[string]struct{}{kept: {}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(kept); err != nil {
+		t.Fatalf("docker bind source removed: %v", err)
+	}
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Fatalf("orphan not removed: %v", err)
 	}
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -33,6 +33,9 @@ DOWNLOAD_CONNECT_TIMEOUT="${AEROL_DOWNLOAD_CONNECT_TIMEOUT:-20}"
 DOWNLOAD_MAX_TIME="${AEROL_DOWNLOAD_MAX_TIME:-300}"
 DOWNLOAD_LOW_SPEED_LIMIT="${AEROL_DOWNLOAD_LOW_SPEED_LIMIT:-1024}"
 DOWNLOAD_LOW_SPEED_TIME="${AEROL_DOWNLOAD_LOW_SPEED_TIME:-30}"
+DOWNLOAD_RETRY="${AEROL_DOWNLOAD_RETRY:-60}"
+DOWNLOAD_RETRY_DELAY="${AEROL_DOWNLOAD_RETRY_DELAY:-5}"
+DOWNLOAD_RETRY_MAX_TIME="${AEROL_DOWNLOAD_RETRY_MAX_TIME:-900}"
 
 # Shared Caddy cert storage (S3). All default empty / off; the feature is
 # off unless --caddy-storage-s3 is passed. When enabled, every node points
@@ -243,8 +246,10 @@ curl_download() {
 	shift
 
 	curl -fL \
-		--retry 5 \
-		--retry-delay 2 \
+		--retry "$DOWNLOAD_RETRY" \
+		--retry-delay "$DOWNLOAD_RETRY_DELAY" \
+		--retry-all-errors \
+		--retry-max-time "$DOWNLOAD_RETRY_MAX_TIME" \
 		--retry-connrefused \
 		--connect-timeout "$DOWNLOAD_CONNECT_TIMEOUT" \
 		--max-time "$DOWNLOAD_MAX_TIME" \


### PR DESCRIPTION
## Summary

- **Ready-socket lifecycle fix:** `ReadyListener.Close()` no longer unlinks the host bind-source file. Docker persists bind mounts across `stop`/`start`, so deleting the socket broke toolboxd boot on container restart. Cleanup now happens only on failed `Create` (defer) or `Destroy` (`RemoveReadySocketsForSandbox`).
- **Smarter orphan sweep:** Daemon startup calls `Client.SweepOrphanReadySockets`, which lists managed containers, collects live ready-socket bind sources from inspect, and passes them to `SweepOrphanReadySocketsExcept` so stopped containers are not swept.
- **Bootstrap reliability:** `integration-tests/run.sh` waits for `install.sh` / `cluster-init.sh` / `cluster-join.sh` release URLs before Terraform apply; `scripts/install.sh` and `Terraform/templates/bootstrap.sh.tftpl` use longer curl retry windows for post-release asset propagation lag.

## Architecture

### Ready-socket lifecycle (create → restart → destroy)

```mermaid
sequenceDiagram
    participant S as sandboxd
    participant L as ReadyListener
    participant D as Docker
    participant T as toolboxd

    S->>L: NewReadyListener(dir, id, nonce)
    L->>L: create host file sb-id.nonce.sock
    S->>D: Create + bind mount socket
    D->>T: start container
    T->>L: push READY handshake
    S->>L: Close listener
    Note over L: socket file kept on disk

    S->>D: stop container
    Note over D: bind mount source still required

    S->>D: start container
    T->>L: push READY on same path
    Note over S,T: restart succeeds

    S->>D: destroy container
    S->>S: RemoveReadySocketsForSandbox
    Note over L: socket file removed
```

### Daemon orphan sweep (startup)

```mermaid
flowchart TD
    A[daemon Run] --> B{readyDir set?}
    B -->|no| Z[skip]
    B -->|yes| C[SweepOrphanReadySockets]
    C --> D[GET /containers/json all=1]
    D --> E[filter managedLabelKey=true]
    E --> F[inspect each container]
    F --> G[collect HostConfig.Binds + Mounts<br/>dest = /run/aerol/ready.sock]
    G --> H[SweepOrphanReadySocketsExcept]
    H --> I{path in keep set<br/>or activeReadySockets?}
    I -->|yes| J[preserve]
    I -->|no| K[os.Remove orphan]
```

### Integration bootstrap gate (pre-apply)

```mermaid
flowchart LR
    A[run_one safety gate] --> B[wait_for_bootstrap_assets]
    B --> C[resolve URLs from tfvars]
    C --> D[HEAD/GET poll install.sh]
    C --> E[HEAD/GET poll cluster-init.sh]
    C --> F[HEAD/GET poll cluster-join.sh]
    D --> G{all 2xx/3xx?}
    E --> G
    F --> G
    G -->|yes| H[terraform apply]
    G -->|no within 900s| I[fail fast with HTTP code]
```

## Sandbox boot impact

**Yes — daemon startup only (not per-create).** `SweepOrphanReadySockets` now lists and inspects all managed containers once at boot to build the `keep` set. Bounded by container count on the host; fires once per `sandboxd` start. Per-create path adds a defer guard (no extra I/O on success) and removes leaked sockets on start failure.

## Idempotency

N/A - no API surface changed. `Create`/`Destroy` behavior is unchanged from the caller's perspective; internal socket cleanup is keyed by sandbox ID and safe under retry (failed create removes socket; successful create retains it until destroy).

## Failure-path consistency

N/A - no multi-step write path touching caddy and the store changed.

## L4 / host-port-pool changes

N/A - neither touched.

## Files changed

| File | Change |
|------|--------|
| `pkg/docker/readysock.go` | `Close()` keeps bind source; `SweepOrphanReadySocketsExcept` |
| `pkg/docker/client.go` | Create defer cleanup; `SweepOrphanReadySockets` via Docker inspect |
| `pkg/daemon/daemon.go` | Wire sweep through `dockerClient` |
| `pkg/docker/*_test.go` | Restart, failure cleanup, bind-source extraction tests |
| `integration-tests/run.sh` | Pre-apply bootstrap asset readiness poll |
| `scripts/install.sh` | Configurable curl retry (60×5s, 900s max) |
| `Terraform/templates/bootstrap.sh.tftpl` | Same curl retry hardening |

## Test plan

- [x] `go test ./pkg/docker/...` — ready socket lifecycle, sweep, create failure/restart paths
- [x] `go test ./pkg/daemon/...` — compiles with new sweep wiring
- [ ] Live integration: verify stopped Docker sandbox restarts and pushes readiness (UC follow-up)
- [ ] Live integration: confirm `wait_for_bootstrap_assets` unblocks after a fresh release publish

## Reviewer guide

1. Start with `readysock.go` — confirm `Close()` no longer calls `os.Remove` and comment explains why.
2. Read `client.go` `SweepOrphanReadySockets` + `readySocketBindSourcesFromInspect` — verify both `Binds` and `Mounts` are collected (Docker may surface the mount either way).
3. Check `Create` defer: `keepReadySocket = true` only after successful start; failure path must not leak sockets.
4. Skim `integration-tests/run.sh` `wait_for_bootstrap_assets` — defaults to `releases/latest/download` when tfvars omit URLs.


Made with [Cursor](https://cursor.com)