### PR TITLE
feat(integration): docker-netns-pool capability enables the pause-netns pool

### DIFF
--- a/Ansible/playbooks/configure-ops.yml
+++ b/Ansible/playbooks/configure-ops.yml
@@ -132,6 +132,13 @@
       SB_DOCKER_POOL_MAX_IMAGES: "{{ docker.pool.max_images | default(8) | int }}"
       SB_DOCKER_POOL_IDLE_TTL: "{{ docker.pool.idle_ttl | default('15m') }}"
       SB_DOCKER_POOL_REFILL_INTERVAL: "{{ docker.pool.refill_interval | default('5s') }}"
+      # Docker pause-netns pool (image-agnostic prepaid network namespaces).
+      # Defaults mirror config.go; pause_image must be pullable from the node
+      # or overridden to a mirror.
+      SB_DOCKER_NETNS_POOL_ENABLED: "{{ docker.netns_pool.enabled | default(false) | bool | string | lower }}"
+      SB_DOCKER_NETNS_POOL_DEPTH: "{{ docker.netns_pool.depth | default(4) | int }}"
+      SB_DOCKER_NETNS_POOL_PAUSE_IMAGE: "{{ docker.netns_pool.pause_image | default('registry.k8s.io/pause:3.10') }}"
+      SB_DOCKER_NETNS_POOL_REFILL_INTERVAL: "{{ docker.netns_pool.refill_interval | default('2s') }}"
 
   pre_tasks:
     - name: Check base sandboxd env file

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -489,12 +489,13 @@ run_one() {
 
   # Capability checks read the structured list (not a substring grep, which
   # would false-match the word "domain" in a caps-file comment).
-  local caps_domain caps_wasm caps_cluster caps_platform_volumes caps_docker_pool
+  local caps_domain caps_wasm caps_cluster caps_platform_volumes caps_docker_pool caps_docker_netns_pool
   caps_domain=$(yq -r '.capabilities | contains(["domain"])' "$caps_file")
   caps_wasm=$(yq -r '.capabilities | contains(["wasm"])' "$caps_file")
   caps_cluster=$(yq -r '.capabilities | contains(["cluster"])' "$caps_file")
   caps_platform_volumes=$(yq -r '.capabilities | contains(["platform-volumes"])' "$caps_file")
   caps_docker_pool=$(yq -r '.capabilities | contains(["docker-pool"])' "$caps_file")
+  caps_docker_netns_pool=$(yq -r '.capabilities | contains(["docker-netns-pool"])' "$caps_file")
   if [[ "$caps_domain" == "true" ]]; then
     leased=$(lease_domain_for_scenario "$scenario")
   else
@@ -536,6 +537,13 @@ run_one() {
   # plans/docker-warm-pool.md §9 for the adjusted density gate).
   local docker_pool_depth
   docker_pool_depth="${AEROL_DOCKER_POOL_DEPTH:-2}"
+  # Pause-netns pool follows its own docker-netns-pool capability: unlike the
+  # per-image warm pool it holds no capacity reservations (a pause slot is
+  # ~1MB + one bridge IP), but it is still opt-in per scenario so the
+  # benchmark rows can compare prepaid-netns creates against plain cold path
+  # scenarios. Depth override mirrors the other pools.
+  local docker_netns_pool_depth
+  docker_netns_pool_depth="${AEROL_DOCKER_NETNS_POOL_DEPTH:-4}"
   # Upstream auto-import (pulling private prod images through AOCR hooks) and
   # the fleet control plane are prod-only side effects we always neutralize.
   yq '.auto_import.enabled = false
@@ -545,6 +553,8 @@ run_one() {
       | .wasm.pool.depth_default = '"$wasm_pool_depth"'
       | .docker.pool.enabled = '"$caps_docker_pool"'
       | .docker.pool.depth = '"$docker_pool_depth"'
+      | .docker.netns_pool.enabled = '"$caps_docker_netns_pool"'
+      | .docker.netns_pool.depth = '"$docker_netns_pool_depth"'
       | .platform_volumes.enabled = '"$caps_platform_volumes"'
       | .platform_volumes.backend = "s3"
       | .platform_volumes.s3_bucket = ""

--- a/integration-tests/scenarios/cluster-3-mixed-docker.caps.yml
+++ b/integration-tests/scenarios/cluster-3-mixed-docker.caps.yml
@@ -18,5 +18,10 @@ capabilities:
   # images parked slots per node hold default-shaped reservations, so the
   # UC-95 density ceiling drops by that budget (plans/docker-warm-pool.md §9).
   - docker-pool
+  # Enable the image-agnostic pause-netns pool alongside it: warm-pool misses
+  # (non-pinned images) then measure the prepaid-netns cold path instead of
+  # the full dockerd network setup. No capacity cost — pause slots hold no
+  # reservations — so the UC-95 density gate is unaffected.
+  - docker-netns-pool
 
 expected_members: 3

--- a/integration-tests/scenarios/cluster-hetero.caps.yml
+++ b/integration-tests/scenarios/cluster-hetero.caps.yml
@@ -20,5 +20,10 @@ capabilities:
   # the one cluster carrying docker/gvisor/wasm together, so a per-runtime
   # create-latency + density benchmark is meaningful here.
   - benchmark
+  # Enable the image-agnostic pause-netns pool so docker creates on this
+  # cluster adopt prepaid network namespaces. Unlike docker-pool this holds
+  # no capacity reservations (a pause slot is ~1MB + one bridge IP), so it
+  # does not move the UC-95 density ceiling.
+  - docker-netns-pool
 
 expected_members: 8

--- a/integration-tests/suite/harness/skip_test.go
+++ b/integration-tests/suite/harness/skip_test.go
@@ -78,7 +78,7 @@ func TestRegistryWellFormed(t *testing.T) {
 		seen[uc.ID] = true
 		for _, c := range uc.Requires {
 			switch c {
-			case CapDocker, CapFirecracker, CapGvisor, CapWasm, CapGPU, CapDomain, CapCluster, CapCustomDomains, CapExternalDNSZone, CapMixedArchNegative, CapPlatformVolumes, CapBenchmark, CapDockerPool:
+			case CapDocker, CapFirecracker, CapGvisor, CapWasm, CapGPU, CapDomain, CapCluster, CapCustomDomains, CapExternalDNSZone, CapMixedArchNegative, CapPlatformVolumes, CapBenchmark, CapDockerPool, CapDockerNetnsPool:
 			default:
 				t.Fatalf("%s requires unknown capability %q", uc.ID, c)
 			}

--- a/integration-tests/suite/harness/usecases.go
+++ b/integration-tests/suite/harness/usecases.go
@@ -65,6 +65,12 @@ const (
 	// reservation, lowering the UC-95 density ceiling — scenarios opt in
 	// (plans/docker-warm-pool.md §9 documents the adjusted gates).
 	CapDockerPool Capability = "docker-pool"
+	// CapDockerNetnsPool is likewise consumed by run.sh's config overlay: it
+	// flips docker.netns_pool.enabled so cold docker creates adopt prepaid
+	// pause-container network namespaces. Separate from CapDockerPool because
+	// the two pools are independent (netns slots hold no capacity
+	// reservations, so this one leaves the UC-95 density gate untouched).
+	CapDockerNetnsPool Capability = "docker-netns-pool"
 )
 
 // UseCase is one row of the coverage matrix.


### PR DESCRIPTION
## Summary

- Wires the pause-netns pool (shipped in v0.5.29, default **off**) through the integration scenario config chain, so it is enabled **only** where we want to measure it — no change to the global default:
  - `cluster-3-mixed-docker` (→ `make integration-benchmark-docker [keep]`): warm-pool misses now measure the prepaid-netns path instead of full dockerd network setup.
  - `cluster-hetero` (→ `make integration-benchmark` / `integration-cluster-hetero`): the full benchmark matrix runs with the pool on.
- Chain mirrors the `docker-pool` capability added in e0b64e8: caps file → `run.sh` yq overlay (`docker.netns_pool.enabled/depth`, `AEROL_DOCKER_NETNS_POOL_DEPTH` override, default depth 4) → `configure-ops.yml` renders `SB_DOCKER_NETNS_POOL_*` env on the nodes.
- Kept as a separate capability from `docker-pool`: netns slots hold no capacity reservations (~1MB + one bridge IP each), so the UC-95 density gate is unaffected — documented in the caps files and the `CapDockerNetnsPool` constant.

## Code-path diagram

N/A - config/wiring-only change (no runtime behavior change; the pool itself shipped in #293 with its diagram).

## Sandbox boot impact

N/A - no work added to sandbox boot path. (Scenario clusters that opt in get the #293 hit path — a boot-latency *reduction* on those clusters only.)

## Idempotency

N/A - no API surface changed.

## Failure-path consistency

N/A - no multi-step write path changed.

## L4 / host-port-pool changes

N/A - neither touched.

## Test plan

- [x] `TestRegistryWellFormed` (harness, `-tags=integration`) passes with the new `CapDockerNetnsPool` in the capability switch
- [x] `bash -n integration-tests/run.sh` clean
- [x] Both caps files and the playbook parse (playbook's duplicate `pre_tasks` key is pre-existing on main, untouched)
- [x] `gofmt`/`go vet` clean on the harness
- [ ] Operator validation: next `make integration-benchmark-docker keep` run should show `docker_netns;desc=hit` in UC-94 Server-Timing and non-zero `aerolvm_docker_netns_pool_hits_total` on the nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)