### PR TITLE
fix(docker): warm-pool adopts survive iptables-nft; reachable pins; self-warming refill; real resource limits

### DIFF
--- a/integration-tests/suite/benchmark_test.go
+++ b/integration-tests/suite/benchmark_test.go
@@ -274,6 +274,60 @@ func warmBenchmarkRuntimes(t *testing.T, c *harness.Client, runtimes []benchRunt
 	}
 }
 
+// waitDockerPoolWarm blocks until a docker create is served from the warm
+// container pool (or a timeout passes). Without this gate the bench races the
+// pool's own self-warming: the suite runs right after node bootstrap, the
+// first creates all record misses (which is what REGISTERS the miss-driven
+// refill targets), and every sample measures the cold path — exactly the
+// v0.5.29 bench artifact, where docker_pool read 0ms on all ten samples. A
+// warm hit is a create whose Server-Timing has a docker_pool stage but no
+// docker_create stage (an adopted container never hits /containers/create).
+// Timing out is logged, not fatal: the samples still run and the stage
+// breakdown in the artifact shows the misses.
+func waitDockerPoolWarm(t *testing.T, c *harness.Client, runtimes []benchRuntimeSpec) {
+	t.Helper()
+	if !sc.Has(harness.CapDockerPool) {
+		return
+	}
+	benchesDocker := false
+	for _, spec := range runtimes {
+		if spec.runtime == "docker" || spec.runtime == "" {
+			benchesDocker = true
+		}
+	}
+	if !benchesDocker {
+		return
+	}
+	deadline := time.Now().Add(time.Duration(benchEnvInt("AEROL_BENCH_POOL_WARM_SECONDS", 120)) * time.Second)
+	attempt := 0
+	for time.Now().Before(deadline) {
+		attempt++
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		sb, err := c.SDK().Create(ctx, sdktypes.CreateSandboxOptions{
+			Name:  harness.UniqueName(sc, t),
+			Image: harness.DefaultImage,
+		})
+		cancel()
+		if err != nil {
+			t.Logf("bench[docker] pool-warm probe %d create failed: %v", attempt, err)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		stages, ok := c.LastServerCreateStages()
+		destroyBest(c, sb.ID)
+		if ok {
+			_, pool := stages["docker_pool"]
+			_, cold := stages["docker_create"]
+			if pool && !cold {
+				t.Logf("bench[docker] warm pool serving hits after %d probe(s)", attempt)
+				return
+			}
+		}
+		time.Sleep(5 * time.Second)
+	}
+	t.Logf("bench[docker] warm pool never served a hit within the warm window; samples will include misses")
+}
+
 func prepareBenchmarkRuntimes(t *testing.T, c *harness.Client, runtimes []benchRuntimeSpec) []benchRuntimeSpec {
 	t.Helper()
 	prepared := append([]benchRuntimeSpec(nil), runtimes...)
@@ -558,6 +612,7 @@ func TestBenchCreateLatency(t *testing.T) {
 	waitBenchmarkReady(t, c, runtimes)
 	runtimes = prepareBenchmarkRuntimes(t, c, runtimes)
 	warmBenchmarkRuntimes(t, c, runtimes)
+	waitDockerPoolWarm(t, c, runtimes)
 
 	var report benchReport
 	for _, br := range runtimes {

--- a/internal/pool/dockerpool/key.go
+++ b/internal/pool/dockerpool/key.go
@@ -15,14 +15,30 @@ type Key struct {
 	Runtime               string
 }
 
-// KeyString returns a stable map key for the pool.
+// KeyString returns a stable map key for the pool. It canonicalizes through
+// the same defaulting rule the service's image-distribution normalization
+// applies (empty mode → external_registry, empty ref → image), because keys
+// reach the pool from two sides that MUST collide: boot-time pins are built
+// bare (Key{Image, Runtime}), while create-path keys are computed after
+// NormalizeCreateImageDistribution filled the metadata. Without this, pinned
+// slots sit under a keystring no create ever computes — permanently
+// unreachable and, being pinned, never idle-reaped.
 func (k Key) KeyString() string {
+	mode := strings.TrimSpace(k.ImageDistributionMode)
+	ref := strings.TrimSpace(k.ImageRegistryRef)
+	image := strings.TrimSpace(k.Image)
+	if mode == "" && image != "" {
+		mode = models.ImageDistributionExternalRegistry
+	}
+	if (mode == models.ImageDistributionExternalRegistry || mode == models.ImageDistributionAOCR) && ref == "" {
+		ref = image
+	}
 	return strings.Join([]string{
-		k.Image,
-		k.ImageDigest,
-		k.ImageRegistryRef,
-		k.ImageDistributionMode,
-		k.Runtime,
+		image,
+		strings.TrimSpace(k.ImageDigest),
+		ref,
+		mode,
+		strings.TrimSpace(k.Runtime),
 	}, "\x00")
 }
 

--- a/internal/pool/dockerpool/metrics.go
+++ b/internal/pool/dockerpool/metrics.go
@@ -5,35 +5,42 @@ import (
 	"sync/atomic"
 )
 
+// The aerolvm_ prefix is load-bearing: observability's expvar exporter only
+// publishes aerolvm_-prefixed vars into /v1/metrics, so anything without it
+// is invisible to Prometheus (readable only via the authed /debug/vars).
+// Names align with the netns pool's aerolvm_docker_netns_pool_* family.
 var (
-	metricHit        = expvar.NewInt("docker_pool_hit")
-	metricMiss       = expvar.NewInt("docker_pool_miss")
-	metricRefill     = expvar.NewInt("docker_pool_refill")
-	metricOrphan     = expvar.NewInt("docker_pool_orphan")
-	metricParked     = expvar.NewInt("docker_pool_parked")
-	metricStaleImage = expvar.NewInt("docker_pool_stale_image")
-	metricSpawnFail  = expvar.NewInt("docker_pool_spawn_fail")
-	adoptMS          = expvar.NewFloat("docker_pool_adopt_ms")
+	metricHit         = expvar.NewInt("aerolvm_docker_pool_hits_total")
+	metricMiss        = expvar.NewInt("aerolvm_docker_pool_misses_total")
+	metricRefill      = expvar.NewInt("aerolvm_docker_pool_refills_total")
+	metricOrphan      = expvar.NewInt("aerolvm_docker_pool_orphans_total")
+	metricParked      = expvar.NewInt("aerolvm_docker_pool_parked")
+	metricStaleImage  = expvar.NewInt("aerolvm_docker_pool_stale_images_total")
+	metricSpawnFail   = expvar.NewInt("aerolvm_docker_pool_spawn_fails_total")
+	metricTargetEvict = expvar.NewInt("aerolvm_docker_pool_target_evictions_total")
+	adoptMS           = expvar.NewFloat("aerolvm_docker_pool_adopt_ms")
 )
 
 // Metrics exposes pool counters for tests and expvar export.
 type Metrics struct {
-	hits       atomic.Int64
-	misses     atomic.Int64
-	refilled   atomic.Int64
-	orphans    atomic.Int64
-	staleImage atomic.Int64
-	spawnFail  atomic.Int64
+	hits         atomic.Int64
+	misses       atomic.Int64
+	refilled     atomic.Int64
+	orphans      atomic.Int64
+	staleImage   atomic.Int64
+	spawnFail    atomic.Int64
+	targetEvicts atomic.Int64
 }
 
 // Snapshot is a point-in-time view of pool counters.
 type Snapshot struct {
-	Hits        int64
-	Misses      int64
-	Refilled    int64
-	Orphans     int64
-	StaleImages int64
-	SpawnFail   int64
+	Hits         int64
+	Misses       int64
+	Refilled     int64
+	Orphans      int64
+	StaleImages  int64
+	SpawnFail    int64
+	TargetEvicts int64
 }
 
 func (m *Metrics) recordHit() {
@@ -66,9 +73,21 @@ func (m *Metrics) RecordSpawnFail() {
 	metricSpawnFail.Add(1)
 }
 
+func (m *Metrics) recordTargetEvict() {
+	m.targetEvicts.Add(1)
+	metricTargetEvict.Add(1)
+}
+
 func (m *Metrics) setParked(n int) { metricParked.Set(int64(n)) }
 
-func (m *Metrics) recordAdoptMS(ms float64) { adoptMS.Set(ms) }
+// RecordAdoptMS publishes the latest successful adopt handshake duration.
+// Exported because the adopt happens in pkg/docker, not in this package.
+func (m *Metrics) RecordAdoptMS(ms float64) {
+	if m == nil {
+		return
+	}
+	adoptMS.Set(ms)
+}
 
 // Stats returns current counter values.
 func (m *Metrics) Stats() Snapshot {
@@ -76,11 +95,12 @@ func (m *Metrics) Stats() Snapshot {
 		return Snapshot{}
 	}
 	return Snapshot{
-		Hits:        m.hits.Load(),
-		Misses:      m.misses.Load(),
-		Refilled:    m.refilled.Load(),
-		Orphans:     m.orphans.Load(),
-		StaleImages: m.staleImage.Load(),
-		SpawnFail:   m.spawnFail.Load(),
+		Hits:         m.hits.Load(),
+		Misses:       m.misses.Load(),
+		Refilled:     m.refilled.Load(),
+		Orphans:      m.orphans.Load(),
+		StaleImages:  m.staleImage.Load(),
+		SpawnFail:    m.spawnFail.Load(),
+		TargetEvicts: m.targetEvicts.Load(),
 	}
 }

--- a/internal/pool/dockerpool/metrics_test.go
+++ b/internal/pool/dockerpool/metrics_test.go
@@ -10,12 +10,14 @@ func TestMetricsStatsAndCounters(t *testing.T) {
 	m.recordOrphan()
 	m.recordStaleImage()
 	m.RecordSpawnFail()
+	m.recordTargetEvict()
 	m.setParked(3)
-	m.recordAdoptMS(12.5)
+	m.RecordAdoptMS(12.5)
 
 	snap := m.Stats()
 	if snap.Hits != 1 || snap.Misses != 1 || snap.Refilled != 1 ||
-		snap.Orphans != 1 || snap.StaleImages != 1 || snap.SpawnFail != 1 {
+		snap.Orphans != 1 || snap.StaleImages != 1 || snap.SpawnFail != 1 ||
+		snap.TargetEvicts != 1 {
 		t.Fatalf("snap = %+v", snap)
 	}
 	var nilMetrics *Metrics

--- a/internal/pool/dockerpool/pool.go
+++ b/internal/pool/dockerpool/pool.go
@@ -23,6 +23,7 @@ type Pool struct {
 	lastUsed      map[string]time.Time
 	ready         map[string][]*ParkedSlot
 	spawning      map[string]int
+	spawnFails    map[string]int // keyString -> consecutive park failures
 	spawner       Spawner
 	onReleasePark func(slotID string)
 	metrics       *Metrics
@@ -41,6 +42,7 @@ func New(logger *slog.Logger) *Pool {
 		lastUsed:   make(map[string]time.Time),
 		ready:      make(map[string][]*ParkedSlot),
 		spawning:   make(map[string]int),
+		spawnFails: make(map[string]int),
 		metrics:    &Metrics{},
 		refillKick: make(chan struct{}, 1),
 	}
@@ -148,7 +150,54 @@ func (p *Pool) evictLRUTargetLocked() []*ParkedSlot {
 	slots := p.ready[oldest]
 	delete(p.ready, oldest)
 	delete(p.spawning, oldest)
+	delete(p.spawnFails, oldest)
 	return slots
+}
+
+// maxConsecutiveSpawnFails is how many refill parks in a row may fail before
+// a miss-driven target is dropped. Without eviction, a target whose image is
+// gone for good (a one-off snapshot or build tag that image-GC removed)
+// wedges the refill loop into a permanent every-tick retry. Six failures is
+// ~30s at the default 5s interval — long enough to ride out a transient
+// registry blip, short enough that a dead image stops burning engine calls.
+// A later create of the same image re-registers the target via NoteMiss, so
+// eviction is never sticky. Pinned targets are operator config and are
+// exempt: silently dropping them would hide a config error.
+const maxConsecutiveSpawnFails = 6
+
+// NoteSpawnFailure counts a failed park for key and evicts the target once
+// the consecutive-failure threshold is crossed. Returns true when the target
+// was evicted. Slot destruction happens outside the lock (same rationale as
+// Acquire/NoteTarget).
+func (p *Pool) NoteSpawnFailure(ks string) bool {
+	var evicted []*ParkedSlot
+	p.mu.Lock()
+	p.spawnFails[ks]++
+	_, pinned := p.pinned[ks]
+	evict := !pinned && p.spawnFails[ks] >= maxConsecutiveSpawnFails
+	if evict {
+		evicted = p.ready[ks]
+		delete(p.targets, ks)
+		delete(p.lastUsed, ks)
+		delete(p.ready, ks)
+		delete(p.spawning, ks)
+		delete(p.spawnFails, ks)
+		p.publishParkedLocked()
+		if p.metrics != nil {
+			p.metrics.recordTargetEvict()
+		}
+	}
+	p.mu.Unlock()
+	p.destroySlots(context.Background(), evicted)
+	return evict
+}
+
+// ClearSpawnFailures resets the consecutive-failure count after a successful
+// park, so the eviction threshold only ever measures an unbroken run.
+func (p *Pool) ClearSpawnFailures(ks string) {
+	p.mu.Lock()
+	delete(p.spawnFails, ks)
+	p.mu.Unlock()
 }
 
 // HasReady reports whether any slot is queued for key. It exists so the
@@ -355,6 +404,7 @@ func (p *Pool) ReapIdle(now time.Time) int {
 		delete(p.lastUsed, ks)
 		delete(p.ready, ks)
 		delete(p.spawning, ks)
+		delete(p.spawnFails, ks)
 	}
 	p.publishParkedLocked()
 	p.mu.Unlock()

--- a/internal/pool/dockerpool/pool_test.go
+++ b/internal/pool/dockerpool/pool_test.go
@@ -305,3 +305,35 @@ func TestKeyFromRequestAndKeyString(t *testing.T) {
 		t.Fatal("empty key string")
 	}
 }
+
+// Boot-time pins are built bare (Key{Image, Runtime}) while create-path keys
+// carry the metadata NormalizeCreateImageDistribution filled in. The two MUST
+// collide in the ready map, or pinned slots are parked under a keystring no
+// create ever computes — permanently unreachable warm capacity that, being
+// pinned, is never idle-reaped either. This is a live-cluster regression:
+// v0.5.29 nodes each carried two orphaned pinned alpine slots.
+func TestKeyStringPinnedBareKeyMatchesNormalizedCreateKey(t *testing.T) {
+	pinned := Key{Image: "alpine:3.20", Runtime: models.RuntimeDocker}
+	create := KeyFromRequest(models.CreateSandboxRequest{
+		Image:                 "alpine:3.20",
+		ImageRegistryRef:      "alpine:3.20",
+		ImageDistributionMode: models.ImageDistributionExternalRegistry,
+	}, models.RuntimeDocker)
+	if pinned.KeyString() != create.KeyString() {
+		t.Fatalf("pinned key %q != normalized create key %q", pinned.KeyString(), create.KeyString())
+	}
+
+	// AOCR refs and digests are identity-bearing: they must stay distinct.
+	aocr := KeyFromRequest(models.CreateSandboxRequest{
+		Image:                 "aocr.example/cluster/snapshots/base:latest",
+		ImageRegistryRef:      "aocr.example/cluster/snapshots/base:latest",
+		ImageDistributionMode: models.ImageDistributionAOCR,
+	}, models.RuntimeDocker)
+	if aocr.KeyString() == create.KeyString() {
+		t.Fatal("aocr key collided with external-registry key")
+	}
+	digested := Key{Image: "alpine:3.20", ImageDigest: "sha256:abc", Runtime: models.RuntimeDocker}
+	if digested.KeyString() == pinned.KeyString() {
+		t.Fatal("digest-bearing key collided with bare key")
+	}
+}

--- a/internal/pool/dockerpool/refill.go
+++ b/internal/pool/dockerpool/refill.go
@@ -80,9 +80,15 @@ func (p *Pool) refillTick(parent context.Context, cfg RefillConfig, spawner Spaw
 				if gate != nil {
 					gate.ReleasePark(slotID)
 				}
-				p.logger.Warn("docker pool refill: park failed", "key", ks, "error", err)
+				if p.NoteSpawnFailure(ks) {
+					p.logger.Warn("docker pool refill: target evicted after consecutive park failures",
+						"key", ks, "fails", maxConsecutiveSpawnFails, "error", err)
+				} else {
+					p.logger.Warn("docker pool refill: park failed", "key", ks, "error", err)
+				}
 				break
 			}
+			p.ClearSpawnFailures(ks)
 			p.RecordLoaded(slot)
 			if p.metrics != nil {
 				p.metrics.recordRefill()

--- a/internal/pool/dockerpool/refill_test.go
+++ b/internal/pool/dockerpool/refill_test.go
@@ -125,3 +125,119 @@ func TestRunRefillWrapper(t *testing.T) {
 	cancel()
 	RunRefill(ctx, p, RefillConfig{}, &refillSpawner{}, nil, nil)
 }
+
+// A target whose image is gone for good (image-GC'd one-off snapshot/build
+// tag) must stop consuming refill ticks: without eviction the loop retries a
+// doomed park every interval forever — the live v0.5.29 nodes accumulated
+// ~190 spawn failures each retrying a deleted snapshot image.
+func TestRefillTickEvictsTargetAfterConsecutiveFailures(t *testing.T) {
+	p := New(nil)
+	p.SetDefaultDepth(1)
+	key := testKey()
+	p.NoteTarget(key)
+
+	spawner := &refillSpawner{err: errors.New("no such image")}
+	gate := &refillGate{canPark: true}
+	cfg := RefillConfig{ParkShape: ParkShape{Runtime: models.RuntimeDocker}}
+
+	for i := range maxConsecutiveSpawnFails {
+		if len(p.ListTargets()) != 1 {
+			t.Fatalf("target evicted early after %d failures", i)
+		}
+		p.refillTick(context.Background(), cfg, spawner, gate)
+	}
+	if len(p.ListTargets()) != 0 {
+		t.Fatalf("target not evicted after %d consecutive failures", maxConsecutiveSpawnFails)
+	}
+	if got := p.Metrics().Stats().TargetEvicts; got != 1 {
+		t.Fatalf("target evictions = %d, want 1", got)
+	}
+	// Every failed park must still have released its reservation.
+	if len(gate.released) != maxConsecutiveSpawnFails {
+		t.Fatalf("released = %d, want %d", len(gate.released), maxConsecutiveSpawnFails)
+	}
+
+	// A later miss re-registers the target — eviction is never sticky, and
+	// the failure streak starts fresh.
+	p.NoteMiss(key)
+	if len(p.ListTargets()) != 1 {
+		t.Fatal("NoteMiss did not re-register an evicted target")
+	}
+	p.refillTick(context.Background(), cfg, spawner, gate)
+	if len(p.ListTargets()) != 1 {
+		t.Fatal("re-registered target evicted after a single failure")
+	}
+}
+
+// Pinned targets are operator config: dropping one would silently disable a
+// deliberately warmed image, so they ride out any failure streak.
+func TestRefillTickNeverEvictsPinnedTarget(t *testing.T) {
+	p := New(nil)
+	p.SetDefaultDepth(1)
+	p.PinTarget(testKey())
+
+	spawner := &refillSpawner{err: errors.New("no such image")}
+	gate := &refillGate{canPark: true}
+	cfg := RefillConfig{ParkShape: ParkShape{Runtime: models.RuntimeDocker}}
+
+	for range maxConsecutiveSpawnFails + 2 {
+		p.refillTick(context.Background(), cfg, spawner, gate)
+	}
+	if len(p.ListTargets()) != 1 {
+		t.Fatal("pinned target was evicted")
+	}
+}
+
+// A success anywhere in the streak resets the count: the threshold measures
+// an unbroken run of failures, not a lifetime tally.
+func TestRefillTickSuccessResetsFailureStreak(t *testing.T) {
+	p := New(nil)
+	p.SetDefaultDepth(1)
+	key := testKey()
+	p.NoteTarget(key)
+
+	spawner := &refillSpawner{err: errors.New("transient")}
+	gate := &refillGate{canPark: true}
+	cfg := RefillConfig{ParkShape: ParkShape{Runtime: models.RuntimeDocker}}
+
+	for range maxConsecutiveSpawnFails - 1 {
+		p.refillTick(context.Background(), cfg, spawner, gate)
+	}
+	spawner.err = nil
+	p.refillTick(context.Background(), cfg, spawner, gate) // success resets
+	spawner.err = errors.New("transient again")
+	for range maxConsecutiveSpawnFails - 1 {
+		p.refillTick(context.Background(), cfg, spawner, gate)
+	}
+	if len(p.ListTargets()) != 1 {
+		t.Fatal("streak did not reset on success")
+	}
+}
+
+// Eviction must destroy any ready slots the target still holds and release
+// their park reservations — otherwise the admitter leaks capacity.
+func TestNoteSpawnFailureEvictionDestroysReadySlots(t *testing.T) {
+	p := New(nil)
+	p.SetDefaultDepth(2)
+	rec := &releaseRecorder{}
+	p.SetParkReleaser(rec.record)
+	spawner := &fakeSpawner{}
+	p.SetSpawner(spawner)
+	key := testKey()
+	p.NoteTarget(key)
+	p.RecordLoaded(&ParkedSlot{ID: "park-live", Key: key, Handle: &fakeHandle{alive: true}})
+
+	ks := key.KeyString()
+	for range maxConsecutiveSpawnFails {
+		p.NoteSpawnFailure(ks)
+	}
+	if len(p.ListTargets()) != 0 {
+		t.Fatal("target not evicted")
+	}
+	if len(spawner.destroyed) != 1 || spawner.destroyed[0] != "park-live" {
+		t.Fatalf("destroyed = %v", spawner.destroyed)
+	}
+	if len(rec.released) != 1 || rec.released[0] != "park-live" {
+		t.Fatalf("released = %v", rec.released)
+	}
+}

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"net"
 	"net/http"
 	"net/url"
@@ -361,6 +362,15 @@ func (c *Client) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 			return warm, nil
 		} else if errors.Is(warmErr, ErrSandboxContainerExists) {
 			return nil, warmErr
+		} else if !errors.Is(warmErr, dockerpool.ErrNoSlot) {
+			// A non-miss failure means a parked slot was acquired and then
+			// burned mid-adopt. The cold fallback below masks it from the
+			// caller, so this WARN is the only place the error surfaces —
+			// swallowing it silently is how a 100% adopt-failure rate went
+			// unnoticed while every create quietly paid rename+destroy on
+			// top of the full cold path.
+			c.logger.Warn("docker warm adopt failed; falling back to cold create",
+				"sandbox_id", sandboxID, "error", warmErr)
 		}
 	}
 
@@ -548,7 +558,12 @@ func (c *Client) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 				hostConfig["StorageOpt"] = map[string]string{"size": fmt.Sprintf("%dG", req.DiskGB)}
 			}
 		}
-		hostConfig["Resources"] = resources
+		// The Docker API embeds Resources fields INLINE in HostConfig (the
+		// Go struct embeds container.Resources without a JSON tag). A nested
+		// "Resources" key is an unknown field dockerd silently drops — that
+		// exact shape shipped from the first version of this client and no
+		// sandbox ever actually received cpu/memory limits.
+		maps.Copy(hostConfig, resources)
 	}
 
 	if req.GPUs != nil {

--- a/pkg/docker/create_coverage_test.go
+++ b/pkg/docker/create_coverage_test.go
@@ -1,7 +1,10 @@
 package docker
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -431,4 +434,60 @@ func TestStartAndWaitForRuntime(t *testing.T) {
 			t.Fatal("waitForRuntime() expected timeout")
 		}
 	})
+}
+
+// The Docker API embeds container.Resources INLINE in HostConfig: a nested
+// "Resources" key is an unknown field dockerd silently drops. That exact
+// shape shipped from the first version of this client, so no sandbox ever
+// actually received cpu/memory limits (live containers showed Memory=0,
+// CpuQuota=0). Pin the wire shape, not just "no error".
+func TestCreate_HostConfigInlinesResourceLimits(t *testing.T) {
+	var createBody []byte
+	d := &fakeDaemon{
+		t: t,
+		imageInspect: func() *http.Response {
+			return jsonResponse(http.StatusOK, map[string]any{
+				"Config": map[string]any{"WorkingDir": "/", "Entrypoint": []string{}, "Cmd": []string{"/bin/sh"}},
+			})
+		},
+		// Failing the create keeps the test off the start/wait path; the
+		// request body is already captured by then.
+		create: func() *http.Response {
+			return textResponse(http.StatusInternalServerError, `{"message":"stop here"}`)
+		},
+	}
+	c := newCreateClient(t, d, true, nil)
+	base := c.httpClient.Transport
+	c.httpClient.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodPost && r.URL.Path == "/containers/create" {
+			b, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read create body: %v", err)
+			}
+			createBody = b
+			r.Body = io.NopCloser(bytes.NewReader(b))
+		}
+		return base.RoundTrip(r)
+	})
+
+	req := models.CreateSandboxRequest{Image: "registry.example/app:v1", CPU: 2, MemoryMB: 1024, DiskGB: 5}
+	if _, err := c.Create(context.Background(), req, "sb", "tok", nil); err == nil {
+		t.Fatal("Create() expected injected create failure")
+	}
+
+	var body struct {
+		HostConfig map[string]any `json:"HostConfig"`
+	}
+	if err := json.Unmarshal(createBody, &body); err != nil {
+		t.Fatalf("create body: %v", err)
+	}
+	if _, nested := body.HostConfig["Resources"]; nested {
+		t.Fatal(`create body nests limits under "Resources" — dockerd drops that key`)
+	}
+	if body.HostConfig["Memory"] == nil || body.HostConfig["CpuQuota"] == nil || body.HostConfig["MemorySwap"] == nil {
+		t.Fatalf("create body missing inline resource limits: %v", body.HostConfig)
+	}
+	if body.HostConfig["StorageOpt"] == nil {
+		t.Fatalf("create body missing StorageOpt: %v", body.HostConfig)
+	}
 }

--- a/pkg/docker/docker_pool.go
+++ b/pkg/docker/docker_pool.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 	"strings"
@@ -132,7 +133,11 @@ func (c *Client) tryWarmAdopt(ctx context.Context, req models.CreateSandboxReque
 		if err == nil {
 			timing.RecordStageDesc("docker_pool", time.Since(start), "hit")
 		} else {
-			timing.RecordStageDesc("docker_pool", 0, "miss")
+			// Distinct desc on purpose: an adopt failure burns a parked slot
+			// and falls back to the cold path — folding it into "miss" is how
+			// the iptables-nft adopt breakage stayed invisible in bench stage
+			// data (every sample read as an ordinary cold miss).
+			timing.RecordStageDesc("docker_pool", time.Since(start), "adopt_failed")
 		}
 	}
 	if err != nil {
@@ -150,6 +155,9 @@ func (c *Client) tryWarmAdopt(ctx context.Context, req models.CreateSandboxReque
 		_ = c.destroyParked(ctx, slot)
 		c.warmPool.ReleasePark(slot.ID)
 		return nil, fmt.Errorf("warm adopt failed: %w", err)
+	}
+	if c.warmPool != nil {
+		c.warmPool.Metrics().RecordAdoptMS(float64(time.Since(start)) / float64(time.Millisecond))
 	}
 	if createtiming.From(ctx) != nil {
 		timing := createtiming.From(ctx)
@@ -188,8 +196,27 @@ func (c *Client) parkContainer(ctx context.Context, slotID string, key dockerpoo
 
 	imageInspect, err := c.inspectImage(ctx, key.Image)
 	if err != nil {
-		_ = pl.Close()
-		return nil, fmt.Errorf("inspect image: %w", err)
+		// Refill must be able to self-warm on a fresh host: without a pull
+		// here, a just-bootstrapped node fails every tick until the first
+		// sandbox create happens to pull the image, and pinned targets never
+		// pre-warm at all. Local-only refs (content-addressed build tags)
+		// can't exist on a registry — fail those immediately so the target
+		// feeds the consecutive-failure eviction instead of retrying forever.
+		// Park slots only serve credential-less creates (poolEligible rejects
+		// req.Registry), so an anonymous pull is the correct shape.
+		if IsLocalOnlyImageRef(key.Image) {
+			_ = pl.Close()
+			return nil, fmt.Errorf("inspect image: %w", err)
+		}
+		if pullErr := c.pullImageDedup(ctx, key.Image, nil); pullErr != nil {
+			_ = pl.Close()
+			return nil, fmt.Errorf("pull image for park: %w", pullErr)
+		}
+		imageInspect, err = c.inspectImage(ctx, key.Image)
+		if err != nil {
+			_ = pl.Close()
+			return nil, fmt.Errorf("inspect image: %w", err)
+		}
 	}
 
 	workingDir := strings.TrimSpace(imageInspect.Config.WorkingDir)
@@ -234,7 +261,9 @@ func (c *Client) parkContainer(ctx context.Context, slotID string, key dockerpoo
 		hostConfig["Runtime"] = ociRuntime
 	}
 	if !c.resourceLimitsOff {
-		hostConfig["Resources"] = parkDefaultResources(c)
+		// Inline, not nested under "Resources": HostConfig embeds the
+		// Resources fields in the Docker API JSON (see the cold path).
+		maps.Copy(hostConfig, parkDefaultResources(c))
 	}
 	if c.parkDiskGB > 0 && effectiveRuntime != models.RuntimeGvisor {
 		hostConfig["StorageOpt"] = map[string]string{"size": fmt.Sprintf("%dG", c.parkDiskGB)}
@@ -426,8 +455,10 @@ func (c *Client) updateContainerResources(ctx context.Context, containerID strin
 	if len(resources) == 0 {
 		return nil
 	}
-	body := map[string]any{"Resources": resources}
-	return c.doJSON(ctx, http.MethodPost, "/containers/"+url.PathEscape(containerID)+"/update", nil, body, nil, nil)
+	// /containers/{id}/update takes container.UpdateConfig, which embeds
+	// Resources inline — a nested "Resources" key is silently ignored and
+	// the adopted container would keep its park-default limits.
+	return c.doJSON(ctx, http.MethodPost, "/containers/"+url.PathEscape(containerID)+"/update", nil, resources, nil, nil)
 }
 
 func mintBootstrapToken() (string, error) {

--- a/pkg/docker/docker_pool_test.go
+++ b/pkg/docker/docker_pool_test.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"log/slog"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/aerol-ai/microvm/internal/pool/dockerpool"
+	"github.com/aerol-ai/microvm/pkg/createtiming"
 	"github.com/aerol-ai/microvm/pkg/docker/netrules"
 	"github.com/aerol-ai/microvm/pkg/models"
 	"github.com/aerol-ai/microvm/pkg/mounts"
@@ -274,12 +276,16 @@ func TestUpdateContainerResourcesNoop(t *testing.T) {
 type poolFakeDaemon struct {
 	t            *testing.T
 	imageInspect func() *http.Response
+	pull         func() *http.Response
 	create       func() *http.Response
 	start        func() *http.Response
 	containerGet func() *http.Response
 	rename       func() *http.Response
 	update       func() *http.Response
 	listJSON     func() *http.Response
+	pullCalls    int
+	createBodies [][]byte
+	updateBodies [][]byte
 	removeCalls  int
 }
 
@@ -296,7 +302,16 @@ func (d *poolFakeDaemon) transport() roundTripFunc {
 			if d.imageInspect != nil {
 				return d.imageInspect(), nil
 			}
+		case r.Method == http.MethodPost && p == "/images/create":
+			d.pullCalls++
+			if d.pull != nil {
+				return d.pull(), nil
+			}
+			return textResponse(http.StatusOK, "{}"), nil
 		case r.Method == http.MethodPost && p == "/containers/create":
+			if body, err := io.ReadAll(r.Body); err == nil {
+				d.createBodies = append(d.createBodies, body)
+			}
 			if d.create != nil {
 				return d.create(), nil
 			}
@@ -314,6 +329,9 @@ func (d *poolFakeDaemon) transport() roundTripFunc {
 			}
 			return textResponse(http.StatusNoContent, ""), nil
 		case r.Method == http.MethodPost && strings.HasSuffix(p, "/update"):
+			if body, err := io.ReadAll(r.Body); err == nil {
+				d.updateBodies = append(d.updateBodies, body)
+			}
 			if d.update != nil {
 				return d.update(), nil
 			}
@@ -437,7 +455,8 @@ func TestTryWarmAdoptFailureReleasesReservation(t *testing.T) {
 		Handle:      badParkHandle{},
 	})
 
-	_, err := c.tryWarmAdopt(context.Background(), models.CreateSandboxRequest{Image: "alpine:3.20"}, "sb-1", "tok", nil, models.RuntimeDocker)
+	ctx, timing := createtiming.With(context.Background())
+	_, err := c.tryWarmAdopt(ctx, models.CreateSandboxRequest{Image: "alpine:3.20"}, "sb-1", "tok", nil, models.RuntimeDocker)
 	if err == nil || errors.Is(err, dockerpool.ErrNoSlot) {
 		t.Fatalf("expected adopt failure, got %v", err)
 	}
@@ -446,6 +465,18 @@ func TestTryWarmAdoptFailureReleasesReservation(t *testing.T) {
 	}
 	if d.removeCalls != 1 {
 		t.Fatalf("parked container not destroyed: removeCalls=%d", d.removeCalls)
+	}
+	// A burned slot must not masquerade as an ordinary miss in Server-Timing
+	// — that disguise is how a 100% adopt-failure rate hid in bench data.
+	var poolStage *createtiming.Stage
+	for _, st := range timing.Stages() {
+		if st.Name == "docker_pool" {
+			poolStage = &st
+			break
+		}
+	}
+	if poolStage == nil || poolStage.Desc != "adopt_failed" {
+		t.Fatalf("docker_pool stage = %+v, want desc=adopt_failed", poolStage)
 	}
 }
 
@@ -607,5 +638,120 @@ func TestRenameContainerConflictMapsToExists(t *testing.T) {
 	_, err = c.adoptParked(context.Background(), models.CreateSandboxRequest{}, "sb-dup", "tok", slot)
 	if !errors.Is(err, ErrSandboxContainerExists) {
 		t.Fatalf("err = %v", err)
+	}
+}
+
+// A fresh host has no images: parkContainer must self-warm with a pull
+// instead of failing every refill tick until some sandbox create happens to
+// pull the image (pinned targets would otherwise never pre-warm at all).
+// The park-default resource limits must also land INLINE in HostConfig —
+// dockerd silently drops an unknown nested "Resources" key.
+func TestParkContainerPullsMissingImageAndInlinesLimits(t *testing.T) {
+	pulled := false
+	d := &poolFakeDaemon{t: t}
+	d.imageInspect = func() *http.Response {
+		if !pulled {
+			return textResponse(http.StatusNotFound, `{"message":"No such image"}`)
+		}
+		return jsonResponse(http.StatusOK, map[string]any{
+			"Id":     "sha256:img1",
+			"Config": map[string]any{"WorkingDir": "/", "Cmd": []string{"/bin/sh"}},
+		})
+	}
+	d.pull = func() *http.Response {
+		pulled = true
+		return textResponse(http.StatusOK, "{}")
+	}
+	// Fail the container create: it proves the flow got past pull+re-inspect
+	// without needing a live parked-handshake guest.
+	d.create = func() *http.Response {
+		return textResponse(http.StatusInternalServerError, `{"message":"boom"}`)
+	}
+	dir, err := os.MkdirTemp("", "rd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	c := newPoolClient(t, d, func(c *Client) {
+		c.pulls = make(map[string]*imagePull)
+		c.readyDir = dir
+	})
+
+	_, err = c.parkContainer(context.Background(), "park-test1", dockerpool.Key{
+		Image: "alpine:3.20", Runtime: models.RuntimeDocker,
+	})
+	if err == nil || !strings.Contains(err.Error(), "park create") {
+		t.Fatalf("err = %v, want park create failure after successful pull", err)
+	}
+	if d.pullCalls != 1 {
+		t.Fatalf("pull calls = %d, want 1", d.pullCalls)
+	}
+	if len(d.createBodies) != 1 {
+		t.Fatalf("create bodies = %d", len(d.createBodies))
+	}
+	var body struct {
+		HostConfig map[string]any `json:"HostConfig"`
+	}
+	if err := json.Unmarshal(d.createBodies[0], &body); err != nil {
+		t.Fatalf("create body: %v", err)
+	}
+	if _, nested := body.HostConfig["Resources"]; nested {
+		t.Fatal(`park create body nests limits under "Resources" — dockerd drops that key`)
+	}
+	if body.HostConfig["Memory"] == nil || body.HostConfig["CpuQuota"] == nil {
+		t.Fatalf("park create body missing inline Memory/CpuQuota: %v", body.HostConfig)
+	}
+}
+
+// Content-addressed local build tags cannot exist on a registry — a missing
+// one must fail immediately (feeding target eviction) without a pull attempt.
+func TestParkContainerLocalOnlyImageSkipsPull(t *testing.T) {
+	d := &poolFakeDaemon{t: t}
+	d.imageInspect = func() *http.Response {
+		return textResponse(http.StatusNotFound, `{"message":"No such image"}`)
+	}
+	dir, err := os.MkdirTemp("", "rd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	c := newPoolClient(t, d, func(c *Client) {
+		c.pulls = make(map[string]*imagePull)
+		c.readyDir = dir
+	})
+
+	_, err = c.parkContainer(context.Background(), "park-test2", dockerpool.Key{
+		Image: BuiltImageNamespace + "/deadbeef:latest", Runtime: models.RuntimeDocker,
+	})
+	if err == nil || !strings.Contains(err.Error(), "inspect image") {
+		t.Fatalf("err = %v, want inspect failure", err)
+	}
+	if d.pullCalls != 0 {
+		t.Fatalf("pull calls = %d, want 0 for local-only ref", d.pullCalls)
+	}
+}
+
+// /containers/{id}/update takes container.UpdateConfig, which embeds the
+// Resources fields inline — nesting them under "Resources" is silently
+// ignored and an adopted container would keep its park-default limits.
+func TestUpdateContainerResourcesInlineBody(t *testing.T) {
+	d := &poolFakeDaemon{t: t}
+	c := newPoolClient(t, d, nil)
+
+	if err := c.updateContainerResources(context.Background(), "cid1", 2, 1024); err != nil {
+		t.Fatal(err)
+	}
+	if len(d.updateBodies) != 1 {
+		t.Fatalf("update bodies = %d", len(d.updateBodies))
+	}
+	var body map[string]any
+	if err := json.Unmarshal(d.updateBodies[0], &body); err != nil {
+		t.Fatalf("update body: %v", err)
+	}
+	if _, nested := body["Resources"]; nested {
+		t.Fatal(`update body nests limits under "Resources" — dockerd ignores that key`)
+	}
+	if body["Memory"] == nil || body["CpuQuota"] == nil {
+		t.Fatalf("update body missing inline Memory/CpuQuota: %v", body)
 	}
 }

--- a/pkg/docker/netrules/manager.go
+++ b/pkg/docker/netrules/manager.go
@@ -1,6 +1,7 @@
 package netrules
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 	"strings"
@@ -8,6 +9,29 @@ import (
 
 	"github.com/coreos/go-iptables/iptables"
 )
+
+// ruleNotExist reports whether a delete failed only because the rule was
+// already absent. The message differs by iptables flavor: legacy says
+// "No chain/target/match by that name", iptables-nft (Ubuntu 22.04's
+// default) says "Bad rule (does a matching rule exist in that chain?)".
+// go-iptables' typed error knows every flavor; the string fallback covers
+// backends that return plain errors (the RuleBackend test seam). Matching
+// only the legacy string here is exactly the bug that made every warm-pool
+// adopt fail on iptables-nft hosts: the duplicate-sweep loop's terminating
+// "rule gone" probe read as a fatal error.
+func ruleNotExist(err error) bool {
+	if err == nil {
+		return false
+	}
+	var iptErr *iptables.Error
+	if errors.As(err, &iptErr) {
+		return iptErr.IsNotExist()
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "No chain/target/match") ||
+		strings.Contains(msg, "does a matching rule exist") ||
+		strings.Contains(msg, "does not exist")
+}
 
 // RuleBackend is the subset of iptables operations the Manager drives.
 // Production always wraps *go-iptables' IPTables; tests substitute an
@@ -99,7 +123,7 @@ func (m *Manager) ClearBlockAllEgress(containerIP string) error {
 		if err == nil {
 			continue
 		}
-		if strings.Contains(err.Error(), "No chain/target/match") {
+		if ruleNotExist(err) {
 			return nil
 		}
 		return fmt.Errorf("delete egress rule: %w", err)
@@ -147,7 +171,7 @@ func (m *Manager) ClearBlockAllIngress(containerIP string) error {
 		if err == nil {
 			continue
 		}
-		if strings.Contains(err.Error(), "No chain/target/match") {
+		if ruleNotExist(err) {
 			return nil
 		}
 		return fmt.Errorf("delete ingress rule: %w", err)
@@ -254,7 +278,7 @@ func (m *Manager) deletePolicyRule(spec ...string) error {
 		if err == nil {
 			continue
 		}
-		if strings.Contains(err.Error(), "No chain/target/match") {
+		if ruleNotExist(err) {
 			return nil
 		}
 		return fmt.Errorf("delete egress policy rule: %w", err)

--- a/pkg/docker/netrules/manager_test.go
+++ b/pkg/docker/netrules/manager_test.go
@@ -183,9 +183,13 @@ func TestManagerEnabledErrors(t *testing.T) {
 
 // memBackend is an in-memory RuleBackend for asserting rule-state semantics
 // of the selective-egress policy paths (allowlist/denylist + comment scoping)
-// without a fake iptables binary.
+// without a fake iptables binary. deleteErr selects which flavor of "rule
+// absent" error a Delete miss returns — legacy iptables and iptables-nft
+// word it differently, and the Manager must terminate its duplicate-sweep
+// loops on both.
 type memBackend struct {
-	rules []string
+	rules     []string
+	deleteErr error
 }
 
 func memKey(table, chain string, spec ...string) string {
@@ -209,12 +213,82 @@ func (m *memBackend) Delete(table, chain string, spec ...string) error {
 			return nil
 		}
 	}
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
 	return errNoMatch{}
 }
 
 type errNoMatch struct{}
 
 func (errNoMatch) Error() string { return "No chain/target/match by that name." }
+
+type errNftBadRule struct{}
+
+func (errNftBadRule) Error() string {
+	return "iptables v1.8.7 (nf_tables): Bad rule (does a matching rule exist in that chain?)."
+}
+
+// The Clear* duplicate-sweep loops probe past the last match, so the flavor
+// of the terminating "rule absent" error decides whether the clear reads as
+// success. Matching only the legacy wording made ClearBlockAllEgress fail on
+// every iptables-nft host (Ubuntu 22.04's default) — which burned a parked
+// slot on every warm-pool adopt. Both flavors must terminate cleanly, on a
+// present rule (sweep past the delete) and an absent one (immediate probe).
+func TestClearLoopsTerminateOnBothIptablesFlavors(t *testing.T) {
+	flavors := map[string]error{
+		"legacy": errNoMatch{},
+		"nft":    errNftBadRule{},
+	}
+	for name, flavor := range flavors {
+		t.Run(name, func(t *testing.T) {
+			backend := &memBackend{deleteErr: flavor}
+			mgr := NewWithBackend(backend)
+
+			if err := mgr.BlockAllEgress("10.0.0.7"); err != nil {
+				t.Fatalf("BlockAllEgress: %v", err)
+			}
+			if err := mgr.ClearBlockAllEgress("10.0.0.7"); err != nil {
+				t.Fatalf("ClearBlockAllEgress with present rule: %v", err)
+			}
+			if len(backend.rules) != 0 {
+				t.Fatalf("rules left after clear: %v", backend.rules)
+			}
+			if err := mgr.ClearBlockAllEgress("10.0.0.7"); err != nil {
+				t.Fatalf("ClearBlockAllEgress with absent rule: %v", err)
+			}
+
+			if err := mgr.BlockAllIngress("10.0.0.7"); err != nil {
+				t.Fatalf("BlockAllIngress: %v", err)
+			}
+			if err := mgr.ClearBlockAllIngress("10.0.0.7"); err != nil {
+				t.Fatalf("ClearBlockAllIngress with present rule: %v", err)
+			}
+
+			if err := mgr.ApplyEgressPolicy("10.0.0.7", []string{"1.2.3.0/24"}, nil); err != nil {
+				t.Fatalf("ApplyEgressPolicy: %v", err)
+			}
+			if err := mgr.ClearEgressPolicy("10.0.0.7", []string{"1.2.3.0/24"}, nil); err != nil {
+				t.Fatalf("ClearEgressPolicy: %v", err)
+			}
+			if len(backend.rules) != 0 {
+				t.Fatalf("policy rules left after clear: %v", backend.rules)
+			}
+		})
+	}
+}
+
+func TestRuleNotExist(t *testing.T) {
+	if ruleNotExist(nil) {
+		t.Fatal("nil error must not read as not-exist")
+	}
+	if !ruleNotExist(errNoMatch{}) || !ruleNotExist(errNftBadRule{}) {
+		t.Fatal("both iptables error flavors must read as not-exist")
+	}
+	if ruleNotExist(os.ErrPermission) {
+		t.Fatal("unrelated error must not read as not-exist")
+	}
+}
 
 func TestNewWithBackend(t *testing.T) {
 	if m := NewWithBackend(nil); m.Enabled() {

--- a/plans/docker-warm-pool.md
+++ b/plans/docker-warm-pool.md
@@ -283,8 +283,10 @@ protocol:
 Acquire with image-ID revalidation, LRU + TTL, kickRefill), `refill.go`
 (ticker + kick + §4 capacity gate + guard band), `spawner.go` (Spawner
 interface; prod impl → `docker.Client.ParkContainer`), `metrics.go`
-(expvars `docker_pool_hit/miss/refill/orphan/parked/stale_image`,
-`docker_pool_adopt_ms`), `errors.go`. Each with `_test.go` (≥85%).
+(expvars `aerolvm_docker_pool_{hits,misses,refills,orphans,stale_images,spawn_fails,target_evictions}_total`,
+`aerolvm_docker_pool_parked`, `aerolvm_docker_pool_adopt_ms` — the aerolvm_
+prefix is what the observability exporter publishes into /v1/metrics),
+`errors.go`. Each with `_test.go` (≥85%).
 
 **`pkg/docker/client.go`** — `ParkContainer` (park identity create+start,
 records image ID, applies park DROP, returns slot handle with held conn);


### PR DESCRIPTION
## Summary

Live-debugging the kept `cluster-3-mixed-docker` cluster (v0.5.29, bench p50 **506ms**, zero warm hits despite parked slots on every node) surfaced four warm-pool defects plus one serious pre-existing bug. All fixed here, each with a regression test.

1. **Every warm adopt failed on iptables-nft hosts.** `ClearBlockAllEgress`'s duplicate-sweep loop treated iptables-nft's "Bad rule (does a matching rule exist in that chain?)" as fatal (it only knew legacy's "No chain/target/match"). Ubuntu 22.04 defaults to iptables-nft, so **100% of adopts** failed *after* a successful handshake: slot destroyed, cold fallback, plus rename+update+destroy overhead on every create — the p50 regression. Verified live via `docker events` (rename→update→kill→die→destroy→cold create→re-park) and by running the double-delete on-node. Fix: `ruleNotExist` uses go-iptables' typed `IsNotExist()` (knows all flavors) with a both-flavor string fallback for the `RuleBackend` test seam.
2. **Pinned slots were unreachable.** Boot pins build `Key{Image, Runtime}`; create-path keys carry `NormalizeCreateImageDistribution` metadata. Two different keystrings for `alpine:3.20` (both observed in node journals) → every node parked 2 permanently unmatchable, never-idle-reaped slots. Fix: `KeyString()` canonicalizes with the same defaulting rule the service normalization applies (empty mode → `external_registry`, empty ref → image). AOCR refs and digests stay distinct.
3. **Refill couldn't self-warm and never gave up.** `parkContainer` only inspected — on a fresh node it failed every 5s tick until some create pulled the image; and a deleted one-off snapshot image (image-GC'd UC-21 artifact) had node1 retrying a doomed park every 5s forever (~190 `spawn_fail`/node). Fix: refill pulls missing images (anonymous pull is the right shape — `poolEligible` rejects credentialed creates; local-only refs fail immediately), and a non-pinned target is evicted after **6 consecutive** spawn failures. `NoteMiss` re-registers, so eviction is never sticky; pinned targets are exempt.
4. **Failures were invisible.** `Create()` swallowed adopt errors unlogged and the failure path recorded `docker_pool;desc=miss` — indistinguishable from a routine miss in bench stage data. Now: WARN log + `desc=adopt_failed` + `adopt_ms` actually recorded on hits + pool expvars renamed to the `aerolvm_` prefix the `/v1/metrics` exporter requires (the old names were reachable only via authed `/debug/vars`; nothing external consumed them).

**Bonus, pre-existing since the original client (787ec6c):** resource limits were never applied to any docker container. The create body nested them under `HostConfig["Resources"]`, but the Docker API embeds `container.Resources` **inline** in HostConfig — dockerd silently dropped the key (live sandboxes showed `Memory=0 CpuQuota=0`). Same shape bug in the park create and the adopt-time `/containers/{id}/update` body. All three now send fields inline, with wire-shape tests pinning the exact JSON.

Harness: UC-94 now waits (≤120s, `AEROL_BENCH_POOL_WARM_SECONDS`) for a genuine warm hit — `docker_pool` stage present *and* `docker_create` stage absent — before sampling, instead of racing the pool's self-warming seconds after node bootstrap.

## Code-path diagram (mermaid)

**Warm adopt on an iptables-nft host — before → after:**

```mermaid
flowchart TD
    A[Acquire parked slot] --> B[rename park-x → sb-id]
    B --> C[update resources]
    C --> D[adopt handshake ✅ succeeds]
    D --> E[applyAdoptNetworkPolicy → ClearBlockAllEgress]
    E --> F{delete #1: DROP rule removed}
    F --> G{delete #2 probe: rule gone}
    G -- "before: nft 'Bad rule…' ≠ 'No chain/target/match' → FATAL" --> H[destroy slot ❌\nfall back to cold create\nrecorded as desc=miss, no log]
    G -- "after: ruleNotExist knows both flavors → loop terminates" --> I[warm hit returned ✅\ndesc=hit, adopt_ms recorded]
    H --> J[refill parks replacement\n⇒ perpetual burn cycle]
```

**Refill target lifecycle — after:**

```mermaid
flowchart TD
    T[refill tick per target] --> P{image local?}
    P -- no, registry ref --> PU[pull image ✅ new] --> S[park slot]
    P -- no, local-only ref --> F[fail fast]
    P -- yes --> S
    S -- success --> R[ClearSpawnFailures ✅ new]
    S -- failure --> N[NoteSpawnFailure ✅ new]
    F --> N
    N -- "< 6 consecutive" --> T
    N -- "≥ 6, non-pinned" --> E[evict target ✅ new\ndestroy slots + release reservations\nNoteMiss re-registers later]
    N -- pinned --> T
```

**Key identity — before → after:**

```mermaid
flowchart LR
    subgraph before
      P1["pin: alpine:3.20␀␀␀␀docker"] -. never match .- C1["create: alpine:3.20␀␀alpine:3.20␀external_registry␀docker"]
    end
    subgraph after
      P2[pin: bare Key] --> K[KeyString canonicalizes\nmode ''→external_registry, ref ''→image]
      C2[create: normalized Key] --> K
      K --> M[same keystring → HasReady/Acquire collide ✅]
    end
```

## Sandbox boot impact

- **Warm-hit path (fixed, was broken):** rename + update + handshake + netrules + inspect, ~20–60ms — replaces the ~350ms cold engine path. No new work added.
- **Miss path:** unchanged (`HasReady` map lookup, no engine calls).
- **Cold path:** unchanged, except limits now actually apply (one more field set in the same create body — no extra round-trip). Removing the perpetual adopt-burn also removes the rename/update/destroy tax every eligible create was silently paying.
- **First-call/background:** image pull moved into the refill goroutine (off the boot path); pull dedup shared with create-path pulls prevents duplicate downloads.

## Failure-path consistency

- Adopt failure: unchanged rollback (destroy slot + `ReleasePark`), now logged and stage-tagged.
- Target eviction destroys ready slots via the same `destroySlots` path (container + netrules + park reservation) — covered by `TestNoteSpawnFailureEvictionDestroysReadySlots`.
- Park pull failure releases the slot reservation via the existing refill failure path.

## Fragile-area call-outs (pr-review.md §5)

- `internal/pool/dockerpool` (pool bookkeeping): new `spawnFails` map lives under the same single-lock discipline; destruction stays outside the lock. Regression tests: eviction threshold, pinned exemption, streak reset, reservation release. `-race -count=2` clean.
- `pkg/docker/netrules`: behavior change is strictly "tolerate both iptables error flavors"; rule-state semantics unchanged (`TestClearLoopsTerminateOnBothIptablesFlavors` asserts terminal rule state for both flavors on egress/ingress/policy paths).
- **Behavior note:** containers now genuinely get cpu/memory limits. UC-95 density and any workload that silently relied on unlimited memory will see real caps (defaults: 1 CPU / 1024MB). This is the documented intent finally taking effect.

## Testing

- `make test` clean; `go vet -tags integration ./integration-tests/...` clean.
- Coverage: dockerpool 91.5%, netrules 88.7%, daemon 88.9%; pkg/docker 76.2% → 77.5% (pre-existing deficit is the netns pool + adopt plumbing from #293, not this change).
- Live validation pending: next `make integration-benchmark-docker keep` after a release — expect `docker_pool desc=hit` samples and server p50 well under the 100ms gate on hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
