### PR TITLE
feat(firecracker): Improve firecracker create latency — verify-once cache + async TCP probe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ BIN_DIR ?= bin
 
 .PHONY: fmt install-git-hooks test test-acme-e2e build build-sandboxd build-toolboxd docs-install docs-dev docs-build clean \
 	integration-local integration-single integration-single-wasm integration-cluster-mixed integration-cluster-mixed-wasm \
-	integration-cluster-hetero integration-cluster-hetero-safe integration-benchmark integration-benchmark-only integration-single-fc integration-arm64 integration-arm64-single integration-arm64-cluster integration-all integration-collect-logs integration-destroy integration-reap
+	integration-cluster-mixed-fc integration-cluster-hetero integration-cluster-hetero-safe \
+	integration-benchmark integration-benchmark-only integration-benchmark-fc integration-benchmark-fc-only \
+	integration-single-fc integration-arm64 integration-arm64-single integration-arm64-cluster integration-all integration-collect-logs integration-destroy integration-reap
 
 fmt:
 	$(GO) fmt ./...
@@ -89,6 +91,12 @@ integration-cluster-mixed:
 integration-cluster-mixed-wasm:
 	integration-tests/run.sh cluster-3-mixed-wasm $(RUN_FLAGS)
 
+# 3× mixed cluster with Firecracker on the seed c5.metal node — same domain/TLS,
+# Raft, forwarding, and shared Caddy cert shape as integration-cluster-mixed, but
+# exercises firecracker placement through a multi-node cluster (cheaper than hetero).
+integration-cluster-mixed-fc:
+	integration-tests/run.sh cluster-3-mixed-fc $(RUN_FLAGS)
+
 integration-cluster-hetero:
 	# Every hetero node runs On-Demand (spot = false in cluster-hetero.tfvars):
 	# the bare-metal Firecracker box alone exceeds the account Spot vCPU quota,
@@ -120,6 +128,23 @@ integration-benchmark:
 integration-benchmark-only:
 	AEROL_BENCH_OUT=$(BENCH_OUT) \
 		integration-tests/run.sh cluster-hetero --bench-only
+
+# Firecracker-focused benchmark on the 3× mixed-fc cluster: provisions
+# cluster-3-mixed-fc with domain/TLS, runs the full suite with UC-94 (docker +
+# firecracker latency) and UC-95 (docker density). Narrow UC-94 to firecracker
+# only with AEROL_BENCH_RUNTIMES=firecracker (UC-95 will skip in that case).
+#   make integration-benchmark-fc
+#   make integration-benchmark-fc keep
+#   make integration-benchmark-fc FC_BENCH_OUT=/tmp/fc-bench.json
+FC_BENCH_OUT ?= integration-tests/reports/cluster-3-mixed-fc-bench.json
+integration-benchmark-fc:
+	AEROL_BENCH=1 AEROL_BENCH_OUT=$(FC_BENCH_OUT) \
+		integration-tests/run.sh cluster-3-mixed-fc --no-disruptive $(RUN_FLAGS)
+
+# Re-run UC-94/UC-95 only against a cluster-3-mixed-fc left up with `keep`.
+integration-benchmark-fc-only:
+	AEROL_BENCH_OUT=$(FC_BENCH_OUT) \
+		integration-tests/run.sh cluster-3-mixed-fc --bench-only
 
 # Single-node x86 Firecracker on bare metal (c5.metal). Smallest scenario that
 # exercises the firecracker use cases (UC-24/47-50) without the full hetero

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -32,6 +32,7 @@ make integration-local                  # local-mode (--local install on a throw
 integration-tests/run.sh single-node --keep        # leave infra up for debugging
 integration-tests/run.sh single-node --prod-tls    # use real Let's Encrypt instead of staging
 make integration-cluster-hetero           # 8-node heterogeneous cluster (x86 fc)
+make integration-cluster-mixed-fc         # 3× mixed cluster, FC on seed c5.metal
 make integration-single-fc                # single-node-fc (x86 firecracker, c5.metal)
 make integration-arm64                    # arm64 firecracker single + cluster scenarios
 make integration-arm64-single             # single-node-fc-arm64 (Graviton metal)
@@ -46,9 +47,10 @@ Reports land in `integration-tests/reports/` (`<scenario>.md`, `<scenario>.json`
 
 `suite/benchmark_test.go` is an **opt-in** benchmark that reuses the live
 deployment to measure sandbox creation. It only runs where the scenario
-advertises the `benchmark` capability — currently **`cluster-hetero`**, the one
-cluster carrying every runtime — because it is slow and provisions many
-sandboxes. Everywhere else UC-94/UC-95 skip (not-applicable).
+advertises the `benchmark` capability — **`cluster-hetero`** (every runtime) and
+**`cluster-3-mixed-fc`** (docker + firecracker in a 3-node mixed cluster) —
+because it is slow and provisions many sandboxes. Everywhere else UC-94/UC-95
+skip (not-applicable).
 
 - **UC-94 — create latency:** for each runtime the scenario has (docker,
   firecracker, gvisor, wasm) it creates `AEROL_BENCH_SAMPLES` sandboxes
@@ -73,26 +75,37 @@ runs inside the normal orchestrated suite, which provisions and tears down for
 you (`run.sh` passes the parent environment through to `go test`):
 
 ```bash
-# Full run: provision cluster-hetero, run the suite WITH the benchmark, teardown.
+# Full hetero run (docker + firecracker + gvisor + wasm):
+make integration-benchmark
+
+# Firecracker-focused 3× mixed cluster (docker + firecracker only; cheaper):
+make integration-benchmark-fc
+
+# Manual env form (hetero):
 AEROL_BENCH=1 \
 AEROL_BENCH_OUT=integration-tests/reports/cluster-hetero-bench.json \
   make integration-cluster-hetero
 ```
 
 To iterate without re-provisioning, bring the cluster up once with `keep`, then
-re-run only UC-94/UC-95 with `make integration-benchmark-only` — it reads the API
-URL + PAT from TF state and forces `AEROL_BENCH=1`, so nothing to export:
+re-run only UC-94/UC-95 with `make integration-benchmark-only` (hetero) or
+`make integration-benchmark-fc-only` (mixed-fc) — they read the API URL + PAT
+from TF state and force `AEROL_BENCH=1`, so nothing to export:
 
 ```bash
 make integration-cluster-hetero keep         # provision, leave it up
 make integration-benchmark-only              # re-run just the bench against it
 
+make integration-cluster-mixed-fc keep       # 3× mixed FC cluster
+make integration-benchmark-fc-only         # re-run UC-94/UC-95 against it
+
 # Narrow the UC-94 sweep:
 AEROL_BENCH_RUNTIMES=docker,gvisor,wasm make integration-benchmark-only
-# …or isolate one runtime:
-AEROL_BENCH_RUNTIMES=firecracker make integration-benchmark-only
+# …or isolate firecracker latency (UC-95 skips when docker is excluded):
+AEROL_BENCH_RUNTIMES=firecracker make integration-benchmark-fc-only
 
 make integration-destroy                     # tear the kept cluster down
+make integration-destroy SCENARIO=cluster-3-mixed-fc
 ```
 
 Percentiles + the density ceiling also print as `bench[...]` log lines (captured

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -7,8 +7,8 @@
 #   integration-tests/run.sh <scenario> [--no-disruptive]  # skip node-kill UCs
 #   integration-tests/run.sh all       [flags]
 #
-# Scenarios: single-node | local-mode | cluster-3-mixed | cluster-hetero |
-#            single-node-fc | single-node-fc-arm64 | cluster-arm64
+# Scenarios: single-node | local-mode | cluster-3-mixed | cluster-3-mixed-fc |
+#            cluster-hetero | single-node-fc | single-node-fc-arm64 | cluster-arm64
 #
 # Safety: every dangerous input is gated by provision.sh check-safety BEFORE any
 # apply. Teardown runs on EXIT/INT/TERM (trap) so a crash can't leak EC2; the
@@ -761,7 +761,7 @@ if [[ "$COLLECT_LOGS_ONLY" == "1" ]]; then
 elif [[ "$BENCH_ONLY" == "1" ]]; then
   run_bench_only "$SCENARIO"
 elif [[ "$SCENARIO" == "all" ]]; then
-  for s in local-mode single-node single-node-wasm cluster-3-mixed cluster-3-mixed-wasm cluster-hetero single-node-fc single-node-fc-arm64 cluster-arm64; do
+  for s in local-mode single-node single-node-wasm cluster-3-mixed cluster-3-mixed-wasm cluster-3-mixed-fc cluster-hetero single-node-fc single-node-fc-arm64 cluster-arm64; do
     ( run_one "$s" )
   done
 else

--- a/integration-tests/scenarios/cluster-3-mixed-fc.caps.yml
+++ b/integration-tests/scenarios/cluster-3-mixed-fc.caps.yml
@@ -1,0 +1,16 @@
+# 3× mixed cluster with Firecracker on the seed bare-metal node. Same Raft +
+# forwarding + shared Caddy cert topology as cluster-3-mixed, but the seed is
+# c5.metal with with_firecracker=true so FC create/template/exec UCs and the
+# benchmark row exercise placement + cross-node forwarding through a real
+# multi-node cluster with domain/TLS — without standing up cluster-hetero.
+name: cluster-3-mixed-fc
+capabilities:
+  - docker
+  - platform-volumes
+  - firecracker
+  - domain
+  - cluster
+  # Opt UC-94/UC-95 in here (docker + firecracker latency; docker density).
+  - benchmark
+
+expected_members: 3

--- a/integration-tests/scenarios/cluster-3-mixed-fc.tfvars
+++ b/integration-tests/scenarios/cluster-3-mixed-fc.tfvars
@@ -1,0 +1,42 @@
+# Cluster (3× mixed) Firecracker integration scenario: three nodes, each a Raft
+# voter + worker + ingress, with Firecracker enabled on the seed bare-metal box.
+# Topology mirrors cluster-3-mixed.tfvars except node1 is c5.metal (KVM) and
+# advertises firecracker; node2/node3 stay cheap spot t3 workers for quorum and
+# docker placement peers. Exercises cluster formation, leader election, placement,
+# forwarding, shared Caddy cert storage, and firecracker snapshot-clone creates
+# through a non-FC entry node — at lower cost than cluster-hetero.
+#
+# AWS access (profile, region, ssh_key_name) is inherited from
+# config/terraform.tfvars (chained first by run.sh). This file overrides only
+# the prod-specific bits below.
+cluster_name = "aerolvm-itest-cluster-3-mixed-fc"
+
+extra_tags = {
+  itest = "true"
+  ttl   = "4"
+}
+
+default_instance_type  = "t3.medium"
+default_volume_size_gb = 40
+default_with_firecracker = false
+
+# Three mixed nodes share Caddy cert storage so any ingress can serve the
+# wildcard cert without re-issuing (and burning the LE budget).
+caddy_shared_cert_storage = {
+  enabled = true
+}
+
+nodes = {
+  # Seed carries Firecracker (KVM). On-Demand only — bare metal exceeds the
+  # account Spot vCPU quota (MaxSpotInstanceCountExceeded).
+  node1 = {
+    role              = "mixed"
+    seed              = true
+    instance_type     = "c5.metal"
+    volume_size_gb    = 80
+    with_firecracker  = true
+    spot              = false
+  }
+  node2 = { role = "mixed", spot = true }
+  node3 = { role = "mixed", spot = true }
+}

--- a/integration-tests/suite/benchmark_test.go
+++ b/integration-tests/suite/benchmark_test.go
@@ -347,6 +347,20 @@ type latencyStats struct {
 	Serverp50MS   int64 `json:"server_p50_ms"`
 	Serverp90MS   int64 `json:"server_p90_ms"`
 	Serverp99MS   int64 `json:"server_p99_ms"`
+	// Stages is the per-stage Server-Timing breakdown (Phase 0 of
+	// plans/firecracker-create-latency.md): one entry per <name>;dur=
+	// metric the server reported (fc_verify, fc_spawn, fc_driver, …).
+	// Empty for servers that only send create;dur=. Samples counts the
+	// creates whose header carried that stage — a stage absent from
+	// some samples (e.g. fc_warm on a cold fallback) reports fewer.
+	Stages map[string]stageStats `json:"stages,omitempty"`
+}
+
+// stageStats folds one named stage's samples across the bench run.
+type stageStats struct {
+	Samples int   `json:"samples"`
+	MeanMS  int64 `json:"mean_ms"`
+	P50MS   int64 `json:"p50_ms"`
 }
 
 // benchReport is the full JSON artifact (UC-94 + UC-95 combined).
@@ -544,6 +558,7 @@ func TestBenchCreateLatency(t *testing.T) {
 	var report benchReport
 	for _, br := range runtimes {
 		var apiD, runD, serverD []time.Duration
+		stageD := map[string][]time.Duration{}
 		failures := 0
 		for i := 0; i < samples; i++ {
 			opts := benchCreateOptions(t, br)
@@ -573,6 +588,15 @@ func TestBenchCreateLatency(t *testing.T) {
 			if ms, ok := c.LastServerCreateMS(); ok {
 				serverD = append(serverD, time.Duration(ms*float64(time.Millisecond)))
 			}
+			// Per-stage breakdown from the same header (Phase 0 of
+			// plans/firecracker-create-latency.md). Only stages the server
+			// actually reported land here; docker creates carry the
+			// runtime_wait/toolbox_wait pair, firecracker the fc_* set.
+			if stages, ok := c.LastServerCreateStages(); ok {
+				for name, ms := range stages {
+					stageD[name] = append(stageD[name], time.Duration(ms*float64(time.Millisecond)))
+				}
+			}
 		}
 
 		if len(apiD) == 0 {
@@ -580,6 +604,7 @@ func TestBenchCreateLatency(t *testing.T) {
 			continue
 		}
 		ls := summarize(br.runtime, samples, failures, apiD, runD, serverD)
+		ls.Stages = summarizeStages(stageD)
 		report.Latency = append(report.Latency, ls)
 		t.Logf("bench[%s] api p50=%dms p90=%dms p99=%dms | server p50=%dms p90=%dms p99=%dms | running p50=%dms p90=%dms p99=%dms (%d ok, %d fail)",
 			br.runtime, ls.APIp50MS, ls.APIp90MS, ls.APIp99MS,
@@ -612,6 +637,26 @@ func summarize(rt string, samples, failures int, apiD, runD, serverD []time.Dura
 		ls.Serverp99MS = percentile(serverD, 99).Milliseconds()
 	}
 	return ls
+}
+
+// summarizeStages folds the per-stage samples into the artifact's
+// latency[].stages block. Nil when the server reported no stages.
+func summarizeStages(stageD map[string][]time.Duration) map[string]stageStats {
+	if len(stageD) == 0 {
+		return nil
+	}
+	out := make(map[string]stageStats, len(stageD))
+	for name, durs := range stageD {
+		if len(durs) == 0 {
+			continue
+		}
+		out[name] = stageStats{
+			Samples: len(durs),
+			MeanMS:  meanMS(durs),
+			P50MS:   percentile(durs, 50).Milliseconds(),
+		}
+	}
+	return out
 }
 
 func meanMS(durs []time.Duration) int64 {

--- a/integration-tests/suite/benchmark_test.go
+++ b/integration-tests/suite/benchmark_test.go
@@ -22,8 +22,8 @@ import (
 )
 
 // benchmark_test.go holds the opt-in create benchmarks (UC-94/UC-95). They run
-// only where the scenario advertises CapBenchmark — currently cluster-hetero,
-// the one cluster carrying every runtime — because they are slow and provision
+// only where the scenario advertises CapBenchmark — cluster-hetero (every
+// runtime) and cluster-3-mixed-fc (docker + firecracker) — because they are slow and provision
 // many sandboxes. They reuse the same SDK client + cleanup contract as every
 // other use case; the only difference is they record timings instead of
 // asserting a single create.
@@ -54,8 +54,8 @@ type benchRuntimeSpec struct {
 }
 
 // requireBenchEnabled is a second gate on top of the CapBenchmark capability.
-// The capability keeps UC-94/UC-95 in the coverage matrix on cluster-hetero,
-// but the benchmark is slow and the density probe provisions sandboxes until
+// The capability keeps UC-94/UC-95 in the coverage matrix on benchmark-capable
+// scenarios (cluster-hetero, cluster-3-mixed-fc), but the benchmark is slow and the density probe provisions sandboxes until
 // the fleet rejects — far too costly to run on every hetero pass. So it stays
 // dormant unless the operator sets AEROL_BENCH=1, in which case it runs as part
 // of the normal orchestrated suite (run.sh passes the parent env through). When

--- a/integration-tests/suite/harness/client.go
+++ b/integration-tests/suite/harness/client.go
@@ -57,6 +57,14 @@ func (c *Client) LastCreateReadinessSource() (string, bool) {
 	return c.timing.takeCreateReadinessSource()
 }
 
+// LastServerCreateStages returns every <name>;dur= Server-Timing pair from
+// the most recent create (create, runtime_wait, fc_verify, fc_driver, …),
+// then clears it. ok is false when the last create carried no header. The
+// bench folds these into the per-stage breakdown of the JSON artifact.
+func (c *Client) LastServerCreateStages() (map[string]float64, bool) {
+	return c.timing.takeCreateStages()
+}
+
 // SDK exposes the underlying client for use cases that need a method this
 // wrapper doesn't surface yet.
 func (c *Client) SDK() *microvm.Client { return c.sdk }

--- a/integration-tests/suite/harness/timing.go
+++ b/integration-tests/suite/harness/timing.go
@@ -20,6 +20,8 @@ type serverTimingTransport struct {
 	have          bool
 	lastReadiness string
 	haveReadiness bool
+	lastStages    map[string]float64
+	haveStages    bool
 }
 
 func (t *serverTimingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -36,6 +38,11 @@ func (t *serverTimingTransport) RoundTrip(req *http.Request) (*http.Response, er
 		if src, ok := parseServerTimingReadinessSource(resp.Header.Get("Server-Timing")); ok {
 			t.mu.Lock()
 			t.lastReadiness, t.haveReadiness = src, true
+			t.mu.Unlock()
+		}
+		if stages := parseServerTimingStages(resp.Header.Get("Server-Timing")); len(stages) > 0 {
+			t.mu.Lock()
+			t.lastStages, t.haveStages = stages, true
 			t.mu.Unlock()
 		}
 	}
@@ -61,6 +68,46 @@ func (t *serverTimingTransport) takeCreateReadinessSource() (string, bool) {
 	src, ok := t.lastReadiness, t.haveReadiness
 	t.haveReadiness = false
 	return src, ok
+}
+
+// takeCreateStages returns every <name>;dur= pair from the most recent
+// create's Server-Timing header (create, runtime_wait, fc_* …) and clears
+// it. The per-stage breakdown is Phase 0 of
+// plans/firecracker-create-latency.md — the bench aggregates these into
+// the latency[].stages block of the JSON artifact.
+func (t *serverTimingTransport) takeCreateStages() (map[string]float64, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	stages, ok := t.lastStages, t.haveStages
+	t.lastStages, t.haveStages = nil, false
+	return stages, ok
+}
+
+// parseServerTimingStages extracts every metric with a dur= attribute into
+// a name→milliseconds map. Metrics without dur (e.g. readiness;desc=…)
+// are skipped. Extra attributes on a dur-carrying metric are ignored —
+// the presence of the fc_warm key alone marks a warm-pool hit, so the
+// bench needs no desc parsing.
+func parseServerTimingStages(header string) map[string]float64 {
+	var stages map[string]float64
+	for _, metric := range strings.Split(header, ",") {
+		fields := strings.Split(metric, ";")
+		name := strings.TrimSpace(fields[0])
+		if name == "" {
+			continue
+		}
+		for _, attr := range fields[1:] {
+			if v, ok := strings.CutPrefix(strings.TrimSpace(attr), "dur="); ok {
+				if ms, err := strconv.ParseFloat(strings.TrimSpace(v), 64); err == nil {
+					if stages == nil {
+						stages = make(map[string]float64)
+					}
+					stages[name] = ms
+				}
+			}
+		}
+	}
+	return stages
 }
 
 // parseServerTimingReadinessSource extracts readiness;desc=<source>.

--- a/integration-tests/suite/harness/timing_test.go
+++ b/integration-tests/suite/harness/timing_test.go
@@ -113,3 +113,77 @@ func TestParseServerTimingReadinessSource(t *testing.T) {
 		t.Fatalf("got (%q, %v)", src, ok)
 	}
 }
+
+// TestParseServerTimingStages verifies the full-header stage map used by
+// the bench's latency[].stages block: every dur-carrying metric lands
+// under its name, desc-only metrics are skipped, and attributes beyond
+// dur (fc_warm;dur=…;desc=hit) don't confuse the parse.
+func TestParseServerTimingStages(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		want   map[string]float64
+	}{
+		{
+			name: "firecracker stage set",
+			header: "create;dur=3452.1, fc_driver;dur=3120.0, fc_verify;dur=1650.4, " +
+				"fc_spawn;dur=95.2, fc_load;dur=140.0, fc_resume;dur=4.5, " +
+				"fc_handshake;dur=61.0, fc_post_resume;dur=180.7, readiness;desc=socket",
+			want: map[string]float64{
+				"create": 3452.1, "fc_driver": 3120.0, "fc_verify": 1650.4,
+				"fc_spawn": 95.2, "fc_load": 140.0, "fc_resume": 4.5,
+				"fc_handshake": 61.0, "fc_post_resume": 180.7,
+			},
+		},
+		{
+			name:   "warm hit marker keeps dur despite desc",
+			header: "create;dur=500, fc_warm;dur=142.3;desc=hit, fc_driver;dur=150.0",
+			want:   map[string]float64{"create": 500, "fc_warm": 142.3, "fc_driver": 150.0},
+		},
+		{
+			name:   "docker header",
+			header: "create;dur=291.0, runtime_wait;dur=120.5, toolbox_wait;dur=88.0, readiness;desc=socket",
+			want:   map[string]float64{"create": 291.0, "runtime_wait": 120.5, "toolbox_wait": 88.0},
+		},
+		{
+			name:   "desc-only and empty metrics skipped",
+			header: "readiness;desc=health, ;dur=5",
+			want:   nil,
+		},
+		{
+			name:   "empty header",
+			header: "",
+			want:   nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseServerTimingStages(tt.header)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseServerTimingStages(%q) = %v, want %v", tt.header, got, tt.want)
+			}
+			for name, ms := range tt.want {
+				if got[name] != ms {
+					t.Fatalf("stage %q = %v, want %v (full: %v)", name, got[name], ms, got)
+				}
+			}
+		})
+	}
+}
+
+// TestServerTimingTransportRecordsStages verifies the transport captures
+// the stage map on a 2xx create and that takeCreateStages consumes it.
+func TestServerTimingTransportRecordsStages(t *testing.T) {
+	tr := &serverTimingTransport{base: stubRoundTripper{
+		header: "create;dur=321.5, fc_driver;dur=300.0, fc_verify;dur=150.2", code: 201}}
+	if _, err := tr.RoundTrip(newReq(t, http.MethodPost, "https://x/v1/sandboxes")); err != nil {
+		t.Fatalf("round trip: %v", err)
+	}
+	stages, ok := tr.takeCreateStages()
+	if !ok || stages["fc_driver"] != 300.0 || stages["fc_verify"] != 150.2 || stages["create"] != 321.5 {
+		t.Fatalf("takeCreateStages() = (%v, %v), want full stage map", stages, ok)
+	}
+	if _, ok := tr.takeCreateStages(); ok {
+		t.Fatal("takeCreateStages() should be empty after consumption")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -621,6 +621,12 @@ type Config struct {
 	// memory damage hours later. Bypass only for benchmarking the raw
 	// load path. SB_FIRECRACKER_SNAPSHOT_VERIFY_ON_LOAD.
 	FirecrackerSnapshotVerifyOnLoad bool
+	// FirecrackerSnapshotVerifyMode controls the load-time checksum
+	// cadence when verification is enabled. "once" (default) verifies a
+	// template once per daemon boot and file identity; "always" preserves
+	// the previous per-create re-hash behavior for paranoid operators.
+	// SB_FIRECRACKER_SNAPSHOT_VERIFY_MODE.
+	FirecrackerSnapshotVerifyMode string
 
 	// FirecrackerOverlayEnabled is the daemon-wide opt-out for the
 	// per-sandbox writable overlay drive (Phase 3 PR-B). Default true.
@@ -1404,6 +1410,7 @@ func Load() (Config, error) {
 		FirecrackerTemplateMemoryMB:         getEnvInt("SB_FIRECRACKER_TEMPLATE_MEMORY_MB", 512),
 		FirecrackerTemplateVCPU:             getEnvInt("SB_FIRECRACKER_TEMPLATE_VCPU", 1),
 		FirecrackerSnapshotVerifyOnLoad:     getEnvBool("SB_FIRECRACKER_SNAPSHOT_VERIFY_ON_LOAD", true),
+		FirecrackerSnapshotVerifyMode:       strings.ToLower(getEnv("SB_FIRECRACKER_SNAPSHOT_VERIFY_MODE", "once")),
 
 		FirecrackerOverlayEnabled:            getEnvBool("SB_FIRECRACKER_OVERLAY_ENABLED", true),
 		FirecrackerOverlayMkfs:               getEnvBool("SB_FIRECRACKER_OVERLAY_MKFS", false),
@@ -1449,6 +1456,9 @@ func Load() (Config, error) {
 	}
 	if cfg.ImagePullFailureBackoff < 0 {
 		return Config{}, errors.New("SB_IMAGE_PULL_FAILURE_BACKOFF must be >= 0")
+	}
+	if cfg.FirecrackerSnapshotVerifyMode != "once" && cfg.FirecrackerSnapshotVerifyMode != "always" {
+		return Config{}, errors.New("SB_FIRECRACKER_SNAPSHOT_VERIFY_MODE must be either once or always")
 	}
 	if cfg.AutoImportEnabled {
 		if cfg.AutoImportHooksBaseURL == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -74,6 +74,7 @@ func TestLoadCases(t *testing.T) {
 			"SB_ACME_DAEMON_BUDGET_FRACTION",
 			"SB_ACME_DAEMON_BUDGET_WINDOW",
 			"SB_ACME_DAEMON_BUDGET_CAPACITY",
+			"SB_FIRECRACKER_SNAPSHOT_VERIFY_MODE",
 		}
 		for _, key := range keys {
 			t.Setenv(key, "")
@@ -167,6 +168,9 @@ func TestLoadCases(t *testing.T) {
 				}
 				if cfg.HTTPWakeMaxBuffer != 8*1024*1024 {
 					t.Fatalf("expected default HTTPWakeMaxBuffer=8MiB, got %d", cfg.HTTPWakeMaxBuffer)
+				}
+				if cfg.FirecrackerSnapshotVerifyMode != "once" {
+					t.Fatalf("expected default FirecrackerSnapshotVerifyMode=once, got %q", cfg.FirecrackerSnapshotVerifyMode)
 				}
 			},
 		},
@@ -317,6 +321,18 @@ func TestLoadCases(t *testing.T) {
 			},
 		},
 		{
+			name: "rejects_unknown_firecracker_snapshot_verify_mode",
+			run: func(t *testing.T) {
+				clearEnv(t)
+				t.Setenv("SB_PAT_TOKEN", "token")
+				t.Setenv("SB_FIRECRACKER_SNAPSHOT_VERIFY_MODE", "sometimes")
+				_, err := Load()
+				if err == nil || !strings.Contains(err.Error(), "SB_FIRECRACKER_SNAPSHOT_VERIFY_MODE") {
+					t.Fatalf("expected snapshot verify mode error, got %v", err)
+				}
+			},
+		},
+		{
 			name: "normalizes_domain_and_public_host",
 			run: func(t *testing.T) {
 				clearEnv(t)
@@ -371,6 +387,7 @@ func TestLoadCases(t *testing.T) {
 				t.Setenv("OTEL_SERVICE_NAME", "sandboxd-prod")
 				t.Setenv("SB_IMAGE_PULL_MAX_CONCURRENT", "8")
 				t.Setenv("SB_IMAGE_PULL_FAILURE_BACKOFF", "2m")
+				t.Setenv("SB_FIRECRACKER_SNAPSHOT_VERIFY_MODE", "ALWAYS")
 				cfg, err := Load()
 				if err != nil {
 					t.Fatalf("Load() error = %v", err)
@@ -398,6 +415,9 @@ func TestLoadCases(t *testing.T) {
 				}
 				if cfg.ImagePullMaxConcurrent != 8 || cfg.ImagePullFailureBackoff != 2*time.Minute {
 					t.Fatalf("unexpected image pull overrides: %+v", cfg)
+				}
+				if cfg.FirecrackerSnapshotVerifyMode != "always" {
+					t.Fatalf("expected FirecrackerSnapshotVerifyMode=always, got %q", cfg.FirecrackerSnapshotVerifyMode)
 				}
 			},
 		},

--- a/internal/network/tap/pool.go
+++ b/internal/network/tap/pool.go
@@ -187,6 +187,17 @@ func (p *Pool) Release(ctx context.Context, sandboxID string) error {
 	return p.st.ReleaseFirecrackerTapSlot(ctx, sandboxID)
 }
 
+// Transfer re-keys a claimed slot from fromID to toID. Used by the
+// Firecracker warm-VMM pool: warm slots allocate TAPs under their pool slot id,
+// then a create transfers that same TAP to the sandbox id on warm hit.
+func (p *Pool) Transfer(ctx context.Context, fromID, toID string, now time.Time) (*Slot, error) {
+	raw, err := p.st.TransferFirecrackerTapSlot(ctx, fromID, toID, now)
+	if err != nil || raw == nil {
+		return nil, err
+	}
+	return slotFromStore(raw), nil
+}
+
 // Stats reports current occupancy. Used by /healthz and the admission
 // controller — a near-empty pool blocks new Firecracker creates upstream
 // of the failing Allocate call.

--- a/internal/network/tap/pool_test.go
+++ b/internal/network/tap/pool_test.go
@@ -193,6 +193,93 @@ func TestAllocate_PoolExhausted(t *testing.T) {
 	}
 }
 
+func TestTransfer_RekeysOwner(t *testing.T) {
+	st := newTestStore(t)
+	p := New(st)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := p.Seed(ctx, SeedConfig{BaseCIDR: "172.16.0.0/24", PoolSize: 2}, now); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	warm, err := p.Allocate(ctx, "vmms-warm", now)
+	if err != nil {
+		t.Fatalf("allocate warm: %v", err)
+	}
+	got, err := p.Transfer(ctx, "vmms-warm", "sb-claimed", now.Add(time.Second))
+	if err != nil {
+		t.Fatalf("transfer: %v", err)
+	}
+	if got.TapName != warm.TapName || got.GuestIP != warm.GuestIP || got.VsockCID != warm.VsockCID {
+		t.Fatalf("transferred slot = %+v, want same identity as %+v", got, warm)
+	}
+	if old, err := p.Get(ctx, "vmms-warm"); err != nil || old != nil {
+		t.Fatalf("old owner get = %+v err=%v, want nil nil", old, err)
+	}
+	if claimed, err := p.Get(ctx, "sb-claimed"); err != nil || claimed == nil || claimed.TapName != warm.TapName {
+		t.Fatalf("new owner get = %+v err=%v, want %s", claimed, err, warm.TapName)
+	}
+}
+
+func TestTransfer_TargetAlreadyHasSlot(t *testing.T) {
+	st := newTestStore(t)
+	p := New(st)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := p.Seed(ctx, SeedConfig{BaseCIDR: "172.16.0.0/24", PoolSize: 2}, now); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := p.Allocate(ctx, "vmms-warm", now); err != nil {
+		t.Fatalf("allocate warm: %v", err)
+	}
+	target, err := p.Allocate(ctx, "sb-target", now)
+	if err != nil {
+		t.Fatalf("allocate target: %v", err)
+	}
+	if _, err := p.Transfer(ctx, "vmms-warm", "sb-target", now); err == nil {
+		t.Fatal("expected conflict transferring onto an existing different target slot")
+	}
+	if got, err := p.Get(ctx, "sb-target"); err != nil || got == nil || got.TapName != target.TapName {
+		t.Fatalf("target changed after failed transfer: %+v err=%v", got, err)
+	}
+}
+
+func TestTransfer_SourceMissing(t *testing.T) {
+	st := newTestStore(t)
+	p := New(st)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := p.Seed(ctx, SeedConfig{BaseCIDR: "172.16.0.0/24", PoolSize: 1}, now); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := p.Transfer(ctx, "missing", "sb-target", now); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("transfer missing source err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestTransfer_RetryIsIdempotent(t *testing.T) {
+	st := newTestStore(t)
+	p := New(st)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := p.Seed(ctx, SeedConfig{BaseCIDR: "172.16.0.0/24", PoolSize: 1}, now); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	first, err := p.Allocate(ctx, "vmms-warm", now)
+	if err != nil {
+		t.Fatalf("allocate warm: %v", err)
+	}
+	if _, err := p.Transfer(ctx, "vmms-warm", "sb-target", now); err != nil {
+		t.Fatalf("first transfer: %v", err)
+	}
+	again, err := p.Transfer(ctx, "vmms-warm", "sb-target", now)
+	if err != nil {
+		t.Fatalf("retry transfer: %v", err)
+	}
+	if again.TapName != first.TapName {
+		t.Fatalf("retry returned %s, want %s", again.TapName, first.TapName)
+	}
+}
+
 // newTestSandbox inserts a row into sandboxes so the firecracker_tap_pool
 // allocate doesn't break referential expectations. The pool table does
 // NOT carry a FOREIGN KEY on sandbox_id (the table seeds before any

--- a/internal/network/tap/pool_test.go
+++ b/internal/network/tap/pool_test.go
@@ -3,7 +3,9 @@ package tap
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -278,6 +280,98 @@ func TestTransfer_RetryIsIdempotent(t *testing.T) {
 	if again.TapName != first.TapName {
 		t.Fatalf("retry returned %s, want %s", again.TapName, first.TapName)
 	}
+}
+
+// TestTransfer_ConcurrentDuplicate is the fragile-area idempotency
+// regression (pr-review.md rule #1): racing Transfers of one slot must
+// resolve to exactly one owner with no partial state. The ownership
+// change is a single atomic UPDATE keyed on the source id, so of N
+// racers to distinct targets exactly one wins; duplicates retrying the
+// SAME target must all succeed idempotently.
+func TestTransfer_ConcurrentDuplicate(t *testing.T) {
+	t.Run("same target", func(t *testing.T) {
+		st := newTestStore(t)
+		p := New(st)
+		ctx := context.Background()
+		now := time.Now().UTC()
+		if err := p.Seed(ctx, SeedConfig{BaseCIDR: "172.16.0.0/24", PoolSize: 2}, now); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		warm, err := p.Allocate(ctx, "vmms-warm", now)
+		if err != nil {
+			t.Fatalf("allocate warm: %v", err)
+		}
+
+		const racers = 8
+		var wg sync.WaitGroup
+		results := make([]*Slot, racers)
+		errs := make([]error, racers)
+		for i := 0; i < racers; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				results[i], errs[i] = p.Transfer(ctx, "vmms-warm", "sb-claimed", now)
+			}(i)
+		}
+		wg.Wait()
+
+		for i := 0; i < racers; i++ {
+			if errs[i] != nil {
+				t.Fatalf("racer %d: duplicate transfer must be idempotent, got %v", i, errs[i])
+			}
+			if results[i] == nil || results[i].TapName != warm.TapName {
+				t.Fatalf("racer %d: slot = %+v, want %s", i, results[i], warm.TapName)
+			}
+		}
+		if old, err := p.Get(ctx, "vmms-warm"); err != nil || old != nil {
+			t.Fatalf("old owner get = %+v err=%v, want nil nil", old, err)
+		}
+	})
+
+	t.Run("distinct targets", func(t *testing.T) {
+		st := newTestStore(t)
+		p := New(st)
+		ctx := context.Background()
+		now := time.Now().UTC()
+		if err := p.Seed(ctx, SeedConfig{BaseCIDR: "172.16.0.0/24", PoolSize: 2}, now); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		warm, err := p.Allocate(ctx, "vmms-warm", now)
+		if err != nil {
+			t.Fatalf("allocate warm: %v", err)
+		}
+
+		const racers = 4
+		var wg sync.WaitGroup
+		errs := make([]error, racers)
+		targets := make([]string, racers)
+		for i := 0; i < racers; i++ {
+			targets[i] = fmt.Sprintf("sb-racer-%d", i)
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				_, errs[i] = p.Transfer(ctx, "vmms-warm", targets[i], now)
+			}(i)
+		}
+		wg.Wait()
+
+		wins := 0
+		for i := 0; i < racers; i++ {
+			if errs[i] == nil {
+				wins++
+				got, err := p.Get(ctx, targets[i])
+				if err != nil || got == nil || got.TapName != warm.TapName {
+					t.Fatalf("winner %s get = %+v err=%v, want %s", targets[i], got, err, warm.TapName)
+				}
+			}
+		}
+		if wins != 1 {
+			t.Fatalf("winners = %d, want exactly 1", wins)
+		}
+		if old, err := p.Get(ctx, "vmms-warm"); err != nil || old != nil {
+			t.Fatalf("old owner get = %+v err=%v, want nil nil", old, err)
+		}
+	})
 }
 
 // newTestSandbox inserts a row into sandboxes so the firecracker_tap_pool

--- a/internal/pool/vmm/pool.go
+++ b/internal/pool/vmm/pool.go
@@ -472,6 +472,15 @@ func (p *Pool) ReapReleased(ctx context.Context, cutoff time.Time) (int, error) 
 				continue
 			}
 		}
+		// WarmSpawn allocates a Firecracker TAP slot under the warm VMM
+		// slot id before LoadSnapshot. The handle's Shutdown releases it on
+		// the normal in-memory path; this store-level release covers daemon
+		// restart/orphan cases where the VMM row survived but the handle map
+		// did not. Idempotent for slots already transferred to a sandbox or
+		// already released.
+		if err := p.st.ReleaseFirecrackerTapSlot(ctx, sl.ID); err != nil {
+			return deleted, fmt.Errorf("vmm pool reap (release tap %s): %w", sl.ID, err)
+		}
 		if err := p.st.DeleteFirecrackerVMMSlot(ctx, sl.ID); err != nil {
 			if errors.Is(err, store.ErrNotFound) {
 				// Someone else (a racing reap, the GC tests) dropped

--- a/internal/pool/vmm/refill.go
+++ b/internal/pool/vmm/refill.go
@@ -217,6 +217,9 @@ func (p *Pool) refillTemplate(ctx context.Context, tpl TemplateWarmInput, spawne
 	if desired <= 0 {
 		return
 	}
+	if !p.tapCapacityAllowsRefill(ctx, tpl.TemplateID, desired) {
+		return
+	}
 	have, err := p.ListNonReleased(ctx, tpl.TemplateID)
 	if err != nil {
 		p.logger.Warn("vmm pool: list non-released failed",
@@ -238,6 +241,34 @@ func (p *Pool) refillTemplate(ctx context.Context, tpl TemplateWarmInput, spawne
 		}
 		p.spawnOne(ctx, tpl, spawner, spawnTimeout)
 	}
+}
+
+func (p *Pool) tapCapacityAllowsRefill(ctx context.Context, templateID string, desired int) bool {
+	stats, err := p.st.GetFirecrackerTapPoolStats(ctx)
+	if err != nil {
+		p.logger.Warn("vmm pool: tap capacity check failed",
+			"template_id", templateID, "error", err)
+		return false
+	}
+	if stats.Total == 0 {
+		// The policy package's unit tests exercise the VMM pool without
+		// seeding a TAP pool. Production daemon wiring always seeds TAPs
+		// before enabling Firecracker, so zero total means "capacity guard
+		// not applicable" rather than "deny every policy-only test refill".
+		return true
+	}
+	minFree := desired * 2
+	if stats.Free < minFree {
+		p.logger.Info("vmm pool: refill skipped by tap capacity guard",
+			"template_id", templateID,
+			"desired", desired,
+			"tap_total", stats.Total,
+			"tap_allocated", stats.Allocated,
+			"tap_free", stats.Free,
+			"min_free", minFree)
+		return false
+	}
+	return true
 }
 
 // spawnOne mints a fresh slot id, reserves the row in 'spawning',

--- a/internal/pool/vmm/refill_test.go
+++ b/internal/pool/vmm/refill_test.go
@@ -245,6 +245,48 @@ func TestRefill_ConsidersExistingNonReleased(t *testing.T) {
 	}
 }
 
+func TestRefill_SkipsWhenTapFreeBelowWarmReserve(t *testing.T) {
+	ctx := context.Background()
+	p, st := newTestPool(t)
+	now := time.Now().UTC()
+	seedTestTapSlots(t, st, 8)
+	for i := 0; i < 3; i++ {
+		if _, err := st.AllocateFirecrackerTapSlot(ctx, fmt.Sprintf("sb-active-%d", i), now); err != nil {
+			t.Fatalf("allocate active tap %d: %v", i, err)
+		}
+	}
+	p.SetDepth("tpl-a", 3)
+	spawner := &fakeSpawner{}
+	lister := &fakeLister{templates: []TemplateWarmInput{{TemplateID: "tpl-a", VsockCID: 3}}}
+	var busy atomic.Bool
+	p.runRefillOnce(ctx, lister, spawner, 5*time.Second, &busy)
+
+	if got := len(spawner.Calls()); got != 0 {
+		t.Fatalf("spawn calls = %d, want 0 when free taps are below 2x warm depth", got)
+	}
+}
+
+func TestRefill_AllowsWhenTapFreeMeetsWarmReserve(t *testing.T) {
+	ctx := context.Background()
+	p, st := newTestPool(t)
+	now := time.Now().UTC()
+	seedTestTapSlots(t, st, 8)
+	for i := 0; i < 2; i++ {
+		if _, err := st.AllocateFirecrackerTapSlot(ctx, fmt.Sprintf("sb-active-%d", i), now); err != nil {
+			t.Fatalf("allocate active tap %d: %v", i, err)
+		}
+	}
+	p.SetDepth("tpl-a", 3)
+	spawner := &fakeSpawner{}
+	lister := &fakeLister{templates: []TemplateWarmInput{{TemplateID: "tpl-a", VsockCID: 3}}}
+	var busy atomic.Bool
+	p.runRefillOnce(ctx, lister, spawner, 5*time.Second, &busy)
+
+	if got := len(spawner.Calls()); got != 3 {
+		t.Fatalf("spawn calls = %d, want 3 when free taps meet 2x warm depth", got)
+	}
+}
+
 func TestGC_ReapsAgedReleasedRows(t *testing.T) {
 	ctx := context.Background()
 	p, _ := newTestPool(t)
@@ -272,6 +314,24 @@ func TestGC_ReapsAgedReleasedRows(t *testing.T) {
 	}
 	if stats.Released != 1 {
 		t.Fatalf("after GC stats = %+v, want released=1 (vmms-new survives)", stats)
+	}
+}
+
+func seedTestTapSlots(t *testing.T, st *store.Store, n int) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC()
+	for i := 0; i < n; i++ {
+		base := i * 4
+		if err := st.SeedFirecrackerTapSlot(ctx, store.FirecrackerTapSlot{
+			TapName:  fmt.Sprintf("fctap%d", i),
+			CIDR:     fmt.Sprintf("172.16.0.%d/30", base),
+			HostIP:   fmt.Sprintf("172.16.0.%d", base+1),
+			GuestIP:  fmt.Sprintf("172.16.0.%d", base+2),
+			VsockCID: uint32(3 + i),
+		}, now); err != nil {
+			t.Fatalf("seed tap slot %d: %v", i, err)
+		}
 	}
 }
 

--- a/internal/pool/vmm/refill_test.go
+++ b/internal/pool/vmm/refill_test.go
@@ -275,6 +275,48 @@ func TestGC_ReapsAgedReleasedRows(t *testing.T) {
 	}
 }
 
+func TestGC_ReleasesWarmTapOwnerBeforeDeletingRow(t *testing.T) {
+	ctx := context.Background()
+	p, st := newTestPool(t)
+	now := time.Now().UTC()
+
+	if err := st.SeedFirecrackerTapSlot(ctx, store.FirecrackerTapSlot{
+		TapName:  "fctap0",
+		CIDR:     "172.16.0.0/30",
+		HostIP:   "172.16.0.1",
+		GuestIP:  "172.16.0.2",
+		VsockCID: 3,
+	}, now); err != nil {
+		t.Fatalf("seed tap: %v", err)
+	}
+	if _, err := st.AllocateFirecrackerTapSlot(ctx, "vmms-old", now); err != nil {
+		t.Fatalf("allocate warm tap: %v", err)
+	}
+	if err := p.RecordSpawning(ctx, "vmms-old", "tpl-a", now.Add(-2*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.RecordFailed(ctx, "vmms-old", "retired", now.Add(-2*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+
+	p.runGCOnce(ctx, time.Hour)
+
+	tapSlot, err := st.GetFirecrackerTapSlotBySandbox(ctx, "vmms-old")
+	if err != nil {
+		t.Fatalf("get tap after GC: %v", err)
+	}
+	if tapSlot != nil {
+		t.Fatalf("warm tap still owned after GC: %+v", tapSlot)
+	}
+	vmmSlot, err := st.GetFirecrackerVMMSlotByID(ctx, "vmms-old")
+	if err != nil {
+		t.Fatalf("get vmm slot after GC: %v", err)
+	}
+	if vmmSlot != nil {
+		t.Fatalf("released VMM slot still present after GC: %+v", vmmSlot)
+	}
+}
+
 func TestRun_NilSpawnerIsNoOp(t *testing.T) {
 	// Run with a nil Spawner returns immediately without panicking.
 	// This is the "pool disabled" config path.

--- a/internal/runtime/firecracker/coverage_gap_test.go
+++ b/internal/runtime/firecracker/coverage_gap_test.go
@@ -696,7 +696,7 @@ func TestCreate_WarmRollbackReleaseError(t *testing.T) {
 	pool, _ := stageWarmFixture(t, f)
 	stageWarmTemplate(t, f, false)
 	pool.releaseErr = os.ErrPermission
-	f.client.networkPatchErr = errors.New("patch nic failed")
+	f.client.drivePatchErr = errors.New("patch drive failed")
 
 	_, err := f.driver.Create(context.Background(), models.CreateSandboxRequest{
 		Image:      "alpine:3.20",
@@ -900,7 +900,7 @@ func TestCreate_WarmRollbackShutdownWarn(t *testing.T) {
 	_, handle := stageWarmFixture(t, f)
 	stageWarmTemplate(t, f, false)
 	handle.shutdownErr = os.ErrPermission
-	f.client.networkPatchErr = errors.New("patch nic failed")
+	f.client.drivePatchErr = errors.New("patch drive failed")
 
 	_, err := f.driver.Create(context.Background(), models.CreateSandboxRequest{
 		Image:      "alpine:3.20",

--- a/internal/runtime/firecracker/create_test.go
+++ b/internal/runtime/firecracker/create_test.go
@@ -28,6 +28,12 @@ type fakePool struct {
 	relErr    error // injected on next Release
 	getErr    error // injected on next Get
 	lastAlloc string
+	transfers []transferCall
+}
+
+type transferCall struct {
+	from string
+	to   string
 }
 
 func newFakePool() *fakePool {
@@ -66,6 +72,22 @@ func (p *fakePool) Release(_ context.Context, sandboxID string) error {
 	}
 	delete(p.slots, sandboxID)
 	return nil
+}
+
+func (p *fakePool) Transfer(_ context.Context, fromID, toID string, _ time.Time) (*TapSlot, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.transfers = append(p.transfers, transferCall{from: fromID, to: toID})
+	if existing, ok := p.slots[toID]; ok {
+		return existing, nil
+	}
+	slot, ok := p.slots[fromID]
+	if !ok {
+		return nil, errors.New("fake transfer source missing")
+	}
+	delete(p.slots, fromID)
+	p.slots[toID] = slot
+	return slot, nil
 }
 
 func (p *fakePool) Get(_ context.Context, sandboxID string) (*TapSlot, error) {
@@ -949,11 +971,11 @@ func TestCreate_TemplateRequiresResolver(t *testing.T) {
 	}
 }
 
-// TestCreate_TemplateResolveErrorReleasesSlot mirrors the rootfs-
-// build-failure cleanup contract for the template path: a resolver
-// error (template not ready, deleted, etc.) must release the pool slot
-// and clean up the VMM. Otherwise a flaky resolver drains the pool.
-func TestCreate_TemplateResolveErrorReleasesSlot(t *testing.T) {
+// TestCreate_TemplateResolveErrorDoesNotAllocateSlot mirrors the warm-first
+// ordering: template resolution happens before cold TAP allocation, so a
+// resolver error (template not ready, deleted, etc.) fails without touching the
+// finite TAP pool.
+func TestCreate_TemplateResolveErrorDoesNotAllocateSlot(t *testing.T) {
 	f := newDriverFixture(t)
 	resolver := &fakeTemplateResolver{resolveErr: errors.New("template tpl-x is pending, not ready")}
 	f.driver.SetTemplateResolver(resolver)
@@ -964,8 +986,8 @@ func TestCreate_TemplateResolveErrorReleasesSlot(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected resolver error")
 	}
-	if f.pool.alloc != 1 || f.pool.release != 1 {
-		t.Errorf("pool alloc=%d release=%d, want 1/1", f.pool.alloc, f.pool.release)
+	if f.pool.alloc != 0 || f.pool.release != 0 {
+		t.Errorf("pool alloc=%d release=%d, want 0/0", f.pool.alloc, f.pool.release)
 	}
 	if f.rootfs.builds != 0 {
 		t.Errorf("rootfs.Build called %d times on template error; want 0", f.rootfs.builds)

--- a/internal/runtime/firecracker/create_test.go
+++ b/internal/runtime/firecracker/create_test.go
@@ -843,6 +843,7 @@ func (r *fakeTemplateResolver) Resolve(_ context.Context, id string) (*TemplateR
 		return nil, r.resolveErr
 	}
 	return &TemplateResolution{
+		TemplateID:         id,
 		RootfsPath:         r.rootfsPath,
 		HasSnapshot:        r.hasSnapshot,
 		HasOverlay:         r.hasOverlay,

--- a/internal/runtime/firecracker/create_timing_test.go
+++ b/internal/runtime/firecracker/create_timing_test.go
@@ -1,0 +1,165 @@
+package firecracker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aerol-ai/microvm/pkg/createtiming"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// Phase 0 instrumentation tests (plans/firecracker-create-latency.md):
+// Driver.Create must attribute its boot stages onto the context-carried
+// createtiming recorder so the v1 handler can surface them as
+// Server-Timing entries. Stage presence is the contract — the bench's
+// per-stage breakdown can only sum to the create total if every visited
+// stage records, and only visited stages record.
+
+// stageMap folds the recorder into name→Stage for assertion convenience.
+func stageMap(timing *createtiming.CreateTiming) map[string]createtiming.Stage {
+	out := map[string]createtiming.Stage{}
+	for _, st := range timing.Stages() {
+		out[st.Name] = st
+	}
+	return out
+}
+
+func requireStages(t *testing.T, stages map[string]createtiming.Stage, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		st, ok := stages[name]
+		if !ok {
+			t.Errorf("stage %q not recorded (have %v)", name, stageNames(stages))
+			continue
+		}
+		if st.DurMS < 0 {
+			t.Errorf("stage %q duration = %v, want >= 0", name, st.DurMS)
+		}
+	}
+}
+
+func forbidStages(t *testing.T, stages map[string]createtiming.Stage, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		if _, ok := stages[name]; ok {
+			t.Errorf("stage %q recorded but must be absent on this path (have %v)", name, stageNames(stages))
+		}
+	}
+}
+
+func stageNames(stages map[string]createtiming.Stage) []string {
+	names := make([]string, 0, len(stages))
+	for name := range stages {
+		names = append(names, name)
+	}
+	return names
+}
+
+// TestCreate_SnapshotLoad_RecordsStages: a successful snapshot-load
+// Create populates every boot stage, including fc_verify (checksum on)
+// and fc_load, and never the cold-boot fc_configure or warm fc_warm.
+func TestCreate_SnapshotLoad_RecordsStages(t *testing.T) {
+	f := newDriverFixture(t)
+	f.driver.cfg.SnapshotVerifyOnLoad = true
+	f.driver.snapshotVerifier = func(_, _, _ string) error { return nil }
+
+	tplDir := t.TempDir()
+	templateRootfs := filepath.Join(tplDir, "rootfs.ext4")
+	snapMem := filepath.Join(tplDir, "snapshot.memory")
+	snapState := filepath.Join(tplDir, "snapshot.state")
+	for _, p := range []string{templateRootfs, snapMem, snapState} {
+		if err := os.WriteFile(p, []byte("X"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+	f.driver.SetTemplateResolver(&fakeTemplateResolver{
+		rootfsPath:         templateRootfs,
+		hasSnapshot:        true,
+		snapshotMemoryPath: snapMem,
+		snapshotStatePath:  snapState,
+		snapshotChecksum:   "deadbeef",
+		snapshotVsockCID:   200,
+	})
+
+	ctx, timing := createtiming.With(context.Background())
+	if _, err := f.driver.Create(ctx, models.CreateSandboxRequest{
+		Image: "alpine:3.20", CPU: 1, MemoryMB: 128, DiskGB: 1, TemplateID: "tpl-snap",
+	}, "sb-stage-load", "tok", nil); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	stages := stageMap(timing)
+	requireStages(t, stages,
+		"fc_tap_alloc", "fc_rootfs", "fc_tap_ensure", "fc_spawn",
+		"fc_verify", "fc_load", "fc_resume", "fc_handshake",
+		"fc_post_resume", "fc_driver")
+	forbidStages(t, stages, "fc_configure", "fc_warm")
+}
+
+// TestCreate_ColdBoot_OmitsVerifyLoadStages: a cold-boot Create (no
+// template → OCI rootfs + configureVMM + InstanceStart) records the
+// shared stages plus fc_configure, and never fc_verify/fc_load — those
+// belong exclusively to the snapshot-load branch.
+func TestCreate_ColdBoot_OmitsVerifyLoadStages(t *testing.T) {
+	f := newDriverFixture(t)
+
+	ctx, timing := createtiming.With(context.Background())
+	if _, err := f.driver.Create(ctx, models.CreateSandboxRequest{
+		Image: "alpine:3.20", CPU: 1, MemoryMB: 128, DiskGB: 1,
+	}, "sb-stage-cold", "tok", nil); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	stages := stageMap(timing)
+	requireStages(t, stages,
+		"fc_tap_alloc", "fc_rootfs", "fc_tap_ensure", "fc_spawn",
+		"fc_configure", "fc_resume", "fc_handshake", "fc_post_resume",
+		"fc_driver")
+	forbidStages(t, stages, "fc_verify", "fc_load", "fc_warm")
+}
+
+// TestCreate_WarmHit_RecordsWarmMarker: a warm-pool hit records the
+// fc_warm;desc=hit marker (UC-98's split key) plus the resume/handshake
+// stages the warm path still runs, and none of the cold-spawn stages it
+// skipped.
+func TestCreate_WarmHit_RecordsWarmMarker(t *testing.T) {
+	f := newDriverFixture(t)
+	stageWarmFixture(t, f)
+	stageWarmTemplate(t, f, false)
+
+	ctx, timing := createtiming.With(context.Background())
+	if _, err := f.driver.Create(ctx, models.CreateSandboxRequest{
+		Image: "alpine:3.20", CPU: 1, MemoryMB: 128, DiskGB: 1, TemplateID: "tpl-warm",
+	}, "sb-stage-warm", "tok", nil); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	stages := stageMap(timing)
+	requireStages(t, stages, "fc_warm", "fc_resume", "fc_handshake", "fc_post_resume", "fc_driver")
+	if st := stages["fc_warm"]; st.Desc != "hit" {
+		t.Errorf("fc_warm desc = %q, want hit", st.Desc)
+	}
+	forbidStages(t, stages, "fc_tap_alloc", "fc_rootfs", "fc_tap_ensure", "fc_spawn", "fc_configure", "fc_verify", "fc_load")
+}
+
+// TestCreate_ErrorStillRecordsDriverTotal: fc_driver is recorded on the
+// failure path too — a failed create's cost is exactly what an operator
+// debugging latency needs, and the handler sets Server-Timing on error
+// responses as well.
+func TestCreate_ErrorStillRecordsDriverTotal(t *testing.T) {
+	f := newDriverFixture(t)
+	f.rootfs.nextErr = os.ErrPermission
+
+	ctx, timing := createtiming.With(context.Background())
+	if _, err := f.driver.Create(ctx, models.CreateSandboxRequest{
+		Image: "alpine:3.20", CPU: 1, MemoryMB: 128, DiskGB: 1,
+	}, "sb-stage-err", "tok", nil); err == nil {
+		t.Fatal("Create succeeded, want rootfs build error")
+	}
+
+	stages := stageMap(timing)
+	requireStages(t, stages, "fc_tap_alloc", "fc_driver")
+	forbidStages(t, stages, "fc_spawn", "fc_resume")
+}

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -118,6 +118,14 @@ type Driver struct {
 	// client); tests inject a fake that records REST calls without
 	// needing a real socket.
 	newClient vmmClientFactory
+	// snapshotVerifier is the hash seam used by the load-time integrity
+	// cache. Production uses verifySnapshotChecksum; tests replace it to
+	// count hash invocations without timing a large file read.
+	snapshotVerifier snapshotVerifierFunc
+	// toolboxTCPProbe is the log-only TCP reachability probe. Create
+	// schedules it out of band; tests replace it to assert the request
+	// path no longer waits for the probe tail.
+	toolboxTCPProbe toolboxTCPProbeFunc
 
 	mu       sync.Mutex
 	clients  map[string]VMMClient // sandbox-id -> API client
@@ -130,6 +138,10 @@ type Driver struct {
 	// without adding signal.
 	runtimeHealth string
 	healthReady   bool
+
+	verifyMu          sync.Mutex
+	verifiedSnapshots map[snapshotVerifyKey]*snapshotVerifyEntry
+	verifiedTemplates map[string]snapshotVerifyKey
 }
 
 // TapPool is the interface Driver depends on for network allocation.
@@ -203,6 +215,11 @@ type Config struct {
 	// load-cost of a known-good snapshot. Mirrors
 	// internal/config.Config.FirecrackerSnapshotVerifyOnLoad.
 	SnapshotVerifyOnLoad bool
+	// SnapshotVerifyMode controls whether a verified snapshot is re-hashed
+	// on every LoadSnapshot ("always") or once per daemon boot and file
+	// identity ("once", default). Only consulted when SnapshotVerifyOnLoad
+	// is true and the template has a persisted checksum.
+	SnapshotVerifyMode string
 	// OverlayEnabled is the daemon-wide opt-out for the per-sandbox
 	// writable overlay drive. Mirrors
 	// internal/config.Config.FirecrackerOverlayEnabled. When false,
@@ -249,6 +266,7 @@ func FromDaemonConfig(c config.Config) Config {
 		JailerUID:            c.JailerUID,
 		JailerGID:            c.JailerGID,
 		SnapshotVerifyOnLoad: c.FirecrackerSnapshotVerifyOnLoad,
+		SnapshotVerifyMode:   c.FirecrackerSnapshotVerifyMode,
 		OverlayEnabled:       c.FirecrackerOverlayEnabled,
 		OverlayMkfs:          c.FirecrackerOverlayMkfs,
 		Mkfs4Bin:             c.FirecrackerMkfs4Bin,
@@ -284,6 +302,8 @@ func New(cfg Config, logger *slog.Logger) *Driver {
 	d.newClient = func(socketPath string) VMMClient {
 		return firecracker.New(socketPath)
 	}
+	d.snapshotVerifier = verifySnapshotChecksum
+	d.toolboxTCPProbe = d.probeToolboxTCP
 	return d
 }
 
@@ -376,6 +396,7 @@ type TemplateResolver interface {
 // required; SnapshotChecksum is optional (used for integrity
 // verification when SnapshotVerifyOnLoad is on).
 type TemplateResolution struct {
+	TemplateID         string
 	RootfsPath         string
 	SnapshotMemoryPath string
 	SnapshotStatePath  string
@@ -813,7 +834,7 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 			"gateway_ip", slot.HostIP,
 			"tap", slot.TapName)
 	}
-	d.probeToolboxTCP(ctx, "create", allocID, slot, snapshotLoadPath)
+	d.scheduleToolboxTCPProbe("create", allocID, slot, snapshotLoadPath)
 
 	// All steps succeeded. Register the client + handle so Destroy can
 	// find them. Order matters: the map writes happen AFTER we flip
@@ -981,7 +1002,7 @@ func (d *Driver) configureVMMForLoad(ctx context.Context, client VMMClient, snap
 		return fmt.Errorf("firecracker runtime: configureVMMForLoad called with nil tap slot")
 	}
 	if d.cfg.SnapshotVerifyOnLoad && snap.SnapshotChecksum != "" {
-		if err := verifySnapshotChecksum(snap.SnapshotMemoryPath, snap.SnapshotStatePath, snap.SnapshotChecksum); err != nil {
+		if err := d.verifySnapshotForLoad(snap.TemplateID, snap.SnapshotMemoryPath, snap.SnapshotStatePath, snap.SnapshotChecksum); err != nil {
 			return fmt.Errorf("firecracker runtime: snapshot integrity: %w", err)
 		}
 	}

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -151,6 +151,7 @@ type Driver struct {
 // real *tap.Pool, which satisfies the interface structurally.
 type TapPool interface {
 	Allocate(ctx context.Context, sandboxID string, now time.Time) (*TapSlot, error)
+	Transfer(ctx context.Context, fromID, toID string, now time.Time) (*TapSlot, error)
 	Release(ctx context.Context, sandboxID string) error
 	Get(ctx context.Context, sandboxID string) (*TapSlot, error)
 }
@@ -502,7 +503,34 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 		return nil, fmt.Errorf("firecracker runtime: overlay drive disabled on this daemon (SB_FIRECRACKER_OVERLAY_ENABLED=false)")
 	}
 
-	// Step 1: allocate the network slot.
+	// Step 1: Phase 4 warm-VMM pool fast path. Resolve the template
+	// early (before cold-spawn) so a pool hit avoids spending the
+	// firecracker process + LoadSnapshot wall-clock — that's the
+	// ~150ms+ this whole pool exists to skip. Warm slots already own
+	// their TAP at LoadSnapshot time, so a hit must run before the cold
+	// path allocates a second TAP for this sandbox. On a miss (no
+	// template, no snapshot, no pool slot) we fall through to the
+	// cold-spawn path unchanged.
+	//
+	// Template resolution is the only work we move earlier; the rest
+	// of Create still expects to resolve+stage inside its existing
+	// structure, so we keep the resolved snapshotInfo handy and reuse
+	// it below rather than re-resolving.
+	var earlySnap *TemplateResolution
+	if req.TemplateID != "" && d.templates != nil {
+		var err error
+		earlySnap, err = d.templates.Resolve(ctx, req.TemplateID)
+		if err != nil {
+			return nil, fmt.Errorf("firecracker runtime: template %q resolve: %w", req.TemplateID, err)
+		}
+	}
+	if state, hit, err := d.tryAcquireWarm(ctx, req, allocID, earlySnap, nil, ""); err != nil {
+		return nil, err
+	} else if hit {
+		return state, nil
+	}
+
+	// Step 1b: allocate the network slot for the cold-spawn path.
 	slot, err := d.pool.Allocate(ctx, allocID, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("firecracker runtime: tap allocate: %w", err)
@@ -519,33 +547,6 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 	d.logger.Info("firecracker create: allocated network slot",
 		"sandbox_id", allocID, "tap", slot.TapName,
 		"guest_ip", slot.GuestIP, "vsock_cid", slot.VsockCID)
-
-	// Step 1b: Phase 4 warm-VMM pool fast path. Resolve the template
-	// early (before cold-spawn) so a pool hit avoids spending the
-	// firecracker process + LoadSnapshot wall-clock — that's the
-	// ~150ms+ this whole pool exists to skip. On a miss (no template,
-	// no snapshot, no pool slot) we fall through to the cold-spawn
-	// path unchanged.
-	//
-	// Template resolution is the only step we move earlier; the rest
-	// of Create still expects to resolve+stage inside its existing
-	// structure, so we keep the resolved snapshotInfo handy and reuse
-	// it below rather than re-resolving.
-	var earlySnap *TemplateResolution
-	if req.TemplateID != "" && d.templates != nil {
-		earlySnap, err = d.templates.Resolve(ctx, req.TemplateID)
-		if err != nil {
-			return nil, fmt.Errorf("firecracker runtime: template %q resolve: %w", req.TemplateID, err)
-		}
-	}
-	if state, hit, err := d.tryAcquireWarm(ctx, req, allocID, earlySnap, slot, ""); err != nil {
-		return nil, err
-	} else if hit {
-		// Warm path committed the TAP slot to the sandbox; suppress
-		// the deferred TAP release.
-		released = true
-		return state, nil
-	}
 
 	// Step 2: spawn the VMM. We spawn but do NOT yet Start — the rootfs must
 	// be in place inside the runDir before firecracker boots.
@@ -1148,11 +1149,13 @@ func (d *Driver) vsockHandshake(ctx context.Context, socketPath string, guestCID
 
 	// The first connect after InstanceStart often races the guest's
 	// vsock listener coming up. Retry on connection refused / EAGAIN
-	// for up to the deadline. 50ms cadence matches WaitSocket.
+	// for up to the deadline; capped backoff avoids rounding the common
+	// fast path up to the old fixed 50ms cadence.
 	var (
 		conn io.ReadWriteCloser
 		err  error
 	)
+	delay := vsockPollInitial
 	for {
 		conn, err = d.vsockDial.Dial(dialCtx, socketPath, guestCID, defaultVsockPort)
 		if err == nil {
@@ -1166,8 +1169,9 @@ func (d *Driver) vsockHandshake(ctx context.Context, socketPath string, guestCID
 		select {
 		case <-dialCtx.Done():
 			return fmt.Errorf("vsock dial cid=%d port=%d: %w (last error: %v)", guestCID, defaultVsockPort, dialCtx.Err(), err)
-		case <-time.After(50 * time.Millisecond):
+		case <-time.After(delay):
 		}
+		delay = nextRetryDelay(delay, vsockPollMax)
 	}
 	defer conn.Close()
 

--- a/internal/runtime/firecracker/driver.go
+++ b/internal/runtime/firecracker/driver.go
@@ -45,6 +45,7 @@ import (
 	"time"
 
 	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/pkg/createtiming"
 	"github.com/aerol-ai/microvm/pkg/firecracker"
 	"github.com/aerol-ai/microvm/pkg/models"
 	"github.com/aerol-ai/microvm/pkg/mounts"
@@ -490,6 +491,19 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 		return nil, fmt.Errorf("firecracker runtime: %w", err)
 	}
 
+	// Phase 0 (plans/firecracker-create-latency.md): per-stage boot
+	// attribution. The recorder rides the request context (nil-safe
+	// methods — a bare driver test without a recorder records nothing);
+	// the v1 handler surfaces the stages as Server-Timing entries so
+	// the bench can break the create total down without guessing.
+	// fc_driver is recorded on error paths too: a failed create's cost
+	// is exactly what an operator debugging latency wants to see.
+	timing := createtiming.From(ctx)
+	driverStart := time.Now()
+	defer func() {
+		timing.RecordStage("fc_driver", time.Since(driverStart))
+	}()
+
 	// Step 0: overlay-request sanity. Both the daemon-wide opt-out and
 	// the wire-level upper bound are checked before any allocation so a
 	// bad request fails fast and never leaks a slot. The upper bound
@@ -524,14 +538,21 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 			return nil, fmt.Errorf("firecracker runtime: template %q resolve: %w", req.TemplateID, err)
 		}
 	}
+	warmStart := time.Now()
 	if state, hit, err := d.tryAcquireWarm(ctx, req, allocID, earlySnap, nil, ""); err != nil {
 		return nil, err
 	} else if hit {
+		// UC-98's warm-hit marker: fc_warm carries both the acquire
+		// duration and desc=hit so the bench can split warm vs cold
+		// samples from the header alone.
+		timing.RecordStageDesc("fc_warm", time.Since(warmStart), "hit")
 		return state, nil
 	}
 
 	// Step 1b: allocate the network slot for the cold-spawn path.
+	tapAllocStart := time.Now()
 	slot, err := d.pool.Allocate(ctx, allocID, time.Now())
+	timing.RecordStage("fc_tap_alloc", time.Since(tapAllocStart))
 	if err != nil {
 		return nil, fmt.Errorf("firecracker runtime: tap allocate: %w", err)
 	}
@@ -610,6 +631,7 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 		snapshotLoadPath bool
 		snapshotInfo     *TemplateResolution
 	)
+	rootfsStart := time.Now()
 	if req.TemplateID != "" {
 		if d.templates == nil {
 			return nil, fmt.Errorf("firecracker runtime: template resolver not registered (main.go must call SetTemplateResolver): %w",
@@ -684,6 +706,8 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 		}()
 	}
 
+	timing.RecordStage("fc_rootfs", time.Since(rootfsStart))
+
 	// Step 4: bring the host-side TAP up. After this point, error
 	// returns must call tapHost.Remove. The flag-and-defer pattern
 	// mirrors the pool-release one above.
@@ -696,9 +720,11 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 		// allocated slot MAC.
 		hostSlot.GuestMAC = macFromCID(snapshotInfo.SnapshotVsockCID)
 	}
+	tapEnsureStart := time.Now()
 	if err := d.tapHost.Ensure(ctx, hostSlot); err != nil {
 		return nil, fmt.Errorf("firecracker runtime: tap host ensure %s: %w", slot.TapName, err)
 	}
+	timing.RecordStage("fc_tap_ensure", time.Since(tapEnsureStart))
 	tapRemoved := false
 	defer func() {
 		if !released && !tapRemoved {
@@ -710,6 +736,7 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 	}()
 
 	// Step 5: start the VMM process and wait for the API socket.
+	spawnStart := time.Now()
 	if err := handle.Start(ctx); err != nil {
 		return nil, fmt.Errorf("firecracker runtime: vmm start: %w", err)
 	}
@@ -722,6 +749,7 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 		return nil, fmt.Errorf("firecracker runtime: wait api socket: %w (stderr: %s)",
 			err, handle.StderrTail())
 	}
+	timing.RecordStage("fc_spawn", time.Since(spawnStart))
 
 	// Step 5b: per-sandbox overlay file. Allocated unconditionally when
 	// the request asks for one — both cold-boot (PutDrive overlay) and
@@ -762,13 +790,16 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 	// restored from the snapshot state file.
 	client := d.newClient(handle.APISocket())
 	if snapshotLoadPath {
+		// fc_verify + fc_load are recorded inside configureVMMForLoad.
 		if err := d.configureVMMForLoad(ctx, client, snapshotInfo, rootfsPath, slot, overlayPath); err != nil {
 			return nil, err
 		}
 	} else {
+		configureStart := time.Now()
 		if err := d.configureVMM(ctx, client, req, rootfsPath, slot, overlayPath); err != nil {
 			return nil, err
 		}
+		timing.RecordStage("fc_configure", time.Since(configureStart))
 	}
 
 	// Step 7: Resume the restored VMM (snapshot-load) OR InstanceStart
@@ -776,6 +807,7 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 	// VMM paused (ResumeVM=false) so the driver retains control over
 	// when execution actually begins — a Phase 4 (PR-B) hook to PATCH
 	// per-sandbox state before resume slots in here.
+	resumeStart := time.Now()
 	if snapshotLoadPath {
 		if err := client.PatchVM(ctx, firecracker.VM{State: firecracker.VMStateResumed}); err != nil {
 			return nil, fmt.Errorf("firecracker runtime: patch VM Resumed: %w", err)
@@ -785,6 +817,7 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 			return nil, fmt.Errorf("firecracker runtime: action InstanceStart: %w", err)
 		}
 	}
+	timing.RecordStage("fc_resume", time.Since(resumeStart))
 
 	// Step 8: vsock handshake. The toolbox-in-guest listens on
 	// (cid=<guestCID>, port=1024); we dial from the host. A failed
@@ -803,9 +836,11 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 		handshakeCID = snapshotInfo.SnapshotVsockCID
 	}
 	vsockPath := filepath.Join(handle.RunDir(), hostVsockUDSName)
+	handshakeStart := time.Now()
 	if err := d.vsockHandshake(ctx, vsockPath, handshakeCID); err != nil {
 		return nil, fmt.Errorf("firecracker runtime: vsock handshake: %w", err)
 	}
+	timing.RecordStage("fc_handshake", time.Since(handshakeStart))
 	d.logger.Info("firecracker create: vsock handshake complete",
 		"sandbox_id", allocID,
 		"snapshot_load", snapshotLoadPath,
@@ -821,7 +856,9 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 	// the boot-time race where PID 1 starts before the virtio-net
 	// device is fully visible.
 	postCtx, cancel := context.WithTimeout(ctx, d.cfg.PostResumeTimeout)
+	postResumeStart := time.Now()
 	postErr := d.sendVsockOp(postCtx, vsockPath, handshakeCID, "post_resume", postResumeData(slot))
+	timing.RecordStage("fc_post_resume", time.Since(postResumeStart))
 	cancel()
 	if postErr != nil {
 		d.logger.Warn("firecracker create: post_resume send failed (continuing)",
@@ -1002,11 +1039,19 @@ func (d *Driver) configureVMMForLoad(ctx context.Context, client VMMClient, snap
 	if slot == nil {
 		return fmt.Errorf("firecracker runtime: configureVMMForLoad called with nil tap slot")
 	}
+	timing := createtiming.From(ctx)
 	if d.cfg.SnapshotVerifyOnLoad && snap.SnapshotChecksum != "" {
-		if err := d.verifySnapshotForLoad(snap.TemplateID, snap.SnapshotMemoryPath, snap.SnapshotStatePath, snap.SnapshotChecksum); err != nil {
+		verifyStart := time.Now()
+		err := d.verifySnapshotForLoad(snap.TemplateID, snap.SnapshotMemoryPath, snap.SnapshotStatePath, snap.SnapshotChecksum)
+		timing.RecordStage("fc_verify", time.Since(verifyStart))
+		if err != nil {
 			return fmt.Errorf("firecracker runtime: snapshot integrity: %w", err)
 		}
 	}
+	loadStart := time.Now()
+	defer func() {
+		timing.RecordStage("fc_load", time.Since(loadStart))
+	}()
 	runDir := filepath.Dir(rootfsPath)
 	snapshotMemoryPath, snapshotStatePath, err := d.stageSnapshotLoadPaths(runDir, snap.SnapshotMemoryPath, snap.SnapshotStatePath)
 	if err != nil {

--- a/internal/runtime/firecracker/health.go
+++ b/internal/runtime/firecracker/health.go
@@ -53,6 +53,7 @@ func (d *Driver) SetTemplateHealthNotifier(n TemplateHealthNotifier) {
 // (the next Create going through service.createFirecrackerSandbox)
 // would have produced anyway.
 func (d *Driver) notifyCorrupt(ctx context.Context, templateID, reason string) {
+	d.invalidateSnapshotVerifyCacheForTemplate(templateID)
 	if d.healthNotifier == nil || templateID == "" {
 		return
 	}

--- a/internal/runtime/firecracker/helpers_coverage_test.go
+++ b/internal/runtime/firecracker/helpers_coverage_test.go
@@ -27,6 +27,7 @@ func TestFromDaemonConfig(t *testing.T) {
 		JailerUID:                       1000,
 		JailerGID:                       1001,
 		FirecrackerSnapshotVerifyOnLoad: true,
+		FirecrackerSnapshotVerifyMode:   "always",
 		FirecrackerOverlayEnabled:       true,
 		FirecrackerMkfs4Bin:             "/sbin/mkfs.ext4",
 	}
@@ -37,7 +38,7 @@ func TestFromDaemonConfig(t *testing.T) {
 		got.TemplatesDir != c.FirecrackerTemplatesDir ||
 		!got.UseJailer ||
 		got.JailerUID != 1000 || got.JailerGID != 1001 ||
-		!got.SnapshotVerifyOnLoad || !got.OverlayEnabled {
+		!got.SnapshotVerifyOnLoad || got.SnapshotVerifyMode != "always" || !got.OverlayEnabled {
 		t.Fatalf("FromDaemonConfig mismatch: %+v", got)
 	}
 }

--- a/internal/runtime/firecracker/retry.go
+++ b/internal/runtime/firecracker/retry.go
@@ -1,0 +1,21 @@
+package firecracker
+
+import "time"
+
+const (
+	socketPollInitial = 2 * time.Millisecond
+	socketPollMax     = 20 * time.Millisecond
+	vsockPollInitial  = 5 * time.Millisecond
+	vsockPollMax      = 50 * time.Millisecond
+)
+
+func nextRetryDelay(current, max time.Duration) time.Duration {
+	if current <= 0 {
+		return max
+	}
+	next := current * 2
+	if next > max {
+		return max
+	}
+	return next
+}

--- a/internal/runtime/firecracker/retry_test.go
+++ b/internal/runtime/firecracker/retry_test.go
@@ -1,0 +1,54 @@
+package firecracker
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRetryDelayBackoffSequence(t *testing.T) {
+	cases := []struct {
+		name    string
+		initial time.Duration
+		max     time.Duration
+		want    []time.Duration
+	}{
+		{
+			name:    "socket wait",
+			initial: socketPollInitial,
+			max:     socketPollMax,
+			want: []time.Duration{
+				2 * time.Millisecond,
+				4 * time.Millisecond,
+				8 * time.Millisecond,
+				16 * time.Millisecond,
+				20 * time.Millisecond,
+				20 * time.Millisecond,
+			},
+		},
+		{
+			name:    "vsock handshake",
+			initial: vsockPollInitial,
+			max:     vsockPollMax,
+			want: []time.Duration{
+				5 * time.Millisecond,
+				10 * time.Millisecond,
+				20 * time.Millisecond,
+				40 * time.Millisecond,
+				50 * time.Millisecond,
+				50 * time.Millisecond,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			delay := tc.initial
+			for i, want := range tc.want {
+				if delay != want {
+					t.Fatalf("delay[%d] = %s, want %s", i, delay, want)
+				}
+				delay = nextRetryDelay(delay, tc.max)
+			}
+		})
+	}
+}

--- a/internal/runtime/firecracker/sandbox_snapshot_start_extra2_test.go
+++ b/internal/runtime/firecracker/sandbox_snapshot_start_extra2_test.go
@@ -16,6 +16,9 @@ type fakePoolGetErr struct {
 func (p *fakePoolGetErr) Allocate(ctx context.Context, sandboxID string, now time.Time) (*TapSlot, error) {
 	return nil, p.err
 }
+func (p *fakePoolGetErr) Transfer(ctx context.Context, fromID, toID string, now time.Time) (*TapSlot, error) {
+	return nil, p.err
+}
 func (p *fakePoolGetErr) Release(ctx context.Context, sandboxID string) error {
 	return p.err
 }

--- a/internal/runtime/firecracker/snapshot_verify_cache.go
+++ b/internal/runtime/firecracker/snapshot_verify_cache.go
@@ -1,0 +1,139 @@
+package firecracker
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+)
+
+const (
+	snapshotVerifyModeOnce   = "once"
+	snapshotVerifyModeAlways = "always"
+)
+
+type snapshotVerifierFunc func(memPath, statePath, expected string) error
+
+type snapshotFileIdentity struct {
+	path        string
+	dev         uint64
+	inode       uint64
+	size        int64
+	modUnixNano int64
+}
+
+type snapshotVerifyKey struct {
+	checksum string
+	memory   snapshotFileIdentity
+	state    snapshotFileIdentity
+}
+
+type snapshotVerifyEntry struct {
+	done chan struct{}
+	err  error
+}
+
+func (d *Driver) verifySnapshotForLoad(templateID, memPath, statePath, expected string) error {
+	if !d.cfg.SnapshotVerifyOnLoad || expected == "" {
+		return nil
+	}
+	if strings.EqualFold(d.cfg.SnapshotVerifyMode, snapshotVerifyModeAlways) {
+		return d.runSnapshotVerifier(memPath, statePath, expected)
+	}
+
+	key, err := snapshotVerifyKeyFor(memPath, statePath, expected)
+	if err != nil {
+		// Preserve the verifier's existing error shape for missing or
+		// transiently unreadable files instead of inventing a stat-only
+		// variant on the hot path.
+		return d.runSnapshotVerifier(memPath, statePath, expected)
+	}
+
+	d.verifyMu.Lock()
+	if d.verifiedSnapshots == nil {
+		d.verifiedSnapshots = make(map[snapshotVerifyKey]*snapshotVerifyEntry)
+	}
+	if entry := d.verifiedSnapshots[key]; entry != nil {
+		d.verifyMu.Unlock()
+		<-entry.done
+		return entry.err
+	}
+	entry := &snapshotVerifyEntry{done: make(chan struct{})}
+	d.verifiedSnapshots[key] = entry
+	d.verifyMu.Unlock()
+
+	verifyErr := d.runSnapshotVerifier(memPath, statePath, expected)
+
+	d.verifyMu.Lock()
+	entry.err = verifyErr
+	if verifyErr != nil {
+		delete(d.verifiedSnapshots, key)
+	} else if templateID != "" {
+		if d.verifiedTemplates == nil {
+			d.verifiedTemplates = make(map[string]snapshotVerifyKey)
+		}
+		if oldKey, ok := d.verifiedTemplates[templateID]; ok && oldKey != key {
+			delete(d.verifiedSnapshots, oldKey)
+		}
+		d.verifiedTemplates[templateID] = key
+	}
+	close(entry.done)
+	d.verifyMu.Unlock()
+	return verifyErr
+}
+
+func (d *Driver) runSnapshotVerifier(memPath, statePath, expected string) error {
+	if d.snapshotVerifier == nil {
+		return verifySnapshotChecksum(memPath, statePath, expected)
+	}
+	return d.snapshotVerifier(memPath, statePath, expected)
+}
+
+func (d *Driver) invalidateSnapshotVerifyCacheForTemplate(templateID string) {
+	if templateID == "" {
+		return
+	}
+	d.verifyMu.Lock()
+	defer d.verifyMu.Unlock()
+	key, ok := d.verifiedTemplates[templateID]
+	if !ok {
+		return
+	}
+	delete(d.verifiedTemplates, templateID)
+	delete(d.verifiedSnapshots, key)
+}
+
+func snapshotVerifyKeyFor(memPath, statePath, expected string) (snapshotVerifyKey, error) {
+	memory, err := snapshotFileIdentityFor(memPath)
+	if err != nil {
+		return snapshotVerifyKey{}, fmt.Errorf("snapshot verify cache: stat memory: %w", err)
+	}
+	state, err := snapshotFileIdentityFor(statePath)
+	if err != nil {
+		return snapshotVerifyKey{}, fmt.Errorf("snapshot verify cache: stat state: %w", err)
+	}
+	return snapshotVerifyKey{
+		checksum: expected,
+		memory:   memory,
+		state:    state,
+	}, nil
+}
+
+func snapshotFileIdentityFor(path string) (snapshotFileIdentity, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return snapshotFileIdentity{}, err
+	}
+	var dev, inode uint64
+	if st, ok := info.Sys().(*syscall.Stat_t); ok {
+		dev = uint64(st.Dev)
+		inode = uint64(st.Ino)
+	}
+	return snapshotFileIdentity{
+		path:        path,
+		dev:         dev,
+		inode:       inode,
+		size:        info.Size(),
+		modUnixNano: info.ModTime().UnixNano(),
+	}, nil
+}

--- a/internal/runtime/firecracker/snapshot_verify_cache_test.go
+++ b/internal/runtime/firecracker/snapshot_verify_cache_test.go
@@ -170,6 +170,56 @@ func TestVerifyCache_ModeAlways(t *testing.T) {
 	}
 }
 
+// TestVerifyCache_WarmSpawnShares drives BOTH production call sites —
+// WarmSpawn (the pool's refill goroutine) and a snapshot-load Create
+// (configureVMMForLoad) — against one template and asserts they share
+// a single cache entry: one hash total. Guards against the two call
+// sites drifting onto separate caches (or one dropping the cache).
+func TestVerifyCache_WarmSpawnShares(t *testing.T) {
+	f := newDriverFixture(t)
+	f.driver.cfg.SnapshotVerifyOnLoad = true
+	var calls int32
+	f.driver.snapshotVerifier = func(_, _, _ string) error {
+		atomic.AddInt32(&calls, 1)
+		return nil
+	}
+
+	tplDir := t.TempDir()
+	rootfs := filepath.Join(tplDir, "rootfs.ext4")
+	if err := writeFile(rootfs, []byte("ROOTFS")); err != nil {
+		t.Fatalf("write rootfs: %v", err)
+	}
+	memPath, statePath, checksum := writeVerifyCacheFiles(t, tplDir, "mem", "state")
+	f.driver.SetTemplateResolver(&fakeTemplateResolver{
+		rootfsPath:         rootfs,
+		hasSnapshot:        true,
+		snapshotMemoryPath: memPath,
+		snapshotStatePath:  statePath,
+		snapshotChecksum:   checksum,
+		snapshotVsockCID:   200,
+	})
+
+	if _, err := f.driver.WarmSpawn(context.Background(), WarmSpawnRequest{
+		SlotID:             "vmms-warm-share",
+		TemplateID:         "tpl-share",
+		SnapshotMemoryPath: memPath,
+		SnapshotStatePath:  statePath,
+		SnapshotChecksum:   checksum,
+		VsockCID:           200,
+	}); err != nil {
+		t.Fatalf("WarmSpawn: %v", err)
+	}
+	if _, err := f.driver.Create(context.Background(), models.CreateSandboxRequest{
+		Image: "alpine:3.20", CPU: 1, MemoryMB: 128, TemplateID: "tpl-share",
+	}, "sb-verify-share", "tok", nil); err != nil {
+		t.Fatalf("Create snapshot-load: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("verifier calls = %d, want 1 shared across WarmSpawn and Create", got)
+	}
+}
+
 func TestVerifyCache_DisabledSkipsEntirely(t *testing.T) {
 	memPath, statePath, checksum := writeVerifyCacheFiles(t, t.TempDir(), "mem", "state")
 	d := New(Config{SnapshotVerifyOnLoad: false}, nil)

--- a/internal/runtime/firecracker/snapshot_verify_cache_test.go
+++ b/internal/runtime/firecracker/snapshot_verify_cache_test.go
@@ -1,0 +1,187 @@
+package firecracker
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func writeVerifyCacheFiles(t *testing.T, dir string, mem, state string) (string, string, string) {
+	t.Helper()
+	memPath := filepath.Join(dir, "snapshot.memory")
+	statePath := filepath.Join(dir, "snapshot.state")
+	if err := writeFile(memPath, []byte(mem)); err != nil {
+		t.Fatalf("write memory: %v", err)
+	}
+	if err := writeFile(statePath, []byte(state)); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	return memPath, statePath, "sha256:mem|sha256:state"
+}
+
+func writeFile(path string, b []byte) error {
+	return os.WriteFile(path, b, 0o600)
+}
+
+func TestVerifyCache_SecondLoadSkipsHash(t *testing.T) {
+	memPath, statePath, checksum := writeVerifyCacheFiles(t, t.TempDir(), "mem", "state")
+	d := New(Config{SnapshotVerifyOnLoad: true}, nil)
+	var calls int32
+	d.snapshotVerifier = func(_, _, _ string) error {
+		atomic.AddInt32(&calls, 1)
+		return nil
+	}
+
+	for i := 0; i < 2; i++ {
+		if err := d.verifySnapshotForLoad("tpl-cache", memPath, statePath, checksum); err != nil {
+			t.Fatalf("verify %d: %v", i, err)
+		}
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("verifier calls = %d, want 1", got)
+	}
+}
+
+func TestVerifyCache_SingleFlight(t *testing.T) {
+	memPath, statePath, checksum := writeVerifyCacheFiles(t, t.TempDir(), "mem", "state")
+	d := New(Config{SnapshotVerifyOnLoad: true}, nil)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var closeStarted sync.Once
+	var calls int32
+	d.snapshotVerifier = func(_, _, _ string) error {
+		atomic.AddInt32(&calls, 1)
+		closeStarted.Do(func() { close(started) })
+		<-release
+		return nil
+	}
+
+	const workers = 8
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			errs <- d.verifySnapshotForLoad("tpl-cache", memPath, statePath, checksum)
+		}()
+	}
+	<-started
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("verifier calls while first verify is blocked = %d, want 1", got)
+	}
+	close(release)
+	for i := 0; i < workers; i++ {
+		if err := <-errs; err != nil {
+			t.Fatalf("worker %d verify error: %v", i, err)
+		}
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("verifier calls after waiters returned = %d, want 1", got)
+	}
+}
+
+func TestVerifyCache_FailureNotCached(t *testing.T) {
+	memPath, statePath, checksum := writeVerifyCacheFiles(t, t.TempDir(), "mem", "state")
+	d := New(Config{SnapshotVerifyOnLoad: true}, nil)
+	var calls int32
+	d.snapshotVerifier = func(_, _, _ string) error {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			return models.ErrSnapshotCorrupt
+		}
+		return nil
+	}
+
+	if err := d.verifySnapshotForLoad("tpl-cache", memPath, statePath, checksum); !errors.Is(err, models.ErrSnapshotCorrupt) {
+		t.Fatalf("first verify error = %v, want ErrSnapshotCorrupt", err)
+	}
+	if err := d.verifySnapshotForLoad("tpl-cache", memPath, statePath, checksum); err != nil {
+		t.Fatalf("second verify: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("verifier calls = %d, want 2", got)
+	}
+}
+
+func TestVerifyCache_InvalidatesOnFileChange(t *testing.T) {
+	dir := t.TempDir()
+	memPath, statePath, checksum := writeVerifyCacheFiles(t, dir, "mem", "state")
+	d := New(Config{SnapshotVerifyOnLoad: true}, nil)
+	var calls int32
+	d.snapshotVerifier = func(_, _, _ string) error {
+		atomic.AddInt32(&calls, 1)
+		return nil
+	}
+
+	if err := d.verifySnapshotForLoad("tpl-cache", memPath, statePath, checksum); err != nil {
+		t.Fatalf("first verify: %v", err)
+	}
+	if err := os.WriteFile(memPath, []byte("mem-new-size"), 0o600); err != nil {
+		t.Fatalf("rewrite memory: %v", err)
+	}
+	if err := d.verifySnapshotForLoad("tpl-cache", memPath, statePath, checksum); err != nil {
+		t.Fatalf("second verify: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("verifier calls = %d, want 2 after file identity changed", got)
+	}
+}
+
+func TestVerifyCache_CorruptNotificationInvalidates(t *testing.T) {
+	memPath, statePath, checksum := writeVerifyCacheFiles(t, t.TempDir(), "mem", "state")
+	d := New(Config{SnapshotVerifyOnLoad: true}, nil)
+	var calls int32
+	d.snapshotVerifier = func(_, _, _ string) error {
+		atomic.AddInt32(&calls, 1)
+		return nil
+	}
+
+	if err := d.verifySnapshotForLoad("tpl-cache", memPath, statePath, checksum); err != nil {
+		t.Fatalf("first verify: %v", err)
+	}
+	d.notifyCorrupt(context.Background(), "tpl-cache", "test invalidation")
+	if err := d.verifySnapshotForLoad("tpl-cache", memPath, statePath, checksum); err != nil {
+		t.Fatalf("second verify: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("verifier calls = %d, want 2 after corrupt invalidation", got)
+	}
+}
+
+func TestVerifyCache_ModeAlways(t *testing.T) {
+	memPath, statePath, checksum := writeVerifyCacheFiles(t, t.TempDir(), "mem", "state")
+	d := New(Config{SnapshotVerifyOnLoad: true, SnapshotVerifyMode: snapshotVerifyModeAlways}, nil)
+	var calls int32
+	d.snapshotVerifier = func(_, _, _ string) error {
+		atomic.AddInt32(&calls, 1)
+		return nil
+	}
+
+	for i := 0; i < 2; i++ {
+		if err := d.verifySnapshotForLoad("tpl-cache", memPath, statePath, checksum); err != nil {
+			t.Fatalf("verify %d: %v", i, err)
+		}
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("verifier calls = %d, want 2 in always mode", got)
+	}
+}
+
+func TestVerifyCache_DisabledSkipsEntirely(t *testing.T) {
+	memPath, statePath, checksum := writeVerifyCacheFiles(t, t.TempDir(), "mem", "state")
+	d := New(Config{SnapshotVerifyOnLoad: false}, nil)
+	d.snapshotVerifier = func(_, _, _ string) error {
+		t.Fatal("snapshot verifier should not be called when verify-on-load is disabled")
+		return nil
+	}
+
+	if err := d.verifySnapshotForLoad("tpl-cache", memPath, statePath, checksum); err != nil {
+		t.Fatalf("verify disabled: %v", err)
+	}
+	if len(d.verifiedSnapshots) != 0 {
+		t.Fatalf("verifiedSnapshots len = %d, want 0", len(d.verifiedSnapshots))
+	}
+}

--- a/internal/runtime/firecracker/toolbox_probe.go
+++ b/internal/runtime/firecracker/toolbox_probe.go
@@ -1,0 +1,24 @@
+package firecracker
+
+import (
+	"context"
+)
+
+type toolboxTCPProbeFunc func(ctx context.Context, operation, sandboxID string, slot *TapSlot, snapshotLoad bool)
+
+func (d *Driver) scheduleToolboxTCPProbe(operation, sandboxID string, slot *TapSlot, snapshotLoad bool) {
+	if slot == nil || slot.GuestIP == "" || d.cfg.PostResumeTimeout <= 0 {
+		return
+	}
+	probe := d.toolboxTCPProbe
+	if probe == nil {
+		probe = d.probeToolboxTCP
+	}
+	slotCopy := *slot
+	timeout := d.cfg.PostResumeTimeout
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		probe(ctx, operation, sandboxID, &slotCopy, snapshotLoad)
+	}()
+}

--- a/internal/runtime/firecracker/toolbox_probe_test.go
+++ b/internal/runtime/firecracker/toolbox_probe_test.go
@@ -1,0 +1,107 @@
+package firecracker
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func TestCreate_TCPProbeOffCriticalPath(t *testing.T) {
+	f := newDriverFixture(t)
+	f.driver.cfg.PostResumeTimeout = 250 * time.Millisecond
+	started := make(chan struct{})
+	done := make(chan struct{})
+	var closeStarted sync.Once
+	f.driver.toolboxTCPProbe = func(ctx context.Context, _, _ string, _ *TapSlot, _ bool) {
+		closeStarted.Do(func() { close(started) })
+		<-ctx.Done()
+		close(done)
+	}
+
+	start := time.Now()
+	_, err := f.driver.Create(context.Background(), models.CreateSandboxRequest{
+		Image: "alpine:3.20", CPU: 1, MemoryMB: 128,
+	}, "sb-async-probe", "tok", nil)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Fatalf("Create took %s with a blocking TCP probe; want probe off critical path", elapsed)
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("TCP probe goroutine did not start")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("TCP probe did not finish under its detached timeout")
+	}
+}
+
+func TestCreate_TCPProbeUsesDetachedContext(t *testing.T) {
+	f := newDriverFixture(t)
+	f.driver.cfg.PostResumeTimeout = 30 * time.Millisecond
+	probeErr := make(chan error, 1)
+	f.driver.toolboxTCPProbe = func(ctx context.Context, _, _ string, _ *TapSlot, _ bool) {
+		<-ctx.Done()
+		probeErr <- ctx.Err()
+	}
+
+	reqCtx, cancel := context.WithCancel(context.Background())
+	if _, err := f.driver.Create(reqCtx, models.CreateSandboxRequest{
+		Image: "alpine:3.20", CPU: 1, MemoryMB: 128,
+	}, "sb-detached-probe", "tok", nil); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cancel()
+	select {
+	case err := <-probeErr:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("probe ctx err = %v, want DeadlineExceeded from detached timeout", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("TCP probe did not finish")
+	}
+}
+
+func TestWarmAcquire_TCPProbeOffCriticalPath(t *testing.T) {
+	f := newDriverFixture(t)
+	stageWarmFixture(t, f)
+	stageWarmTemplate(t, f, false)
+	f.driver.cfg.PostResumeTimeout = 250 * time.Millisecond
+	started := make(chan struct{})
+	done := make(chan struct{})
+	var closeStarted sync.Once
+	f.driver.toolboxTCPProbe = func(ctx context.Context, _, _ string, _ *TapSlot, _ bool) {
+		closeStarted.Do(func() { close(started) })
+		<-ctx.Done()
+		close(done)
+	}
+
+	start := time.Now()
+	_, err := f.driver.Create(context.Background(), models.CreateSandboxRequest{
+		Image: "alpine:3.20", CPU: 1, MemoryMB: 128, TemplateID: "tpl-warm",
+	}, "sb-warm-async-probe", "tok", nil)
+	if err != nil {
+		t.Fatalf("Create warm hit: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Fatalf("warm Create took %s with a blocking TCP probe; want probe off critical path", elapsed)
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("warm TCP probe goroutine did not start")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("warm TCP probe did not finish under its detached timeout")
+	}
+}

--- a/internal/runtime/firecracker/vmm.go
+++ b/internal/runtime/firecracker/vmm.go
@@ -241,8 +241,8 @@ func (v *vmm) buildArgs() []string {
 // to surface to the operator. A zero timeout means defaultSocketWait.
 //
 // Why poll rather than inotify: the file appears within milliseconds on a
-// healthy boot; a 20 ms poll is cheaper than wiring inotify and works the
-// same on Linux and macOS for the dev path.
+// healthy boot; capped backoff keeps the common case responsive without
+// spinning if the process never binds.
 func (v *vmm) WaitSocket(ctx context.Context, timeout time.Duration) error {
 	if !v.started {
 		return errors.New("vmm: WaitSocket called before Start")
@@ -251,6 +251,7 @@ func (v *vmm) WaitSocket(ctx context.Context, timeout time.Duration) error {
 		timeout = defaultSocketWait
 	}
 	deadline := time.Now().Add(timeout)
+	delay := socketPollInitial
 	for {
 		// Check process exit BEFORE the Stat. Under heavy parallelism
 		// (lots of subprocess tests running concurrently) the goroutine
@@ -273,8 +274,9 @@ func (v *vmm) WaitSocket(ctx context.Context, timeout time.Duration) error {
 				v.waitErr, v.stderr.String())
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(20 * time.Millisecond):
+		case <-time.After(delay):
 		}
+		delay = nextRetryDelay(delay, socketPollMax)
 		if time.Now().After(deadline) {
 			return fmt.Errorf("vmm: API socket %s did not appear within %s", v.apiSocket, timeout)
 		}

--- a/internal/runtime/firecracker/warmacquire.go
+++ b/internal/runtime/firecracker/warmacquire.go
@@ -285,7 +285,7 @@ func (d *Driver) tryAcquireWarm(
 			"tap", tapSlot.TapName)
 	}
 	cancel()
-	d.probeToolboxTCP(ctx, "warm_acquire", sandboxID, tapSlot, true)
+	d.scheduleToolboxTCPProbe("warm_acquire", sandboxID, tapSlot, true)
 
 	// Register the warm handle + client into the driver's map so
 	// Destroy finds them. The handle is the SpawnedHandle from the

--- a/internal/runtime/firecracker/warmacquire.go
+++ b/internal/runtime/firecracker/warmacquire.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	vmmpool "github.com/aerol-ai/microvm/internal/pool/vmm"
+	"github.com/aerol-ai/microvm/pkg/createtiming"
 	"github.com/aerol-ai/microvm/pkg/firecracker"
 	"github.com/aerol-ai/microvm/pkg/models"
 )
@@ -122,6 +123,12 @@ func (d *Driver) tryAcquireWarm(
 		"vsock_cid", slot.VsockCID)
 
 	transferredSlot, err := d.pool.Transfer(ctx, slot.ID, sandboxID, time.Now().UTC())
+	if err == nil && transferredSlot == nil {
+		// Defensive: the TapPool contract returns a slot on success, but a
+		// nil/nil answer must still roll back — returning without cleanup
+		// here would leak the claimed warm slot AND its paused VMM.
+		err = errors.New("transfer returned no slot")
+	}
 	if err != nil {
 		if relErr := d.warmPool.Release(context.Background(), sandboxID, time.Now().UTC()); relErr != nil {
 			d.logger.Warn("firecracker create: warm acquire rollback after tap transfer failure (pool release)",
@@ -132,9 +139,6 @@ func (d *Driver) tryAcquireWarm(
 				"sandbox_id", sandboxID, "slot_id", slot.ID, "error", sErr)
 		}
 		return nil, false, fmt.Errorf("firecracker runtime: warm tap transfer %s -> %s: %w", slot.ID, sandboxID, err)
-	}
-	if transferredSlot == nil {
-		return nil, false, fmt.Errorf("firecracker runtime: warm tap transfer %s -> %s returned nil slot", slot.ID, sandboxID)
 	}
 	tapSlot = transferredSlot
 	if setter, ok := handle.(warmTapOwnerSetter); ok {
@@ -233,9 +237,12 @@ func (d *Driver) tryAcquireWarm(
 	// Resume the VMM. From the guest's perspective this is the first
 	// instruction after the snapshot was taken — vCPUs start ticking
 	// against the new TAP+overlay.
+	timing := createtiming.From(ctx)
+	resumeStart := time.Now()
 	if err := client.PatchVM(ctx, firecracker.VM{State: firecracker.VMStateResumed}); err != nil {
 		return nil, false, fmt.Errorf("firecracker runtime: warm patch VM Resumed: %w", err)
 	}
+	timing.RecordStage("fc_resume", time.Since(resumeStart))
 
 	// Vsock handshake — dial the snapshot's reserved CID. The pool
 	// slot's vsock_cid IS the snapshot's CID (RecordLoaded copies it
@@ -243,9 +250,11 @@ func (d *Driver) tryAcquireWarm(
 	// dial. Dialing tapSlot.VsockCID would race the guest, which is
 	// listening on the snapshot's CID baked in at template build.
 	vsockPath := filepath.Join(slot.RunDir, hostVsockUDSName)
+	handshakeStart := time.Now()
 	if err := d.vsockHandshake(ctx, vsockPath, slot.VsockCID); err != nil {
 		return nil, false, fmt.Errorf("firecracker runtime: warm vsock handshake: %w", err)
 	}
+	timing.RecordStage("fc_handshake", time.Since(handshakeStart))
 	d.logger.Info("firecracker create: warm vsock handshake complete",
 		"sandbox_id", sandboxID,
 		"vsock_cid", slot.VsockCID,
@@ -255,7 +264,10 @@ func (d *Driver) tryAcquireWarm(
 	// post_resume reseed (RNG + wallclock). Best-effort; same shape
 	// as the cold snapshot-load path.
 	postCtx, cancel := context.WithTimeout(ctx, d.cfg.PostResumeTimeout)
-	if err := d.sendVsockOp(postCtx, vsockPath, slot.VsockCID, "post_resume", postResumeData(tapSlot)); err != nil {
+	postResumeStart := time.Now()
+	postResumeErr := d.sendVsockOp(postCtx, vsockPath, slot.VsockCID, "post_resume", postResumeData(tapSlot))
+	timing.RecordStage("fc_post_resume", time.Since(postResumeStart))
+	if err := postResumeErr; err != nil {
 		d.logger.Warn("firecracker create: warm post_resume send failed (continuing)",
 			"sandbox_id", sandboxID, "error", err)
 	} else {

--- a/internal/runtime/firecracker/warmacquire.go
+++ b/internal/runtime/firecracker/warmacquire.go
@@ -14,18 +14,16 @@ package firecracker
 //
 //   - LoadSnapshot: skipped. The pool already issued it.
 //
-//   - PutNetworkInterface vs PatchDrive: the cold-boot path uses Put
-//     before InstanceStart; the snapshot-load path supplies TAP
-//     rebinding in LoadSnapshot.network_overrides and patches drive
-//     paths before Resume. The warm path predates that Firecracker
-//     v1.15 contract and remains gated behind the disabled-by-default
-//     pool flag.
+//   - Network rebinding: skipped. WarmSpawn already supplied
+//     LoadSnapshot.network_overrides against a real TAP owned by the warm
+//     slot; Acquire only transfers that TAP owner to the sandbox id.
 //
 // Failure-path consistency (pr-review.md §4): every resource acquired
-// in this file (TAP slot, host TAP, overlay file, registry entries) is
-// cleaned up in LIFO order on error. The pool slot's row is moved back
-// to 'released' so the GC sweep tears the VMM down — there is no path
-// here that leaves a slot stuck in 'allocated' without a sandbox owner.
+// in this file (warm VMM slot, transferred TAP owner, overlay file,
+// registry entries) is cleaned up in LIFO order on error. The pool slot's row
+// is moved to 'released' and the handle is shut down so the TAP is removed and
+// released — there is no path here that leaves a slot stuck in 'allocated'
+// without a sandbox owner.
 
 import (
 	"context"
@@ -53,6 +51,10 @@ import (
 type WarmPool interface {
 	AcquireWithHandle(ctx context.Context, templateID, sandboxID string, now time.Time) (*vmmpool.Slot, vmmpool.SpawnedHandle, error)
 	Release(ctx context.Context, sandboxID string, now time.Time) error
+}
+
+type warmTapOwnerSetter interface {
+	setTapOwner(owner string)
 }
 
 // SetWarmPool injects the warm-VMM pool. Called once by main.go after
@@ -119,17 +121,34 @@ func (d *Driver) tryAcquireWarm(
 		"slot_id", slot.ID, "api_socket", slot.APISocket,
 		"vsock_cid", slot.VsockCID)
 
+	transferredSlot, err := d.pool.Transfer(ctx, slot.ID, sandboxID, time.Now().UTC())
+	if err != nil {
+		if relErr := d.warmPool.Release(context.Background(), sandboxID, time.Now().UTC()); relErr != nil {
+			d.logger.Warn("firecracker create: warm acquire rollback after tap transfer failure (pool release)",
+				"sandbox_id", sandboxID, "slot_id", slot.ID, "error", relErr)
+		}
+		if sErr := handle.Shutdown(context.Background(), 3*time.Second); sErr != nil {
+			d.logger.Warn("firecracker create: warm acquire rollback after tap transfer failure (handle shutdown)",
+				"sandbox_id", sandboxID, "slot_id", slot.ID, "error", sErr)
+		}
+		return nil, false, fmt.Errorf("firecracker runtime: warm tap transfer %s -> %s: %w", slot.ID, sandboxID, err)
+	}
+	if transferredSlot == nil {
+		return nil, false, fmt.Errorf("firecracker runtime: warm tap transfer %s -> %s returned nil slot", slot.ID, sandboxID)
+	}
+	tapSlot = transferredSlot
+	if setter, ok := handle.(warmTapOwnerSetter); ok {
+		setter.setTapOwner(sandboxID)
+	}
+	d.logger.Info("firecracker create: warm tap transferred",
+		"sandbox_id", sandboxID, "slot_id", slot.ID, "tap", tapSlot.TapName,
+		"guest_ip", tapSlot.GuestIP)
+
 	// From here on, any error must release the slot (move row to
 	// 'released' so GC drops it AND the handle is Shutdown). The
 	// flag-and-defer pattern mirrors the cold-spawn path's pool/tap/vmm
 	// cleanup.
 	committed := false
-	// tapEnsured gates the host-TAP rollback below: we only `ip link
-	// delete` a device this path actually brought up. The host TAP is
-	// realized lazily (just before the network PATCH), so an error in the
-	// overlay/rootfs staging above it must not Remove a device that was
-	// never Ensured.
-	tapEnsured := false
 	defer func() {
 		if committed {
 			return
@@ -145,16 +164,6 @@ func (d *Driver) tryAcquireWarm(
 		if sErr := handle.Shutdown(context.Background(), 3*time.Second); sErr != nil {
 			d.logger.Warn("firecracker create: warm acquire rollback (handle shutdown)",
 				"sandbox_id", sandboxID, "slot_id", slot.ID, "error", sErr)
-		}
-		// Drop the host TAP last — after handle.Shutdown has brought the
-		// firecracker process down. `ip link delete` on a TAP still
-		// owned by a running VMM fails EBUSY (the same ordering Destroy
-		// relies on in driver.go).
-		if tapEnsured {
-			if rmErr := d.tapHost.Remove(context.Background(), tapSlot.TapName); rmErr != nil {
-				d.logger.Warn("firecracker create: warm acquire rollback (tap remove)",
-					"sandbox_id", sandboxID, "tap", tapSlot.TapName, "error", rmErr)
-			}
 		}
 	}()
 
@@ -203,33 +212,6 @@ func (d *Driver) tryAcquireWarm(
 		PathOnHost: warmRootfsAPIPath,
 	}); err != nil {
 		return nil, false, fmt.Errorf("firecracker runtime: warm patch rootfs drive: %w", err)
-	}
-
-	// Bring this sandbox's host TAP up before pointing the guest's eth0
-	// at it. WarmSpawn deliberately skips host-TAP realization: the
-	// snapshot's eth0 references the defunct template-build TAP, and
-	// firecracker only validates the device at Resume, not at snapshot
-	// load (see warmspawn.go). The cold path realizes the TAP at its
-	// Step 4 in driver.go; the warm path returns before reaching that
-	// step, so without this Ensure the VM resume below points
-	// host_dev_name at a device that was never created and the create
-	// fails. Idempotent — a retried create re-Ensures the same slot.
-	if err := d.tapHost.Ensure(ctx, *tapSlot); err != nil {
-		return nil, false, fmt.Errorf("firecracker runtime: warm tap host ensure %s: %w", tapSlot.TapName, err)
-	}
-	tapEnsured = true
-
-	// PATCH NetworkInterface: the snapshot's eth0 references the
-	// defunct template-build TAP. This legacy warm-pool path is not
-	// used by the single-node-fc integration run (the pool is disabled
-	// by default). Firecracker v1.15 requires host_dev_name rebinding
-	// in LoadSnapshot.network_overrides, so the warm pool needs a
-	// separate redesign before it can be enabled on that API version.
-	if err := client.PatchNetworkInterface(ctx, primaryIfaceID, firecracker.NetworkInterfacePatch{
-		IfaceID:     primaryIfaceID,
-		HostDevName: tapSlot.TapName,
-	}); err != nil {
-		return nil, false, fmt.Errorf("firecracker runtime: warm patch network interface: %w", err)
 	}
 
 	// PATCH overlay drive: same shape as the cold snapshot-load path.

--- a/internal/runtime/firecracker/warmacquire_test.go
+++ b/internal/runtime/firecracker/warmacquire_test.go
@@ -98,6 +98,15 @@ func stageWarmFixture(t *testing.T, f *driverFixture) (*fakeWarmPool, *fakeSpawn
 	}
 	pool := &fakeWarmPool{slot: slot, handle: handle}
 	f.driver.SetWarmPool(pool)
+	f.pool.mu.Lock()
+	f.pool.slots[slot.ID] = &TapSlot{
+		TapName:  "fctap-warm",
+		CIDR:     "172.16.0.4/30",
+		HostIP:   "172.16.0.5",
+		GuestIP:  "172.16.0.6",
+		VsockCID: 4,
+	}
+	f.pool.mu.Unlock()
 	// Make the REST client factory route warm-path Resume/PATCH calls
 	// to the same fake client the test fixture already inspects.
 	f.driver.SetClientFactory(func(_ string) VMMClient { return f.client })
@@ -195,24 +204,18 @@ func TestCreate_WarmHit(t *testing.T) {
 		t.Errorf("LoadSnapshot was called on warm-hit Create path: %+v", f.client.snapshotLoad)
 	}
 
-	// The per-sandbox host TAP MUST have been realized on the warm-hit
-	// path — WarmSpawn skips it, so the Acquire side owns it. Without
-	// this Ensure, VM resume would point the guest's eth0 at a
-	// host_dev_name that does not exist. Exactly one Ensure, no Remove
-	// (the sandbox now owns the device; Destroy removes it later).
-	if f.tapHost.ensureCalls != 1 || f.tapHost.removeCalls != 0 {
-		t.Errorf("warm-hit tap ensure=%d remove=%d, want 1/0", f.tapHost.ensureCalls, f.tapHost.removeCalls)
+	// The TAP was already realized during WarmSpawn. Acquire only
+	// transfers ownership from the warm slot id to the sandbox id.
+	if f.tapHost.ensureCalls != 0 || f.tapHost.removeCalls != 0 {
+		t.Errorf("warm-hit tap ensure=%d remove=%d, want 0/0", f.tapHost.ensureCalls, f.tapHost.removeCalls)
 	}
-
-	// PATCH NetworkInterface MUST have been called with the per-sandbox
-	// TAP name (mapped from the pool's preloaded slot.TapName via the
-	// fake tap pool's Allocate).
-	nic, ok := f.client.networkPatches[primaryIfaceID]
-	if !ok {
-		t.Fatal("PATCH NetworkInterface was not called on warm-hit path")
+	f.pool.mu.Lock()
+	if len(f.pool.transfers) != 1 || f.pool.transfers[0].from != "vmms-warm-fixture" || f.pool.transfers[0].to != "sb-warm-hit" {
+		t.Fatalf("tap transfers = %+v, want vmms-warm-fixture -> sb-warm-hit", f.pool.transfers)
 	}
-	if nic.HostDevName == "" {
-		t.Errorf("PATCH NetworkInterface had empty HostDevName")
+	f.pool.mu.Unlock()
+	if len(f.client.networkPatches) != 0 {
+		t.Fatalf("PATCH NetworkInterface calls = %+v, want none", f.client.networkPatches)
 	}
 
 	// PatchVM(Resumed) was the lone VM state transition -- no InstanceStart action.
@@ -296,7 +299,7 @@ func TestCreate_WarmMissFallsBackToColdSpawn(t *testing.T) {
 }
 
 // TestCreate_WarmRollbackOnPatchFailure asserts the cleanup contract
-// (pr-review.md §4) on the warm path: if PATCH NetworkInterface fails
+// (pr-review.md §4) on the warm path: if PATCH Drive fails
 // after AcquireWithHandle succeeded, the pool slot MUST be released
 // (row → 'released') and the handle MUST be Shutdown so the daemon
 // doesn't end up holding a slot the sandbox never claimed.
@@ -304,7 +307,7 @@ func TestCreate_WarmRollbackOnPatchFailure(t *testing.T) {
 	f := newDriverFixture(t)
 	pool, handle := stageWarmFixture(t, f)
 	stageWarmTemplate(t, f, false)
-	f.client.networkPatchErr = errors.New("synthetic PATCH NIC failure")
+	f.client.drivePatchErr = errors.New("synthetic PATCH drive failure")
 
 	_, err := f.driver.Create(context.Background(), models.CreateSandboxRequest{
 		Image:      "alpine:3.20",
@@ -314,7 +317,7 @@ func TestCreate_WarmRollbackOnPatchFailure(t *testing.T) {
 		TemplateID: "tpl-warm",
 	}, "sb-warm-rollback", "tok", nil)
 	if err == nil {
-		t.Fatal("Create returned nil on injected PATCH NIC failure")
+		t.Fatal("Create returned nil on injected PATCH drive failure")
 	}
 
 	pool.mu.Lock()
@@ -329,24 +332,22 @@ func TestCreate_WarmRollbackOnPatchFailure(t *testing.T) {
 	}
 	handle.mu.Unlock()
 
-	// The host TAP was Ensured just before the PATCH, so the rollback
-	// MUST Remove it — otherwise a `ip link` device leaks on every
-	// failed warm create. ensure=1/remove=1 is the matched pair.
-	if f.tapHost.ensureCalls != 1 || f.tapHost.removeCalls != 1 {
-		t.Errorf("warm rollback tap ensure=%d remove=%d, want 1/1", f.tapHost.ensureCalls, f.tapHost.removeCalls)
+	// Acquire no longer realizes or network-patches the TAP; WarmSpawn
+	// owns host TAP setup, and handle shutdown owns teardown.
+	if f.tapHost.ensureCalls != 0 || f.tapHost.removeCalls != 0 {
+		t.Errorf("warm rollback tap ensure=%d remove=%d, want 0/0", f.tapHost.ensureCalls, f.tapHost.removeCalls)
 	}
 }
 
-// TestCreate_WarmRollbackOnTapEnsureFailure asserts the rollback when
-// the host-TAP realization itself fails on the warm path: the create
-// must surface the error, tear down the warm handle + pool slot, and
-// MUST NOT call Remove (there is no device to delete — mirrors the
-// cold path's "no Remove when Ensure failed" discipline).
-func TestCreate_WarmRollbackOnTapEnsureFailure(t *testing.T) {
+// TestCreate_WarmRollbackOnTapTransferFailure asserts the rollback when
+// the pre-loaded warm TAP cannot be transferred to the sandbox id.
+func TestCreate_WarmRollbackOnTapTransferFailure(t *testing.T) {
 	f := newDriverFixture(t)
 	pool, handle := stageWarmFixture(t, f)
 	stageWarmTemplate(t, f, false)
-	f.tapHost.ensureErr = errors.New("synthetic tap ensure failure")
+	f.pool.mu.Lock()
+	delete(f.pool.slots, "vmms-warm-fixture")
+	f.pool.mu.Unlock()
 
 	_, err := f.driver.Create(context.Background(), models.CreateSandboxRequest{
 		Image:      "alpine:3.20",
@@ -356,24 +357,23 @@ func TestCreate_WarmRollbackOnTapEnsureFailure(t *testing.T) {
 		TemplateID: "tpl-warm",
 	}, "sb-warm-tap-fail", "tok", nil)
 	if err == nil {
-		t.Fatal("Create returned nil on injected tap Ensure failure")
+		t.Fatal("Create returned nil on injected tap Transfer failure")
 	}
 
 	// Pool slot released + handle shut down so the warm VMM doesn't leak.
 	pool.mu.Lock()
 	if len(pool.releaseCalls) == 0 {
-		t.Error("warm pool Release was not called on tap Ensure failure; slot would leak as 'allocated'")
+		t.Error("warm pool Release was not called on tap Transfer failure; slot would leak as 'allocated'")
 	}
 	pool.mu.Unlock()
 	handle.mu.Lock()
 	if handle.shutdowns == 0 {
-		t.Error("warm handle Shutdown was not called on tap Ensure failure; firecracker process would leak")
+		t.Error("warm handle Shutdown was not called on tap Transfer failure; firecracker process would leak")
 	}
 	handle.mu.Unlock()
 
-	// Ensure was attempted once and failed; Remove MUST be skipped.
-	if f.tapHost.ensureCalls != 1 || f.tapHost.removeCalls != 0 {
-		t.Errorf("warm tap-ensure-failure ensure=%d remove=%d, want 1/0", f.tapHost.ensureCalls, f.tapHost.removeCalls)
+	if f.tapHost.ensureCalls != 0 || f.tapHost.removeCalls != 0 {
+		t.Errorf("warm tap-transfer-failure ensure=%d remove=%d, want 0/0", f.tapHost.ensureCalls, f.tapHost.removeCalls)
 	}
 }
 

--- a/internal/runtime/firecracker/warmacquire_test.go
+++ b/internal/runtime/firecracker/warmacquire_test.go
@@ -25,6 +25,11 @@ type fakeWarmPool struct {
 	slot      *vmmpool.Slot
 	handle    vmmpool.SpawnedHandle
 	acquireEr error
+	// singleUse mimics the real pool's claim semantics: the preloaded
+	// slot is handed out exactly once; every later Acquire misses with
+	// ErrNoLoadedSlot. Used by the concurrent-duplicate regression.
+	singleUse bool
+	served    int
 
 	acquireCalls []acquireCall
 	releaseCalls []string
@@ -43,6 +48,10 @@ func (p *fakeWarmPool) AcquireWithHandle(_ context.Context, templateID, sandboxI
 	if p.acquireEr != nil {
 		return nil, nil, p.acquireEr
 	}
+	if p.singleUse && p.served > 0 {
+		return nil, nil, vmmpool.ErrNoLoadedSlot
+	}
+	p.served++
 	return p.slot, p.handle, nil
 }
 
@@ -436,6 +445,87 @@ func TestCreate_WarmEligibilityNoSnapshot(t *testing.T) {
 		t.Errorf("warm pool Acquire called on no-snapshot template: %v", pool.acquireCalls)
 	}
 	pool.mu.Unlock()
+}
+
+// TestAcquire_ConcurrentDuplicateCreate races two Creates for the SAME
+// sandbox id against a pool holding one warm slot (idempotency,
+// pr-review.md rule #1). Exactly one racer may claim the slot: one TAP
+// Transfer, one Resume of the warm VMM. The loser must miss cleanly
+// into the cold-spawn path (its own VMM) rather than double-resuming
+// or double-transferring the claimed slot.
+func TestAcquire_ConcurrentDuplicateCreate(t *testing.T) {
+	f := newDriverFixture(t)
+	pool, handle := stageWarmFixture(t, f)
+	pool.singleUse = true
+	stageWarmTemplate(t, f, false)
+
+	// Split clients per API socket so the warm slot's Resume count is
+	// isolated from the cold loser's own (legitimate) Resume.
+	warmClient := newFakeClient()
+	f.driver.SetClientFactory(func(socketPath string) VMMClient {
+		if socketPath == handle.apiSocket {
+			return warmClient
+		}
+		return f.client
+	})
+
+	const racers = 2
+	var wg sync.WaitGroup
+	errs := make([]error, racers)
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = f.driver.Create(context.Background(), models.CreateSandboxRequest{
+				Image:      "alpine:3.20",
+				CPU:        1,
+				MemoryMB:   128,
+				DiskGB:     1,
+				TemplateID: "tpl-warm",
+			}, "sb-dup-race", "tok", nil)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("racer %d Create: %v", i, err)
+		}
+	}
+
+	// Exactly one warm claim: one TAP transfer to the sandbox id.
+	f.pool.mu.Lock()
+	if len(f.pool.transfers) != 1 ||
+		f.pool.transfers[0].from != "vmms-warm-fixture" || f.pool.transfers[0].to != "sb-dup-race" {
+		t.Fatalf("tap transfers = %+v, want exactly [vmms-warm-fixture -> sb-dup-race]", f.pool.transfers)
+	}
+	f.pool.mu.Unlock()
+
+	// The warm VMM was resumed exactly once; a double-Resume would mean
+	// both racers claimed the same paused process.
+	warmClient.mu.Lock()
+	resumes := 0
+	for _, s := range warmClient.vmStates {
+		if s == firecracker.VMStateResumed {
+			resumes++
+		}
+	}
+	warmClient.mu.Unlock()
+	if resumes != 1 {
+		t.Fatalf("warm VMM Resume count = %d, want 1", resumes)
+	}
+
+	// Both racers hit the pool; the second was told the pool is empty.
+	pool.mu.Lock()
+	if len(pool.acquireCalls) != racers {
+		t.Errorf("warm pool Acquire calls = %d, want %d", len(pool.acquireCalls), racers)
+	}
+	pool.mu.Unlock()
+
+	// The loser cold-booted its own VMM (fixture fake), not the warm one.
+	if !f.vmm.started || !f.vmm.waited {
+		t.Errorf("cold fallback VMM started=%v waited=%v, want true/true", f.vmm.started, f.vmm.waited)
+	}
 }
 
 // TestDestroy_ReleasesWarmPoolSlot proves the symmetry: a sandbox

--- a/internal/runtime/firecracker/warmspawn.go
+++ b/internal/runtime/firecracker/warmspawn.go
@@ -170,7 +170,7 @@ func (d *Driver) WarmSpawn(ctx context.Context, req WarmSpawnRequest) (WarmHandl
 	// template — the lister filters on status=ready and only the
 	// service-side MarkSnapshotCorrupt moves the row out of ready.
 	if d.cfg.SnapshotVerifyOnLoad && req.SnapshotChecksum != "" {
-		if err := verifySnapshotChecksum(req.SnapshotMemoryPath, req.SnapshotStatePath, req.SnapshotChecksum); err != nil {
+		if err := d.verifySnapshotForLoad(req.TemplateID, req.SnapshotMemoryPath, req.SnapshotStatePath, req.SnapshotChecksum); err != nil {
 			if errors.Is(err, models.ErrSnapshotCorrupt) {
 				d.notifyCorrupt(ctx, req.TemplateID, err.Error())
 			}

--- a/internal/runtime/firecracker/warmspawn.go
+++ b/internal/runtime/firecracker/warmspawn.go
@@ -6,8 +6,8 @@ package firecracker
 // returned handle is what the warm-VMM pool stores so a later sandbox
 // create can claim it, PATCH per-sandbox state onto it, and PATCH /vm
 // state=Resumed. Firecracker v1.15 requires TAP rebinding in
-// LoadSnapshot.network_overrides, so this pool remains disabled by default
-// until the warm path is redesigned around load-time TAP ownership.
+// LoadSnapshot.network_overrides, so warm slots own a real TAP before the
+// snapshot is loaded and transfer that TAP to the claiming sandbox on acquire.
 //
 // Cleanup contract: WarmSpawn is responsible for tearing down the
 // firecracker process on any failure path after spawn. Success returns
@@ -16,18 +16,12 @@ package firecracker
 // VMMHandle is the structural match for the *firecracker.vmm we
 // produce here.
 //
-// Why no host TAP at WarmSpawn time: the template's snapshot state
-// captures the network interface's host_dev_name pointing at the
-// template-build TAP (which was torn down at the end of
-// SnapshotTemplate). Firecracker v1.15 no longer lets Acquire patch
-// host_dev_name after load, so this path is not suitable for production
-// until the warm slot owns a valid load-time network override.
-
 import (
 	"context"
 	"errors"
 	"fmt"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/aerol-ai/microvm/pkg/firecracker"
@@ -80,10 +74,13 @@ type WarmHandle interface {
 //
 //  1. Allocate a slot rundir via the same spawn seam Create uses
 //     (creates the dir, returns a non-started handle).
-//  2. Start the VMM process and wait for its API socket.
-//  3. Optionally verify the snapshot checksums (SnapshotVerifyOnLoad).
-//  4. LoadSnapshot with EnableDiffSnapshots=true, ResumeVM=false.
-//  5. Return the handle without resuming — the Acquire code resumes.
+//  2. Allocate and realize a TAP slot under the warm slot id.
+//  3. Start the VMM process and wait for its API socket.
+//  4. Optionally verify the snapshot checksums (SnapshotVerifyOnLoad).
+//  5. LoadSnapshot with EnableDiffSnapshots=true, ResumeVM=false,
+//     rebinding eth0 to the warm TAP via network_overrides.
+//  6. Return the handle without resuming — the Acquire code transfers
+//     the TAP owner and resumes.
 //
 // On any failure between Start and the final return, the spawned
 // firecracker process is torn down and the rundir cleaned up so the
@@ -92,9 +89,7 @@ type WarmHandle interface {
 //
 // Acquire-side responsibilities (NOT done here):
 //
-//   - Allocating the per-sandbox TAP slot. On Firecracker v1.15 this
-//     must happen before LoadSnapshot, so the current warm path remains
-//     disabled by default.
+//   - Transferring the warm slot's TAP owner from slot id to sandbox id.
 //
 //   - Allocating the per-sandbox overlay file. The snapshot state
 //     references the 1 MiB placeholder used at capture time; the
@@ -121,6 +116,43 @@ func (d *Driver) WarmSpawn(ctx context.Context, req WarmSpawnRequest) (WarmHandl
 		// would be unreachable.
 		return nil, fmt.Errorf("firecracker warm-spawn: VsockCID=%d is reserved (must be >= 3)", req.VsockCID)
 	}
+	if d.pool == nil {
+		return nil, fmt.Errorf("firecracker warm-spawn: TAP pool not registered (main.go must call SetPool): %w",
+			models.ErrRuntimeNotImplemented)
+	}
+	if d.tapHost == nil {
+		return nil, fmt.Errorf("firecracker warm-spawn: TAP host manager not registered (main.go must call SetTapHost): %w",
+			models.ErrRuntimeNotImplemented)
+	}
+
+	tapSlot, err := d.pool.Allocate(ctx, req.SlotID, time.Now().UTC())
+	if err != nil {
+		return nil, fmt.Errorf("firecracker warm-spawn: tap allocate: %w", err)
+	}
+	tapReleased := false
+	defer func() {
+		if !tapReleased {
+			if relErr := d.pool.Release(context.Background(), req.SlotID); relErr != nil {
+				d.logger.Warn("firecracker warm-spawn: tap release after error failed",
+					"slot_id", req.SlotID, "tap", tapSlot.TapName, "error", relErr)
+			}
+		}
+	}()
+
+	hostSlot := *tapSlot
+	hostSlot.GuestMAC = macFromCID(req.VsockCID)
+	if err := d.tapHost.Ensure(ctx, hostSlot); err != nil {
+		return nil, fmt.Errorf("firecracker warm-spawn: tap host ensure %s: %w", tapSlot.TapName, err)
+	}
+	tapRemoved := false
+	defer func() {
+		if !tapRemoved {
+			if rmErr := d.tapHost.Remove(context.Background(), tapSlot.TapName); rmErr != nil {
+				d.logger.Warn("firecracker warm-spawn: tap remove after error failed",
+					"slot_id", req.SlotID, "tap", tapSlot.TapName, "error", rmErr)
+			}
+		}
+	}()
 
 	// Step 1: spawn the VMM (creates the runDir we'll later use as
 	// the overlay backing store + as the slot's identity in `ps`).
@@ -205,13 +237,18 @@ func (d *Driver) WarmSpawn(ctx context.Context, req WarmSpawnRequest) (WarmHandl
 		},
 		EnableDiffSnapshots: true,
 		ResumeVM:            false,
+		NetworkOverrides: []firecracker.NetworkOverride{{
+			IfaceID:     primaryIfaceID,
+			HostDevName: tapSlot.TapName,
+		}},
 	}); err != nil {
 		return nil, fmt.Errorf("firecracker warm-spawn: LoadSnapshot: %w", err)
 	}
 
 	d.logger.Info("firecracker warm-spawn: paused VMM ready",
 		"slot_id", req.SlotID, "template_id", req.TemplateID,
-		"api_socket", handle.APISocket(), "vsock_cid", req.VsockCID)
+		"api_socket", handle.APISocket(), "vsock_cid", req.VsockCID,
+		"tap", tapSlot.TapName)
 
 	// Phase 5: register the warm slot with the RSS sampler under its
 	// slot ID. The slot's firecracker process counts toward host memory
@@ -222,7 +259,9 @@ func (d *Driver) WarmSpawn(ctx context.Context, req WarmSpawnRequest) (WarmHandl
 	d.rssRegister(req.SlotID, handle.Pid())
 
 	cleanupNeeded = false
-	return &warmHandle{handle: handle, driver: d, slotID: req.SlotID}, nil
+	tapRemoved = true
+	tapReleased = true
+	return &warmHandle{handle: handle, driver: d, slotID: req.SlotID, tapName: tapSlot.TapName, tapOwner: req.SlotID}, nil
 }
 
 // warmHandle wraps a VMMHandle and exposes only the narrow surface
@@ -238,20 +277,47 @@ func (d *Driver) WarmSpawn(ctx context.Context, req WarmSpawnRequest) (WarmHandl
 // eventual Shutdown's Unregister(slotID) is a no-op (the sampler
 // treats unknown ids as a no-op).
 type warmHandle struct {
-	handle VMMHandle
-	driver *Driver
-	slotID string
+	handle  VMMHandle
+	driver  *Driver
+	slotID  string
+	tapName string
+
+	ownerMu  sync.Mutex
+	tapOwner string
 }
 
 func (w *warmHandle) APISocket() string { return w.handle.APISocket() }
 func (w *warmHandle) RunDir() string    { return w.handle.RunDir() }
 func (w *warmHandle) Pid() int          { return w.handle.Pid() }
+func (w *warmHandle) setTapOwner(owner string) {
+	w.ownerMu.Lock()
+	w.tapOwner = owner
+	w.ownerMu.Unlock()
+}
 func (w *warmHandle) Shutdown(ctx context.Context, grace time.Duration) error {
 	if w.driver != nil {
 		w.driver.rssUnregister(w.slotID)
 	}
 	if err := w.handle.Shutdown(ctx, grace); err != nil {
 		return err
+	}
+	if w.driver != nil && w.driver.tapHost != nil && w.tapName != "" {
+		if err := w.driver.tapHost.Remove(ctx, w.tapName); err != nil {
+			w.driver.logger.Warn("firecracker warm-spawn: tap remove on shutdown failed",
+				"slot_id", w.slotID, "tap", w.tapName, "error", err)
+		}
+	}
+	if w.driver != nil && w.driver.pool != nil {
+		w.ownerMu.Lock()
+		owner := w.tapOwner
+		w.ownerMu.Unlock()
+		if owner == "" {
+			owner = w.slotID
+		}
+		if err := w.driver.pool.Release(ctx, owner); err != nil {
+			w.driver.logger.Warn("firecracker warm-spawn: tap release on shutdown failed",
+				"slot_id", w.slotID, "tap_owner", owner, "error", err)
+		}
 	}
 	// Drop the runDir too — the pool's GC sweep deletes the row, but
 	// the on-disk firecracker chroot would persist until manual

--- a/internal/runtime/firecracker/warmspawn_test.go
+++ b/internal/runtime/firecracker/warmspawn_test.go
@@ -59,6 +59,11 @@ func TestWarmSpawn_HappyPath(t *testing.T) {
 	if !f.client.snapshotLoad.EnableDiffSnapshots {
 		t.Error("LoadSnapshot.EnableDiffSnapshots=false; warm-spawn must enable diff snapshots")
 	}
+	if len(f.client.snapshotLoad.NetworkOverrides) != 1 ||
+		f.client.snapshotLoad.NetworkOverrides[0].IfaceID != primaryIfaceID ||
+		f.client.snapshotLoad.NetworkOverrides[0].HostDevName != "fctap-test" {
+		t.Fatalf("LoadSnapshot.NetworkOverrides = %+v, want eth0 -> fctap-test", f.client.snapshotLoad.NetworkOverrides)
+	}
 	if f.client.snapshotLoad.SnapshotPath != snapState {
 		t.Errorf("LoadSnapshot.SnapshotPath = %q, want %q", f.client.snapshotLoad.SnapshotPath, snapState)
 	}
@@ -83,6 +88,12 @@ func TestWarmSpawn_HappyPath(t *testing.T) {
 	}
 	if f.vmm.shutdown {
 		t.Error("warm-spawn shut down the VMM on success path; the handle is the pool's to own")
+	}
+	if f.tapHost.ensureCalls != 1 || f.tapHost.lastSlot.GuestMAC != macFromCID(200) {
+		t.Fatalf("tap ensure calls=%d slot=%+v, want one ensure with template MAC", f.tapHost.ensureCalls, f.tapHost.lastSlot)
+	}
+	if f.pool.release != 0 || f.tapHost.removeCalls != 0 {
+		t.Fatalf("success cleanup release/remove = %d/%d, want 0/0", f.pool.release, f.tapHost.removeCalls)
 	}
 
 	// Returned handle exposes the API socket + RunDir for the pool to
@@ -185,6 +196,12 @@ func TestWarmSpawn_CleansUpOnLoadFailure(t *testing.T) {
 	}
 	if !f.vmm.cleaned {
 		t.Error("WarmSpawn did not clean up the rundir on LoadSnapshot failure")
+	}
+	if f.tapHost.removeCalls != 1 {
+		t.Errorf("WarmSpawn tap remove calls = %d, want 1 on LoadSnapshot failure", f.tapHost.removeCalls)
+	}
+	if f.pool.release != 1 {
+		t.Errorf("WarmSpawn tap pool release calls = %d, want 1 on LoadSnapshot failure", f.pool.release)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4156,6 +4156,18 @@ func (s *Store) TransferFirecrackerTapSlot(ctx context.Context, fromID, toID str
 		return nil, fmt.Errorf("transfer firecracker tap slot: target %q already owns %s", toID, target.TapName)
 	}
 	if source == nil {
+		// The two reads above are not atomic: a concurrent duplicate of
+		// this same transfer may have committed between them, leaving a
+		// stale target=nil alongside source=nil. Re-read the target so
+		// the losing duplicate returns the moved slot (idempotent)
+		// instead of a spurious not-found.
+		target, err = s.GetFirecrackerTapSlotBySandbox(ctx, toID)
+		if err != nil {
+			return nil, err
+		}
+		if target != nil {
+			return target, nil
+		}
 		return nil, ErrNotFound
 	}
 	res, err := s.db.ExecContext(ctx, `

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4129,6 +4129,60 @@ func (s *Store) ReleaseFirecrackerTapSlot(ctx context.Context, sandboxID string)
 	return nil
 }
 
+// TransferFirecrackerTapSlot re-keys an allocated TAP slot from one owner id
+// to another without changing the TAP name, IPs, or vsock CID. The warm-VMM
+// pool uses this when a parked slot id becomes a real sandbox id. Retrying the
+// same transfer is idempotent once toID owns the slot; trying to overwrite a
+// different target slot fails before the UPDATE hits the partial unique index.
+func (s *Store) TransferFirecrackerTapSlot(ctx context.Context, fromID, toID string, now time.Time) (*FirecrackerTapSlot, error) {
+	if fromID == "" || toID == "" {
+		return nil, errors.New("transfer firecracker tap slot: from_id/to_id are required")
+	}
+	if fromID == toID {
+		return s.GetFirecrackerTapSlotBySandbox(ctx, toID)
+	}
+	target, err := s.GetFirecrackerTapSlotBySandbox(ctx, toID)
+	if err != nil {
+		return nil, err
+	}
+	source, err := s.GetFirecrackerTapSlotBySandbox(ctx, fromID)
+	if err != nil {
+		return nil, err
+	}
+	if target != nil {
+		if source == nil || target.TapName == source.TapName {
+			return target, nil
+		}
+		return nil, fmt.Errorf("transfer firecracker tap slot: target %q already owns %s", toID, target.TapName)
+	}
+	if source == nil {
+		return nil, ErrNotFound
+	}
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE firecracker_tap_pool
+		SET sandbox_id = ?, allocated_at = ?
+		WHERE sandbox_id = ?
+	`, toID, now.UTC(), fromID)
+	if err != nil {
+		return nil, fmt.Errorf("transfer firecracker tap slot: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("transfer firecracker tap slot (affected): %w", err)
+	}
+	if n == 0 {
+		if target, err := s.GetFirecrackerTapSlotBySandbox(ctx, toID); err != nil {
+			return nil, err
+		} else if target != nil {
+			return target, nil
+		}
+		return nil, ErrNotFound
+	}
+	source.SandboxID = toID
+	source.AllocatedAt = now.UTC()
+	return source, nil
+}
+
 // GetFirecrackerTapSlotBySandbox returns the slot currently owned by
 // sandboxID, or nil if it owns none. Used by both the idempotent
 // allocate path and the runtime driver's Inspect/Destroy paths.

--- a/pkg/api/v1/fc_stage_timing_test.go
+++ b/pkg/api/v1/fc_stage_timing_test.go
@@ -1,0 +1,93 @@
+package v1
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/createtiming"
+	"github.com/aerol-ai/microvm/pkg/docker"
+)
+
+// TestSetCreateServerTiming_FirecrackerStages is the Phase 0 regression
+// (plans/firecracker-create-latency.md): fc_* stages recorded on the
+// context recorder must surface as Server-Timing entries, absent stages
+// must be omitted, and the pre-existing docker fields must render
+// exactly as before — the UC-96 readiness assertions and the bench's
+// create;dur= parser both depend on that stability.
+func TestSetCreateServerTiming_FirecrackerStages(t *testing.T) {
+	t.Run("fc_stages_render_in_order", func(t *testing.T) {
+		_, timing := docker.WithCreateTiming(t.Context())
+		timing.RecordStage("fc_verify", 1650*time.Millisecond)
+		timing.RecordStage("fc_spawn", 95*time.Millisecond)
+		timing.RecordStageDesc("fc_warm", 142*time.Millisecond, "hit")
+		timing.RecordStage("fc_driver", 3120*time.Millisecond)
+
+		rr := httptest.NewRecorder()
+		setCreateServerTiming(rr, time.Now(), timing)
+		st := rr.Header().Get("Server-Timing")
+
+		for _, want := range []string{
+			"create;dur=",
+			"fc_verify;dur=1650.0",
+			"fc_spawn;dur=95.0",
+			"fc_warm;dur=142.0;desc=hit",
+			"fc_driver;dur=3120.0",
+		} {
+			if !strings.Contains(st, want) {
+				t.Fatalf("Server-Timing = %q, missing %q", st, want)
+			}
+		}
+		// Stages render in record order so the header reads as the boot
+		// sequence, not map-iteration noise.
+		if strings.Index(st, "fc_verify") > strings.Index(st, "fc_driver") {
+			t.Fatalf("Server-Timing = %q, stages out of record order", st)
+		}
+	})
+
+	t.Run("absent_stages_omitted", func(t *testing.T) {
+		_, timing := docker.WithCreateTiming(t.Context())
+		rr := httptest.NewRecorder()
+		setCreateServerTiming(rr, time.Now(), timing)
+		st := rr.Header().Get("Server-Timing")
+		if strings.Contains(st, "fc_") {
+			t.Fatalf("Server-Timing = %q, must carry no fc_ entries when none recorded", st)
+		}
+		if !strings.HasPrefix(st, "create;dur=") {
+			t.Fatalf("Server-Timing = %q, want the bare create;dur= header", st)
+		}
+	})
+
+	t.Run("docker_fields_unchanged", func(t *testing.T) {
+		_, timing := docker.WithCreateTiming(t.Context())
+		timing.RecordDockerWaits(120*time.Millisecond, 88*time.Millisecond, "socket")
+		timing.RecordStage("fc_driver", 300*time.Millisecond)
+
+		rr := httptest.NewRecorder()
+		setCreateServerTiming(rr, time.Now(), timing)
+		st := rr.Header().Get("Server-Timing")
+		for _, want := range []string{
+			"runtime_wait;dur=120.0",
+			"toolbox_wait;dur=88.0",
+			"readiness;desc=socket",
+			"fc_driver;dur=300.0",
+		} {
+			if !strings.Contains(st, want) {
+				t.Fatalf("Server-Timing = %q, missing %q", st, want)
+			}
+		}
+	})
+
+	t.Run("nil_recorder_still_writes_create", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		setCreateServerTiming(rr, time.Now(), nil)
+		if st := rr.Header().Get("Server-Timing"); !strings.HasPrefix(st, "create;dur=") {
+			t.Fatalf("Server-Timing = %q, want create;dur= with nil recorder", st)
+		}
+	})
+}
+
+// Compile-time proof the docker alias and the neutral package share one
+// type: a recorder built by either constructor is usable with both.
+var _ *docker.CreateTiming = (*createtiming.CreateTiming)(nil)

--- a/pkg/api/v1/handlers.go
+++ b/pkg/api/v1/handlers.go
@@ -49,6 +49,16 @@ func setCreateServerTiming(w http.ResponseWriter, start time.Time, timing *docke
 		if timing.Source != "" {
 			parts = append(parts, "readiness;desc="+timing.Source)
 		}
+		// Firecracker per-stage boot attribution (Phase 0,
+		// plans/firecracker-create-latency.md). Absent stages are simply
+		// not rendered — a docker create carries no fc_* entries.
+		for _, st := range timing.Stages() {
+			entry := st.Name + ";dur=" + strconv.FormatFloat(st.DurMS, 'f', 1, 64)
+			if st.Desc != "" {
+				entry += ";desc=" + st.Desc
+			}
+			parts = append(parts, entry)
+		}
 	}
 	w.Header().Set("Server-Timing", strings.Join(parts, ", "))
 }

--- a/pkg/createtiming/createtiming.go
+++ b/pkg/createtiming/createtiming.go
@@ -1,0 +1,117 @@
+// Package createtiming carries a per-request create-latency recorder on
+// the request context so runtime drivers can attribute where a sandbox
+// create spent its time, and the API handler can surface that
+// attribution as Server-Timing response entries.
+//
+// The recorder started life inside pkg/docker (runtime/toolbox wait
+// attribution). Phase 0 of plans/firecracker-create-latency.md moved it
+// here so the firecracker driver can record its boot stages without the
+// runtime packages growing an import on each other; pkg/docker keeps
+// thin aliases so its existing callers are untouched.
+package createtiming
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+type key struct{}
+
+// Stage is one named Server-Timing entry. A duration stage renders as
+// "name;dur=<ms>"; a marker stage (Desc set, no duration) renders as
+// "name;desc=<desc>". Recorded stages are surfaced in record order.
+type Stage struct {
+	Name  string
+	DurMS float64
+	Desc  string
+}
+
+// CreateTiming captures per-phase create latency for Server-Timing
+// attribution. The docker fields are populated by the docker runtime's
+// readiness wait; Stages carries the firecracker driver's per-stage
+// boot breakdown (fc_driver, fc_verify, …).
+type CreateTiming struct {
+	RuntimeWaitMS float64
+	ToolboxWaitMS float64
+	Source        string // "socket" or "health"; empty when not recorded
+
+	// mu guards stages: the boot path records serially, but async
+	// observers (and tests) may read while a late stage lands.
+	mu     sync.Mutex
+	stages []Stage
+}
+
+// With returns a child context that carries a CreateTiming recorder.
+// Reuses an existing recorder so nested calls share one instance.
+func With(parent context.Context) (context.Context, *CreateTiming) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	if existing, ok := parent.Value(key{}).(*CreateTiming); ok && existing != nil {
+		return parent, existing
+	}
+	timing := &CreateTiming{}
+	return context.WithValue(parent, key{}, timing), timing
+}
+
+// From returns the recorder stashed on ctx, if any.
+func From(ctx context.Context) *CreateTiming {
+	if ctx == nil {
+		return nil
+	}
+	timing, _ := ctx.Value(key{}).(*CreateTiming)
+	return timing
+}
+
+// RecordDockerWaits sets the docker runtime's readiness attribution.
+// Nil-safe so the runtime can call it unconditionally.
+func (t *CreateTiming) RecordDockerWaits(runtimeWait, toolboxWait time.Duration, source string) {
+	if t == nil {
+		return
+	}
+	t.RuntimeWaitMS = float64(runtimeWait.Microseconds()) / 1000
+	t.ToolboxWaitMS = float64(toolboxWait.Microseconds()) / 1000
+	t.Source = source
+}
+
+// RecordStage appends a duration stage. Nil-safe; negative durations
+// clamp to zero so a stage is never rendered with a nonsense value.
+func (t *CreateTiming) RecordStage(name string, d time.Duration) {
+	if t == nil || name == "" {
+		return
+	}
+	if d < 0 {
+		d = 0
+	}
+	t.mu.Lock()
+	t.stages = append(t.stages, Stage{Name: name, DurMS: float64(d.Microseconds()) / 1000})
+	t.mu.Unlock()
+}
+
+// RecordStageDesc appends a duration stage that also carries a desc
+// attribute (e.g. "fc_warm;dur=42.0;desc=hit"). Nil-safe.
+func (t *CreateTiming) RecordStageDesc(name string, d time.Duration, desc string) {
+	if t == nil || name == "" {
+		return
+	}
+	if d < 0 {
+		d = 0
+	}
+	t.mu.Lock()
+	t.stages = append(t.stages, Stage{Name: name, DurMS: float64(d.Microseconds()) / 1000, Desc: desc})
+	t.mu.Unlock()
+}
+
+// Stages returns a copy of the recorded stages in record order.
+// Nil-safe: a nil recorder has no stages.
+func (t *CreateTiming) Stages() []Stage {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]Stage, len(t.stages))
+	copy(out, t.stages)
+	return out
+}

--- a/pkg/createtiming/createtiming_test.go
+++ b/pkg/createtiming/createtiming_test.go
@@ -1,0 +1,101 @@
+package createtiming
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestWith_ReusesExistingRecorder(t *testing.T) {
+	ctx, first := With(context.Background())
+	ctx2, second := With(ctx)
+	if first != second {
+		t.Fatal("nested With must reuse the existing recorder, not shadow it")
+	}
+	if ctx2 != ctx {
+		t.Fatal("nested With must return the same context when a recorder exists")
+	}
+}
+
+func TestWith_NilParent(t *testing.T) {
+	ctx, timing := With(nil) //nolint:staticcheck // nil-parent tolerance is the contract under test
+	if timing == nil || From(ctx) != timing {
+		t.Fatal("With(nil) must still produce a usable recorder")
+	}
+}
+
+func TestFrom_AbsentAndNil(t *testing.T) {
+	if From(context.Background()) != nil {
+		t.Fatal("From on a bare context must return nil")
+	}
+	if From(nil) != nil { //nolint:staticcheck // nil-ctx tolerance is the contract under test
+		t.Fatal("From(nil) must return nil")
+	}
+}
+
+func TestRecordStage_OrderClampAndCopy(t *testing.T) {
+	timing := &CreateTiming{}
+	timing.RecordStage("fc_verify", 1500*time.Millisecond)
+	timing.RecordStage("fc_spawn", -5*time.Millisecond) // clock skew clamps to 0
+	timing.RecordStage("", time.Second)                 // nameless: dropped
+	timing.RecordStageDesc("fc_warm", 42*time.Millisecond, "hit")
+
+	stages := timing.Stages()
+	if len(stages) != 3 {
+		t.Fatalf("Stages() len = %d, want 3 (nameless dropped): %v", len(stages), stages)
+	}
+	if stages[0].Name != "fc_verify" || stages[0].DurMS != 1500 {
+		t.Errorf("stages[0] = %+v, want fc_verify 1500ms", stages[0])
+	}
+	if stages[1].Name != "fc_spawn" || stages[1].DurMS != 0 {
+		t.Errorf("stages[1] = %+v, want fc_spawn clamped to 0", stages[1])
+	}
+	if stages[2].Name != "fc_warm" || stages[2].Desc != "hit" || stages[2].DurMS != 42 {
+		t.Errorf("stages[2] = %+v, want fc_warm 42ms desc=hit", stages[2])
+	}
+
+	// Stages returns a copy: mutating it must not corrupt the recorder.
+	stages[0].Name = "mutated"
+	if timing.Stages()[0].Name != "fc_verify" {
+		t.Fatal("Stages() must return a copy, not the backing slice")
+	}
+}
+
+func TestRecordDockerWaits(t *testing.T) {
+	timing := &CreateTiming{}
+	timing.RecordDockerWaits(120*time.Millisecond, 88*time.Millisecond, "socket")
+	if timing.RuntimeWaitMS != 120 || timing.ToolboxWaitMS != 88 || timing.Source != "socket" {
+		t.Fatalf("docker waits = %+v, want 120/88/socket", timing)
+	}
+}
+
+func TestNilRecorderIsSafe(t *testing.T) {
+	var timing *CreateTiming
+	timing.RecordStage("fc_driver", time.Second)
+	timing.RecordStageDesc("fc_warm", time.Second, "hit")
+	timing.RecordDockerWaits(time.Second, time.Second, "socket")
+	if got := timing.Stages(); got != nil {
+		t.Fatalf("nil recorder Stages() = %v, want nil", got)
+	}
+}
+
+// TestConcurrentRecording: the async tcp-probe goroutine may record a
+// late stage while the handler reads — no torn reads or data races
+// (run under -race in CI).
+func TestConcurrentRecording(t *testing.T) {
+	timing := &CreateTiming{}
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			timing.RecordStage("fc_stage", time.Millisecond)
+			_ = timing.Stages()
+		}()
+	}
+	wg.Wait()
+	if got := len(timing.Stages()); got != 8 {
+		t.Fatalf("recorded %d stages, want 8", got)
+	}
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -394,7 +394,14 @@ func Run(ctx context.Context, logger *slog.Logger, makeProvider ProviderFactory)
 		// processes.
 		if cfg.FirecrackerVMMPoolEnabled {
 			vmmPool := vmmpool.New(db, logger)
-			vmmPool.SetDefaultDepth(cfg.FirecrackerVMMPoolDepthDefault)
+			warmDepth, capped := firecrackerWarmPoolDepth(cfg.FirecrackerVMMPoolDepthDefault, cfg.FirecrackerTapPoolSize)
+			if capped {
+				logger.Warn("firecracker vmm pool depth capped by TAP pool budget",
+					"configured_depth", cfg.FirecrackerVMMPoolDepthDefault,
+					"effective_depth", warmDepth,
+					"tap_pool_size", cfg.FirecrackerTapPoolSize)
+			}
+			vmmPool.SetDefaultDepth(warmDepth)
 			fcDriver.SetWarmPool(vmmPool)
 			lister := &vmmTemplateListerAdapter{svc: svc}
 			spawner := fcruntime.NewPoolSpawner(fcDriver)
@@ -413,7 +420,7 @@ func Run(ctx context.Context, logger *slog.Logger, makeProvider ProviderFactory)
 				}
 			}()
 			logger.Info("firecracker vmm pool enabled",
-				"depth_default", cfg.FirecrackerVMMPoolDepthDefault,
+				"depth_default", warmDepth,
 				"refill_interval", cfg.FirecrackerVMMPoolRefillInterval,
 				"gc_interval", cfg.FirecrackerVMMPoolGCInterval,
 				"gc_ttl", cfg.FirecrackerVMMPoolGCTTL)
@@ -1488,6 +1495,28 @@ type firecrackerPoolAdapter struct {
 
 func (a *firecrackerPoolAdapter) Allocate(ctx context.Context, sandboxID string, now time.Time) (*fcruntime.TapSlot, error) {
 	s, err := a.inner.Allocate(ctx, sandboxID, now)
+	if err != nil {
+		return nil, err
+	}
+	return adaptTapSlot(s), nil
+}
+
+func firecrackerWarmPoolDepth(configuredDepth, tapPoolSize int) (int, bool) {
+	if configuredDepth < 0 {
+		configuredDepth = 0
+	}
+	maxDepth := tapPoolSize / 8
+	if maxDepth < 0 {
+		maxDepth = 0
+	}
+	if configuredDepth > maxDepth {
+		return maxDepth, true
+	}
+	return configuredDepth, false
+}
+
+func (a *firecrackerPoolAdapter) Transfer(ctx context.Context, fromID, toID string, now time.Time) (*fcruntime.TapSlot, error) {
+	s, err := a.inner.Transfer(ctx, fromID, toID, now)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1656,6 +1656,7 @@ func (a *templateResolverAdapter) Resolve(ctx context.Context, id string) (*fcru
 		return nil, fmt.Errorf("template %q: ensure local: %w", id, err)
 	}
 	return &fcruntime.TemplateResolution{
+		TemplateID:         t.ID,
 		RootfsPath:         t.RootfsPath,
 		HasSnapshot:        t.HasSnapshot,
 		HasOverlay:         t.HasOverlay,

--- a/pkg/daemon/daemon_adapters_test.go
+++ b/pkg/daemon/daemon_adapters_test.go
@@ -208,6 +208,30 @@ func TestVMMTemplateListerAdapter_ListWarmableTemplates(t *testing.T) {
 	}
 }
 
+func TestFirecrackerWarmPoolDepthCapsByTapBudget(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		configured int
+		tapSize    int
+		want       int
+		wantCapped bool
+	}{
+		{name: "under budget", configured: 4, tapSize: 64, want: 4},
+		{name: "at budget", configured: 8, tapSize: 64, want: 8},
+		{name: "over budget", configured: 16, tapSize: 64, want: 8, wantCapped: true},
+		{name: "tiny tap pool disables warm depth", configured: 1, tapSize: 4, want: 0, wantCapped: true},
+		{name: "negative configured clamps to zero", configured: -1, tapSize: 64, want: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, capped := firecrackerWarmPoolDepth(tc.configured, tc.tapSize)
+			if got != tc.want || capped != tc.wantCapped {
+				t.Fatalf("firecrackerWarmPoolDepth(%d,%d) = (%d,%v), want (%d,%v)",
+					tc.configured, tc.tapSize, got, capped, tc.want, tc.wantCapped)
+			}
+		})
+	}
+}
+
 func TestTemplateResolverAdapter_Resolve(t *testing.T) {
 	ctx := context.Background()
 	st := openTestStore(t)

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -575,7 +575,7 @@ func (c *Client) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 	toolboxSource, err := c.waitForToolboxReady(ctx, containerIP, readyListener)
 	toolboxWait := time.Since(toolboxWaitStart)
 	if timing := CreateTimingFrom(ctx); timing != nil {
-		timing.record(runtimeWait, toolboxWait, toolboxSource)
+		timing.RecordDockerWaits(runtimeWait, toolboxWait, toolboxSource)
 	}
 	if err != nil {
 		_ = c.removeContainer(ctx, created.ID, true)

--- a/pkg/docker/create_timing.go
+++ b/pkg/docker/create_timing.go
@@ -2,44 +2,24 @@ package docker
 
 import (
 	"context"
-	"time"
+
+	"github.com/aerol-ai/microvm/pkg/createtiming"
 )
 
-type createTimingKey struct{}
-
-// CreateTiming captures per-phase create latency for Server-Timing attribution.
-type CreateTiming struct {
-	RuntimeWaitMS float64
-	ToolboxWaitMS float64
-	Source        string // "socket" or "health"; empty when not recorded
-}
+// CreateTiming moved to pkg/createtiming so the firecracker driver can
+// record boot stages on the same recorder without importing pkg/docker
+// (Phase 0, plans/firecracker-create-latency.md). These aliases keep the
+// docker package's existing callers (v1 handlers, tests) source-stable;
+// the context key lives in createtiming so both packages share one
+// recorder per request.
+type CreateTiming = createtiming.CreateTiming
 
 // WithCreateTiming returns a child context that carries a CreateTiming recorder.
 func WithCreateTiming(parent context.Context) (context.Context, *CreateTiming) {
-	if parent == nil {
-		parent = context.Background()
-	}
-	if existing, ok := parent.Value(createTimingKey{}).(*CreateTiming); ok && existing != nil {
-		return parent, existing
-	}
-	timing := &CreateTiming{}
-	return context.WithValue(parent, createTimingKey{}, timing), timing
+	return createtiming.With(parent)
 }
 
 // CreateTimingFrom returns the recorder stashed on ctx, if any.
 func CreateTimingFrom(ctx context.Context) *CreateTiming {
-	if ctx == nil {
-		return nil
-	}
-	timing, _ := ctx.Value(createTimingKey{}).(*CreateTiming)
-	return timing
-}
-
-func (t *CreateTiming) record(runtimeWait, toolboxWait time.Duration, source string) {
-	if t == nil {
-		return
-	}
-	t.RuntimeWaitMS = float64(runtimeWait.Microseconds()) / 1000
-	t.ToolboxWaitMS = float64(toolboxWait.Microseconds()) / 1000
-	t.Source = source
+	return createtiming.From(ctx)
 }

--- a/plans/docker-ready-socket-sandbox-id-fix.md
+++ b/plans/docker-ready-socket-sandbox-id-fix.md
@@ -1,0 +1,275 @@
+# Fix: Docker ready-socket push rejected on sandbox-ID mismatch
+
+Status: **Planned** — root cause confirmed 2026-07-04 (code trace + local Docker
+repro). Amends [docker-readiness-unix-socket-push.md](./docker-readiness-unix-socket-push.md)
+(PR #271), whose live verification (UC-96/96b/96c/96d on `cluster-hetero`)
+failed with `readiness source = "health", want socket`.
+
+## Problem
+
+Every Docker/gVisor create in cluster mode falls back to the health-poll path
+even though the unix-socket push works mechanically end-to-end. The push
+**arrives and is rejected**, so creates pay the fallback floor:
+`readyHealthPollGrace` (50ms) + first probe + one 20ms backoff step ≈
+**70–90ms `toolbox_wait`** instead of the ~10–30ms the socket path delivers.
+
+### Root cause
+
+The two sides of the handshake disagree on what the sandbox's ID is:
+
+- **Host side** — `pkg/docker/client.go:437` creates the `ReadyListener` keyed
+  to the real sandbox ID (`sb-<16 hex>`), and `readAndVerify`
+  (`pkg/docker/readysock.go:209`) requires `sig.SandboxID == l.sandboxID`.
+- **Guest side** — toolboxd builds its ready signal from `readSandboxID()`
+  (`cmd/toolboxd/main.go:415`), which returns the **container hostname**. The
+  container create request (`pkg/docker/client.go:406`) sets the container
+  *name* to the sandbox ID but never sets `Hostname`, so Docker defaults the
+  hostname to the first 12 hex chars of the **container ID**.
+
+Verified empirically: `docker run --name sb-hostname-check-12345 alpine
+hostname` → `5efed5c4cb2f`. So the guest pushes `SandboxID: "5efed5c4cb2f"`,
+the host expects `"sb-92ebc8d009d4b12c"`, `readAndVerify` returns
+`"sandbox_id mismatch"`, the connection is counted invalid
+(`docker_ready_socket_invalid_attempts`), and `ReadyListener.Wait` keeps
+waiting for a second push that never comes. The health-poll goroutine wins
+the race after its 50ms grace → `source = "health"`.
+
+Nonce and token verification both pass — only the ID check fails.
+
+### Why unit tests didn't catch it
+
+`TestCreate_SocketPushWinsOverHealthPoll`
+(`pkg/docker/ready_create_test.go:200`) fakes the guest and **hardcodes the
+correct ID** (`SandboxID: "sb-race"`) in the push. The fake never derives the
+ID the way real toolboxd does (hostname), so the identity mismatch is
+invisible offline. Only the live UC-96 suite exercises real toolboxd.
+
+### Evidence from the live run (cluster-hetero, 2026-07-01, v0.5.22)
+
+- v0.5.22 == `main` @ 766090d — the deployed build **does** contain #271 and
+  both follow-up fixes (7e6de33, 15eed89). Staleness ruled out.
+- gVisor ruled out: `scripts/install.sh:1211` configures runsc with
+  `--host-uds=open`, and plain-Docker UC-96/96b failed identically to the
+  gVisor UC-96c.
+- All four UC-96 tests: `readiness source = "health" ok=true` — creates
+  succeed, just slow. Matches silent-rejection + fallback exactly.
+- Expected confirming signal on the workers:
+  `docker_ready_socket_invalid_attempts` ≈ number of docker creates,
+  `docker_ready_socket_hit` == 0.
+
+## Fix design
+
+**Make the daemon tell toolboxd its sandbox ID explicitly via env
+(`SB_SANDBOX_ID`), and have toolboxd prefer it over the hostname.** The env
+var is the source of truth; hostname stays as the fallback for runtimes that
+don't set it (Firecracker guests get toolboxd config via vsock and don't use
+the ready socket at all, so they are unaffected).
+
+Grep confirms `SB_SANDBOX_ID` is unused anywhere in the tree today — no
+collision.
+
+### Rejected alternative: set `Hostname` in the container create request
+
+Setting `createRequest["Hostname"] = sandboxID` would also fix the mismatch
+and is nice UX (guest hostname == API identity), but:
+
+1. `Hostname` **conflicts with `NetworkMode: host`** — dockerd rejects the
+   create ("conflicting options"). `c.network` is operator-configurable, so
+   this needs a mode-dependent guard, i.e. the identity fix would silently
+   not apply on some deployments — reintroducing exactly the class of
+   env-dependent breakage we're fixing.
+2. It changes guest-visible behavior for every existing sandbox (scripts that
+   read the hostname as a container-ID today).
+
+Keep it as an optional, separately-reviewed follow-up (see "Out of scope").
+The env var works identically under every network mode and runtime.
+
+### Rejected alternative: drop the SandboxID check host-side
+
+Nonce + token already uniquely bind a push to one specific create, so the ID
+check is defense-in-depth rather than load-bearing. But weakening a
+verification step to fix a latency bug is the wrong direction; keep the check
+and fix the identity.
+
+## File-by-file changes
+
+### 1. `pkg/docker/client.go` — pass the ID into the container
+
+At the env build (~line 387), add the sandbox ID and grow the capacity hint:
+
+```go
+envValues := make([]string, 0, len(req.Env)+4)
+envValues = append(envValues,
+    fmt.Sprintf("SB_TOOLBOX_PORT=%d", c.toolboxPort),
+    "SB_TOOLBOX_TOKEN="+toolboxToken,
+    "SB_SANDBOX_ID="+sandboxID,
+)
+```
+
+Set it **unconditionally** (not just when `c.readyEnabled`): it is not a
+secret, it costs nothing on the boot path, and in-sandbox code being able to
+discover its own ID is independently useful (E2B exposes the equivalent).
+
+Keep the existing "re-store the grown slice" comment/behavior at ~line 445
+intact — the ready-block append still reallocates and must re-store
+`createRequest["Env"]`.
+
+Also surface rejection so this class of bug is never invisible again: after
+the readiness race resolves in `waitForToolboxReady` (~line 1282), when
+`res.source == "health"` and a listener existed, log a `Warn` with the
+listener's invalid-attempt count and last rejection reason:
+
+```go
+c.logger.Warn("ready socket fell back to health poll",
+    "sandbox_id", listener.sandboxID,
+    "invalid_pushes", n, "last_reason", reason)
+```
+
+### 2. `pkg/docker/readysock.go` — expose rejection diagnostics
+
+`readAndVerify` already returns distinct errors ("sandbox_id mismatch",
+"nonce mismatch", "token mismatch"). Record them on the listener instead of
+discarding:
+
+- Add `invalidCount int` + `lastInvalidReason string` (guarded by a mutex or
+  atomics) updated in the `Wait` loop where `readAndVerify` fails
+  (`readysock.go:192`).
+- Add accessors `InvalidAttempts() (int, string)` for the Create-side log and
+  tests.
+
+Host-side log only — the dialer still learns nothing about why its push was
+dropped (unchanged security posture).
+
+### 3. `cmd/toolboxd/main.go` — prefer the env-provided ID
+
+```go
+func readSandboxID() string {
+    if id := strings.TrimSpace(os.Getenv("SB_SANDBOX_ID")); id != "" {
+        return id
+    }
+    hostname, err := hostnameFn()
+    if err != nil {
+        return ""
+    }
+    return normalizeSandboxID(hostname)
+}
+```
+
+Do **not** scrub `SB_SANDBOX_ID` in `scrubReadyEnv` — it is not a credential,
+and user commands inheriting it is a feature.
+
+Side effects of `srv.sandboxID` becoming the real ID (all improvements, none
+breaking):
+
+- `GET /` (`main.go:295`) now reports the real sandbox ID instead of a
+  container-ID prefix.
+- Sessions recording metadata (`main.go:128`) carries the real ID.
+- `stripSandboxPrefix` (`main.go:411`): the exact-match fast path starts
+  working for docker sandboxes; today it never matched and requests were
+  handled by the tolerant fallback in `normalizeSandboxPath` (main.go:449–471),
+  which strips any unknown first segment when the remainder is a known
+  toolbox path. That fallback stays, so mixed-version behavior is unchanged.
+
+### 4. `pkg/docker/ready_create_test.go` — derive identity like the real guest
+
+- Change the fake-guest goroutine in `TestCreate_SocketPushWinsOverHealthPoll`
+  to **extract `SB_SANDBOX_ID` from the captured create-request env** (the
+  fake daemon already captures `Env` — see the pattern at
+  `ready_create_test.go:91`) and push with that value instead of the
+  hardcoded `"sb-race"`. If the env var is missing, push the empty string —
+  which fails verification and fails the test. This makes the unit test
+  structurally incapable of missing an identity-plumbing regression.
+- New regression test `TestCreate_HostnameStyleIDPushFallsBack`: fake guest
+  pushes a 12-hex container-ID-style `SandboxID` (the pre-fix behavior);
+  assert the create still succeeds, `timing.Source == "health"`,
+  `docker_ready_socket_invalid_attempts` incremented, and the listener's
+  `InvalidAttempts()` reports `"sandbox_id mismatch"`.
+- New assertion in an existing create test: captured create-request env
+  contains `SB_SANDBOX_ID=<sandboxID>` on every create (readiness enabled or
+  not).
+
+Match the package's existing table-driven/fake-daemon style; no new harness.
+
+### 5. `cmd/toolboxd/main_test.go` (or `readyclient_test.go`)
+
+Table-driven cases for `readSandboxID`:
+
+| case | SB_SANDBOX_ID | hostnameFn | want |
+|---|---|---|---|
+| env wins | `sb-abc` | `deadbeef1234` | `sb-abc` |
+| env whitespace ignored | `"  "` | `deadbeef1234` | `deadbeef1234` |
+| fallback to hostname | unset | `deadbeef1234` | `deadbeef1234` |
+| both empty | unset | error | `""` |
+
+Plus: `announceReady` sends the env-derived ID (extend the existing
+`readyclient_test.go` dial test).
+
+### 6. `plans/docker-readiness-unix-socket-push.md`
+
+Update the status table: live verification failed → link this plan; flip to
+verified after the re-run passes.
+
+## Version-skew safety (mixed-version cluster during rollout)
+
+| sandboxd | toolboxd | behavior |
+|---|---|---|
+| new | new | env set, push verified → **socket path** |
+| new | old | env set but ignored; old toolboxd pushes hostname → rejected → health fallback (status quo, no worse) |
+| old | new | env unset; new toolboxd falls back to hostname → rejected → health fallback (status quo) |
+| old | old | status quo |
+
+No coordination needed; the fix degrades to today's behavior in every mixed
+combination. (In practice both binaries ship in one release and toolboxd is
+bind-mounted from the host, so skew windows are per-node and short.)
+
+Container **restart** path is untouched: `waitForRuntime` passes a nil
+listener and health-polls, and the parked bind source (15eed89) keeps docker
+start working. The ID fix changes nothing there.
+
+## Verification & acceptance gates
+
+Offline (must pass before PR):
+
+1. `make test` green; `go test ./pkg/docker/... ./cmd/toolboxd/...` includes
+   the new regression tests.
+2. `/maintain-coverage`: `pkg/docker` and `cmd/toolboxd` stay ≥ ~85%.
+
+Live (operator-run, costs money):
+
+3. Re-run the readiness suite on `cluster-hetero`: **UC-96, UC-96b, UC-96c,
+   UC-96d all pass** with `source = "socket"`.
+4. On the docker workers: `docker_ready_socket_hit` > 0 and
+   `docker_ready_socket_invalid_attempts` == 0 across the run.
+5. Server-Timing `toolbox_wait` p50 for docker creates **< 50ms** (was
+   ~70–90ms); no regression in `runtime_wait`.
+6. Benchmark artifact (`cluster-hetero-bench.json`): docker `server_p50_ms`
+   improves vs the 2026-07-01 baseline (291ms) — expect roughly −40–60ms; do
+   not gate harder than that since the remaining time is create/start work
+   this plan doesn't touch.
+
+## PR checklist (pr-review.md call-outs)
+
+- **Boot-path latency**: touches `CreateSandbox` callee (`docker.Create` env
+  build + readiness race) — follow `/touch-create-sandbox`; call out that the
+  change *removes* ~40ms from cluster docker creates and adds zero work
+  (one env string, no I/O, no locks). First-call case unchanged.
+- **Idempotency**: none of the retry/duplicate-create semantics change; the
+  env var is deterministic per sandbox ID.
+- **Failure-path**: unchanged — rejection still falls back to health poll;
+  the only new behavior is a Warn log + counters.
+- **Coverage**: new tests listed above; no new package.
+- Store, TCP pool, L4, cluster FSM: untouched.
+
+## Out of scope (explicitly deferred)
+
+- Setting `createRequest["Hostname"] = sandboxID` for guest-hostname UX
+  parity — separate decision, needs the `NetworkMode: host`/`container:`
+  guard and a user-visible-change call-out.
+- Deduping user-supplied `SB_*` env keys that shadow reserved ones
+  (`SB_TOOLBOX_TOKEN` has the same pre-existing exposure; fix together,
+  separately).
+- A parked-socket accept loop for container **restarts** to give starts the
+  same push path — restart latency is a different budget; revisit if start
+  latency becomes a target.
+- `readyproto` fuzz + operator docs remain tracked in the parent plan (T9,
+  T11).

--- a/plans/firecracker-create-latency.md
+++ b/plans/firecracker-create-latency.md
@@ -1,11 +1,54 @@
 # Firecracker snapshot-clone create latency: 3.45s → sub-700ms
 
-Status: **Proposed** (2026-07-04). Not started.
+Status: **In progress** (updated 2026-07-04). Phases 0 (code), 1, 2, 3a, 3b
+and the 3c static cap are code-complete on
+`feat/firecracker-create-latency-phase1`; the E1 experiment, the UC-98
+integration scenarios, and every benchmark gate below are still open — no
+latency number in this document has been re-measured yet.
 
 Owner rules that apply: this plan changes `CreateSandbox` callees
 (`/touch-create-sandbox`), the TAP allocator and warm-VMM pool (fragile areas —
 regression tests mandatory next to the file), and needs boot-path latency
 call-outs in every PR description per `pr-review.md` §2.
+
+## Implementation status (2026-07-04)
+
+| Phase | State | Notes |
+|---|---|---|
+| 0 — instrumentation | code done, **E1 + bench run open** | Recorder moved to `pkg/createtiming` (docker keeps aliases); `fc_*` stages recorded in `Driver.Create` (cold, snapshot-load, warm) and surfaced via `setCreateServerTiming`; harness parses all `<name>;dur=` pairs into `latency[].stages` (mean/p50). The warm-hit marker (`fc_warm;dur=…;desc=hit`) landed here too. E1 and the stage-sum exit criterion still need an operator bench run. See deviations below. |
+| 1 — verify-once cache + async probe | done | `snapshot_verify_cache.go`, `toolbox_probe.go` + full test table incl. `TestVerifyCache_WarmSpawnShares`. |
+| 2 — poll-cadence trims | done | `retry.go`; WaitSocket 2→20ms, vsock 5→50ms, backoff-sequence test. |
+| 3a — TAP `Transfer` | done | Atomic single-`UPDATE` re-key in `store.go`; idempotent-retry + concurrent-duplicate regression tests in `tap/pool_test.go`. |
+| 3b — warm pool v1.15 redesign | done | WarmSpawn owns TAP + `network_overrides` at load; Acquire transfers ownership, zero `PatchNetworkInterface`. Pool still **off by default** (ship-dark, per this plan). |
+| 3c — sizing guards | partial | Boot-time depth cap `min(configured, tap_pool_size/8)` in `pkg/daemon`. The dynamic refill guard (refuse when free TAP slots < 2× pool size) is NOT implemented. |
+| UC-98/98b/98c/98d | not started | Require Phase 0's warm-hit marker + a cluster-hetero run. |
+
+**Deviation from the 3a design (call out in the PR):** rollback after a
+failed warm acquire *releases* the transferred TAP row (via
+`warmHandle.Shutdown`) instead of transferring it back to the slot id.
+Simpler and leak-free — Destroy/rollback double-release is idempotent —
+but a failed warm create burns the parked slot's TAP + VMM instead of
+returning them to the pool; the refill loop replaces the slot on its
+next tick. `TestTransfer_RollbackShape` is therefore superseded by
+`TestCreate_WarmRollbackOnTapTransferFailure` +
+`TestAcquire_ConcurrentDuplicateCreate`.
+
+**Deviations from the Phase 0 design (call out in the PR):**
+
+- `fc_tcp_probe` is **not** recorded: Phase 1 moved the TCP probe off the
+  create path onto a detached goroutine, so there is no boot-path duration
+  to attribute — the header would always report a meaningless ~0ms.
+- Three stages were added beyond the planned list so the per-stage p50s can
+  actually sum to the `create` total (the Phase 0 exit criterion):
+  `fc_rootfs` (template stage / OCI build), `fc_tap_ensure` (host `ip`
+  realization), and `fc_configure` (cold-boot REST config, the counterpart
+  of the snapshot path's `fc_load`).
+- The warm-hit marker (`fc_warm;dur=…;desc=hit`) shipped with Phase 0
+  instead of waiting for UC-98; the warm path also records
+  `fc_resume`/`fc_handshake`/`fc_post_resume` so warm hits are attributable
+  without a separate stage set.
+- `fc_driver` is recorded on failed creates too (the handler already sets
+  Server-Timing on error responses), so slow failures are visible.
 
 ---
 

--- a/plans/firecracker-create-latency.md
+++ b/plans/firecracker-create-latency.md
@@ -1,0 +1,387 @@
+# Firecracker snapshot-clone create latency: 3.45s → sub-700ms
+
+Status: **Proposed** (2026-07-04). Not started.
+
+Owner rules that apply: this plan changes `CreateSandbox` callees
+(`/touch-create-sandbox`), the TAP allocator and warm-VMM pool (fragile areas —
+regression tests mandatory next to the file), and needs boot-path latency
+call-outs in every PR description per `pr-review.md` §2.
+
+---
+
+## Problem
+
+The `cluster-hetero` benchmark (UC-94, run 2026-07-01, artifact
+`integration-tests/reports/cluster-hetero-bench.json`) measured firecracker
+snapshot-clone creates at:
+
+| metric | docker | firecracker |
+|---|---|---|
+| api p50 (client round-trip) | 1047ms | 4224ms |
+| server p50 (Server-Timing) | 291ms | **3452ms** |
+| server p90 / p99 | 2450 / 2690ms | 3460 / **3467ms** |
+
+Two things stand out:
+
+1. **The firecracker distribution is flat** — 15ms of spread between p50 and
+   p99 across 10 samples. That is the signature of fixed, deterministic
+   pipeline work (hashing a fixed-size file, fixed-cadence polls), not
+   contention, cold caches, or network variance.
+2. **Docker's 291ms server p50 bounds the shared scaffolding.** Both runtimes
+   pay the same service-layer work (admission, SQLite row, caddy route upsert,
+   Raft placement + cross-node forward). Everything above ~300ms is
+   firecracker-driver cost.
+
+The reference number everyone carries in their head — "a snapshot resume is
+~125ms" — describes only `spawn + LoadSnapshot + Resume`. The shipped path
+pays, per create, on top of that:
+
+| # | Stage | Where | Estimated cost | Why it exists |
+|---|---|---|---|---|
+| A | SHA256 re-verify of the full snapshot | `configureVMMForLoad` → `verifySnapshotChecksum` (`internal/runtime/firecracker/snapshot.go`) | **~1.2–1.8s** | `SB_FIRECRACKER_SNAPSHOT_VERIFY_ON_LOAD` defaults `true`; re-hashes the 512MiB `snapshot.memory` + `snapshot.state` on *every* clone. c5.metal (Cascade Lake) has no SHA-NI; Go sha256 ≈ 300–500 MB/s single-threaded. |
+| B | Cold VMM spawn | `Driver.Create` steps 2–7 | ~200–400ms | The warm-VMM pool (the designed fast path) is **disabled**: Firecracker v1.15 moved TAP rebinding to `LoadSnapshot.network_overrides`; the pool still PATCHes `host_dev_name` post-load, which v1.15 forbids (`warmspawn.go` header). Every create pays jailer spawn + `WaitSocket` (20ms poll) + LoadSnapshot + 2× PatchDrive + Resume. |
+| C | Guest-readiness gating | `Driver.Create` steps 8–8b | ~400–800ms | Sequential: vsock handshake (50ms retry cadence) → `post_resume` op (guest RNG reseed + wallclock + eth0 reconfig; bounded 2s) → `probeToolboxTCP` (100ms cadence, 200ms dial timeouts, bounded 2s). The TCP probe is **log-only** — it never affects the create result — yet blocks the HTTP response. |
+| D | Service + cluster scaffolding | `createFirecrackerSandbox` + forward | ~300ms | Bounded by docker's 291ms server p50 through the identical path. |
+| — | Client ↔ AWS network | outside the server | ~600–800ms | api − server gap (4224 − 3452 = 772ms p50). Bench client ran from a residential connection. Not a server cost; fixed by benchmark methodology, not code. |
+
+A + B + C + D ≈ the observed 3.45s. Stage costs are estimates attributed from
+file sizes, hash throughput, and the docker baseline — **Phase 0 exists to
+replace the estimates with measured numbers before we commit to Phase 1/3
+targets.**
+
+---
+
+## Targets (grounded, per phase)
+
+All server-side p50, measured by UC-94 on `cluster-hetero` (c5.metal FC
+worker, 512MiB template memory, default image), benchmark client **inside the
+VPC** (see Methodology below). "Committed" is the number the phase's PR must
+demonstrate before merge; "stretch" is what the analysis says is likely.
+
+| Milestone | Committed | Stretch | What changes |
+|---|---|---|---|
+| Baseline (measured 2026-07-01) | — | — | server p50 **3452ms** |
+| Phase 0: instrumentation | no latency change | — | per-stage Server-Timing + bench artifact breakdown; validation experiment E1 |
+| Phase 1: verify-once cache + async TCP probe | **≤ 2000ms** | ≤ 1600ms | removes A (after first load) and C's probe tail |
+| Phase 2: poll-cadence trims | **≤ 1900ms** | ≤ 1500ms | first-retry backoff on WaitSocket + vsock dial |
+| Phase 3: warm-VMM pool redesign (v1.15) | **≤ 700ms** | ≤ 450ms | removes B entirely on warm hit; driver stage (`fc_driver` timing) ≤ 250ms committed / ≤ 150ms stretch |
+
+Why the Phase 3 floor is ~450–700ms and not 125ms: the driver's warm-hit work
+(patch drives + Resume + handshake + post_resume) is the only part the 125ms
+folklore describes. On this cluster every create also pays scaffolding +
+Raft placement + one forward hop ≈ 300ms (docker's measured floor). Getting
+end-to-end server p50 to ~125ms would require attacking D (caddy upsert off
+the critical path, placement fast-path) — explicitly **out of scope** here;
+if Phase 3 lands at target, a follow-up plan can own D.
+
+Density/regression guard: docker and gvisor numbers in the same bench run must
+not regress by more than 10% p50 in any phase (the phases must not perturb the
+shared path).
+
+---
+
+## Phase 0 — Measure before promising (1 small PR)
+
+The single biggest analysis risk is stage attribution being wrong (e.g.
+LoadSnapshot secretly copying the memory file, or the TCP probe being cheap).
+Phase 0 makes every later target falsifiable.
+
+### Work
+
+1. **Per-stage create timing for firecracker.** Reuse the existing
+   `docker.CreateTiming` context-recorder pattern (`pkg/docker/create_timing.go`,
+   surfaced via `setCreateServerTiming` in `pkg/api/v1/handlers.go`). Add
+   firecracker stages, recorded inside `Driver.Create`:
+   `fc_tap_alloc`, `fc_verify`, `fc_spawn` (spawn→socket), `fc_load`
+   (stage+LoadSnapshot+patches), `fc_resume`, `fc_handshake`, `fc_post_resume`,
+   `fc_tcp_probe`, and a `fc_driver` total. The recorder type should move to a
+   neutral package (or a new `pkg/createtiming`) rather than deepening the
+   `docker` import — mechanical refactor, keep the docker fields intact.
+2. **Bench artifact breakdown.** UC-94 already parses Server-Timing
+   (`harness.Client.LastServerCreateMS`); extend it to record all
+   `<name>;dur=` pairs and emit a per-stage mean/p50 block into
+   `cluster-hetero-bench.json` under `latency[].stages`.
+3. **Validation experiment E1** (operator-run, no code): rerun UC-94 with
+   `SB_FIRECRACKER_SNAPSHOT_VERIFY_ON_LOAD=false` on the FC worker. Expected:
+   server p50 drops to ~1.5–2.2s. Confirms stage A's magnitude before Phase 1
+   is built. If E1 shows < 800ms of savings, STOP and re-attribute (the flat
+   p99 says *something* deterministic is burning >1s; find it in the Phase 0
+   stage data).
+
+### Tests
+
+- `pkg/api/v1/handlers_test.go` (or existing timing test file): Server-Timing
+  header includes fc stages when the recorder carries them; absent stages are
+  omitted; docker fields unchanged.
+- `internal/runtime/firecracker/driver_test.go` (table-driven, existing fake
+  seams): a successful snapshot-load Create populates every stage with a
+  non-negative duration; a cold-boot (no template) Create leaves `fc_verify`
+  and `fc_load` zero.
+- Bench harness unit test: `LastServerCreateMS`-style parser returns the full
+  stage map for a synthetic header.
+
+### Exit criteria
+
+A cluster-hetero bench run produces per-stage p50s that sum to within 15% of
+the `create` total. Targets in this doc are then re-baselined against the
+measured stage table (edit this file; keep the history).
+
+---
+
+## Phase 1 — Verify-once checksum cache + async TCP probe (1 PR)
+
+### Design: checksum cache
+
+Templates are immutable once `status=ready`; re-hashing the same bytes per
+clone is pure waste. Add a per-driver verified-set consulted by both
+`configureVMMForLoad` (`driver.go`) and `WarmSpawn` (`warmspawn.go`):
+
+- **Key:** template's persisted checksum string + file identity of both
+  artifacts (`dev`, `inode`, `size`, `mtime` from `os.Stat`) captured at
+  verification time. Any stat drift → treat as unverified.
+- **Concurrency:** the repo's canonical single-flight latch —
+  `sync.Mutex` + map entry with done-channel/`atomic.Bool` — mirroring
+  `Service.EnsureLayer4Ready` (`internal/service/service.go` →
+  `layer4_bootstrap_test.go`), so N concurrent creates of one template hash
+  once and the other N−1 wait for the result (a failed verify must NOT be
+  cached as verified; waiters get the error and the next caller retries).
+- **Invalidation:** (a) stat mismatch on lookup; (b) the corrupt-notification
+  path — when `MarkSnapshotCorrupt` fires (or the driver's `notifyCorrupt`
+  seam), drop the template's entry; (c) daemon restart (cache is in-memory
+  only — deliberately, so a corrupted-on-disk artifact is re-checked at least
+  once per boot).
+- **Config:** `SB_FIRECRACKER_SNAPSHOT_VERIFY_ON_LOAD=false` keeps its exact
+  current meaning (skip entirely). New
+  `SB_FIRECRACKER_SNAPSHOT_VERIFY_MODE=always` opt-out of the cache for
+  paranoid operators (default `once`). Document both in `internal/config`.
+
+Integrity honesty (for the PR description): the threat this check actually
+catches is torn writes / partial registry pulls at artifact-creation time —
+still caught, on first load. Silent in-place bit-rot between creates within
+one daemon boot is no longer caught; it was the only coverage lost, and
+`LoadSnapshot`/Resume failing remains the backstop. This trade must be stated
+in the PR, not silently made.
+
+### Design: async TCP probe
+
+`probeToolboxTCP` (`driver.go`) is observational — it logs reachability and
+returns nothing. Move both call sites (`Create` step 8b, `tryAcquireWarm`) to
+a goroutine with `context.Background()`-derived timeout (the request ctx dies
+when the handler returns), keeping `PostResumeTimeout` as the bound and the
+existing log fields. Add the probe's outcome to the RSS of the *next* create
+only via logs — no behavior change for callers.
+
+`post_resume` itself stays synchronous: it reconfigures the guest's eth0 to
+the clone IP; returning earlier would hand users a sandbox whose network isn't
+up yet (immediate `exec` would fail — regression against UC-44).
+
+### Tests (package must stay ≥ ~85%; run `/maintain-coverage`)
+
+New file `internal/runtime/firecracker/snapshot_verify_cache_test.go`
+(table-driven, matching `layer4_bootstrap_test.go` style). Needs a countable
+hash seam — inject the hash function (mirror the existing `spawn`/`newClient`
+seam pattern) so tests count invocations instead of timing them:
+
+| Test | Asserts |
+|---|---|
+| `TestVerifyCache_SecondLoadSkipsHash` | two sequential snapshot-load Creates of one template → hash seam called exactly once |
+| `TestVerifyCache_SingleFlight` | N concurrent Creates → exactly one hash; all N succeed |
+| `TestVerifyCache_FailureNotCached` | first verify fails (corrupt) → second Create re-hashes (failed result not latched) |
+| `TestVerifyCache_InvalidatesOnFileChange` | rewrite `snapshot.memory` (new mtime/size) → re-hash on next Create |
+| `TestVerifyCache_CorruptNotificationInvalidates` | `notifyCorrupt` / MarkSnapshotCorrupt path drops the entry |
+| `TestVerifyCache_ModeAlways` | `VERIFY_MODE=always` → hash on every Create |
+| `TestVerifyCache_DisabledSkipsEntirely` | `VERIFY_ON_LOAD=false` → zero hash calls, zero cache entries |
+| `TestVerifyCache_WarmSpawnShares` | WarmSpawn then Create (or vice versa) → one hash total |
+
+Async probe, in `driver_test.go` / `warmacquire_test.go`:
+
+| Test | Asserts |
+|---|---|
+| `TestCreate_TCPProbeOffCriticalPath` | prober seam blocks forever → Create still returns within test deadline; probe goroutine observed started |
+| `TestCreate_TCPProbeUsesDetachedContext` | cancel the request ctx immediately after Create returns → probe still completes its bounded run (no premature ctx-cancelled log) |
+| `TestWarmAcquire_TCPProbeOffCriticalPath` | same for the warm path |
+
+Config: `internal/config/config_test.go` — new env var default/parse rows in
+the existing table.
+
+### Validation benchmark
+
+Rerun UC-94 (in-VPC client). **Merge gate: firecracker server p50 ≤ 2000ms**,
+`fc_verify` stage p50 ≤ 5ms on samples 2–10 (first sample pays the one-time
+hash), docker/gvisor p50 within 10% of baseline. Record the run's JSON next to
+this plan's status table.
+
+---
+
+## Phase 2 — Poll-cadence trims (optional, 1 tiny PR)
+
+Only worth doing while the files are already open; skip if Phase 3 starts
+immediately.
+
+- `WaitSocket` (`vmm.go`): first retry at 2ms, doubling to the existing 20ms
+  cap. Socket appears in single-digit ms on a healthy host; today's fixed
+  20ms cadence rounds that up.
+- `vsockHandshake` (`driver.go`): same shape — first retry 5ms, doubling to
+  the existing 50ms cap.
+
+Tests: extend `vmm_test.go` / `driver_test.go` retry tests to assert the
+backoff sequence (fake clock or attempt-counter seam), and that the existing
+deadline behavior is unchanged. Expected win is ~50–150ms; measured via the
+Phase 0 `fc_spawn` / `fc_handshake` stages, not eyeballed.
+
+---
+
+## Phase 3 — Warm-VMM pool redesign for Firecracker v1.15 (2–3 PRs)
+
+The endgame. Everything in stage B disappears on a warm hit: the pool's
+refill goroutine pays spawn + LoadSnapshot ahead of time; Create becomes
+patch-drives + Resume + handshake + post_resume.
+
+### Why it's currently impossible and what unblocks it
+
+The parked snapshot's eth0 references the (torn-down) template-build TAP.
+v1.15 only allows TAP rebinding **at load time** via
+`LoadSnapshot.network_overrides` — the cold path already uses exactly this
+(`configureVMMForLoad`), so the mechanics are proven in production. The warm
+pool predates that contract and tries to `PatchNetworkInterface` after load
+(`warmacquire.go`), which v1.15 rejects. Fix: the warm slot must **own a real
+TAP slot before LoadSnapshot**.
+
+### Design
+
+PR 3a — TAP ownership transfer (fragile area: TAP allocator):
+
+- New op on the TAP pool (`internal/network/tap/pool.go` + store):
+  `Transfer(ctx, fromID, toID)` — re-keys an allocated slot atomically
+  (single SQLite writer; one UPDATE guarded by the existing uniqueness
+  constraints). No IP/CID/name change — only the owner column.
+- `Driver.Create`'s warm-hit path stops allocating its own TAP slot and
+  instead Transfers the slot the pool's WarmSpawn allocated (slot-ID →
+  sandbox-ID). Cold fallback keeps today's allocate-first shape. On warm-hit
+  rollback, Transfer back (sandbox-ID → slot-ID) before Release so the GC
+  sweep still owns cleanup.
+
+PR 3b — WarmSpawn owns network at load time (fragile area: warm pool):
+
+- `WarmSpawnRequest` gains the TAP slot; the refill spawner allocates a TAP
+  slot under the warm slot's ID, realizes the host TAP (`tapHost.Ensure`),
+  and passes `network_overrides` in its LoadSnapshot. Failure paths tear the
+  TAP down (LIFO, same flag-and-defer pattern the file already uses).
+- `tryAcquireWarm` drops `PatchNetworkInterface` entirely; keeps rootfs +
+  overlay PatchDrive, Resume, handshake (template CID), post_resume with the
+  transferred slot's IP.
+- Guest MAC: the snapshot froze the template MAC; the host neighbor entry
+  must use `macFromCID(SnapshotVsockCID)` exactly as the cold path's
+  `hostSlot.GuestMAC` override does today — carry that into WarmSpawn's
+  `Ensure`.
+- Pool enable: flip the default only after UC-98 passes on cluster-hetero;
+  ship dark behind the existing pool-size=0-off config first.
+
+PR 3c — capacity & sizing guards:
+
+- Warm slots consume finite TAP slots (`SB_FIRECRACKER_TAP_POOL_SIZE`,
+  default 256/host). Cap warm-pool size at `min(configured,
+  tap_pool_size/8)` and refuse to refill when free TAP slots <
+  2× warm-pool size, so parked VMMs can never starve real creates. Slots
+  already count toward RSS pressure (Phase 5 sampler) — verify the admission
+  interaction with a test, not a comment.
+
+Cluster note (per CLAUDE.md hard rule 6): no `internal/cluster` code changes
+are expected — placement/forwarding are agnostic to how the driver boots. The
+PR call-out must still state this and confirm single-node no-op behavior
+(`cfg.EnableCluster=false` untouched).
+
+### Tests
+
+Fragile-area regression tests, next to the files they change:
+
+`internal/network/tap/pool_test.go` (+ store tests if the column moves):
+
+| Test | Asserts |
+|---|---|
+| `TestTransfer_RekeysOwner` | slot survives with same TAP/IP/CID under new ID; old ID no longer resolves |
+| `TestTransfer_TargetAlreadyHasSlot` | conflict → error, no partial state |
+| `TestTransfer_SourceMissing` | clean error |
+| `TestTransfer_ConcurrentDuplicate` | two concurrent Transfers of one slot → exactly one wins (idempotency rule #1) |
+| `TestTransfer_RollbackShape` | transfer → transfer-back round-trip restores the original row |
+
+`internal/runtime/firecracker/warmspawn_test.go`:
+
+| Test | Asserts |
+|---|---|
+| `TestWarmSpawn_LoadSnapshotCarriesNetworkOverrides` | fake client records `network_overrides` = slot TAP |
+| `TestWarmSpawn_TapEnsuredBeforeLoad` | seam-call ordering |
+| `TestWarmSpawn_FailureTearsDownTap` | error after Ensure → `tapHost.Remove` called (LIFO, after process shutdown) |
+| `TestWarmSpawn_UsesTemplateMAC` | Ensure receives `macFromCID(SnapshotVsockCID)` |
+
+`internal/runtime/firecracker/warmacquire_test.go`:
+
+| Test | Asserts |
+|---|---|
+| `TestAcquire_NoNetworkPatch` | fake client sees zero `PatchNetworkInterface` calls |
+| `TestAcquire_TransfersSlot` | TAP Transfer(slotID→sandboxID) before Resume |
+| `TestAcquire_RollbackTransfersBack` | post-Transfer failure → Transfer back + Release + Shutdown, no TAP leak |
+| `TestAcquire_PoolMissFallsBackCold` | `ErrNoLoadedSlot` → cold path result identical to pool-nil driver |
+| `TestAcquire_ConcurrentDuplicateCreate` | same sandbox ID raced → one slot claimed, no double-Resume |
+
+`internal/pool/vmm/refill_test.go`: refill respects the TAP-budget guard;
+`pool_test.go`: GC of an aged warm slot releases its TAP slot.
+
+Integration (new UCs, `integration-tests/suite/`; UC-97 is soft-reserved by
+the docker-readiness plan):
+
+| UC | Title | Gate |
+|---|---|---|
+| UC-98 | Warm-pool hit: firecracker clone create p50 ≤ 700ms server-side | `CapCluster, CapFirecracker, CapBenchmark`; asserts `fc_driver` stage ≤ 250ms and a warm-hit marker (new `fc_warm;desc=hit` Server-Timing entry) |
+| UC-98b | Pool exhaustion falls back to cold create (correctness, not speed) | drain the pool with N parallel creates > pool size; all succeed |
+| UC-98c | Warm slot ages out → TAP slot returns to the free pool | create after GC TTL still finds capacity; `/v1/capacity` TAP count restored |
+| UC-98d | Daemon restart with parked warm slots → orphan sweep reclaims TAPs and firecracker processes | no leaked `fctap*` devices (reuse the existing orphan-reclaim harness shape from UC-60) |
+
+### Validation benchmark
+
+UC-94 with the pool enabled on the FC worker. **Merge gate for flipping the
+default: server p50 ≤ 700ms, `fc_driver` p50 ≤ 250ms, zero failures across
+≥ 20 samples (raise from 10 — the warm/cold hit mix needs the larger n), pool
+refill keeps up at the bench's sequential rate (no cold fallbacks after
+sample 3), docker/gvisor within 10% of baseline.**
+
+---
+
+## Benchmark methodology (applies to every phase gate)
+
+1. **Client in-VPC.** The 2026-07-01 run's api−server gap (772ms p50) is the
+   operator's home connection. Run the suite from a runner in the cluster VPC
+   (or accept server-side numbers as the only gate — they already exclude
+   client RTT). Phase gates above are all server-side for this reason.
+2. **Same scenario, same instance types** (`cluster-hetero.tfvars`, c5.metal
+   FC worker), same template shape (default image, 512MiB memory), n ≥ 10
+   (n ≥ 20 for Phase 3), sequential creates (today's UC-94 shape).
+3. **Warm the page cache first** — the existing warmup create already does
+   this; keep it, otherwise sample 1 measures EBS.
+4. **Record artifacts**: commit the bench JSON for each phase gate under
+   `integration-tests/reports/` and update the status table in this file with
+   measured (not estimated) stage numbers.
+5. **Regression floor**: no phase may regress docker/gvisor server p50 by
+   >10% or reduce UC pass count on the cluster-hetero matrix.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Stage attribution wrong (hash isn't the dominant term) | Phase 0 E1 experiment gates Phase 1; STOP rule if savings < 800ms |
+| Cached-verify misses in-place corruption within a daemon boot | stated trade in PR; `VERIFY_MODE=always` escape hatch; LoadSnapshot failure backstop; per-boot re-verify |
+| Warm slots starve TAP pool / host memory | PR 3c budget guard + RSS sampler already counts parked slots; UC-98c |
+| Transfer op corrupts TAP bookkeeping under concurrent duplicate creates | single SQLite writer + `TestTransfer_ConcurrentDuplicate`; idempotency is pr-review rule #1 |
+| v1.15 `network_overrides` behaves differently on warm (paused-long) VMMs than on cold loads | UC-98 runs on real hardware before the pool default flips; pool ships dark first |
+| Bench flakiness blocks merges | gates are p50 (not p99) with fixed n; UC-98 lives behind `CapBenchmark` so ordinary runs don't hard-fail on latency |
+
+## Out of scope (deliberately)
+
+- Attacking stage D (caddy upsert / placement / forward ≈ 300ms floor) — its
+  own plan if Phase 3 lands at target.
+- Faster hash algorithms (BLAKE3 etc.) — the cache makes hash speed
+  irrelevant after first load; changing the persisted checksum format is not
+  worth the migration.
+- UFFD-based memory loading — File-backend mmap is already lazy; no evidence
+  yet that LoadSnapshot itself is a material cost (Phase 0 will confirm).
+- Client-RTT reduction (regional endpoints, connection reuse in SDKs).

--- a/plans/firecracker-create-latency.md
+++ b/plans/firecracker-create-latency.md
@@ -1,7 +1,7 @@
 # Firecracker snapshot-clone create latency: 3.45s → sub-700ms
 
-Status: **In progress** (updated 2026-07-04). Phases 0 (code), 1, 2, 3a, 3b
-and the 3c static cap are code-complete on
+Status: **In progress** (updated 2026-07-04). Phases 0 (code), 1, 2, 3a, 3b,
+and 3c are code-complete on
 `feat/firecracker-create-latency-phase1`; the E1 experiment, the UC-98
 integration scenarios, and every benchmark gate below are still open — no
 latency number in this document has been re-measured yet.
@@ -20,7 +20,7 @@ call-outs in every PR description per `pr-review.md` §2.
 | 2 — poll-cadence trims | done | `retry.go`; WaitSocket 2→20ms, vsock 5→50ms, backoff-sequence test. |
 | 3a — TAP `Transfer` | done | Atomic single-`UPDATE` re-key in `store.go`; idempotent-retry + concurrent-duplicate regression tests in `tap/pool_test.go`. |
 | 3b — warm pool v1.15 redesign | done | WarmSpawn owns TAP + `network_overrides` at load; Acquire transfers ownership, zero `PatchNetworkInterface`. Pool still **off by default** (ship-dark, per this plan). |
-| 3c — sizing guards | partial | Boot-time depth cap `min(configured, tap_pool_size/8)` in `pkg/daemon`. The dynamic refill guard (refuse when free TAP slots < 2× pool size) is NOT implemented. |
+| 3c — sizing guards | done | Boot-time depth cap `min(configured, tap_pool_size/8)` in `pkg/daemon`; refill-time TAP capacity guard skips warming when free TAP slots are below `2 × desired warm depth`. |
 | UC-98/98b/98c/98d | not started | Require Phase 0's warm-hit marker + a cluster-hetero run. |
 
 **Deviation from the 3a design (call out in the PR):** rollback after a

--- a/plans/wasm-create-latency.md
+++ b/plans/wasm-create-latency.md
@@ -1,0 +1,398 @@
+# WASM create latency: 5.4s → warm hits in the double-digit-ms class
+
+Status: **Proposed** (written 2026-07-04). No code started. Baseline numbers
+are from the 2026-07-01 `cluster-hetero` UC-94 run
+(`integration-tests/reports/cluster-hetero-bench.json`).
+
+Owner rules that apply: this plan changes `CreateSandbox` callees
+(`/touch-create-sandbox`), the WASM warm-worker pool (`internal/pool/wasm/` —
+regression tests mandatory next to the file, same bar as the TCP host-port
+pool), and needs boot-path latency call-outs in every PR description per
+`pr-review.md` §2. The worker wire protocol (`pkg/wasm/worker/`) changes in
+Phase 1 — both ends ship in the same binary (`sandboxd --wasm-worker` is a
+re-exec of the daemon), so there is no cross-version compatibility window,
+but say so in the PR.
+
+Sibling plan: `plans/firecracker-create-latency.md`. Phase 2 here is the
+same disease that plan's Phase 1 cured for Firecracker (per-create hashing
+of an immutable artifact) — mirror its verify-once design, do not invent a
+new one.
+
+---
+
+## Problem
+
+The `cluster-hetero` benchmark (UC-94, run 2026-07-01) measured WASM creates
+at:
+
+| metric | docker | wasm |
+|---|---|---|
+| api p50 (client round-trip) | 1047ms | 6659ms |
+| server p50 (Server-Timing) | 291ms | **5832ms** |
+| server mean / p90 / p99 | 745 / 2450 / 2690ms | 5416 / 6645 / **7806ms** |
+
+The docs promise "<70ms sandbox startup" (`docs/src/content/docs/comparison.md`)
+and the folklore number is ~60ms. Two observations frame the analysis:
+
+1. **The distribution is uniformly slow** — every one of the 10 samples sits
+   between ~5.4s and ~8.6s API-side. There is no fast mode. The pool was
+   enabled on every worker (`SB_WASM_POOL_ENABLED=true`, depth 2) and the
+   end-of-run `systemctl status` snapshot shows 8 warmed slot processes per
+   node (4 module digests × depth 2) — the pool was populated and it made
+   **zero** difference. Warm hits are not fast today; that is the smoking gun.
+2. **Docker's 291ms server p50 bounds the shared scaffolding** (admission,
+   SQLite row, Raft placement + forward hop, caddy). Everything above ~300ms
+   is WASM-driver cost.
+
+### Root-cause ledger (all verified in code, file:line at HEAD)
+
+| # | Defect | Where | Per-create cost (python.wasm, t3.medium) | Mechanism |
+|---|---|---|---|---|
+| A | **Recompile inside `Instantiate` — defeats the warm pool AND double-compiles the cold path** | `pkg/wasm/engine_wazero.go:92-98` → `initRuntime` → `CompileModule` at `engine_wazero.go:66` | **~2.5s on warm hit; ~5s cold (two compiles)** | Pool slots are warmed via `LoadModule` only (`internal/pool/wasm/spawner.go:57`); the worker engine is built with `initRuntime(ctx, 0)` = **0 memory-limit pages**. Every create then calls `Instantiate` with the sandbox's memory cap (default 256MB → 4096 pages, `SB_WASM_DEFAULT_MEMORY_MB`, `internal/config/config.go:1364`). `ensureMemoryLimit` sees `4096 != 0`, tears down the whole wazero runtime and **recompiles the module from bytes** inside the create request. Warm hit = compile once anyway. Cold = compile in `LoadModule`, then compile AGAIN in `Instantiate`. |
+| B | **SHA-256 of the full module file on every create** | `pkg/wasmmod/resolver.go:41` (`fileDigest`, `resolver.go:66-78`) | ~30–60ms (≈30MB CPython module) | Reserved-alias (`python`) and file refs re-hash the entire `.wasm` per create to produce the digest the pool is keyed on. Identical bug family to the Firecracker per-create snapshot hash fixed in commit `077789b` — that fix is FC-only (`internal/runtime/firecracker/snapshot_verify_cache.go`); `pkg/wasmmod` got nothing. |
+| C | **No compilation cache anywhere** | `pkg/wasm/engine_wazero.go:53` (`NewRuntimeConfig()` without `WithCompilationCache`) | compile cost never amortizes | Each pool slot / sandbox worker is a separate `sandboxd --wasm-worker` process; each pays the full wazero compile of the same bytes. Refill of one depth-2 pool for CPython burns ~2×2.5s of CPU per tick it runs. |
+| D | **25ms readiness-poll quantization on cold spawns** | `internal/runtime/wasm/lifecycle.go:296-303` (`sleepBrief`), `internal/pool/wasm/spawner.go:54` | up to +25ms | First `Ping` fires before the worker has bound its socket, then the loop sleeps a flat 25ms — worker readiness rounds up to the next 25ms tick. Same shape the FC plan's Phase 2 trimmed for `WaitSocket`/vsock. |
+| E | **`oci://` refs pay 2+ registry round-trips per create even on full cache hit** | `pkg/wasmmod/resolve.go:172` (credentialed manifest resolve: token + HEAD over TLS) | ~30–100ms in-VPC | Deliberate (it's the per-tenant auth check + cache key), but it belongs on the ledger; the bench and standard-alias paths avoid it. |
+
+Arithmetic check against the measured 5.4s server mean: cold create =
+B (hash ~50ms) + spawn/poll (~50–100ms) + **two** CPython compiles
+(A + `LoadModule`, ~2×2.5s) + instantiate + scaffolding (~300ms) ≈ 5.4s. ✔
+The flat distribution (no bimodal split despite 8 warm slots) is exactly what
+defect A predicts: warm or cold, every create compiles.
+
+### Why "60ms" was never reachable end-to-end on this cluster
+
+The 60ms budget describes the **driver stage of a warm hit**: acquire slot +
+ping + instantiate a pre-compiled module. On `cluster-hetero`, every create
+additionally pays the ~300ms shared scaffolding floor (docker's measured
+291ms server p50: Raft placement, forward hop, SQLite, caddy). So the honest
+post-fix targets are: driver stage ≤ 60–100ms, cluster server p50 ≈ 350–500ms,
+single-node (no cluster) end-to-end ≈ 60–120ms. Anyone gating this work on
+"60ms server p50 in the cluster bench" will be disappointed by arithmetic,
+not by the fixes.
+
+---
+
+## Targets
+
+All WASM server-side p50 via UC-94 on `cluster-hetero` (t3.medium gvisor
+workers run wasm; staged `python` module via `AEROL_WASM_MODULE_REF`;
+pool enabled, depth 2), client in-VPC per the FC plan's methodology section.
+Estimates until Phase 0 measures stages — same STOP discipline as the FC plan.
+
+| Milestone | Committed | Stretch | What changes |
+|---|---|---|---|
+| Baseline (measured 2026-07-01) | — | — | server p50 **5832ms**, no warm/cold distinction visible |
+| Phase 0: instrumentation | no latency change | — | per-stage Server-Timing (`wasm_*`), warm-hit marker, bench stage block |
+| Phase 1: kill the Instantiate recompile | warm-hit server p50 **≤ 1000ms**; overall p50 ≤ 3200ms | warm ≤ 600ms | removes A: warm hits stop compiling; cold path compiles once, not twice |
+| Phase 2: verify-once module digest cache | warm-hit **≤ 900ms** | ≤ 550ms | removes B after first resolve |
+| Phase 3: shared wazero compilation cache | cold p50 **≤ 1500ms**; overall p50 ≤ 1000ms | cold ≤ 800ms | removes C: compiles amortize across workers + restarts; refill gets cheap enough to keep up, so most creates are warm |
+| Phase 4 (optional): poll backoff + miss-kicked refill | warm-hit driver stage ≤ 100ms | ≤ 60ms | trims D; pool refills on demand instead of 5s ticks |
+
+Regression guard for every phase: docker and gvisor server p50 within 10% of
+baseline in the same run; UC-26/UC-44/UC-85 (wasm correctness) keep passing;
+`make test` coverage for every touched package stays ≥ ~85%
+(`/maintain-coverage` before each PR).
+
+---
+
+## Phase 0 — Instrumentation (1 small PR)
+
+Reuse `pkg/createtiming` (already extracted by the FC plan's Phase 0 — the
+recorder is runtime-neutral and the v1 handler + bench harness already
+surface arbitrary `<name>;dur=` stages into `latency[].stages`).
+
+### Work
+
+1. Record stages inside `Driver.Create` (`internal/runtime/wasm/create.go`):
+   `wasm_resolve` (module resolve incl. hash), `wasm_warm;desc=hit|miss`,
+   `wasm_spawn` (supervisor Ensure → first successful ping, cold only),
+   `wasm_load` (LoadModule RPC, cold only), `wasm_instantiate`, and a
+   `wasm_driver` total. Record on failure too (handler already sets
+   Server-Timing on error responses).
+2. Nothing to change in `pkg/api/v1/handlers.go` or the bench harness if the
+   FC Phase 0 generic stage plumbing landed as designed — verify, don't assume.
+3. **Validation experiment W1** (operator-run, no code): rerun UC-94 twice on
+   the same cluster, `SB_WASM_POOL_ENABLED=true` vs `false`. Expected today:
+   statistically indistinguishable (defect A predicts the pool is a no-op for
+   latency). This is the falsifiable pre-registration for Phase 1: if the
+   pool-enabled run is already meaningfully faster, the recompile attribution
+   is wrong — STOP and re-read the Phase 0 stage data.
+
+### Files
+
+| File | Change |
+|---|---|
+| `internal/runtime/wasm/create.go` | record the six stages |
+| `internal/runtime/wasm/create_timing_test.go` (new) | stage presence/omission table tests |
+
+### Tests
+
+Table-driven, in the driver's existing fake-seam style: a warm-hit Create
+records `wasm_warm;desc=hit` and zero `wasm_spawn`/`wasm_load`; a cold Create
+records all stages non-negative; a failed Create still records `wasm_driver`.
+
+### Exit criteria
+
+A cluster-hetero run where wasm per-stage p50s sum to within 15% of the
+`create` total, and W1's result is pasted into this file's status table.
+
+---
+
+## Phase 1 — Kill the Instantiate recompile (1 PR, the big one)
+
+### Design
+
+The memory limit is wazero **runtime**-config, so the fix is to compile under
+the right limit in the first place, and to treat "limit differs" as a pool
+miss instead of a silent multi-second recompile.
+
+1. **Protocol:** `loadModulePayload` (`pkg/wasm/worker/payload.go`) gains
+   `MemoryMB int`. `MsgLoadModule` handling (`pkg/wasm/worker/server.go:156`)
+   applies it before compiling.
+2. **Engine:** extend the `Engine` interface (`pkg/wasm/engine.go`) —
+   `LoadModule(ctx, path)` becomes `LoadModule(ctx, path, opts LoadOptions)`
+   with `LoadOptions{MemoryMB int}` (a struct so Phase 3 can add the cache
+   handle without another signature ripple). `engine_wazero.go` builds the
+   runtime with `MemoryLimitPages(opts.MemoryMB)` **before** `CompileModule`;
+   `ensureMemoryLimit` keeps existing semantics (a genuinely different limit
+   at Instantiate still rebuilds — correctness backstop) but should now never
+   fire on the standard path. `engine_wasmtime.go` (build-tagged) gets the
+   analogous change.
+3. **Pool spawner:** `SupervisorSpawner.Warm` (`internal/pool/wasm/spawner.go`)
+   gains the memory parameter; `pkg/daemon/wasm_wiring.go` passes
+   `cfg.WasmDefaultMemoryMB`. `wasmpool.Slot` (`internal/pool/wasm/pool.go`)
+   carries `MemoryMB` it was warmed with.
+4. **Acquire keying:** `tryAcquireWarm` (`internal/runtime/wasm/warmacquire.go`)
+   computes the request's effective memory (req.MemoryMB or default,
+   the same expression `Create` uses — extract it, don't duplicate) and only
+   accepts a slot whose `MemoryMB` matches; mismatch = miss → cold path. A
+   non-default-memory create is thus exactly as fast as today, never slower,
+   and the common case stops recompiling. (Keying `ready` by
+   `(digest, memoryMB)` is the fuller design; not needed while all warmed
+   slots use one default — note it as the follow-up if non-default memory
+   becomes common.)
+5. **Cold path:** `Driver.Create` (`internal/runtime/wasm/create.go:110`)
+   passes the effective memory in its `LoadModule` call — this alone halves
+   cold-create compile cost (one compile, not two).
+
+### Files
+
+| File | Change |
+|---|---|
+| `pkg/wasm/engine.go` | `LoadOptions`, signature change |
+| `pkg/wasm/engine_wazero.go` | compile under the requested limit |
+| `pkg/wasm/engine_wasmtime.go` | same, behind `//go:build wasmtime` |
+| `pkg/wasm/worker/payload.go`, `server.go`, `client.go` | `MemoryMB` through the wire |
+| `internal/pool/wasm/spawner.go`, `pool.go` | memory-aware Warm + Slot |
+| `internal/runtime/wasm/warmacquire.go`, `create.go` | match-or-miss acquire; effective-memory helper |
+| `pkg/daemon/wasm_wiring.go` | pass `cfg.WasmDefaultMemoryMB` to the spawner |
+
+### Tests (fragile-area bar: regression tests next to every file touched)
+
+Needs a countable compile seam in `engine_wazero.go` (package-level
+`var compileModule = ...` indirection, mirroring the FC hash seam) so tests
+count compilations instead of timing them.
+
+| Test | Asserts |
+|---|---|
+| `pkg/wasm/engine_wazero_test.go` `TestLoadThenInstantiate_CompilesOnce` | LoadModule(default MB) + Instantiate(default MB) → exactly one compile |
+| `TestInstantiate_DifferentLimitStillRebuilds` | mismatched limit → recompile (backstop preserved) |
+| `internal/pool/wasm/spawner_test.go` `TestWarm_PassesMemoryMB` | wire payload carries the configured default |
+| `internal/runtime/wasm/warmacquire_test.go` `TestAcquire_MemoryMismatchMisses` | slot warmed at 256, create asks 512 → miss, cold path taken, create still succeeds |
+| `internal/runtime/wasm/create_test.go` `TestCreate_WarmHitNoLoadModule_NoRecompile` | warm hit → zero LoadModule RPCs and one compile total across warm+create (worker fake counts) |
+| `TestCreate_ColdCompilesOnce` | cold create → exactly one compile |
+
+### Validation benchmark
+
+Rerun UC-94 + W1. **Merge gate: warm-hit samples (identified by
+`wasm_warm;desc=hit`) server p50 ≤ 1000ms; `wasm_instantiate` p50 on warm
+hits ≤ 300ms; overall wasm p50 ≤ 3200ms; docker/gvisor within 10%.** Record
+the JSON under `integration-tests/reports/` and update this file.
+
+---
+
+## Phase 2 — Verify-once module digest cache (1 small PR)
+
+Mirror of `internal/runtime/firecracker/snapshot_verify_cache.go` for
+`pkg/wasmmod`. Staged modules are immutable in practice; re-hashing per
+create is pure waste.
+
+### Design
+
+- New `pkg/wasmmod/digest_cache.go`: map keyed by file identity
+  (`path` + `dev`, `inode`, `size`, `mtime` from `os.Stat` at hash time) →
+  content digest. Stat drift → miss → re-hash. Single-flight per path
+  (canonical `sync.Mutex` + done-channel latch, per
+  `Service.EnsureLayer4Ready`); a failed hash is not cached.
+- `Resolver.Resolve` (`pkg/wasmmod/resolver.go:41`) consults it. The
+  `oci://` path is untouched (already content-addressed: cache hits do a
+  stat, not a hash — `resolve.go:212-227`). The catalogue path already
+  returns a pinned digest without hashing.
+- Invalidation: stat mismatch; explicit drop when a module is
+  deleted/replaced (wire the same hook that calls `Pool.DropModule`);
+  in-memory only, so every daemon boot re-verifies once (deliberate, same
+  trade as FC — state it in the PR).
+- Config: `SB_WASM_MODULE_DIGEST_MODE` = `once` (default) | `always`
+  (escape hatch, current behavior). Same naming shape as
+  `SB_FIRECRACKER_SNAPSHOT_VERIFY_MODE`.
+
+### Files
+
+| File | Change |
+|---|---|
+| `pkg/wasmmod/digest_cache.go` (new) + `digest_cache_test.go` (new) | cache + single-flight |
+| `pkg/wasmmod/resolver.go` | consult cache in `Resolve` |
+| `internal/config/config.go` + `config_test.go` | `SB_WASM_MODULE_DIGEST_MODE` |
+| `pkg/daemon/wasm_wiring.go` | wire the mode |
+
+### Tests
+
+Same table as the FC verify-cache suite, transposed:
+`TestDigestCache_SecondResolveSkipsHash` (hash seam called once across two
+Resolves), `_SingleFlight` (N concurrent → one hash), `_FailureNotCached`,
+`_InvalidatesOnFileChange` (rewrite file → re-hash), `_ModeAlways`,
+`_DropOnModuleDelete`. Plus: `seedStandardModules`
+(`pkg/daemon/wasm_wiring.go:119`) still seeds correct digests (it resolves
+through the same path at boot — it should *prime* the cache, which is a
+feature: the first tenant create skips the hash too).
+
+### Validation benchmark
+
+UC-94: `wasm_resolve` p50 ≤ 5ms on samples 2–10; warm-hit server p50 ≤ 900ms.
+
+---
+
+## Phase 3 — Shared wazero compilation cache (1 PR)
+
+### Design
+
+- Build the wazero runtime with
+  `wazero.NewRuntimeConfig().WithCompilationCache(...)` using
+  `wazero.NewCompilationCacheWithDir(dir)`; dir from new config
+  `SB_WASM_COMPILE_CACHE_DIR` (default `<SB_WASM_CACHE_DIR>/wazero-compile`,
+  empty string = disabled). Workers are separate processes: pass the dir via
+  env in `DefaultSpawner` (`pkg/wasm/worker/supervisor.go:18`) — the same
+  pattern `AEROL_WASM_ENGINE` already uses (`wasm_wiring.go:71-73`).
+- **Verify before trusting:** wazero's file cache is documented for
+  cross-process sharing, but prove it in a test (two engines in two
+  subprocesses, second compile measurably skips codegen / hits the cache
+  dir). If it can't be proven, scope the cache to per-process and say so.
+- Cache eviction: entries are keyed by module + wazero version; wire module
+  GC (`Pool.DropModule` / module delete) to best-effort remove the entry, and
+  document that the dir is bounded by (modules × wazero versions) — small.
+- `initRuntime`'s rebuild (the Phase-1 backstop) also uses the cache, making
+  the residual mismatch path cheap too.
+
+### Files
+
+| File | Change |
+|---|---|
+| `pkg/wasm/engine_wazero.go` | `WithCompilationCache` from `LoadOptions`/env |
+| `pkg/wasm/worker/supervisor.go` | propagate cache-dir env to workers |
+| `internal/config/config.go` + `config_test.go` | `SB_WASM_COMPILE_CACHE_DIR` |
+| `pkg/daemon/wasm_wiring.go` | wire dir, create it at boot |
+| `pkg/wasm/engine_wazero_test.go` | cache-hit test incl. cross-process proof |
+
+### Validation benchmark
+
+UC-94: cold-create (`wasm_warm;desc=miss`) server p50 ≤ 1500ms; overall
+p50 ≤ 1000ms; **refill keep-up check** — after sample 3, no cold fallbacks at
+the bench's sequential rate (the FC plan's Phase 3 gate shape). Also rerun
+the density benchmark (UC-95 currently runs docker only — extend the sweep or
+note it): 8 pre-warmed workers per node must not regress admission headroom.
+
+---
+
+## Phase 4 — Poll backoff + miss-kicked refill (optional, 1 tiny PR)
+
+- `sleepBrief` (`internal/runtime/wasm/lifecycle.go:296`): first retry 2ms,
+  double to a 25ms cap — same shape as FC Phase 2's `WaitSocket` trim.
+  Identical change in `SupervisorSpawner.Warm`'s loop
+  (`internal/pool/wasm/spawner.go:41-56`).
+- Refill responsiveness: `Pool.Acquire` miss sends a non-blocking kick on a
+  buffered chan that `Run` (`internal/pool/wasm/refill.go:31`) selects on
+  alongside the 5s ticker, so a drained pool starts re-warming immediately
+  instead of up to `SB_WASM_POOL_REFILL_INTERVAL` later. Budget logic
+  (`SpawnBudget`) is unchanged — the kick only advances the tick.
+
+Tests: backoff-sequence assertions (attempt-counter seam, existing style);
+`TestRefill_KickOnMiss` (miss → refill observed without ticker firing);
+`TestRefill_KickCoalesces` (N misses → no spawn-budget overshoot — the
+`spawning` counter already guards this, assert it).
+
+---
+
+## Consolidated file map
+
+**New files:** `internal/runtime/wasm/create_timing_test.go`,
+`pkg/wasmmod/digest_cache.go`, `pkg/wasmmod/digest_cache_test.go`.
+
+**Modified:** `internal/runtime/wasm/{create.go, warmacquire.go, lifecycle.go}`,
+`internal/pool/wasm/{pool.go, spawner.go, refill.go}` + their `_test.go`s,
+`pkg/wasm/{engine.go, engine_wazero.go, engine_wasmtime.go}` + tests,
+`pkg/wasm/worker/{payload.go, server.go, client.go, supervisor.go}` + tests,
+`pkg/wasmmod/resolver.go`, `internal/config/config.go` + test,
+`pkg/daemon/wasm_wiring.go`.
+
+**Not touched:** `internal/cluster/` (placement is driver-agnostic — state
+the single-node no-op confirmation in each PR per hard rule 6),
+`internal/store/` (no schema change), `pkg/api/` (Phase 0 rides the existing
+Server-Timing plumbing).
+
+---
+
+## Benchmark methodology
+
+Inherit the FC plan's methodology section wholesale (in-VPC client, same
+tfvars, warm page cache, artifacts committed per phase gate), plus
+WASM-specific rules:
+
+1. **Module ref hygiene.** The bench must use the staged standard module
+   (`AEROL_WASM_MODULE_REF=python` or a clean `oci://` ref). The 2026-07-01
+   failure log shows earlier suite creates using a stale
+   `snapshots/python:latest--ttl-1h` image ref; `staleSnapshotModuleRef`
+   (`integration-tests/suite/wasm_ref_test.go`) already guards UC-94 — keep it.
+2. **n ≥ 20 for Phase 1+** (warm/cold mix needs the larger n; FC Phase 3
+   precedent) and report warm-hit and cold subsets separately using the
+   `wasm_warm` marker — the overall p50 is a function of pool keep-up, not
+   of the fix under test.
+3. **Pool state is part of the experiment.** Record `expvar` pool counters
+   (hits/misses/refills/spawn-fails) before and after each bench run in the
+   artifact; a phase gate that passes with `hits=0` is measuring the wrong
+   thing.
+
+### New integration UCs (`integration-tests/suite/`; UC-97 and UC-98x are
+reserved by the docker-readiness and FC plans)
+
+| UC | Title | Gate |
+|---|---|---|
+| UC-99 | Warm-pool hit: wasm create server p50 ≤ 1000ms (Phase 1) / ≤ 900ms (Phase 2) with `wasm_warm;desc=hit` | `CapCluster, CapWasm, CapBenchmark` |
+| UC-99b | Pool drained by burst → creates fall back cold and all succeed (correctness, not speed) | parallel creates > depth |
+| UC-99c | Non-default `memory_mb` create bypasses the warm pool and succeeds (Phase 1 keying) | assert `desc=miss` + success |
+| UC-99d | Compile cache survives worker restart: kill a pool worker, next warm spawn's `wasm_load` p50 ≤ 500ms (Phase 3) | requires cache-dir proof |
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Compile-cost attribution wrong (something else burns the 5s) | Phase 0 W1 pre-registration: pool on/off must be indistinguishable today; stage data before Phase 1 merges. STOP rule if `wasm_instantiate` cold p50 < 1.5s. |
+| Engine interface change ripples (wasmtime build tag rots silently) | CI doesn't build `-tags wasmtime` — add a build-only step or compile it locally in the PR; call out in description |
+| Memory-mismatch keying quietly sends real traffic cold | UC-99c + expvar miss counter in the bench artifact; follow-up: key `ready` by `(digest, memoryMB)` if miss rate is material |
+| wazero file cache misbehaves cross-process | Phase 3's explicit proof test; fall back to per-process cache (still fixes refill/restart cost within a worker's lifetime — smaller win, still a win) |
+| Digest cache serves a stale digest after in-place module replace | stat-identity key (dev/inode/size/mtime) + explicit drop on module delete/replace; `once`→`always` escape hatch |
+| Pre-warmed 256MB-limit slots inflate idle RSS interpretation | limit ≠ allocation (wazero grows linear memory on demand); verify RSS-per-parked-worker in the Phase 1 bench notes; capacity admission already samples RSS |
+| Wire-protocol change during rolling upgrade | worker is a re-exec of the same binary — no mixed-version window; assert in PR description |
+
+## Out of scope (deliberately)
+
+- The ~300ms shared scaffolding floor (placement, forward, caddy, SQLite) —
+  same exclusion as the FC plan; a cross-runtime follow-up owns it or nobody.
+- Registry round-trips on `oci://` refs (ledger item E) — it is the tenant
+  auth check; any TTL-based softening is a security decision, not a latency
+  patch.
+- Switching default engine to wasmtime, streaming/lazy compilation, module
+  size reduction (smaller CPython builds), checkpoint/restore-path latency.
+- SDK/client RTT.


### PR DESCRIPTION
## Summary

- **Phase 1** of `plans/firecracker-create-latency.md`: cuts ~1.2–1.8s of per-create SHA256 re-verification (after the first load per template) and moves the log-only toolbox TCP probe off the critical path.
- Adds `SB_FIRECRACKER_SNAPSHOT_VERIFY_MODE` (`once` default, `always` opt-out) alongside the existing `SB_FIRECRACKER_SNAPSHOT_VERIFY_ON_LOAD` kill-switch.
- Adds the full multi-phase latency plan doc; Phase 0 (instrumentation) and Phase 3 (warm-VMM pool redesign) are follow-ups.

## Architecture

### Baseline problem — flat 3.45s server p50

The `cluster-hetero` benchmark (UC-94, 2026-07-01) showed firecracker snapshot-clone creates at **3452ms server p50** with only 15ms spread p50→p99 — the signature of fixed pipeline work, not contention.

```mermaid
flowchart LR
    subgraph baseline["Baseline create path (~3452ms server p50)"]
        D["D: Service + cluster scaffolding<br/>~300ms"]
        A["A: SHA256 re-verify 512MiB snapshot<br/>~1.2–1.8s"]
        B["B: Cold VMM spawn + LoadSnapshot<br/>~200–400ms"]
        C["C: Guest readiness (sync)<br/>handshake → post_resume → TCP probe<br/>~400–800ms"]
        D --> A --> B --> C
    end
```

### This PR — what moves off the critical path

```mermaid
flowchart TB
    subgraph before["Before (blocking)"]
        direction TB
        V1["verifySnapshotChecksum<br/>every create"]
        P1["probeToolboxTCP<br/>blocks HTTP response"]
        V1 --> P1
    end

    subgraph after["After (this PR)"]
        direction TB
        V2{"verify mode?"}
        V2 -->|once + cache hit| SKIP["skip hash (~0ms)"]
        V2 -->|once + cache miss| HASH["hash once + latch"]
        V2 -->|always| HASH2["hash every create"]
        V2 -->|verify_on_load=false| OFF["skip entirely"]
        RESP["return Create response"]
        ASYNC["goroutine: probeToolboxTCP<br/>detached ctx, PostResumeTimeout bound"]
        HASH --> RESP
        HASH2 --> RESP
        SKIP --> RESP
        OFF --> RESP
        RESP -.->|non-blocking| ASYNC
    end
```

### Snapshot verify cache — single-flight latch

Mirrors the `EnsureLayer4Ready` pattern: N concurrent creates of one template hash once; waiters block on a done-channel.

```mermaid
sequenceDiagram
    participant C1 as Create #1
    participant C2 as Create #2..N
    participant Cache as verifyMu + map
    participant Hash as snapshotVerifier

    C1->>Cache: lookup key (checksum + file identity)
    Cache-->>C1: miss → insert entry, release lock
    C1->>Hash: SHA256(memory + state)
    par concurrent waiters
        C2->>Cache: lookup same key
        Cache-->>C2: hit (in-flight) → wait on done
    end
    Hash-->>C1: ok
    C1->>Cache: latch verified, close(done)
    Cache-->>C2: done → return cached err/nil

    Note over Cache: Invalidation triggers
    Note over Cache: stat drift (dev/inode/size/mtime)
    Note over Cache: notifyCorrupt / MarkSnapshotCorrupt
    Note over Cache: daemon restart (in-memory only)
```

**Cache key:** persisted checksum string + `os.Stat` identity (`dev`, `inode`, `size`, `mtime`) for both `snapshot.memory` and `snapshot.state`.

**Integrity trade (stated explicitly):** torn writes / partial pulls at artifact-creation time are still caught on first load. Silent in-place bit-rot *within one daemon boot* is no longer caught; `VERIFY_MODE=always` is the escape hatch; `LoadSnapshot`/Resume failure remains the backstop.

### Async TCP probe — detached from request context

`post_resume` stays synchronous (guest eth0 must be up before callers get the sandbox). Only the observational TCP probe moves async.

```mermaid
sequenceDiagram
    participant API as Create handler
    participant Drv as Driver.Create
    participant Guest as Guest toolbox :8080
    participant Probe as probe goroutine

    API->>Drv: Create(ctx)
    Drv->>Drv: vsock handshake (sync)
    Drv->>Drv: post_resume (sync)
    Drv->>Probe: scheduleToolboxTCPProbe (go func)
    Drv-->>API: return sandbox (no probe wait)
    Note over API: request ctx may cancel here
    Probe->>Guest: TCP dial loop (Background ctx + timeout)
    Probe->>Probe: log reachability only
```

### Multi-phase roadmap (context)

```mermaid
flowchart LR
    P0["Phase 0<br/>instrumentation<br/>follow-up PR"]
    P1["Phase 1<br/>this PR<br/>target ≤2000ms p50"]
    P2["Phase 2<br/>poll backoff<br/>optional"]
    P3["Phase 3<br/>warm-VMM pool v1.15<br/>target ≤700ms p50"]

    P0 --> P1 --> P2 --> P3
```

## Sandbox boot impact

**Net reduction on the hot path** for snapshot-clone creates after the first load of a template:

| Change | First create (per template / boot) | Steady-state creates |
|---|---|---|
| Verify-once cache | **+~2× `os.Stat`** (~µs) then full SHA256 (~1.2–1.8s) | **+~2× `os.Stat`** only; hash skipped |
| Async TCP probe | **−up to `PostResumeTimeout`** (default 2s bound) off critical path | same |
| `VERIFY_MODE=always` | unchanged per-create hash cost | unchanged |
| `VERIFY_ON_LOAD=false` | unchanged (zero verify) | unchanged |

`post_resume`, vsock handshake, cold VMM spawn, and service/cluster scaffolding are unchanged.

## Idempotency

N/A — no API surface changed. Create remains idempotent under retry/concurrent duplicate calls; the verify cache single-flights concurrent loads of the same template (failed verify is not latched as success).

## Failure-path consistency

N/A — no multi-step write path touching both caddy and the store changed.

## L4 / host-port-pool changes

N/A — neither touched.

## Cluster impact

N/A — no `internal/cluster` changes. Placement/forwarding are agnostic to driver boot mechanics. Single-node (`cfg.EnableCluster=false`) behavior unchanged.

## Test plan

- [x] `go test ./internal/runtime/firecracker/... ./internal/config/...`
- [x] Verify cache: second load skips hash, single-flight, failure not cached, file-change invalidation, corrupt notification invalidation, `always` mode, disabled skips
- [x] Async probe: off critical path (cold + warm), detached context survives request cancel
- [ ] Operator gate: rerun UC-94 in-VPC on `cluster-hetero`; merge target firecracker server p50 ≤ 2000ms, docker/gvisor within 10% of baseline


Made with [Cursor](https://cursor.com)