### PR TITLE
fix(docker): park ready-socket bind source after listener close

### DIFF
--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -584,6 +584,9 @@ func (c *Client) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 	if readyListener != nil {
 		readyListenerClosed = true
 		_ = readyListener.Close()
+		if err := readyListener.ParkBindSource(); err != nil {
+			c.logger.Warn("park ready socket bind source failed", "sandbox_id", sandboxID, "error", err)
+		}
 		readyListener = nil
 	}
 

--- a/pkg/docker/ready_create_test.go
+++ b/pkg/docker/ready_create_test.go
@@ -40,9 +40,19 @@ func fakeCreateDaemon(t *testing.T) *fakeDaemon {
 	}
 }
 
+func shortReadyDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "rd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
 func TestCreate_WiresReadySocketWhenEnabled(t *testing.T) {
 	requireLinuxUnix(t)
-	readyDir := t.TempDir()
+	readyDir := shortReadyDir(t)
 	var captured map[string]any
 	d := fakeCreateDaemon(t)
 	base := d.transport()
@@ -96,7 +106,7 @@ func TestCreate_WiresReadySocketWhenEnabled(t *testing.T) {
 
 func TestCreate_RetainsReadySocketBindSourceForRestart(t *testing.T) {
 	requireLinuxUnix(t)
-	readyDir := t.TempDir()
+	readyDir := shortReadyDir(t)
 	d := fakeCreateDaemon(t)
 	c := newCreateClient(t, d, true, func(c *Client) {
 		c.readyEnabled = true
@@ -121,7 +131,7 @@ func TestCreate_RetainsReadySocketBindSourceForRestart(t *testing.T) {
 
 func TestCreate_RemovesReadySocketOnStartFailure(t *testing.T) {
 	requireLinuxUnix(t)
-	readyDir := t.TempDir()
+	readyDir := shortReadyDir(t)
 	d := fakeCreateDaemon(t)
 	d.start = func() *http.Response { return textResponse(http.StatusInternalServerError, "boom") }
 	c := newCreateClient(t, d, true, func(c *Client) {

--- a/pkg/docker/readysock.go
+++ b/pkg/docker/readysock.go
@@ -29,7 +29,12 @@ const (
 	maxInvalidReadyAttempts = 16
 )
 
-var activeReadySockets sync.Map // path -> struct{}
+var (
+	activeReadySockets sync.Map // path -> struct{}
+	parkedReadySockets sync.Map // path -> net.Listener
+)
+
+const maxUnixSocketPathLen = 107 // sun_path includes trailing NUL on Linux.
 
 // validateReadySandboxID mirrors the daemon's sandbox ID charset because the
 // ID is embedded in a host filesystem path.
@@ -95,7 +100,10 @@ func NewReadyListener(dir, sandboxID, token, nonce string) (*ReadyListener, erro
 		return nil, fmt.Errorf("mkdir ready dir: %w", err)
 	}
 
-	hostPath := filepath.Join(dir, sandboxID+"."+nonce+".sock")
+	hostPath := readySocketHostPath(dir, sandboxID, nonce)
+	if len(hostPath) > maxUnixSocketPathLen {
+		return nil, fmt.Errorf("ready socket path exceeds %d bytes: %s", maxUnixSocketPathLen, hostPath)
+	}
 	if err := os.Remove(hostPath); err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("unlink stale ready socket: %w", err)
 	}
@@ -210,10 +218,9 @@ func (l *ReadyListener) readAndVerify(conn net.Conn) error {
 	return nil
 }
 
-// Close shuts down the listener but deliberately leaves the socket file in
-// place. Docker persists bind mounts across stop/start, so the host-side bind
-// source must remain present for the container lifetime. Destroy removes the
-// sandbox-keyed socket after the container is gone.
+// Close shuts down the readiness accept loop. The kernel unlinks the socket
+// path when the listener fd closes; call ParkBindSource afterward when Docker
+// must keep bind-mounting the path across stop/start.
 func (l *ReadyListener) Close() error {
 	if l == nil {
 		return nil
@@ -234,6 +241,43 @@ func (l *ReadyListener) Close() error {
 		l.listener = nil
 	}
 	return err
+}
+
+// ParkBindSource re-listens on the host path so the bind-mount source inode
+// survives listener shutdown. Docker validates bind sources on container start.
+func (l *ReadyListener) ParkBindSource() error {
+	if l == nil || strings.TrimSpace(l.hostPath) == "" {
+		return nil
+	}
+	if _, loaded := parkedReadySockets.Load(l.hostPath); loaded {
+		return nil
+	}
+	if err := os.Remove(l.hostPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("unlink stale ready socket before park: %w", err)
+	}
+	ln, err := net.Listen("unix", l.hostPath)
+	if err != nil {
+		return fmt.Errorf("park ready socket: %w", err)
+	}
+	if err := os.Chmod(l.hostPath, 0o666); err != nil {
+		_ = ln.Close()
+		_ = os.Remove(l.hostPath)
+		return fmt.Errorf("chmod parked ready socket: %w", err)
+	}
+	parkedReadySockets.Store(l.hostPath, ln)
+	return nil
+}
+
+func readySocketHostPath(dir, sandboxID, nonce string) string {
+	return filepath.Join(dir, sandboxID+"."+nonce+".sock")
+}
+
+func closeParkedReadySocket(path string) {
+	if v, ok := parkedReadySockets.LoadAndDelete(path); ok {
+		if ln, ok := v.(net.Listener); ok {
+			_ = ln.Close()
+		}
+	}
 }
 
 // EnsureReadyDir creates the sandboxd-owned ready-socket parent directory.
@@ -274,6 +318,9 @@ func SweepOrphanReadySocketsExcept(dir string, keep map[string]struct{}) error {
 		if _, active := activeReadySockets.Load(path); active {
 			continue
 		}
+		if _, parked := parkedReadySockets.Load(path); parked {
+			continue
+		}
 		if _, ok := keep[path]; ok {
 			continue
 		}
@@ -292,6 +339,7 @@ func RemoveReadySocketsForSandbox(dir, sandboxID string) {
 		if _, active := activeReadySockets.Load(path); active {
 			continue
 		}
+		closeParkedReadySocket(path)
 		_ = os.Remove(path)
 	}
 }

--- a/pkg/docker/readysock_test.go
+++ b/pkg/docker/readysock_test.go
@@ -97,7 +97,7 @@ func TestReadyListenerNeverConnectTimesOut(t *testing.T) {
 }
 
 func TestReadyListenerCloseLeavesBindSourceForDockerRestart(t *testing.T) {
-	dir := t.TempDir()
+	dir := shortReadyTestDir(t)
 	ln, err := NewReadyListener(dir, "sb", "tok", "n1")
 	if err != nil {
 		t.Fatal(err)
@@ -106,8 +106,11 @@ func TestReadyListenerCloseLeavesBindSourceForDockerRestart(t *testing.T) {
 	if err := ln.Close(); err != nil {
 		t.Fatalf("close: %v", err)
 	}
+	if err := ln.ParkBindSource(); err != nil {
+		t.Fatalf("park: %v", err)
+	}
 	if _, err := os.Stat(path); err != nil {
-		t.Fatalf("socket bind source missing after close: %v", err)
+		t.Fatalf("socket bind source missing after park: %v", err)
 	}
 	if err := ln.Close(); err != nil {
 		t.Fatalf("double close: %v", err)
@@ -116,6 +119,16 @@ func TestReadyListenerCloseLeavesBindSourceForDockerRestart(t *testing.T) {
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Fatalf("socket still present after sandbox cleanup: %v", err)
 	}
+}
+
+func shortReadyTestDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "rd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
 }
 
 func TestSweepOrphanReadySocketsSkipsActive(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Root cause:** On Linux, `listener.Close()` unlinks the unix socket path from the filesystem even without `os.Remove()`. PR #273 only stopped explicit removal, so CI tests and Docker restart bind mounts still lost the socket inode.
- **Fix:** After successful create readiness, call `ParkBindSource()` to re-`Listen` on the same path and hold the fd in `parkedReadySockets` until `Destroy` / `RemoveReadySocketsForSandbox`.
- **Test fix:** `t.TempDir()` paths for long test names exceeded the 108-byte `AF_UNIX` limit (`bind: invalid argument`). Tests now use `os.MkdirTemp("", "rd")`.

## Lifecycle (fixed)

```mermaid
sequenceDiagram
    participant S as sandboxd
    participant L as ReadyListener
    participant P as parkedReadySockets
    participant D as Docker

    S->>L: NewReadyListener + Wait READY
    S->>L: Close accept loop
    Note over L: kernel unlinks path
    S->>L: ParkBindSource
    L->>P: net.Listen same path, keep fd
    Note over P: bind source exists for docker start

    S->>D: destroy container
    S->>P: close parked fd + unlink path
```

## Sandbox boot impact

N/A beyond PR #273 — `ParkBindSource` runs once after toolbox readiness on successful create (same timing as the prior `Close()` call).

## Idempotency

N/A - no API surface changed.

## Failure-path consistency

N/A - no multi-step write path changed.

## L4 / host-port-pool changes

N/A - neither touched.

## Test plan

- [x] `go test ./pkg/docker/...` on Linux (Docker container)
- [x] `TestReadyListenerCloseLeavesBindSourceForDockerRestart`
- [x] `TestCreate_RetainsReadySocketBindSourceForRestart`
- [x] `TestCreate_RemovesReadySocketOnStartFailure`


Made with [Cursor](https://cursor.com)