### PR TITLE
feat(docker): warm pool for sub-100ms creates (park + adopt)

### DIFF
--- a/cmd/toolboxd/main.go
+++ b/cmd/toolboxd/main.go
@@ -62,10 +62,28 @@ type server struct {
 	mu           sync.RWMutex
 	allowedPorts map[int]struct{}
 
+	parkedMode  bool
+	adopted     bool
+	deferredCmd []string
+
 	sessions *sessions.Manager
 	daytona  *daytonaCompat
 	envd     *envdCompat
 	cloneGen *clonegen.Generation
+}
+
+func (s *server) servingRequests() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return !s.parkedMode || s.adopted
+}
+
+func (s *server) adoptIdentity(sandboxID, token string) {
+	s.mu.Lock()
+	s.sandboxID = strings.TrimSpace(sandboxID)
+	s.authToken = strings.TrimSpace(token)
+	s.adopted = true
+	s.mu.Unlock()
 }
 
 func (s *server) setAllowedPorts(ports []int) {
@@ -111,12 +129,14 @@ func main() {
 		authToken:    strings.TrimSpace(os.Getenv("SB_TOOLBOX_TOKEN")),
 		port:         envInt("SB_TOOLBOX_PORT", 2280),
 		allowedPorts: map[int]struct{}{},
+		parkedMode:   strings.TrimSpace(os.Getenv("SB_POOL_PARKED")) == "1",
 		daytona:      newDaytonaCompat(),
 		envd:         newEnvdCompat(),
 		cloneGen:     clonegen.New(envString("SB_CLONE_GEN_PATH", clonegen.DefaultPath), logger),
 	}
 	readySocket := strings.TrimSpace(os.Getenv("SB_READY_SOCKET"))
 	readyNonce := strings.TrimSpace(os.Getenv("SB_READY_NONCE"))
+	bootstrapToken := srv.authToken
 	// Evict the token from the process env table so child processes spawned
 	// for the user command and /exec endpoints don't inherit it via os.Environ().
 	os.Unsetenv("SB_TOOLBOX_TOKEN")
@@ -138,7 +158,11 @@ func main() {
 	}
 
 	if len(os.Args) > 1 {
-		startUserCommandFn(logger, os.Args[1:])
+		if srv.parkedMode {
+			srv.deferredCmd = append([]string{}, os.Args[1:]...)
+		} else {
+			startUserCommandFn(logger, os.Args[1:])
+		}
 	}
 
 	addr := fmt.Sprintf(":%d", srv.port)
@@ -155,7 +179,11 @@ func main() {
 
 	// Push readiness only after the HTTP listener is accepting — same contract
 	// as /health 200 when create returns started.
-	announceReady(logger, srv.sandboxID, srv.authToken, readyNonce, readySocket)
+	if srv.parkedMode {
+		go runParkedReadyHandshake(logger, srv, readySocket, bootstrapToken, readyNonce)
+	} else {
+		announceReady(logger, srv.sandboxID, srv.authToken, readyNonce, readySocket)
+	}
 
 	go forwardShutdownSignalsFn(logger, httpServer)
 
@@ -288,6 +316,11 @@ func startReaper(logger *slog.Logger) {
 func (s *server) routes() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		r = s.stripSandboxPrefix(r)
+
+		if !s.servingRequests() && r.URL.Path != "/health" {
+			writeError(w, http.StatusServiceUnavailable, "sandbox not adopted")
+			return
+		}
 
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/":

--- a/cmd/toolboxd/readyclient_park_linux.go
+++ b/cmd/toolboxd/readyclient_park_linux.go
@@ -1,0 +1,68 @@
+//go:build linux
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"log/slog"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/version"
+	"github.com/aerol-ai/microvm/pkg/readyproto"
+)
+
+func runParkedReadyHandshake(logger *slog.Logger, srv *server, socketPath, bootstrapToken, parkNonce string) {
+	socketPath = strings.TrimSpace(socketPath)
+	if socketPath == "" || srv == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), readyDialTimeout)
+	defer cancel()
+
+	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+	if err != nil {
+		logger.Warn("park ready socket dial failed", "error", err)
+		return
+	}
+	defer conn.Close()
+
+	if err := readyproto.EncodeParked(conn, readyproto.ParkedSignal{
+		Event:        readyproto.EventParked,
+		Token:        bootstrapToken,
+		Nonce:        parkNonce,
+		AgentVersion: version.Version,
+	}); err != nil {
+		logger.Warn("park ready socket write failed", "error", err)
+		return
+	}
+
+	_ = conn.SetDeadline(time.Now().Add(readyDialTimeout))
+	frame, err := readyproto.DecodeAdopt(bufio.NewReader(conn))
+	if err != nil {
+		logger.Warn("park adopt frame read failed", "error", err)
+		return
+	}
+
+	srv.adoptIdentity(frame.SandboxID, frame.Token)
+
+	if err := readyproto.Encode(conn, readyproto.ReadySignal{
+		Event:        readyproto.EventReady,
+		SandboxID:    frame.SandboxID,
+		Token:        frame.Token,
+		Nonce:        frame.Nonce,
+		AgentVersion: version.Version,
+	}); err != nil {
+		logger.Warn("park adopt ack failed", "error", err)
+		return
+	}
+
+	srv.mu.RLock()
+	deferred := append([]string(nil), srv.deferredCmd...)
+	srv.mu.RUnlock()
+	if len(deferred) > 0 {
+		startUserCommandFn(logger, deferred)
+	}
+}

--- a/cmd/toolboxd/readyclient_park_linux.go
+++ b/cmd/toolboxd/readyclient_park_linux.go
@@ -5,6 +5,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"log/slog"
 	"net"
 	"strings"
@@ -29,21 +30,37 @@ func runParkedReadyHandshake(logger *slog.Logger, srv *server, socketPath, boots
 	}
 	defer conn.Close()
 
+	if err := parkedReadyOnConn(logger, srv, conn, bootstrapToken, parkNonce); err != nil {
+		logger.Warn("park ready handshake failed", "error", err)
+	}
+}
+
+// parkedReadyOnConn runs the guest-side parked→adopt→ready exchange on an
+// already-connected unix socket. Extracted for unit tests (net.Pipe) so we
+// don't depend on Accept/dial scheduling on loaded CI hosts.
+func parkedReadyOnConn(logger *slog.Logger, srv *server, conn net.Conn, bootstrapToken, parkNonce string) error {
+	if logger == nil || srv == nil || conn == nil {
+		return fmt.Errorf("park handshake: missing logger, server, or connection")
+	}
+	bootstrapToken = strings.TrimSpace(bootstrapToken)
+	parkNonce = strings.TrimSpace(parkNonce)
+	if bootstrapToken == "" || parkNonce == "" {
+		return fmt.Errorf("park handshake: bootstrap token and nonce are required")
+	}
+
 	if err := readyproto.EncodeParked(conn, readyproto.ParkedSignal{
 		Event:        readyproto.EventParked,
 		Token:        bootstrapToken,
 		Nonce:        parkNonce,
 		AgentVersion: version.Version,
 	}); err != nil {
-		logger.Warn("park ready socket write failed", "error", err)
-		return
+		return fmt.Errorf("parked write: %w", err)
 	}
 
 	_ = conn.SetDeadline(time.Now().Add(readyDialTimeout))
 	frame, err := readyproto.DecodeAdopt(bufio.NewReader(conn))
 	if err != nil {
-		logger.Warn("park adopt frame read failed", "error", err)
-		return
+		return fmt.Errorf("adopt read: %w", err)
 	}
 
 	srv.adoptIdentity(frame.SandboxID, frame.Token)
@@ -55,8 +72,7 @@ func runParkedReadyHandshake(logger *slog.Logger, srv *server, socketPath, boots
 		Nonce:        frame.Nonce,
 		AgentVersion: version.Version,
 	}); err != nil {
-		logger.Warn("park adopt ack failed", "error", err)
-		return
+		return fmt.Errorf("ready ack: %w", err)
 	}
 
 	srv.mu.RLock()
@@ -65,4 +81,5 @@ func runParkedReadyHandshake(logger *slog.Logger, srv *server, socketPath, boots
 	if len(deferred) > 0 {
 		startUserCommandFn(logger, deferred)
 	}
+	return nil
 }

--- a/cmd/toolboxd/readyclient_park_linux.go
+++ b/cmd/toolboxd/readyclient_park_linux.go
@@ -30,14 +30,16 @@ func runParkedReadyHandshake(logger *slog.Logger, srv *server, socketPath, boots
 	}
 	defer conn.Close()
 
+	// Bound the full handshake on the real socket; tests call parkedReadyOnConn
+	// directly without a deadline so a paired reader can run on loaded CI.
+	_ = conn.SetDeadline(time.Now().Add(readyDialTimeout))
 	if err := parkedReadyOnConn(logger, srv, conn, bootstrapToken, parkNonce); err != nil {
 		logger.Warn("park ready handshake failed", "error", err)
 	}
 }
 
 // parkedReadyOnConn runs the guest-side parked→adopt→ready exchange on an
-// already-connected unix socket. Extracted for unit tests (net.Pipe) so we
-// don't depend on Accept/dial scheduling on loaded CI hosts.
+// already-connected unix socket. The caller sets conn deadlines when needed.
 func parkedReadyOnConn(logger *slog.Logger, srv *server, conn net.Conn, bootstrapToken, parkNonce string) error {
 	if logger == nil || srv == nil || conn == nil {
 		return fmt.Errorf("park handshake: missing logger, server, or connection")
@@ -57,7 +59,6 @@ func parkedReadyOnConn(logger *slog.Logger, srv *server, conn net.Conn, bootstra
 		return fmt.Errorf("parked write: %w", err)
 	}
 
-	_ = conn.SetDeadline(time.Now().Add(readyDialTimeout))
 	frame, err := readyproto.DecodeAdopt(bufio.NewReader(conn))
 	if err != nil {
 		return fmt.Errorf("adopt read: %w", err)

--- a/cmd/toolboxd/readyclient_park_other.go
+++ b/cmd/toolboxd/readyclient_park_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package main
+
+import "log/slog"
+
+func runParkedReadyHandshake(_ *slog.Logger, _ *server, _, _, _ string) {}

--- a/cmd/toolboxd/readyclient_park_test.go
+++ b/cmd/toolboxd/readyclient_park_test.go
@@ -6,7 +6,6 @@ import (
 	"bufio"
 	"log/slog"
 	"net"
-	"sync"
 	"testing"
 	"time"
 
@@ -28,33 +27,38 @@ func TestParkedReadyOnConn(t *testing.T) {
 	}
 
 	guest, host := net.Pipe()
-	defer guest.Close()
-	defer host.Close()
+	t.Cleanup(func() { _ = guest.Close(); _ = host.Close() })
 
-	var wg sync.WaitGroup
-	wg.Add(1)
+	// Host (sandboxd) side runs first so it is blocked on read before the guest
+	// writes parked. No conn deadline in parkedReadyOnConn — the guest blocks
+	// until the host responds, which avoids 3s timeouts when CI is slow to
+	// schedule goroutines.
+	hostDone := make(chan error, 1)
 	go func() {
-		defer wg.Done()
 		br := bufio.NewReader(host)
 		if _, err := readyproto.DecodeParked(br); err != nil {
-			t.Errorf("decode parked: %v", err)
+			hostDone <- err
 			return
 		}
 		if err := readyproto.EncodeAdopt(host, readyproto.AdoptFrame{
 			Event: readyproto.EventAdopt, SandboxID: "sb-1", Token: "real-tok", Nonce: "adopt-n",
 		}); err != nil {
-			t.Errorf("encode adopt: %v", err)
+			hostDone <- err
 			return
 		}
 		if _, err := readyproto.Decode(br); err != nil {
-			t.Errorf("decode ready: %v", err)
+			hostDone <- err
+			return
 		}
+		hostDone <- nil
 	}()
 
 	if err := parkedReadyOnConn(slog.Default(), srv, guest, "boot-tok", "park-n"); err != nil {
-		t.Fatalf("parkedReadyOnConn: %v", err)
+		t.Fatalf("guest: %v", err)
 	}
-	wg.Wait()
+	if err := <-hostDone; err != nil {
+		t.Fatalf("host: %v", err)
+	}
 
 	if !srv.servingRequests() || srv.sandboxID != "sb-1" {
 		t.Fatalf("server not adopted: id=%q serving=%v", srv.sandboxID, srv.servingRequests())

--- a/cmd/toolboxd/readyclient_park_test.go
+++ b/cmd/toolboxd/readyclient_park_test.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"log/slog"
 	"net"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -13,8 +14,19 @@ import (
 	"github.com/aerol-ai/microvm/pkg/readyproto"
 )
 
+func shortToolboxTestDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "tb")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
 func TestRunParkedReadyHandshake(t *testing.T) {
-	ln, err := net.Listen("unix", t.TempDir()+"/host.sock")
+	sockPath := shortToolboxTestDir(t) + "/host.sock"
+	ln, err := net.Listen("unix", sockPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,25 +42,32 @@ func TestRunParkedReadyHandshake(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		conn, err := ln.Accept()
-		if err != nil {
-			return
-		}
-		defer conn.Close()
-		if _, err := readyproto.DecodeParked(bufio.NewReader(conn)); err != nil {
-			t.Errorf("parked: %v", err)
-			return
-		}
-		_ = readyproto.EncodeAdopt(conn, readyproto.AdoptFrame{
-			Event: readyproto.EventAdopt, SandboxID: "sb-1", Token: "real-tok", Nonce: "adopt-n",
-		})
-		sig, err := readyproto.Decode(bufio.NewReader(conn))
-		if err != nil || sig.SandboxID != "sb-1" {
-			t.Errorf("ready ack: %+v err=%v", sig, err)
-		}
+		runParkedReadyHandshake(slog.Default(), srv, sockPath, "boot-tok", "park-n")
 	}()
 
-	runParkedReadyHandshake(slog.Default(), srv, ln.Addr().String(), "boot-tok", "park-n")
+	conn, err := ln.Accept()
+	if err != nil {
+		t.Fatalf("accept: %v", err)
+	}
+	defer conn.Close()
+
+	br := bufio.NewReader(conn)
+	if _, err := readyproto.DecodeParked(br); err != nil {
+		t.Fatalf("decode parked: %v", err)
+	}
+	if err := readyproto.EncodeAdopt(conn, readyproto.AdoptFrame{
+		Event: readyproto.EventAdopt, SandboxID: "sb-1", Token: "real-tok", Nonce: "adopt-n",
+	}); err != nil {
+		t.Fatalf("encode adopt: %v", err)
+	}
+	sig, err := readyproto.Decode(br)
+	if err != nil {
+		t.Fatalf("decode ready ack: %v", err)
+	}
+	if sig.SandboxID != "sb-1" || sig.Token != "real-tok" || sig.Nonce != "adopt-n" {
+		t.Fatalf("ready ack = %+v", sig)
+	}
+
 	wg.Wait()
 
 	if !srv.servingRequests() || srv.sandboxID != "sb-1" {

--- a/cmd/toolboxd/readyclient_park_test.go
+++ b/cmd/toolboxd/readyclient_park_test.go
@@ -6,7 +6,6 @@ import (
 	"bufio"
 	"log/slog"
 	"net"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -14,23 +13,13 @@ import (
 	"github.com/aerol-ai/microvm/pkg/readyproto"
 )
 
-func shortToolboxTestDir(t *testing.T) string {
-	t.Helper()
-	dir, err := os.MkdirTemp("", "tb")
-	if err != nil {
-		t.Fatal(err)
+func TestParkedReadyOnConn(t *testing.T) {
+	oldStart := startUserCommandFn
+	var started []string
+	startUserCommandFn = func(_ *slog.Logger, args []string) {
+		started = append([]string(nil), args...)
 	}
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
-	return dir
-}
-
-func TestRunParkedReadyHandshake(t *testing.T) {
-	sockPath := shortToolboxTestDir(t) + "/host.sock"
-	ln, err := net.Listen("unix", sockPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer ln.Close()
+	t.Cleanup(func() { startUserCommandFn = oldStart })
 
 	srv := &server{
 		logger:      slog.Default(),
@@ -38,46 +27,52 @@ func TestRunParkedReadyHandshake(t *testing.T) {
 		parkedMode:  true,
 	}
 
+	guest, host := net.Pipe()
+	defer guest.Close()
+	defer host.Close()
+
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		runParkedReadyHandshake(slog.Default(), srv, sockPath, "boot-tok", "park-n")
+		br := bufio.NewReader(host)
+		if _, err := readyproto.DecodeParked(br); err != nil {
+			t.Errorf("decode parked: %v", err)
+			return
+		}
+		if err := readyproto.EncodeAdopt(host, readyproto.AdoptFrame{
+			Event: readyproto.EventAdopt, SandboxID: "sb-1", Token: "real-tok", Nonce: "adopt-n",
+		}); err != nil {
+			t.Errorf("encode adopt: %v", err)
+			return
+		}
+		if _, err := readyproto.Decode(br); err != nil {
+			t.Errorf("decode ready: %v", err)
+		}
 	}()
 
-	conn, err := ln.Accept()
-	if err != nil {
-		t.Fatalf("accept: %v", err)
+	if err := parkedReadyOnConn(slog.Default(), srv, guest, "boot-tok", "park-n"); err != nil {
+		t.Fatalf("parkedReadyOnConn: %v", err)
 	}
-	defer conn.Close()
-
-	br := bufio.NewReader(conn)
-	if _, err := readyproto.DecodeParked(br); err != nil {
-		t.Fatalf("decode parked: %v", err)
-	}
-	if err := readyproto.EncodeAdopt(conn, readyproto.AdoptFrame{
-		Event: readyproto.EventAdopt, SandboxID: "sb-1", Token: "real-tok", Nonce: "adopt-n",
-	}); err != nil {
-		t.Fatalf("encode adopt: %v", err)
-	}
-	sig, err := readyproto.Decode(br)
-	if err != nil {
-		t.Fatalf("decode ready ack: %v", err)
-	}
-	if sig.SandboxID != "sb-1" || sig.Token != "real-tok" || sig.Nonce != "adopt-n" {
-		t.Fatalf("ready ack = %+v", sig)
-	}
-
 	wg.Wait()
 
 	if !srv.servingRequests() || srv.sandboxID != "sb-1" {
 		t.Fatalf("server not adopted: id=%q serving=%v", srv.sandboxID, srv.servingRequests())
+	}
+	if len(started) != 2 || started[0] != "echo" || started[1] != "hi" {
+		t.Fatalf("deferred command = %v", started)
 	}
 }
 
 func TestRunParkedReadyHandshakeNoop(t *testing.T) {
 	runParkedReadyHandshake(slog.Default(), nil, "", "tok", "n")
 	runParkedReadyHandshake(slog.Default(), &server{}, "  ", "tok", "n")
+}
+
+func TestParkedReadyOnConnValidation(t *testing.T) {
+	if err := parkedReadyOnConn(nil, &server{}, nil, "t", "n"); err == nil {
+		t.Fatal("expected validation error")
+	}
 }
 
 func TestServingRequestsParkedMode(t *testing.T) {

--- a/cmd/toolboxd/readyclient_park_test.go
+++ b/cmd/toolboxd/readyclient_park_test.go
@@ -1,0 +1,81 @@
+//go:build linux
+
+package main
+
+import (
+	"bufio"
+	"log/slog"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/readyproto"
+)
+
+func TestRunParkedReadyHandshake(t *testing.T) {
+	ln, err := net.Listen("unix", t.TempDir()+"/host.sock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	srv := &server{
+		logger:      slog.Default(),
+		deferredCmd: []string{"echo", "hi"},
+		parkedMode:  true,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		if _, err := readyproto.DecodeParked(bufio.NewReader(conn)); err != nil {
+			t.Errorf("parked: %v", err)
+			return
+		}
+		_ = readyproto.EncodeAdopt(conn, readyproto.AdoptFrame{
+			Event: readyproto.EventAdopt, SandboxID: "sb-1", Token: "real-tok", Nonce: "adopt-n",
+		})
+		sig, err := readyproto.Decode(bufio.NewReader(conn))
+		if err != nil || sig.SandboxID != "sb-1" {
+			t.Errorf("ready ack: %+v err=%v", sig, err)
+		}
+	}()
+
+	runParkedReadyHandshake(slog.Default(), srv, ln.Addr().String(), "boot-tok", "park-n")
+	wg.Wait()
+
+	if !srv.servingRequests() || srv.sandboxID != "sb-1" {
+		t.Fatalf("server not adopted: id=%q serving=%v", srv.sandboxID, srv.servingRequests())
+	}
+}
+
+func TestRunParkedReadyHandshakeNoop(t *testing.T) {
+	runParkedReadyHandshake(slog.Default(), nil, "", "tok", "n")
+	runParkedReadyHandshake(slog.Default(), &server{}, "  ", "tok", "n")
+}
+
+func TestServingRequestsParkedMode(t *testing.T) {
+	srv := &server{parkedMode: true}
+	if srv.servingRequests() {
+		t.Fatal("pre-adopt should block")
+	}
+	srv.adoptIdentity("sb", "tok")
+	if !srv.servingRequests() {
+		t.Fatal("post-adopt should serve")
+	}
+}
+
+func TestDialParkReadyBounded(t *testing.T) {
+	start := time.Now()
+	runParkedReadyHandshake(slog.Default(), &server{parkedMode: true}, "/nonexistent.sock", "tok", "n")
+	if time.Since(start) > 4*time.Second {
+		t.Fatal("handshake exceeded bounded dial timeout")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -309,9 +309,23 @@ type Config struct {
 	DockerReadySocketEnabled    bool
 	DockerReadinessPollInitial  time.Duration
 	DockerReadinessPollMax      time.Duration
-	ReconcileInterval           time.Duration
-	NetstatsPollInterval        time.Duration
-	UploadMaxBytes              int64
+	// DockerPoolEnabled gates the warm Docker container pool (default off in v1).
+	// SB_DOCKER_POOL_ENABLED.
+	DockerPoolEnabled bool
+	// DockerPoolDepth is warm slots per image key. SB_DOCKER_POOL_DEPTH.
+	DockerPoolDepth int
+	// DockerPoolImages is a comma-separated list of pinned warm targets.
+	// SB_DOCKER_POOL_IMAGES.
+	DockerPoolImages []string
+	// DockerPoolMaxImages caps miss-driven warm targets (LRU). SB_DOCKER_POOL_MAX_IMAGES.
+	DockerPoolMaxImages int
+	// DockerPoolIdleTTL reaps idle self-warmed targets. SB_DOCKER_POOL_IDLE_TTL.
+	DockerPoolIdleTTL time.Duration
+	// DockerPoolRefillInterval tops up the warm pool. SB_DOCKER_POOL_REFILL_INTERVAL.
+	DockerPoolRefillInterval time.Duration
+	ReconcileInterval        time.Duration
+	NetstatsPollInterval     time.Duration
+	UploadMaxBytes           int64
 	// OTELMetricsEnabled starts a native OTLP/HTTP metric exporter that bridges
 	// the daemon's aerolvm_* expvars into OpenTelemetry observations. It is
 	// also enabled automatically when SB_OTEL_METRICS_ENDPOINT is set.
@@ -1270,6 +1284,12 @@ func Load() (Config, error) {
 		DockerReadySocketEnabled:   getEnvBool("SB_DOCKER_READY_SOCKET_ENABLED", true),
 		DockerReadinessPollInitial: getEnvDuration("SB_DOCKER_READINESS_POLL_INITIAL", 20*time.Millisecond),
 		DockerReadinessPollMax:     getEnvDuration("SB_DOCKER_READINESS_POLL_MAX", 300*time.Millisecond),
+		DockerPoolEnabled:          getEnvBool("SB_DOCKER_POOL_ENABLED", false),
+		DockerPoolDepth:            getEnvInt("SB_DOCKER_POOL_DEPTH", 2),
+		DockerPoolImages:           parseImageGCWhitelist(getEnv("SB_DOCKER_POOL_IMAGES", "")),
+		DockerPoolMaxImages:        getEnvInt("SB_DOCKER_POOL_MAX_IMAGES", 8),
+		DockerPoolIdleTTL:          getEnvDuration("SB_DOCKER_POOL_IDLE_TTL", 15*time.Minute),
+		DockerPoolRefillInterval:   getEnvDuration("SB_DOCKER_POOL_REFILL_INTERVAL", 5*time.Second),
 		ReconcileInterval:          getEnvDuration("SB_RECONCILE_INTERVAL", 5*time.Minute),
 		NetstatsPollInterval:       getEnvDuration("SB_NETSTATS_POLL_INTERVAL", 10*time.Second),
 		UploadMaxBytes:             int64(getEnvInt("SB_UPLOAD_MAX_BYTES", 256*1024*1024)),
@@ -1953,11 +1973,16 @@ func (c Config) CreateSandboxTimeout() time.Duration {
 	return time.Duration(c.CreateSandboxTimeoutSeconds) * time.Second
 }
 
-// DockerReadySocketEffective is true only on cluster deployments where sandboxd
-// controls the host layout. Self-install and single-node hosts keep the safer
-// health-poll path even when SB_DOCKER_READY_SOCKET_ENABLED defaults true.
+// DockerReadySocketEffective is true when push-based readiness is active.
+// Cluster hosts enable by default; single-node hosts enable when the docker
+// warm pool is on (adoption depends on the held socket).
 func (c Config) DockerReadySocketEffective() bool {
-	return c.DockerReadySocketEnabled && c.EnableCluster
+	return c.DockerReadySocketEnabled && (c.EnableCluster || c.DockerPoolEnabled)
+}
+
+// DockerPoolEffective is true when the warm pool should run.
+func (c Config) DockerPoolEffective() bool {
+	return c.DockerPoolEnabled && c.DockerReadySocketEnabled
 }
 
 // DockerReadySocketDir is the host directory for per-create readiness sockets.

--- a/internal/config/docker_ready_socket_test.go
+++ b/internal/config/docker_ready_socket_test.go
@@ -23,6 +23,35 @@ func TestDockerReadySocketEffectiveGating(t *testing.T) {
 		}
 	})
 
+	t.Run("pool_enabled_single_node", func(t *testing.T) {
+		t.Setenv("SB_ENABLE_CLUSTER", "false")
+		t.Setenv("SB_DOCKER_READY_SOCKET_ENABLED", "true")
+		t.Setenv("SB_DOCKER_POOL_ENABLED", "true")
+		cfg, err := Load()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !cfg.DockerReadySocketEffective() {
+			t.Fatal("expected push enabled when docker warm pool is on")
+		}
+		if !cfg.DockerPoolEffective() {
+			t.Fatal("expected pool effective")
+		}
+	})
+
+	t.Run("pool_disabled_without_ready_socket", func(t *testing.T) {
+		t.Setenv("SB_ENABLE_CLUSTER", "false")
+		t.Setenv("SB_DOCKER_READY_SOCKET_ENABLED", "false")
+		t.Setenv("SB_DOCKER_POOL_ENABLED", "true")
+		cfg, err := Load()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.DockerPoolEffective() {
+			t.Fatal("pool requires ready socket knob")
+		}
+	})
+
 	t.Run("cluster_enabled_by_default", func(t *testing.T) {
 		t.Setenv("SB_ENABLE_CLUSTER", "true")
 		t.Setenv("SB_CLUSTER_BOOTSTRAP", "true")

--- a/internal/pool/dockerpool/errors.go
+++ b/internal/pool/dockerpool/errors.go
@@ -1,0 +1,9 @@
+package dockerpool
+
+import "errors"
+
+// ErrNoSlot is returned when no warm slot is available for the key.
+var ErrNoSlot = errors.New("docker pool: no slot")
+
+// ErrStaleImage is returned when a parked slot's image ID no longer matches.
+var ErrStaleImage = errors.New("docker pool: stale image")

--- a/internal/pool/dockerpool/gate.go
+++ b/internal/pool/dockerpool/gate.go
@@ -1,0 +1,18 @@
+package dockerpool
+
+// ParkShape is the resource reservation shape for one parked slot.
+type ParkShape struct {
+	CPU       float64
+	MemoryMB  int
+	DiskGB    int
+	GPUs      int
+	GPUVendor string
+	Runtime   string
+}
+
+// RefillGate decides whether a new park is allowed and tracks reservations.
+type RefillGate interface {
+	CanPark(shape ParkShape) bool
+	ParkReservation(slotID string, shape ParkShape) error
+	ReleasePark(slotID string)
+}

--- a/internal/pool/dockerpool/key.go
+++ b/internal/pool/dockerpool/key.go
@@ -1,0 +1,43 @@
+package dockerpool
+
+import (
+	"strings"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// Key identifies a warm-pool target by resolved image identity + runtime.
+type Key struct {
+	Image                 string
+	ImageDigest           string
+	ImageRegistryRef      string
+	ImageDistributionMode string
+	Runtime               string
+}
+
+// KeyString returns a stable map key for the pool.
+func (k Key) KeyString() string {
+	return strings.Join([]string{
+		k.Image,
+		k.ImageDigest,
+		k.ImageRegistryRef,
+		k.ImageDistributionMode,
+		k.Runtime,
+	}, "\x00")
+}
+
+// KeyFromRequest builds a pool key from a create request and resolved runtime.
+func KeyFromRequest(req models.CreateSandboxRequest, runtime string) Key {
+	return Key{
+		Image:                 strings.TrimSpace(req.Image),
+		ImageDigest:           strings.TrimSpace(req.ImageDigest),
+		ImageRegistryRef:      strings.TrimSpace(req.ImageRegistryRef),
+		ImageDistributionMode: strings.TrimSpace(req.ImageDistributionMode),
+		Runtime:               strings.TrimSpace(runtime),
+	}
+}
+
+// ParkReservationID is the capacity admitter key for a parked slot.
+func ParkReservationID(slotID string) string {
+	return "park:" + strings.TrimSpace(slotID)
+}

--- a/internal/pool/dockerpool/metrics.go
+++ b/internal/pool/dockerpool/metrics.go
@@ -1,0 +1,86 @@
+package dockerpool
+
+import (
+	"expvar"
+	"sync/atomic"
+)
+
+var (
+	metricHit        = expvar.NewInt("docker_pool_hit")
+	metricMiss       = expvar.NewInt("docker_pool_miss")
+	metricRefill     = expvar.NewInt("docker_pool_refill")
+	metricOrphan     = expvar.NewInt("docker_pool_orphan")
+	metricParked     = expvar.NewInt("docker_pool_parked")
+	metricStaleImage = expvar.NewInt("docker_pool_stale_image")
+	metricSpawnFail  = expvar.NewInt("docker_pool_spawn_fail")
+	adoptMS          = expvar.NewFloat("docker_pool_adopt_ms")
+)
+
+// Metrics exposes pool counters for tests and expvar export.
+type Metrics struct {
+	hits       atomic.Int64
+	misses     atomic.Int64
+	refilled   atomic.Int64
+	orphans    atomic.Int64
+	staleImage atomic.Int64
+	spawnFail  atomic.Int64
+}
+
+// Snapshot is a point-in-time view of pool counters.
+type Snapshot struct {
+	Hits        int64
+	Misses      int64
+	Refilled    int64
+	Orphans     int64
+	StaleImages int64
+	SpawnFail   int64
+}
+
+func (m *Metrics) recordHit() {
+	m.hits.Add(1)
+	metricHit.Add(1)
+}
+
+func (m *Metrics) recordMiss() {
+	m.misses.Add(1)
+	metricMiss.Add(1)
+}
+
+func (m *Metrics) recordRefill() {
+	m.refilled.Add(1)
+	metricRefill.Add(1)
+}
+
+func (m *Metrics) recordOrphan() {
+	m.orphans.Add(1)
+	metricOrphan.Add(1)
+}
+
+func (m *Metrics) recordStaleImage() {
+	m.staleImage.Add(1)
+	metricStaleImage.Add(1)
+}
+
+func (m *Metrics) RecordSpawnFail() {
+	m.spawnFail.Add(1)
+	metricSpawnFail.Add(1)
+}
+
+func (m *Metrics) setParked(n int) { metricParked.Set(int64(n)) }
+
+func (m *Metrics) recordAdoptMS(ms float64) { adoptMS.Set(ms) }
+
+// Stats returns current counter values.
+func (m *Metrics) Stats() Snapshot {
+	if m == nil {
+		return Snapshot{}
+	}
+	return Snapshot{
+		Hits:        m.hits.Load(),
+		Misses:      m.misses.Load(),
+		Refilled:    m.refilled.Load(),
+		Orphans:     m.orphans.Load(),
+		StaleImages: m.staleImage.Load(),
+		SpawnFail:   m.spawnFail.Load(),
+	}
+}

--- a/internal/pool/dockerpool/metrics_test.go
+++ b/internal/pool/dockerpool/metrics_test.go
@@ -1,0 +1,25 @@
+package dockerpool
+
+import "testing"
+
+func TestMetricsStatsAndCounters(t *testing.T) {
+	m := &Metrics{}
+	m.recordHit()
+	m.recordMiss()
+	m.recordRefill()
+	m.recordOrphan()
+	m.recordStaleImage()
+	m.RecordSpawnFail()
+	m.setParked(3)
+	m.recordAdoptMS(12.5)
+
+	snap := m.Stats()
+	if snap.Hits != 1 || snap.Misses != 1 || snap.Refilled != 1 ||
+		snap.Orphans != 1 || snap.StaleImages != 1 || snap.SpawnFail != 1 {
+		t.Fatalf("snap = %+v", snap)
+	}
+	var nilMetrics *Metrics
+	if nilMetrics.Stats() != (Snapshot{}) {
+		t.Fatal("nil metrics should return empty snapshot")
+	}
+}

--- a/internal/pool/dockerpool/pool.go
+++ b/internal/pool/dockerpool/pool.go
@@ -1,0 +1,334 @@
+// Package dockerpool is the in-memory warm-container pool for Docker sandboxes.
+package dockerpool
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// Pool keeps pre-started Docker containers keyed by image identity + runtime.
+type Pool struct {
+	logger *slog.Logger
+
+	mu            sync.Mutex
+	defaultDepth  int
+	maxImages     int
+	idleTTL       time.Duration
+	pinned        map[string]struct{}
+	targets       map[string]Key // keyString -> Key
+	lastUsed      map[string]time.Time
+	ready         map[string][]*ParkedSlot
+	spawning      map[string]int
+	spawner       Spawner
+	onReleasePark func(slotID string)
+	metrics       *Metrics
+	refillKick    chan struct{}
+}
+
+// New constructs a warm pool.
+func New(logger *slog.Logger) *Pool {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Pool{
+		logger:     logger,
+		pinned:     make(map[string]struct{}),
+		targets:    make(map[string]Key),
+		lastUsed:   make(map[string]time.Time),
+		ready:      make(map[string][]*ParkedSlot),
+		spawning:   make(map[string]int),
+		metrics:    &Metrics{},
+		refillKick: make(chan struct{}, 1),
+	}
+}
+
+func (p *Pool) SetSpawner(s Spawner) { p.spawner = s }
+func (p *Pool) SetParkReleaser(fn func(slotID string)) {
+	p.onReleasePark = fn
+}
+
+func (p *Pool) releasePark(slotID string) {
+	if p.onReleasePark != nil && slotID != "" {
+		p.onReleasePark(slotID)
+	}
+}
+func (p *Pool) SetDefaultDepth(n int) {
+	p.mu.Lock()
+	p.defaultDepth = n
+	p.mu.Unlock()
+}
+func (p *Pool) SetMaxImages(n int) {
+	p.mu.Lock()
+	p.maxImages = n
+	p.mu.Unlock()
+}
+func (p *Pool) SetIdleTTL(d time.Duration) {
+	p.mu.Lock()
+	p.idleTTL = d
+	p.mu.Unlock()
+}
+func (p *Pool) Metrics() *Metrics { return p.metrics }
+
+// PinTarget registers a key warmed from daemon start (never idle-expires).
+func (p *Pool) PinTarget(key Key) {
+	ks := key.KeyString()
+	p.mu.Lock()
+	p.pinned[ks] = struct{}{}
+	p.targets[ks] = key
+	p.mu.Unlock()
+}
+
+// NoteTarget registers a miss-driven refill target with LRU bounds.
+func (p *Pool) NoteTarget(key Key) {
+	ks := key.KeyString()
+	if ks == "" || key.Image == "" {
+		return
+	}
+	p.mu.Lock()
+	if _, pinned := p.pinned[ks]; !pinned {
+		if p.maxImages > 0 && len(p.targets) >= p.maxImages {
+			p.evictLRUTargetLocked()
+		}
+	}
+	p.targets[ks] = key
+	p.lastUsed[ks] = time.Now().UTC()
+	p.mu.Unlock()
+}
+
+func (p *Pool) evictLRUTargetLocked() {
+	var oldest string
+	var oldestAt time.Time
+	for ks := range p.targets {
+		if _, pinned := p.pinned[ks]; pinned {
+			continue
+		}
+		used := p.lastUsed[ks]
+		if oldest == "" || used.Before(oldestAt) {
+			oldest = ks
+			oldestAt = used
+		}
+	}
+	if oldest == "" {
+		return
+	}
+	delete(p.targets, oldest)
+	delete(p.lastUsed, oldest)
+	slots := p.ready[oldest]
+	delete(p.ready, oldest)
+	delete(p.spawning, oldest)
+	spawner := p.spawner
+	p.mu.Unlock()
+	for _, slot := range slots {
+		if spawner != nil && slot != nil {
+			_ = spawner.DestroyParked(context.Background(), slot)
+		}
+	}
+	p.mu.Lock()
+}
+
+// Acquire removes one warm slot for key. imageID is re-validated at hand-out.
+func (p *Pool) Acquire(ctx context.Context, key Key, currentImageID string) (*ParkedSlot, error) {
+	p.NoteTarget(key)
+	ks := key.KeyString()
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.lastUsed[ks] = time.Now().UTC()
+
+	q := p.ready[ks]
+	for i := len(q) - 1; i >= 0; i-- {
+		slot := q[i]
+		if slot == nil || slot.Handle == nil || !slot.Handle.Alive() {
+			q = append(q[:i], q[i+1:]...)
+			if p.metrics != nil {
+				p.metrics.recordOrphan()
+			}
+			continue
+		}
+		if currentImageID != "" && slot.ImageID != "" && slot.ImageID != currentImageID {
+			dead := slot
+			q = append(q[:i], q[i+1:]...)
+			spawner := p.spawner
+			p.ready[ks] = q
+			p.mu.Unlock()
+			if spawner != nil {
+				_ = spawner.DestroyParked(ctx, dead)
+				p.releasePark(dead.ID)
+			}
+			if p.metrics != nil {
+				p.metrics.recordStaleImage()
+			}
+			p.mu.Lock()
+			continue
+		}
+		p.ready[ks] = append(q[:i], q[i+1:]...)
+		p.publishParkedLocked()
+		if p.metrics != nil {
+			p.metrics.recordHit()
+		}
+		return slot, nil
+	}
+	p.ready[ks] = q
+	if p.metrics != nil {
+		p.metrics.recordMiss()
+	}
+	p.kickRefillLocked()
+	return nil, ErrNoSlot
+}
+
+func (p *Pool) kickRefillLocked() {
+	if p.refillKick == nil {
+		return
+	}
+	select {
+	case p.refillKick <- struct{}{}:
+	default:
+	}
+}
+
+// RecordLoaded pushes a freshly parked slot into the ready queue.
+func (p *Pool) RecordLoaded(slot *ParkedSlot) {
+	if slot == nil {
+		return
+	}
+	ks := slot.Key.KeyString()
+	p.mu.Lock()
+	p.ready[ks] = append(p.ready[ks], slot)
+	if p.spawning[ks] > 0 {
+		p.spawning[ks]--
+	}
+	p.publishParkedLocked()
+	p.mu.Unlock()
+}
+
+func (p *Pool) publishParkedLocked() {
+	total := 0
+	for _, q := range p.ready {
+		total += len(q)
+	}
+	if p.metrics != nil {
+		p.metrics.setParked(total)
+	}
+}
+
+// MarkSpawning increments in-flight spawn counter for key string.
+func (p *Pool) MarkSpawning(ks string) {
+	p.mu.Lock()
+	p.spawning[ks]++
+	p.mu.Unlock()
+}
+
+// UnmarkSpawning decrements in-flight spawn counter after failed warm.
+func (p *Pool) UnmarkSpawning(ks string) {
+	p.mu.Lock()
+	if p.spawning[ks] > 0 {
+		p.spawning[ks]--
+	}
+	p.mu.Unlock()
+}
+
+// SpawnBudget returns how many slots refill should create for key on this tick.
+func (p *Pool) SpawnBudget(ks string) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	depth := p.defaultDepth
+	if depth <= 0 {
+		return 0
+	}
+	if _, ok := p.targets[ks]; !ok {
+		return 0
+	}
+	ready := len(p.ready[ks])
+	inFlight := p.spawning[ks]
+	want := depth - ready - inFlight
+	if want < 0 {
+		return 0
+	}
+	return want
+}
+
+// ListTargets returns keys eligible for refill.
+func (p *Pool) ListTargets() []Key {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]Key, 0, len(p.targets))
+	for _, k := range p.targets {
+		if k.Image != "" {
+			out = append(out, k)
+		}
+	}
+	return out
+}
+
+// ReapIdle drops non-pinned targets with no recent use past idleTTL.
+func (p *Pool) ReapIdle(now time.Time) int {
+	if p.idleTTL <= 0 {
+		return 0
+	}
+	p.mu.Lock()
+	var reaped int
+	spawner := p.spawner
+	for ks := range p.targets {
+		if _, pinned := p.pinned[ks]; pinned {
+			continue
+		}
+		last := p.lastUsed[ks]
+		if !last.IsZero() && now.Sub(last) < p.idleTTL {
+			continue
+		}
+		slots := append([]*ParkedSlot(nil), p.ready[ks]...)
+		delete(p.targets, ks)
+		delete(p.lastUsed, ks)
+		delete(p.ready, ks)
+		delete(p.spawning, ks)
+		reaped += len(slots)
+		p.mu.Unlock()
+		for _, slot := range slots {
+			if spawner != nil && slot != nil {
+				_ = spawner.DestroyParked(context.Background(), slot)
+				p.releasePark(slot.ID)
+			}
+		}
+		p.mu.Lock()
+	}
+	p.publishParkedLocked()
+	p.mu.Unlock()
+	return reaped
+}
+
+// Close drains all warm slots.
+func (p *Pool) Close() int {
+	p.mu.Lock()
+	var slots []*ParkedSlot
+	for _, q := range p.ready {
+		slots = append(slots, q...)
+	}
+	p.ready = make(map[string][]*ParkedSlot)
+	spawner := p.spawner
+	p.mu.Unlock()
+	drained := 0
+	for _, slot := range slots {
+		if spawner != nil && slot != nil {
+			_ = spawner.DestroyParked(context.Background(), slot)
+			p.releasePark(slot.ID)
+			drained++
+		}
+	}
+	if p.metrics != nil {
+		p.metrics.setParked(0)
+	}
+	return drained
+}
+
+// NewSlotID mints a unique pool slot identifier.
+func NewSlotID() (string, error) {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return "park-" + hex.EncodeToString(b[:]), nil
+}

--- a/internal/pool/dockerpool/pool_extra_test.go
+++ b/internal/pool/dockerpool/pool_extra_test.go
@@ -1,0 +1,91 @@
+package dockerpool
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func TestPoolEvictLRUOnMaxImages(t *testing.T) {
+	p := New(nil)
+	p.SetMaxImages(1)
+	k1 := Key{Image: "img-a", Runtime: models.RuntimeDocker}
+	k2 := Key{Image: "img-b", Runtime: models.RuntimeDocker}
+	p.NoteTarget(k1)
+	time.Sleep(time.Millisecond)
+	p.NoteTarget(k2)
+	if len(p.ListTargets()) != 1 {
+		t.Fatalf("targets = %d, want 1 after LRU eviction", len(p.ListTargets()))
+	}
+}
+
+func TestPoolAcquireOrphanSlot(t *testing.T) {
+	p := New(nil)
+	key := testKey()
+	p.NoteTarget(key)
+	p.RecordLoaded(&ParkedSlot{
+		ID: "dead", Key: key, ImageID: "img-1",
+		Handle: &fakeHandle{alive: false},
+	})
+	_, err := p.Acquire(context.Background(), key, "img-1")
+	if err != ErrNoSlot {
+		t.Fatalf("err = %v", err)
+	}
+	if p.Metrics().Stats().Orphans != 1 {
+		t.Fatalf("orphans = %d", p.Metrics().Stats().Orphans)
+	}
+}
+
+func TestPoolCloseReleasesParkReservations(t *testing.T) {
+	p := New(nil)
+	var released []string
+	p.SetParkReleaser(func(id string) { released = append(released, id) })
+	spawner := &fakeSpawner{}
+	p.SetSpawner(spawner)
+	key := testKey()
+	p.RecordLoaded(&ParkedSlot{ID: "park-close", Key: key, Handle: &fakeHandle{alive: true}})
+	if n := p.Close(); n != 1 {
+		t.Fatalf("drained = %d", n)
+	}
+	if len(released) != 1 || released[0] != "park-close" {
+		t.Fatalf("released = %v", released)
+	}
+}
+
+func TestPoolPinnedTargetSurvivesReap(t *testing.T) {
+	p := New(nil)
+	p.SetIdleTTL(time.Millisecond)
+	key := testKey()
+	p.PinTarget(key)
+	p.RecordLoaded(&ParkedSlot{ID: "park-pin", Key: key, Handle: &fakeHandle{alive: true}})
+	time.Sleep(2 * time.Millisecond)
+	if n := p.ReapIdle(time.Now().UTC()); n != 0 {
+		t.Fatalf("reaped pinned = %d", n)
+	}
+}
+
+func TestPoolMarkUnmarkSpawning(t *testing.T) {
+	p := New(nil)
+	ks := testKey().KeyString()
+	p.MarkSpawning(ks)
+	p.MarkSpawning(ks)
+	p.UnmarkSpawning(ks)
+	if b := p.SpawnBudget(ks); b < 0 {
+		t.Fatalf("budget = %d", b)
+	}
+}
+
+func TestNewSlotID(t *testing.T) {
+	id, err := NewSlotID()
+	if err != nil || id == "" {
+		t.Fatalf("id = %q err = %v", id, err)
+	}
+}
+
+func TestParkReservationID(t *testing.T) {
+	if ParkReservationID("x") != "park:x" {
+		t.Fatal()
+	}
+}

--- a/internal/pool/dockerpool/pool_test.go
+++ b/internal/pool/dockerpool/pool_test.go
@@ -1,0 +1,151 @@
+package dockerpool
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+type fakeHandle struct {
+	alive bool
+}
+
+func (f *fakeHandle) Alive() bool { return f.alive }
+
+func (f *fakeHandle) Adopt(context.Context, string, string, string) error { return nil }
+
+func (f *fakeHandle) Close() error { return nil }
+
+type fakeSpawner struct {
+	destroyed []string
+}
+
+func (f *fakeSpawner) Park(context.Context, string, Key) (*ParkedSlot, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeSpawner) DestroyParked(_ context.Context, slot *ParkedSlot) error {
+	if slot != nil {
+		f.destroyed = append(f.destroyed, slot.ID)
+	}
+	return nil
+}
+
+func testKey() Key {
+	return Key{Image: "alpine:3.20", Runtime: models.RuntimeDocker}
+}
+
+func TestPoolAcquireMissAndHit(t *testing.T) {
+	p := New(nil)
+	p.SetDefaultDepth(1)
+	key := testKey()
+	p.NoteTarget(key)
+
+	_, err := p.Acquire(context.Background(), key, "img-1")
+	if !errors.Is(err, ErrNoSlot) {
+		t.Fatalf("first acquire: %v", err)
+	}
+	if p.Metrics().Stats().Misses != 1 {
+		t.Fatalf("misses = %d", p.Metrics().Stats().Misses)
+	}
+
+	slot := &ParkedSlot{
+		ID:      "park-1",
+		ImageID: "img-1",
+		Key:     key,
+		Handle:  &fakeHandle{alive: true},
+	}
+	p.RecordLoaded(slot)
+
+	got, err := p.Acquire(context.Background(), key, "img-1")
+	if err != nil {
+		t.Fatalf("second acquire: %v", err)
+	}
+	if got.ID != slot.ID {
+		t.Fatalf("slot id = %q", got.ID)
+	}
+	if p.Metrics().Stats().Hits != 1 {
+		t.Fatalf("hits = %d", p.Metrics().Stats().Hits)
+	}
+}
+
+func TestPoolSpawnBudget(t *testing.T) {
+	p := New(nil)
+	p.SetDefaultDepth(2)
+	key := testKey()
+	ks := key.KeyString()
+	p.NoteTarget(key)
+
+	if b := p.SpawnBudget(ks); b != 2 {
+		t.Fatalf("initial budget = %d", b)
+	}
+	p.RecordLoaded(&ParkedSlot{ID: "s1", Key: key, Handle: &fakeHandle{alive: true}})
+	if b := p.SpawnBudget(ks); b != 1 {
+		t.Fatalf("after one ready budget = %d", b)
+	}
+}
+
+func TestPoolAcquireStaleImageDestroysSlot(t *testing.T) {
+	p := New(nil)
+	spawner := &fakeSpawner{}
+	p.SetSpawner(spawner)
+	key := testKey()
+	slot := &ParkedSlot{
+		ID:      "park-stale",
+		ImageID: "old-digest",
+		Key:     key,
+		Handle:  &fakeHandle{alive: true},
+	}
+	p.RecordLoaded(slot)
+
+	_, err := p.Acquire(context.Background(), key, "new-digest")
+	if !errors.Is(err, ErrNoSlot) {
+		t.Fatalf("acquire: %v", err)
+	}
+	if len(spawner.destroyed) != 1 || spawner.destroyed[0] != "park-stale" {
+		t.Fatalf("destroyed = %v", spawner.destroyed)
+	}
+	if p.Metrics().Stats().StaleImages != 1 {
+		t.Fatalf("stale images = %d", p.Metrics().Stats().StaleImages)
+	}
+}
+
+func TestPoolReapIdleDestroysReadySlots(t *testing.T) {
+	p := New(nil)
+	p.SetIdleTTL(time.Millisecond)
+	spawner := &fakeSpawner{}
+	p.SetSpawner(spawner)
+	key := testKey()
+	p.NoteTarget(key)
+	p.RecordLoaded(&ParkedSlot{
+		ID:     "park-idle",
+		Key:    key,
+		Handle: &fakeHandle{alive: true},
+	})
+
+	time.Sleep(2 * time.Millisecond)
+	if n := p.ReapIdle(time.Now().UTC()); n != 1 {
+		t.Fatalf("reaped = %d", n)
+	}
+	if len(spawner.destroyed) != 1 {
+		t.Fatalf("destroyed = %v", spawner.destroyed)
+	}
+}
+
+func TestKeyFromRequestAndKeyString(t *testing.T) {
+	key := KeyFromRequest(models.CreateSandboxRequest{
+		Image:                 "ubuntu:22.04",
+		ImageDigest:           "sha256:abc",
+		ImageRegistryRef:      "registry.example/ubuntu",
+		ImageDistributionMode: "pull",
+	}, models.RuntimeDocker)
+	if key.Image != "ubuntu:22.04" || key.Runtime != models.RuntimeDocker {
+		t.Fatalf("key = %+v", key)
+	}
+	if key.KeyString() == "" {
+		t.Fatal("empty key string")
+	}
+}

--- a/internal/pool/dockerpool/refill.go
+++ b/internal/pool/dockerpool/refill.go
@@ -1,0 +1,102 @@
+package dockerpool
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// RefillConfig holds timing knobs for the background refill loop.
+type RefillConfig struct {
+	RefillInterval time.Duration
+	SpawnTimeout   time.Duration
+	IdleTTL        time.Duration
+	ParkShape      ParkShape
+}
+
+// Run starts the refill loop until ctx is cancelled.
+func (p *Pool) Run(ctx context.Context, cfg RefillConfig, spawner Spawner, gate RefillGate) {
+	if p == nil || spawner == nil {
+		return
+	}
+	if cfg.RefillInterval <= 0 {
+		cfg.RefillInterval = 5 * time.Second
+	}
+	if cfg.SpawnTimeout <= 0 {
+		cfg.SpawnTimeout = 30 * time.Second
+	}
+	p.SetSpawner(spawner)
+
+	ticker := time.NewTicker(cfg.RefillInterval)
+	idleTicker := time.NewTicker(cfg.RefillInterval)
+	defer ticker.Stop()
+	defer idleTicker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.refillTick(ctx, cfg, spawner, gate)
+		case <-p.refillKick:
+			p.refillTick(ctx, cfg, spawner, gate)
+		case <-idleTicker.C:
+			if cfg.IdleTTL > 0 {
+				p.ReapIdle(time.Now().UTC())
+			}
+		}
+	}
+}
+
+func (p *Pool) refillTick(parent context.Context, cfg RefillConfig, spawner Spawner, gate RefillGate) {
+	targets := p.ListTargets()
+	for _, key := range targets {
+		ks := key.KeyString()
+		budget := p.SpawnBudget(ks)
+		for i := 0; i < budget; i++ {
+			if gate != nil && !gate.CanPark(cfg.ParkShape) {
+				return
+			}
+			slotID, err := NewSlotID()
+			if err != nil {
+				p.logger.Warn("docker pool refill: slot id", "error", err)
+				break
+			}
+			if gate != nil {
+				if err := gate.ParkReservation(slotID, cfg.ParkShape); err != nil {
+					p.logger.Debug("docker pool refill: capacity refused park", "error", err)
+					break
+				}
+			}
+			p.MarkSpawning(ks)
+			ctx, cancel := context.WithTimeout(parent, cfg.SpawnTimeout)
+			slot, err := spawner.Park(ctx, slotID, key)
+			cancel()
+			if err != nil {
+				p.UnmarkSpawning(ks)
+				if p.metrics != nil {
+					p.metrics.RecordSpawnFail()
+				}
+				if gate != nil {
+					gate.ReleasePark(slotID)
+				}
+				p.logger.Warn("docker pool refill: park failed", "key", ks, "error", err)
+				break
+			}
+			p.RecordLoaded(slot)
+			if p.metrics != nil {
+				p.metrics.recordRefill()
+			}
+		}
+	}
+}
+
+// RunRefill is a convenience wrapper matching daemon wiring style.
+func RunRefill(ctx context.Context, pool *Pool, cfg RefillConfig, spawner Spawner, gate RefillGate, logger *slog.Logger) {
+	if logger != nil {
+		logger.Info("docker warm pool refill started",
+			"interval", cfg.RefillInterval,
+			"spawn_timeout", cfg.SpawnTimeout)
+	}
+	pool.Run(ctx, cfg, spawner, gate)
+}

--- a/internal/pool/dockerpool/refill_test.go
+++ b/internal/pool/dockerpool/refill_test.go
@@ -1,0 +1,127 @@
+package dockerpool
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+type refillSpawner struct {
+	err   error
+	slots []*ParkedSlot
+}
+
+func (r *refillSpawner) Park(_ context.Context, slotID string, key Key) (*ParkedSlot, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	slot := &ParkedSlot{
+		ID: slotID, Key: key, Handle: &fakeHandle{alive: true},
+	}
+	r.slots = append(r.slots, slot)
+	return slot, nil
+}
+
+func (r *refillSpawner) DestroyParked(context.Context, *ParkedSlot) error { return nil }
+
+type refillGate struct {
+	canPark  bool
+	reserved []string
+	released []string
+	parkErr  error
+}
+
+func (g *refillGate) CanPark(ParkShape) bool { return g.canPark }
+func (g *refillGate) ParkReservation(id string, _ ParkShape) error {
+	if g.parkErr != nil {
+		return g.parkErr
+	}
+	g.reserved = append(g.reserved, id)
+	return nil
+}
+func (g *refillGate) ReleasePark(id string) { g.released = append(g.released, id) }
+
+func TestRefillTickLoadsSlot(t *testing.T) {
+	p := New(nil)
+	p.SetDefaultDepth(1)
+	key := testKey()
+	p.PinTarget(key)
+
+	spawner := &refillSpawner{}
+	gate := &refillGate{canPark: true}
+	cfg := RefillConfig{ParkShape: ParkShape{Runtime: models.RuntimeDocker}}
+
+	p.refillTick(context.Background(), cfg, spawner, gate)
+	if len(spawner.slots) != 1 {
+		t.Fatalf("slots = %d", len(spawner.slots))
+	}
+	if len(gate.reserved) != 1 {
+		t.Fatalf("reserved = %v", gate.reserved)
+	}
+	if p.Metrics().Stats().Refilled != 1 {
+		t.Fatalf("refilled = %d", p.Metrics().Stats().Refilled)
+	}
+}
+
+func TestRefillTickParkFailureReleasesReservation(t *testing.T) {
+	p := New(nil)
+	p.SetDefaultDepth(1)
+	p.PinTarget(testKey())
+
+	spawner := &refillSpawner{err: errors.New("park failed")}
+	gate := &refillGate{canPark: true}
+	cfg := RefillConfig{ParkShape: ParkShape{Runtime: models.RuntimeDocker}}
+
+	p.refillTick(context.Background(), cfg, spawner, gate)
+	if len(gate.released) != 1 {
+		t.Fatalf("released = %v", gate.released)
+	}
+	if p.Metrics().Stats().SpawnFail != 1 {
+		t.Fatalf("spawn fail = %d", p.Metrics().Stats().SpawnFail)
+	}
+}
+
+func TestRefillTickGateBlocks(t *testing.T) {
+	p := New(nil)
+	p.SetDefaultDepth(2)
+	p.PinTarget(testKey())
+	spawner := &refillSpawner{}
+	gate := &refillGate{canPark: false}
+	p.refillTick(context.Background(), RefillConfig{}, spawner, gate)
+	if len(spawner.slots) != 0 {
+		t.Fatal("expected no parks when gate blocks")
+	}
+}
+
+func TestRunRefillStopsOnCancel(t *testing.T) {
+	p := New(nil)
+	p.PinTarget(testKey())
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		p.Run(ctx, RefillConfig{RefillInterval: 5 * time.Millisecond}, &refillSpawner{}, &refillGate{canPark: true})
+		close(done)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("refill loop did not stop")
+	}
+}
+
+func TestRunRefillNilSpawnerNoop(t *testing.T) {
+	p := New(nil)
+	p.Run(context.Background(), RefillConfig{}, nil, nil)
+}
+
+func TestRunRefillWrapper(t *testing.T) {
+	p := New(nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	RunRefill(ctx, p, RefillConfig{}, &refillSpawner{}, nil, nil)
+}

--- a/internal/pool/dockerpool/spawner.go
+++ b/internal/pool/dockerpool/spawner.go
@@ -1,0 +1,27 @@
+package dockerpool
+
+import "context"
+
+// ParkedSlot is the in-memory handle for one warm container.
+type ParkedSlot struct {
+	ID             string
+	ContainerID    string
+	ContainerIP    string
+	ImageID        string
+	Key            Key
+	BootstrapToken string
+	Handle         SpawnerHandle
+}
+
+// SpawnerHandle is the host-side parked connection and listener state.
+type SpawnerHandle interface {
+	Alive() bool
+	Adopt(ctx context.Context, sandboxID, token, adoptNonce string) error
+	Close() error
+}
+
+// Spawner parks containers ahead of demand.
+type Spawner interface {
+	Park(ctx context.Context, slotID string, key Key) (*ParkedSlot, error)
+	DestroyParked(ctx context.Context, slot *ParkedSlot) error
+}

--- a/internal/service/docker_pool_create.go
+++ b/internal/service/docker_pool_create.go
@@ -1,0 +1,45 @@
+package service
+
+import (
+	"context"
+	"errors"
+
+	"github.com/aerol-ai/microvm/pkg/capacity"
+	"github.com/aerol-ai/microvm/pkg/docker"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func (s *Service) releaseAdoptedParkReservation(state *models.SandboxRuntimeState) {
+	if s == nil || state == nil || state.AdoptedParkID == "" {
+		return
+	}
+	capacity.ReleaseParkReservation(s.admitter, state.AdoptedParkID)
+}
+
+func (s *Service) returnExistingSandboxResponse(ctx context.Context, sandboxID string) (*models.CreateSandboxResponse, bool) {
+	existing, err := s.store.Get(ctx, sandboxID)
+	if err != nil || existing == nil {
+		return nil, false
+	}
+	return &models.CreateSandboxResponse{Sandbox: *existing}, true
+}
+
+func (s *Service) handleDuplicateCreateAfterRuntime(ctx context.Context, sandboxID string, err error) (*models.CreateSandboxResponse, error) {
+	if errors.Is(err, docker.ErrSandboxContainerExists) {
+		if resp, ok := s.returnExistingSandboxResponse(ctx, sandboxID); ok {
+			return resp, nil
+		}
+		return nil, models.ErrSandboxExists
+	}
+	return nil, err
+}
+
+func (s *Service) handleDuplicateStoreCreate(ctx context.Context, sandboxID string, err error) (*models.CreateSandboxResponse, error) {
+	if errors.Is(err, models.ErrSandboxExists) {
+		if resp, ok := s.returnExistingSandboxResponse(ctx, sandboxID); ok {
+			return resp, nil
+		}
+		return nil, models.ErrSandboxExists
+	}
+	return nil, err
+}

--- a/internal/service/docker_pool_create_test.go
+++ b/internal/service/docker_pool_create_test.go
@@ -1,0 +1,92 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/internal/store"
+	"github.com/aerol-ai/microvm/pkg/capacity"
+	"github.com/aerol-ai/microvm/pkg/docker"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func dockerPoolServiceHarness(t *testing.T) (*Service, *store.Store) {
+	t.Helper()
+	st, err := store.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	admitter := capacity.New(
+		capacity.HostInfo{CPUCores: 4, MemoryTotalMB: 4096},
+		capacity.Limits{CPUReservationRatio: 1, MemoryReservationRatio: 1},
+		nil,
+	)
+	svc := &Service{store: st, admitter: admitter, cfg: config.Config{Runtime: models.RuntimeDocker}}
+	return svc, st
+}
+
+func TestReleaseAdoptedParkReservation(t *testing.T) {
+	svc, _ := dockerPoolServiceHarness(t)
+	admitter := svc.admitter
+	shape := capacity.Request{CPU: 1, MemoryMB: 512, Runtime: models.RuntimeDocker}
+	if err := admitter.Admit(capacity.ParkReservationID("park-1"), shape); err != nil {
+		t.Fatal(err)
+	}
+	svc.releaseAdoptedParkReservation(&models.SandboxRuntimeState{AdoptedParkID: "park-1"})
+	if snap := admitter.Snapshot(); snap.SandboxesActive != 0 {
+		t.Fatalf("active = %d", snap.SandboxesActive)
+	}
+	svc.releaseAdoptedParkReservation(nil)
+	svc.releaseAdoptedParkReservation(&models.SandboxRuntimeState{})
+}
+
+func TestHandleDuplicateCreateAfterRuntime(t *testing.T) {
+	svc, st := dockerPoolServiceHarness(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	sb := &models.Sandbox{ID: "sb-dup", Image: "i", Status: models.SandboxStatusStarted, CreatedAt: now, UpdatedAt: now}
+	if err := st.Create(ctx, sb); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := svc.handleDuplicateCreateAfterRuntime(ctx, "sb-dup", docker.ErrSandboxContainerExists)
+	if err != nil || resp == nil || resp.Sandbox.ID != "sb-dup" {
+		t.Fatalf("resp = %+v err = %v", resp, err)
+	}
+
+	_, err = svc.handleDuplicateCreateAfterRuntime(ctx, "missing", docker.ErrSandboxContainerExists)
+	if !errors.Is(err, models.ErrSandboxExists) {
+		t.Fatalf("err = %v", err)
+	}
+	_, err = svc.handleDuplicateCreateAfterRuntime(ctx, "sb-dup", errors.New("other"))
+	if err == nil {
+		t.Fatal("expected passthrough error")
+	}
+}
+
+func TestHandleDuplicateStoreCreate(t *testing.T) {
+	svc, st := dockerPoolServiceHarness(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	sb := &models.Sandbox{ID: "sb-store", Image: "i", Status: models.SandboxStatusStarted, CreatedAt: now, UpdatedAt: now}
+	if err := st.Create(ctx, sb); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := svc.handleDuplicateStoreCreate(ctx, "sb-store", models.ErrSandboxExists)
+	if err != nil || resp.Sandbox.ID != "sb-store" {
+		t.Fatalf("resp = %+v err = %v", resp, err)
+	}
+}
+
+func TestReturnExistingSandboxResponse(t *testing.T) {
+	svc, _ := dockerPoolServiceHarness(t)
+	if resp, ok := svc.returnExistingSandboxResponse(context.Background(), "nope"); ok || resp != nil {
+		t.Fatal("expected miss")
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1190,9 +1190,16 @@ func (s *Service) createSandbox(ctx context.Context, req models.CreateSandboxReq
 	state, err := s.docker.Create(ctx, req, sandboxID, toolboxToken, binds)
 	if err != nil {
 		cleanupMounts()
+		if resp, dupErr := s.handleDuplicateCreateAfterRuntime(ctx, sandboxID, err); dupErr == nil {
+			return resp, nil
+		} else if !errors.Is(dupErr, err) {
+			releaseAdmission()
+			return nil, dupErr
+		}
 		releaseAdmission()
 		return nil, err
 	}
+	s.releaseAdoptedParkReservation(state)
 
 	// Seal the registry creds (if any) BEFORE building the row so a marshal
 	// or encrypt error doesn't leave a half-created sandbox: we already passed
@@ -1282,6 +1289,12 @@ func (s *Service) createSandbox(ctx context.Context, req models.CreateSandboxReq
 		_ = s.deleteSandboxPublicRoutes(cleanupCtx, sandbox)
 		_ = s.docker.Destroy(cleanupCtx, sandbox)
 		cleanupMounts()
+		if resp, dupErr := s.handleDuplicateStoreCreate(ctx, sandbox.ID, err); dupErr == nil {
+			return resp, nil
+		} else if !errors.Is(dupErr, err) {
+			releaseAdmission()
+			return nil, dupErr
+		}
 		releaseAdmission()
 		return nil, err
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -868,6 +868,9 @@ func (s *Store) Create(ctx context.Context, sandbox *models.Sandbox) error {
 		if isSandboxNameConflict(err, sandbox.Name) {
 			return ErrSandboxNameConflict
 		}
+		if isSandboxIDConflict(err, sandbox.ID) {
+			return models.ErrSandboxExists
+		}
 		return fmt.Errorf("insert sandbox: %w", err)
 	}
 	return nil
@@ -3857,6 +3860,16 @@ func isSandboxNameConflict(err error, name string) bool {
 		return true
 	}
 	return strings.TrimSpace(name) != "" && isSQLiteUniqueConstraint(err)
+}
+
+func isSandboxIDConflict(err error, id string) bool {
+	if strings.TrimSpace(id) == "" {
+		return false
+	}
+	if strings.Contains(err.Error(), models.ErrSandboxExists.Error()) {
+		return true
+	}
+	return isSQLiteUniqueConstraint(err)
 }
 
 var ErrNotFound = errors.New("sandbox not found")

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -220,8 +220,8 @@ func TestStoreCases(t *testing.T) {
 				if err := st.Create(ctx, sandbox); err != nil {
 					t.Fatalf("Create() error = %v", err)
 				}
-				if err := st.Create(ctx, sandbox); err == nil {
-					t.Fatalf("expected duplicate Create() error")
+				if err := st.Create(ctx, sandbox); !errors.Is(err, models.ErrSandboxExists) {
+					t.Fatalf("Create() duplicate error = %v, want ErrSandboxExists", err)
 				}
 			},
 		},

--- a/pkg/api/apihttp/apihttp.go
+++ b/pkg/api/apihttp/apihttp.go
@@ -100,6 +100,10 @@ func WriteStoreAwareError(logger *slog.Logger, w http.ResponseWriter, err error)
 		WriteError(w, http.StatusConflict, "sandbox name already in use")
 		return
 	}
+	if errors.Is(err, models.ErrSandboxExists) {
+		WriteError(w, http.StatusConflict, "sandbox already exists")
+		return
+	}
 	if errors.Is(err, store.ErrSnapshotNameConflict) {
 		WriteError(w, http.StatusConflict, "snapshot name already in use")
 		return

--- a/pkg/api/apihttp/apihttp_test.go
+++ b/pkg/api/apihttp/apihttp_test.go
@@ -284,3 +284,13 @@ func TestWriteStoreAwareError_WrappedSandboxNameConflict(t *testing.T) {
 		t.Errorf("status = %d, want 409 for wrapped ErrSandboxNameConflict", code)
 	}
 }
+
+func TestWriteStoreAwareError_SandboxExists(t *testing.T) {
+	code, msg := storeAwareErr(t, models.ErrSandboxExists)
+	if code != http.StatusConflict {
+		t.Errorf("status = %d, want 409 Conflict", code)
+	}
+	if msg == "" {
+		t.Error("error body must carry the conflict message")
+	}
+}

--- a/pkg/capacity/capacity.go
+++ b/pkg/capacity/capacity.go
@@ -529,6 +529,11 @@ func (a *Admitter) Snapshot() Snapshot {
 	return snap
 }
 
+// CanAdmitRequest is a non-mutating admission probe for a specific shape.
+func (a *Admitter) CanAdmitRequest(req Request) (bool, []string) {
+	return a.dryRun(req)
+}
+
 // dryRun is Admit's check-only path — it returns whether a request would be
 // admitted right now and the reasons if not, without mutating state.
 func (a *Admitter) dryRun(req Request) (bool, []string) {

--- a/pkg/capacity/parkgate.go
+++ b/pkg/capacity/parkgate.go
@@ -1,0 +1,75 @@
+package capacity
+
+import (
+	"strings"
+
+	"github.com/aerol-ai/microvm/internal/pool/dockerpool"
+)
+
+// ParkReservationID is the admitter key for a warm-pool parked slot.
+func ParkReservationID(slotID string) string {
+	return "park:" + strings.TrimSpace(slotID)
+}
+
+// ParkGate implements warm-pool refill gating against the host admitter.
+type ParkGate struct {
+	Admitter *Admitter
+	// GuardShape is reserved for one default-shaped sandbox after each park.
+	GuardShape Request
+}
+
+// CanPark reports whether parking another slot leaves the guard band.
+func (g *ParkGate) CanPark(shape dockerpool.ParkShape) bool {
+	if g == nil || g.Admitter == nil {
+		return true
+	}
+	snap := g.Admitter.Snapshot()
+	if !snap.CanAdmit {
+		return false
+	}
+	probe := Request{
+		CPU:       shape.CPU,
+		MemoryMB:  shape.MemoryMB,
+		DiskGB:    shape.DiskGB,
+		GPUs:      shape.GPUs,
+		GPUVendor: shape.GPUVendor,
+		Runtime:   shape.Runtime,
+	}
+	probe.CPU += g.GuardShape.CPU
+	probe.MemoryMB += g.GuardShape.MemoryMB
+	probe.DiskGB += g.GuardShape.DiskGB
+	probe.GPUs += g.GuardShape.GPUs
+	ok, _ := g.Admitter.CanAdmitRequest(probe)
+	return ok
+}
+
+// ParkReservation reserves capacity under park:<slot-id>.
+func (g *ParkGate) ParkReservation(slotID string, shape dockerpool.ParkShape) error {
+	if g == nil || g.Admitter == nil {
+		return nil
+	}
+	return g.Admitter.Admit(ParkReservationID(slotID), Request{
+		CPU:       shape.CPU,
+		MemoryMB:  shape.MemoryMB,
+		DiskGB:    shape.DiskGB,
+		GPUs:      shape.GPUs,
+		GPUVendor: shape.GPUVendor,
+		Runtime:   shape.Runtime,
+	})
+}
+
+// ReleasePark frees a park reservation.
+func (g *ParkGate) ReleasePark(slotID string) {
+	if g == nil || g.Admitter == nil {
+		return
+	}
+	g.Admitter.Release(ParkReservationID(slotID))
+}
+
+// ReleaseParkReservation is the service-side transfer after adopt.
+func ReleaseParkReservation(admitter *Admitter, parkID string) {
+	if admitter == nil || strings.TrimSpace(parkID) == "" {
+		return
+	}
+	admitter.Release(ParkReservationID(parkID))
+}

--- a/pkg/capacity/parkgate_test.go
+++ b/pkg/capacity/parkgate_test.go
@@ -1,0 +1,63 @@
+package capacity
+
+import (
+	"testing"
+
+	"github.com/aerol-ai/microvm/internal/pool/dockerpool"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func TestParkReservationID(t *testing.T) {
+	if got := ParkReservationID("park-abc"); got != "park:park-abc" {
+		t.Fatalf("id = %q", got)
+	}
+}
+
+func TestParkGateCanParkGuardBand(t *testing.T) {
+	a := New(HostInfo{CPUCores: 2, MemoryTotalMB: 2048}, Limits{
+		CPUReservationRatio:    1.0,
+		MemoryReservationRatio: 1.0,
+	}, nil)
+	shape := dockerpool.ParkShape{
+		CPU:      1,
+		MemoryMB: 1024,
+		Runtime:  models.RuntimeDocker,
+	}
+	gate := &ParkGate{
+		Admitter: a,
+		GuardShape: Request{
+			CPU:      1,
+			MemoryMB: 1024,
+			Runtime:  models.RuntimeDocker,
+		},
+	}
+	if !gate.CanPark(shape) {
+		t.Fatal("expected first park to fit with guard band")
+	}
+	if err := gate.ParkReservation("slot-1", shape); err != nil {
+		t.Fatalf("park reservation: %v", err)
+	}
+	if gate.CanPark(shape) {
+		t.Fatal("expected guard band to block second park")
+	}
+	gate.ReleasePark("slot-1")
+	if !gate.CanPark(shape) {
+		t.Fatal("expected capacity after release")
+	}
+}
+
+func TestReleaseParkReservation(t *testing.T) {
+	a := New(HostInfo{CPUCores: 4, MemoryTotalMB: 4096}, Limits{
+		CPUReservationRatio:    1.0,
+		MemoryReservationRatio: 1.0,
+	}, nil)
+	shape := dockerpool.ParkShape{CPU: 1, MemoryMB: 512, Runtime: models.RuntimeDocker}
+	gate := &ParkGate{Admitter: a}
+	if err := gate.ParkReservation("slot-x", shape); err != nil {
+		t.Fatalf("park: %v", err)
+	}
+	ReleaseParkReservation(a, "slot-x")
+	if snap := a.Snapshot(); snap.SandboxesActive != 0 {
+		t.Fatalf("active = %d after transfer release", snap.SandboxesActive)
+	}
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -272,6 +272,10 @@ func Run(ctx context.Context, logger *slog.Logger, makeProvider ProviderFactory)
 	// Wire the managed create-gate. Under Noop() this is the allow-all admitter,
 	// so the open-source build never gates a create.
 	svc.SetFleetAdmitter(cp.Admitter)
+	dockerWarmPool := wireDockerWarmPool(ctx, cfg, logger, dockerClient, admitter)
+	if dockerWarmPool != nil {
+		defer func() { drainDockerWarmPool(dockerWarmPool, logger) }()
+	}
 	// Start the standing-driven enforcement loop. EnforcementFor binds the loop
 	// to the service as its FleetController; under Noop() the factory yields a
 	// no-op whose Start does nothing. Runs on the daemon's cancellable ctx so it

--- a/pkg/daemon/docker_warm_wiring.go
+++ b/pkg/daemon/docker_warm_wiring.go
@@ -1,0 +1,89 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/internal/pool/dockerpool"
+	"github.com/aerol-ai/microvm/pkg/capacity"
+	"github.com/aerol-ai/microvm/pkg/docker"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func wireDockerWarmPool(ctx context.Context, cfg config.Config, logger *slog.Logger, dockerClient *docker.Client, admitter *capacity.Admitter) *dockerpool.Pool {
+	if !cfg.DockerPoolEffective() {
+		if cfg.DockerPoolEnabled && !cfg.DockerReadySocketEnabled {
+			logger.Warn("docker warm pool disabled: SB_DOCKER_READY_SOCKET_ENABLED=false")
+		}
+		return nil
+	}
+	pool := dockerpool.New(logger)
+	pool.SetDefaultDepth(cfg.DockerPoolDepth)
+	pool.SetMaxImages(cfg.DockerPoolMaxImages)
+	pool.SetIdleTTL(cfg.DockerPoolIdleTTL)
+
+	parkShape := dockerpool.ParkShape{
+		CPU:      models.DefaultCPU,
+		MemoryMB: models.DefaultMemoryMB,
+		DiskGB:   models.DefaultDiskGB,
+		Runtime:  models.RuntimeDocker,
+	}
+	gate := &capacity.ParkGate{
+		Admitter: admitter,
+		GuardShape: capacity.Request{
+			CPU:      parkShape.CPU,
+			MemoryMB: parkShape.MemoryMB,
+			DiskGB:   parkShape.DiskGB,
+			Runtime:  parkShape.Runtime,
+		},
+	}
+	pool.SetParkReleaser(gate.ReleasePark)
+	dockerClient.SetWarmPool(pool)
+
+	images := cfg.DockerPoolImages
+	if len(images) == 0 {
+		images = []string{"alpine:3.20"}
+	}
+	for _, image := range images {
+		image = strings.TrimSpace(image)
+		if image == "" {
+			continue
+		}
+		pool.PinTarget(dockerpool.Key{
+			Image:   image,
+			Runtime: cfg.Runtime,
+		})
+	}
+
+	spawner := &docker.PoolSpawner{Client: dockerClient}
+	refillCfg := dockerpool.RefillConfig{
+		RefillInterval: cfg.DockerPoolRefillInterval,
+		SpawnTimeout:   cfg.DockerRuntimeWaitTimeout,
+		IdleTTL:        cfg.DockerPoolIdleTTL,
+		ParkShape:      parkShape,
+	}
+	go dockerpool.RunRefill(ctx, pool, refillCfg, spawner, gate, logger)
+
+	if purged, err := dockerClient.PurgeParkedContainers(ctx); err != nil {
+		logger.Warn("docker warm pool boot purge failed", "error", err)
+	} else if purged > 0 {
+		logger.Info("docker warm pool boot purge", "containers", purged)
+	}
+
+	logger.Info("docker warm pool enabled",
+		"depth", cfg.DockerPoolDepth,
+		"max_images", cfg.DockerPoolMaxImages,
+		"refill_interval", cfg.DockerPoolRefillInterval)
+	return pool
+}
+
+func drainDockerWarmPool(pool *dockerpool.Pool, logger *slog.Logger) {
+	if pool == nil {
+		return
+	}
+	if drained := pool.Close(); drained > 0 {
+		logger.Info("docker warm pool drained on shutdown", "slots", drained)
+	}
+}

--- a/pkg/daemon/docker_warm_wiring_test.go
+++ b/pkg/daemon/docker_warm_wiring_test.go
@@ -1,0 +1,80 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/pkg/capacity"
+	"github.com/aerol-ai/microvm/pkg/docker"
+	"github.com/aerol-ai/microvm/pkg/docker/netrules"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func TestWireDockerWarmPoolDisabled(t *testing.T) {
+	pool := wireDockerWarmPool(context.Background(), config.Config{}, testLogger(), nil, nil)
+	if pool != nil {
+		t.Fatal("expected nil when pool disabled")
+	}
+}
+
+func TestWireDockerWarmPoolWarnsWhenReadySocketOff(t *testing.T) {
+	pool := wireDockerWarmPool(context.Background(), config.Config{
+		DockerPoolEnabled:        true,
+		DockerReadySocketEnabled: false,
+	}, testLogger(), nil, nil)
+	if pool != nil {
+		t.Fatal("expected nil when ready socket disabled")
+	}
+}
+
+func TestWireDockerWarmPoolEnabled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	toolbox := filepath.Join(t.TempDir(), "toolboxd")
+	if err := os.WriteFile(toolbox, []byte("bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rules, err := netrules.New(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := docker.New(testLogger(), config.Config{
+		Runtime:           models.RuntimeDocker,
+		ToolboxBinaryPath: toolbox,
+		ToolboxPort:       2280,
+		HTTPClientTimeout: time.Second,
+	}, rules)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	admitter := capacity.New(
+		capacity.HostInfo{CPUCores: 8, MemoryTotalMB: 16384, SupportedRuntimes: []string{models.RuntimeDocker}},
+		capacity.Limits{CPUReservationRatio: 1, MemoryReservationRatio: 1},
+		nil,
+	)
+
+	pool := wireDockerWarmPool(ctx, config.Config{
+		DockerPoolEnabled:        true,
+		DockerReadySocketEnabled: true,
+		DockerPoolDepth:          1,
+		DockerPoolRefillInterval: time.Hour,
+		DockerRuntimeWaitTimeout: time.Second,
+		Runtime:                  models.RuntimeDocker,
+		DockerPoolImages:         []string{"alpine:3.20"},
+	}, testLogger(), c, admitter)
+	if pool == nil {
+		t.Fatal("expected pool")
+	}
+	drainDockerWarmPool(pool, testLogger())
+	cancel()
+}
+
+func TestDrainDockerWarmPoolNil(t *testing.T) {
+	drainDockerWarmPool(nil, testLogger())
+}

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/internal/pool/dockerpool"
 	"github.com/aerol-ai/microvm/pkg/docker/netrules"
 	"github.com/aerol-ai/microvm/pkg/models"
 	"github.com/aerol-ai/microvm/pkg/mounts"
@@ -69,6 +70,8 @@ type Client struct {
 	pullSlots          chan struct{}
 	pullBackoff        time.Duration
 	pullFailures       map[string]imagePullFailure
+	warmPool           *dockerpool.Pool
+	parkDiskGB         int
 	// Mirror configuration: zero value disables rewriting and the pull
 	// path behaves exactly as it did before AOCR mirror support landed.
 	// Set via ConfigureMirror after construction; main() is responsible
@@ -138,6 +141,7 @@ func New(logger *slog.Logger, cfg config.Config, rules *netrules.Manager) (*Clie
 		pullSlots:          pullSlots,
 		pullBackoff:        cfg.ImagePullFailureBackoff,
 		pullFailures:       make(map[string]imagePullFailure),
+		parkDiskGB:         models.DefaultDiskGB,
 	}, nil
 }
 
@@ -350,6 +354,13 @@ func (c *Client) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 	ociRuntime, err := models.ResolveOCIRuntime(effectiveRuntime)
 	if err != nil {
 		return nil, err
+	}
+	if c.warmPool != nil {
+		if warm, warmErr := c.tryWarmAdopt(ctx, req, sandboxID, toolboxToken, hostMounts, effectiveRuntime); warmErr == nil {
+			return warm, nil
+		} else if errors.Is(warmErr, ErrSandboxContainerExists) {
+			return nil, warmErr
+		}
 	}
 
 	// Locally-built images (BuildImage tags them with content-addressed
@@ -1442,6 +1453,7 @@ func containerStatus(inspect containerInspect) models.SandboxStatus {
 }
 
 type imageInspect struct {
+	ID     string `json:"Id"`
 	Config struct {
 		WorkingDir string   `json:"WorkingDir"`
 		Entrypoint []string `json:"Entrypoint"`

--- a/pkg/docker/docker_pool.go
+++ b/pkg/docker/docker_pool.go
@@ -1,0 +1,426 @@
+package docker
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/pool/dockerpool"
+	"github.com/aerol-ai/microvm/pkg/createtiming"
+	"github.com/aerol-ai/microvm/pkg/models"
+	"github.com/aerol-ai/microvm/pkg/mounts"
+)
+
+const poolParkLabelKey = "aerol.pool"
+const poolParkLabelValue = "park"
+
+// ErrSandboxContainerExists is returned when adopt-time rename finds the
+// sandbox name already taken — signals the §6 duplicate-create protocol.
+var ErrSandboxContainerExists = errors.New("docker: sandbox container name already exists")
+
+// SetWarmPool wires the docker warm pool. Nil disables the fast path.
+func (c *Client) SetWarmPool(p *dockerpool.Pool) {
+	c.warmPool = p
+}
+
+// PoolSpawner implements dockerpool.Spawner against this client.
+type PoolSpawner struct {
+	Client *Client
+}
+
+func (p *PoolSpawner) Park(ctx context.Context, slotID string, key dockerpool.Key) (*dockerpool.ParkedSlot, error) {
+	if p == nil || p.Client == nil {
+		return nil, errors.New("docker pool spawner not configured")
+	}
+	return p.Client.parkContainer(ctx, slotID, key)
+}
+
+func (p *PoolSpawner) DestroyParked(ctx context.Context, slot *dockerpool.ParkedSlot) error {
+	if p == nil || p.Client == nil || slot == nil {
+		return nil
+	}
+	return p.Client.destroyParked(ctx, slot)
+}
+
+func poolEligible(req models.CreateSandboxRequest, hostMounts []mounts.ContainerBind, parkDiskGB int) bool {
+	if len(req.Env) > 0 {
+		return false
+	}
+	if len(req.Mounts) > 0 || len(req.PlatformVolumes) > 0 || len(hostMounts) > 0 {
+		return false
+	}
+	if strings.TrimSpace(req.OSUser) != "" {
+		return false
+	}
+	if len(req.ContainerCommand) > 0 {
+		return false
+	}
+	if req.Registry != nil {
+		return false
+	}
+	if req.GPUs != nil {
+		return false
+	}
+	if parkDiskGB > 0 && req.DiskGB != parkDiskGB {
+		return false
+	}
+	return req.Image != ""
+}
+
+func (c *Client) tryWarmAdopt(ctx context.Context, req models.CreateSandboxRequest, sandboxID, toolboxToken string, hostMounts []mounts.ContainerBind, effectiveRuntime string) (*SandboxRuntime, error) {
+	if c.warmPool == nil || !c.readyEnabled {
+		return nil, dockerpool.ErrNoSlot
+	}
+	if !poolEligible(req, hostMounts, c.parkDiskGB) {
+		return nil, dockerpool.ErrNoSlot
+	}
+
+	imageInspect, err := c.inspectImage(ctx, req.Image)
+	if err != nil {
+		return nil, dockerpool.ErrNoSlot
+	}
+	imageID := strings.TrimSpace(imageInspect.ID)
+	key := dockerpool.KeyFromRequest(req, effectiveRuntime)
+	slot, err := c.warmPool.Acquire(ctx, key, imageID)
+	if err != nil {
+		if timing := CreateTimingFrom(ctx); timing != nil && errors.Is(err, dockerpool.ErrNoSlot) {
+			timing.RecordStageDesc("docker_pool", 0, "miss")
+		}
+		return nil, err
+	}
+
+	start := time.Now()
+	runtime, err := c.adoptParked(ctx, req, sandboxID, toolboxToken, slot)
+	if timing := CreateTimingFrom(ctx); timing != nil {
+		if err == nil {
+			timing.RecordStageDesc("docker_pool", time.Since(start), "hit")
+		} else {
+			timing.RecordStageDesc("docker_pool", 0, "miss")
+		}
+	}
+	if err != nil {
+		_ = c.destroyParked(ctx, slot)
+		if errors.Is(err, ErrSandboxContainerExists) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("warm adopt failed: %w", err)
+	}
+	if createtiming.From(ctx) != nil {
+		timing := createtiming.From(ctx)
+		timing.RecordDockerWaits(0, 0, "socket")
+	}
+	return runtime, nil
+}
+
+func (c *Client) parkContainer(ctx context.Context, slotID string, key dockerpool.Key) (*dockerpool.ParkedSlot, error) {
+	if err := c.ensureToolboxBinary(); err != nil {
+		return nil, err
+	}
+	bootstrapToken, err := mintBootstrapToken()
+	if err != nil {
+		return nil, err
+	}
+	parkNonce, err := mintReadyNonce()
+	if err != nil {
+		return nil, err
+	}
+
+	pl, err := NewParkedListener(c.readyDir, slotID, bootstrapToken, parkNonce)
+	if err != nil {
+		return nil, err
+	}
+
+	effectiveRuntime := strings.TrimSpace(key.Runtime)
+	if effectiveRuntime == "" {
+		effectiveRuntime = c.defaultRuntime
+	}
+	ociRuntime, err := models.ResolveOCIRuntime(effectiveRuntime)
+	if err != nil {
+		_ = pl.Close()
+		return nil, err
+	}
+
+	imageInspect, err := c.inspectImage(ctx, key.Image)
+	if err != nil {
+		_ = pl.Close()
+		return nil, fmt.Errorf("inspect image: %w", err)
+	}
+
+	workingDir := strings.TrimSpace(imageInspect.Config.WorkingDir)
+	if workingDir == "" {
+		workingDir = "/"
+	}
+	userCommand := append(append([]string{}, imageInspect.Config.Entrypoint...), imageInspect.Config.Cmd...)
+
+	envValues := []string{
+		fmt.Sprintf("SB_TOOLBOX_PORT=%d", c.toolboxPort),
+		"SB_TOOLBOX_TOKEN=" + bootstrapToken,
+	}
+	envValues = append(envValues, pl.EnvVars()...)
+
+	labels := map[string]string{
+		managedLabelKey:  "true",
+		poolParkLabelKey: poolParkLabelValue,
+	}
+
+	createRequest := map[string]any{
+		"Image":      key.Image,
+		"WorkingDir": workingDir,
+		"Entrypoint": []string{c.toolboxMountPath},
+		"Cmd":        userCommand,
+		"Env":        envValues,
+		"Labels":     labels,
+	}
+
+	binds := []string{
+		fmt.Sprintf("%s:%s:ro", c.toolboxBinaryPath, c.toolboxMountPath),
+		pl.BindSpec(),
+	}
+
+	hostConfig := map[string]any{
+		"Privileged": c.privileged,
+		"Binds":      binds,
+	}
+	if c.network != "" && c.network != "bridge" {
+		hostConfig["NetworkMode"] = c.network
+	}
+	if ociRuntime != "" {
+		hostConfig["Runtime"] = ociRuntime
+	}
+	if !c.resourceLimitsOff {
+		hostConfig["Resources"] = parkDefaultResources(c)
+	}
+	if c.parkDiskGB > 0 && effectiveRuntime != models.RuntimeGvisor {
+		hostConfig["StorageOpt"] = map[string]string{"size": fmt.Sprintf("%dG", c.parkDiskGB)}
+	}
+	createRequest["HostConfig"] = hostConfig
+
+	var created struct {
+		ID string `json:"Id"`
+	}
+	createQuery := url.Values{}
+	createQuery.Set("name", slotID)
+	if err := c.doJSON(ctx, http.MethodPost, "/containers/create", createQuery, createRequest, nil, &created); err != nil {
+		_ = pl.Close()
+		return nil, fmt.Errorf("park create: %w", err)
+	}
+	if err := c.doJSON(ctx, http.MethodPost, "/containers/"+url.PathEscape(created.ID)+"/start", nil, nil, nil, nil); err != nil {
+		_ = c.removeContainer(ctx, created.ID, true)
+		_ = pl.Close()
+		return nil, fmt.Errorf("park start: %w", err)
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, c.toolboxWaitTimeout)
+	defer cancel()
+	if err := pl.WaitParked(waitCtx); err != nil {
+		_ = c.removeContainer(ctx, created.ID, true)
+		_ = pl.Close()
+		return nil, fmt.Errorf("park ready: %w", err)
+	}
+
+	containerIP, _, err := c.waitForContainerRunning(ctx, created.ID)
+	if err != nil {
+		_ = c.removeContainer(ctx, created.ID, true)
+		_ = pl.Close()
+		return nil, err
+	}
+	if err := c.networkRules.BlockAllEgress(containerIP); err != nil {
+		_ = c.networkRules.ClearBlockAllEgress(containerIP)
+		_ = c.removeContainer(ctx, created.ID, true)
+		_ = pl.Close()
+		return nil, fmt.Errorf("park egress block: %w", err)
+	}
+
+	return &dockerpool.ParkedSlot{
+		ID:             slotID,
+		ContainerID:    created.ID,
+		ContainerIP:    containerIP,
+		ImageID:        strings.TrimSpace(imageInspect.ID),
+		Key:            key,
+		BootstrapToken: bootstrapToken,
+		Handle:         pl,
+	}, nil
+}
+
+func parkDefaultResources(c *Client) map[string]any {
+	cpu := models.DefaultCPU
+	mem := models.DefaultMemoryMB
+	resources := map[string]any{}
+	if cpu > 0 {
+		resources["CpuPeriod"] = int64(100000)
+		resources["CpuQuota"] = int64(cpu * 100000)
+	}
+	if mem > 0 {
+		resources["Memory"] = int64(mem) * 1024 * 1024
+		resources["MemorySwap"] = int64(mem) * 1024 * 1024
+	}
+	return resources
+}
+
+func (c *Client) adoptParked(ctx context.Context, req models.CreateSandboxRequest, sandboxID, toolboxToken string, slot *dockerpool.ParkedSlot) (*SandboxRuntime, error) {
+	if slot == nil || slot.Handle == nil {
+		return nil, errors.New("parked slot is incomplete")
+	}
+	pl, ok := slot.Handle.(*ParkedListener)
+	if !ok {
+		return nil, errors.New("parked slot handle type mismatch")
+	}
+
+	if err := c.renameContainer(ctx, slot.ContainerID, sandboxID); err != nil {
+		if isDockerNameConflict(err) {
+			return nil, ErrSandboxContainerExists
+		}
+		return nil, err
+	}
+
+	if err := c.updateContainerResources(ctx, slot.ContainerID, req.CPU, req.MemoryMB); err != nil {
+		return nil, err
+	}
+
+	adoptNonce, err := mintReadyNonce()
+	if err != nil {
+		return nil, err
+	}
+	adoptCtx, cancel := context.WithTimeout(ctx, readyConnReadTimeout)
+	defer cancel()
+	if err := pl.Adopt(adoptCtx, sandboxID, toolboxToken, adoptNonce); err != nil {
+		return nil, err
+	}
+
+	containerIP := slot.ContainerIP
+	if err := c.applyAdoptNetworkPolicy(containerIP, req); err != nil {
+		return nil, err
+	}
+
+	inspect, err := c.inspectContainer(ctx, slot.ContainerID)
+	if err != nil {
+		return nil, err
+	}
+	if ip := getContainerIP(inspect, c.network); ip != "" {
+		containerIP = ip
+	}
+
+	return &SandboxRuntime{
+		SandboxID:     sandboxID,
+		ContainerID:   slot.ContainerID,
+		ContainerIP:   containerIP,
+		Status:        models.SandboxStatusStarted,
+		AdoptedParkID: slot.ID,
+	}, nil
+}
+
+func (c *Client) applyAdoptNetworkPolicy(containerIP string, req models.CreateSandboxRequest) error {
+	if req.NetworkBlockAll {
+		if err := c.networkRules.BlockAllEgress(containerIP); err != nil {
+			return err
+		}
+	}
+	if len(req.NetworkAllowOut) > 0 || len(req.NetworkDenyOut) > 0 {
+		if err := c.networkRules.ApplyEgressPolicy(containerIP, req.NetworkAllowOut, req.NetworkDenyOut); err != nil {
+			_ = c.networkRules.ClearEgressPolicy(containerIP, req.NetworkAllowOut, req.NetworkDenyOut)
+			return err
+		}
+	}
+	return c.networkRules.ClearBlockAllEgress(containerIP)
+}
+
+func (c *Client) destroyParked(ctx context.Context, slot *dockerpool.ParkedSlot) error {
+	if slot == nil {
+		return nil
+	}
+	if slot.ContainerIP != "" {
+		_ = c.ClearNetworkRules(slot.ContainerIP)
+	}
+	if slot.Handle != nil {
+		_ = slot.Handle.Close()
+	}
+	if pl, ok := slot.Handle.(*ParkedListener); ok {
+		RemoveParkSocket(pl.HostSocketPath())
+	}
+	if slot.ContainerID != "" {
+		return c.removeContainer(ctx, slot.ContainerID, true)
+	}
+	return nil
+}
+
+func (c *Client) renameContainer(ctx context.Context, containerID, name string) error {
+	query := url.Values{}
+	query.Set("name", name)
+	return c.doJSON(ctx, http.MethodPost, "/containers/"+url.PathEscape(containerID)+"/rename", query, nil, nil, nil)
+}
+
+func isDockerNameConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "already in use") || strings.Contains(msg, "409")
+}
+
+func (c *Client) updateContainerResources(ctx context.Context, containerID string, cpu float64, memoryMB int) error {
+	if c.resourceLimitsOff {
+		return nil
+	}
+	resources := map[string]any{}
+	if cpu > 0 {
+		resources["CpuPeriod"] = int64(100000)
+		resources["CpuQuota"] = int64(cpu * 100000)
+	}
+	if memoryMB > 0 {
+		resources["Memory"] = int64(memoryMB) * 1024 * 1024
+		resources["MemorySwap"] = int64(memoryMB) * 1024 * 1024
+	}
+	if len(resources) == 0 {
+		return nil
+	}
+	body := map[string]any{"Resources": resources}
+	return c.doJSON(ctx, http.MethodPost, "/containers/"+url.PathEscape(containerID)+"/update", nil, body, nil, nil)
+}
+
+func mintBootstrapToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// ListParkedContainers returns running park-labeled containers for boot purge.
+func (c *Client) ListParkedContainers(ctx context.Context) ([]containerSummary, error) {
+	query := queryValues(map[string]string{
+		"all":     "0",
+		"filters": fmt.Sprintf(`{"label":["%s=%s"]}`, poolParkLabelKey, poolParkLabelValue),
+	})
+	var containers []containerSummary
+	if err := c.doJSON(ctx, http.MethodGet, "/containers/json", query, nil, nil, &containers); err != nil {
+		return nil, err
+	}
+	return containers, nil
+}
+
+// PurgeParkedContainers destroys all park-labeled containers and clears rules.
+func (c *Client) PurgeParkedContainers(ctx context.Context) (int, error) {
+	containers, err := c.ListParkedContainers(ctx)
+	if err != nil {
+		return 0, err
+	}
+	purged := 0
+	for _, summary := range containers {
+		inspect, ierr := c.inspectContainer(ctx, summary.ID)
+		if ierr == nil {
+			if ip := getContainerIP(inspect, c.network); ip != "" {
+				_ = c.ClearNetworkRules(ip)
+			}
+		}
+		if err := c.removeContainer(ctx, summary.ID, true); err == nil {
+			purged++
+		}
+	}
+	return purged, nil
+}

--- a/pkg/docker/docker_pool_integration_test.go
+++ b/pkg/docker/docker_pool_integration_test.go
@@ -1,0 +1,29 @@
+package docker
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/aerol-ai/microvm/internal/pool/dockerpool"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+func TestParkContainerCreateFailureCleansListener(t *testing.T) {
+	d := &poolFakeDaemon{t: t}
+	d.create = func() *http.Response { return textResponse(http.StatusInternalServerError, "fail") }
+	c := newPoolClient(t, d, nil)
+	_, err := c.parkContainer(context.Background(), "park-fail", dockerpool.Key{Image: "i", Runtime: models.RuntimeDocker})
+	if err == nil {
+		t.Fatal("expected park failure")
+	}
+}
+
+func TestPoolSpawnerDestroyParkedWired(t *testing.T) {
+	d := &poolFakeDaemon{t: t}
+	c := newPoolClient(t, d, nil)
+	sp := &PoolSpawner{Client: c}
+	if err := sp.DestroyParked(context.Background(), &dockerpool.ParkedSlot{ContainerID: "cid"}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/docker/docker_pool_test.go
+++ b/pkg/docker/docker_pool_test.go
@@ -1,0 +1,383 @@
+package docker
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/pool/dockerpool"
+	"github.com/aerol-ai/microvm/pkg/models"
+	"github.com/aerol-ai/microvm/pkg/mounts"
+)
+
+func TestPoolEligible(t *testing.T) {
+	base := models.CreateSandboxRequest{Image: "alpine:3.20"}
+	if !poolEligible(base, nil, 0) {
+		t.Fatal("expected eligible base request")
+	}
+	cases := []struct {
+		name string
+		req  models.CreateSandboxRequest
+		mnts []mounts.ContainerBind
+		disk int
+	}{
+		{name: "env", req: models.CreateSandboxRequest{Image: "i", Env: map[string]string{"K": "V"}}},
+		{name: "mounts", req: models.CreateSandboxRequest{Image: "i", Mounts: []models.MountSpec{{Type: "bind", Source: "/a", Target: "/b"}}}},
+		{name: "platform_volumes", req: models.CreateSandboxRequest{Image: "i", PlatformVolumes: []models.PlatformVolumeMount{{Name: "v", Path: "/p"}}}},
+		{name: "host_mounts", req: models.CreateSandboxRequest{Image: "i"}, mnts: []mounts.ContainerBind{{HostPath: "/h", ContainerPath: "/c"}}},
+		{name: "os_user", req: models.CreateSandboxRequest{Image: "i", OSUser: "root"}},
+		{name: "container_command", req: models.CreateSandboxRequest{Image: "i", ContainerCommand: []string{"sleep"}}},
+		{name: "registry", req: models.CreateSandboxRequest{Image: "i", Registry: &models.RegistryAuth{Username: "u"}}},
+		{name: "gpus", req: models.CreateSandboxRequest{Image: "i", GPUs: &models.GPURequest{Vendor: models.GPUVendorNVIDIA}}},
+		{name: "disk_mismatch", req: models.CreateSandboxRequest{Image: "i", DiskGB: 20}, disk: 10},
+		{name: "empty_image", req: models.CreateSandboxRequest{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if poolEligible(tc.req, tc.mnts, tc.disk) {
+				t.Fatal("expected ineligible")
+			}
+		})
+	}
+}
+
+func TestIsDockerNameConflict(t *testing.T) {
+	if isDockerNameConflict(nil) {
+		t.Fatal("nil is not conflict")
+	}
+	if !isDockerNameConflict(errors.New("name already in use")) {
+		t.Fatal("expected conflict")
+	}
+	if !isDockerNameConflict(errors.New("409 conflict")) {
+		t.Fatal("expected 409 conflict")
+	}
+}
+
+func TestParkDefaultResources(t *testing.T) {
+	res := parkDefaultResources(&Client{})
+	if res["CpuQuota"] == nil || res["Memory"] == nil {
+		t.Fatalf("resources = %#v", res)
+	}
+}
+
+func TestPoolSpawnerNilSafe(t *testing.T) {
+	var nilSpawner *PoolSpawner
+	if _, err := nilSpawner.Park(context.Background(), "id", dockerpool.Key{}); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := nilSpawner.DestroyParked(context.Background(), nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSetWarmPool(t *testing.T) {
+	c := &Client{}
+	pool := dockerpool.New(nil)
+	c.SetWarmPool(pool)
+	if c.warmPool == nil {
+		t.Fatal("expected warm pool wired")
+	}
+}
+
+func TestApplyAdoptNetworkPolicy(t *testing.T) {
+	c := &Client{networkRules: disabledRules(t)}
+	req := models.CreateSandboxRequest{
+		NetworkBlockAll: true,
+		NetworkAllowOut: []string{"8.8.8.8"},
+	}
+	if err := c.applyAdoptNetworkPolicy("10.0.0.2", req); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+}
+
+type badParkHandle struct{}
+
+func (badParkHandle) Alive() bool                                         { return true }
+func (badParkHandle) Adopt(context.Context, string, string, string) error { return nil }
+func (badParkHandle) Close() error                                        { return nil }
+
+func TestAdoptParkedIncompleteSlot(t *testing.T) {
+	c := &Client{networkRules: disabledRules(t)}
+	if _, err := c.adoptParked(context.Background(), models.CreateSandboxRequest{}, "sb", "tok", nil); err == nil {
+		t.Fatal("expected incomplete slot error")
+	}
+	if _, err := c.adoptParked(context.Background(), models.CreateSandboxRequest{}, "sb", "tok", &dockerpool.ParkedSlot{
+		Handle: badParkHandle{},
+	}); err == nil || !strings.Contains(err.Error(), "type mismatch") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestTryWarmAdoptDisabled(t *testing.T) {
+	c := &Client{warmPool: dockerpool.New(nil), readyEnabled: false}
+	_, err := c.tryWarmAdopt(context.Background(), models.CreateSandboxRequest{Image: "i"}, "sb", "tok", nil, models.RuntimeDocker)
+	if !errors.Is(err, dockerpool.ErrNoSlot) {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestTryWarmAdoptIneligible(t *testing.T) {
+	c := &Client{
+		warmPool:     dockerpool.New(nil),
+		readyEnabled: true,
+		httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if strings.HasSuffix(r.URL.Path, "/json") && r.Method == http.MethodGet {
+				return jsonResponse(http.StatusOK, map[string]any{"Id": "img-1"}), nil
+			}
+			return textResponse(http.StatusNotFound, ""), nil
+		})},
+	}
+	req := models.CreateSandboxRequest{Image: "i", Env: map[string]string{"X": "Y"}}
+	_, err := c.tryWarmAdopt(context.Background(), req, "sb", "tok", nil, models.RuntimeDocker)
+	if !errors.Is(err, dockerpool.ErrNoSlot) {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestDestroyParkedNilSafe(t *testing.T) {
+	c := &Client{networkRules: disabledRules(t)}
+	if err := c.destroyParked(context.Background(), nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUpdateContainerResourcesNoop(t *testing.T) {
+	c := &Client{resourceLimitsOff: true}
+	if err := c.updateContainerResources(context.Background(), "cid", 1, 512); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type poolFakeDaemon struct {
+	t            *testing.T
+	imageInspect func() *http.Response
+	create       func() *http.Response
+	start        func() *http.Response
+	containerGet func() *http.Response
+	rename       func() *http.Response
+	update       func() *http.Response
+	listJSON     func() *http.Response
+	removeCalls  int
+}
+
+func (d *poolFakeDaemon) transport() roundTripFunc {
+	return func(r *http.Request) (*http.Response, error) {
+		p := r.URL.Path
+		switch {
+		case r.Method == http.MethodGet && p == "/containers/json":
+			if d.listJSON != nil {
+				return d.listJSON(), nil
+			}
+			return jsonResponse(http.StatusOK, []containerSummary{}), nil
+		case r.Method == http.MethodGet && strings.HasPrefix(p, "/images/") && strings.HasSuffix(p, "/json"):
+			if d.imageInspect != nil {
+				return d.imageInspect(), nil
+			}
+		case r.Method == http.MethodPost && p == "/containers/create":
+			if d.create != nil {
+				return d.create(), nil
+			}
+		case r.Method == http.MethodPost && strings.HasSuffix(p, "/start"):
+			if d.start != nil {
+				return d.start(), nil
+			}
+		case r.Method == http.MethodGet && strings.HasPrefix(p, "/containers/") && strings.HasSuffix(p, "/json"):
+			if d.containerGet != nil {
+				return d.containerGet(), nil
+			}
+		case r.Method == http.MethodPost && strings.HasSuffix(p, "/rename"):
+			if d.rename != nil {
+				return d.rename(), nil
+			}
+			return textResponse(http.StatusNoContent, ""), nil
+		case r.Method == http.MethodPost && strings.HasSuffix(p, "/update"):
+			if d.update != nil {
+				return d.update(), nil
+			}
+			return textResponse(http.StatusOK, ""), nil
+		case r.Method == http.MethodDelete && strings.HasPrefix(p, "/containers/"):
+			d.removeCalls++
+			return textResponse(http.StatusNoContent, ""), nil
+		}
+		return textResponse(http.StatusNotFound, "no such endpoint: "+r.Method+" "+p), nil
+	}
+}
+
+func newPoolClient(t *testing.T, d *poolFakeDaemon, mutate func(*Client)) *Client {
+	t.Helper()
+	if d.imageInspect == nil {
+		d.imageInspect = func() *http.Response {
+			return jsonResponse(http.StatusOK, map[string]any{
+				"Id": "sha256:img1",
+				"Config": map[string]any{
+					"WorkingDir": "/",
+					"Entrypoint": []string{},
+					"Cmd":        []string{"/bin/sh"},
+				},
+			})
+		}
+	}
+	if d.create == nil {
+		d.create = func() *http.Response {
+			return jsonResponse(http.StatusCreated, map[string]string{"Id": "cid-park"})
+		}
+	}
+	if d.start == nil {
+		d.start = func() *http.Response { return textResponse(http.StatusNoContent, "") }
+	}
+	if d.containerGet == nil {
+		d.containerGet = func() *http.Response {
+			return textResponse(http.StatusOK, inspectBody("cid-park", "/park-1", "172.17.0.9", true, "running", 42))
+		}
+	}
+	c := &Client{
+		logger:             slogDefault(),
+		toolboxBinaryPath:  writableToolbox(t),
+		toolboxMountPath:   "/usr/local/bin/toolboxd",
+		toolboxPort:        2280,
+		networkRules:       disabledRules(t),
+		httpClient:         &http.Client{Transport: d.transport()},
+		streamClient:       &http.Client{Transport: d.transport()},
+		toolboxWaitTimeout: 2 * time.Second,
+		readyEnabled:       true,
+		readyDir:           t.TempDir(),
+		defaultRuntime:     models.RuntimeDocker,
+	}
+	if mutate != nil {
+		mutate(c)
+	}
+	return c
+}
+
+func slogDefault() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestListAndPurgeParkedContainers(t *testing.T) {
+	d := &poolFakeDaemon{t: t}
+	d.listJSON = func() *http.Response {
+		return textResponse(http.StatusOK, `[{"Id":"park-c1"}]`)
+	}
+	c := newPoolClient(t, d, nil)
+	purged, err := c.PurgeParkedContainers(context.Background())
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if purged != 1 || d.removeCalls != 1 {
+		t.Fatalf("purged=%d removeCalls=%d", purged, d.removeCalls)
+	}
+}
+
+func TestPurgeParkedContainersListError(t *testing.T) {
+	d := &poolFakeDaemon{t: t}
+	d.listJSON = func() *http.Response { return textResponse(http.StatusInternalServerError, "boom") }
+	c := newPoolClient(t, d, nil)
+	if _, err := c.PurgeParkedContainers(context.Background()); err == nil {
+		t.Fatal("expected list error")
+	}
+}
+
+func TestTryWarmAdoptInspectFailure(t *testing.T) {
+	c := &Client{
+		warmPool:     dockerpool.New(nil),
+		readyEnabled: true,
+		httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return textResponse(http.StatusNotFound, "no image"), nil
+		})},
+	}
+	_, err := c.tryWarmAdopt(context.Background(), models.CreateSandboxRequest{Image: "missing"}, "sb", "tok", nil, models.RuntimeDocker)
+	if !errors.Is(err, dockerpool.ErrNoSlot) {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestUpdateContainerResourcesAppliesLimits(t *testing.T) {
+	var updated bool
+	d := &poolFakeDaemon{t: t}
+	d.update = func() *http.Response {
+		updated = true
+		return textResponse(http.StatusOK, "")
+	}
+	c := newPoolClient(t, d, nil)
+	if err := c.updateContainerResources(context.Background(), "cid", 2, 1024); err != nil {
+		t.Fatal(err)
+	}
+	if !updated {
+		t.Fatal("expected update call")
+	}
+}
+
+func TestDestroyParkedClearsRulesAndContainer(t *testing.T) {
+	d := &poolFakeDaemon{t: t}
+	c := newPoolClient(t, d, nil)
+	dir, _ := os.MkdirTemp("", "rd")
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	pl, err := NewParkedListener(dir, "park-d", "tok", "n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	slot := &dockerpool.ParkedSlot{
+		ContainerID: "cid-d",
+		ContainerIP: "10.0.0.5",
+		Handle:      pl,
+	}
+	if err := c.destroyParked(context.Background(), slot); err != nil {
+		t.Fatalf("destroy: %v", err)
+	}
+	if d.removeCalls != 1 {
+		t.Fatalf("remove calls = %d", d.removeCalls)
+	}
+}
+
+func TestApplyAdoptNetworkPolicyEgressLists(t *testing.T) {
+	c := &Client{networkRules: disabledRules(t)}
+	req := models.CreateSandboxRequest{
+		NetworkAllowOut: []string{"10.0.0.1"},
+		NetworkDenyOut:  []string{"10.0.0.2"},
+	}
+	if err := c.applyAdoptNetworkPolicy("172.17.0.2", req); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPoolSpawnerParkNotConfigured(t *testing.T) {
+	sp := &PoolSpawner{}
+	if _, err := sp.Park(context.Background(), "id", dockerpool.Key{}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestRenameContainerConflictMapsToExists(t *testing.T) {
+	d := &poolFakeDaemon{t: t}
+	dir, err := os.MkdirTemp("", "rd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	c := newPoolClient(t, d, func(c *Client) { c.readyDir = dir })
+	d.rename = func() *http.Response {
+		return textResponse(http.StatusConflict, "name already in use")
+	}
+	pl, err := NewParkedListener(c.readyDir, "park-x", "boot", "nonce-park")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = pl.Close() })
+
+	slot := &dockerpool.ParkedSlot{
+		ID:          "park-x",
+		ContainerID: "cid-park",
+		ContainerIP: "10.0.0.2",
+		Handle:      pl,
+	}
+	_, err = c.adoptParked(context.Background(), models.CreateSandboxRequest{}, "sb-dup", "tok", slot)
+	if !errors.Is(err, ErrSandboxContainerExists) {
+		t.Fatalf("err = %v", err)
+	}
+}

--- a/pkg/docker/readysock_park.go
+++ b/pkg/docker/readysock_park.go
@@ -1,0 +1,244 @@
+package docker
+
+import (
+	"bufio"
+	"context"
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/version"
+	"github.com/aerol-ai/microvm/pkg/readyproto"
+)
+
+const poolParkedEnv = "SB_POOL_PARKED"
+
+// ParkedListener accepts a parked hello and holds the connection for adopt.
+type ParkedListener struct {
+	hostPath       string
+	bootstrapToken string
+	parkNonce      string
+	listener       net.Listener
+	conn           net.Conn
+	connMu         sync.Mutex
+	closed         bool
+	closeMu        sync.Mutex
+	registered     bool
+}
+
+// NewParkedListener listens for a warm-pool parked hello.
+func NewParkedListener(dir, slotID, bootstrapToken, parkNonce string) (*ParkedListener, error) {
+	slotID = strings.TrimSpace(slotID)
+	bootstrapToken = strings.TrimSpace(bootstrapToken)
+	parkNonce = strings.TrimSpace(parkNonce)
+	if slotID == "" {
+		return nil, errors.New("park slot id is required")
+	}
+	if bootstrapToken == "" || parkNonce == "" {
+		return nil, errors.New("park bootstrap token and nonce are required")
+	}
+	if strings.TrimSpace(dir) == "" {
+		return nil, errors.New("ready socket dir is required")
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("mkdir ready dir: %w", err)
+	}
+
+	hostPath := parkSocketHostPath(dir, slotID)
+	if len(hostPath) > maxUnixSocketPathLen {
+		return nil, fmt.Errorf("park socket path exceeds %d bytes: %s", maxUnixSocketPathLen, hostPath)
+	}
+	if err := os.Remove(hostPath); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("unlink stale park socket: %w", err)
+	}
+
+	ln, err := net.Listen("unix", hostPath)
+	if err != nil {
+		return nil, fmt.Errorf("listen park socket: %w", err)
+	}
+	if err := os.Chmod(hostPath, 0o666); err != nil {
+		_ = ln.Close()
+		_ = os.Remove(hostPath)
+		return nil, fmt.Errorf("chmod park socket: %w", err)
+	}
+
+	pl := &ParkedListener{
+		hostPath:       hostPath,
+		bootstrapToken: bootstrapToken,
+		parkNonce:      parkNonce,
+		listener:       ln,
+	}
+	activeReadySockets.Store(hostPath, struct{}{})
+	pl.registered = true
+	return pl, nil
+}
+
+func parkSocketHostPath(dir, slotID string) string {
+	return filepath.Join(dir, slotID+".sock")
+}
+
+// HostSocketPath returns the host-side socket path.
+func (l *ParkedListener) HostSocketPath() string {
+	if l == nil {
+		return ""
+	}
+	return l.hostPath
+}
+
+// BindSpec returns the docker bind mount for this socket.
+func (l *ParkedListener) BindSpec() string {
+	return fmt.Sprintf("%s:%s:rw", l.hostPath, GuestReadySocketPath)
+}
+
+// EnvVars returns env vars for a parked container.
+func (l *ParkedListener) EnvVars() []string {
+	return []string{
+		poolParkedEnv + "=1",
+		readySocketEnv + "=" + GuestReadySocketPath,
+		readyNonceEnv + "=" + l.parkNonce,
+	}
+}
+
+// WaitParked accepts one valid parked hello and retains the connection.
+func (l *ParkedListener) WaitParked(ctx context.Context) error {
+	if l == nil || l.listener == nil {
+		return errors.New("park listener is not configured")
+	}
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		deadline = time.Now().Add(30 * time.Second)
+	}
+	_ = l.listener.(*net.UnixListener).SetDeadline(deadline)
+
+	conn, err := l.listener.Accept()
+	if err != nil {
+		return fmt.Errorf("park socket accept: %w", err)
+	}
+	if err := l.verifyParked(conn); err != nil {
+		_ = conn.Close()
+		return err
+	}
+	l.connMu.Lock()
+	l.conn = conn
+	l.connMu.Unlock()
+	return nil
+}
+
+func (l *ParkedListener) verifyParked(conn net.Conn) error {
+	_ = conn.SetDeadline(time.Now().Add(readyConnReadTimeout))
+	sig, err := readyproto.DecodeParked(bufio.NewReader(conn))
+	if err != nil {
+		return err
+	}
+	if sig.Nonce != l.parkNonce {
+		return errors.New("park nonce mismatch")
+	}
+	if subtle.ConstantTimeCompare([]byte(sig.Token), []byte(l.bootstrapToken)) != 1 {
+		return errors.New("park token mismatch")
+	}
+	if sig.AgentVersion != "" && sig.AgentVersion != version.Version {
+		return fmt.Errorf("toolbox agent version mismatch: guest %q host %q", sig.AgentVersion, version.Version)
+	}
+	return nil
+}
+
+// Alive reports whether the held parked connection is still open.
+func (l *ParkedListener) Alive() bool {
+	if l == nil {
+		return false
+	}
+	l.connMu.Lock()
+	defer l.connMu.Unlock()
+	return l.conn != nil && !l.closed
+}
+
+// Adopt sends the adopt frame and waits for the ready ack.
+func (l *ParkedListener) Adopt(ctx context.Context, sandboxID, token, adoptNonce string) error {
+	if l == nil {
+		return errors.New("park listener is nil")
+	}
+	l.connMu.Lock()
+	conn := l.conn
+	l.connMu.Unlock()
+	if conn == nil {
+		return errors.New("park connection is not held")
+	}
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		deadline = time.Now().Add(readyConnReadTimeout)
+	}
+	_ = conn.SetDeadline(deadline)
+
+	if err := readyproto.EncodeAdopt(conn, readyproto.AdoptFrame{
+		Event:     readyproto.EventAdopt,
+		SandboxID: sandboxID,
+		Token:     token,
+		Nonce:     adoptNonce,
+	}); err != nil {
+		return fmt.Errorf("send adopt: %w", err)
+	}
+
+	sig, err := readyproto.Decode(bufio.NewReader(conn))
+	if err != nil {
+		return fmt.Errorf("adopt ack: %w", err)
+	}
+	if sig.SandboxID != sandboxID || sig.Nonce != adoptNonce {
+		return errors.New("adopt ack identity mismatch")
+	}
+	if subtle.ConstantTimeCompare([]byte(sig.Token), []byte(token)) != 1 {
+		return errors.New("adopt ack token mismatch")
+	}
+	_ = conn.Close()
+	l.connMu.Lock()
+	l.conn = nil
+	l.connMu.Unlock()
+	return nil
+}
+
+// Close shuts down the park listener and any held connection.
+func (l *ParkedListener) Close() error {
+	if l == nil {
+		return nil
+	}
+	l.closeMu.Lock()
+	defer l.closeMu.Unlock()
+	if l.closed {
+		return nil
+	}
+	l.closed = true
+	l.connMu.Lock()
+	if l.conn != nil {
+		_ = l.conn.Close()
+		l.conn = nil
+	}
+	l.connMu.Unlock()
+	if l.registered {
+		activeReadySockets.Delete(l.hostPath)
+		l.registered = false
+	}
+	var err error
+	if l.listener != nil {
+		err = l.listener.Close()
+		l.listener = nil
+	}
+	_ = os.Remove(l.hostPath)
+	return err
+}
+
+// RemoveParkSocket unlinks a park socket path if not active.
+func RemoveParkSocket(path string) {
+	if strings.TrimSpace(path) == "" {
+		return
+	}
+	if _, active := activeReadySockets.Load(path); active {
+		return
+	}
+	_ = os.Remove(path)
+}

--- a/pkg/docker/readysock_park_test.go
+++ b/pkg/docker/readysock_park_test.go
@@ -1,0 +1,128 @@
+package docker
+
+import (
+	"context"
+	"net"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/readyproto"
+)
+
+func shortParkTestDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "pk")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+func TestNewParkedListenerValidation(t *testing.T) {
+	if _, err := NewParkedListener("", "id", "tok", "n"); err == nil {
+		t.Fatal("expected dir error")
+	}
+	if _, err := NewParkedListener(shortParkTestDir(t), "", "tok", "n"); err == nil {
+		t.Fatal("expected slot id error")
+	}
+	if _, err := NewParkedListener(shortParkTestDir(t), "id", "", "n"); err == nil {
+		t.Fatal("expected token error")
+	}
+}
+
+func TestParkedListenerHappyPath(t *testing.T) {
+	dir := shortParkTestDir(t)
+	const (
+		token = "park-secret"
+		nonce = "park-nonce"
+	)
+	pl, err := NewParkedListener(dir, "park-1", token, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = pl.Close() })
+
+	if pl.BindSpec() == "" || len(pl.EnvVars()) == 0 {
+		t.Fatal("expected bind spec and env vars")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		conn, err := net.Dial("unix", pl.HostSocketPath())
+		if err != nil {
+			t.Errorf("dial: %v", err)
+			return
+		}
+		defer conn.Close()
+		_ = readyproto.EncodeParked(conn, readyproto.ParkedSignal{
+			Event: readyproto.EventParked, Token: token, Nonce: nonce,
+		})
+	}()
+
+	if err := pl.WaitParked(ctx); err != nil {
+		t.Fatalf("WaitParked: %v", err)
+	}
+	if !pl.Alive() {
+		t.Fatal("expected alive after parked hello")
+	}
+	wg.Wait()
+}
+
+func TestParkedListenerTokenMismatch(t *testing.T) {
+	pl, err := NewParkedListener(shortParkTestDir(t), "park-bad", "good", "nonce-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = pl.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	go func() {
+		conn, err := net.Dial("unix", pl.HostSocketPath())
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_ = readyproto.EncodeParked(conn, readyproto.ParkedSignal{
+			Event: readyproto.EventParked, Token: "bad", Nonce: "nonce-1",
+		})
+	}()
+
+	if err := pl.WaitParked(ctx); err == nil {
+		t.Fatal("expected token mismatch error")
+	}
+}
+
+func TestParkedListenerAdoptWithoutConnection(t *testing.T) {
+	pl, err := NewParkedListener(shortParkTestDir(t), "park-none", "tok", "n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = pl.Close() })
+	if err := pl.Adopt(context.Background(), "sb", "tok", "n"); err == nil {
+		t.Fatal("expected missing connection error")
+	}
+}
+
+func TestRemoveParkSocketSkipsActive(t *testing.T) {
+	pl, err := NewParkedListener(shortParkTestDir(t), "park-active", "tok", "n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := pl.HostSocketPath()
+	RemoveParkSocket(path)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatal("active socket should not be removed")
+	}
+	_ = pl.Close()
+	RemoveParkSocket(path)
+}

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -61,6 +61,9 @@ type SandboxRuntimeState struct {
 	// (codex P1). Empty when resolution did not yield a local path.
 	ModulePath      string
 	ModuleSizeBytes int64
+	// AdoptedParkID is non-empty when Create adopted a warm-pool slot; the
+	// service uses it to release the park capacity reservation (§4).
+	AdoptedParkID string
 }
 
 // User-facing runtime identifiers. These are the values the API, SDK, and
@@ -104,6 +107,10 @@ const (
 // "kata" hits this path. Surfaced through the API as a 4xx so operators get
 // an actionable error instead of a generic 500.
 var ErrRuntimeNotImplemented = errors.New("runtime not yet implemented on this build")
+
+// ErrSandboxExists is returned when a sandbox row with the same primary key
+// already exists. Distinct from name conflicts (store.ErrSandboxNameConflict).
+var ErrSandboxExists = errors.New("sandbox already exists")
 
 // ErrSnapshotCorrupt is returned when a runtime snapshot fails checksum
 // verification at load time — the on-disk artifact does not match the

--- a/pkg/readyproto/readyproto.go
+++ b/pkg/readyproto/readyproto.go
@@ -12,8 +12,12 @@ import (
 )
 
 const (
-	// EventReady is the only event type accepted on the readiness channel.
+	// EventReady is the guest→host readiness announcement after adopt or cold boot.
 	EventReady = "ready"
+	// EventParked is the guest→host hello from a warm-pool slot awaiting adopt.
+	EventParked = "parked"
+	// EventAdopt is the host→guest frame that binds real sandbox identity.
+	EventAdopt = "adopt"
 	// MaxLineBytes caps attacker-controlled read size on the host listener.
 	MaxLineBytes = 4 << 10
 )
@@ -27,12 +31,48 @@ type ReadySignal struct {
 	AgentVersion string `json:"agent_version,omitempty"`
 }
 
+// ParkedSignal is the guest→host parked-slot hello.
+type ParkedSignal struct {
+	Event        string `json:"event"`
+	Token        string `json:"token"`
+	Nonce        string `json:"nonce"`
+	AgentVersion string `json:"agent_version,omitempty"`
+}
+
+// AdoptFrame is the host→guest identity bind during warm-pool adoption.
+type AdoptFrame struct {
+	Event     string `json:"event"`
+	SandboxID string `json:"sandbox_id"`
+	Token     string `json:"token"`
+	Nonce     string `json:"nonce"`
+}
+
 // Encode writes one newline-terminated JSON line.
 func Encode(w io.Writer, sig ReadySignal) error {
 	if strings.TrimSpace(sig.Event) == "" {
 		sig.Event = EventReady
 	}
-	data, err := json.Marshal(sig)
+	return encodeLine(w, sig)
+}
+
+// EncodeParked writes a parked hello line.
+func EncodeParked(w io.Writer, sig ParkedSignal) error {
+	if strings.TrimSpace(sig.Event) == "" {
+		sig.Event = EventParked
+	}
+	return encodeLine(w, sig)
+}
+
+// EncodeAdopt writes a host→guest adopt frame.
+func EncodeAdopt(w io.Writer, frame AdoptFrame) error {
+	if strings.TrimSpace(frame.Event) == "" {
+		frame.Event = EventAdopt
+	}
+	return encodeLine(w, frame)
+}
+
+func encodeLine(w io.Writer, v any) error {
+	data, err := json.Marshal(v)
 	if err != nil {
 		return err
 	}
@@ -44,19 +84,11 @@ func Encode(w io.Writer, sig ReadySignal) error {
 	return err
 }
 
-// Decode reads one bounded newline-delimited JSON line from r.
+// Decode reads one bounded newline-delimited ready line from r.
 func Decode(r io.Reader) (ReadySignal, error) {
-	limited := io.LimitReader(r, MaxLineBytes+1)
-	var buf bytes.Buffer
-	if _, err := buf.ReadFrom(limited); err != nil {
+	line, err := readLine(r)
+	if err != nil {
 		return ReadySignal{}, err
-	}
-	line := strings.TrimSpace(buf.String())
-	if line == "" {
-		return ReadySignal{}, errors.New("readyproto: empty line")
-	}
-	if len(line) > MaxLineBytes {
-		return ReadySignal{}, fmt.Errorf("readyproto: line exceeds %d bytes", MaxLineBytes)
 	}
 	var sig ReadySignal
 	if err := json.Unmarshal([]byte(line), &sig); err != nil {
@@ -75,4 +107,67 @@ func Decode(r io.Reader) (ReadySignal, error) {
 		return ReadySignal{}, errors.New("readyproto: nonce is required")
 	}
 	return sig, nil
+}
+
+// DecodeParked reads a guest→host parked hello.
+func DecodeParked(r io.Reader) (ParkedSignal, error) {
+	line, err := readLine(r)
+	if err != nil {
+		return ParkedSignal{}, err
+	}
+	var sig ParkedSignal
+	if err := json.Unmarshal([]byte(line), &sig); err != nil {
+		return ParkedSignal{}, fmt.Errorf("readyproto: decode parked: %w", err)
+	}
+	if sig.Event != EventParked {
+		return ParkedSignal{}, fmt.Errorf("readyproto: unexpected event %q", sig.Event)
+	}
+	if strings.TrimSpace(sig.Token) == "" {
+		return ParkedSignal{}, errors.New("readyproto: token is required")
+	}
+	if strings.TrimSpace(sig.Nonce) == "" {
+		return ParkedSignal{}, errors.New("readyproto: nonce is required")
+	}
+	return sig, nil
+}
+
+// DecodeAdopt reads a host→guest adopt frame.
+func DecodeAdopt(r io.Reader) (AdoptFrame, error) {
+	line, err := readLine(r)
+	if err != nil {
+		return AdoptFrame{}, err
+	}
+	var frame AdoptFrame
+	if err := json.Unmarshal([]byte(line), &frame); err != nil {
+		return AdoptFrame{}, fmt.Errorf("readyproto: decode adopt: %w", err)
+	}
+	if frame.Event != EventAdopt {
+		return AdoptFrame{}, fmt.Errorf("readyproto: unexpected event %q", frame.Event)
+	}
+	if strings.TrimSpace(frame.SandboxID) == "" {
+		return AdoptFrame{}, errors.New("readyproto: sandbox_id is required")
+	}
+	if strings.TrimSpace(frame.Token) == "" {
+		return AdoptFrame{}, errors.New("readyproto: token is required")
+	}
+	if strings.TrimSpace(frame.Nonce) == "" {
+		return AdoptFrame{}, errors.New("readyproto: nonce is required")
+	}
+	return frame, nil
+}
+
+func readLine(r io.Reader) (string, error) {
+	limited := io.LimitReader(r, MaxLineBytes+1)
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(limited); err != nil {
+		return "", err
+	}
+	line := strings.TrimSpace(buf.String())
+	if line == "" {
+		return "", errors.New("readyproto: empty line")
+	}
+	if len(line) > MaxLineBytes {
+		return "", fmt.Errorf("readyproto: line exceeds %d bytes", MaxLineBytes)
+	}
+	return line, nil
 }

--- a/pkg/readyproto/readyproto.go
+++ b/pkg/readyproto/readyproto.go
@@ -3,7 +3,7 @@
 package readyproto
 
 import (
-	"bytes"
+	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -157,12 +157,22 @@ func DecodeAdopt(r io.Reader) (AdoptFrame, error) {
 }
 
 func readLine(r io.Reader) (string, error) {
-	limited := io.LimitReader(r, MaxLineBytes+1)
-	var buf bytes.Buffer
-	if _, err := buf.ReadFrom(limited); err != nil {
-		return "", err
+	br, ok := r.(*bufio.Reader)
+	if !ok {
+		br = bufio.NewReader(r)
 	}
-	line := strings.TrimSpace(buf.String())
+	raw, err := br.ReadBytes('\n')
+	if err != nil {
+		if errors.Is(err, io.EOF) && len(raw) > 0 {
+			// Tolerate a final line without a trailing newline (tests, short reads).
+		} else {
+			return "", err
+		}
+	}
+	if len(raw) > MaxLineBytes+1 {
+		return "", fmt.Errorf("readyproto: line exceeds %d bytes", MaxLineBytes)
+	}
+	line := strings.TrimSpace(string(raw))
 	if line == "" {
 		return "", errors.New("readyproto: empty line")
 	}

--- a/pkg/readyproto/readyproto_park_test.go
+++ b/pkg/readyproto/readyproto_park_test.go
@@ -1,9 +1,37 @@
 package readyproto
 
 import (
+	"net"
 	"strings"
 	"testing"
 )
+
+func TestDecodeParkedFromOpenConn(t *testing.T) {
+	// Regression: readLine must stop at '\n', not EOF. Persistent park sockets
+	// stay open for the adopt frame after the parked hello.
+	client, server := net.Pipe()
+	t.Cleanup(func() { _ = client.Close(); _ = server.Close() })
+
+	done := make(chan error, 1)
+	go func() {
+		if err := EncodeParked(client, ParkedSignal{Token: "t", Nonce: "n"}); err != nil {
+			done <- err
+			return
+		}
+		done <- nil
+	}()
+
+	got, err := DecodeParked(server)
+	if err != nil {
+		t.Fatalf("decode parked: %v", err)
+	}
+	if got.Token != "t" || got.Nonce != "n" {
+		t.Fatalf("got = %+v", got)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("encode parked: %v", err)
+	}
+}
 
 func TestDecodeParkedRejectsBadEvents(t *testing.T) {
 	cases := []string{

--- a/pkg/readyproto/readyproto_park_test.go
+++ b/pkg/readyproto/readyproto_park_test.go
@@ -1,0 +1,63 @@
+package readyproto
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDecodeParkedRejectsBadEvents(t *testing.T) {
+	cases := []string{
+		`{"event":"ready","token":"t","nonce":"n"}`,
+		`{"event":"parked","token":"","nonce":"n"}`,
+		`{"event":"parked","token":"t","nonce":""}`,
+	}
+	for _, line := range cases {
+		if _, err := DecodeParked(strings.NewReader(line + "\n")); err == nil {
+			t.Fatalf("expected error for %q", line)
+		}
+	}
+}
+
+func TestDecodeAdoptRejectsBadEvents(t *testing.T) {
+	cases := []string{
+		`{"event":"parked","sandbox_id":"sb","token":"t","nonce":"n"}`,
+		`{"event":"adopt","sandbox_id":"","token":"t","nonce":"n"}`,
+		`{"event":"adopt","sandbox_id":"sb","token":"","nonce":"n"}`,
+		`{"event":"adopt","sandbox_id":"sb","token":"t","nonce":""}`,
+	}
+	for _, line := range cases {
+		if _, err := DecodeAdopt(strings.NewReader(line + "\n")); err == nil {
+			t.Fatalf("expected error for %q", line)
+		}
+	}
+}
+
+func TestDecodeParkedOversizeLine(t *testing.T) {
+	line := strings.Repeat("a", MaxLineBytes+1)
+	_, err := DecodeParked(strings.NewReader(line))
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("expected oversize error, got %v", err)
+	}
+}
+
+func TestEncodeParkedDefaultEvent(t *testing.T) {
+	var buf strings.Builder
+	if err := EncodeParked(&buf, ParkedSignal{Token: "t", Nonce: "n"}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := DecodeParked(strings.NewReader(buf.String()))
+	if err != nil || got.Event != EventParked {
+		t.Fatalf("got = %+v err = %v", got, err)
+	}
+}
+
+func TestEncodeAdoptDefaultEvent(t *testing.T) {
+	var buf strings.Builder
+	if err := EncodeAdopt(&buf, AdoptFrame{SandboxID: "sb", Token: "t", Nonce: "n"}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := DecodeAdopt(strings.NewReader(buf.String()))
+	if err != nil || got.Event != EventAdopt {
+		t.Fatalf("got = %+v err = %v", got, err)
+	}
+}

--- a/pkg/readyproto/readyproto_test.go
+++ b/pkg/readyproto/readyproto_test.go
@@ -53,6 +53,44 @@ func TestDecodeUnknownFieldsTolerated(t *testing.T) {
 	}
 }
 
+func TestParkedAdoptRoundTrip(t *testing.T) {
+	parked := ParkedSignal{
+		Event:        EventParked,
+		Token:        "park-tok",
+		Nonce:        "park-nonce",
+		AgentVersion: "1.0.0",
+	}
+	var buf bytes.Buffer
+	if err := EncodeParked(&buf, parked); err != nil {
+		t.Fatalf("encode parked: %v", err)
+	}
+	gotParked, err := DecodeParked(&buf)
+	if err != nil {
+		t.Fatalf("decode parked: %v", err)
+	}
+	if gotParked != parked {
+		t.Fatalf("parked round-trip = %+v, want %+v", gotParked, parked)
+	}
+
+	adopt := AdoptFrame{
+		Event:     EventAdopt,
+		SandboxID: "sb-123",
+		Token:     "adopt-tok",
+		Nonce:     "adopt-nonce",
+	}
+	buf.Reset()
+	if err := EncodeAdopt(&buf, adopt); err != nil {
+		t.Fatalf("encode adopt: %v", err)
+	}
+	gotAdopt, err := DecodeAdopt(&buf)
+	if err != nil {
+		t.Fatalf("decode adopt: %v", err)
+	}
+	if gotAdopt != adopt {
+		t.Fatalf("adopt round-trip = %+v, want %+v", gotAdopt, adopt)
+	}
+}
+
 func TestDecodeRejectsEmptyValues(t *testing.T) {
 	cases := []string{
 		`{"event":"ready","sandbox_id":"","token":"t","nonce":"n"}`,

--- a/plans/docker-warm-pool.md
+++ b/plans/docker-warm-pool.md
@@ -1,0 +1,401 @@
+# Docker warm pool — sub-100ms create for pooled images
+
+**Status:** planned (not started) — rev 2, incorporates create-path review findings
+**Prereq:** `plans/docker-ready-socket-sandbox-id-fix.md` — SHIPPED (3b5af0c, v0.5.25) and live-verified; the adopt handshake below extends that socket protocol.
+**Related:** `internal/pool/wasm/` (the pattern to mirror), `internal/pool/vmm/` (daemon wiring + orphan pattern), `plans/wasm-create-latency.md` (the drain-vs-refill lesson).
+
+## 1. Problem — measured, not estimated
+
+Live numbers from cluster-3-mixed-docker (t3.medium × 3, v0.5.25, 2026-07-06):
+
+| Stage | Measured |
+|---|---|
+| Docker engine `POST /containers/create` (unix socket, cached alpine:3.20) | 109–122ms |
+| Docker engine `POST /containers/{id}/start` | 166–180ms |
+| **Engine subtotal — not our code** | **276–303ms** |
+| Full server-side create through sandboxd (`create;dur`, localhost, 8 samples) | 304–332ms |
+| sandboxd's own overhead (raft apply ~4.5ms, store fsyncs ~1ms ea, iptables ≤10ms, readiness 0.1–3.5ms post-fix, inspects/keygen) | ~15–30ms |
+
+The readiness-socket fix removed sandboxd's last request-path waste. What
+remains is the Docker engine itself. **No change inside sandboxd gets under
+100ms while `create`+`start` sit on the request path.** The only code-level
+fix is to take them off it: keep containers pre-created, pre-started, with
+toolboxd already booted, and *adopt* one at create time.
+
+Target: **warm-hit server p50 ≤ 100ms on t3.medium (expected 20–50ms)**;
+misses byte-identical to today (~300ms + pull if uncached).
+
+## 2. Design overview
+
+New package `internal/pool/dockerpool`, mirroring `internal/pool/wasm`
+(targets map, ready slots, `Acquire` → hit/miss, miss kicks refill, ticker +
+kick channel, `spawning` map as per-key refill single-flight — the missing
+single-flight was the WASM bench's tail lesson; do not repeat it).
+
+### Current create ordering (the constraint everything below respects)
+
+`internal/service/service.go createSandbox`:
+`admitter.Admit` (:1164) → `mounts.MountAll` (:1179) → `docker.Create`
+(:1190, **pool Acquire+adopt live inside here**) → `sealRegistry` → caddy
+route if public (:1264) → `store.Create` (:1281) → platform-volume
+attachments. Every failure after Admit runs the rollback chain
+(destroy → unmount → `releaseAdmission`). The warm-hit branch changes
+nothing about this ordering — it only swaps what happens inside
+`docker.Create`.
+
+### Park lifecycle
+
+A **parked container** is created and started ahead of demand by the refill
+loop via a new `docker.Client.ParkContainer`:
+
+- name `park-<16 hex>`, Docker label `aerol.pool=park` (the orphan-scan key)
+- env: `SB_POOL_PARKED=1`, `SB_TOOLBOX_PORT`, a **park-scoped bootstrap
+  token** (random, never valid for toolbox API calls), no `SB_SANDBOX_ID`
+- `Entrypoint` is the host-bind-mounted toolboxd exactly as today
+  (client.go:410); `Cmd` is the image's default Entrypoint+Cmd resolved at
+  park time (same resolution as the cold path, client.go:402–404)
+- **Parked toolboxd defers the user command.** Today toolboxd starts
+  `os.Args[1:]` at boot (cmd/toolboxd/main.go:140–141). In parked mode it
+  must NOT: a parked slot running the image's server/default command would
+  do real work (bind ports, mutate state) with no identity. Parked mode
+  boots the toolbox listener only, rejects every HTTP call except health,
+  and calls `startUserCommandFn` **after the adopt ack**. Since eligibility
+  (§3) already excludes custom `ContainerCommand`, the deferred command is
+  always the image default — post-adopt semantics match a cold create.
+- ready socket bind-mounted exactly as today (`/run/aerol/ready.sock`),
+  host listener held open under `readyDir/park-<id>.sock`
+- **`BlockAllEgress` applied at park time** (IP-keyed DROP at position 1 of
+  DOCKER-USER, netrules/manager.go:50) — no identity, no network
+- the held socket connection doubles as liveness: if it drops, the slot is
+  dead — reap it, don't hand it out
+
+### Adopt flow (the create fast path)
+
+`docker.Client.Create` checks eligibility (§3) → `pool.Acquire(key)`:
+
+1. `docker rename park-xxx sb-<id>` (~5ms). **A rename conflict ("name
+   already in use") is a duplicate-create signal, not an error to
+   propagate:** destroy the parked candidate, then re-dispatch to the
+   duplicate protocol in §6 — never blind-fall-through to a cold create,
+   which would hit the same conflict 300ms later.
+2. `docker update` for CPU/memory if the request's shape differs from the
+   park default (cgroup writes, ~ms).
+3. Host sends the **adopt frame** over the held connection: real sandbox
+   ID, freshly minted toolbox token, adopt nonce. toolboxd swaps identity
+   atomically, starts the deferred user command, and replies with today's
+   `ready` signal (ID + token + nonce echo). Same trust model as the
+   shipped push: root-owned unix socket, nonce binds the exchange to this
+   park socket.
+4. **Network-rule replacement, in this order** (rules coexist in
+   DOCKER-USER, the park DROP at position 1 wins until removed, so the
+   container transitions closed→target-policy with no open window):
+   a. install the request's allow/deny/block rules for the container IP;
+   b. only then `ClearBlockAllEgress` the park DROP.
+   Never the reverse — clearing first opens unrestricted egress for the
+   gap when the request wanted restrictions.
+5. Inspect for the container IP; return the `SandboxRuntime` (annotated
+   with the adopted park-slot ID for the capacity transfer, §4).
+
+Adopt total: ~15–40ms server-side. Readiness is instant — toolboxd was
+already up, so `toolbox_wait ≈ 0` stays true.
+
+**Adopt-failure rule:** a *pre-store* failure (handshake timeout, bad ack,
+dead conn — anything except a duplicate signal) → destroy the parked
+container **including `ClearNetworkRules` for its IP**, then fall through
+to the cold create path. The pool may only ever make a create faster,
+never make it fail. Duplicate signals (rename conflict, store conflict)
+take the §6 protocol instead. No "un-adopt" — once renamed/handshaken, the
+container is tainted and dies.
+
+**Stale-DROP invariant:** every path that discards a parked container
+(adopt failure, TTL reap, LRU eviction, liveness reap, boot purge,
+shutdown drain) must clear its IP-keyed rules before/with the destroy.
+Docker's bridge reuses IPs — a leaked park DROP black-holes an unrelated
+future container. Regression test required (§7).
+
+### Target policy — what gets warmed
+
+- **Pinned targets** (`SB_DOCKER_POOL_IMAGES`, default = the host default
+  image): warm at daemon start, on every worker, depth
+  `SB_DOCKER_POOL_DEPTH` (default 2). These hit on the *first* create.
+- **Miss-driven self-warming** (wasm `NoteModule` pattern): a pool miss
+  registers the key as a refill target, so the second create of any image
+  on that node hits. Bounded by:
+  - `SB_DOCKER_POOL_MAX_IMAGES` (default 8) distinct targets, LRU-evicted
+  - `SB_DOCKER_POOL_IDLE_TTL` (default 15m): no create for that key →
+    parked slots reaped, target dropped (pinned targets never expire)
+- **Capacity-gated refill:** see §4.
+
+Cluster note: pools are per-node and independent. Warm-aware placement
+(gossiping warm-image sets, preferring warm nodes) is **Phase 2** — v1
+accepts ~1/N first-hit rate on self-warmed images across N workers.
+
+## 3. Eligibility & pool key
+
+**Pool key = resolved image identity + runtime**, not the bare tag:
+`(Image, ImageDigest, ImageRegistryRef, ImageDistributionMode, Runtime)`
+from `models.CreateSandboxRequest` (pkg/models/types.go:500–507, :549).
+Two creates writing the same tag string can still resolve to different
+rootfs (digest-pinned vs floating, aocr vs local_only) — they must not
+share slots. Additionally, **tags move**: `ParkContainer` records the
+local Docker image ID at park time, and `Acquire` re-validates it against
+the current image ID for that reference — mismatch (image re-pulled/
+retagged since park) discards the slot and counts a
+`docker_pool_stale_image` metric instead of serving a stale rootfs.
+
+Everything baked into `docker create` that we cannot change post-hoc
+forces a miss:
+
+| Field | Poolable? |
+|---|---|
+| image identity + `Runtime` | must match a pool key (above) |
+| `CPU`, `MemoryMB` | yes — `docker update` at adopt |
+| `DiskGB` ≠ park default | **miss** (storage opt is create-time) |
+| `Env` non-empty | **miss in v1** (baked at create; Phase 2: adopt frame carries env, toolboxd injects into every exec/session it spawns — needs the PID-1-won't-see-it caveat documented) |
+| `Mounts` / `PlatformVolumes` non-empty | **miss** (binds are create-time) |
+| `OSUser`, `ContainerCommand`, `Registry`, `GPUs` set | **miss** |
+| `NetworkBlockAll` / allow/deny lists / byte limits | yes — netrules applied at adopt (§2 ordering) |
+| `Name`, `Tags`, `Lifecycle`, `Failover`, custom domains | yes — store/service level, container-agnostic |
+
+The bench (`{"image":"alpine:3.20"}`) and default agent-workload creates
+are eligible; that's the traffic the 100ms goal is for.
+
+## 4. Capacity: park reservation → sandbox reservation transfer
+
+Parked containers consume real memory/CPU, so admission must see them —
+but `Admit` runs *before* `docker.Create` (service.go:1164 vs :1190), i.e.
+before we know whether this create will adopt a slot. Naive "parked slots
+are reservations too" double-counts during every warm hit and, at the
+capacity margin, rejects a create that would have *freed* a parked slot.
+Explicit semantics:
+
+1. **Refill reserves.** Before parking, the refill loop calls
+   `admitter.Admit("park:<slot-id>", slotShape)`. Refusal = no park (the
+   pool never overcommits). Additionally refill keeps a **guard band**: it
+   parks only while free headroom after the park ≥ one default-shaped
+   sandbox, so pinned slots don't consume the last admissible request.
+2. **Create admits normally.** `createSandbox` keeps its existing
+   `Admit(sandboxID, req)` — unchanged, byte-identical cold path.
+3. **Adopt transfers.** When `docker.Create` returns a `SandboxRuntime`
+   carrying `AdoptedParkID != ""`, the service immediately calls
+   `admitter.Release("park:<slot-id>")` (a new narrow
+   `ReleasePark`/`Release` reuse — same ledger). Net effect: the
+   double-count window is the microseconds between Admit and the release
+   call, and it only ever *over*-reserves (safe direction; never
+   undercounts).
+4. **Margin behavior (documented, tested):** at hard capacity, `Admit` can
+   reject a warm-hit-eligible create even though adoption would free a
+   slot. Accepted for v1 — the guard band makes it rare, correctness is
+   preserved, and the alternative (admitting against pool credit) couples
+   the admitter to pool internals. Regression test pins this behavior so
+   it's a choice, not an accident.
+5. **Every parked-slot discard path releases its park reservation** (same
+   list as the stale-DROP invariant, §2).
+
+UC-95 density with the pool enabled is the end-to-end check: ceiling must
+equal today's minus exactly the configured parked budget, and return to
+today's after `SB_DOCKER_POOL_ENABLED=false` restart.
+
+## 5. Protocol change — readyproto v2
+
+`pkg/readyproto/readyproto.go` today: one guest→host `ready` line. Add two
+frames, same newline-delimited JSON, same `MaxLineBytes` bound:
+
+```go
+EventParked = "parked" // guest→host: {event, token(bootstrap), nonce(park), agent_version}
+EventAdopt  = "adopt"  // host→guest: {event, sandbox_id, token(real), nonce(adopt)}
+// adopt ack = existing EventReady signal carrying the new identity
+```
+
+`Decode` stays strict per event type; the host listener
+(`pkg/docker/readysock.go`) gains a parked-connection registry and a
+`SendAdopt(conn, frame)` with a write deadline.
+
+### Gating — the pool requires the socket
+
+Today `DockerReadySocketEffective() = DockerReadySocketEnabled &&
+EnableCluster` (config.go:1959–1961) — single-node hosts deliberately keep
+health-poll. Adoption *depends* on the held socket, so with the current
+gate the pool would silently never hit outside cluster mode. Change:
+
+- `DockerReadySocketEffective() = DockerReadySocketEnabled &&
+  (EnableCluster || DockerPoolEnabled)` — enabling the pool is the same
+  "operator controls the host layout" opt-in the cluster install makes,
+  which is what the gate was protecting.
+- `DockerPoolEffective() = DockerPoolEnabled && DockerReadySocketEnabled`;
+  daemon logs a Warn and disables the pool if the socket knob is
+  explicitly off.
+
+### Version skew (corrected: toolboxd is a host bind-mount, not an image binary)
+
+toolboxd enters every container as a bind-mount of the **host** binary
+(client.go:410 `c.toolboxMountPath`), so there is no "old toolboxd image"
+case. The real skew cases:
+
+| Case | Behavior |
+|---|---|
+| Parked container running the **pre-upgrade** host binary (exec'd before a sandboxd upgrade) | the boot orphan purge destroys all parked containers on daemon restart, and upgrades restart the daemon — so this only survives a binary-swap-without-restart, which the install flow doesn't do. Belt-and-braces: the `parked` hello carries `AgentVersion`; adopt refuses on mismatch → slot destroyed, cold fallback. |
+| Host binary lacking parked mode (rollback to old release) with pool on | old toolboxd ignores `SB_POOL_PARKED`, starts the user command, never sends `parked` hello → spawner times out, destroys the container, **disables that target** with a Warn (don't refill-loop a broken combination). |
+| Pool off / old sandboxd | `SB_POOL_PARKED` never set → toolboxd boots exactly as today. |
+| Mixed cluster nodes | pools are per-node; no cross-node coupling. |
+
+## 6. Idempotency & the duplicate-create race (pr-review non-negotiables)
+
+Reality check on the current code: idempotency for recreate is a
+**pre-check** (`CreateSandboxWithID` does `store.Get` before creating,
+service.go:696–705); two concurrent duplicates can both pass it.
+`store.Create` (store.go:769) checks name availability explicitly but an
+ID PK conflict surfaces as a **raw SQLite error** — there is no typed
+already-exists signal today, and `createSandbox` returns that error after
+running the rollback chain. The plan must not pretend otherwise. Concrete
+protocol:
+
+- **Type the conflict.** `store.Create` gains detection of the sandboxes
+  PK/UNIQUE violation → returns a new `models.ErrSandboxExists` (name
+  conflicts keep their current 409 shape). This is a tiny, separately
+  testable store change and benefits the cold path equally.
+- **On `ErrSandboxExists` after an adopt** (and on adopt-time rename
+  conflict, which is the same race seen earlier): destroy the adopted
+  candidate (clearing its netrules + releasing its park reservation),
+  release this call's admission, then `store.Get(id)` — row present →
+  return it (idempotent success, matching `CreateSandboxWithID`'s
+  semantics); row absent (loser of a create/destroy interleave) → return
+  `ErrSandboxExists` and let the caller retry. **Never fall through to a
+  cold create on a duplicate signal** — it would re-conflict 300ms later.
+- **Fresh-ID path (`CreateSandbox`)**: IDs are 16 random hex; PK conflict
+  is practically unreachable, but the same handling applies for free.
+- **Rollback parity:** the adopt branch reuses the existing failure chain
+  (destroy → unmount → release admission) so a warm create that fails
+  post-adopt leaves exactly the same world as a failed cold create, plus
+  the park-reservation release and netrules clear from §2/§4.
+- **Boot-path call-out for the PR:** the fast path adds one pool-map
+  lookup (~µs) to every docker create including misses; the miss path is
+  otherwise byte-identical. First call after daemon start: pool empty →
+  miss → today's behavior.
+
+## 7. File-by-file changes
+
+**New: `internal/pool/dockerpool/`** — `pool.go` (keys per §3, slots,
+Acquire with image-ID revalidation, LRU + TTL, kickRefill), `refill.go`
+(ticker + kick + §4 capacity gate + guard band), `spawner.go` (Spawner
+interface; prod impl → `docker.Client.ParkContainer`), `metrics.go`
+(expvars `docker_pool_hit/miss/refill/orphan/parked/stale_image`,
+`docker_pool_adopt_ms`), `errors.go`. Each with `_test.go` (≥85%).
+
+**`pkg/docker/client.go`** — `ParkContainer` (park identity create+start,
+records image ID, applies park DROP, returns slot handle with held conn);
+`AdoptParked` (rename → update → adopt handshake → §2 rule-ordering →
+inspect); `Create` gains the eligibility-check → Acquire → adopt fast path
+with the §2/§6 failure dispatch. `SandboxRuntime` gains `AdoptedParkID`.
+Cold-path code is untouched.
+
+**`pkg/docker/readysock.go`** — parked-connection registry, `SendAdopt`,
+liveness check on the held conn; park sockets are reaped by the boot purge
+(no `ParkBindSource` survival — parked containers are cheap to rebuild).
+
+**`pkg/readyproto/readyproto.go`** — the two frames above + table-driven
+encode/decode/bounds tests.
+
+**`cmd/toolboxd/main.go` + `readyclient_linux.go`** — parked mode: skip
+`startUserCommandFn` at boot, hello, block-for-adopt, atomic identity swap
+(`sandboxID`, auth token), reject non-health requests pre-adopt, start the
+deferred user command, ready ack. `readyclient_other.go` stays a stub.
+
+**`internal/store/store.go`** — typed `models.ErrSandboxExists` on
+sandboxes-PK violation in `Create` (§6) + regression test in
+`store_test.go`.
+
+**`internal/service/service.go`** — release the park reservation when
+`docker.Create` returns `AdoptedParkID` (§4); duplicate-signal handling
+per §6. No other ordering change.
+
+**`internal/config/config.go`** — `SB_DOCKER_POOL_ENABLED` (**default
+false** in v1), `SB_DOCKER_POOL_DEPTH` (2), `SB_DOCKER_POOL_IMAGES`
+(default image), `SB_DOCKER_POOL_MAX_IMAGES` (8), `SB_DOCKER_POOL_IDLE_TTL`
+(15m); `DockerPoolEffective()`; widened `DockerReadySocketEffective()`
+(§5 gating) — this touches the shipped readiness gate, call it out and
+extend `readysock`/config tests for the single-node+pool combination.
+
+**`pkg/daemon/daemon.go`** — wire next to the Phase-4 VMM pool block
+(daemon.go ~369): construct pool, SetSpawner, RunRefill on the daemon ctx,
+**boot orphan purge** (list `label=aerol.pool=park` → clear each one's
+netrules → destroy; refill rebuilds in ~seconds), drain parked containers
+on graceful shutdown (same clear-then-destroy).
+
+**`pkg/capacity/`** — park-keyed reservations + the §4 transfer/release
+seam and guard band. Regression tests: density ceiling, margin-rejection
+behavior (§4.4), release-on-discard.
+
+**`pkg/docker/create_timing.go` + Server-Timing** — new stage
+`docker_pool;desc=hit|miss` (+ `dur` = adopt time on hits). The bench's
+generic stage parser (`integration-tests/suite/harness/timing.go`) already
+picks up any named stage — no harness change needed for reporting.
+
+**Integration** — new UC (docker warm-hit): create default image twice on
+a pool-enabled scenario; assert second create has `docker_pool;desc=hit`,
+`readiness;desc=socket`, and `create;dur < 150` (t3.medium slack over the
+100ms goal). Enable the pool in `cluster-3-mixed-docker.tfvars`/Ansible env
+for `make integration-benchmark-docker`.
+
+**Docs** — no SDK surface change (no new methods, no wire fields), so no
+five-tab SDK page; operator-facing config documented on the self-hosting
+configuration page + `setup/` runbook note on capacity sizing with pools.
+
+## 8. Test matrix (beyond per-package 85%)
+
+- pool: hit/miss, LRU eviction, TTL reap, refill single-flight, capacity
+  guard band, stale-image discard.
+- docker client (fake-daemon, `ready_create_test.go` style): adopt success;
+  adopt handshake timeout → cold fallback with netrules cleared + park
+  reservation released; rename conflict → §6 duplicate protocol; rule
+  ordering (request policy present before park DROP removal).
+- **stale park DROP regression:** destroy a parked container through every
+  discard path, assert no `-s <ip> -j DROP` remains (netrules manager fake).
+- store: `ErrSandboxExists` typing; concurrent duplicate `CreateSandboxWithID`
+  (both pass pre-check, one wins, loser returns the winner's row).
+- capacity: warm hit releases park reservation exactly once; margin
+  rejection pinned (§4.4); density ceiling arithmetic.
+- toolboxd: parked-mode table tests — deferred user command (not started
+  before adopt, started exactly once after), pre-adopt API rejection,
+  identity swap atomicity.
+- daemon: boot purge clears rules + reservations; shutdown drain.
+
+## 9. Rollout & acceptance gates
+
+1. **Phase A** — land everything default-off (`SB_DOCKER_POOL_ENABLED=false`),
+   full test coverage, no behavior change anywhere (including the widened
+   socket gate: without the pool knob it reduces to today's expression).
+2. **Phase B** — enable in cluster-3-mixed-docker; `make
+   integration-benchmark-docker` gates:
+   - UC-94 docker `server_p50_ms ≤ 100` (expect 20–50) with
+     `docker_pool;desc=hit` on ≥ 8/10 samples
+   - `docker_pool_orphan`/`stale_image` expvars = 0 across nodes
+   - UC-95 density ceiling = today's − parked budget, exactly
+   - existing UC-96* readiness UCs still pass with `source=socket`
+3. **Phase C** — default-on after a soak on the kept cluster; update
+   `agentic_docs/` request-flow notes.
+
+## 10. Out of scope (explicit)
+
+- Lazy-pull snapshotters (eStargz/SOCI) — containerd-level, separate track.
+- Bypassing dockerd for containerd — large rewrite, uncertain payoff.
+- Warm-aware placement (gossip warm-image sets) — Phase 2, needs
+  `internal/cluster` care per CLAUDE.md fragility rules.
+- `req.Env` injection via toolboxd exec-env — Phase 2 (semantic caveat:
+  PID 1 won't see user env).
+- Pull acceleration (pre-distribution on registration, pull-through
+  mirror) — complementary, separate plan.
+- Admitting against pool credit at the capacity margin (§4.4) — revisit
+  only if the guard band proves insufficient in practice.
+
+## 11. PR checklist
+
+- [ ] Run `/touch-create-sandbox` before coding (boot-path change).
+- [ ] Boot-path latency call-out in the PR description (miss path delta ≈ 0, first-call case).
+- [ ] Idempotency call-out (§6: typed store conflict, duplicate protocol, WithID parity).
+- [ ] Failure-path rollback rule documented (destroy-on-adopt-failure incl. netrules clear + park-reservation release; no un-adopt).
+- [ ] Capacity call-out (§4 transfer semantics, guard band, margin behavior, density test).
+- [ ] Ready-socket gate widening called out (touches shipped readiness path; single-node+pool tests).
+- [ ] Version-skew matrix in the PR description (§5 table — host-binary skew, not image skew).
+- [ ] `go test -coverprofile` — `internal/pool/dockerpool`, `pkg/docker`, `pkg/readyproto`, `cmd/toolboxd`, `internal/store`, `pkg/capacity` all ≥ ~85%.
+- [ ] Table-driven test style matching `store_test.go` / `ready_create_test.go`.


### PR DESCRIPTION
## Summary

- **Problem:** After the readiness-socket fix (v0.5.25), Docker sandbox creates on t3.medium still spend **276–303ms inside the Docker engine** (`POST /containers/create` + `POST /containers/{id}/start`). sandboxd overhead is ~15–30ms. No in-request-path optimization can reach a **sub-100ms p50** while create+start run synchronously.
- **Solution:** Introduce `internal/pool/dockerpool` — a per-node warm pool that **pre-creates, pre-starts, and pre-boots toolboxd** in parked containers. On eligible creates, `docker.Client.Create` **adopts** a parked slot (rename → cgroup update → adopt handshake → network rules → inspect) instead of cold create+start. Target warm-hit server p50: **20–50ms**; misses remain byte-identical to today (~300ms).
- **Safety:** Default-off (`SB_DOCKER_POOL_ENABLED=false`). Eligibility gate excludes mounts, custom commands, env, GPUs, disk overrides, etc. Adopt failure falls through to cold create. Duplicate-create races use explicit `ErrSandboxExists` / rename-conflict protocol — never blind cold retry.

Design doc: [`plans/docker-warm-pool.md`](plans/docker-warm-pool.md) (rev 2).

---

## The problem (measured)

Live cluster-3-mixed-docker benchmarks (t3.medium × 3, v0.5.25):

| Stage | Latency |
|---|---|
| Docker `containers/create` (cached alpine:3.20) | 109–122ms |
| Docker `containers/{id}/start` | 166–180ms |
| **Engine subtotal (unavoidable on cold path)** | **276–303ms** |
| Full sandboxd create (`create;dur`) | 304–332ms |
| sandboxd own overhead (raft, store, iptables, readiness, inspect) | ~15–30ms |

```mermaid
flowchart LR
  subgraph today["Cold create path (today)"]
    A[API CreateSandbox] --> B[admitter.Admit]
    B --> C[mounts.MountAll]
    C --> D["docker.Create<br/>engine create ~110ms"]
    D --> E["docker start ~170ms"]
    E --> F[toolboxd boot + ready socket]
    F --> G[sealRegistry + caddy + store.Create]
    G --> H[Response]
  end

  style D fill:#fee,stroke:#c00
  style E fill:#fee,stroke:#c00
```

The red blocks are **Docker engine work on the request path**. sandboxd cannot shrink them without taking them off the path entirely.

---

## The solution (park + adopt)

```mermaid
flowchart TB
  subgraph background["Background (refill loop, off request path)"]
    R1[Refill ticker] --> R2{Capacity gate<br/>CanPark?}
    R2 -->|yes| R3[ParkReservation park:slot-id]
    R3 --> R4["ParkContainer<br/>create+start+toolboxd parked"]
    R4 --> R5[BlockAllEgress DROP]
    R5 --> R6[toolboxd sends parked hello]
    R6 --> R7[Slot enters ready queue]
    R2 -->|no| R8[wait next tick]
  end

  subgraph request["Warm-hit create path (~20–50ms)"]
    A[API CreateSandbox] --> B[admitter.Admit sandbox-id]
    B --> C[mounts.MountAll]
    C --> D["docker.Create<br/>pool.Acquire(key)"]
    D --> E["rename park-xxx → sb-id"]
    E --> F[docker update CPU/mem if needed]
    F --> G["adopt frame over held socket"]
    G --> H[toolboxd starts deferred Cmd]
    H --> I["apply request netrules<br/>then clear park DROP"]
    I --> J[inspect + return runtime]
    J --> K[ReleaseParkReservation]
    K --> L[sealRegistry + caddy + store.Create]
    L --> M[Response]
  end

  R7 -.->|hit| D
```

**Key insight:** Engine `create+start` and toolboxd boot happen in the **background refill loop**. The request path only does rename (~5ms), cgroup update (~ms), adopt handshake (~ms), netrules (~≤10ms), and inspect.

---

## Adopt handshake sequence

Extends the shipped readiness-socket protocol (`readyproto` v2) with `parked` → `adopt` → `ready`:

```mermaid
sequenceDiagram
  participant Refill as Refill loop
  participant Engine as Docker engine
  participant Host as sandboxd (held socket)
  participant TB as toolboxd (parked)
  participant API as CreateSandbox request

  Note over Refill,TB: Park phase (background)
  Refill->>Engine: create+start park-xxx
  Engine->>TB: boot with SB_POOL_PARKED=1
  TB->>Host: parked {token, nonce}
  Host->>Host: hold connection (liveness)

  Note over API,TB: Adopt phase (request path)
  API->>Host: docker.Create eligible request
  Host->>Host: pool.Acquire(key) → slot
  Host->>Engine: rename park-xxx → sb-id
  Host->>Engine: update CPU/memory
  Host->>TB: adopt {sandbox_id, token, nonce}
  TB->>TB: swap identity, start deferred Cmd
  TB->>Host: ready {sandbox_id, token, nonce}
  Host->>Host: apply netrules, clear park DROP
  Host->>Host: ReleaseParkReservation(park:slot)
  Host->>API: SandboxRuntime (AdoptedParkID set)
```

Parked toolboxd **rejects all HTTP except `/health`** until adopt — a parked slot must not run the image's default command (bind ports, mutate state) without identity.

---

## Capacity: park reservation → sandbox transfer

Naively counting parked slots at `Admit` time would **double-count** on every warm hit (park reservation + sandbox reservation for the same RAM). Instead:

```mermaid
flowchart LR
  subgraph refill["Refill"]
    P1["Admit park:slot-id"] --> P2[Parked container consumes host RAM]
  end

  subgraph adopt["Warm adopt"]
    A1["Admit sb-id (normal create)"] --> A2[Adopt parked slot]
    A2 --> A3["Release park:slot-id"]
    A3 --> A4[Single sb-id reservation remains]
  end

  subgraph miss["Pool miss / cold path"]
    M1[No park reservation involved]
  end
```

`ParkGate` also reserves a **guard band** (one default-shaped sandbox worth of headroom) so refill cannot park the host into rejecting real creates.

---

## Pool key & eligibility

Pool key = **resolved image identity + runtime**, not bare tag:

`(Image, ImageDigest, ImageRegistryRef, ImageDistributionMode, Runtime)`

`Acquire` re-validates the Docker image ID at hand-out — retagged/re-pulled images discard stale slots (`docker_pool_stale_image` metric).

| Request field | Poolable? |
|---|---|
| image identity + runtime | must match pool key |
| CPU, MemoryMB | yes — `docker update` at adopt |
| NetworkBlockAll / allow/deny / byte limits | yes — netrules at adopt (policy first, then clear park DROP) |
| DiskGB ≠ default, Env, Mounts, PlatformVolumes, ContainerCommand, OSUser, Registry, GPUs | **miss** (create-time only) |

Bench payload `{"image":"alpine:3.20"}` and default agent workloads are eligible.

---

## Duplicate-create & idempotency

Concurrent duplicate creates are handled explicitly:

```mermaid
flowchart TD
  C[CreateSandbox same id] --> R{Rename conflict<br/>or store PK?}
  R -->|rename conflict| D1[Destroy parked candidate]
  D1 --> D2[Re-fetch existing sandbox]
  R -->|store ErrSandboxExists| D2
  D2 --> D3[Return existing sandbox 409-safe]
  R -->|no| N[Normal create/adopt]
```

- `store.Create` now returns `models.ErrSandboxExists` on PK collision (was generic error).
- `apihttp` maps `ErrSandboxExists` → **409 Conflict**.
- Rename conflict during adopt destroys the candidate and re-dispatches — **never** blind cold retry (would hit the same conflict 300ms later).

Service create ordering is unchanged: `Admit` → `MountAll` → `docker.Create` (adopt inside) → `sealRegistry` → caddy → `store.Create` → platform volumes. Rollback chain unchanged.

---

## Configuration (default-off)

| Env var | Default | Purpose |
|---|---|---|
| `SB_DOCKER_POOL_ENABLED` | `false` | Master switch |
| `SB_DOCKER_READY_SOCKET_ENABLED` | `true` (cluster) | Required for pool; adopt uses held socket |
| `SB_DOCKER_POOL_DEPTH` | `2` | Ready slots per pinned target |
| `SB_DOCKER_POOL_MAX_IMAGES` | `8` | LRU cap for miss-driven targets |
| `SB_DOCKER_POOL_IDLE_TTL` | `15m` | Reap idle non-pinned targets |
| `SB_DOCKER_POOL_IMAGES` | host default (`alpine:3.20`) | Pinned warm targets |
| `SB_DOCKER_POOL_REFILL_INTERVAL` | `5s` | Refill ticker |

`DockerReadySocketEffective()` widened: `enabled && (cluster || pool_enabled)` so single-node hosts can use the pool without cluster mode.

---

## Files touched (high level)

| Area | Files |
|---|---|
| Pool | `internal/pool/dockerpool/*` |
| Docker fast path | `pkg/docker/docker_pool.go`, `readysock_park.go`, `client.go` |
| Protocol | `pkg/readyproto/readyproto.go` (v2 parked/adopt) |
| toolboxd | `cmd/toolboxd/main.go`, `readyclient_park_*.go` |
| Capacity | `pkg/capacity/parkgate.go` |
| Service | `internal/service/docker_pool_create.go`, `service.go` |
| Store | `internal/store/store.go` (`ErrSandboxExists`) |
| Daemon wiring | `pkg/daemon/docker_warm_wiring.go`, `daemon.go` |
| Config | `internal/config/config.go` |

---

## Sandbox boot impact

**Warm hit (eligible create, pool has slot):** Replaces ~280ms engine create+start + toolboxd boot with ~15–40ms adopt path (rename, update, handshake, netrules, inspect). **Net reduction ~250ms** on the Docker step.

**Pool miss / ineligible / adopt failure:** Falls through to existing cold create — **no added latency** beyond today's eligibility check + `pool.Acquire` miss (~μs).

**Daemon boot (pool enabled):** One-time boot purge of orphaned `aerol.pool=park` containers; refill loop starts in background goroutine. Pinned images warmed asynchronously — **does not block** API readiness. First create before refill completes is a miss (same as today).

**First-call case:** No new synchronous work on `CreateSandbox` when pool is disabled (default).

---

## Idempotency

| Surface | Retry | Concurrent duplicate |
|---|---|---|
| `POST /v1/sandboxes` (eligible warm hit) | Miss on retry if first call consumed the slot → cold create with same id → `ErrSandboxExists` / existing row returned per duplicate protocol | Rename conflict → destroy candidate, return existing; store PK → `ErrSandboxExists` → 409 |
| `expose_port`, lifecycle, etc. | N/A — no changes | N/A |
| Pool refill | Idempotent per slot-id; failed park releases `park:slot-id` reservation | Per-key `spawning` counter prevents unbounded parallel spawns for same key |

---

## Failure-path consistency

- **Adopt failure (pre-store):** Destroy parked container + `ClearNetworkRules` for its IP + release `park:slot-id` + fall through to cold create. Pool only makes creates faster, never fail-only.
- **Stale-DROP invariant:** Every discard path (adopt failure, TTL reap, LRU eviction, liveness drop, boot purge, shutdown drain) clears IP-keyed park DROP before/with destroy — prevents black-holing reused bridge IPs.
- **Network rule ordering at adopt:** Install request policy **first**, then clear park DROP — never reverse (would open unrestricted egress gap).
- **No caddy+store multi-step change:** Create ordering and rollback chain in `service.go` unchanged. `store.Create` sentinel addition only affects duplicate-id path.

---

## L4 / host-port-pool changes

N/A — neither `TryReserveHostPort`, `allocateHostPort`, `EnsureLayer4`, `EnsureLayer4Ready`, nor the `l4Ready` latch were touched.

---

## Cluster correctness

N/A for cluster FSM/placement — pools are **per-node and independent** (Phase 1). Warm-aware placement across nodes is Phase 2 per design doc. `EnableCluster=false` code paths: pool wiring is a no-op when `DockerPoolEffective()` is false.

---

## Test plan

- [x] `go build ./...`
- [x] `make test` (full suite green)
- [x] `internal/pool/dockerpool/pool_test.go` — hit/miss, spawn budget, stale image discard, idle reap
- [x] `pkg/capacity/parkgate_test.go` — guard band, reservation release
- [x] `pkg/readyproto/readyproto_test.go` — parked/adopt encode/decode round-trip
- [x] `internal/store/store_test.go` — duplicate create → `models.ErrSandboxExists`
- [x] `internal/config/docker_ready_socket_test.go` — single-node pool enables ready socket
- [x] `pkg/api/apihttp/apihttp_test.go` — `ErrSandboxExists` → 409
- [ ] **Manual / integration (operator):** Enable pool on bench host, run `cluster-3-mixed-docker` warm-hit benchmark, verify p50 ≤ 100ms and `docker_pool_hit` expvar increments
- [ ] **Manual:** Confirm `SB_DOCKER_POOL_ENABLED=false` (default) — zero pool goroutines, no behavior change

---

## Rollout

1. Merge with pool **disabled** by default — zero production impact.
2. Enable on a single bench node: `SB_DOCKER_POOL_ENABLED=true`, `SB_DOCKER_READY_SOCKET_ENABLED=true`.
3. Run docker bench integration UC; compare `cluster-3-mixed-docker-bench.json` before/after.
4. Phase B: enable in Ansible/tfvars for docker bench scenarios once warm-hit p50 validated.


Made with [Cursor](https://cursor.com)