### PR TITLE
fix(cluster): repair L4 TLS mux fallback and harden integration harness

### DIFF
--- a/Terraform/nodes.tf
+++ b/Terraform/nodes.tf
@@ -372,8 +372,12 @@ resource "aws_instance" "joiner" {
     each.value.tags,
   )
 
+  # Joiners bootstrap against the seed private IP. If the seed is replaced, the
+  # joiners need a planned replacement too instead of a provider-discovered
+  # user_data replacement during apply.
   lifecycle {
-    ignore_changes = [ami]
+    ignore_changes       = [ami]
+    replace_triggered_by = [aws_instance.seed]
   }
 }
 

--- a/integration-tests/lib/common.sh
+++ b/integration-tests/lib/common.sh
@@ -306,16 +306,18 @@ wait_for_tls() {
 wait_for_members() {
   local base="$1" pat="$2" expected="$3" timeout="${4:-300}"
   local deadline=$(( $(date +%s) + timeout ))
+  local last=0
   while (( $(date +%s) < deadline )); do
     local n
-    n=$(curl -s -H "Authorization: Bearer ${pat}" "${base}/v1/cluster/members" \
-      | jq 'length' 2>/dev/null || echo 0)
+    n=$(curl -sS --max-time 10 -H "Authorization: Bearer ${pat}" "${base}/v1/cluster/members" 2>/dev/null \
+      | jq -r 'if type == "array" then length else (.members // [] | length) end' 2>/dev/null || echo 0)
+    last="$n"
     if [[ "$n" == "$expected" ]]; then
       echo "cluster: ${n} members"
       return 0
     fi
     sleep 5
   done
-  echo "cluster: expected ${expected} members, never reached" >&2
+  echo "cluster: expected ${expected} members, never reached (last ${last})" >&2
   return 1
 }

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -106,12 +106,15 @@ teardown() {
   fi
   echo "teardown: destroying ${scenario}"
   # shellcheck disable=SC2046
-  TF_DATA_DIR="${REPO_ROOT}/integration-tests/.tf/${scenario}" \
+  if TF_DATA_DIR="${REPO_ROOT}/integration-tests/.tf/${scenario}" \
     terraform -chdir="${REPO_ROOT}/Terraform" destroy -auto-approve -input=false \
     $(tf_varfile_args "$scenario") \
     -var="config_dir=${REPO_ROOT}/integration-tests/.tf/${scenario}/config" \
-    -var="force_on_demand=$(on_demand_tfvar)" || \
+    -var="force_on_demand=$(on_demand_tfvar)"; then
+    rm -f "${REPO_ROOT}/integration-tests/.tf/${scenario}/.leased-domain"
+  else
     echo "teardown: destroy returned non-zero for ${scenario} — run 'make integration-reap'" >&2
+  fi
 }
 
 if [[ "$DESTROY_ONLY" == "1" ]]; then
@@ -121,15 +124,12 @@ if [[ "$DESTROY_ONLY" == "1" ]]; then
   exit 0
 fi
 
-# lease_domain picks a RANDOM test domain from the pool, never repeating the
-# previous run's pick. Reusing one name re-requests the same cert set and trips
-# Let's Encrypt's duplicate-certificate limit (5 identical sets/week); random
-# selection spreads runs across the pool so each gets a fresh quota, and the
-# "exclude last" rule guarantees we never hit the same FQDN twice in a row (the
-# one case that actually accumulates against the duplicate limit). The persisted
-# lease file under .tf/ (gitignored) only remembers the last index for that
-# exclusion. With a single-domain pool there's nothing to rotate to, so it
-# degrades to always returning that one.
+# lease_domain picks a RANDOM test domain from the pool for fresh runs, never
+# repeating the previous fresh pick. Reusing one name re-requests the same cert
+# set and trips Let's Encrypt's duplicate-certificate limit (5 identical
+# sets/week); random selection spreads fresh infra across the pool. Kept runs
+# must not rotate, though: changing the domain of an existing cluster rewrites
+# DNS, Caddy, and bootstrap user-data and can leave the kept state half-mutated.
 lease_domain() {
   local n last idx
   local lease_file="${REPO_ROOT}/integration-tests/.tf/.domain-lease"
@@ -147,6 +147,65 @@ lease_domain() {
   mkdir -p "$(dirname "$lease_file")"
   echo "$idx" > "$lease_file"
   yq -r ".itest.domains[$idx]" "$DOMAINS_FILE"
+}
+
+terraform_state_domain() {
+  local scenario="$1" sdir domain
+  sdir="${REPO_ROOT}/integration-tests/.tf/${scenario}"
+  [[ -d "$sdir" ]] || return 1
+  domain=$(TF_DATA_DIR="$sdir" terraform -chdir="${REPO_ROOT}/Terraform" \
+    output -json integration_targets 2>/dev/null | jq -r '.domain // empty' 2>/dev/null) || return 1
+  [[ -n "$domain" && "$domain" != "null" ]] || return 1
+  echo "$domain"
+}
+
+scenario_overlay_domain() {
+  local scenario="$1" file domain
+  file="${REPO_ROOT}/integration-tests/.tf/${scenario}/config/cluster.yml"
+  [[ -f "$file" ]] || return 1
+  domain=$(yq -r '.ingress.domain_name // ""' "$file" 2>/dev/null) || return 1
+  [[ -n "$domain" && "$domain" != "null" ]] || return 1
+  echo "$domain"
+}
+
+lease_domain_for_scenario() {
+  local scenario="$1" sdir pin domain state_domain overlay_domain
+  sdir="${REPO_ROOT}/integration-tests/.tf/${scenario}"
+  pin="${sdir}/.leased-domain"
+
+  if [[ "$KEEP" == "1" ]]; then
+    if [[ -s "$pin" ]]; then
+      domain=$(tr -d '[:space:]' < "$pin")
+      if [[ -n "$domain" ]]; then
+        echo "$domain"
+        return 0
+      fi
+    fi
+    state_domain=$(terraform_state_domain "$scenario" || true)
+    overlay_domain=$(scenario_overlay_domain "$scenario" || true)
+    if [[ -n "$state_domain" && -n "$overlay_domain" && "$state_domain" != "$overlay_domain" ]]; then
+      echo "scenario ${scenario}: kept domain mismatch: terraform output=${state_domain}, generated config=${overlay_domain}" >&2
+      echo "scenario ${scenario}: previous --keep apply likely stopped mid-domain rotation; refusing to pick one automatically" >&2
+      return 1
+    fi
+    if [[ -n "$state_domain" ]]; then
+      mkdir -p "$sdir"
+      printf '%s\n' "$state_domain" > "$pin"
+      echo "$state_domain"
+      return 0
+    fi
+    if [[ -n "$overlay_domain" ]]; then
+      mkdir -p "$sdir"
+      printf '%s\n' "$overlay_domain" > "$pin"
+      echo "$overlay_domain"
+      return 0
+    fi
+  fi
+
+  domain=$(lease_domain)
+  mkdir -p "$sdir"
+  printf '%s\n' "$domain" > "$pin"
+  echo "$domain"
 }
 
 # allow_disruptive_for decides AEROL_ALLOW_DISRUPTIVE for the suite. cluster-hetero
@@ -289,7 +348,7 @@ run_one() {
   caps_cluster=$(yq -r '.capabilities | contains(["cluster"])' "$caps_file")
   caps_platform_volumes=$(yq -r '.capabilities | contains(["platform-volumes"])' "$caps_file")
   if [[ "$caps_domain" == "true" ]]; then
-    leased=$(lease_domain)
+    leased=$(lease_domain_for_scenario "$scenario")
   else
     leased="" # local-mode: no domain
   fi
@@ -448,6 +507,9 @@ run_one() {
   # AEROL_EXPECTED_MEMBERS so the cluster UCs assert an exact node count.
   local expected_members
   expected_members=$(yq -r '.expected_members // ""' "$caps_file")
+  if [[ "$inconclusive" != "1" && "$caps_cluster" == "true" && -n "$expected_members" ]]; then
+    wait_for_members "$base_url" "$pat" "$expected_members" || inconclusive=1
+  fi
 
   # For wasm-capable scenarios the runtime UC references a staged standard
   # module by alias; default to python (override by exporting the env var).
@@ -662,6 +724,9 @@ run_bench_only() {
   if ! wait_for_health "$base_url" "$pat"; then
     echo "scenario ${scenario}: API not healthy at ${base_url}" >&2
     exit 2
+  fi
+  if [[ -n "$expected_members" ]]; then
+    wait_for_members "$base_url" "$pat" "$expected_members" || exit 2
   fi
 
   set +e

--- a/integration-tests/suite/benchmark_test.go
+++ b/integration-tests/suite/benchmark_test.go
@@ -48,6 +48,7 @@ var benchRuntimes = []struct {
 
 type benchRuntimeSpec struct {
 	runtime    string
+	image      string
 	wasmRef    string
 	templateID string
 }
@@ -124,10 +125,12 @@ func benchCreateOptions(t *testing.T, spec benchRuntimeSpec) sdktypes.CreateSand
 		opts.Image = spec.wasmRef
 		opts.ModuleRef = spec.wasmRef
 	case "firecracker":
+		opts.Image = spec.image
+		if opts.Image == "" {
+			opts.Image = harness.DefaultImage
+		}
 		if spec.templateID != "" {
 			opts.TemplateID = spec.templateID
-		} else {
-			opts.Image = harness.DefaultImage
 		}
 	default:
 		opts.Image = harness.DefaultImage
@@ -272,17 +275,23 @@ func prepareBenchmarkRuntimes(t *testing.T, c *harness.Client, runtimes []benchR
 	prepared := append([]benchRuntimeSpec(nil), runtimes...)
 	for i := range prepared {
 		if prepared[i].runtime == "firecracker" {
-			prepared[i].templateID = createBenchmarkFirecrackerTemplate(t, c)
+			templateID, image := createBenchmarkFirecrackerTemplate(t, c)
+			prepared[i].templateID = templateID
+			prepared[i].image = image
 		}
 	}
 	return prepared
 }
 
-func createBenchmarkFirecrackerTemplate(t *testing.T, c *harness.Client) string {
+func createBenchmarkFirecrackerTemplate(t *testing.T, c *harness.Client) (string, string) {
 	t.Helper()
 	image := strings.TrimSpace(os.Getenv("AEROL_BENCH_FC_TEMPLATE_IMAGE"))
 	if image == "" {
 		image = "docker://" + harness.DefaultImage
+	}
+	createImage := strings.TrimPrefix(image, "docker://")
+	if createImage == "" {
+		createImage = harness.DefaultImage
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 18*time.Minute)
 	tmpl, err := c.SDK().CreateTemplate(ctx, sdktypes.CreateTemplateOptions{Image: image})
@@ -298,7 +307,7 @@ func createBenchmarkFirecrackerTemplate(t *testing.T, c *harness.Client) string 
 	t.Logf("bench[firecracker] waiting for template %s (%s)", tmpl.ID, image)
 	waitTemplateReady(t, c, tmpl.ID)
 	t.Logf("bench[firecracker] template %s ready; measuring snapshot clones", tmpl.ID)
-	return tmpl.ID
+	return tmpl.ID, createImage
 }
 
 // percentile returns the p-th percentile (0..100) of durs using nearest-rank.

--- a/internal/service/ingress_scale_test.go
+++ b/internal/service/ingress_scale_test.go
@@ -157,8 +157,9 @@ func TestRunIngressOpsAt10KCompletesAll(t *testing.T) {
 // small artificial delay forces concurrent ops to actually overlap so the
 // runIngressOps concurrency cap is observable instead of vacuously true on
 // a fast loopback. The handler accepts whatever shape the reconciler sends
-// (PATCH /id/*, DELETE /id/*, PUT /config/.../routes/0, PUT/DELETE
-// /config/apps/layer4/servers/*) so a real caddy.Client can drive it.
+// (PATCH /id/*, DELETE /id/*, PUT /config/.../routes/0, the L4 app probe,
+// and PUT/DELETE /config/apps/layer4/servers/*) so a real caddy.Client can
+// drive it.
 type countingCaddyFake struct {
 	mu              sync.Mutex
 	totalCalls      int64
@@ -201,6 +202,9 @@ func (f *countingCaddyFake) handler() http.Handler {
 			// empty config has none.
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"apps":{"http":{"servers":{"srv0":{"routes":[]}}},"layer4":{"servers":{"tls-mux":{"listen":[":443"],"routes":[]}}}}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/config/apps/layer4":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"servers":{}}`))
 		case r.Method == http.MethodPatch && len(r.URL.Path) > len("/id/") && r.URL.Path[:4] == "/id/":
 			id := r.URL.Path[4:]
 			f.mu.Lock()
@@ -286,12 +290,6 @@ func TestReconcileClusterIngressFailoverStormBoundedBurst(t *testing.T) {
 		store:  st,
 		caddy:  caddyClient,
 	}
-	// Skip the caddy-l4 bootstrap path — this test exercises the per-tick
-	// ingress write loop, not the L4 app handshake (covered in
-	// layer4_bootstrap_test.go). Without this the first reconcile would
-	// 400 on GET /config/apps/layer4 which our minimal fake doesn't model.
-	svc.l4Ready.Store(true)
-
 	// Healthy: 50 placements owned by node-A; we're "self" (router/peer).
 	// Each carries one HTTP port and one TCP port, matching makeScalePlacements
 	// shape so the per-port ingress branches all get exercised.

--- a/internal/service/layer4_bootstrap_test.go
+++ b/internal/service/layer4_bootstrap_test.go
@@ -116,3 +116,57 @@ func TestEnsureLayer4ReadyDisabledCaddyLatchesImmediately(t *testing.T) {
 		t.Fatal("disabled caddy still latches ready (no work to redo)")
 	}
 }
+
+func TestRepairLayer4ReadyBypassesSuccessLatch(t *testing.T) {
+	var repairPosts atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/config/apps/layer4", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method %s on %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"servers":{}}`)
+	})
+	mux.HandleFunc("/config/apps/layer4/servers/tls-mux", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"listen":[":443"],"routes":[{"@id":"sandbox-abc-ingress-sni","match":[{"tls":{"sni":["abc.sandbox.example.com"]}}],"handle":[{"handler":"proxy","upstreams":[{"dial":["10.0.0.9:443"]}]}]}]}`)
+		case http.MethodPost:
+			repairPosts.Add(1)
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Fatalf("unexpected method %s on %s", r.Method, r.URL.Path)
+		}
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	caddyClient := caddy.New(config.Config{
+		CaddyAdminURL:     server.URL,
+		EnableCaddy:       true,
+		HTTPClientTimeout: time.Second,
+		L4TLSListen:       ":443",
+		L4TLSFallback:     "127.0.0.1:8443",
+	})
+	svc := &Service{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		caddy:  caddyClient,
+		cfg: config.Config{
+			L4TLSListen:   ":443",
+			L4TLSFallback: "127.0.0.1:8443",
+		},
+	}
+	svc.l4Ready.Store(true)
+
+	if err := svc.RepairLayer4Ready(context.Background()); err != nil {
+		t.Fatalf("RepairLayer4Ready: %v", err)
+	}
+	if got := repairPosts.Load(); got != 1 {
+		t.Fatalf("repair posts = %d, want 1", got)
+	}
+	if !svc.l4Ready.Load() {
+		t.Fatal("repair should keep the ready latch true after success")
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -2534,12 +2534,20 @@ func (s *Service) exposePort(ctx context.Context, id string, port int, protocol 
 // expose call instead of surfacing as a confusing "layer4 app missing"
 // error from caddy.
 func (s *Service) EnsureLayer4Ready(ctx context.Context) error {
-	if s.l4Ready.Load() {
+	return s.ensureLayer4Ready(ctx, false)
+}
+
+func (s *Service) RepairLayer4Ready(ctx context.Context) error {
+	return s.ensureLayer4Ready(ctx, true)
+}
+
+func (s *Service) ensureLayer4Ready(ctx context.Context, force bool) error {
+	if !force && s.l4Ready.Load() {
 		return nil
 	}
 	s.l4Mu.Lock()
 	defer s.l4Mu.Unlock()
-	if s.l4Ready.Load() {
+	if !force && s.l4Ready.Load() {
 		return nil
 	}
 	if err := s.caddy.EnsureLayer4(ctx, s.cfg.L4TLSListen, s.cfg.L4TLSFallback); err != nil {
@@ -4502,7 +4510,7 @@ func (s *Service) ReconcileClusterIngress(ctx context.Context) error {
 	var firstErr error
 	desired, needL4 := s.buildClusterIngressIntents(placements, self)
 	if needL4 {
-		if err := s.EnsureLayer4Ready(ctx); err != nil {
+		if err := s.RepairLayer4Ready(ctx); err != nil {
 			return err
 		}
 	}

--- a/pkg/caddy/client.go
+++ b/pkg/caddy/client.go
@@ -946,41 +946,100 @@ func (c *Client) EnsureLayer4(ctx context.Context, tlsListen, tlsFallback string
 		return nil
 	}
 	muxPath := fmt.Sprintf("/config/apps/layer4/servers/%s", tlsMuxServerID)
-	exists, err = c.pathExists(ctx, muxPath)
+	server, exists, err := c.getConfigMap(ctx, muxPath)
 	if err != nil {
 		return err
 	}
-	if exists {
-		return nil
+	needsPut := true
+	if !exists {
+		server = newTLSMuxServer(tlsListen, tlsFallback)
+	} else {
+		server, needsPut = ensureTLSMuxFallback(server, tlsListen, tlsFallback)
 	}
-	// The fallback route has no match clause and sits at the END of the
-	// routes array; per-sandbox SNI routes inserted via UpsertTLSSNIRoute go
-	// to routes/0, so they always win over the fallback. Only connections
-	// whose SNI doesn't match any sandbox subdomain hit the proxy below.
-	server := map[string]any{
-		"listen": []string{tlsListen},
-		"routes": []any{
-			map[string]any{
-				"@id": tlsFallbackRouteID,
-				"handle": []map[string]any{{
-					"handler":   "proxy",
-					"upstreams": []map[string]any{{"dial": []string{tlsFallback}}},
-				}},
-			},
-		},
+	if !needsPut {
+		return nil
 	}
 	body, err := json.Marshal(server)
 	if err != nil {
 		return fmt.Errorf("marshal tls mux server: %w", err)
 	}
-	status, err := c.sendJSON(ctx, http.MethodPut, c.baseURL+muxPath, body)
+	method := http.MethodPut
+	action := "create"
+	if exists {
+		method = http.MethodPost
+		action = "update"
+	}
+	status, err := c.sendJSON(ctx, method, c.baseURL+muxPath, body)
 	if err != nil {
 		return err
 	}
 	if status >= 400 {
-		return fmt.Errorf("create tls mux server failed: %d", status)
+		return fmt.Errorf("%s tls mux server failed: %d", action, status)
 	}
 	return nil
+}
+
+func newTLSMuxServer(tlsListen, tlsFallback string) map[string]any {
+	return map[string]any{
+		"listen": []string{tlsListen},
+		"routes": []any{tlsMuxFallbackRoute(tlsFallback)},
+	}
+}
+
+func ensureTLSMuxFallback(server map[string]any, tlsListen, tlsFallback string) (map[string]any, bool) {
+	before, _ := json.Marshal(server)
+
+	server["listen"] = []string{tlsListen}
+	routes := l4RouteSlice(server["routes"])
+	filtered := make([]any, 0, len(routes)+1)
+	for _, route := range routes {
+		routeMap, _ := route.(map[string]any)
+		if routeMap != nil && isTLSMuxFallbackRoute(routeMap) {
+			continue
+		}
+		filtered = append(filtered, route)
+	}
+	// The fallback route has no match clause and sits at the END of the
+	// routes array; per-sandbox SNI routes inserted via UpsertTLSSNIRoute go
+	// to routes/0, so they always win over the fallback. Only connections
+	// whose SNI doesn't match any sandbox subdomain hit the proxy below.
+	server["routes"] = append(filtered, tlsMuxFallbackRoute(tlsFallback))
+
+	after, _ := json.Marshal(server)
+	return server, !bytes.Equal(before, after)
+}
+
+func l4RouteSlice(v any) []any {
+	switch routes := v.(type) {
+	case []any:
+		return routes
+	case []map[string]any:
+		out := make([]any, 0, len(routes))
+		for _, route := range routes {
+			out = append(out, route)
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func isTLSMuxFallbackRoute(route map[string]any) bool {
+	if id, _ := route["@id"].(string); id == tlsFallbackRouteID {
+		return true
+	}
+	_, hasMatch := route["match"]
+	return !hasMatch
+}
+
+func tlsMuxFallbackRoute(tlsFallback string) map[string]any {
+	return map[string]any{
+		"@id": tlsFallbackRouteID,
+		"handle": []map[string]any{{
+			"handler":   "proxy",
+			"upstreams": []map[string]any{{"dial": []string{tlsFallback}}},
+		}},
+	}
 }
 
 // UpsertTCPRoute creates (or replaces) the layer4 server bound to hostPort.
@@ -1406,4 +1465,34 @@ func (c *Client) pathExists(ctx context.Context, path string) (bool, error) {
 		return false, fmt.Errorf("read %s body: %w", path, err)
 	}
 	return strings.TrimSpace(string(body)) != "null", nil
+}
+
+func (c *Client) getConfigMap(ctx context.Context, path string) (map[string]any, bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, false, fmt.Errorf("get %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, false, nil
+	}
+	if resp.StatusCode >= 400 {
+		return nil, false, fmt.Errorf("get %s failed: %d", path, resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, false, fmt.Errorf("read %s body: %w", path, err)
+	}
+	if strings.TrimSpace(string(body)) == "null" {
+		return nil, false, nil
+	}
+	var out map[string]any
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, false, fmt.Errorf("decode %s: %w", path, err)
+	}
+	return out, out != nil, nil
 }

--- a/pkg/caddy/client_test.go
+++ b/pkg/caddy/client_test.go
@@ -778,6 +778,42 @@ func TestL4Cases(t *testing.T) {
 			},
 		},
 		{
+			name: "ensure_layer4_repairs_existing_tls_mux_without_fallback",
+			run: func(t *testing.T) {
+				fake := newFakeCaddy(t)
+				fake.layer4Exists = true
+				fake.l4Servers[tlsMuxServerID] = map[string]any{
+					"listen": []any{":443"},
+					"routes": []any{
+						map[string]any{
+							"@id": "sandbox-abc-port-443-tls",
+							"match": []any{map[string]any{
+								"tls": map[string]any{"sni": []any{"abc-443.sandbox.example.com"}},
+							}},
+							"handle": []any{map[string]any{
+								"handler":   "proxy",
+								"upstreams": []any{map[string]any{"dial": []any{"10.0.0.9:443"}}},
+							}},
+						},
+					},
+				}
+				client := &Client{enabled: true, baseURL: fake.URL, httpClient: fake.Client}
+				if err := client.EnsureLayer4(context.Background(), ":443", "127.0.0.1:8443"); err != nil {
+					t.Fatalf("EnsureLayer4() error = %v", err)
+				}
+				server := fake.l4Servers[tlsMuxServerID]
+				routes, _ := server["routes"].([]any)
+				if len(routes) != 2 {
+					t.Fatalf("routes len = %d, want 2: %#v", len(routes), routes)
+				}
+				first := firstL4Route(t, server)
+				assertRouteField(t, first, "@id", "sandbox-abc-port-443-tls")
+				last := lastL4Route(t, server)
+				assertRouteField(t, last, "@id", tlsFallbackRouteID)
+				assertL4Dial(t, last, "127.0.0.1:8443")
+			},
+		},
+		{
 			name: "ensure_layer4_rejects_listen_without_fallback",
 			run: func(t *testing.T) {
 				fake := newFakeCaddy(t)
@@ -1356,6 +1392,19 @@ func firstL4Route(t *testing.T, server map[string]any) map[string]any {
 	route, _ := routes[0].(map[string]any)
 	if route == nil {
 		t.Fatalf("first route not an object: %#v", routes[0])
+	}
+	return route
+}
+
+func lastL4Route(t *testing.T, server map[string]any) map[string]any {
+	t.Helper()
+	routes, ok := server["routes"].([]any)
+	if !ok || len(routes) == 0 {
+		t.Fatalf("server has no routes: %#v", server)
+	}
+	route, _ := routes[len(routes)-1].(map[string]any)
+	if route == nil {
+		t.Fatalf("last route not an object: %#v", routes[len(routes)-1])
 	}
 	return route
 }


### PR DESCRIPTION
## Summary

- **L4 TLS mux repair**: `EnsureLayer4` no longer no-ops when `tls-mux` already exists — it GETs the server, ensures the fallback route is present at the end of the routes array, and POSTs only when the config changed. `ReconcileClusterIngress` calls new `RepairLayer4Ready` (force path) so cluster ingress reconcile can fix a half-bootstrapped mux even when the `l4Ready` latch is already true.
- **Integration harness**: `--keep` runs pin the leased domain per scenario (refuse auto-pick on terraform/config mismatch), `wait_for_members` is more resilient, cluster scenarios wait for expected membership before UC execution, teardown clears the lease pin on successful destroy, and Firecracker benchmarks pass both `template_id` and `image` to create options.
- **Terraform**: joiner instances use `replace_triggered_by = [aws_instance.seed]` so a seed replacement triggers planned joiner replacement instead of a surprise `user_data` drift mid-apply.

## Problem

In hetero cluster runs (`cluster-hetero`), ingress nodes can end up with a `tls-mux` L4 server that has per-sandbox SNI routes but **no fallback route** to the ingress node's L7 Caddy. The old `EnsureLayer4` path returned early when the server existed, and `EnsureLayer4Ready` skipped work when `l4Ready` was already latched — so `ReconcileClusterIngress` could not self-heal.

Separately, integration `--keep` runs were rotating domains on re-apply, which rewrites DNS/Caddy/bootstrap `user_data` and leaves state half-mutated. Cluster membership polling also failed on non-array API shapes and timed-out curls.

## Architecture

```mermaid
flowchart TD
    subgraph reconcile["Cluster ingress reconcile"]
        R1["ReconcileClusterIngress"] --> R2{"needL4?"}
        R2 -->|yes| R3["RepairLayer4Ready"]
        R2 -->|no| R7["sync L7 routes only"]
        R3 --> R4["ensureLayer4Ready force=true"]
        R4 --> R5["caddy.EnsureLayer4"]
    end

    subgraph l4["Caddy L4 tls-mux bootstrap"]
        R5 --> L1{"tls-mux server exists?"}
        L1 -->|no| L2["PUT new server + fallback route"]
        L1 -->|yes| L3["GET existing config"]
        L3 --> L4{"fallback route at end?"}
        L4 -->|yes| L5["no-op"]
        L4 -->|no| L6["POST repaired config"]
        L2 --> L7["set l4Ready latch"]
        L6 --> L7
        L5 --> L7
    end

    subgraph routes["Route ordering"]
        S1["SNI routes at routes/0 via UpsertTLSSNIRoute"] --> S2["win over fallback"]
        S3["fallback route at routes/end"] --> S4["proxy to L7 Caddy"]
    end
```

```mermaid
flowchart LR
    subgraph itest["Integration harness"]
        I1["run_one / run_bench_only"] --> I2{"caps.domain?"}
        I2 -->|yes| I3["lease_domain_for_scenario"]
        I3 --> I4{"--keep?"}
        I4 -->|yes| I5["pin from .leased-domain / tf output / overlay"]
        I4 -->|no| I6["random pool pick + write pin"]
        I1 --> I7{"caps.cluster + expected_members?"}
        I7 -->|yes| I8["wait_for_members before UCs"]
    end
```

## Files changed

| Area | File | Change |
|------|------|--------|
| L4 repair | `pkg/caddy/client.go` | GET+repair tls-mux; `getConfigMap`, `ensureTLSMuxFallback` |
| L4 latch | `internal/service/service.go` | `RepairLayer4Ready` force path; reconcile uses it |
| Tests | `pkg/caddy/client_test.go`, `layer4_bootstrap_test.go`, `ingress_scale_test.go` | repair + latch bypass coverage |
| Integration | `integration-tests/run.sh`, `lib/common.sh`, `suite/benchmark_test.go` | domain pin, member wait, FC bench image |
| Terraform | `Terraform/nodes.tf` | joiner `replace_triggered_by` seed |

## PR review callouts

| Axis | Notes |
|------|-------|
| **Idempotency** | `EnsureLayer4` is safe under retry: unchanged config → no POST; existing fallback → no-op. SNI routes untouched. |
| **L4 bootstrap / latch** | `EnsureLayer4Ready` unchanged for hot path (`force=false`). `RepairLayer4Ready` only used from `ReconcileClusterIngress`. |
| **Boot-path latency** | No change to `CreateSandbox` or first-call expose path. |
| **Failure-path consistency** | Repair is best-effort idempotent PUT/POST to Caddy admin; reconcile surfaces first error. |
| **Cluster mode** | Repair runs on ingress reconcile when `needL4`; no FSM/placement changes. |

## Test plan

- [x] `go test ./pkg/caddy/... ./internal/service/... -run 'Layer4|RepairLayer4|Ingress'`
- [ ] `make test` (full offline suite)
- [ ] `make integration-cluster-hetero` (live AWS — validates member wait + domain pin + L4 ingress)

## How to review

1. Start with `pkg/caddy/client.go` → `ensureTLSMuxFallback` — confirm fallback is appended **last** and SNI routes are preserved.
2. Check `service.go` → only `ReconcileClusterIngress` uses `RepairLayer4Ready` (not `CreateSandbox` / `exposePort`).
3. Skim `integration-tests/run.sh` → `lease_domain_for_scenario` mismatch guard for `--keep`.
4. Confirm `Terraform/nodes.tf` lifecycle block matches the seed-replace runbook expectation.


Made with [Cursor](https://cursor.com)