### PR TITLE
fix(docker): make warm-pool hits reachable for default creates

### DIFF
--- a/internal/service/capacity_lifecycle_test.go
+++ b/internal/service/capacity_lifecycle_test.go
@@ -36,6 +36,9 @@ type fakeCapacityRuntime struct {
 	// startCount counts Start invocations so wake-helper tests can
 	// assert single-flight collapsing.
 	startCount int
+	// destroyedIDs records Destroy targets so orphan-skip tests can assert
+	// park-* inventory is left alone.
+	destroyedIDs []string
 }
 
 func (f *fakeCapacityRuntime) ListManaged(_ context.Context) (map[string]*models.SandboxRuntimeState, error) {
@@ -69,8 +72,13 @@ func (f *fakeCapacityRuntime) Start(context.Context, string) (*models.SandboxRun
 	}
 	return nil, nil
 }
-func (f *fakeCapacityRuntime) Stop(context.Context, string) error             { return nil }
-func (f *fakeCapacityRuntime) Destroy(context.Context, *models.Sandbox) error { return nil }
+func (f *fakeCapacityRuntime) Stop(context.Context, string) error { return nil }
+func (f *fakeCapacityRuntime) Destroy(_ context.Context, sb *models.Sandbox) error {
+	if sb != nil {
+		f.destroyedIDs = append(f.destroyedIDs, sb.ID)
+	}
+	return nil
+}
 func (f *fakeCapacityRuntime) Resize(context.Context, string, models.ResizeSandboxRequest) error {
 	return nil
 }
@@ -1142,6 +1150,50 @@ func TestReconcileMixedRuntimeStates(t *testing.T) {
 		if got.Status != models.SandboxStatusStarted {
 			t.Fatalf("%s status = %s, want started", id, got.Status)
 		}
+	}
+}
+
+// TestReconcileSkipsWarmPoolParkOrphans: parked warm-pool containers have no
+// DB row (by design) but still appear in ListManaged if a runtime surfaces
+// them. Reconcile must not Destroy them — that was emptying the pool on every
+// UC-63 / reconcile tick and forcing every create down the cold path.
+func TestReconcileSkipsWarmPoolParkOrphans(t *testing.T) {
+	ctx := context.Background()
+	parkID := "park-d316b60bc106a6f6"
+	realOrphan := "sb-real-orphan"
+	managed := map[string]*models.SandboxRuntimeState{
+		parkID: {
+			SandboxID:   parkID,
+			ContainerID: "ctr-" + parkID,
+			ContainerIP: "172.17.0.9",
+			Status:      models.SandboxStatusStarted,
+		},
+		realOrphan: {
+			SandboxID:   realOrphan,
+			ContainerID: "ctr-" + realOrphan,
+			ContainerIP: "172.17.0.10",
+			Status:      models.SandboxStatusStarted,
+		},
+	}
+	svc, _, _ := newCapacityHarness(t, managed, nil)
+	rt := svc.docker.(*fakeCapacityRuntime)
+
+	if err := svc.Reconcile(ctx); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	for _, id := range rt.destroyedIDs {
+		if id == parkID {
+			t.Fatalf("Reconcile destroyed warm-pool park %q; destroyed=%v", parkID, rt.destroyedIDs)
+		}
+	}
+	foundReal := false
+	for _, id := range rt.destroyedIDs {
+		if id == realOrphan {
+			foundReal = true
+		}
+	}
+	if !foundReal {
+		t.Fatalf("Reconcile must still destroy real orphans; destroyed=%v", rt.destroyedIDs)
 	}
 }
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -3807,9 +3807,15 @@ func (s *Service) Reconcile(ctx context.Context) error {
 
 	// Orphan runtime instances: managed by us but no DB row. Remove them so
 	// leaked state from a crashed create or a wiped DB doesn't accumulate.
+	// Skip warm-pool park-* ids: they are intentional inventory without a
+	// sandbox row. ListManaged already filters the park label; this is the
+	// defense-in-depth gate for any runtime that still surfaces them.
 	removeOrphans := func(rt runtime.Runtime, runtimeName string, items map[string]*models.SandboxRuntimeState) {
 		for sandboxID, state := range items {
 			if _, ok := knownIDs[sandboxID]; ok {
+				continue
+			}
+			if strings.HasPrefix(sandboxID, "park-") {
 				continue
 			}
 			s.logger.Warn("removing orphan runtime instance",

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -854,6 +854,13 @@ func (c *Client) ListManaged(ctx context.Context) (map[string]*SandboxRuntime, e
 		if summary.Labels[managedLabelKey] != "true" {
 			continue
 		}
+		// Warm-pool parked containers carry aerolvm.managed=true (so the
+		// boot purge / events filter can find them) but they are not
+		// sandboxes — they have no DB row. Exclude them here so Reconcile's
+		// orphan pass does not destroy live park inventory.
+		if isParkedContainerLabels(summary.Labels) {
+			continue
+		}
 		inspect, err := c.inspectContainer(ctx, summary.ID)
 		if err != nil {
 			continue
@@ -864,9 +871,10 @@ func (c *Client) ListManaged(ctx context.Context) (map[string]*SandboxRuntime, e
 			ContainerIP: getContainerIP(inspect, c.network),
 			Status:      containerStatus(inspect),
 		}
-		if runtime.SandboxID != "" {
-			result[runtime.SandboxID] = runtime
+		if runtime.SandboxID == "" || isParkedSandboxID(runtime.SandboxID) {
+			continue
 		}
+		result[runtime.SandboxID] = runtime
 	}
 
 	return result, nil

--- a/pkg/docker/coverage_full_test.go
+++ b/pkg/docker/coverage_full_test.go
@@ -322,11 +322,20 @@ func TestListManaged(t *testing.T) {
 					{"Id": "managed", "Labels": map[string]string{managedLabelKey: "true"}},
 					{"Id": "unmanaged", "Labels": map[string]string{}},
 					{"Id": "inspect-fails", "Labels": map[string]string{managedLabelKey: "true"}},
+					// Warm-pool park: managed label + park label. Must not
+					// appear in ListManaged or reconcile will destroy it.
+					{"Id": "parked", "Labels": map[string]string{
+						managedLabelKey:  "true",
+						poolParkLabelKey: poolParkLabelValue,
+					}},
 				}), nil
 			case r.URL.Path == "/containers/managed/json":
 				return textResponse(http.StatusOK, inspectBody("managed", "/sb-managed", "172.17.0.2", true, "running", 1)), nil
 			case r.URL.Path == "/containers/inspect-fails/json":
 				return textResponse(http.StatusInternalServerError, "boom"), nil
+			case r.URL.Path == "/containers/parked/json":
+				t.Fatal("ListManaged must not inspect park-labeled containers")
+				return nil, nil
 			default:
 				t.Fatalf("unexpected path %s", r.URL.Path)
 				return nil, nil
@@ -341,6 +350,34 @@ func TestListManaged(t *testing.T) {
 		}
 		if _, ok := result["sb-managed"]; !ok {
 			t.Fatalf("ListManaged() missing sb-managed: %+v", result)
+		}
+		if _, ok := result["park-d316b60bc106a6f6"]; ok {
+			t.Fatal("ListManaged() must exclude parked containers")
+		}
+	})
+
+	t.Run("excludes_park_name_without_label", func(t *testing.T) {
+		// Defense in depth: even if the park label is missing, a park-*
+		// container name must not enter the orphan set.
+		c := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			switch {
+			case r.URL.Path == "/containers/json":
+				return jsonResponse(http.StatusOK, []map[string]any{
+					{"Id": "parked-nolabel", "Labels": map[string]string{managedLabelKey: "true"}},
+				}), nil
+			case r.URL.Path == "/containers/parked-nolabel/json":
+				return textResponse(http.StatusOK, inspectBody("parked-nolabel", "/park-aabbccddeeff0011", "172.17.0.9", true, "running", 1)), nil
+			default:
+				t.Fatalf("unexpected path %s", r.URL.Path)
+				return nil, nil
+			}
+		})}}
+		result, err := c.ListManaged(context.Background())
+		if err != nil {
+			t.Fatalf("ListManaged() = %v", err)
+		}
+		if len(result) != 0 {
+			t.Fatalf("ListManaged() = %+v, want empty (park-* name excluded)", result)
 		}
 	})
 

--- a/pkg/docker/docker_pool.go
+++ b/pkg/docker/docker_pool.go
@@ -20,6 +20,20 @@ import (
 const poolParkLabelKey = "aerol.pool"
 const poolParkLabelValue = "park"
 
+// isParkedContainerLabels reports whether Docker labels mark a warm-pool
+// parked container (not a sandbox). Used by ListManaged so reconcile does
+// not treat park inventory as orphans.
+func isParkedContainerLabels(labels map[string]string) bool {
+	return labels != nil && labels[poolParkLabelKey] == poolParkLabelValue
+}
+
+// isParkedSandboxID reports whether a container name / sandbox-id slot is a
+// warm-pool park id (park-<hex>). Belt-and-braces for ListManaged and the
+// service orphan pass when the park label is missing after a partial adopt.
+func isParkedSandboxID(id string) bool {
+	return strings.HasPrefix(strings.TrimSpace(id), "park-")
+}
+
 // ErrSandboxContainerExists is returned when adopt-time rename finds the
 // sandbox name already taken — signals the §6 duplicate-create protocol.
 var ErrSandboxContainerExists = errors.New("docker: sandbox container name already exists")
@@ -55,7 +69,13 @@ func poolEligible(req models.CreateSandboxRequest, hostMounts []mounts.Container
 	if len(req.Mounts) > 0 || len(req.PlatformVolumes) > 0 || len(hostMounts) > 0 {
 		return false
 	}
-	if strings.TrimSpace(req.OSUser) != "" {
+	// normalizeCreateRequest fills OSUser="root" for every default create.
+	// Parked containers also run as the image default user (root for alpine),
+	// and the cold Docker path never sets Docker's User field from OSUser —
+	// so the default/root case is byte-identical to a park slot. Only a
+	// non-default OSUser forces a miss (we cannot change the container user
+	// post-create).
+	if user := strings.TrimSpace(req.OSUser); user != "" && !strings.EqualFold(user, "root") {
 		return false
 	}
 	if len(req.ContainerCommand) > 0 {

--- a/pkg/docker/docker_pool_test.go
+++ b/pkg/docker/docker_pool_test.go
@@ -26,6 +26,14 @@ func TestPoolEligible(t *testing.T) {
 	if !poolEligible(base, nil, 0) {
 		t.Fatal("expected eligible base request")
 	}
+	// Default create path fills OSUser=root via normalizeCreateRequest; that
+	// must remain poolable or every warm-pool create falls through cold.
+	if !poolEligible(models.CreateSandboxRequest{Image: "alpine:3.20", OSUser: "root", DiskGB: 10}, nil, 10) {
+		t.Fatal("expected root OSUser (normalize default) to be eligible")
+	}
+	if !poolEligible(models.CreateSandboxRequest{Image: "alpine:3.20", OSUser: "ROOT", DiskGB: 10}, nil, 10) {
+		t.Fatal("expected case-insensitive root OSUser to be eligible")
+	}
 	cases := []struct {
 		name string
 		req  models.CreateSandboxRequest
@@ -36,7 +44,7 @@ func TestPoolEligible(t *testing.T) {
 		{name: "mounts", req: models.CreateSandboxRequest{Image: "i", Mounts: []models.MountSpec{{Type: "bind", Source: "/a", Target: "/b"}}}},
 		{name: "platform_volumes", req: models.CreateSandboxRequest{Image: "i", PlatformVolumes: []models.PlatformVolumeMount{{Name: "v", Path: "/p"}}}},
 		{name: "host_mounts", req: models.CreateSandboxRequest{Image: "i"}, mnts: []mounts.ContainerBind{{HostPath: "/h", ContainerPath: "/c"}}},
-		{name: "os_user", req: models.CreateSandboxRequest{Image: "i", OSUser: "root"}},
+		{name: "os_user_non_root", req: models.CreateSandboxRequest{Image: "i", OSUser: "ubuntu"}},
 		{name: "container_command", req: models.CreateSandboxRequest{Image: "i", ContainerCommand: []string{"sleep"}}},
 		{name: "registry", req: models.CreateSandboxRequest{Image: "i", Registry: &models.RegistryAuth{Username: "u"}}},
 		{name: "gpus", req: models.CreateSandboxRequest{Image: "i", GPUs: &models.GPURequest{Vendor: models.GPUVendorNVIDIA}}},
@@ -49,6 +57,24 @@ func TestPoolEligible(t *testing.T) {
 				t.Fatal("expected ineligible")
 			}
 		})
+	}
+}
+
+func TestIsParkedHelpers(t *testing.T) {
+	if !isParkedContainerLabels(map[string]string{poolParkLabelKey: poolParkLabelValue}) {
+		t.Fatal("expected park label to match")
+	}
+	if isParkedContainerLabels(map[string]string{managedLabelKey: "true"}) {
+		t.Fatal("managed-only labels must not look parked")
+	}
+	if isParkedContainerLabels(nil) {
+		t.Fatal("nil labels must not look parked")
+	}
+	if !isParkedSandboxID("park-d316b60bc106a6f6") {
+		t.Fatal("expected park- prefix id")
+	}
+	if isParkedSandboxID("sb-abc") {
+		t.Fatal("sandbox id must not look parked")
 	}
 }
 

--- a/plans/docker-warm-pool.md
+++ b/plans/docker-warm-pool.md
@@ -153,12 +153,16 @@ forces a miss:
 | `DiskGB` ≠ park default | **miss** (storage opt is create-time) |
 | `Env` non-empty | **miss in v1** (baked at create; Phase 2: adopt frame carries env, toolboxd injects into every exec/session it spawns — needs the PID-1-won't-see-it caveat documented) |
 | `Mounts` / `PlatformVolumes` non-empty | **miss** (binds are create-time) |
-| `OSUser`, `ContainerCommand`, `Registry`, `GPUs` set | **miss** |
+| `OSUser` empty or `root` (normalize default) | **yes** — cold path never sets Docker `User` from OSUser; park slots run as image default (root). Non-root OSUser → **miss** |
+| `ContainerCommand`, `Registry`, `GPUs` set | **miss** |
 | `NetworkBlockAll` / allow/deny lists / byte limits | yes — netrules applied at adopt (§2 ordering) |
 | `Name`, `Tags`, `Lifecycle`, `Failover`, custom domains | yes — store/service level, container-agnostic |
 
 The bench (`{"image":"alpine:3.20"}`) and default agent-workload creates
-are eligible; that's the traffic the 100ms goal is for.
+are eligible; that's the traffic the 100ms goal is for. Note:
+`normalizeCreateRequest` fills `OSUser="root"` before `docker.Create`, so
+eligibility must treat root as the park default — rejecting any non-empty
+OSUser made every create cold.
 
 ## 4. Capacity: park reservation → sandbox reservation transfer
 


### PR DESCRIPTION
## Summary
- Treat empty/`root` `OSUser` as warm-pool eligible so default creates (after `normalizeCreateRequest`) can adopt parked containers instead of always taking the cold Docker path (~300ms server).
- Stop Reconcile from destroying warm-pool `park-*` inventory: `ListManaged` skips `aerol.pool=park` / `park-*` names, and the orphan pass has a defense-in-depth `park-` skip.
- Live `cluster-3-mixed-docker` bench on v0.5.28 showed `server_p50=327ms` with no `docker_pool` stage and journal lines `removing orphan runtime instance sandbox_id=park-…` — both bugs explained that.

## Code-path diagram

```mermaid
flowchart TD
  A[CreateSandbox] --> B[normalizeCreateRequest<br/>OSUser='' → 'root']
  B --> C[docker.Create → tryWarmAdopt]
  C --> D{poolEligible?}
  D -->|before: OSUser non-empty → miss| E[cold create+start ~300ms]
  D -->|after: empty/root eligible| F{HasReady park slot?}
  F -->|no| E
  F -->|yes| G[adopt rename+handshake<br/>target ≤100ms server]
  H[Reconcile orphan pass] --> I{managed container<br/>with no DB row?}
  I -->|before: park-* destroyed| J[pool emptied every tick]
  I -->|after: skip aerol.pool=park<br/>and park-* ids| K[park inventory preserved]
```

## Sandbox boot impact
Warm-hit path only: adopt replaces Docker `create`+`start` on the request path (expected server p50 ≤ 100ms vs ~300ms cold). Miss path unchanged except eligibility now correctly reaches `HasReady`/`NoteMiss` for default creates (still no extra engine work on a guaranteed miss). No new DB/HTTP/I/O on the cold path.

## Idempotency
N/A - no API surface changed. Adopt still returns `ErrSandboxContainerExists` on rename conflict (duplicate-create protocol unchanged).

## Failure-path consistency
N/A - no multi-step caddy+store write path changed. Orphan skip only avoids destroying park inventory; real orphans (`sb-*` without a row) are still destroyed.

## L4 / host-port-pool changes
N/A - neither touched.

## Test plan
- [x] `go test ./pkg/docker/ -run 'TestPoolEligible|TestIsParkedHelpers|TestListManaged|TestTryWarmAdopt'`
- [x] `go test ./internal/service/ -run 'TestReconcileSkipsWarmPoolParkOrphans|TestReconcileMixedRuntimeStates'`
- [ ] After release with this fix: `make integration-benchmark-docker-only` on kept cluster — expect `server_p50_ms ≤ 100` and `docker_pool;desc=hit` on most samples; no `removing orphan … park-` in journal


Made with [Cursor](https://cursor.com)