### PR TITLE
feat: private-by-default sandboxes — exposePort opts in to public ingress

### DIFF
--- a/docs/src/content/docs/firecracker-sandbox.mdx
+++ b/docs/src/content/docs/firecracker-sandbox.mdx
@@ -14,7 +14,7 @@ Use Firecracker when:
 
 ## Create a Firecracker sandbox
 
-Pass `runtime: "firecracker"` and an OCI image reference. The daemon pulls the image and builds a Firecracker-compatible rootfs from it.
+Pass `runtime: "firecracker"` and an OCI image reference. The daemon pulls the image and builds a Firecracker-compatible rootfs from it. Public exposure is opt-in — set `allowPublicTraffic: true` when you need a public URL or `exposePort`; see [Network Isolation](/network-isolation/).
 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">
@@ -34,7 +34,6 @@ Pass `runtime: "firecracker"` and an OCI image reference. The daemon pulls the i
     })
 
     console.log(sandbox.id)
-    console.log(sandbox.publicURL)
     ```
   </TabItem>
   <TabItem label="Python">
@@ -54,7 +53,6 @@ Pass `runtime: "firecracker"` and an OCI image reference. The daemon pulls the i
     })
 
     print(sandbox.id)
-    print(sandbox.publicURL)
     ```
   </TabItem>
   <TabItem label="Go">
@@ -87,7 +85,7 @@ Pass `runtime: "firecracker"` and an OCI image reference. The daemon pulls the i
         log.Fatal(err)
     }
 
-    fmt.Println(sandbox.ID, sandbox.PublicURL)
+    fmt.Println(sandbox.ID)
     ```
   </TabItem>
   <TabItem label="Rust">
@@ -107,7 +105,7 @@ Pass `runtime: "firecracker"` and an OCI image reference. The daemon pulls the i
         ..Default::default()
     })?;
 
-    println!("{} {:?}", sandbox.data.id, sandbox.data.public_url);
+    println!("{}", sandbox.data.id);
     ```
   </TabItem>
   <TabItem label="Java">
@@ -131,7 +129,7 @@ Pass `runtime: "firecracker"` and an OCI image reference. The daemon pulls the i
             .setMemoryMb(512)
     );
 
-    System.out.println(sandbox.id + " " + sandbox.publicUrl);
+    System.out.println(sandbox.id);
     ```
   </TabItem>
 </Tabs>

--- a/docs/src/content/docs/firecracker-sandbox.mdx
+++ b/docs/src/content/docs/firecracker-sandbox.mdx
@@ -14,7 +14,7 @@ Use Firecracker when:
 
 ## Create a Firecracker sandbox
 
-Pass `runtime: "firecracker"` and an OCI image reference. The daemon pulls the image and builds a Firecracker-compatible rootfs from it. Public exposure is opt-in — set `allowPublicTraffic: true` when you need a public URL or `exposePort`; see [Network Isolation](/network-isolation/).
+Pass `runtime: "firecracker"` and an OCI image reference. The daemon pulls the image and builds a Firecracker-compatible rootfs from it. Public exposure is opt-in — `exposePort` flips the sandbox public on first use, or set `allowPublicTraffic: true` at create for a boot-time public URL; see [Network Isolation](/network-isolation/).
 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">

--- a/docs/src/content/docs/gvisor-sandbox.mdx
+++ b/docs/src/content/docs/gvisor-sandbox.mdx
@@ -23,7 +23,7 @@ gVisor works on **any standard server** - there are no bare-metal or special har
 
 ## Create a gVisor sandbox
 
-Pass `runtime: "gvisor"` in the create request. Public exposure is opt-in — set `allowPublicTraffic: true` when you need a public URL or `exposePort`; see [Network Isolation](/network-isolation/).
+Pass `runtime: "gvisor"` in the create request. Public exposure is opt-in — `exposePort` flips the sandbox public on first use, or set `allowPublicTraffic: true` at create for a boot-time public URL; see [Network Isolation](/network-isolation/).
 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">

--- a/docs/src/content/docs/gvisor-sandbox.mdx
+++ b/docs/src/content/docs/gvisor-sandbox.mdx
@@ -23,7 +23,7 @@ gVisor works on **any standard server** - there are no bare-metal or special har
 
 ## Create a gVisor sandbox
 
-Pass `runtime: "gvisor"` in the create request.
+Pass `runtime: "gvisor"` in the create request. Public exposure is opt-in — set `allowPublicTraffic: true` when you need a public URL or `exposePort`; see [Network Isolation](/network-isolation/).
 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">
@@ -43,7 +43,6 @@ Pass `runtime: "gvisor"` in the create request.
     })
 
     console.log(sandbox.id)
-    console.log(sandbox.publicURL)
     ```
   </TabItem>
   <TabItem label="Python">
@@ -63,7 +62,6 @@ Pass `runtime: "gvisor"` in the create request.
     })
 
     print(sandbox.id)
-    print(sandbox.publicURL)
     ```
   </TabItem>
   <TabItem label="Go">
@@ -96,7 +94,7 @@ Pass `runtime: "gvisor"` in the create request.
         log.Fatal(err)
     }
 
-    fmt.Println(sandbox.ID, sandbox.PublicURL)
+    fmt.Println(sandbox.ID)
     ```
   </TabItem>
   <TabItem label="Rust">
@@ -116,7 +114,7 @@ Pass `runtime: "gvisor"` in the create request.
         ..Default::default()
     })?;
 
-    println!("{} {:?}", sandbox.data.id, sandbox.data.public_url);
+    println!("{}", sandbox.data.id);
     ```
   </TabItem>
   <TabItem label="Java">
@@ -140,7 +138,7 @@ Pass `runtime: "gvisor"` in the create request.
             .setMemoryMb(512)
     );
 
-    System.out.println(sandbox.id + " " + sandbox.publicUrl);
+    System.out.println(sandbox.id);
     ```
   </TabItem>
 </Tabs>

--- a/docs/src/content/docs/network-isolation.mdx
+++ b/docs/src/content/docs/network-isolation.mdx
@@ -282,9 +282,12 @@ The policy is persisted with the sandbox and reapplied automatically across stop
 
 ## Public Exposure Is Opt-In
 
-The options above control **outbound** traffic. Inbound public reachability is a separate, create-time decision — and the default is **private**: a sandbox created without **`allowPublicTraffic`** gets no `<sandbox-id>.<domain>` ingress route, has an empty `public_url`, and `exposePort` returns an error. The platform's own access paths (the toolbox `exec`/file proxy and the SSH gateway) always work, since they do not route through the public ingress.
+The options above control **outbound** traffic. Inbound public reachability is a separate decision — and the default is **private**: a sandbox created without **`allowPublicTraffic`** boots with no `<sandbox-id>.<domain>` ingress route and an empty `public_url`. The platform's own access paths (the toolbox `exec`/file proxy and the SSH gateway) always work, since they do not route through the public ingress.
 
-Set `allowPublicTraffic` to `true` at create time to opt in to public exposure:
+There are two ways to opt in to public exposure:
+
+1. **Call `exposePort`.** Asking for a public port *is* the consent: the first `exposePort` on a private sandbox flips it to public — the flag is persisted, the `<sandbox-id>.<domain>` route is installed, `public_url` becomes live — and then the port route goes in. No extra step needed.
+2. **Set `allowPublicTraffic: true` at create time** if you want the sandbox URL live from boot, before any port is exposed:
 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">
@@ -293,7 +296,7 @@ Set `allowPublicTraffic` to `true` at create time to opt in to public exposure:
       image: 'ubuntu:22.04',
       allowPublicTraffic: true,
     })
-    // sandbox.exposePort(80) now works and returns a public URL.
+    // sandbox.publicUrl is live from boot, before any exposePort call.
     ```
   </TabItem>
   <TabItem label="Python">
@@ -333,7 +336,7 @@ Set `allowPublicTraffic` to `true` at create time to opt in to public exposure:
   </TabItem>
 </Tabs>
 
-Because AerolVM has no auth-gated public route, "no public traffic" is enforced by **refusing exposure** rather than by serving a private URL. Omitting the field (or setting it to `false`) keeps the sandbox private; custom domains likewise require the opt-in. Private creates also skip the ingress proxy entirely on the boot path, which shaves the route-install round trips off create latency.
+The opt-in is one-way and sandbox-wide: once a port has been exposed, the sandbox is public (flag, root route, and `public_url`) and stays public even if every port is later unexposed. **Custom domains alone do not flip a private sandbox** — attaching a domain to a sandbox you kept private returns an error, so a domain can never silently publish it; expose a port (or create with the flag) first. Private creates also skip the ingress proxy entirely on the boot path, which shaves the route-install round trips off create latency.
 
 The Daytona compatibility facade maps its `public` field onto this flag (omitted means `true`, matching Daytona's platform default), and the E2B facade opts in by default for the same reason — E2B sandboxes are publicly addressable by contract.
 

--- a/docs/src/content/docs/network-isolation.mdx
+++ b/docs/src/content/docs/network-isolation.mdx
@@ -280,34 +280,36 @@ The policy is persisted with the sandbox and reapplied automatically across stop
 
 ---
 
-## Disabling Public Exposure
+## Public Exposure Is Opt-In
 
-The options above control **outbound** traffic. To stop a sandbox from being reachable from the public internet at all, set **`allowPublicTraffic`** to `false` at create time. The sandbox can then never be exposed — `exposePort` returns an error — while the platform's own access paths (the toolbox `exec`/file proxy and the SSH gateway) keep working, since they do not route through the public ingress.
+The options above control **outbound** traffic. Inbound public reachability is a separate, create-time decision — and the default is **private**: a sandbox created without **`allowPublicTraffic`** gets no `<sandbox-id>.<domain>` ingress route, has an empty `public_url`, and `exposePort` returns an error. The platform's own access paths (the toolbox `exec`/file proxy and the SSH gateway) always work, since they do not route through the public ingress.
+
+Set `allowPublicTraffic` to `true` at create time to opt in to public exposure:
 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">
     ```ts
     const sandbox = await client.create({
       image: 'ubuntu:22.04',
-      allowPublicTraffic: false,
+      allowPublicTraffic: true,
     })
-    // sandbox.exposePort(80) now rejects — no public URL is ever created.
+    // sandbox.exposePort(80) now works and returns a public URL.
     ```
   </TabItem>
   <TabItem label="Python">
     ```python
     sandbox = client.create({
         'image': 'ubuntu:22.04',
-        'allowPublicTraffic': False,
+        'allowPublicTraffic': True,
     })
     ```
   </TabItem>
   <TabItem label="Go">
     ```go
-    publicOff := false
+    publicOn := true
     sandbox, err := client.Create(ctx, sdktypes.CreateSandboxOptions{
         Image:              "ubuntu:22.04",
-        AllowPublicTraffic: &publicOff,
+        AllowPublicTraffic: &publicOn,
     })
     ```
   </TabItem>
@@ -315,7 +317,7 @@ The options above control **outbound** traffic. To stop a sandbox from being rea
     ```rust
     let sandbox = client.create(CreateOptions {
         image: "ubuntu:22.04".to_string(),
-        allow_public_traffic: Some(false),
+        allow_public_traffic: Some(true),
         ..Default::default()
     })?;
     ```
@@ -325,13 +327,15 @@ The options above control **outbound** traffic. To stop a sandbox from being rea
     Sandbox sandbox = client.create(
         new CreateOptions()
             .setImage("ubuntu:22.04")
-            .setAllowPublicTraffic(false)
+            .setAllowPublicTraffic(true)
     );
     ```
   </TabItem>
 </Tabs>
 
-Because AerolVM has no auth-gated public route, "no public traffic" is enforced by **refusing exposure** rather than by serving a private URL. Omit the field (or set it to `true`) to keep the default behaviour, where exposed ports are publicly reachable.
+Because AerolVM has no auth-gated public route, "no public traffic" is enforced by **refusing exposure** rather than by serving a private URL. Omitting the field (or setting it to `false`) keeps the sandbox private; custom domains likewise require the opt-in. Private creates also skip the ingress proxy entirely on the boot path, which shaves the route-install round trips off create latency.
+
+The Daytona compatibility facade maps its `public` field onto this flag (omitted means `true`, matching Daytona's platform default), and the E2B facade opts in by default for the same reason — E2B sandboxes are publicly addressable by contract.
 
 ---
 

--- a/docs/src/content/docs/port-allowlist.mdx
+++ b/docs/src/content/docs/port-allowlist.mdx
@@ -27,7 +27,7 @@ Both URLs become active after `exposePort` and return 403 before it. The dedicat
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">
     ```ts
-    const sandbox = await client.create({ image: 'ubuntu:22.04' })
+    const sandbox = await client.create({ image: 'ubuntu:22.04', allowPublicTraffic: true })
 
     // Before exposing - 403
     await fetch(`${sandbox.publicURL}/proxy/21212/`)
@@ -43,7 +43,7 @@ Both URLs become active after `exposePort` and return 403 before it. The dedicat
   </TabItem>
   <TabItem label="Python">
     ```python
-    sandbox = client.create({'image': 'ubuntu:22.04'})
+    sandbox = client.create({'image': 'ubuntu:22.04', 'allowPublicTraffic': True})
 
     # Before exposing - 403
     # GET sandbox['publicURL'] + '/proxy/21212/'
@@ -58,8 +58,10 @@ Both URLs become active after `exposePort` and return 403 before it. The dedicat
   </TabItem>
   <TabItem label="Go">
     ```go
+    public := true
     sandbox, err := client.Create(ctx, sdktypes.CreateSandboxOptions{
-        Image: "ubuntu:22.04",
+        Image:              "ubuntu:22.04",
+        AllowPublicTraffic: &public,
     })
     if err != nil { log.Fatal(err) }
 
@@ -79,6 +81,7 @@ Both URLs become active after `exposePort` and return 403 before it. The dedicat
     ```rust
     let sandbox = client.create(CreateOptions {
         image: "ubuntu:22.04".to_string(),
+        allow_public_traffic: Some(true),
         ..Default::default()
     })?;
 
@@ -96,7 +99,9 @@ Both URLs become active after `exposePort` and return 403 before it. The dedicat
   <TabItem label="Java">
     ```java
     Sandbox sandbox = client.create(
-        new CreateOptions().setImage("ubuntu:22.04")
+        new CreateOptions()
+            .setImage("ubuntu:22.04")
+            .setAllowPublicTraffic(true)
     );
 
     // Before exposing - 403

--- a/docs/src/content/docs/preview.mdx
+++ b/docs/src/content/docs/preview.mdx
@@ -7,7 +7,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 Every sandbox+port can get a public URL that routes to the sandbox's API endpoint.
 
 :::note
-Public exposure is **opt-in at create time**: the sandbox must have been created with `allowPublicTraffic: true`, otherwise `exposePort` returns an error and no public URL exists. See [Network Isolation](/network-isolation/) for the create-time flag in all five SDKs.
+Sandboxes are **private by default** — no public URL exists until you opt in. Calling `exposePort` is the opt-in: the first call on a private sandbox flips it to public, installs the sandbox's `<sandbox-id>.<domain>` route, and then publishes the port. To have the sandbox URL live from boot instead, create with `allowPublicTraffic: true` — see [Network Isolation](/network-isolation/) for the flag in all five SDKs.
 :::
 
 ## Expose a Port

--- a/docs/src/content/docs/preview.mdx
+++ b/docs/src/content/docs/preview.mdx
@@ -6,6 +6,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 Every sandbox+port can get a public URL that routes to the sandbox's API endpoint.
 
+:::note
+Public exposure is **opt-in at create time**: the sandbox must have been created with `allowPublicTraffic: true`, otherwise `exposePort` returns an error and no public URL exists. See [Network Isolation](/network-isolation/) for the create-time flag in all five SDKs.
+:::
+
 ## Expose a Port
 
 Services running inside the sandbox are not reachable publicly by default. Call `exposePort` to add a port to the allowlist and create a public route for it.

--- a/docs/src/content/docs/sandboxes.mdx
+++ b/docs/src/content/docs/sandboxes.mdx
@@ -34,7 +34,7 @@ created ──► running ──► stopped ──► running
 ## Create
 
 :::note
-Sandboxes are **private by default**: omitting `allowPublicTraffic` gives no public ingress URL and `exposePort` returns an error. Set `allowPublicTraffic: true` to opt in — see [Network Isolation](/network-isolation/).
+Sandboxes are **private by default**: omitting `allowPublicTraffic` gives no public ingress URL at boot. The first `exposePort` call opts the sandbox in (flips it public and installs its routes); set `allowPublicTraffic: true` at create to have the URL live from boot instead — see [Network Isolation](/network-isolation/).
 :::
 
 <Tabs syncKey="lang">

--- a/docs/src/content/docs/sandboxes.mdx
+++ b/docs/src/content/docs/sandboxes.mdx
@@ -33,6 +33,10 @@ created ──► running ──► stopped ──► running
 
 ## Create
 
+:::note
+Sandboxes are **private by default**: omitting `allowPublicTraffic` gives no public ingress URL and `exposePort` returns an error. Set `allowPublicTraffic: true` to opt in — see [Network Isolation](/network-isolation/).
+:::
+
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">
     ```ts
@@ -55,7 +59,6 @@ created ──► running ──► stopped ──► running
     })
 
     console.log(sandbox.id)
-    console.log(sandbox.publicURL)
     console.log(sandbox.sshPrivateKey) // only returned by create()
     ```
   </TabItem>
@@ -80,7 +83,6 @@ created ──► running ──► stopped ──► running
     })
 
     print(sandbox.id)
-    print(sandbox.publicURL)
     print(sandbox.sshPrivateKey)  # only returned by create()
     ```
   </TabItem>
@@ -119,7 +121,7 @@ created ──► running ──► stopped ──► running
         log.Fatal(err)
     }
 
-    fmt.Println(sandbox.ID, sandbox.PublicURL)
+    fmt.Println(sandbox.ID)
     fmt.Println(sandbox.SSHPrivateKey) // only returned by Create()
     ```
   </TabItem>
@@ -145,7 +147,7 @@ created ──► running ──► stopped ──► running
         ..Default::default()
     })?;
 
-    println!("{} {:?}", sandbox.data.id, sandbox.data.public_url);
+    println!("{}", sandbox.data.id);
     println!("{:?}", sandbox.ssh_private_key); // only returned by create()
     ```
   </TabItem>
@@ -174,7 +176,7 @@ created ──► running ──► stopped ──► running
                 .setDestroyAtAge(86_400_000_000_000L))
     );
 
-    System.out.println(sandbox.id + " " + sandbox.publicUrl);
+    System.out.println(sandbox.id);
     System.out.println(sandbox.sshPrivateKey); // only returned by create()
     ```
   </TabItem>

--- a/docs/src/content/docs/sdk-setup.md
+++ b/docs/src/content/docs/sdk-setup.md
@@ -60,7 +60,7 @@ client = MicroVM(
 )
 
 sandbox = client.create(image='ubuntu:22.04')
-print(sandbox['public_url'])
+print(sandbox['id'])
 sandbox.destroy()
 ```
 

--- a/docs/src/content/docs/serverless.mdx
+++ b/docs/src/content/docs/serverless.mdx
@@ -33,13 +33,14 @@ The sandbox keeps its ID, public URL, environment, mounts, and disk across stop 
 
 ## Enable per-sandbox
 
-`stopIfIdleFor` is required when `serverless: true`. The server rejects the request otherwise.
+`stopIfIdleFor` is required when `serverless: true`. The server rejects the request otherwise. Serverless wake rides the sandbox's **public** endpoints, so the sandbox must be created with `allowPublicTraffic: true` — a private sandbox (the default) has no public routes to wake through.
 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">
     ```ts
     const sandbox = await client.create({
       image: 'ghcr.io/me/my-http-app:latest',
+      allowPublicTraffic: true, // wake rides the public URL — required
       lifecycle: {
         stopIfIdleFor: 5 * 60 * 1_000_000_000, // 5 minutes
         serverless: true,
@@ -52,6 +53,7 @@ The sandbox keeps its ID, public URL, environment, mounts, and disk across stop 
     ```python
     sandbox = client.create({
         'image': 'ghcr.io/me/my-http-app:latest',
+        'allowPublicTraffic': True,  # wake rides the public URL — required
         'lifecycle': {
             'stopIfIdleFor': 5 * 60 * 1_000_000_000,
             'serverless': True,
@@ -62,8 +64,10 @@ The sandbox keeps its ID, public URL, environment, mounts, and disk across stop 
   </TabItem>
   <TabItem label="Go">
     ```go
+    public := true // wake rides the public URL — required
     sandbox, err := client.Create(ctx, sdktypes.CreateSandboxOptions{
-        Image: "ghcr.io/me/my-http-app:latest",
+        Image:              "ghcr.io/me/my-http-app:latest",
+        AllowPublicTraffic: &public,
         Lifecycle: &sdktypes.Lifecycle{
             StopIfIdleFor: 5 * time.Minute,
             Serverless:    true,
@@ -79,6 +83,7 @@ The sandbox keeps its ID, public URL, environment, mounts, and disk across stop 
     ```rust
     let sandbox = client.create(CreateOptions {
         image: "ghcr.io/me/my-http-app:latest".to_string(),
+        allow_public_traffic: Some(true), // wake rides the public URL — required
         lifecycle: Some(Lifecycle {
             stop_if_idle_for: 300_000_000_000,
             serverless: true,
@@ -94,6 +99,7 @@ The sandbox keeps its ID, public URL, environment, mounts, and disk across stop 
     Sandbox sandbox = client.create(
         new CreateOptions()
             .setImage("ghcr.io/me/my-http-app:latest")
+            .setAllowPublicTraffic(true) // wake rides the public URL — required
             .setLifecycle(new Lifecycle()
                 .setStopIfIdleFor(300_000_000_000L)
                 .setServerless(Boolean.TRUE))

--- a/docs/src/content/docs/serverless.mdx
+++ b/docs/src/content/docs/serverless.mdx
@@ -33,14 +33,13 @@ The sandbox keeps its ID, public URL, environment, mounts, and disk across stop 
 
 ## Enable per-sandbox
 
-`stopIfIdleFor` is required when `serverless: true`. The server rejects the request otherwise. Serverless wake rides the sandbox's **public** endpoints, so the sandbox must be created with `allowPublicTraffic: true` — a private sandbox (the default) has no public routes to wake through.
+`stopIfIdleFor` is required when `serverless: true`. The server rejects the request otherwise. Serverless wake rides the sandbox's **public** endpoints — a fully private sandbox has no routes to wake through. Calling `exposePort` (as below) opts the sandbox into public traffic automatically, so the usual create → expose flow needs no extra flag; only a serverless sandbox that never exposes a port would need `allowPublicTraffic: true` at create to be wakeable via its root URL. See [Network Isolation](/network-isolation/).
 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">
     ```ts
     const sandbox = await client.create({
       image: 'ghcr.io/me/my-http-app:latest',
-      allowPublicTraffic: true, // wake rides the public URL — required
       lifecycle: {
         stopIfIdleFor: 5 * 60 * 1_000_000_000, // 5 minutes
         serverless: true,
@@ -53,7 +52,6 @@ The sandbox keeps its ID, public URL, environment, mounts, and disk across stop 
     ```python
     sandbox = client.create({
         'image': 'ghcr.io/me/my-http-app:latest',
-        'allowPublicTraffic': True,  # wake rides the public URL — required
         'lifecycle': {
             'stopIfIdleFor': 5 * 60 * 1_000_000_000,
             'serverless': True,
@@ -64,10 +62,8 @@ The sandbox keeps its ID, public URL, environment, mounts, and disk across stop 
   </TabItem>
   <TabItem label="Go">
     ```go
-    public := true // wake rides the public URL — required
     sandbox, err := client.Create(ctx, sdktypes.CreateSandboxOptions{
-        Image:              "ghcr.io/me/my-http-app:latest",
-        AllowPublicTraffic: &public,
+        Image: "ghcr.io/me/my-http-app:latest",
         Lifecycle: &sdktypes.Lifecycle{
             StopIfIdleFor: 5 * time.Minute,
             Serverless:    true,
@@ -83,7 +79,6 @@ The sandbox keeps its ID, public URL, environment, mounts, and disk across stop 
     ```rust
     let sandbox = client.create(CreateOptions {
         image: "ghcr.io/me/my-http-app:latest".to_string(),
-        allow_public_traffic: Some(true), // wake rides the public URL — required
         lifecycle: Some(Lifecycle {
             stop_if_idle_for: 300_000_000_000,
             serverless: true,
@@ -99,7 +94,6 @@ The sandbox keeps its ID, public URL, environment, mounts, and disk across stop 
     Sandbox sandbox = client.create(
         new CreateOptions()
             .setImage("ghcr.io/me/my-http-app:latest")
-            .setAllowPublicTraffic(true) // wake rides the public URL — required
             .setLifecycle(new Lifecycle()
                 .setStopIfIdleFor(300_000_000_000L)
                 .setServerless(Boolean.TRUE))

--- a/integration-tests/suite/harness/client.go
+++ b/integration-tests/suite/harness/client.go
@@ -106,10 +106,11 @@ func (c *Client) NewSandbox(t *testing.T, opts sdktypes.CreateSandboxOptions) *m
 	if opts.Image == "" {
 		opts.Image = DefaultImage
 	}
-	// The server create default is private (no <id>.<domain> route, expose
-	// refused). The suite's UCs exercise public reachability, so the harness
-	// opts in unless a test sets the flag itself; a privacy-default UC should
-	// call c.SDK().Create directly with the flag omitted.
+	// The server create default is private: no <id>.<domain> route until the
+	// first expose_port flips the sandbox public. The suite's UCs exercise the
+	// root URL straight after create, so the harness opts in at create unless
+	// a test sets the flag itself; a privacy-default UC should call
+	// c.SDK().Create directly with the flag omitted.
 	if opts.AllowPublicTraffic == nil {
 		public := true
 		opts.AllowPublicTraffic = &public

--- a/integration-tests/suite/harness/client.go
+++ b/integration-tests/suite/harness/client.go
@@ -106,6 +106,14 @@ func (c *Client) NewSandbox(t *testing.T, opts sdktypes.CreateSandboxOptions) *m
 	if opts.Image == "" {
 		opts.Image = DefaultImage
 	}
+	// The server create default is private (no <id>.<domain> route, expose
+	// refused). The suite's UCs exercise public reachability, so the harness
+	// opts in unless a test sets the flag itself; a privacy-default UC should
+	// call c.SDK().Create directly with the flag omitted.
+	if opts.AllowPublicTraffic == nil {
+		public := true
+		opts.AllowPublicTraffic = &public
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 

--- a/integration-tests/suite/harness/usecases.go
+++ b/integration-tests/suite/harness/usecases.go
@@ -126,6 +126,7 @@ var Registry = []UseCase{
 	{ID: "UC-36", Title: "Custom domain reachable after CNAME", Requires: []Capability{CapDocker, CapDomain, CapCustomDomains, CapExternalDNSZone}, Implemented: true},
 	{ID: "UC-37", Title: "Network usage counters returned", Requires: []Capability{CapDocker}, Implemented: true},
 	{ID: "UC-38", Title: "Network limits patch enforced", Requires: []Capability{CapDocker}, Implemented: true},
+	{ID: "UC-97", Title: "Private-by-default create: no public URL, expose refused, exec works", Requires: []Capability{CapDocker}, Implemented: true},
 
 	// E. Exec, files, sessions, SSH
 	{ID: "UC-39", Title: "Toolbox exec returns output", Requires: []Capability{CapDocker}, Implemented: true},

--- a/integration-tests/suite/harness/usecases.go
+++ b/integration-tests/suite/harness/usecases.go
@@ -126,7 +126,7 @@ var Registry = []UseCase{
 	{ID: "UC-36", Title: "Custom domain reachable after CNAME", Requires: []Capability{CapDocker, CapDomain, CapCustomDomains, CapExternalDNSZone}, Implemented: true},
 	{ID: "UC-37", Title: "Network usage counters returned", Requires: []Capability{CapDocker}, Implemented: true},
 	{ID: "UC-38", Title: "Network limits patch enforced", Requires: []Capability{CapDocker}, Implemented: true},
-	{ID: "UC-97", Title: "Private-by-default create: no public URL, expose refused, exec works", Requires: []Capability{CapDocker}, Implemented: true},
+	{ID: "UC-97", Title: "Private-by-default create: no public URL until expose_port opts the sandbox in; exec works while private", Requires: []Capability{CapDocker}, Implemented: true},
 
 	// E. Exec, files, sessions, SSH
 	{ID: "UC-39", Title: "Toolbox exec returns output", Requires: []Capability{CapDocker}, Implemented: true},

--- a/integration-tests/suite/networking_test.go
+++ b/integration-tests/suite/networking_test.go
@@ -5,6 +5,7 @@ package suite
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -80,4 +81,50 @@ func TestPreviewURLReachable(t *testing.T) {
 		time.Sleep(3 * time.Second)
 	}
 	t.Fatalf("preview URL %s never became reachable (last code %d, last err %v)", res.PublicURL, lastCode, lastErr)
+}
+
+// UC-97 — A create that omits allow_public_traffic is private: no ingress route,
+// empty public_url, exposePort refused, while toolbox exec still works.
+func TestCreatePrivateByDefault(t *testing.T) {
+	harness.Require(t, sc, "UC-97")
+	c := client(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	// Bypass NewSandbox — the harness opts in to public traffic for the other UCs.
+	sb, err := c.SDK().Create(ctx, sdktypes.CreateSandboxOptions{
+		Image: harness.DefaultImage,
+		Name:  harness.UniqueName(sc, t),
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	t.Cleanup(func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), time.Minute)
+		defer ccancel()
+		_ = c.SDK().Destroy(cctx, sb.ID)
+	})
+	waitRunning(t, sb)
+
+	if sb.PublicURL != "" {
+		t.Fatalf("public_url = %q, want empty for a default (private) create", sb.PublicURL)
+	}
+
+	ectx, ecancel := context.WithTimeout(context.Background(), time.Minute)
+	defer ecancel()
+	_, err = sb.ExposePort(ectx, 8080)
+	if err == nil {
+		t.Fatal("expose port on private sandbox succeeded; want refusal")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "public traffic") {
+		t.Fatalf("expose error = %v, want public-traffic refusal", err)
+	}
+
+	res, err := sb.ExecCommand(ectx, "echo private-ok")
+	if err != nil {
+		t.Fatalf("exec on private sandbox: %v", err)
+	}
+	if !strings.Contains(res.Stdout, "private-ok") {
+		t.Fatalf("exec stdout = %q, want private-ok", res.Stdout)
+	}
 }

--- a/integration-tests/suite/networking_test.go
+++ b/integration-tests/suite/networking_test.go
@@ -83,8 +83,10 @@ func TestPreviewURLReachable(t *testing.T) {
 	t.Fatalf("preview URL %s never became reachable (last code %d, last err %v)", res.PublicURL, lastCode, lastErr)
 }
 
-// UC-97 — A create that omits allow_public_traffic is private: no ingress route,
-// empty public_url, exposePort refused, while toolbox exec still works.
+// UC-97 — A create that omits allow_public_traffic is private: no ingress
+// route, empty public_url, toolbox exec still works. expose_port is then the
+// opt-in lever: it succeeds on the private sandbox, flips it public, and the
+// sandbox's public_url becomes non-empty.
 func TestCreatePrivateByDefault(t *testing.T) {
 	harness.Require(t, sc, "UC-97")
 	c := client(t)
@@ -110,21 +112,31 @@ func TestCreatePrivateByDefault(t *testing.T) {
 		t.Fatalf("public_url = %q, want empty for a default (private) create", sb.PublicURL)
 	}
 
+	// The toolbox path must work while the sandbox has no public ingress.
 	ectx, ecancel := context.WithTimeout(context.Background(), time.Minute)
 	defer ecancel()
-	_, err = sb.ExposePort(ectx, 8080)
-	if err == nil {
-		t.Fatal("expose port on private sandbox succeeded; want refusal")
-	}
-	if !strings.Contains(strings.ToLower(err.Error()), "public traffic") {
-		t.Fatalf("expose error = %v, want public-traffic refusal", err)
-	}
-
 	res, err := sb.ExecCommand(ectx, "echo private-ok")
 	if err != nil {
 		t.Fatalf("exec on private sandbox: %v", err)
 	}
 	if !strings.Contains(res.Stdout, "private-ok") {
 		t.Fatalf("exec stdout = %q, want private-ok", res.Stdout)
+	}
+
+	// expose_port opts the sandbox in: it must succeed and flip the sandbox
+	// public rather than refuse.
+	exposure, err := sb.ExposePort(ectx, 8080)
+	if err != nil {
+		t.Fatalf("expose port on private sandbox should opt it in, got: %v", err)
+	}
+	if exposure.PublicURL == "" {
+		t.Fatal("expose returned empty public URL after the opt-in flip")
+	}
+	flipped, err := c.SDK().Get(ectx, sb.ID)
+	if err != nil {
+		t.Fatalf("get after expose: %v", err)
+	}
+	if flipped.PublicURL == "" {
+		t.Fatal("sandbox public_url still empty after expose; the flip must persist flag + public_url")
 	}
 }

--- a/internal/service/branch_coverage_test.go
+++ b/internal/service/branch_coverage_test.go
@@ -173,9 +173,11 @@ func TestCreateSandboxValidationBranches(t *testing.T) {
 		svc, _, _ := newServiceRuntimeHarness(t, rt)
 		svc.cfg.EnableCustomDomains = true
 		svc.cfg.Domain = "sandbox.test"
+		allowPublic := true
 		_, err := svc.CreateSandbox(ctx, models.CreateSandboxRequest{
-			Image:         "alpine:3.20",
-			CustomDomains: []string{"not-a-host"},
+			Image:              "alpine:3.20",
+			CustomDomains:      []string{"not-a-host"},
+			AllowPublicTraffic: &allowPublic,
 		})
 		if err == nil || !strings.Contains(err.Error(), "custom domain") {
 			t.Fatalf("CreateSandbox() error = %v, want custom domain validation failure", err)
@@ -268,7 +270,8 @@ func TestCreateSandboxRollbackAndCustomDomainBranches(t *testing.T) {
 		svc.caddy = caddy.New(svc.cfg)
 		svc.admitter = nil
 
-		_, err := svc.CreateSandbox(ctx, models.CreateSandboxRequest{Image: "alpine:3.20"})
+		allowPublic := true
+		_, err := svc.CreateSandbox(ctx, models.CreateSandboxRequest{Image: "alpine:3.20", AllowPublicTraffic: &allowPublic})
 		if err == nil || !strings.Contains(err.Error(), "patch caddy route failed") {
 			t.Fatalf("CreateSandbox() error = %v, want caddy failure", err)
 		}
@@ -287,9 +290,11 @@ func TestCreateSandboxRollbackAndCustomDomainBranches(t *testing.T) {
 		svc.cfg.Domain = "sandbox.test"
 		svc.admitter = nil
 
+		allowPublic := true
 		first, err := svc.CreateSandboxWithID(ctx, models.CreateSandboxRequest{
-			Image:         "alpine:3.20",
-			CustomDomains: []string{"api.external.test"},
+			Image:              "alpine:3.20",
+			CustomDomains:      []string{"api.external.test"},
+			AllowPublicTraffic: &allowPublic,
 		}, "sb-domain-1")
 		if err != nil {
 			t.Fatalf("seed create: %v", err)
@@ -298,8 +303,9 @@ func TestCreateSandboxRollbackAndCustomDomainBranches(t *testing.T) {
 			t.Fatal("seed create returned nil response")
 		}
 		_, err = svc.CreateSandboxWithID(ctx, models.CreateSandboxRequest{
-			Image:         "alpine:3.20",
-			CustomDomains: []string{"api.external.test"},
+			Image:              "alpine:3.20",
+			CustomDomains:      []string{"api.external.test"},
+			AllowPublicTraffic: &allowPublic,
 		}, "sb-domain-2")
 		if err == nil || !errors.Is(err, storepkg.ErrCustomDomainConflict) {
 			t.Fatalf("CreateSandboxWithID() error = %v, want custom domain conflict", err)
@@ -325,9 +331,11 @@ func TestCreateSandboxRollbackAndCustomDomainBranches(t *testing.T) {
 		}
 		svc.AttachCluster(clusterStub)
 
+		allowPublic := true
 		_, err := svc.CreateSandboxWithID(ctx, models.CreateSandboxRequest{
-			Image:         "alpine:3.20",
-			CustomDomains: []string{"api.external.test"},
+			Image:              "alpine:3.20",
+			CustomDomains:      []string{"api.external.test"},
+			AllowPublicTraffic: &allowPublic,
 		}, "sb-domain-close")
 		if err == nil || !strings.Contains(err.Error(), "database is closed") {
 			t.Fatalf("CreateSandboxWithID() error = %v, want store close failure", err)
@@ -494,10 +502,12 @@ func TestCreateWasmSandboxBranchCoverage(t *testing.T) {
 		svc.cfg.CaddyServerID = "srv0"
 		svc.caddy = caddy.New(svc.cfg)
 
+		allowPublic := true
 		_, err := svc.CreateSandboxWithID(ctx, models.CreateSandboxRequest{
-			ModuleRef:     "hello.wasm",
-			Runtime:       models.RuntimeWasm,
-			CustomDomains: []string{"api.external.test"},
+			ModuleRef:          "hello.wasm",
+			Runtime:            models.RuntimeWasm,
+			CustomDomains:      []string{"api.external.test"},
+			AllowPublicTraffic: &allowPublic,
 		}, "sb-wasm-sync-fail")
 		if err == nil || !strings.Contains(err.Error(), "install wasm custom-domain route") {
 			t.Fatalf("CreateSandboxWithID() error = %v, want caddy sync failure", err)
@@ -543,10 +553,12 @@ func TestCreateWasmSandboxBranchCoverage(t *testing.T) {
 		svc.cfg.CaddyServerID = "srv0"
 		svc.caddy = caddy.New(svc.cfg)
 
+		allowPublic := true
 		_, err := svc.CreateSandboxWithID(ctx, models.CreateSandboxRequest{
-			ModuleRef:     "hello.wasm",
-			Runtime:       models.RuntimeWasm,
-			CustomDomains: []string{"api.external.test"},
+			ModuleRef:          "hello.wasm",
+			Runtime:            models.RuntimeWasm,
+			CustomDomains:      []string{"api.external.test"},
+			AllowPublicTraffic: &allowPublic,
 		}, "sb-wasm-close")
 		if err == nil || !strings.Contains(err.Error(), "database is closed") {
 			t.Fatalf("CreateSandboxWithID() error = %v, want final store read failure", err)

--- a/internal/service/bugfix_test.go
+++ b/internal/service/bugfix_test.go
@@ -228,10 +228,12 @@ func TestExposePortSkipsProbeOnStoppedSandbox(t *testing.T) {
 	}
 }
 
-// TestExposePortRejectedWhenPublicTrafficDisabled verifies that a sandbox
-// created with allow_public_traffic=false cannot be exposed: ExposePort returns
-// ErrPublicTrafficDisabled instead of installing a public route.
-func TestExposePortRejectedWhenPublicTrafficDisabled(t *testing.T) {
+// TestExposePortFlipsPublicTrafficDisabledSandbox verifies that ExposePort is
+// the opt-in lever for a sandbox created with allow_public_traffic=false:
+// instead of refusing, it flips the stored flag to true and the exposure
+// succeeds. A validation failure on the same sandbox must NOT flip the flag —
+// the mutation only happens once every reject path has been cleared.
+func TestExposePortFlipsPublicTrafficDisabledSandbox(t *testing.T) {
 	ctx := context.Background()
 	svc, st := newProbeSvc(t, func(_ context.Context, _ string, _ int) error { return nil })
 
@@ -249,9 +251,30 @@ func TestExposePortRejectedWhenPublicTrafficDisabled(t *testing.T) {
 		t.Fatalf("seed sandbox: %v", err)
 	}
 
-	_, err := svc.ExposePort(ctx, "sb-no-public", 8080, models.ExposedPortProtocolHTTP)
-	if !errors.Is(err, ErrPublicTrafficDisabled) {
-		t.Fatalf("ExposePort err = %v, want ErrPublicTrafficDisabled", err)
+	// A rejected call (invalid port) must leave the sandbox private.
+	if _, err := svc.ExposePort(ctx, "sb-no-public", 0, models.ExposedPortProtocolHTTP); err == nil {
+		t.Fatal("ExposePort with invalid port should fail")
+	}
+	afterReject, err := st.Get(ctx, "sb-no-public")
+	if err != nil {
+		t.Fatalf("store.Get after rejected expose: %v", err)
+	}
+	if afterReject.AllowPublicTraffic == nil || *afterReject.AllowPublicTraffic {
+		t.Fatalf("AllowPublicTraffic after rejected expose = %v, want still explicit false", afterReject.AllowPublicTraffic)
+	}
+
+	if _, err := svc.ExposePort(ctx, "sb-no-public", 8080, models.ExposedPortProtocolHTTP); err != nil {
+		t.Fatalf("ExposePort on a private sandbox should opt it in, got: %v", err)
+	}
+	flipped, err := st.Get(ctx, "sb-no-public")
+	if err != nil {
+		t.Fatalf("store.Get after expose: %v", err)
+	}
+	if flipped.AllowPublicTraffic == nil || !*flipped.AllowPublicTraffic {
+		t.Fatalf("AllowPublicTraffic after expose = %v, want explicit true", flipped.AllowPublicTraffic)
+	}
+	if len(flipped.ExposedPorts) != 1 || flipped.ExposedPorts[0].Port != 8080 {
+		t.Fatalf("ExposedPorts after expose = %+v, want port 8080", flipped.ExposedPorts)
 	}
 }
 

--- a/internal/service/public_traffic.go
+++ b/internal/service/public_traffic.go
@@ -41,6 +41,47 @@ func (s *Service) syncSandboxPublicRoute(ctx context.Context, sandbox *models.Sa
 	return s.caddy.UpsertSandboxRoute(ctx, sandbox.ID, sandbox.ContainerIP, s.cfg.ToolboxPort, sandboxCustomHostnames(sandbox))
 }
 
+// enableSandboxPublicTraffic flips a private sandbox to public in place:
+// installs the root <id>.<domain> route, persists flag + public_url in one
+// store write, and mirrors the flip into the FSM-replicated spec so a
+// failover recreate keeps the sandbox public even if every port is later
+// unexposed. expose_port is the only caller — asking for a public port IS
+// the opt-in (there is no standalone flag-update endpoint).
+//
+// Caddy-first on purpose: a crash between the route install and the store
+// write leaves a route for a still-private row, which the reconcile sweep
+// (cleanupPublicTrafficDisabledIngressState) removes; the reverse order
+// would leave a stored-public sandbox with a dead public_url and no repair
+// pass. On a store failure the route is rolled back so caddy and the store
+// never disagree past this function. Safe under concurrent duplicates: the
+// route install is an upsert and the store write is an absolute SET.
+func (s *Service) enableSandboxPublicTraffic(ctx context.Context, sandbox *models.Sandbox) error {
+	if sandbox == nil || sandbox.ID == "" || sandboxAllowsPublicTraffic(sandbox) {
+		return nil
+	}
+	public := true
+	sandbox.AllowPublicTraffic = &public
+	if err := s.syncSandboxPublicRoute(ctx, sandbox); err != nil {
+		private := false
+		sandbox.AllowPublicTraffic = &private
+		return err
+	}
+	publicURL := s.sandboxPublicURL(sandbox.ID, sandbox.AllowPublicTraffic)
+	if s.store != nil {
+		if err := s.store.SetAllowPublicTraffic(ctx, sandbox.ID, true, publicURL); err != nil {
+			_ = s.deleteSandboxPublicRoutes(ctx, sandbox)
+			private := false
+			sandbox.AllowPublicTraffic = &private
+			return err
+		}
+	}
+	sandbox.PublicURL = publicURL
+	s.replicateSpecPatch(ctx, sandbox.ID, func(spec *models.CreateSandboxRequest) {
+		spec.AllowPublicTraffic = &public
+	})
+	return nil
+}
+
 func (s *Service) deleteSandboxPublicRoutes(ctx context.Context, sandbox *models.Sandbox) error {
 	if sandbox == nil || sandbox.ID == "" || s == nil || s.caddy == nil {
 		return nil

--- a/internal/service/public_traffic_create_rollback_test.go
+++ b/internal/service/public_traffic_create_rollback_test.go
@@ -122,9 +122,11 @@ func TestCreateSandboxRollbackDeletesCustomDomainLeafRoutes(t *testing.T) {
 	const host = "api.external.test"
 
 	// Seed sandbox claims the custom domain and installs its main + leaf routes.
+	allowPublic := true
 	if _, err := svc.CreateSandboxWithID(ctx, models.CreateSandboxRequest{
-		Image:         "alpine:3.20",
-		CustomDomains: []string{host},
+		Image:              "alpine:3.20",
+		CustomDomains:      []string{host},
+		AllowPublicTraffic: &allowPublic,
 	}, "sb-keep"); err != nil {
 		t.Fatalf("seed create: %v", err)
 	}
@@ -139,8 +141,9 @@ func TestCreateSandboxRollbackDeletesCustomDomainLeafRoutes(t *testing.T) {
 	// then trips the custom-domain conflict at persistCustomDomainsOnCreate, which
 	// runs the post-route rollback chain.
 	_, err := svc.CreateSandboxWithID(ctx, models.CreateSandboxRequest{
-		Image:         "alpine:3.20",
-		CustomDomains: []string{host},
+		Image:              "alpine:3.20",
+		CustomDomains:      []string{host},
+		AllowPublicTraffic: &allowPublic,
 	}, "sb-roll")
 	if err == nil || !errors.Is(err, storepkg.ErrCustomDomainConflict) {
 		t.Fatalf("CreateSandboxWithID() error = %v, want custom domain conflict", err)

--- a/internal/service/public_traffic_default_test.go
+++ b/internal/service/public_traffic_default_test.go
@@ -1,0 +1,133 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/cluster"
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/pkg/caddy"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// Regression tests for the private-by-default flip: a create that does not
+// pass allow_public_traffic=true must install no public route (and make zero
+// caddy admin calls at all — not even the defensive delete), while opting in
+// restores the old behavior. Legacy nil specs replayed by the failover
+// recreate path must stay public.
+
+func TestCreateSandboxPrivateByDefault(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+
+	var caddyHits int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&caddyHits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+	svc.cfg.EnableCaddy = true
+	svc.cfg.CaddyAdminURL = server.URL
+	svc.cfg.CaddyServerID = "srv0"
+	svc.cfg.Domain = "sandbox.test"
+	svc.caddy = caddy.New(config.Config{
+		EnableCaddy:       true,
+		CaddyAdminURL:     server.URL,
+		CaddyServerID:     "srv0",
+		Domain:            "sandbox.test",
+		HTTPClientTimeout: time.Second,
+	})
+
+	resp, err := svc.CreateSandbox(ctx, models.CreateSandboxRequest{Image: "alpine:3.20"})
+	if err != nil {
+		t.Fatalf("CreateSandbox() error = %v", err)
+	}
+	if resp.PublicURL != "" {
+		t.Fatalf("PublicURL = %q, want empty for a default (private) create", resp.PublicURL)
+	}
+	if got := atomic.LoadInt64(&caddyHits); got != 0 {
+		t.Fatalf("caddy admin calls = %d, want 0 on a private create", got)
+	}
+	stored, err := st.Get(ctx, resp.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if stored.AllowPublicTraffic == nil || *stored.AllowPublicTraffic {
+		t.Fatalf("stored AllowPublicTraffic = %v, want explicit false", stored.AllowPublicTraffic)
+	}
+	if _, err := svc.ExposePort(ctx, resp.ID, 8080, "http"); !errors.Is(err, ErrPublicTrafficDisabled) {
+		t.Fatalf("ExposePort() error = %v, want ErrPublicTrafficDisabled", err)
+	}
+}
+
+func TestCreateSandboxOptInPublicInstallsRoute(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+
+	fake := newRouteAdminCaddyFake()
+	server := httptest.NewServer(fake.handler(t))
+	t.Cleanup(server.Close)
+	svc.cfg.EnableCaddy = true
+	svc.cfg.CaddyAdminURL = server.URL
+	svc.cfg.CaddyServerID = "srv0"
+	svc.cfg.Domain = "sandbox.test"
+	svc.caddy = caddy.New(config.Config{
+		EnableCaddy:       true,
+		CaddyAdminURL:     server.URL,
+		CaddyServerID:     "srv0",
+		Domain:            "sandbox.test",
+		HTTPClientTimeout: time.Second,
+	})
+
+	allowPublic := true
+	resp, err := svc.CreateSandbox(ctx, models.CreateSandboxRequest{
+		Image:              "alpine:3.20",
+		AllowPublicTraffic: &allowPublic,
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox() error = %v", err)
+	}
+	if resp.PublicURL == "" {
+		t.Fatal("PublicURL empty, want the sandbox URL for an opted-in create")
+	}
+	if !fake.hasHTTPRoute(caddy.SandboxRouteID(resp.ID)) {
+		t.Fatalf("route %q not installed for an opted-in create", caddy.SandboxRouteID(resp.ID))
+	}
+	stored, err := st.Get(ctx, resp.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if stored.AllowPublicTraffic == nil || !*stored.AllowPublicTraffic {
+		t.Fatalf("stored AllowPublicTraffic = %v, want explicit true", stored.AllowPublicTraffic)
+	}
+}
+
+func TestRecreateSandboxLegacyNilSpecStaysPublic(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+
+	// A replicated spec written before the private-by-default flip has a nil
+	// flag; failover recreate must pin it to public rather than letting the
+	// createSandbox normalization silently flip reachability.
+	err := svc.RecreateSandbox(ctx, "sb-legacy-nil-flag", models.CreateSandboxRequest{
+		Image: "alpine:3.20",
+	}, cluster.PlacementSecrets{}, nil)
+	if err != nil {
+		t.Fatalf("RecreateSandbox() error = %v", err)
+	}
+	stored, err := st.Get(ctx, "sb-legacy-nil-flag")
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if stored.AllowPublicTraffic == nil || !*stored.AllowPublicTraffic {
+		t.Fatalf("stored AllowPublicTraffic = %v, want explicit true for a legacy nil spec", stored.AllowPublicTraffic)
+	}
+}

--- a/internal/service/public_traffic_default_test.go
+++ b/internal/service/public_traffic_default_test.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -61,8 +60,165 @@ func TestCreateSandboxPrivateByDefault(t *testing.T) {
 	if stored.AllowPublicTraffic == nil || *stored.AllowPublicTraffic {
 		t.Fatalf("stored AllowPublicTraffic = %v, want explicit false", stored.AllowPublicTraffic)
 	}
-	if _, err := svc.ExposePort(ctx, resp.ID, 8080, "http"); !errors.Is(err, ErrPublicTrafficDisabled) {
-		t.Fatalf("ExposePort() error = %v, want ErrPublicTrafficDisabled", err)
+}
+
+// TestExposePortOptsPrivateSandboxIn verifies the post-create opt-in lever:
+// exposing a port on a default (private) sandbox installs BOTH the root
+// <id>.<domain> route and the port route, persists flag + public_url, and is
+// idempotent on re-expose.
+func TestExposePortOptsPrivateSandboxIn(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+	svc.probeContainerPortFn = func(_ context.Context, _ string, _ int) error { return nil }
+
+	fake := newRouteAdminCaddyFake()
+	server := httptest.NewServer(fake.handler(t))
+	t.Cleanup(server.Close)
+	svc.cfg.EnableCaddy = true
+	svc.cfg.CaddyAdminURL = server.URL
+	svc.cfg.CaddyServerID = "srv0"
+	svc.cfg.Domain = "sandbox.test"
+	svc.caddy = caddy.New(config.Config{
+		EnableCaddy:       true,
+		CaddyAdminURL:     server.URL,
+		CaddyServerID:     "srv0",
+		Domain:            "sandbox.test",
+		HTTPClientTimeout: time.Second,
+	})
+
+	resp, err := svc.CreateSandbox(ctx, models.CreateSandboxRequest{Image: "alpine:3.20"})
+	if err != nil {
+		t.Fatalf("CreateSandbox() error = %v", err)
+	}
+	if fake.hasHTTPRoute(caddy.SandboxRouteID(resp.ID)) {
+		t.Fatal("root route installed at create for a private sandbox")
+	}
+
+	exposed, err := svc.ExposePort(ctx, resp.ID, 8080, "http")
+	if err != nil {
+		t.Fatalf("ExposePort() on a private sandbox should opt it in, got: %v", err)
+	}
+	if exposed.PublicURL == "" {
+		t.Fatal("ExposePort() returned empty PublicURL")
+	}
+	if !fake.hasHTTPRoute(caddy.SandboxRouteID(resp.ID)) {
+		t.Fatalf("root route %q not installed by the expose flip", caddy.SandboxRouteID(resp.ID))
+	}
+	if !fake.hasHTTPRoute(caddy.PortRouteID(resp.ID, 8080)) {
+		t.Fatalf("port route %q not installed", caddy.PortRouteID(resp.ID, 8080))
+	}
+	stored, err := st.Get(ctx, resp.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if stored.AllowPublicTraffic == nil || !*stored.AllowPublicTraffic {
+		t.Fatalf("stored AllowPublicTraffic = %v, want explicit true after expose", stored.AllowPublicTraffic)
+	}
+	if stored.PublicURL == "" {
+		t.Fatal("stored PublicURL empty after the expose flip; SetAllowPublicTraffic must refresh it")
+	}
+
+	again, err := svc.ExposePort(ctx, resp.ID, 8080, "http")
+	if err != nil {
+		t.Fatalf("re-expose after flip: %v", err)
+	}
+	if again.PublicURL != exposed.PublicURL {
+		t.Fatalf("re-expose URL = %q, want %q (idempotent)", again.PublicURL, exposed.PublicURL)
+	}
+}
+
+// TestEnablePublicTrafficStoreFailureRollsBackRoute verifies the other half
+// of the flip's rollback rule: when the store write fails after the root
+// route went in, the route is torn down and the in-memory sandbox reverts to
+// private — caddy and the store never disagree past the helper.
+func TestEnablePublicTrafficStoreFailureRollsBackRoute(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+
+	fake := newRouteAdminCaddyFake()
+	server := httptest.NewServer(fake.handler(t))
+	t.Cleanup(server.Close)
+	svc.cfg.EnableCaddy = true
+	svc.cfg.CaddyAdminURL = server.URL
+	svc.cfg.CaddyServerID = "srv0"
+	svc.cfg.Domain = "sandbox.test"
+	svc.caddy = caddy.New(config.Config{
+		EnableCaddy:       true,
+		CaddyAdminURL:     server.URL,
+		CaddyServerID:     "srv0",
+		Domain:            "sandbox.test",
+		HTTPClientTimeout: time.Second,
+	})
+
+	resp, err := svc.CreateSandbox(ctx, models.CreateSandboxRequest{Image: "alpine:3.20"})
+	if err != nil {
+		t.Fatalf("CreateSandbox() error = %v", err)
+	}
+	sandbox, err := st.Get(ctx, resp.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	// Make the store write fail with ErrNotFound by removing the row out from
+	// under the helper — the cheapest deterministic store failure the real
+	// sqlite store can produce.
+	if err := st.Delete(ctx, resp.ID); err != nil {
+		t.Fatalf("store.Delete: %v", err)
+	}
+	if err := svc.enableSandboxPublicTraffic(ctx, sandbox); err == nil {
+		t.Fatal("enableSandboxPublicTraffic should surface the store failure")
+	}
+	if fake.hasHTTPRoute(caddy.SandboxRouteID(resp.ID)) {
+		t.Fatal("root route left installed after the store write failed; rollback must remove it")
+	}
+	if sandbox.AllowPublicTraffic == nil || *sandbox.AllowPublicTraffic {
+		t.Fatalf("in-memory AllowPublicTraffic = %v after failed flip, want reverted to explicit false", sandbox.AllowPublicTraffic)
+	}
+}
+
+// TestExposePortFlipCaddyFailureStaysPrivate verifies the flip's rollback
+// rule: if the root-route install fails, ExposePort surfaces the error and
+// the sandbox stays private in the store (flag false, empty public_url) — no
+// half-public state.
+func TestExposePortFlipCaddyFailureStaysPrivate(t *testing.T) {
+	ctx := context.Background()
+	rt := &recordingRuntime{}
+	svc, st, _ := newServiceRuntimeHarness(t, rt)
+	svc.probeContainerPortFn = func(_ context.Context, _ string, _ int) error { return nil }
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+	svc.cfg.EnableCaddy = true
+	svc.cfg.CaddyAdminURL = server.URL
+	svc.cfg.CaddyServerID = "srv0"
+	svc.cfg.Domain = "sandbox.test"
+	svc.caddy = caddy.New(config.Config{
+		EnableCaddy:       true,
+		CaddyAdminURL:     server.URL,
+		CaddyServerID:     "srv0",
+		Domain:            "sandbox.test",
+		HTTPClientTimeout: time.Second,
+	})
+
+	resp, err := svc.CreateSandbox(ctx, models.CreateSandboxRequest{Image: "alpine:3.20"})
+	if err != nil {
+		t.Fatalf("CreateSandbox() error = %v (private create must not touch caddy)", err)
+	}
+	if _, err := svc.ExposePort(ctx, resp.ID, 8080, "http"); err == nil {
+		t.Fatal("ExposePort should fail when the root-route install fails")
+	}
+	stored, err := st.Get(ctx, resp.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if stored.AllowPublicTraffic == nil || *stored.AllowPublicTraffic {
+		t.Fatalf("stored AllowPublicTraffic = %v, want still explicit false after failed flip", stored.AllowPublicTraffic)
+	}
+	if stored.PublicURL != "" {
+		t.Fatalf("stored PublicURL = %q, want empty after failed flip", stored.PublicURL)
 	}
 }
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -799,6 +799,15 @@ func (s *Service) RecreateSandbox(ctx context.Context, id string, spec models.Cr
 	if err != nil {
 		return fmt.Errorf("recreate %s: %w", id, err)
 	}
+	// A replicated spec written before the private-by-default flip carries a
+	// nil flag, and store-backed rows always materialize the tri-state — so a
+	// nil here can only be a legacy replica from when public WAS the default.
+	// Pin it to true so failover never silently changes a sandbox's
+	// reachability; createSandbox would otherwise normalize nil to private.
+	if merged.AllowPublicTraffic == nil {
+		public := true
+		merged.AllowPublicTraffic = &public
+	}
 	if _, err := s.CreateSandboxWithID(ctx, merged, id); err != nil {
 		return err
 	}
@@ -934,6 +943,20 @@ func (s *Service) createSandbox(ctx context.Context, req models.CreateSandboxReq
 	}
 	if err := NormalizeCreateFailover(&req); err != nil {
 		return nil, err
+	}
+	// Private-by-default: a create that doesn't opt in with
+	// allow_public_traffic=true gets no public ingress route (and ExposePort
+	// refuses). The default is pinned to an explicit false HERE, not inside
+	// allowPublicTrafficEnabled, because nil must keep meaning "public" for
+	// store rows written before the default flipped. Unconditional on purpose:
+	// cluster-mode creates arrive via CreateSandboxWithID (reserved ID), so an
+	// idOverride guard would silently exempt every cluster create. The one
+	// caller that must NOT re-interpret a legacy nil — the failover recreate
+	// replaying a pre-flag replicated spec — pins it to true in
+	// RecreateSandbox before calling in.
+	if req.AllowPublicTraffic == nil {
+		private := false
+		req.AllowPublicTraffic = &private
 	}
 	if req.Image == "" && strings.TrimSpace(req.ModuleRef) == "" {
 		return nil, errors.New("image is required")
@@ -1226,18 +1249,24 @@ func (s *Service) createSandbox(ctx context.Context, req models.CreateSandboxReq
 		}
 	}
 
-	if err := s.syncSandboxPublicRoute(ctx, sandbox); err != nil {
-		// UpsertSandboxRoute is non-atomic in domain mode: it installs the
-		// main route and then a per-custom-domain leaf route in a loop, so a
-		// failure on a later leaf can leave the main route + earlier leaves
-		// installed. deleteSandboxPublicRoutes (not DeleteSandboxRoute) tears
-		// down the main route AND every custom-domain leaf — 404 per leaf is
-		// a no-op, so it's safe on a partial install.
-		_ = s.deleteSandboxPublicRoutes(cleanupCtx, sandbox)
-		_ = s.docker.Destroy(cleanupCtx, sandbox)
-		cleanupMounts()
-		releaseAdmission()
-		return nil, err
+	// Private sandboxes skip caddy entirely on the boot path: a fresh create
+	// has no route to install, and the defensive delete inside
+	// syncSandboxPublicRoute is redundant here — crash residue is swept by
+	// the reconcile pass (cleanupPublicTrafficDisabledIngressState).
+	if sandboxAllowsPublicTraffic(sandbox) {
+		if err := s.syncSandboxPublicRoute(ctx, sandbox); err != nil {
+			// UpsertSandboxRoute is non-atomic in domain mode: it installs the
+			// main route and then a per-custom-domain leaf route in a loop, so a
+			// failure on a later leaf can leave the main route + earlier leaves
+			// installed. deleteSandboxPublicRoutes (not DeleteSandboxRoute) tears
+			// down the main route AND every custom-domain leaf — 404 per leaf is
+			// a no-op, so it's safe on a partial install.
+			_ = s.deleteSandboxPublicRoutes(cleanupCtx, sandbox)
+			_ = s.docker.Destroy(cleanupCtx, sandbox)
+			cleanupMounts()
+			releaseAdmission()
+			return nil, err
+		}
 	}
 
 	sandbox.OwnerRef = ownerRef
@@ -1493,14 +1522,17 @@ func (s *Service) createFirecrackerSandbox(ctx context.Context, req models.Creat
 		}
 	}
 
-	if err := s.syncSandboxPublicRoute(ctx, sandbox); err != nil {
-		// deleteSandboxPublicRoutes (not DeleteSandboxRoute) so a non-atomic
-		// partial UpsertSandboxRoute — main route + per-custom-domain leaves —
-		// is fully torn down. See the docker path for the rationale.
-		_ = s.deleteSandboxPublicRoutes(cleanupCtx, sandbox)
-		_ = s.firecracker.Destroy(cleanupCtx, sandbox)
-		releaseAdmission()
-		return nil, err
+	// Private sandboxes skip caddy on the boot path; see the docker path.
+	if sandboxAllowsPublicTraffic(sandbox) {
+		if err := s.syncSandboxPublicRoute(ctx, sandbox); err != nil {
+			// deleteSandboxPublicRoutes (not DeleteSandboxRoute) so a non-atomic
+			// partial UpsertSandboxRoute — main route + per-custom-domain leaves —
+			// is fully torn down. See the docker path for the rationale.
+			_ = s.deleteSandboxPublicRoutes(cleanupCtx, sandbox)
+			_ = s.firecracker.Destroy(cleanupCtx, sandbox)
+			releaseAdmission()
+			return nil, err
+		}
 	}
 
 	// Same owner attribution as the docker path; createSandbox already

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -55,10 +55,14 @@ const allocatorRandomAttempts = 16
 // contract behind the client's back.
 var ErrPreferredHostPortUnavailable = errors.New("preferred host port unavailable on this node; exposure parked")
 
-// ErrPublicTrafficDisabled is returned when the sandbox was created with
-// allow_public_traffic=false and the caller asks for a public ingress route.
-// The sandbox stays reachable through the toolbox proxy and SSH gateway.
-var ErrPublicTrafficDisabled = errors.New("public traffic is disabled for this sandbox; expose is not available")
+// ErrPublicTrafficDisabled is returned when a still-private sandbox
+// (allow_public_traffic=false) is asked for a custom-domain route. It is NOT
+// returned by expose_port — expose is the opt-in lever that flips the
+// sandbox public (enableSandboxPublicTraffic); custom domains alone stay
+// refused so that attaching a domain never silently publishes a sandbox the
+// caller kept private. The sandbox stays reachable through the toolbox proxy
+// and SSH gateway.
+var ErrPublicTrafficDisabled = errors.New("public traffic is disabled for this sandbox; pass allow_public_traffic=true at create or expose a port to opt in")
 
 const clusterIngressReconcileInterval = 5 * time.Second
 
@@ -2373,14 +2377,6 @@ func (s *Service) exposePort(ctx context.Context, id string, port int, protocol 
 	if err != nil {
 		return models.ExposePortResponse{}, err
 	}
-	// A sandbox created with allow_public_traffic=false must never get a public
-	// route. AerolVM has no auth-gated public route, so the only honest way to
-	// enforce "no public traffic" is to refuse exposure outright — the sandbox
-	// stays reachable through the toolbox proxy and SSH gateway, which do not
-	// route through the public ingress. Nil/true keep the default (allowed).
-	if sandbox.AllowPublicTraffic != nil && !*sandbox.AllowPublicTraffic {
-		return models.ExposePortResponse{}, ErrPublicTrafficDisabled
-	}
 	if port <= 0 || port > 65535 {
 		return models.ExposePortResponse{}, errors.New("invalid port")
 	}
@@ -2410,6 +2406,20 @@ func (s *Service) exposePort(ctx context.Context, id string, port int, protocol 
 		}
 		if existingProto != canonicalProto {
 			return models.ExposePortResponse{}, fmt.Errorf("port %d already exposed as %s; unexpose it first", port, existingProto)
+		}
+	}
+	// expose_port is the opt-in lever for a sandbox created private: there is
+	// no standalone flag-update endpoint, so asking for a public port IS the
+	// consent to public exposure. The flip runs after every reject path above
+	// (a call that fails validation must not mutate the sandbox) and before
+	// the port route goes in, so a successful expose always leaves a fully
+	// public sandbox: flag, public_url, and root route. Deliberately not
+	// rolled back if a later port-route step fails — the flip is an
+	// idempotent prerequisite and the expose retry completes it, same stance
+	// as EnsureLayer4Ready rather than un-publishing on a transient error.
+	if !sandboxAllowsPublicTraffic(sandbox) {
+		if err := s.enableSandboxPublicTraffic(ctx, sandbox); err != nil {
+			return models.ExposePortResponse{}, err
 		}
 	}
 	// Probe the container port before routing traffic to it. Skipped on

--- a/internal/service/service_firecracker_dispatch_test.go
+++ b/internal/service/service_firecracker_dispatch_test.go
@@ -378,10 +378,12 @@ func TestFirecrackerDispatch_CustomDomainsPersistOnCreate(t *testing.T) {
 	svc.admitter = nil
 	svc.SetFirecrackerRuntime(rt)
 
+	allowPublic := true
 	resp, err := svc.CreateSandbox(ctx, models.CreateSandboxRequest{
-		Image:         "alpine:3.20",
-		Runtime:       models.RuntimeFirecracker,
-		CustomDomains: []string{"api.external.test", "www.external.test"},
+		Image:              "alpine:3.20",
+		Runtime:            models.RuntimeFirecracker,
+		CustomDomains:      []string{"api.external.test", "www.external.test"},
+		AllowPublicTraffic: &allowPublic,
 	})
 	if err != nil {
 		t.Fatalf("CreateSandbox() error = %v", err)
@@ -450,9 +452,11 @@ func TestFirecrackerDispatch_RollsBackWhenCaddyUpsertFails(t *testing.T) {
 		HTTPClientTimeout: time.Second,
 	})
 
+	allowPublic := true
 	_, err := svc.CreateSandbox(context.Background(), models.CreateSandboxRequest{
-		Image:   "alpine:3.20",
-		Runtime: models.RuntimeFirecracker,
+		Image:              "alpine:3.20",
+		Runtime:            models.RuntimeFirecracker,
+		AllowPublicTraffic: &allowPublic,
 	})
 	if err == nil || !strings.Contains(err.Error(), "patch caddy route failed") {
 		t.Fatalf("expected caddy failure, got %v", err)
@@ -483,10 +487,12 @@ func TestFirecrackerDispatch_RollsBackWhenCustomDomainPersistenceFails(t *testin
 		Noop: cluster.NewNoop("self", "http://self", "sandbox.test"),
 	})
 
+	allowDomains := true
 	resp, err := svc.CreateSandboxWithID(context.Background(), models.CreateSandboxRequest{
-		Image:         "alpine:3.20",
-		Runtime:       models.RuntimeFirecracker,
-		CustomDomains: []string{"api.example.com", "www.example.com"},
+		Image:              "alpine:3.20",
+		Runtime:            models.RuntimeFirecracker,
+		CustomDomains:      []string{"api.example.com", "www.example.com"},
+		AllowPublicTraffic: &allowDomains,
 	}, "sb-fc-domains")
 	t.Logf("custom-domain create error: %v", err)
 	if err == nil {

--- a/internal/service/service_runtime_flow_test.go
+++ b/internal/service/service_runtime_flow_test.go
@@ -858,10 +858,12 @@ func TestCreateSandboxWithCustomDomainsPersistsRows(t *testing.T) {
 	svc.cfg.EnableCustomDomains = true
 	svc.cfg.Domain = "sandbox.test"
 
+	allowPublic := true
 	resp, err := svc.CreateSandboxWithID(ctx, models.CreateSandboxRequest{
-		Image:         "alpine:3.20",
-		Name:          "custom-domains",
-		CustomDomains: []string{"api.external.test", "www.external.test"},
+		Image:              "alpine:3.20",
+		Name:               "custom-domains",
+		CustomDomains:      []string{"api.external.test", "www.external.test"},
+		AllowPublicTraffic: &allowPublic,
 	}, "sb-custom-domains")
 	if err != nil {
 		t.Fatalf("CreateSandboxWithID() error = %v", err)
@@ -910,7 +912,8 @@ func TestExposeAndUnexposePortProtocols(t *testing.T) {
 	}
 	svc.caddy = caddy.New(svc.cfg)
 
-	resp, err := svc.CreateSandboxWithID(ctx, models.CreateSandboxRequest{Image: "alpine:3.20"}, "sb-ports")
+	allowPublic := true
+	resp, err := svc.CreateSandboxWithID(ctx, models.CreateSandboxRequest{Image: "alpine:3.20", AllowPublicTraffic: &allowPublic}, "sb-ports")
 	if err != nil {
 		t.Fatalf("CreateSandboxWithID() error = %v", err)
 	}

--- a/internal/service/service_wasm_dispatch_test.go
+++ b/internal/service/service_wasm_dispatch_test.go
@@ -253,10 +253,12 @@ func TestWasmCreateSandboxCustomDomainsPersistOnCreate(t *testing.T) {
 	svc.admitter = nil
 	svc.SetWasmRuntime(rt)
 
+	allowPublic := true
 	resp, err := svc.CreateSandboxWithID(ctx, models.CreateSandboxRequest{
-		ModuleRef:     "hello.wasm",
-		Runtime:       models.RuntimeWasm,
-		CustomDomains: []string{"api.external.test", "www.external.test"},
+		ModuleRef:          "hello.wasm",
+		Runtime:            models.RuntimeWasm,
+		CustomDomains:      []string{"api.external.test", "www.external.test"},
+		AllowPublicTraffic: &allowPublic,
 	}, "sb-wasm-custom-domains")
 	if err != nil {
 		t.Fatalf("CreateSandboxWithID() error = %v", err)
@@ -422,9 +424,11 @@ func TestWasmCreateSandboxRollbackBranches(t *testing.T) {
 			HTTPClientTimeout: time.Second,
 		})
 
+		allowPublic := true
 		_, err := svc.CreateSandbox(ctx, models.CreateSandboxRequest{
-			Image:   "demo.wasm",
-			Runtime: models.RuntimeWasm,
+			Image:              "demo.wasm",
+			Runtime:            models.RuntimeWasm,
+			AllowPublicTraffic: &allowPublic,
 		})
 		if err == nil || !strings.Contains(err.Error(), "patch caddy route failed") {
 			t.Fatalf("CreateSandbox() error = %v, want caddy failure", err)
@@ -450,10 +454,12 @@ func TestWasmCreateSandboxRollbackBranches(t *testing.T) {
 			Noop: cluster.NewNoop("self", "http://self", "sandbox.test"),
 		})
 
+		allowDomains := true
 		_, err := svc.CreateSandboxWithID(ctx, models.CreateSandboxRequest{
-			Image:         "demo.wasm",
-			Runtime:       models.RuntimeWasm,
-			CustomDomains: []string{"api.example.com", "www.example.com"},
+			Image:              "demo.wasm",
+			Runtime:            models.RuntimeWasm,
+			CustomDomains:      []string{"api.example.com", "www.example.com"},
+			AllowPublicTraffic: &allowDomains,
 		}, "sb-wasm-domains")
 		if err == nil {
 			t.Fatal("expected custom-domain conflict")

--- a/internal/service/wasm.go
+++ b/internal/service/wasm.go
@@ -195,18 +195,21 @@ func (s *Service) createWasmSandbox(ctx context.Context, req models.CreateSandbo
 	}
 	sandbox.OwnerRef = ownerRefForCreate(ctx)
 
-	if err := s.syncSandboxPublicRoute(ctx, sandbox); err != nil {
-		// deleteSandboxPublicRoutes (not DeleteSandboxRoute) tears down the
-		// main route AND every per-custom-domain leaf. WASM is doubly exposed
-		// here: routes get installed both via syncSandboxPublicRoute's
-		// UpsertSandboxRoute loop and via syncWasmCustomDomainRoutes below,
-		// and both key on IngressCustomDomainHTTPRouteID — so the leaf delete
-		// covers both. 404 per leaf is a no-op, safe on a partial install.
-		_ = s.deleteSandboxPublicRoutes(ctx, sandbox)
-		_ = s.wasm.Destroy(ctx, sandbox)
-		cleanupMounts()
-		releaseAdmission()
-		return nil, err
+	// Private sandboxes skip caddy on the boot path; see the docker path.
+	if sandboxAllowsPublicTraffic(sandbox) {
+		if err := s.syncSandboxPublicRoute(ctx, sandbox); err != nil {
+			// deleteSandboxPublicRoutes (not DeleteSandboxRoute) tears down the
+			// main route AND every per-custom-domain leaf. WASM is doubly exposed
+			// here: routes get installed both via syncSandboxPublicRoute's
+			// UpsertSandboxRoute loop and via syncWasmCustomDomainRoutes below,
+			// and both key on IngressCustomDomainHTTPRouteID — so the leaf delete
+			// covers both. 404 per leaf is a no-op, safe on a partial install.
+			_ = s.deleteSandboxPublicRoutes(ctx, sandbox)
+			_ = s.wasm.Destroy(ctx, sandbox)
+			cleanupMounts()
+			releaseAdmission()
+			return nil, err
+		}
 	}
 	if err := s.store.Create(ctx, sandbox); err != nil {
 		_ = s.deleteSandboxPublicRoutes(ctx, sandbox)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1722,6 +1722,31 @@ func (s *Store) SetWakeArmed(ctx context.Context, id string, armed bool) error {
 	return nil
 }
 
+// SetAllowPublicTraffic flips the public-exposure flag together with the
+// derived public_url in one statement. The expose_port opt-in path (the only
+// way a private sandbox becomes public after create) is the caller; the two
+// columns must move atomically because every Get materializes both — a
+// public row with an empty public_url (or the reverse) would misreport
+// reachability. A dedicated setter rather than Upsert so the flip doesn't
+// race the runtime-state machine on the rest of the row.
+func (s *Store) SetAllowPublicTraffic(ctx context.Context, id string, allow bool, publicURL string) error {
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE sandboxes
+		SET allow_public_traffic = ?,
+		    public_url = ?,
+		    updated_at = ?
+		WHERE id = ?
+	`, boolToInt(allow), publicURL, time.Now().UTC(), id)
+	if err != nil {
+		return fmt.Errorf("set allow_public_traffic: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err == nil && affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 // SetAutoImportPending toggles the AOCR auto-import retry flag. The post-pull
 // auto-import path sets it to true on failure; the reconciler clears it after
 // a successful import. The reconciler must call this rather than Upsert to

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1301,6 +1301,46 @@ func TestStoreCases(t *testing.T) {
 			},
 		},
 		{
+			// The expose_port opt-in flips flag and public_url in ONE
+			// statement — a Get must never observe one moved without the
+			// other, or reachability is misreported.
+			name: "set_allow_public_traffic_moves_flag_and_url_together",
+			run: func(t *testing.T) {
+				st := newTestStore(t)
+				sandbox := sampleSandbox("sb-flip-public")
+				deny := false
+				sandbox.AllowPublicTraffic = &deny
+				sandbox.PublicURL = ""
+				if err := st.Create(ctx, sandbox); err != nil {
+					t.Fatalf("Create() error = %v", err)
+				}
+				const url = "https://sb-flip-public.sandbox.test"
+				if err := st.SetAllowPublicTraffic(ctx, sandbox.ID, true, url); err != nil {
+					t.Fatalf("SetAllowPublicTraffic() error = %v", err)
+				}
+				got, err := st.Get(ctx, sandbox.ID)
+				if err != nil {
+					t.Fatalf("Get() error = %v", err)
+				}
+				if got.AllowPublicTraffic == nil || !*got.AllowPublicTraffic {
+					t.Fatalf("AllowPublicTraffic = %v after flip, want explicit true", got.AllowPublicTraffic)
+				}
+				if got.PublicURL != url {
+					t.Fatalf("PublicURL = %q after flip, want %q", got.PublicURL, url)
+				}
+			},
+		},
+		{
+			name: "set_allow_public_traffic_returns_not_found_for_missing_id",
+			run: func(t *testing.T) {
+				st := newTestStore(t)
+				err := st.SetAllowPublicTraffic(ctx, "missing", true, "https://missing.sandbox.test")
+				if !errors.Is(err, ErrNotFound) {
+					t.Fatalf("expected ErrNotFound, got %v", err)
+				}
+			},
+		},
+		{
 			name: "list_returns_all_ports_with_one_query_per_call",
 			run: func(t *testing.T) {
 				// Three sandboxes: one with two ports, one with one port, one

--- a/pkg/api/daytona/handlers.go
+++ b/pkg/api/daytona/handlers.go
@@ -145,13 +145,14 @@ func (h *handlers) clusterPlacementRequest(ctx context.Context, req createSandbo
 		}
 	}
 	out := models.CreateSandboxRequest{
-		Image:           "daytona-create",
-		CPU:             float64(int32Value(req.Cpu, 0)),
-		MemoryMB:        int(int32Value(req.Memory, 0)) * 1024,
-		DiskGB:          int(int32Value(req.Disk, 0)),
-		Name:            trimmedString(req.Name),
-		Tags:            cloneStringMap(mapValue(req.Labels)),
-		NetworkBlockAll: boolValue(req.NetworkBlockAll),
+		Image:              "daytona-create",
+		CPU:                float64(int32Value(req.Cpu, 0)),
+		MemoryMB:           int(int32Value(req.Memory, 0)) * 1024,
+		DiskGB:             int(int32Value(req.Disk, 0)),
+		Name:               trimmedString(req.Name),
+		Tags:               cloneStringMap(mapValue(req.Labels)),
+		NetworkBlockAll:    boolValue(req.NetworkBlockAll),
+		AllowPublicTraffic: daytonaPublicFlag(req.Public),
 	}
 	out.Image = image
 	if !distribution.IsZero() {
@@ -872,7 +873,7 @@ func (h *handlers) toSandboxResponse(r *http.Request, sandbox *models.Sandbox, m
 		User:                user,
 		Env:                 cloneStringMap(sandbox.Env),
 		Labels:              labels,
-		Public:              true,
+		Public:              sandbox.AllowPublicTraffic == nil || *sandbox.AllowPublicTraffic,
 		NetworkBlockAll:     sandbox.NetworkBlockAll,
 		NetworkAllowList:    cloneStringPtr(meta.NetworkAllowList),
 		Target:              meta.Target,
@@ -1018,6 +1019,7 @@ func (h *handlers) translateCreateSandboxRequest(ctx context.Context, req create
 		wasmReq.NetworkBlockAll = boolValue(req.NetworkBlockAll)
 		wasmReq.Name = trimmedString(req.Name)
 		wasmReq.Tags = cloneStringMap(mapValue(req.Labels))
+		wasmReq.AllowPublicTraffic = daytonaPublicFlag(req.Public)
 		if !lifecycle.IsZero() {
 			wasmReq.Lifecycle = &lifecycle
 		}
@@ -1030,21 +1032,33 @@ func (h *handlers) translateCreateSandboxRequest(ctx context.Context, req create
 	}
 
 	serviceReq := models.CreateSandboxRequest{
-		Image:           image,
-		CPU:             float64(int32Value(req.Cpu, 0)),
-		MemoryMB:        int(int32Value(req.Memory, 0)) * 1024,
-		DiskGB:          int(int32Value(req.Disk, 0)),
-		Env:             cloneStringMap(mapValue(req.Env)),
-		OSUser:          trimmedString(req.User),
-		NetworkBlockAll: boolValue(req.NetworkBlockAll),
-		Name:            trimmedString(req.Name),
-		Tags:            cloneStringMap(mapValue(req.Labels)),
-		PlatformVolumes: platformVolumes,
+		Image:              image,
+		CPU:                float64(int32Value(req.Cpu, 0)),
+		MemoryMB:           int(int32Value(req.Memory, 0)) * 1024,
+		DiskGB:             int(int32Value(req.Disk, 0)),
+		Env:                cloneStringMap(mapValue(req.Env)),
+		OSUser:             trimmedString(req.User),
+		NetworkBlockAll:    boolValue(req.NetworkBlockAll),
+		Name:               trimmedString(req.Name),
+		Tags:               cloneStringMap(mapValue(req.Labels)),
+		PlatformVolumes:    platformVolumes,
+		AllowPublicTraffic: daytonaPublicFlag(req.Public),
 	}
 	if !lifecycle.IsZero() {
 		serviceReq.Lifecycle = &lifecycle
 	}
 	return serviceReq, freshlyBuilt, nil
+}
+
+// daytonaPublicFlag maps the Daytona create "public" field onto the core
+// allow_public_traffic flag. Daytona's platform default is public preview
+// links, so an omitted field opts in; an explicit public=false maps to a
+// fully private sandbox — stricter than Daytona (which still serves
+// token-authenticated previews), because AerolVM has no auth-gated public
+// route.
+func daytonaPublicFlag(public *bool) *bool {
+	v := public == nil || *public
+	return &v
 }
 
 // resolveDaytonaVolumes turns the Daytona attach-at-create shape

--- a/pkg/api/daytona/public_flag_test.go
+++ b/pkg/api/daytona/public_flag_test.go
@@ -1,0 +1,32 @@
+package daytona
+
+import "testing"
+
+// The Daytona platform default is public preview links, so an omitted
+// "public" field must opt in to allow_public_traffic even though the core
+// create default is private; an explicit false maps to a fully private
+// sandbox.
+func TestDaytonaPublicFlag(t *testing.T) {
+	truth := true
+	falsity := false
+	cases := []struct {
+		name string
+		in   *bool
+		want bool
+	}{
+		{name: "omitted defaults to public", in: nil, want: true},
+		{name: "explicit true stays public", in: &truth, want: true},
+		{name: "explicit false goes private", in: &falsity, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := daytonaPublicFlag(tc.in)
+			if got == nil {
+				t.Fatal("daytonaPublicFlag returned nil; the service must receive an explicit value")
+			}
+			if *got != tc.want {
+				t.Fatalf("daytonaPublicFlag(%v) = %v, want %v", tc.in, *got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/api/e2b/handlers.go
+++ b/pkg/api/e2b/handlers.go
@@ -580,6 +580,13 @@ func (h *handlers) translateCreateSandboxRequest(ctx context.Context, req create
 		allowPublicTraffic = cloneBoolPtr(req.Network.AllowPublicTraffic)
 		maskRequestHost = strings.TrimSpace(req.Network.MaskRequestHost)
 	}
+	// E2B sandboxes are publicly addressable by contract (getHost / per-port
+	// URLs), so the facade opts in explicitly when the client didn't say
+	// otherwise — the core create default is private (no public route).
+	if allowPublicTraffic == nil {
+		public := true
+		allowPublicTraffic = &public
+	}
 
 	secure := true
 	if req.Secure != nil {

--- a/pkg/api/e2b/public_traffic_default_test.go
+++ b/pkg/api/e2b/public_traffic_default_test.go
@@ -1,0 +1,62 @@
+package e2b
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// E2B sandboxes are publicly addressable by contract (getHost / per-port
+// URLs), so the facade must opt in to allow_public_traffic when the client
+// says nothing — the core create default is private — while still honoring an
+// explicit network.allowPublicTraffic=false.
+func TestE2BCreatePublicTrafficDefaults(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name       string
+		body       string
+		wantPublic bool
+	}{
+		{
+			name:       "omitted network opts in to public",
+			body:       `{"templateID":"base","timeout":120}`,
+			wantPublic: true,
+		},
+		{
+			name:       "explicit opt-out stays private",
+			body:       `{"templateID":"base","timeout":120,"network":{"allowPublicTraffic":false}}`,
+			wantPublic: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, st, handler := newE2BHandlerTestEnv(t)
+
+			req := httptest.NewRequest(http.MethodPost, "/e2b/sandboxes", strings.NewReader(tc.body))
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			if rr.Code != http.StatusCreated {
+				t.Fatalf("status = %d, want 201; body=%s", rr.Code, rr.Body.String())
+			}
+			var created sandboxResponse
+			if err := json.NewDecoder(rr.Body).Decode(&created); err != nil {
+				t.Fatalf("decode create: %v", err)
+			}
+
+			sb, err := st.Get(ctx, created.SandboxID)
+			if err != nil {
+				t.Fatalf("get sandbox: %v", err)
+			}
+			if sb.AllowPublicTraffic == nil {
+				t.Fatal("stored AllowPublicTraffic is nil; the facade must send an explicit value")
+			}
+			if *sb.AllowPublicTraffic != tc.wantPublic {
+				t.Fatalf("stored AllowPublicTraffic = %v, want %v", *sb.AllowPublicTraffic, tc.wantPublic)
+			}
+		})
+	}
+}

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -572,11 +572,12 @@ type CreateSandboxRequest struct {
 	// NetworkBlockAll, not a denyOut of 0.0.0.0/0.
 	NetworkDenyOut []string `json:"network_deny_out,omitempty"`
 	// AllowPublicTraffic controls whether the sandbox may be exposed to the
-	// public internet. Nil (default) and true allow public exposure; false
-	// makes expose_port fail — the sandbox stays reachable only via the
-	// platform's own paths (toolbox exec/file proxy, SSH gateway), which do
-	// not route through the public ingress. There is no auth-gated public
-	// route concept, so "no public traffic" is enforced by refusing exposure.
+	// public internet. On create, omitted (nil) defaults to private — no
+	// <id>.<domain> ingress route, empty public_url, and expose_port fails.
+	// Pass an explicit true to opt in to public exposure. False always refuses
+	// exposure. The sandbox stays reachable via the platform's own paths
+	// (toolbox exec/file proxy, SSH gateway), which do not route through the
+	// public ingress.
 	AllowPublicTraffic *bool `json:"allow_public_traffic,omitempty"`
 	// MaskRequestHost, when non-empty, rewrites the upstream Host header on
 	// ingress to exposed HTTP ports to this value. Dev servers and frameworks

--- a/sdk/java/src/main/java/ai/aerol/microvm/model/CreateOptions.java
+++ b/sdk/java/src/main/java/ai/aerol/microvm/model/CreateOptions.java
@@ -23,7 +23,7 @@ public class CreateOptions {
     /** Egress blocklist of CIDRs; sandbox may reach anything except these. Mutually exclusive with networkAllowOut. */
     @JsonProperty("network_deny_out")
     public List<String> networkDenyOut;
-    /** Whether the sandbox may be exposed publicly. Null/true allow it; false makes exposePort fail. */
+    /** Whether the sandbox may be exposed publicly. Omitted defaults to private; true opts in; false permanently refuses exposePort. */
     @JsonProperty("allow_public_traffic")
     public Boolean allowPublicTraffic;
     /** Rewrite the upstream Host header on ingress to exposed HTTP ports to this value

--- a/sdk/java/src/test/java/ai/aerol/microvm/MicroVMClientTest.java
+++ b/sdk/java/src/test/java/ai/aerol/microvm/MicroVMClientTest.java
@@ -365,6 +365,38 @@ class MicroVMClientTest {
     }
 
     @Test
+    void createOmitsAllowPublicTrafficWhenUnset() throws Exception {
+        AtomicReference<Map<String, Object>> requestBody = new AtomicReference<>();
+        HttpServer server = startServer(exchange -> {
+            requestBody.set(castMap(JsonSupport.read(exchange.getRequestBody().readAllBytes(), Map.class)));
+            writeJson(exchange, 200, mapOf(
+                "id", "sb-private-default",
+                "image", "ubuntu:22.04",
+                "status", "started",
+                "public_url", "",
+                "cpu", 1,
+                "memory_mb", 1024,
+                "disk_gb", 10,
+                "os_user", "root",
+                "network_block_all", false,
+                "toolbox_enabled", true,
+                "exposed_ports", List.of(),
+                "created_at", "2026-05-24T10:00:00Z",
+                "updated_at", "2026-05-24T10:00:00Z",
+                "last_active_at", "2026-05-24T10:00:00Z"
+            ));
+        });
+
+        try {
+            MicroVMClient client = clientFor(server);
+            client.create(new CreateOptions().setImage("ubuntu:22.04"));
+            assertNull(requestBody.get().get("allow_public_traffic"));
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
     void createRoundTripsServerlessLifecycleFlag() throws Exception {
         AtomicReference<Map<String, Object>> requestBody = new AtomicReference<>();
         HttpServer server = startServer(exchange -> {

--- a/sdk/python/microvm/types.py
+++ b/sdk/python/microvm/types.py
@@ -157,8 +157,8 @@ class CreateOptions(TypedDict, total=False):
     # mutually exclusive; a full block is networkBlockAll, not a 0.0.0.0/0 deny.
     networkAllowOut: List[str]
     networkDenyOut: List[str]
-    # Whether the sandbox may be exposed publicly. Defaults to True; False makes
-    # expose_port fail (reachable only via the toolbox proxy and SSH gateway).
+    # Whether the sandbox may be exposed publicly. Omitted defaults to private
+    # (no public URL, expose_port fails). True opts in; False permanently refuses.
     allowPublicTraffic: bool
     # Rewrite the upstream Host header on ingress to exposed HTTP ports to this
     # value so frameworks that validate Host (Vite, Django ALLOWED_HOSTS,

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -341,6 +341,12 @@ class ClientTests(unittest.TestCase):
         _, _, payload = client.calls[0]
         self.assertEqual(payload["allow_public_traffic"], False)
 
+    def test_create_omits_allow_public_traffic_when_unset(self):
+        client = RecordingMicroVM()
+        client.create({"image": "ubuntu:22.04"})
+        _, _, payload = client.calls[0]
+        self.assertNotIn("allow_public_traffic", payload)
+
     def test_create_serializes_mask_request_host(self):
         client = RecordingMicroVM()
         client.create({"image": "ubuntu:22.04", "maskRequestHost": "localhost"})

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -1995,6 +1995,13 @@ mod tests {
     }
 
     #[test]
+    fn create_options_omits_allow_public_traffic_when_unset() {
+        let opts = minimal_create_options();
+        let value = serde_json::to_value(&opts).expect("serialize create options");
+        assert!(value.get("allow_public_traffic").is_none());
+    }
+
+    #[test]
     fn create_options_serializes_selective_egress() {
         let mut opts = minimal_create_options();
         opts.network_allow_out = Some(vec!["1.1.1.0/24".to_string(), "8.8.8.8/32".to_string()]);

--- a/sdk/typescript/src/examples/browserIsolation.ts
+++ b/sdk/typescript/src/examples/browserIsolation.ts
@@ -36,6 +36,7 @@ async function main(): Promise<void> {
 		memoryMB: options.memoryMB,
 		diskGB: options.diskGB,
 		osUser: "root",
+		allowPublicTraffic: true,
 		containerCommand: keepAliveCommand,
 		runtime: options.runtime,
 	});

--- a/sdk/typescript/src/examples/createFirecrackerSandbox.ts
+++ b/sdk/typescript/src/examples/createFirecrackerSandbox.ts
@@ -33,6 +33,7 @@ async function main() {
     runtime: "firecracker",
     cpu: 2,
     memoryMB: 1024,
+    allowPublicTraffic: true,
   });
 
   console.log(`Sandbox created successfully!`);

--- a/sdk/typescript/src/examples/createSandbox.ts
+++ b/sdk/typescript/src/examples/createSandbox.ts
@@ -76,6 +76,7 @@ async function main(): Promise<void> {
 		memoryMB: options.memoryMB,
 		diskGB: options.diskGB,
 		env: options.env,
+		allowPublicTraffic: true,
 		containerCommand: keepAliveCommand,
 	});
 

--- a/sdk/typescript/src/internal/client.test.ts
+++ b/sdk/typescript/src/internal/client.test.ts
@@ -89,6 +89,22 @@ test("internal client create serializes platform volumes", async () => {
   ]);
 });
 
+test("internal client create omits allowPublicTraffic when unset", async () => {
+  let seenRequest: Request | undefined;
+  const client = new APIClient({
+    baseURL: "https://api.example.com",
+    patToken: "pat-token",
+    fetch: async (input, init) => {
+      seenRequest = new Request(input, init);
+      return jsonResponse(apiSandbox("sb-default-private"));
+    },
+  });
+  await client.create({ image: "ubuntu:22.04" });
+  assert.ok(seenRequest);
+  const body = (await seenRequest.json()) as Record<string, unknown>;
+  assert.equal(body.allow_public_traffic, undefined);
+});
+
 test("internal client create serializes allowPublicTraffic=false", async () => {
   let seenRequest: Request | undefined;
   const client = new APIClient({

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -189,9 +189,9 @@ export interface CreateOptions {
    */
   networkDenyOut?: string[];
   /**
-   * Whether the sandbox may be exposed to the public internet. Defaults to
-   * true; set `false` to make `exposePort` fail — the sandbox stays reachable
-   * only via the toolbox proxy and SSH gateway, not a public URL.
+   * Whether the sandbox may be exposed to the public internet. Omitted defaults
+   * to private (no public URL, `exposePort` fails). Set `true` to opt in to
+   * public exposure; `false` permanently refuses it for this sandbox.
    */
   allowPublicTraffic?: boolean;
   /**


### PR DESCRIPTION
## Plain-English summary (start here)

**Default:** New sandboxes are **private** — no public internet address at boot, faster create (no Caddy calls).

**Two ways to go public:**

| When | How | Result |
|------|-----|--------|
| **After create** (usual path) | Call `exposePort` | First call **opts the sandbox in**: flips flag, installs `<id>.<domain>` route, sets `public_url`, then exposes the port |
| **At create** (boot-time URL) | `allowPublicTraffic: true` | Public URL live from boot, before any port is exposed |

**Still private-only paths:** exec, files, sessions, SSH — unchanged.

**Custom domains:** attaching a domain to a still-private sandbox still **fails** — a domain alone cannot silently publish a sandbox you kept private. Expose a port (or create with the flag) first.

**One-way:** once opted in via `exposePort`, the sandbox stays public even if every port is later unexposed. There is no flip-back-to-private API.

**Compat:** Daytona/E2B facades still default to public when their clients omit the field.

---

## Summary

- **Private-by-default create:** omit `allow_public_traffic` → explicit `false`, empty `public_url`, **zero Caddy calls** on boot (docker / firecracker / wasm).
- **`exposePort` is the post-create opt-in:** first call on a private sandbox runs `enableSandboxPublicTraffic` — root route + atomic `SetAllowPublicTraffic(flag, public_url)` + FSM spec patch — then installs the port route.
- **Create-time opt-in unchanged:** `allow_public_traffic: true` still installs the root route at boot.
- **Rollback on flip failure:** Caddy install fails → stays private; store write fails → route deleted, stays private. Port-route failure after a successful flip is **not** rolled back (retry is idempotent).
- **Legacy / failover:** stored `nil` still reads as public; `RecreateSandbox` pins nil replicated specs to `true`.
- **Facades:** Daytona `public` + E2B `network.allowPublicTraffic` opt in when omitted.
- **Tests & docs:** `enableSandboxPublicTraffic` regression tests, `store.SetAllowPublicTraffic`, UC-97 (exec while private → expose flips), SDK/docs updated (38 files).

---

## Sandbox boot impact

**Yes — improvement on the default path; added work only on first `exposePort` for private sandboxes.**

| Change | When | Impact | Bounded? |
|---|---|---|---|
| **Removed** `syncSandboxPublicRoute` | Private create (flag omitted/false) | **Saves** ~1–2 Caddy admin HTTP round-trips | Yes — zero Caddy on boot |
| **Added** `enableSandboxPublicTraffic` | First `exposePort` on a private sandbox | ~1–2 Caddy round-trips (root route) + one store `UPDATE` | Yes — once per sandbox lifetime |
| **Unchanged** public create (`allow_public_traffic=true`) | Explicit opt-in at create | Same Caddy work as before | Yes |
| **Unchanged** `exposePort` on already-public sandbox | Re-expose / second port | No flip overhead (`enableSandboxPublicTraffic` no-ops) | Yes |

**Net:** default create is faster; public exposure cost moves to the first `exposePort` (or create-time flag).

---

## Idempotency

**`POST /v1/sandboxes`**
- Retry/concurrent: unchanged. Private stays private until first successful expose.

**`expose_port`**
- **Private sandbox, first expose:** `enableSandboxPublicTraffic` is safe under concurrent duplicates — route upsert + absolute store SET.
- **Already public:** flip is a no-op; same-port re-expose returns existing URL (unchanged).
- **Validation failure** (bad port, protocol conflict, etc.): runs **before** the flip — sandbox stays private.

**`add_custom_domain`**
- Still-private sandbox: `ErrPublicTrafficDisabled` immediately (no mutation).

**Failover recreate**
- Legacy nil spec → pinned `true` before create.

---

## Failure-path consistency

**`enableSandboxPublicTraffic` (Caddy-first):**
1. Install root route → on failure: revert in-memory flag, return error (stays private).
2. `SetAllowPublicTraffic(id, true, publicURL)` → on failure: `deleteSandboxPublicRoutes` + revert flag (stays private).
3. Port route install after flip → on failure: flip **not** rolled back; retry completes exposure (documented stance, same family as `EnsureLayer4Ready`).

**Crash between route install and store write:** reconcile `cleanupPublicTrafficDisabledIngressState` removes orphan route for still-private row.

**Private create:** no caddy+store partial-failure window on boot.

N/A — no changes to L4 host-port pool or new multi-step sequences beyond the flip above.

---

## L4 / host-port-pool changes

N/A — `TryReserveHostPort`, `host_port` index, `allocateHostPort`, `EnsureLayer4`, `EnsureLayer4Ready`, and `l4Ready` latch were not touched.

---

## Cluster correctness

N/A — no placement, FSM, or forwarding changes.

- Flip replicates `allow_public_traffic: true` into the FSM spec via `replicateSpecPatch` so failover recreate preserves public reachability.
- `shouldArmWake` still blocks serverless wake on private sandboxes until opted in.

---

## Test plan

- [x] `make test` — all packages green
- [x] `TestCreateSandboxPrivateByDefault` — zero Caddy hits on private create
- [x] `TestExposePortOptsPrivateSandboxIn` — flip installs root + port routes, persists flag + URL, re-expose idempotent
- [x] `TestExposePortFlipCaddyFailureStaysPrivate` — Caddy failure → still private
- [x] `TestEnableSandboxPublicTrafficStoreFailureRollsBack` — store failure → route removed
- [x] `TestExposePortFlipsPublicTrafficDisabledSandbox` — invalid port doesn't flip; valid expose does
- [x] `store.SetAllowPublicTraffic` round-trip + not-found tests
- [x] Daytona/E2B facade default tests
- [x] SDK omit-field serialization tests (all five)
- [x] `go test -tags=integration -c ./integration-tests/suite/...`
- [ ] Live: `make integration-single` — **UC-97** (private create → exec → expose flips) + UC-29–36

---

## Key files

| Area | Files |
|---|---|
| Flip logic | `internal/service/public_traffic.go` (`enableSandboxPublicTraffic`) |
| Expose hook | `internal/service/service.go` (`exposePort`) |
| Atomic persist | `internal/store/store.go` (`SetAllowPublicTraffic`) |
| Regression tests | `public_traffic_default_test.go`, `bugfix_test.go`, `store_test.go` |
| Integration | `integration-tests/suite/networking_test.go` (UC-97) |
| Docs | `network-isolation.mdx`, `preview.mdx`, `serverless.mdx`, `sandboxes.mdx` |

---

## SDK usage (no API changes)

```ts
// Default: private at boot, opt in when you need a public port
const sandbox = await client.create({ image: 'ubuntu:22.04' })
await sandbox.exec({ command: 'echo hi' })        // works while private
const { url } = await sandbox.exposePort(8080)    // opts in + exposes

// Boot-time public URL (serverless wake before any expose, etc.)
const sandbox = await client.create({
  image: 'ubuntu:22.04',
  allowPublicTraffic: true,
})
```

SDKs omit `allow_public_traffic` when unset — correct for private-by-default. No new SDK methods required.