### PR TITLE
perf(cluster): parallelize recovery-blob replication fan-out

### DIFF
--- a/internal/cluster/recovery_replication.go
+++ b/internal/cluster/recovery_replication.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 
 	"github.com/aerol-ai/microvm/pkg/models"
 )
@@ -91,23 +92,46 @@ func commandCarriesRecoveryPayload(spec *models.CreateSandboxRequest, secretRef 
 	return spec != nil || secretRef != "" || secretVersion != 0 || len(sealed) > 0
 }
 
+// replicateBlobToMembers pushes blob to every member concurrently. The PUTs
+// are independent (same blob, keyed by Ref, different hosts), and this runs
+// synchronously on the sandbox-create path — twice per create (opReserve and
+// opPlace) — so the wall-clock cost must be the slowest peer, not the sum of
+// all peers. Every member is attempted even when one fails, and the first
+// error in member order is returned, matching the previous serial loop.
+func replicateBlobToMembers(ctx context.Context, members []Member, blob RecoveryBlob, put func(context.Context, Member, RecoveryBlob) error) error {
+	if len(members) == 1 {
+		return put(ctx, members[0], blob)
+	}
+	errs := make([]error, len(members))
+	var wg sync.WaitGroup
+	for i, m := range members {
+		wg.Add(1)
+		go func(i int, m Member) {
+			defer wg.Done()
+			errs[i] = put(ctx, m, blob)
+		}(i, m)
+	}
+	wg.Wait()
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (c *Cluster) storeAndReplicateRecoveryBlob(ctx context.Context, blob RecoveryBlob) error {
 	if err := c.StoreRecoveryBlob(ctx, blob); err != nil {
 		return err
 	}
-	var firstErr error
+	peers := make([]Member, 0)
 	for _, m := range c.recoveryServerMembers() {
 		if m.NodeID == "" || m.NodeID == c.nodeID {
 			continue
 		}
-		if err := c.putRecoveryBlobToMember(ctx, m, blob); err != nil && firstErr == nil {
-			firstErr = err
-		}
+		peers = append(peers, m)
 	}
-	if firstErr != nil {
-		return firstErr
-	}
-	return nil
+	return replicateBlobToMembers(ctx, peers, blob, c.putRecoveryBlobToMember)
 }
 
 func (a *Agent) replicateRecoveryBlob(ctx context.Context, blob RecoveryBlob) error {
@@ -115,16 +139,7 @@ func (a *Agent) replicateRecoveryBlob(ctx context.Context, blob RecoveryBlob) er
 	if len(members) == 0 {
 		return errors.New("cluster agent: no live server-role control-plane members for recovery blob")
 	}
-	var firstErr error
-	for _, m := range members {
-		if err := a.putRecoveryBlobToMember(ctx, m, blob); err != nil && firstErr == nil {
-			firstErr = err
-		}
-	}
-	if firstErr != nil {
-		return firstErr
-	}
-	return nil
+	return replicateBlobToMembers(ctx, members, blob, a.putRecoveryBlobToMember)
 }
 
 func (c *Cluster) StoreRecoveryBlob(ctx context.Context, blob RecoveryBlob) error {

--- a/internal/cluster/recovery_replication_parallel_test.go
+++ b/internal/cluster/recovery_replication_parallel_test.go
@@ -1,0 +1,164 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestReplicateBlobToMembersAttemptsAllMembers(t *testing.T) {
+	members := []Member{{NodeID: "a"}, {NodeID: "b"}, {NodeID: "c"}}
+	var mu sync.Mutex
+	called := map[string]int{}
+	put := func(_ context.Context, m Member, _ RecoveryBlob) error {
+		mu.Lock()
+		defer mu.Unlock()
+		called[m.NodeID]++
+		if m.NodeID == "b" {
+			return errors.New("b down")
+		}
+		return nil
+	}
+	err := replicateBlobToMembers(context.Background(), members, RecoveryBlob{Ref: "r"}, put)
+	if err == nil || err.Error() != "b down" {
+		t.Fatalf("expected b's error, got %v", err)
+	}
+	for _, id := range []string{"a", "b", "c"} {
+		if called[id] != 1 {
+			t.Errorf("member %s called %d times, want 1", id, called[id])
+		}
+	}
+}
+
+func TestReplicateBlobToMembersFirstErrorInMemberOrder(t *testing.T) {
+	// The old serial loop returned the first error in member order. Two
+	// members fail here, with the earlier one finishing LAST, to prove the
+	// concurrent version still picks by member order, not completion order.
+	members := []Member{{NodeID: "a"}, {NodeID: "b"}, {NodeID: "c"}}
+	errA := errors.New("a failed")
+	errC := errors.New("c failed")
+	cDone := make(chan struct{})
+	put := func(_ context.Context, m Member, _ RecoveryBlob) error {
+		switch m.NodeID {
+		case "a":
+			<-cDone
+			return errA
+		case "c":
+			defer close(cDone)
+			return errC
+		}
+		return nil
+	}
+	err := replicateBlobToMembers(context.Background(), members, RecoveryBlob{}, put)
+	if !errors.Is(err, errA) {
+		t.Fatalf("expected first member's error %v, got %v", errA, err)
+	}
+}
+
+func TestReplicateBlobToMembersRunsConcurrently(t *testing.T) {
+	// Each put blocks until every put has started. A serial implementation
+	// never gets past the first member and the watchdog fails the test.
+	const n = 4
+	members := make([]Member, n)
+	for i := range members {
+		members[i] = Member{NodeID: string(rune('a' + i))}
+	}
+	started := make(chan struct{}, n)
+	release := make(chan struct{})
+	put := func(_ context.Context, _ Member, _ RecoveryBlob) error {
+		started <- struct{}{}
+		<-release
+		return nil
+	}
+	go func() {
+		deadline := time.After(5 * time.Second)
+		for i := 0; i < n; i++ {
+			select {
+			case <-started:
+			case <-deadline:
+				t.Error("puts did not all start concurrently; replication appears serial")
+				close(release)
+				return
+			}
+		}
+		close(release)
+	}()
+	if err := replicateBlobToMembers(context.Background(), members, RecoveryBlob{}, put); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestReplicateBlobToMembersEdgeCases(t *testing.T) {
+	var calls atomic.Int32
+	put := func(_ context.Context, _ Member, _ RecoveryBlob) error {
+		calls.Add(1)
+		return nil
+	}
+	if err := replicateBlobToMembers(context.Background(), nil, RecoveryBlob{}, put); err != nil {
+		t.Fatalf("no members: unexpected error %v", err)
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("no members: put called %d times", calls.Load())
+	}
+	if err := replicateBlobToMembers(context.Background(), []Member{{NodeID: "a"}}, RecoveryBlob{}, put); err != nil {
+		t.Fatalf("single member: unexpected error %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("single member: put called %d times, want 1", calls.Load())
+	}
+}
+
+func TestStoreAndReplicateRecoveryBlobFansOutToAllPeers(t *testing.T) {
+	// End-to-end: the blob must land on every remote control-plane peer,
+	// skipping self, via real HTTP PUTs.
+	var hits atomic.Int32
+	newPeer := func() *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPut {
+				t.Errorf("unexpected method %s", r.Method)
+			}
+			hits.Add(1)
+			w.WriteHeader(http.StatusCreated)
+		}))
+	}
+	peer1 := newPeer()
+	defer peer1.Close()
+	peer2 := newPeer()
+	defer peer2.Close()
+
+	fsm := newPlacementFSM()
+	fsm.recoveryStore = newPlacementRecoveryMemoryStore()
+	c := &Cluster{
+		nodeID: "self",
+		fsm:    fsm,
+		gossip: &gossipNode{
+			memberIndex: &gossipMemberIndex{
+				members: map[string]Member{
+					"self":  {NodeID: "self", Alive: true, Role: "server", APIURL: "http://ignored"},
+					"node2": {NodeID: "node2", Alive: true, Role: "server", APIURL: peer1.URL},
+					"node3": {NodeID: "node3", Alive: true, Role: "server", APIURL: peer2.URL},
+				},
+			},
+		},
+		httpClient: http.DefaultClient,
+	}
+
+	blob, err := newRecoveryBlob("sb1", placementRecovery{})
+	if err != nil {
+		t.Fatalf("newRecoveryBlob: %v", err)
+	}
+	if err := c.storeAndReplicateRecoveryBlob(context.Background(), blob); err != nil {
+		t.Fatalf("storeAndReplicateRecoveryBlob: %v", err)
+	}
+	if hits.Load() != 2 {
+		t.Fatalf("expected 2 peer PUTs, got %d", hits.Load())
+	}
+	if _, ok, err := c.RecoveryBlob(context.Background(), blob.Ref); err != nil || !ok {
+		t.Fatalf("blob not stored locally: ok=%v err=%v", ok, err)
+	}
+}


### PR DESCRIPTION
## Summary

- Recovery-blob replication (`storeAndReplicateRecoveryBlob` / `Agent.replicateRecoveryBlob`) sent blocking HTTP PUTs to every alive control-plane member **serially**, and it runs synchronously on the sandbox-create path twice per create (`opReserve` on the router, `opPlace` on the owner). Wall-clock cost was N × peer-RTT — ~10–40ms per create at 5 control-plane nodes, and one slow peer's latency added directly to every create in the cluster.
- Extracted `replicateBlobToMembers`, which sends the PUTs concurrently, so the cost is the slowest single peer instead of the sum. Both the `Cluster` (control-plane) and `Agent` (worker) paths use it.
- Semantics are deliberately unchanged: every member is still attempted even when one fails, and the first error **in member order** is returned (errors collected in an index-slotted slice, so completion order cannot reorder them) — exactly what the serial loop did.

## Code-path diagram

```mermaid
sequenceDiagram
    participant R as Router or Owner node
    participant P1 as CP peer 1
    participant P2 as CP peer 2
    participant P3 as CP peer 3
    Note over R: BEFORE (serial) - total = RTT1 + RTT2 + RTT3
    R->>P1: PUT recovery blob
    P1-->>R: 201
    R->>P2: PUT recovery blob
    P2-->>R: 201
    R->>P3: PUT recovery blob
    P3-->>R: 201
    Note over R: AFTER (concurrent) - total = max(RTT1, RTT2, RTT3)
    par peer 1
        R->>P1: PUT recovery blob
        P1-->>R: 201
    and peer 2
        R->>P2: PUT recovery blob
        P2-->>R: 201
    and peer 3
        R->>P3: PUT recovery blob
        P3-->>R: 201
    end
    Note over R,P3: Failure branch (unchanged) - all peers attempted, first error in member order returned, caller aborts the create exactly as before
```

## Sandbox boot impact

Yes — this changes work already on the boot path, strictly reducing it. No new DB queries, HTTP round trips, file I/O, or locks were added; the same per-peer PUTs now overlap in time instead of running single-file. Expected effect: create latency drops by roughly (N−1) × peer-RTT per replication, twice per cluster create (reserve + place). Fires on every cluster-mode create that carries a recovery payload; bounded by the caller's existing ctx deadline (`ClusterRaftCommitTimeout`, default 5s). Single-node (non-cluster) boots are unaffected — this code doesn't run there.

## Idempotency

N/A - no API surface changed. (The blob PUT itself is unchanged and remains idempotent: same blob keyed by `blob.Ref`, PUT to each host.)

## Failure-path consistency

No caddy+store multi-step write touched. Cluster-correctness call-out per CLAUDE.md: no FSM, placement, replay, or leader-change behavior changes — this is purely the pre-Raft externalization step. Failure semantics preserved bit-for-bit: all members attempted, first error in member order propagated, so `applyCommand` aborts the create under exactly the same conditions as before. No split-brain or replay-safety impact; commands entering the Raft log are unchanged. Single-node regression: none (`Noop`/non-cluster paths never reach this code; zero-peer and one-peer cases covered by tests).

## L4 / host-port-pool changes

N/A - neither touched.

## Test plan

- [x] New regression tests in `internal/cluster/recovery_replication_parallel_test.go`:
  - all members attempted even when one fails, failing member's error returned
  - first-error-by-**member-order** preserved even when a later member fails first temporally
  - deterministic concurrency proof: every put blocks on a barrier until all have started — a serial implementation cannot pass (watchdog fails cleanly, no sleeps/flakes)
  - zero-member and single-member edge cases
  - end-to-end `storeAndReplicateRecoveryBlob` against two `httptest` peers: both receive the PUT, self skipped, blob stored locally
- [x] `go test -count=1 ./internal/cluster/` fully green
- [x] `go vet` + `gofmt` clean
- [x] `go test -race` on the package: the 5 pre-existing races in `coverage_boost_test.go`/`coverage_final_test.go`/`coverage_push_test.go` (tests mutating a live `Cluster` while its capacity-lease loop reads it) reproduce identically on clean `main` and do not involve this change; no new races introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)