### PR TITLE
feat(integration): docker-cold benchmark row keeps the cold floor visible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,10 @@ integration-benchmark-only:
 #   make integration-benchmark-docker DOCKER_BENCH_OUT=/tmp/docker-bench.json
 DOCKER_BENCH_OUT ?= integration-tests/reports/cluster-3-mixed-docker-bench.json
 DOCKER_BENCH_SAMPLES ?= 10
-DOCKER_BENCH_RUNTIMES ?= docker
+# docker-cold is the pool-ineligible variant of the same runtime: with the
+# warm pool on, the docker row measures warm hits and docker-cold keeps the
+# cold floor visible next to it (and shows the pause-netns pool's effect).
+DOCKER_BENCH_RUNTIMES ?= docker,docker-cold
 integration-benchmark-docker:
 	AEROL_BENCH=1 AEROL_BENCH_OUT=$(DOCKER_BENCH_OUT) \
 	AEROL_BENCH_SAMPLES=$(DOCKER_BENCH_SAMPLES) \

--- a/integration-tests/suite/benchmark_test.go
+++ b/integration-tests/suite/benchmark_test.go
@@ -43,6 +43,11 @@ var benchRuntimes = []struct {
 	cap     harness.Capability
 }{
 	{"docker", harness.CapDocker},
+	// docker-cold is the same docker runtime forced past the warm container
+	// pool (see benchCreateOptions), so a pool-enabled scenario reports the
+	// cold floor next to the warm-hit row instead of losing it. On a
+	// pool-less scenario the two rows converge — cheap redundancy.
+	{"docker-cold", harness.CapDocker},
 	{"firecracker", harness.CapFirecracker},
 	{"gvisor", harness.CapGvisor},
 	{"wasm", harness.CapWasm},
@@ -136,6 +141,15 @@ func benchCreateOptions(t *testing.T, spec benchRuntimeSpec) sdktypes.CreateSand
 		if spec.templateID != "" {
 			opts.TemplateID = spec.templateID
 		}
+	case "docker-cold":
+		// The row name is docker-cold; the create itself is a plain docker
+		// create forced past the warm container pool: any Env entry makes
+		// poolEligible reject it, so every sample measures the cold engine
+		// path. The pause-netns pool still applies when enabled — it IS the
+		// cold path's accelerator, and this row is how its win is measured.
+		opts.Runtime = "docker"
+		opts.Image = harness.DefaultImage
+		opts.Env = map[string]string{"AEROL_BENCH_COLD": "1"}
 	default:
 		opts.Image = harness.DefaultImage
 	}


### PR DESCRIPTION
## Summary

With the warm pool enabled, UC-94's `docker` row measures warm hits and the cold path vanishes from the bench artifact — but the cold floor is the baseline the pool's win is judged against, and the pause-netns pool's effect is only visible there. This adds a **`docker-cold`** benchmark row: the same docker runtime and default image, but the create carries an `Env` entry, which `poolEligible` rejects — so every sample is guaranteed to measure the cold engine path (still including the netns adopt when that pool is enabled: it is the cold path's accelerator by design, and this row is how its win gets measured).

`make integration-benchmark-docker` now sweeps `docker,docker-cold` by default (override with `AEROL_BENCH_RUNTIMES`), producing two latency rows in the bench JSON:

| row | measures |
|---|---|
| `docker` | warm-hit path (pool adopt) — gated by the pool-warm wait from #298 |
| `docker-cold` | cold engine path (+ pause-netns adopt when enabled) |

## Code-path diagram (mermaid)

```mermaid
flowchart TD
    B[UC-94 sweep] --> W[docker row: plain create] --> WP{poolEligible?} -- yes --> H[warm adopt → hit samples]
    B --> C[docker-cold row: create with Env buster ✅ new] --> CP{poolEligible?} -- "no (Env set)" --> CO[cold engine path\n+ netns adopt if enabled]
```

Design notes:
- `docker-cold` does **not** trigger the pool-warm wait gate (`waitDockerPoolWarm` keys on the plain `docker` spec).
- Eligibility is checked before the pool key is computed, so cold samples do **not** register miss-driven refill targets — the cold row cannot pollute the pool.
- On pool-less scenarios the two rows converge (cheap redundancy, no skip logic needed).

## Sandbox boot impact

None on the server — harness/Makefile only. The cold row adds ~`AEROL_BENCH_SAMPLES` extra creates per bench run.

## Testing

- `go vet -tags integration ./integration-tests/...` clean.
- Live validation: next `make integration-benchmark-docker keep` produces both rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
