### PR TITLE
perf(toolboxd): announce readiness at listener bind, strip the binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,13 @@ build-sandboxd:
 	mkdir -p $(BIN_DIR)
 	$(GO) build -ldflags "-X github.com/aerol-ai/microvm/internal/version.Version=$$(git describe --tags --always --dirty 2>/dev/null || echo dev)" -o $(BIN_DIR)/sandboxd ./cmd/sandboxd
 
+# -s -w: toolboxd is bind-mounted into every sandbox and exec'd as the
+# container entrypoint; a stripped binary means fewer pages to fault in on
+# the first boot per host and a smaller deploy artifact. Debug symbols for
+# the in-guest agent add no value — it's never debugged in place.
 build-toolboxd:
 	mkdir -p $(BIN_DIR)
-	CGO_ENABLED=0 $(GO) build -ldflags "-X github.com/aerol-ai/microvm/internal/version.Version=$$(git describe --tags --always --dirty 2>/dev/null || echo dev)" -o $(BIN_DIR)/toolboxd ./cmd/toolboxd
+	CGO_ENABLED=0 $(GO) build -ldflags "-s -w -X github.com/aerol-ai/microvm/internal/version.Version=$$(git describe --tags --always --dirty 2>/dev/null || echo dev)" -o $(BIN_DIR)/toolboxd ./cmd/toolboxd
 
 docs-install:
 	cd docs && npm install

--- a/cmd/toolboxd/main.go
+++ b/cmd/toolboxd/main.go
@@ -144,25 +144,10 @@ func main() {
 
 	startReaperFn(logger)
 
-	sessionsMgr, err := sessionsNewFn(logger, sessions.Config{
-		SandboxID:          srv.sandboxID,
-		RecordingDir:       envString("SB_RECORDING_DIR", "/var/lib/toolboxd/recordings"),
-		RecordingRetention: envDuration("SB_RECORDING_RETENTION", 7*24*time.Hour),
-		BufferBytes:        envInt("SB_SESSION_BUFFER_BYTES", 1<<20),
-	})
-	if err != nil {
-		logger.Warn("session manager init failed; sessions disabled", "error", err)
-	} else {
-		srv.sessions = sessionsMgr
-		defer sessionsMgr.Close()
-	}
-
-	if len(os.Args) > 1 {
-		if srv.parkedMode {
-			srv.deferredCmd = append([]string{}, os.Args[1:]...)
-		} else {
-			startUserCommandFn(logger, os.Args[1:])
-		}
+	// The parked-mode handshake goroutine reads deferredCmd, so it must be
+	// assigned before the announce below starts that goroutine.
+	if len(os.Args) > 1 && srv.parkedMode {
+		srv.deferredCmd = append([]string{}, os.Args[1:]...)
 	}
 
 	addr := fmt.Sprintf(":%d", srv.port)
@@ -177,12 +162,40 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Push readiness only after the HTTP listener is accepting — same contract
-	// as /health 200 when create returns started.
+	// Snapshot identity fields before the parked handshake goroutine exists:
+	// adoptIdentity mutates them under srv.mu, and the sessions.Config read
+	// below would otherwise race. Park-time ID is also the correct one for
+	// the recordings dir — that matches the pre-reorder behavior, where the
+	// session manager was constructed before adoption could happen.
+	bootSandboxID := srv.sandboxID
+
+	// Push readiness as soon as the port is bound. Connections arriving
+	// before srv.Serve are held in the kernel accept backlog and served the
+	// moment Serve starts, so a bound listener satisfies the same contract
+	// as /health 200: a client that connects will get a response. Everything
+	// between here and Serve (session dir mkdir, user-command fork/exec) is
+	// deliberately kept off the time-to-ready path.
 	if srv.parkedMode {
 		go runParkedReadyHandshake(logger, srv, readySocket, bootstrapToken, readyNonce)
 	} else {
 		announceReady(logger, srv.sandboxID, srv.authToken, readyNonce, readySocket)
+	}
+
+	sessionsMgr, err := sessionsNewFn(logger, sessions.Config{
+		SandboxID:          bootSandboxID,
+		RecordingDir:       envString("SB_RECORDING_DIR", "/var/lib/toolboxd/recordings"),
+		RecordingRetention: envDuration("SB_RECORDING_RETENTION", 7*24*time.Hour),
+		BufferBytes:        envInt("SB_SESSION_BUFFER_BYTES", 1<<20),
+	})
+	if err != nil {
+		logger.Warn("session manager init failed; sessions disabled", "error", err)
+	} else {
+		srv.sessions = sessionsMgr
+		defer sessionsMgr.Close()
+	}
+
+	if len(os.Args) > 1 && !srv.parkedMode {
+		startUserCommandFn(logger, os.Args[1:])
 	}
 
 	go forwardShutdownSignalsFn(logger, httpServer)

--- a/cmd/toolboxd/main_startup_order_test.go
+++ b/cmd/toolboxd/main_startup_order_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/aerol-ai/microvm/cmd/toolboxd/sessions"
+)
+
+// The listener must bind before the session manager's filesystem setup and
+// before the user command's fork/exec: readiness is announced right after
+// bind, and both of those belong off the time-to-ready path. This pins the
+// startup order so a refactor can't silently put them back in front.
+func TestMainStartupListensBeforeSessionsAndUserCommand(t *testing.T) {
+	oldArgs := os.Args
+	oldSessionsNewFn := sessionsNewFn
+	oldStartReaperFn := startReaperFn
+	oldStartUserCommandFn := startUserCommandFn
+	oldForwardShutdownSignalsFn := forwardShutdownSignalsFn
+	oldServeHTTPFn := serveHTTPFn
+	oldNetListenFn := netListenFn
+	oldNewVsockServerFn := newVsockServerFn
+	defer func() {
+		os.Args = oldArgs
+		sessionsNewFn = oldSessionsNewFn
+		startReaperFn = oldStartReaperFn
+		startUserCommandFn = oldStartUserCommandFn
+		forwardShutdownSignalsFn = oldForwardShutdownSignalsFn
+		serveHTTPFn = oldServeHTTPFn
+		netListenFn = oldNetListenFn
+		newVsockServerFn = oldNewVsockServerFn
+	}()
+
+	var order []string
+	startReaperFn = func(*slog.Logger) {}
+	forwardShutdownSignalsFn = func(*slog.Logger, *http.Server) {}
+	netListenFn = func(network, addr string) (net.Listener, error) {
+		order = append(order, "listen")
+		return net.Listen("tcp", "127.0.0.1:0")
+	}
+	sessionsNewFn = func(logger *slog.Logger, cfg sessions.Config) (*sessions.Manager, error) {
+		order = append(order, "sessions")
+		return sessions.New(logger, sessions.Config{
+			SandboxID:    cfg.SandboxID,
+			RecordingDir: t.TempDir(),
+		})
+	}
+	startUserCommandFn = func(*slog.Logger, []string) {
+		order = append(order, "usercmd")
+	}
+	serveHTTPFn = func(_ *http.Server, ln net.Listener) error {
+		ln.Close()
+		return http.ErrServerClosed
+	}
+	newVsockServerFn = func(uint32, VsockHandler, *slog.Logger) (vsockServerAPI, error) {
+		return nil, http.ErrServerClosed
+	}
+
+	os.Args = []string{"toolboxd", "echo", "hello"}
+	main()
+
+	want := []string{"listen", "sessions", "usercmd"}
+	if len(order) != len(want) {
+		t.Fatalf("startup calls = %v, want %v", order, want)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("startup order = %v, want %v", order, want)
+		}
+	}
+}
+
+// In parked mode the user command must not be exec'd at startup — it is
+// deferred until the adopt handshake delivers the sandbox identity.
+func TestMainStartupParkedDefersUserCommand(t *testing.T) {
+	oldArgs := os.Args
+	oldSessionsNewFn := sessionsNewFn
+	oldStartReaperFn := startReaperFn
+	oldStartUserCommandFn := startUserCommandFn
+	oldForwardShutdownSignalsFn := forwardShutdownSignalsFn
+	oldServeHTTPFn := serveHTTPFn
+	oldNetListenFn := netListenFn
+	oldNewVsockServerFn := newVsockServerFn
+	defer func() {
+		os.Args = oldArgs
+		sessionsNewFn = oldSessionsNewFn
+		startReaperFn = oldStartReaperFn
+		startUserCommandFn = oldStartUserCommandFn
+		forwardShutdownSignalsFn = oldForwardShutdownSignalsFn
+		serveHTTPFn = oldServeHTTPFn
+		netListenFn = oldNetListenFn
+		newVsockServerFn = oldNewVsockServerFn
+	}()
+
+	t.Setenv("SB_POOL_PARKED", "1")
+
+	userCmdCalled := false
+	startReaperFn = func(*slog.Logger) {}
+	forwardShutdownSignalsFn = func(*slog.Logger, *http.Server) {}
+	netListenFn = func(string, string) (net.Listener, error) {
+		return net.Listen("tcp", "127.0.0.1:0")
+	}
+	sessionsNewFn = func(logger *slog.Logger, cfg sessions.Config) (*sessions.Manager, error) {
+		return sessions.New(logger, sessions.Config{
+			SandboxID:    cfg.SandboxID,
+			RecordingDir: t.TempDir(),
+		})
+	}
+	startUserCommandFn = func(*slog.Logger, []string) {
+		userCmdCalled = true
+	}
+	serveHTTPFn = func(_ *http.Server, ln net.Listener) error {
+		ln.Close()
+		return http.ErrServerClosed
+	}
+	newVsockServerFn = func(uint32, VsockHandler, *slog.Logger) (vsockServerAPI, error) {
+		return nil, http.ErrServerClosed
+	}
+
+	os.Args = []string{"toolboxd", "sleep", "infinity"}
+	main()
+
+	if userCmdCalled {
+		t.Fatal("parked mode must defer the user command until adopt, but it was started at boot")
+	}
+}


### PR DESCRIPTION
## Summary

- toolboxd's readiness (ready-socket push, or the first `/health` 200 seen by the poller) previously waited on the session manager's recordings-dir setup and the user command's fork/exec, because both ran before `net.Listen`. The listener now binds first and readiness is announced immediately after; session-manager construction and the user-command exec run between announce and `Serve`, off the time-to-ready path.
- Safe because connections arriving before `srv.Serve` are held in the kernel accept backlog and served the moment `Serve` starts — a bound port satisfies the same contract as `/health` 200: a client that connects gets a response.
- `build-toolboxd` now strips the binary (`-s -w`): **10.9MB → 7.5MB (−31%)**. toolboxd is bind-mounted into every sandbox and exec'd as the entrypoint, so this means fewer pages faulted in on the first boot per host; in-guest debug symbols are never used.

## Code-path diagram

```mermaid
flowchart TD
    A[toolboxd main] --> B[reaper + parked deferredCmd assignment]
    B --> C[net.Listen bind port]
    C --> D[announce ready / parked handshake goroutine]
    D --> E[sessions.New mkdir recordings dir]
    E --> F[fork/exec user command non-parked]
    F --> G[srv.Serve drains accept backlog]
    style D fill:#9f9,stroke:#333
    C -.->|before: sessions.New and user fork/exec ran HERE, delaying announce| A
```

Before: `sessions.New` → user fork/exec → listen → announce. After: listen → announce → `sessions.New` → user fork/exec → Serve.

Failure branches touched:
- `net.Listen` failure still exits(1); it now does so **before** the user command is exec'd (previously the user entrypoint could be started and then orphaned by the exit).
- `sessions.New` failure is unchanged: WARN + sessions disabled.
- Parked mode: `deferredCmd` is assigned **before** the handshake goroutine starts (it reads `deferredCmd` under `srv.mu`), and `sessions.Config` snapshots the boot-time sandbox ID so a concurrent `adoptIdentity` cannot race the config read — recordings dir keeps the park-time ID, matching pre-reorder behavior.

## Sandbox boot impact

Yes — this removes work from the time-to-ready path inside the guest (the recordings-dir `MkdirAll` and the user-command fork/exec no longer precede the readiness announce), and shrinks the entrypoint binary that gets page-faulted in on every cold exec. Expected effect: a few ms per boot typically; more when the recordings dir is on slow storage or on first boot per host (smaller binary working set). No work added anywhere.

## Idempotency

N/A - no API surface changed.

## Failure-path consistency

N/A - no multi-step write path changed (no caddy/store involvement; guest-local startup ordering only).

## L4 / host-port-pool changes

N/A - neither touched.

## Test plan

- [x] New `TestMainStartupListensBeforeSessionsAndUserCommand` pins the order (listen → sessions → usercmd) via the existing seam stubs — a refactor that puts filesystem/exec work back in front of the bind fails the test
- [x] New `TestMainStartupParkedDefersUserCommand` pins that parked mode never execs the user command at boot
- [x] `go test ./cmd/toolboxd/...` green (including existing startup-branch and parked-handshake tests)
- [x] `go vet` + `gofmt` clean
- [x] Verified stripped linux/amd64 build: 10,963,722 → 7,536,802 bytes

🤖 Generated with [Claude Code](https://claude.com/claude-code)