### PR TITLE
fix(cluster): gate wasm to worker nodes and drop caddy on_demand rate_limit

### DIFF
--- a/integration-tests/lib/common.sh
+++ b/integration-tests/lib/common.sh
@@ -194,16 +194,24 @@ stage_wasm_modules() {
     return 1
   fi
 
-  # Resolve the per-node IP set: domain scenarios stage every node so a sandbox
-  # can be placed anywhere; IP/local scenarios have only the seed.
+  # Resolve the per-node IP set. Domain scenarios only stage worker-capable
+  # nodes: pure ingress/server roles do not own sandboxes, and restarting them
+  # for module staging can destabilize health/gossip during bootstrap.
   local ips=()
   if [[ "$caps_domain" == "true" ]]; then
     while IFS= read -r ip; do [[ -n "$ip" ]] && ips+=("$ip"); done \
-      < <(echo "$targets" | jq -r '.nodes[].public_ip')
+      < <(echo "$targets" | jq -r '
+        .nodes[]
+        | select(
+            ((.role // "mixed") | ascii_downcase | split(",") | map(gsub("^\\s+|\\s+$"; ""))) as $roles
+            | ($roles | any(. == "worker" or . == "mixed"))
+          )
+        | .public_ip
+      ')
   else
     ips+=("$(echo "$targets" | jq -r '.seed_ip')")
   fi
-  [[ "${#ips[@]}" -gt 0 ]] || { echo "stage_wasm: no node IPs in targets" >&2; return 1; }
+  [[ "${#ips[@]}" -gt 0 ]] || { echo "stage_wasm: no worker-capable node IPs in targets" >&2; return 1; }
 
   local n
   n=$(yq -r '.standard_modules | length' "${fxdir}/modules.yml")

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -305,20 +305,14 @@ run_one() {
   # wasm.enabled follows the scenario's wasm capability so the wasm worker can
   # actually run modules (the wasm-runtime UCs still gate on a staged module
   # ref via AEROL_WASM_MODULE_REF; this just turns the runtime on).
-  # When wasm runs we also turn on the warm-worker pool so creates skip the cold
-  # module compile (CPython-on-wasm is ~10s cold on a t3). depth_default is per
-  # module digest. Benchmark provisions size the default to the serial sample
-  # count so `make integration-benchmark keep` measures warm creates without an
-  # extra operator override; non-benchmark wasm scenarios keep the shallow pool.
+  # When wasm runs we also turn on a shallow warm-worker pool so creates can
+  # skip cold module compile without overloading small cluster nodes. The depth
+  # is per module digest; raising it to the benchmark sample count multiplies
+  # across every staged language runtime and can prevent the cluster from
+  # reaching readiness. Operators can still override with AEROL_WASM_POOL_DEPTH.
   local wasm_pool_enabled="false" wasm_pool_depth=0
   if [[ "$caps_wasm" == "true" ]]; then
     local wasm_pool_default_depth=2
-    if [[ "${AEROL_BENCH:-}" == "1" ]]; then
-      local bench_samples="${AEROL_BENCH_SAMPLES:-10}"
-      if [[ "$bench_samples" =~ ^[0-9]+$ && "$bench_samples" -gt 0 ]]; then
-        wasm_pool_default_depth="$bench_samples"
-      fi
-    fi
     wasm_pool_enabled="true"
     wasm_pool_depth="${AEROL_WASM_POOL_DEPTH:-$wasm_pool_default_depth}"
   fi

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -156,13 +156,12 @@ type Config struct {
 	// CustomDomainVerifyValuePrefix sets the required prefix value for
 	// the TXT record, followed by the sandbox ID. Defaults to "aerol-verify=".
 	CustomDomainVerifyValuePrefix string
-	// TLSOnDemandBurst is the Caddy on-demand TLS policy's per-interval
-	// burst (matches the JSON shape `rate_limit.burst`). Bounds simultaneous
-	// ACME orders Caddy will start before throttling. Default 5; the
-	// daemon-wide ACME budget (acme_budget.go) is the second layer.
+	// TLSOnDemandBurst is the daemon-side on-demand TLS issuance budget burst.
+	// It is enforced by the TLS ask handler before Caddy starts an ACME order.
+	// Default 5.
 	TLSOnDemandBurst int
-	// TLSOnDemandInterval is the Caddy on-demand TLS policy's refill
-	// interval (`rate_limit.interval`). Default 1m.
+	// TLSOnDemandInterval is the daemon-side on-demand TLS issuance budget
+	// refill interval. Default 1m.
 	TLSOnDemandInterval time.Duration
 	// ACMEDaemonBudgetFraction is the high-water mark on the daemon-wide
 	// ACME issuance bucket — when usage crosses this fraction of Let's

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -3212,14 +3212,18 @@ func (s *Service) Health(ctx context.Context) (models.HealthStatus, error) {
 
 	wasmStatus := "disabled"
 	if s.cfg.EnableWasm {
-		switch rt := s.wasm.(type) {
-		case nil:
-			wasmStatus = fmt.Sprintf("runtime %q: driver not registered", models.RuntimeWasm)
-		default:
-			if err := rt.Ping(ctx); err != nil {
-				wasmStatus = err.Error()
-			} else {
-				wasmStatus = "ok"
+		if !s.cfg.IsWorker() {
+			wasmStatus = "skipped on non-worker node"
+		} else {
+			switch rt := s.wasm.(type) {
+			case nil:
+				wasmStatus = fmt.Sprintf("runtime %q: driver not registered", models.RuntimeWasm)
+			default:
+				if err := rt.Ping(ctx); err != nil {
+					wasmStatus = err.Error()
+				} else {
+					wasmStatus = "ok"
+				}
 			}
 		}
 	}
@@ -3231,7 +3235,7 @@ func (s *Service) Health(ctx context.Context) (models.HealthStatus, error) {
 	if s.cfg.EnableFirecracker && firecrackerStatus != "ok" {
 		status = "degraded"
 	}
-	if s.cfg.EnableWasm && wasmStatus != "ok" {
+	if s.cfg.EnableWasm && s.cfg.IsWorker() && wasmStatus != "ok" {
 		status = "degraded"
 	}
 	// SSH gateway being down only degrades health when it's expected to be up.

--- a/internal/service/service_runtime_flow_test.go
+++ b/internal/service/service_runtime_flow_test.go
@@ -389,6 +389,21 @@ func TestHealthReportsFirecrackerCapabilityDegraded(t *testing.T) {
 	}
 }
 
+func TestHealthSkipsWasmProbeOnNonWorkerRole(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := newServiceRuntimeHarness(t, &recordingRuntime{})
+	svc.cfg.EnableWasm = true
+	svc.cfg.NodeRole = config.NodeRoleIngress
+
+	health, err := svc.Health(ctx)
+	if err != nil {
+		t.Fatalf("Health() error = %v", err)
+	}
+	if health.Status != "ok" || health.Wasm != "skipped on non-worker node" {
+		t.Fatalf("health = %+v, want ok with skipped wasm probe", health)
+	}
+}
+
 func TestStartSandboxReleasesAdmissionWhenMountLoadFails(t *testing.T) {
 	ctx := context.Background()
 	rt := &recordingRuntime{}

--- a/internal/service/testfixtures/caddyfx/config.json.tmpl
+++ b/internal/service/testfixtures/caddyfx/config.json.tmpl
@@ -32,7 +32,6 @@
       "automation": {
         "policies": [],
         "on_demand": {
-          "rate_limit": {"interval": "5s", "burst": 5},
           "ask": "http://placeholder/internal/tls-ask"
         }
       }

--- a/pkg/caddy/client.go
+++ b/pkg/caddy/client.go
@@ -787,9 +787,10 @@ func IngressCustomDomainHTTPRouteID(sandboxID, hostname string) string {
 // at those paths only, leaving any pre-existing wildcard policy and other
 // automation knobs untouched.
 //
-//   - PUT /config/apps/tls/automation/on_demand → rate limit + ask URL.
-//     Replacing the leaf on every boot makes config-driven changes to
-//     SB_TLS_ON_DEMAND_* take effect without a manual Caddy reload.
+//   - PUT /config/apps/tls/automation/on_demand → ask URL. Replacing the leaf on
+//     every boot makes handler URL changes take effect without a manual Caddy
+//     reload. The daemon-side ACME budget performs issuance throttling; the
+//     deployed Caddy schema rejects the older `rate_limit` field here.
 //   - POST /config/apps/tls/automation/policies (with a catch-all policy
 //     {on_demand: true, issuers: [acme]}) only when no on-demand policy is
 //     present yet. Discovered by checking pathExists on automation/policies
@@ -815,13 +816,7 @@ func (c *Client) EnsureOnDemandTLS(ctx context.Context, askURL string, burst int
 		return errors.New("burst and interval must be > 0")
 	}
 
-	onDemand := map[string]any{
-		"rate_limit": map[string]any{
-			"interval": interval.String(),
-			"burst":    burst,
-		},
-		"ask": askURL,
-	}
+	onDemand := map[string]any{"ask": askURL}
 	onDemandBody, err := json.Marshal(onDemand)
 	if err != nil {
 		return fmt.Errorf("marshal on-demand block: %w", err)

--- a/pkg/caddy/custom_domains_test.go
+++ b/pkg/caddy/custom_domains_test.go
@@ -179,12 +179,8 @@ func TestEnsureOnDemandTLS_FreshCaddy(t *testing.T) {
 	if got := srv.onDemand["ask"]; got != "http://127.0.0.1:21213/internal/tls-ask" {
 		t.Fatalf("ask = %v", got)
 	}
-	rl, _ := srv.onDemand["rate_limit"].(map[string]any)
-	if rl["burst"].(float64) != 5 {
-		t.Fatalf("burst = %v", rl["burst"])
-	}
-	if rl["interval"] != "1m0s" {
-		t.Fatalf("interval = %v", rl["interval"])
+	if _, ok := srv.onDemand["rate_limit"]; ok {
+		t.Fatalf("rate_limit must not be written; deployed Caddy rejects that field: %v", srv.onDemand)
 	}
 
 	// Catch-all policy appended.
@@ -203,7 +199,7 @@ func TestEnsureOnDemandTLS_Idempotent(t *testing.T) {
 	defer srv.Close()
 	client := &Client{enabled: true, baseURL: srv.URL, httpClient: srv.Client}
 
-	if err := client.EnsureOnDemandTLS(context.Background(), "http://x/ask", 3, 2*time.Minute); err != nil {
+	if err := client.EnsureOnDemandTLS(context.Background(), "http://x/ask-old", 3, 2*time.Minute); err != nil {
 		t.Fatalf("first call error = %v", err)
 	}
 	if err := client.EnsureOnDemandTLS(context.Background(), "http://x/ask", 7, 30*time.Second); err != nil {
@@ -212,9 +208,8 @@ func TestEnsureOnDemandTLS_Idempotent(t *testing.T) {
 	if len(srv.policies) != 1 {
 		t.Fatalf("policy duplicated on second call: %d", len(srv.policies))
 	}
-	rl := srv.onDemand["rate_limit"].(map[string]any)
-	if rl["burst"].(float64) != 7 {
-		t.Fatalf("second call did not replace on_demand leaf: %v", rl)
+	if got := srv.onDemand["ask"]; got != "http://x/ask" {
+		t.Fatalf("second call did not replace on_demand leaf: %v", srv.onDemand)
 	}
 }
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -420,7 +420,7 @@ func Run(ctx context.Context, logger *slog.Logger, makeProvider ProviderFactory)
 		}
 	}
 
-	if cfg.EnableWasm {
+	if cfg.EnableWasm && cfg.IsWorker() {
 		wasmPool := wireWasmRuntime(ctx, cfg, logger, svc, db)
 		if wasmPool != nil {
 			defer func() {
@@ -429,6 +429,8 @@ func Run(ctx context.Context, logger *slog.Logger, makeProvider ProviderFactory)
 				}
 			}()
 		}
+	} else if cfg.EnableWasm {
+		logger.Info("wasm runtime skipped on non-worker node", "node_role", cfg.NodeRole)
 	}
 
 	// Cluster startup. Server-role nodes host Raft/FSM. Worker/ingress-only
@@ -483,7 +485,7 @@ func Run(ctx context.Context, logger *slog.Logger, makeProvider ProviderFactory)
 				})
 			}
 		}
-		if cfg.EnableWasm {
+		if cfg.EnableWasm && cfg.IsWorker() {
 			if withModules, ok := clusterClient.(interface {
 				SetLocalWasmModuleIDsProvider(func() ([]string, bool))
 			}); ok {
@@ -809,8 +811,7 @@ func Run(ctx context.Context, logger *slog.Logger, makeProvider ProviderFactory)
 				logger.Warn("failed to install caddy on-demand TLS policy; will retry on next reconcile",
 					"error", err, "ask_url", askURL)
 			} else {
-				logger.Info("caddy on-demand TLS policy installed",
-					"ask_url", askURL, "burst", cfg.TLSOnDemandBurst, "interval", cfg.TLSOnDemandInterval)
+				logger.Info("caddy on-demand TLS policy installed", "ask_url", askURL)
 			}
 		}
 		ingressServer = &http.Server{
@@ -844,7 +845,7 @@ func Run(ctx context.Context, logger *slog.Logger, makeProvider ProviderFactory)
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), cfg.ShutdownTimeout)
 	defer shutdownCancel()
-	if cfg.EnableWasm {
+	if cfg.EnableWasm && cfg.IsWorker() {
 		if err := svc.DrainWasmSandboxes(shutdownCtx); err != nil {
 			logger.Warn("wasm drain checkpoint failed", "error", err)
 		}
@@ -1439,7 +1440,7 @@ func supportedRuntimesForConfig(cfg config.Config) []string {
 	if cfg.EnableFirecracker {
 		runtimes = appendRuntimeIfMissing(runtimes, models.RuntimeFirecracker)
 	}
-	if cfg.EnableWasm {
+	if cfg.EnableWasm && cfg.IsWorker() {
 		runtimes = appendRuntimeIfMissing(runtimes, models.RuntimeWasm)
 	}
 	return runtimes

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -157,6 +157,9 @@ func TestSupportedRuntimesForConfig(t *testing.T) {
 	}{
 		{name: "docker_only_default", cfg: config.Config{}, want: []string{models.RuntimeDocker}},
 		{name: "wasm_enabled_advertises_wasm", cfg: config.Config{EnableWasm: true}, want: []string{models.RuntimeDocker, models.RuntimeWasm}},
+		{name: "wasm_enabled_worker_advertises_wasm", cfg: config.Config{EnableWasm: true, NodeRole: config.NodeRoleWorker}, want: []string{models.RuntimeDocker, models.RuntimeWasm}},
+		{name: "wasm_enabled_ingress_does_not_advertise_wasm", cfg: config.Config{EnableWasm: true, NodeRole: config.NodeRoleIngress}, want: []string{models.RuntimeDocker}},
+		{name: "wasm_enabled_server_does_not_advertise_wasm", cfg: config.Config{EnableWasm: true, NodeRole: config.NodeRoleServer}, want: []string{models.RuntimeDocker}},
 		{name: "firecracker_enabled_advertises_fc", cfg: config.Config{EnableFirecracker: true}, want: []string{models.RuntimeDocker, models.RuntimeFirecracker}},
 		{name: "both_enabled", cfg: config.Config{EnableFirecracker: true, EnableWasm: true}, want: []string{models.RuntimeDocker, models.RuntimeFirecracker, models.RuntimeWasm}},
 		{name: "explicit_host_runtimes_override", cfg: config.Config{HostSupportedRuntimes: []string{models.RuntimeGvisor}, EnableWasm: true}, want: []string{models.RuntimeGvisor, models.RuntimeWasm}},


### PR DESCRIPTION
## Summary

- **WASM on worker nodes only:** Ingress and server roles no longer wire the WASM runtime pool, advertise WASM in supported runtimes, probe WASM in `/health`, or register cluster module IDs. Pure ingress/server nodes stay healthy during hetero cluster bootstrap.
- **Caddy on-demand TLS:** `EnsureOnDemandTLS` writes only the `ask` URL — deployed Caddy rejects the legacy `rate_limit` field under `automation.on_demand`. Issuance throttling remains in the daemon-side ACME budget (`TLSOnDemandBurst` / `TLSOnDemandInterval`).
- **Integration hardening:** WASM modules stage only on worker-capable nodes (not ingress-only). Default warm pool depth stays at 2 instead of scaling to benchmark sample count, which overloaded small cluster nodes.

## Architecture

### Node-role WASM gating

```mermaid
flowchart TD
    A[daemon Run] --> B{EnableWasm?}
    B -->|no| Z[skip wasm entirely]
    B -->|yes| C{cfg.IsWorker?}
    C -->|yes| D[wireWasmRuntime + warm pool]
    C -->|no| E[log skipped on non-worker]
    D --> F[advertise wasm in supportedRuntimes]
    D --> G[register cluster wasm module IDs]
    E --> H[health: wasm skipped on non-worker node]
    E --> I[no wasm in supportedRuntimes]
```

### On-demand TLS config split

```mermaid
flowchart LR
    subgraph daemon [sandboxd]
        A[TLS ask handler] --> B[ACME budget burst + interval]
    end
    subgraph caddy [Caddy automation]
        C[on_demand.ask URL only]
        D[policies with on_demand true]
    end
    B -->|throttle before order| A
    A -->|allow/deny| C
    C --> D
```

### Integration WASM staging (domain scenarios)

```mermaid
flowchart TD
    A[stage_wasm_modules] --> B{caps_domain?}
    B -->|no| C[stage on seed_ip only]
    B -->|yes| D[filter targets.nodes]
    D --> E{role contains worker or mixed?}
    E -->|yes| F[scp modules to node]
    E -->|no| G[skip ingress and server-only nodes]
    F --> H[restart sandboxd on workers only]
```

## Sandbox boot impact

N/A on ingress/server nodes — WASM pool wiring is skipped, reducing boot work on nodes that never run sandboxes. Worker/mixed nodes unchanged.

## Idempotency

N/A - no sandbox API surface changed. `EnsureOnDemandTLS` remains idempotent (re-PUTs `on_demand` leaf with updated `ask` URL).

## Failure-path consistency

N/A - no multi-step caddy + store write path changed.

## L4 / host-port-pool changes

N/A - neither touched.

## Cluster correctness

Ingress/server nodes no longer report `degraded` health due to WASM ping failures they were never meant to serve. Supported-runtime advertisement matches actual placement capability, avoiding WASM creates routed to ingress-only nodes.

## Files changed

| File | Change |
|------|--------|
| `pkg/daemon/daemon.go` | Gate `wireWasmRuntime`, drain, cluster module provider, `supportedRuntimesForConfig` on `IsWorker()` |
| `internal/service/service.go` | Skip WASM health probe on non-worker; don't degrade for skipped probe |
| `pkg/caddy/client.go` | Drop `rate_limit` from `on_demand` PUT body |
| `internal/config/config.go` | Clarify TLS burst/interval are daemon-side |
| `integration-tests/lib/common.sh` | Stage WASM modules on worker-capable nodes only |
| `integration-tests/run.sh` | Shallow WASM pool default (depth 2); remove bench auto-scale |
| `*_test.go` | Health skip, caddy on-demand, supported runtimes regressions |

## Test plan

- [x] `TestHealthSkipsWasmProbeOnNonWorkerRole`
- [x] `TestSupportedRuntimesForConfig` ingress/server cases
- [x] `TestEnsureOnDemandTLS_FreshCaddy` / `Idempotent` — no `rate_limit` written
- [ ] Live `cluster-hetero` integration — ingress nodes reach healthy during bootstrap

## Reviewer guide

1. **`pkg/daemon/daemon.go`** — confirm every `EnableWasm` path that touches runtime/pool/drain also checks `IsWorker()`.
2. **`internal/service/service.go`** — health must stay `ok` on ingress when WASM is enabled cluster-wide but this node is ingress-only.
3. **`pkg/caddy/client.go`** — `burst`/`interval` params are now unused for Caddy writes; budget still enforced in TLS ask handler (verify separately if needed).
4. **`integration-tests/lib/common.sh`** — jq role filter matches `config.IsWorker()` semantics (`worker`, `mixed`, and comma-separated combos).


Made with [Cursor](https://cursor.com)