### PR TITLE
perf(cluster): Tier 2 — inline recovery payloads off the promote path (≤30ms gate unlock)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -49,8 +49,7 @@ no longer serialize. See `ip_lock_test.go`.
   shape, so mixed-version-safe both directions); blob mesh remains only for
   legacy sealed bytes / oversized specs. Raft-quorum durability is strictly
   stronger than today's best-effort mesh for failover recreate.
-- **Status:** IMPLEMENTED 2026-07-11 (branch
-  `perf/warm-create-latency-tier2-inline-recovery`, stacked on PR #306):
+- **Status:** IMPLEMENTED 2026-07-11 (PR #307, stacked on PR #306):
   `inlineRecoveryEligible` gate in `recovery_replication.go`, externalize-mode
   metric, determinism-parity + replay + threshold-crossing regression tests.
   **Remaining:** operator bench re-run (plan T4) to confirm `create;dur`

--- a/TODOS.md
+++ b/TODOS.md
@@ -49,8 +49,14 @@ no longer serialize. See `ip_lock_test.go`.
   shape, so mixed-version-safe both directions); blob mesh remains only for
   legacy sealed bytes / oversized specs. Raft-quorum durability is strictly
   stronger than today's best-effort mesh for failover recreate.
-- **Start:** `internal/cluster/recovery_replication.go`
-  (`storeAndReplicateRecoveryBlob`), `recovery_store.go` fetch path; bench
+- **Status:** IMPLEMENTED 2026-07-11 (branch
+  `perf/warm-create-latency-tier2-inline-recovery`, stacked on PR #306):
+  `inlineRecoveryEligible` gate in `recovery_replication.go`, externalize-mode
+  metric, determinism-parity + replay + threshold-crossing regression tests.
+  **Remaining:** operator bench re-run (plan T4) to confirm `create;dur`
+  p50 ≤ 30ms / `cluster_promote` ≤ 8ms, then close this entry.
+- **Start (for the bench re-run):** `make integration-benchmark-docker-only`
+  + `-sparse` with `SB_NETRULES_BACKEND=netlink`, all-WAL raft; prior
   artifacts `integration-tests/reports/cluster-3-mixed-docker-bench-{baseline,netlink,netlink-wal}.json`.
 
 ## netrules backend switch on iptables-legacy hosts — DONE

--- a/internal/cluster/agent_wrapper_additional_test.go
+++ b/internal/cluster/agent_wrapper_additional_test.go
@@ -282,7 +282,10 @@ func TestAgentLookupDerivedReadsAndMutationWrappers(t *testing.T) {
 	if err := agent.ClaimOrphan(ctx, "sb-claim", nil, PlacementSecrets{}); err != nil {
 		t.Fatalf("ClaimOrphan() error = %v", err)
 	}
-	if err := agent.UpsertSpec(ctx, "sb-upsert", &models.CreateSandboxRequest{Image: "alpine:3.20", Name: "named"}, PlacementSecrets{}); err != nil {
+	// LegacySealed forces the blob path: since Tier 2, a small secret-free
+	// spec stays inline in the raft command and produces no recovery blob
+	// (that contract is pinned in recovery_inline_test.go).
+	if err := agent.UpsertSpec(ctx, "sb-upsert", &models.CreateSandboxRequest{Image: "alpine:3.20", Name: "named"}, PlacementSecrets{LegacySealed: []byte("sealed")}); err != nil {
 		t.Fatalf("UpsertSpec() error = %v", err)
 	}
 	if err := agent.AddExposedPort(ctx, "sb-port", 8080, ExposedPortRoute{Protocol: "http", PublicURL: "https://sandbox.example.com"}); err != nil {

--- a/internal/cluster/coverage_final_test.go
+++ b/internal/cluster/coverage_final_test.go
@@ -909,10 +909,14 @@ func TestAgentApplyCommandExternalizeFailure(t *testing.T) {
 		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
 		gossip: &gossipNode{memberIndex: newGossipMemberIndex()},
 	}
+	// SealedSecrets force the blob path: since Tier 2, a small secret-free
+	// payload stays inline and never needs a recovery peer at externalize
+	// time (it would fail later, at the control-plane forward instead).
 	err := agent.applyCommand(context.Background(), command{
-		Op:        opPlace,
-		SandboxID: "sb-no-recovery-peers",
-		Spec:      &models.CreateSandboxRequest{Image: "alpine"},
+		Op:            opPlace,
+		SandboxID:     "sb-no-recovery-peers",
+		Spec:          &models.CreateSandboxRequest{Image: "alpine"},
+		SealedSecrets: []byte("sealed"),
 	})
 	if err == nil || !strings.Contains(err.Error(), "no live server-role control-plane members") {
 		t.Fatalf("applyCommand() = %v, want recovery replication failure", err)

--- a/internal/cluster/fsm_recovery_inline_test.go
+++ b/internal/cluster/fsm_recovery_inline_test.go
@@ -1,0 +1,214 @@
+package cluster
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// refCommandForTest replays the pre-Tier-2 externalize behavior byte-for-byte:
+// store the payload as a blob and strip it from the command. This is exactly
+// what an old-version emitter produces, so tests built on it double as the
+// mixed-version compatibility proof (old emitter → new voter).
+func refCommandForTest(t *testing.T, store placementRecoveryStore, cmd command) command {
+	t.Helper()
+	blob, err := newRecoveryBlob(cmd.SandboxID, placementRecovery{
+		Spec:          cmd.Spec,
+		SecretRef:     cmd.SecretRef,
+		SecretVersion: cmd.SecretVersion,
+		SealedSecrets: cloneBytes(cmd.SealedSecrets),
+	})
+	if err != nil {
+		t.Fatalf("newRecoveryBlob: %v", err)
+	}
+	if ref, err := store.Put(blob.SandboxID, blob.recovery()); err != nil || ref != blob.Ref {
+		t.Fatalf("seed blob: ref=%q err=%v, want %q", ref, err, blob.Ref)
+	}
+	cmd.Name = commandName(cmd)
+	cmd.RecoveryRef = blob.Ref
+	cmd.Spec = nil
+	cmd.SecretRef = ""
+	cmd.SecretVersion = 0
+	cmd.SealedSecrets = nil
+	return cmd
+}
+
+// normalizePlacementTimes zeroes the wall-clock fields so placements applied
+// in different test runs (or across a second boundary) compare equal.
+func normalizePlacementTimes(p Placement) Placement {
+	p.CreatedUnix = 0
+	p.UpdatedUnix = 0
+	return p
+}
+
+// TestFSMInlineAndRefPlaceProduceIdenticalState is the Tier 2 determinism
+// gate: the same create carried inline vs pre-externalized as a ref must
+// materialize identical FSM rows — including the content-addressed
+// RecoveryRef, because storePlacementLocked splits an inline payload into the
+// voter's local recovery store under the same ref the blob path would use.
+func TestFSMInlineAndRefPlaceProduceIdenticalState(t *testing.T) {
+	base := command{
+		Op:            opPlace,
+		SandboxID:     "sb-parity",
+		OwnerNodeID:   "node-a",
+		OwnerAPIURL:   "http://a",
+		Spec:          &models.CreateSandboxRequest{Name: "parity", Image: "alpine:3.20"},
+		SecretRef:     "provider-ref",
+		SecretVersion: 2,
+	}
+
+	inlineFSM := newPlacementFSMWithRecoveryStore(newPlacementRecoveryMemoryStore())
+	if got := applyOp(t, inlineFSM, base); got != nil {
+		t.Fatalf("inline apply: %v", got)
+	}
+
+	refStore := newPlacementRecoveryMemoryStore()
+	refFSM := newPlacementFSMWithRecoveryStore(refStore)
+	if got := applyOp(t, refFSM, refCommandForTest(t, refStore, base)); got != nil {
+		t.Fatalf("ref apply: %v", got)
+	}
+
+	a, ok := inlineFSM.get("sb-parity")
+	if !ok {
+		t.Fatal("inline placement missing")
+	}
+	b, ok := refFSM.get("sb-parity")
+	if !ok {
+		t.Fatal("ref placement missing")
+	}
+	if !reflect.DeepEqual(normalizePlacementTimes(a), normalizePlacementTimes(b)) {
+		t.Fatalf("inline vs ref placement diverged:\ninline: %+v\nref:    %+v", a, b)
+	}
+	if a.RecoveryRef == "" {
+		t.Fatal("inline apply did not split payload into the local recovery store")
+	}
+	// The failover contract: after an inline apply the voter holds the blob
+	// locally, same as if the blob mesh had pre-replicated it.
+	if _, ok, err := inlineFSM.recoveryStore.Get(a.RecoveryRef); err != nil || !ok {
+		t.Fatalf("recovery blob missing locally after inline apply: ok=%v err=%v", ok, err)
+	}
+}
+
+// TestFSMInlineSpecEnforcesNameUniqueness pins that the cluster-wide name
+// index derives from the inline spec (commandName falls back to specName), so
+// inline commands get the same duplicate-name rejection as ref commands.
+func TestFSMInlineSpecEnforcesNameUniqueness(t *testing.T) {
+	fsm := newPlacementFSMWithRecoveryStore(newPlacementRecoveryMemoryStore())
+	if got := applyOp(t, fsm, command{
+		Op: opPlace, SandboxID: "sb-1", OwnerNodeID: "node-a",
+		Spec: &models.CreateSandboxRequest{Name: "uniq", Image: "alpine"},
+	}); got != nil {
+		t.Fatalf("first place: %v", got)
+	}
+	got := applyOp(t, fsm, command{
+		Op: opPlace, SandboxID: "sb-2", OwnerNodeID: "node-b",
+		Spec: &models.CreateSandboxRequest{Name: "uniq", Image: "alpine"},
+	})
+	err, ok := got.(error)
+	if !ok || !errors.Is(err, ErrNameConflict) {
+		t.Fatalf("duplicate name via inline spec = %v, want ErrNameConflict", got)
+	}
+}
+
+// TestFSMReplayMixedInlineAndRefEntries pins the replay contract for a log
+// that interleaves inline and ref entries (the steady state of a
+// mixed-version cluster): a restarted FSM replaying the same entries against
+// the same recovery store converges to identical state.
+func TestFSMReplayMixedInlineAndRefEntries(t *testing.T) {
+	store := newPlacementRecoveryMemoryStore()
+	expiry := time.Now().Add(5 * time.Minute).Unix()
+	entries := []command{
+		{
+			Op: opReserve, SandboxID: "sb-a", OwnerNodeID: "node-a", ExpiresUnix: expiry,
+			Spec: &models.CreateSandboxRequest{Name: "a", Image: "alpine:3.20"}, SecretRef: "ra", SecretVersion: 1,
+		},
+		refCommandForTest(t, store, command{
+			Op: opReserve, SandboxID: "sb-b", OwnerNodeID: "node-b", ExpiresUnix: expiry,
+			Spec: oversizedSpec("b"),
+		}),
+		// Promotes carry no payload — the realistic RecordPlacement-after-
+		// reserve shape; the spec must be preserved from the reservation row.
+		{Op: opPlace, SandboxID: "sb-a", OwnerNodeID: "node-a"},
+		{Op: opPlace, SandboxID: "sb-b", OwnerNodeID: "node-b"},
+	}
+
+	replay := func() (Placement, Placement) {
+		fsm := newPlacementFSMWithRecoveryStore(store)
+		for i, cmd := range entries {
+			if got := applyOp(t, fsm, cmd); got != nil {
+				t.Fatalf("entry %d apply: %v", i, got)
+			}
+		}
+		a, ok := fsm.get("sb-a")
+		if !ok {
+			t.Fatal("sb-a missing")
+		}
+		b, ok := fsm.get("sb-b")
+		if !ok {
+			t.Fatal("sb-b missing")
+		}
+		return a, b
+	}
+
+	a1, b1 := replay()
+	a2, b2 := replay() // restart: fresh FSM, same store, same log
+
+	if !reflect.DeepEqual(normalizePlacementTimes(a1), normalizePlacementTimes(a2)) {
+		t.Fatalf("sb-a diverged across replay:\nfirst:  %+v\nsecond: %+v", a1, a2)
+	}
+	if !reflect.DeepEqual(normalizePlacementTimes(b1), normalizePlacementTimes(b2)) {
+		t.Fatalf("sb-b diverged across replay:\nfirst:  %+v\nsecond: %+v", b1, b2)
+	}
+	if a1.State != PlacementStatePlaced || a1.Spec == nil || a1.Spec.Image != "alpine:3.20" {
+		t.Fatalf("inline-reserved spec not preserved through promote: %+v", a1)
+	}
+	if b1.State != PlacementStatePlaced || b1.Spec == nil || len(b1.Spec.Image) <= inlineRecoveryMaxBytes {
+		t.Fatalf("ref-reserved spec not preserved through promote: %+v", b1)
+	}
+}
+
+// TestFSMThresholdCrossingReserveAndPlaceConverge pins the §5 edge: a
+// sandbox whose payload crosses inlineRecoveryMaxBytes between reserve and
+// place (or the reverse) still converges — both shapes are valid per-command.
+func TestFSMThresholdCrossingReserveAndPlaceConverge(t *testing.T) {
+	store := newPlacementRecoveryMemoryStore()
+	fsm := newPlacementFSMWithRecoveryStore(store)
+	expiry := time.Now().Add(5 * time.Minute).Unix()
+
+	// Inline reserve → ref place.
+	if got := applyOp(t, fsm, command{
+		Op: opReserve, SandboxID: "sb-x", OwnerNodeID: "node-a", ExpiresUnix: expiry,
+		Spec: &models.CreateSandboxRequest{Name: "cross-x", Image: "alpine:3.20"},
+	}); got != nil {
+		t.Fatalf("inline reserve: %v", got)
+	}
+	if got := applyOp(t, fsm, refCommandForTest(t, store, command{
+		Op: opPlace, SandboxID: "sb-x", OwnerNodeID: "node-a",
+		Spec: oversizedSpec("cross-x"),
+	})); got != nil {
+		t.Fatalf("ref place: %v", got)
+	}
+	if p, _ := fsm.get("sb-x"); p.State != PlacementStatePlaced || p.Spec == nil || len(p.Spec.Image) <= inlineRecoveryMaxBytes {
+		t.Fatalf("inline→ref crossing did not converge on the placed spec: %+v", p)
+	}
+
+	// Ref reserve → inline place.
+	if got := applyOp(t, fsm, refCommandForTest(t, store, command{
+		Op: opReserve, SandboxID: "sb-y", OwnerNodeID: "node-b", ExpiresUnix: expiry,
+		Spec: oversizedSpec("cross-y"),
+	})); got != nil {
+		t.Fatalf("ref reserve: %v", got)
+	}
+	if got := applyOp(t, fsm, command{
+		Op: opPlace, SandboxID: "sb-y", OwnerNodeID: "node-b",
+		Spec: &models.CreateSandboxRequest{Name: "cross-y", Image: "alpine:3.20"},
+	}); got != nil {
+		t.Fatalf("inline place: %v", got)
+	}
+	if p, _ := fsm.get("sb-y"); p.State != PlacementStatePlaced || p.Spec == nil || p.Spec.Image != "alpine:3.20" {
+		t.Fatalf("ref→inline crossing did not converge on the placed spec: %+v", p)
+	}
+}

--- a/internal/cluster/metrics.go
+++ b/internal/cluster/metrics.go
@@ -47,6 +47,11 @@ var (
 
 	clusterReservationsExpired = expvar.NewInt("aerolvm_cluster_reservations_expired_total")
 
+	// recoveryExternalizeTotal counts externalize decisions by mode so an
+	// unexpected blob-path share (legacy sealed bytes or oversized specs on
+	// the create path) is visible before it shows up as promote latency.
+	recoveryExternalizeTotal = expvar.NewMap("aerolvm_cluster_recovery_externalize_total")
+
 	schedulerDecisions        = expvar.NewMap("aerolvm_scheduler_decisions_total")
 	schedulerCandidateRejects = expvar.NewMap("aerolvm_scheduler_candidate_rejects_total")
 	schedulerCandidatesLast   = expvar.NewInt("aerolvm_scheduler_candidates_last")
@@ -129,6 +134,15 @@ func recordOwnerForwardTargetMiss(reason string) {
 
 func recordExpiredReservation() {
 	clusterReservationsExpired.Add(1)
+}
+
+const (
+	recoveryExternalizeModeInline = "inline"
+	recoveryExternalizeModeBlob   = "blob"
+)
+
+func recordRecoveryExternalize(mode string) {
+	scaleobs.Add(recoveryExternalizeTotal, mode, 1)
 }
 
 func recordSchedulerDecision(reason string, candidates int, rejects map[string]int64) {

--- a/internal/cluster/recovery_inline_test.go
+++ b/internal/cluster/recovery_inline_test.go
@@ -1,0 +1,173 @@
+package cluster
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// oversizedSpec returns a spec whose encoded recovery record exceeds
+// inlineRecoveryMaxBytes, forcing the blob path without sealed bytes.
+func oversizedSpec(name string) *models.CreateSandboxRequest {
+	return &models.CreateSandboxRequest{
+		Name:  name,
+		Image: "alpine:" + strings.Repeat("x", inlineRecoveryMaxBytes),
+	}
+}
+
+// TestExternalizeInlineEligibleSkipsBlobPath pins the Tier 2 contract: a
+// small, secret-free payload stays inline in the raft command — no blob is
+// stored or replicated before the apply, and the command keeps its original
+// wire shape (the one hydrateCommandRecovery no-ops on).
+func TestExternalizeInlineEligibleSkipsBlobPath(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  command
+	}{
+		{
+			name: "small spec with secret handle",
+			cmd: command{
+				Op:            opPlace,
+				SandboxID:     "sb-inline",
+				OwnerNodeID:   "node-a",
+				Spec:          &models.CreateSandboxRequest{Name: "inline", Image: "alpine:3.20"},
+				SecretRef:     "provider-ref-1",
+				SecretVersion: 3,
+			},
+		},
+		{
+			name: "secret handle only",
+			cmd: command{
+				Op:            opUpsertSpec,
+				SandboxID:     "sb-handle-only",
+				SecretRef:     "provider-ref-2",
+				SecretVersion: 1,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			put := func(ctx context.Context, blob RecoveryBlob) error {
+				t.Fatalf("blob put called for inline-eligible payload: %+v", blob)
+				return nil
+			}
+			out, err := externalizeCommandRecovery(context.Background(), tc.cmd, put)
+			if err != nil {
+				t.Fatalf("externalize: %v", err)
+			}
+			if out.RecoveryRef != "" {
+				t.Fatalf("inline command gained RecoveryRef %q", out.RecoveryRef)
+			}
+			if (out.Spec == nil) != (tc.cmd.Spec == nil) || out.SecretRef != tc.cmd.SecretRef || out.SecretVersion != tc.cmd.SecretVersion {
+				t.Fatalf("inline command payload mutated: %+v", out)
+			}
+		})
+	}
+}
+
+// TestExternalizeBlobPathForSealedAndOversized pins the two conditions that
+// must keep using the blob mesh: legacy sealed secret bytes (never allowed in
+// the immutable raft log) and payloads over inlineRecoveryMaxBytes.
+func TestExternalizeBlobPathForSealedAndOversized(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  command
+	}{
+		{
+			name: "legacy sealed secrets",
+			cmd: command{
+				Op:            opPlace,
+				SandboxID:     "sb-sealed",
+				OwnerNodeID:   "node-a",
+				Spec:          &models.CreateSandboxRequest{Name: "sealed", Image: "alpine:3.20"},
+				SealedSecrets: []byte("sealed-bytes"),
+			},
+		},
+		{
+			name: "oversized spec",
+			cmd: command{
+				Op:          opPlace,
+				SandboxID:   "sb-big",
+				OwnerNodeID: "node-a",
+				Spec:        oversizedSpec("big"),
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			puts := 0
+			put := func(ctx context.Context, blob RecoveryBlob) error {
+				puts++
+				return nil
+			}
+			out, err := externalizeCommandRecovery(context.Background(), tc.cmd, put)
+			if err != nil {
+				t.Fatalf("externalize: %v", err)
+			}
+			if puts != 1 {
+				t.Fatalf("blob put called %d times, want 1", puts)
+			}
+			if out.RecoveryRef == "" {
+				t.Fatal("blob-path command missing RecoveryRef")
+			}
+			if out.Spec != nil || out.SecretRef != "" || out.SecretVersion != 0 || len(out.SealedSecrets) != 0 {
+				t.Fatalf("blob-path command still carries payload: %+v", out)
+			}
+			if out.Name != commandName(tc.cmd) {
+				t.Fatalf("blob-path command Name = %q, want %q", out.Name, commandName(tc.cmd))
+			}
+		})
+	}
+}
+
+// TestExternalizeReserveBatchMixedEligibility pins per-reservation gating:
+// one opReserveBatch may carry inline and ref reservations side by side.
+func TestExternalizeReserveBatchMixedEligibility(t *testing.T) {
+	puts := 0
+	put := func(ctx context.Context, blob RecoveryBlob) error {
+		puts++
+		return nil
+	}
+	cmd := command{
+		Op: opReserveBatch,
+		Reservations: []reservationCommand{
+			{SandboxID: "sb-small", OwnerNodeID: "node-a", Spec: &models.CreateSandboxRequest{Name: "small", Image: "alpine:3.20"}},
+			{SandboxID: "sb-sealed", OwnerNodeID: "node-a", Spec: &models.CreateSandboxRequest{Name: "sealed"}, SealedSecrets: []byte("sealed")},
+			{SandboxID: "sb-big", OwnerNodeID: "node-a", Spec: oversizedSpec("big")},
+		},
+	}
+	out, err := externalizeCommandRecovery(context.Background(), cmd, put)
+	if err != nil {
+		t.Fatalf("externalize: %v", err)
+	}
+	if puts != 2 {
+		t.Fatalf("blob put called %d times, want 2", puts)
+	}
+	if r := out.Reservations[0]; r.RecoveryRef != "" || r.Spec == nil {
+		t.Fatalf("small reservation should stay inline: %+v", r)
+	}
+	for _, i := range []int{1, 2} {
+		if r := out.Reservations[i]; r.RecoveryRef == "" || r.Spec != nil || len(r.SealedSecrets) != 0 {
+			t.Fatalf("reservation %d should be blob-externalized: %+v", i, r)
+		}
+	}
+}
+
+// TestInlineRecoveryEligible pins the gate directly, including that sealed
+// bytes disqualify regardless of size.
+func TestInlineRecoveryEligible(t *testing.T) {
+	small := placementRecovery{Spec: &models.CreateSandboxRequest{Name: "n", Image: "alpine"}, SecretRef: "r", SecretVersion: 1}
+	if ok, err := inlineRecoveryEligible("sb", small); err != nil || !ok {
+		t.Fatalf("small secret-free payload: eligible=%v err=%v, want true", ok, err)
+	}
+	sealedTiny := placementRecovery{SealedSecrets: []byte{1}}
+	if ok, err := inlineRecoveryEligible("sb", sealedTiny); err != nil || ok {
+		t.Fatalf("sealed payload: eligible=%v err=%v, want false", ok, err)
+	}
+	big := placementRecovery{Spec: oversizedSpec("n")}
+	if ok, err := inlineRecoveryEligible("sb", big); err != nil || ok {
+		t.Fatalf("oversized payload: eligible=%v err=%v, want false", ok, err)
+	}
+}

--- a/internal/cluster/recovery_replication.go
+++ b/internal/cluster/recovery_replication.go
@@ -38,16 +38,63 @@ func externalizeCommandRecovery(ctx context.Context, cmd command, put func(conte
 	return cmd, nil
 }
 
+// inlineRecoveryMaxBytes bounds the recovery payload a command may carry
+// inline in the raft log instead of pre-replicating it as a blob. The value
+// keeps log entries and FSM snapshots small: typical redacted specs encode to
+// ~0.5–1KiB, so 4KiB covers the normal create with headroom while capping
+// worst-case snapshot growth at ~4KiB per placement. A const, not config —
+// an env knob would make what the emitter sends diverge per node for no
+// benefit (any mix of inline and ref commands is valid either way).
+const inlineRecoveryMaxBytes = 4096
+
+// inlineRecoveryEligible reports whether a recovery payload may stay inline
+// in the raft command, skipping the blob store + synchronous replication to
+// every control-plane member. Two conditions, both load-bearing:
+//
+//   - Sealed secret bytes must NEVER enter the raft log: the log and FSM
+//     snapshots are not erasable per-sandbox, while blob files are deleted on
+//     destroy. The modern path's SecretRef is a provider handle, not secret
+//     material, so it may ride the log.
+//   - The encoded payload (the exact bytes the blob store would persist) must
+//     fit inlineRecoveryMaxBytes so log/snapshot growth stays bounded.
+//
+// Inline commands are the original wire shape: hydrateCommandRecovery is a
+// no-op for RecoveryRef == "", and at apply time storePlacementLocked splits
+// the payload into each voter's local recovery store under the same
+// content-addressed ref this encoding produces — so failover recreate and
+// destroy-time blob deletion behave exactly as on the blob path, minus the
+// pre-apply HTTP fan-out.
+func inlineRecoveryEligible(sandboxID string, rec placementRecovery) (bool, error) {
+	if len(rec.SealedSecrets) > 0 {
+		return false, nil
+	}
+	_, payload, err := encodePlacementRecoveryRecord(placementRecoveryStoreRecord{SandboxID: sandboxID, Recovery: rec})
+	if err != nil {
+		return false, err
+	}
+	return len(payload) <= inlineRecoveryMaxBytes, nil
+}
+
 func externalizeSingleCommandRecovery(ctx context.Context, cmd command, put func(context.Context, RecoveryBlob) error) (command, error) {
 	if !commandCarriesRecoveryPayload(cmd.Spec, cmd.SecretRef, cmd.SecretVersion, cmd.SealedSecrets) {
 		return cmd, nil
 	}
-	blob, err := newRecoveryBlob(cmd.SandboxID, placementRecovery{
+	rec := placementRecovery{
 		Spec:          cmd.Spec,
 		SecretRef:     cmd.SecretRef,
 		SecretVersion: cmd.SecretVersion,
 		SealedSecrets: cloneBytes(cmd.SealedSecrets),
-	})
+	}
+	inline, err := inlineRecoveryEligible(cmd.SandboxID, rec)
+	if err != nil {
+		return command{}, err
+	}
+	if inline {
+		recordRecoveryExternalize(recoveryExternalizeModeInline)
+		return cmd, nil
+	}
+	recordRecoveryExternalize(recoveryExternalizeModeBlob)
+	blob, err := newRecoveryBlob(cmd.SandboxID, rec)
 	if err != nil {
 		return command{}, err
 	}
@@ -67,12 +114,22 @@ func externalizeReservationRecovery(ctx context.Context, r reservationCommand, p
 	if !commandCarriesRecoveryPayload(r.Spec, r.SecretRef, r.SecretVersion, r.SealedSecrets) {
 		return r, nil
 	}
-	blob, err := newRecoveryBlob(r.SandboxID, placementRecovery{
+	rec := placementRecovery{
 		Spec:          r.Spec,
 		SecretRef:     r.SecretRef,
 		SecretVersion: r.SecretVersion,
 		SealedSecrets: cloneBytes(r.SealedSecrets),
-	})
+	}
+	inline, err := inlineRecoveryEligible(r.SandboxID, rec)
+	if err != nil {
+		return reservationCommand{}, err
+	}
+	if inline {
+		recordRecoveryExternalize(recoveryExternalizeModeInline)
+		return r, nil
+	}
+	recordRecoveryExternalize(recoveryExternalizeModeBlob)
+	blob, err := newRecoveryBlob(r.SandboxID, rec)
 	if err != nil {
 		return reservationCommand{}, err
 	}

--- a/internal/cluster/recovery_replication_additional_test.go
+++ b/internal/cluster/recovery_replication_additional_test.go
@@ -19,15 +19,20 @@ func TestCommandCarriesRecoveryPayload(t *testing.T) {
 	}
 }
 
+// TestExternalizeCommandRecovery covers the blob path of the two externalize
+// wrappers. Payloads are blob-forced (sealed bytes / oversized spec) because
+// small secret-free payloads stay inline since Tier 2 — that contract is
+// pinned in recovery_inline_test.go.
 func TestExternalizeCommandRecovery(t *testing.T) {
 	put := func(ctx context.Context, blob RecoveryBlob) error {
 		return nil
 	}
 
 	cmd := command{
-		Op:        opPlace,
-		Spec:      &models.CreateSandboxRequest{},
-		SandboxID: "sb1",
+		Op:            opPlace,
+		Spec:          &models.CreateSandboxRequest{},
+		SealedSecrets: []byte("sealed"),
+		SandboxID:     "sb1",
 	}
 
 	out, err := externalizeCommandRecovery(context.Background(), cmd, put)
@@ -44,7 +49,7 @@ func TestExternalizeCommandRecovery(t *testing.T) {
 	cmd2 := command{
 		Op: opReserveBatch,
 		Reservations: []reservationCommand{
-			{SandboxID: "sb2", Spec: &models.CreateSandboxRequest{}},
+			{SandboxID: "sb2", Spec: oversizedSpec("sb2")},
 		},
 	}
 	out2, err := externalizeCommandRecovery(context.Background(), cmd2, put)

--- a/plans/warm-create-latency-tier2-recovery-replication.md
+++ b/plans/warm-create-latency-tier2-recovery-replication.md
@@ -1,6 +1,9 @@
 # Warm create latency Tier 2: inline recovery payloads (40ms → ≤30ms gate unlock)
 
-Status: **draft — needs eng review.** Follow-up to
+Status: **implemented 2026-07-11** on branch
+`perf/warm-create-latency-tier2-inline-recovery` (stacked on PR #306) —
+T1–T3 done, offline suite green; **bench gate re-run (T4) pending**, which is
+what proves the ≤30ms unlock and closes T5. Follow-up to
 `plans/warm-create-latency-tier1.md` (gates run 2026-07-11) and the TODOS
 entry "cluster_promote is recovery-replication-bound". Tier 1 + 1.5 got the
 create leg to 17ms and the seal to 0ms, but the ≤30ms warm-p50 gate failed
@@ -84,9 +87,14 @@ inline-eligible iff:
   store+replicate entirely. The Raft command keeps `Spec`, `SecretRef`,
   `SecretVersion` inline — the ORIGINAL wire shape. FSM apply:
   `hydrateCommandRecovery` is already a no-op when `RecoveryRef == ""`;
-  `opPlace`/`opReserve` handling is unchanged. No blob file is created, so
-  there is nothing for `deletePlacementRecoveryLocked` / snapshot GC to
-  clean — both are already no-ops for refless rows.
+  `opPlace`/`opReserve` handling is unchanged. **Verified at implementation
+  time:** `storePlacementLocked` splits an inline payload into each voter's
+  *local* recovery store at apply time under the same content-addressed ref
+  the blob path would compute — so a blob file still lands on every voter
+  (written locally, not pushed over HTTP pre-apply), destroy-time deletion
+  and snapshot GC behave identically, and the stored FSM row is
+  byte-identical between the two wire shapes (pinned by the determinism
+  parity test).
 - **Not eligible (legacy sealed bytes, or oversized spec):** today's path,
   byte-for-byte — externalize, store locally, sync-replicate to all
   members, apply with `RecoveryRef`.
@@ -210,14 +218,17 @@ drift.
 
 ## Implementation tasks
 
-- [ ] **T1** — Eligibility gate in `externalizeCommandRecovery` (+ const,
-  rationale comment, externalize-mode metric)
-- [ ] **T2** — Regression tests §6.1–6.4 (`recovery_replication_test.go`,
-  `fsm_recovery_*_test.go`)
-- [ ] **T3** — PR call-outs: boot-path (§2 pr-review), cluster-correctness
-  (§4 rollout matrix, §5 failure modes), coverage at ~85%
+- [x] **T1** — Eligibility gate in `externalizeCommandRecovery` (+ const,
+  rationale comment, externalize-mode metric
+  `aerolvm_cluster_recovery_externalize_total{inline,blob}`)
+- [x] **T2** — Regression tests §6.1–6.4 (`recovery_inline_test.go` for the
+  gate + batch mixing; `fsm_recovery_inline_test.go` for determinism parity,
+  mixed-log replay, name-index-from-inline-spec, threshold crossing)
+- [x] **T3** — PR call-outs: boot-path (§2 pr-review), cluster-correctness
+  (§4 rollout matrix, §5 failure modes), coverage at ~85% — branch
+  `perf/warm-create-latency-tier2-inline-recovery`, stacked on PR #306
 - [ ] **T4** — Bench gate re-run (burst + sparse, netlink, all-WAL) —
   ≤30ms p50 with `cluster_promote` ≤8ms; update Tier 1/1.5 plan status
   lines to "gate MET" with the artifact paths
 - [ ] **T5** — Close the TODOS entry ("cluster_promote is
-  recovery-replication-bound") pointing here
+  recovery-replication-bound") pointing here (after T4 confirms the gate)

--- a/plans/warm-create-latency-tier2-recovery-replication.md
+++ b/plans/warm-create-latency-tier2-recovery-replication.md
@@ -1,7 +1,7 @@
 # Warm create latency Tier 2: inline recovery payloads (40ms → ≤30ms gate unlock)
 
-Status: **implemented 2026-07-11** on branch
-`perf/warm-create-latency-tier2-inline-recovery` (stacked on PR #306) —
+Status: **implemented 2026-07-11 — PR #307** (branch
+`perf/warm-create-latency-tier2-inline-recovery`, stacked on PR #306) —
 T1–T3 done, offline suite green; **bench gate re-run (T4) pending**, which is
 what proves the ≤30ms unlock and closes T5. Follow-up to
 `plans/warm-create-latency-tier1.md` (gates run 2026-07-11) and the TODOS


### PR DESCRIPTION
## What this PR does — in plain English

**The problem.** AerolVM clusters keep a "recovery note" for every sandbox: what image it runs, its settings, and a handle to its secrets. If the server owning a sandbox dies, another server reads the note and rebuilds the sandbox. Useful — but the way we *delivered* that note was slow: on **every** create, the note was written to a local file (waiting for the disk) and then **copied over the network to every other server, and the create waited for the slowest one to answer**. And this happened **twice** per create (once when the request is routed, once when the owning server commits). On our 3-machine test cluster this waiting was 23–25ms of a 40–44ms create — more than half the total.

**The fix.** For normal sandboxes, the note now **rides inside the cluster message we were already sending** (the Raft log entry that says "this sandbox now exists on server X"). That message already reaches every server with majority acknowledgment — so the extra file write and the copy-to-everyone round trip simply disappear. No new work replaces them; the only cost kept is a microseconds-level size check.

**Who still uses the old path.** Two kinds of sandbox, on purpose:
1. Sandboxes with **legacy embedded secrets**. The cluster log is permanent and can't be selectively erased, but the old note-files *can* be deleted when a sandbox is destroyed. So secret bytes must never enter the log — this rule is now enforced by the code itself, not by convention. (Modern sandboxes don't carry secret bytes in the note at all — only a reference handle, which is safe.)
2. Notes bigger than 4KB (rare, oversized configurations), to keep log entries small.

**What does NOT change:**
- Every server still ends up holding its own local copy of the note — it now writes it while applying the log entry instead of receiving it over HTTP beforehand. Same file, same name, same cleanup on destroy.
- Rebuild-after-server-death works the same or **better**: before, the copy-to-everyone was best-effort and a badly-timed crash could leave no server with the note; now the note is guaranteed on a majority of servers the moment the create succeeds.
- Old and new software versions can run together during a rolling upgrade, **in either order**, because "note inside the message" is the format the cluster originally used — old servers already understand it.
- Single-server (non-cluster) deployments: zero change.

**Use cases solved:**

| # | Before | After |
|---|---|---|
| 1 | Every cluster create waited twice for the slowest server in the cluster to accept a copy of the recovery note. | Normal creates send no copies at all — the note travels in the existing cluster message. |
| 2 | Warm create was 40–44ms (goal: ≤30ms); 23–25ms of it was this copying. | Expected ~22–27ms, with the copying step at ~4–8ms (just the normal cluster commit). To be confirmed by the live re-run (T4). |
| 3 | Cold creates paid the same copying tax on top of Docker's ~300ms container start. | Same ~20–35ms saved; relatively small there (~5–10%) because Docker dominates the cold path. |
| 4 | Adding servers made creates *slower* (more copies to wait for, higher chance one is slow). | Create speed no longer degrades with cluster size for normal sandboxes. |
| 5 | A worker with no reachable control-plane server failed the create early, even when the note never needed copying. | Inline-eligible creates skip that failure mode entirely (they fail later, at the normal forwarding step, only if the cluster is actually unreachable). |
| 6 | No visibility into which delivery path creates were using. | New counter `aerolvm_cluster_recovery_externalize_total{inline,blob}` — if the slow path ever grows, operators see it before users feel it. |

**What's left:** one live benchmark re-run (T4) on real AWS to confirm the numbers, now also verifying the firewall backend (`AEROL_BENCH_EXPECT_NETRULES=netlink`) and running the new UC-98 traffic-drop probe from PR #306's follow-up fixes.

---

## Summary (technical)

- Implements `plans/warm-create-latency-tier2-recovery-replication.md` (Tier 2): the follow-up that unlocks the Tier 1 ≤30ms warm-p50 gate, which PR #306's live bench showed failing at 40–44ms because `cluster_promote` spends 23–25ms in synchronous recovery-blob replication — **identical on BoltDB and raft-wal**, so it was never the fsync.
- `externalizeCommandRecovery` gains an eligibility gate (`inlineRecoveryEligible`): payloads with **no legacy sealed bytes** whose encoded record is **≤ 4KiB** (`inlineRecoveryMaxBytes`) stay **inline in the Raft command** — the original wire shape — skipping the blob store write (fsync) and the synchronous HTTP PUT to every alive control-plane member. This fan-out ran **twice per create** (`opReserve` on the router, `opPlace` on the owner).
- The blob mesh is untouched for the residual path: legacy sealed secrets (must stay OUT of the immutable Raft log — blob files are deletable on destroy; the log/snapshots are not erasable per-sandbox) and oversized specs.
- New per-node metric `aerolvm_cluster_recovery_externalize_total{inline,blob}` so an unexpected blob-path share is visible before it shows up as promote latency.
- Expected (plan §3): `cluster_promote` p50 23–25ms → ~4–8ms; warm `create;dur` p50 40–44ms → ~22–27ms (**gate ≤30ms PASS**); the router's `ReserveOnTarget` sheds the same replication cost again on the api side. Bench re-run (plan T4) is the acceptance gate and is still pending (operator-run, real AWS).
- Base branch updated 2026-07-12 with PR #306's second-audit fixes (2c0b7f7: retract metric fidelity, netrules backend bench gate, UC-98 drop probe) — merged in so the stack stays consistent; this PR's own diff is still Tier-2-only.

**Stacked on `perf/warm-create-latency-tier1` (PR #306)** — review only the top commits.

## Code-path diagram

```mermaid
flowchart TD
  rp["RecordPlacement / ReserveOnTarget"] --> ext{"externalizeCommandRecovery<br/>inlineRecoveryEligible?"}
  ext -->|"no sealed bytes AND ≤4KiB (the warm-path case)"| inline["command keeps Spec + SecretRef inline<br/>(original wire shape) — no blob, no fan-out"]
  ext -->|"legacy sealed bytes OR oversized"| blob["newRecoveryBlob → local store (fsync)<br/>→ sync HTTP PUT to EVERY alive CP member<br/>(unchanged today-path)"]
  inline --> raft["raft apply (leader forward + commit)"]
  blob --> raft
  raft --> hydrate{"FSM hydrateCommandRecovery"}
  hydrate -->|"RecoveryRef == '' (inline)"| noop["no-op — pre-recovery-store code path"]
  hydrate -->|"ref"| resolve["local store Get → fetch-on-miss resolver"]
  noop --> store["storePlacementLocked: split payload →<br/>LOCAL recoveryStore.Put on each voter<br/>same content-addressed ref either way"]
  resolve --> store
  store --> row["identical FSM row (determinism parity test)"]
```

## Sandbox boot impact

**Net removal of synchronous boot-path work; nothing added.** On the cluster reserved-path create, the two `externalizeCommandRecovery` calls (reserve on the router, promote on the owner) drop: one local blob-file write+fsync and one concurrent HTTP PUT to every alive control-plane member (wall clock = slowest peer) **each**. What remains on the inline path is one ≤4KiB JSON encode + SHA-256 (~µs) for the eligibility check. First-call case: same win (the gate is stateless). Fires on every cluster create whose payload is secret-free and ≤4KiB — the normal modern create (redacted spec ~0.5–1KiB + secret *handle*); legacy-sealed and oversized creates are byte-for-byte unchanged. At apply time each voter now does the `recoveryStore.Put` it already did on the blob path (content-addressed, idempotent) — moved from pre-apply HTTP push to local write during apply. Single-node / `EnableCluster=false`: untouched (`Noop`).

## Idempotency

- The gate is a pure function of the command payload — retries and concurrent duplicates make the same inline/blob decision deterministically.
- Inline apply is as idempotent as today's: `storePlacementLocked` → `recoveryStore.Put` is content-addressed (same payload → same ref, overwrite-safe), and `opPlace`/`opReserve` semantics are unchanged (re-place no-op rule, spec/ports/hostname preservation rules all apply identically — pinned by the parity test).
- A leader-forwarded inline command is re-gated on the leader (`ApplyEncoded` → hydrate no-op → externalize): deterministic, so it stays inline; a forwarded ref command stays on the ref path.

## Failure-path consistency

- **Inline create, owner dies after commit:** spec + secret handle are quorum-committed in the Raft log and split into every voter's local recovery store at apply. **Strictly better than today**, where a blob PUT racing the death can leave survivors without the blob (fetch-on-miss can 404 if no survivor holds it).
- **Voter restart / log replay:** inline entries are self-contained; replay does not depend on blob files existing (regression test: mixed inline+ref log replay converges).
- **Blob-path failures:** unchanged — first PUT error still fails the create before the Raft apply, same rollback story as today (Tier 1.5 retract paths in PR #306 are unaffected).
- **Destroy-time erasure:** unchanged — inline payloads contain no secret material by construction (`SealedSecrets` never inlines; `SecretRef` is a provider handle), and the locally-split blob files are deleted by the same destroy/GC paths as today.

## Cluster-correctness (pr-review §7)

- **Mixed-version rollout is symmetric, no ordering requirement** (plan §4): inline is the original wire shape. Old voter applying a new node's inline command = the pre-recovery-store code path (hydrate no-ops on `RecoveryRef==""`; name index derives from the inline spec via `commandName`→`specName`). Old leader receiving a forwarded inline command re-externalizes it — cluster behaves as today until the leader upgrades. New voter applying an old node's ref command = unchanged ref path. Rollback-safe in both directions.
- **FSM determinism:** the same create carried inline vs as a ref materializes an **identical row including the content-addressed `RecoveryRef`** (each voter's `storePlacementLocked` computes the same sha256 ref locally). Pinned by `TestFSMInlineAndRefPlaceProduceIdenticalState`.
- **Split brain / leader change:** no new FSM ops, no change to placement selection, forwarding, or pending-reservation accounting; the Tier 1.5 "row stays Reserved until local create succeeds" invariant is untouched.
- **Replay safety:** interleaved inline+ref logs replay deterministically (regression test); snapshot shape unchanged (rows carry refs either way; `RetainSnapshotRefs` GC unchanged).
- **Single-node regression:** cluster-off is a no-op path (`Noop`); the memory-FSM (no recovery store) case keeps the pre-existing in-memory `f.recovery` behavior for inline payloads.
- **Threshold edge:** a spec crossing 4KiB between reserve and place yields one inline + one ref command — both valid per-command; convergence pinned by `TestFSMThresholdCrossingReserveAndPlaceConverge`.
- **Worker (Agent) behavior change:** an inline-eligible command no longer fails at externalize when no control-plane member is reachable — it fails at the leader forward instead (same user-visible outcome, one fewer failure mode; `TestAgentApplyCommandExternalizeFailure` updated to pin the blob path's original error).

## L4 / host-port-pool changes

N/A — neither touched.

## Test plan

- [x] `go test ./cmd/... ./internal/... ./pkg/...` (full offline suite) — green (re-verified after the 2026-07-12 base merge, including the full `internal/cluster` suite)
- [x] `recovery_inline_test.go` — eligibility gate matrix (small secret-free → inline with put-forbidden hook; sealed → blob; oversized → blob; `opReserveBatch` mixed eligibility gates per-reservation)
- [x] `fsm_recovery_inline_test.go` — determinism parity (inline vs old-emitter ref command → `reflect.DeepEqual` rows incl. same `RecoveryRef`, local blob present after inline apply), name-uniqueness enforced from an inline spec, mixed inline+ref log replay convergence, reserve/place threshold-crossing both directions
- [x] Contract updates: `TestExternalizeCommandRecovery`, `TestAgentApplyCommandExternalizeFailure`, `TestAgentLookupDerivedReadsAndMutationWrappers` re-pointed at blob-forced payloads (sealed/oversized) with comments referencing the new inline contract
- [x] `internal/cluster` coverage at the ~85% bar (see coverage note in PR)
- [ ] **Bench gate re-run (plan T4, operator-run, real AWS):** `make integration-benchmark-docker-only` + `-sparse` (netlink, all-WAL, `AEROL_BENCH_EXPECT_NETRULES=netlink`) — acceptance is `create;dur` p50 ≤ 30ms with `cluster_promote` p50 ≤ 8ms and `aerolvm_cluster_recovery_externalize_total{mode="inline"}` covering the bench creates; UC-98 (egress drop probe) rides the same suite pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
