### PR TITLE
fix(terraform): plumb pause-netns pool config to bootstrapped nodes

### DIFF
--- a/Terraform/locals.tf
+++ b/Terraform/locals.tf
@@ -266,6 +266,17 @@ locals {
     refill_interval = try(local.cluster_ops.docker.pool.refill_interval, "5s")
   }
 
+  # Pause-netns pool (image-agnostic prepaid network namespaces for docker
+  # cold creates). Values come from cluster.yml's docker.netns_pool block;
+  # defaults mirror config.go so Terraform and Ansible
+  # (playbooks/configure-ops.yml) render identical env on every node.
+  docker_netns_pool_cfg = {
+    enabled         = try(local.cluster_ops.docker.netns_pool.enabled, false) ? "true" : "false"
+    depth           = tostring(try(local.cluster_ops.docker.netns_pool.depth, 4))
+    pause_image     = try(local.cluster_ops.docker.netns_pool.pause_image, "registry.k8s.io/pause:3.10")
+    refill_interval = try(local.cluster_ops.docker.netns_pool.refill_interval, "2s")
+  }
+
   # Homogeneous per-arch clusters (D5): one GOARCH for snapshot tagging and
   # Firecracker upstream artifact selection. The precondition on
   # validate_cluster_ops enforces a single distinct arch across nodes.

--- a/Terraform/nodes.tf
+++ b/Terraform/nodes.tf
@@ -179,6 +179,7 @@ resource "aws_instance" "seed" {
     fleet_contract_refresh = local.fleet.contract_refresh
     wasm_cfg               = local.wasm_cfg
     docker_pool_cfg        = local.docker_pool_cfg
+    docker_netns_pool_cfg  = local.docker_netns_pool_cfg
     platform_volumes_cfg   = local.platform_volumes_cfg
   }))
 
@@ -359,6 +360,7 @@ resource "aws_instance" "joiner" {
     fleet_contract_refresh = local.fleet.contract_refresh
     wasm_cfg               = local.wasm_cfg
     docker_pool_cfg        = local.docker_pool_cfg
+    docker_netns_pool_cfg  = local.docker_netns_pool_cfg
     platform_volumes_cfg   = local.platform_volumes_cfg
   }))
 

--- a/Terraform/templates/bootstrap.sh.tftpl
+++ b/Terraform/templates/bootstrap.sh.tftpl
@@ -623,6 +623,16 @@ SB_DOCKER_POOL_IMAGES=${docker_pool_cfg.images}
 SB_DOCKER_POOL_MAX_IMAGES=${docker_pool_cfg.max_images}
 SB_DOCKER_POOL_IDLE_TTL=${docker_pool_cfg.idle_ttl}
 SB_DOCKER_POOL_REFILL_INTERVAL=${docker_pool_cfg.refill_interval}
+
+# Managed by Terraform bootstrap: pause-netns pool (prepaid network
+# namespaces for docker cold creates). Without these lines the
+# docker-netns-pool capability silently no-ops: run.sh writes
+# docker.netns_pool.enabled into cluster.yml but only this template
+# turns cluster.yml into sandboxd env on Terraform-provisioned nodes.
+SB_DOCKER_NETNS_POOL_ENABLED=${docker_netns_pool_cfg.enabled}
+SB_DOCKER_NETNS_POOL_DEPTH=${docker_netns_pool_cfg.depth}
+SB_DOCKER_NETNS_POOL_PAUSE_IMAGE=${docker_netns_pool_cfg.pause_image}
+SB_DOCKER_NETNS_POOL_REFILL_INTERVAL=${docker_netns_pool_cfg.refill_interval}
 EOF
 
 sudo tee -a /etc/sandboxd/cluster.env < /tmp/aerolvm-ops.env >/dev/null

--- a/integration-tests/suite/benchmark_artifact_test.go
+++ b/integration-tests/suite/benchmark_artifact_test.go
@@ -29,6 +29,40 @@ func TestMergeBenchReportsPreservesLatencyWhenDensityArrives(t *testing.T) {
 	}
 }
 
+func TestMissingBenchRuntimeTargetsDockerColdUsesDockerGossip(t *testing.T) {
+	members := capacityView{}
+	members.Members = append(members.Members, struct {
+		NodeID        string `json:"node_id"`
+		NodeName      string `json:"node_name"`
+		Role          string `json:"role"`
+		Alive         bool   `json:"alive"`
+		Drained       bool   `json:"drained"`
+		CapacityStale bool   `json:"capacity_stale"`
+		Capacity      struct {
+			CanAdmit          bool     `json:"can_admit"`
+			SupportedRuntimes []string `json:"supported_runtimes"`
+		} `json:"capacity"`
+	}{
+		Role:  "mixed",
+		Alive: true,
+		Capacity: struct {
+			CanAdmit          bool     `json:"can_admit"`
+			SupportedRuntimes []string `json:"supported_runtimes"`
+		}{
+			CanAdmit:          true,
+			SupportedRuntimes: []string{"docker"},
+		},
+	})
+
+	missing := missingBenchRuntimeTargets(members, []benchRuntimeSpec{
+		{runtime: "docker"},
+		{runtime: "docker-cold"},
+	})
+	if len(missing) != 0 {
+		t.Fatalf("want no missing targets when docker is advertised, got %v", missing)
+	}
+}
+
 func TestMergeBenchReportsPreservesDensityWhenLatencyArrives(t *testing.T) {
 	existing := benchReport{
 		Density: &densityStats{

--- a/integration-tests/suite/benchmark_test.go
+++ b/integration-tests/suite/benchmark_test.go
@@ -225,6 +225,16 @@ func benchClusterMembers(c *harness.Client) (capacityView, error) {
 	return members, nil
 }
 
+// benchClusterRuntime maps a UC-94 row name to the runtime string cluster
+// gossip advertises in supported_runtimes. docker-cold is a pool-ineligible
+// docker variant for the bench artifact, not a distinct engine.
+func benchClusterRuntime(runtime string) string {
+	if runtime == "docker-cold" {
+		return "docker"
+	}
+	return runtime
+}
+
 func missingBenchRuntimeTargets(members capacityView, runtimes []benchRuntimeSpec) []string {
 	var missing []string
 	for _, spec := range runtimes {
@@ -236,12 +246,13 @@ func missingBenchRuntimeTargets(members capacityView, runtimes []benchRuntimeSpe
 }
 
 func benchHasRuntimeTarget(members capacityView, runtime string) bool {
+	clusterRT := benchClusterRuntime(runtime)
 	for _, m := range members.Members {
 		if !m.Alive || m.Drained || m.CapacityStale || !benchCanOwnSandbox(m.Role) || !m.Capacity.CanAdmit {
 			continue
 		}
 		for _, rt := range m.Capacity.SupportedRuntimes {
-			if rt == runtime {
+			if rt == clusterRT {
 				return true
 			}
 		}


### PR DESCRIPTION
## Summary

- The `docker-netns-pool` capability silently no-oped on every Terraform-provisioned cluster: `run.sh` writes `docker.netns_pool.enabled` into the overlay `cluster.yml`, and Ansible's `configure-ops.yml` knows the keys — but nodes bootstrap via `bootstrap.sh.tftpl`, which never rendered `SB_DOCKER_NETNS_POOL_*`. `wireDockerNetnsPool` saw `enabled=false` and returned nil, so every cold docker create paid full dockerd network setup. Proof from the 2026-07-11 bench: **zero `docker_netns` stage samples** (the stage is recorded on hit AND miss whenever the pool is wired), cold p50 328ms = raw engine floor.
- Fix mirrors `docker_pool_cfg`: new `docker_netns_pool_cfg` local (defaults identical to `config.go` and Ansible), passed at both `templatefile` sites in `nodes.tf`, rendered into `/etc/sandboxd/cluster.env`.
- Also carries the UC-94 prereq fix: `docker-cold` is a bench row name, not a gossip runtime, so `benchHasRuntimeTarget` timed out 5m waiting for a `docker-cold` target on full-suite runs. `benchClusterRuntime` maps it to `docker` (+ unit test).

## Code-path diagram

```mermaid
flowchart TD
    caps["caps.yml: docker-netns-pool"] --> runsh["run.sh overlay:<br/>docker.netns_pool.enabled=true"]
    runsh --> tf["Terraform locals.tf"]
    tf -- "before: no netns mapping<br/>(env never written)" --> off["SB_DOCKER_NETNS_POOL_ENABLED unset<br/>wireDockerNetnsPool -> nil<br/>cold create pays full dockerd net setup"]
    tf -- "after: docker_netns_pool_cfg -><br/>nodes.tf (2 sites) -> bootstrap.sh.tftpl" --> on["SB_DOCKER_NETNS_POOL_* in cluster.env<br/>NetnsPool wired<br/>cold create adopts prepaid netns"]
```

## Sandbox boot impact

N/A - no work added to sandbox boot path. Deploy plumbing only: this turns on the *existing* netns adopt path (PR #293) on nodes whose scenario opts in; that path replaces dockerd's in-create network setup with a pool lookup. Default remains off.

## Idempotency

N/A - no API surface changed.

## Failure-path consistency

N/A - no multi-step write path changed.

## L4 / host-port-pool changes

N/A - neither touched.

## Test plan

- `terraform validate` — success; `terraform fmt -check` clean.
- Both `templatefile` call sites patched (asserted exactly 2 occurrences).
- `go vet -tags=integration ./integration-tests/suite/...` clean.
- `go test -tags=integration -run 'TestMissingBenchRuntimeTargets|TestMergeBenchReports' ./integration-tests/suite/` — 3/3 pass with a stub scenario env.
- Defaults cross-checked against `internal/config/config.go` (depth 4, `registry.k8s.io/pause:3.10`, 2s) and `Ansible/playbooks/configure-ops.yml:138-141` so both provisioning paths render identical env.
- Note: user_data change ⇒ nodes replace on next apply (`user_data_replace_on_change`), which is the normal bench flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)