### PR TITLE
fix(containerd): real netns creation + CNI plugin install (live-validated)

### DIFF
--- a/Terraform/templates/bootstrap.sh.tftpl
+++ b/Terraform/templates/bootstrap.sh.tftpl
@@ -635,8 +635,8 @@ SB_DOCKER_NETNS_POOL_PAUSE_IMAGE=${docker_netns_pool_cfg.pause_image}
 SB_DOCKER_NETNS_POOL_REFILL_INTERVAL=${docker_netns_pool_cfg.refill_interval}
 
 # Managed by Terraform bootstrap: container engine (plans/containerd-engine.md).
-# Default docker. containerd requires CNI plugins under cni_plugin_dir
-# (install via Ansible configure-ops or install.sh --with-containerd-engine).
+# Default docker. containerd requires CNI plugin binaries under cni_plugin_dir
+# (installed below when the engine is containerd).
 SB_CONTAINER_ENGINE=${container_engine}
 SB_CONTAINERD_SOCKET=${containerd_cfg.socket}
 SB_CONTAINERD_NAMESPACE=${containerd_cfg.namespace}
@@ -645,6 +645,35 @@ SB_CONTAINERD_NATIVE_NETNS_POOL_ENABLED=${containerd_cfg.native_netns_pool_enabl
 EOF
 
 sudo tee -a /etc/sandboxd/cluster.env < /tmp/aerolvm-ops.env >/dev/null
+
+# containerd engine needs the CNI bridge+host-local+loopback plugin binaries
+# under cni_plugin_dir, or the native netns pool's CNI ADD fails hard on every
+# create ("stat /opt/cni/bin/bridge: no such file or directory"). Nothing else
+# on the Terraform-provisioned path installs them (install.sh's
+# --with-containerd-engine covers the manual path). Gated on the engine so
+# docker-default nodes skip it entirely. Idempotent: skipped if bridge exists.
+if [ "${container_engine}" = "containerd" ]; then
+  cni_dir="${containerd_cfg.cni_plugin_dir}"
+  if [ ! -x "$${cni_dir}/bridge" ]; then
+    case "$$(uname -m)" in
+      x86_64|amd64) cni_arch=amd64 ;;
+      aarch64|arm64) cni_arch=arm64 ;;
+      *) echo "[bootstrap] unsupported arch $$(uname -m) for CNI plugins" >&2; exit 1 ;;
+    esac
+    cni_ver=v1.5.1
+    cni_url="https://github.com/containernetworking/plugins/releases/download/$${cni_ver}/cni-plugins-linux-$${cni_arch}-$${cni_ver}.tgz"
+    echo "[bootstrap] installing CNI plugins $${cni_ver} ($${cni_arch}) to $${cni_dir}"
+    sudo mkdir -p "$${cni_dir}"
+    curl -fsSL "$${cni_url}" | sudo tar -xz -C "$${cni_dir}"
+    for p in bridge host-local loopback; do
+      if [ ! -x "$${cni_dir}/$${p}" ]; then
+        echo "[bootstrap] expected $${cni_dir}/$${p} after CNI extract" >&2
+        exit 1
+      fi
+    done
+  fi
+fi
+
 sudo systemctl restart sandboxd
 
 ${extra_user_data}

--- a/internal/network/cni/cni.go
+++ b/internal/network/cni/cni.go
@@ -126,7 +126,14 @@ func (r *ExecRunner) runPlugin(ctx context.Context, cmd, netnsPath, containerID 
 	invoke.Stdout = &stdout
 	invoke.Stderr = &stderr
 	if err := invoke.Run(); err != nil {
-		return nil, fmt.Errorf("cni %s %s: %w: %s", cmd, containerID, err, strings.TrimSpace(stderr.String()))
+		// CNI plugins report failures as a JSON error object on STDOUT (and
+		// commonly write nothing to stderr), so fall back to stdout or the real
+		// cause is lost as a bare "exit status 1".
+		detail := strings.TrimSpace(stderr.String())
+		if detail == "" {
+			detail = strings.TrimSpace(stdout.String())
+		}
+		return nil, fmt.Errorf("cni %s %s: %w: %s", cmd, containerID, err, detail)
 	}
 	return stdout.Bytes(), nil
 }

--- a/internal/network/netns/host.go
+++ b/internal/network/netns/host.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -25,10 +26,13 @@ type HostManager interface {
 type Host struct {
 	Runner    cni.Runner
 	NetnsRoot string
-	// mkdir is a test seam; production leaves nil (os.MkdirAll).
+	// mkdir is a test seam for the netns root dir; production leaves nil.
 	mkdir func(path string, perm os.FileMode) error
-	// unlink removes a netns path; production uses os.Remove.
-	unlink func(path string) error
+	// addNetns/delNetns create and remove a REAL named network namespace.
+	// Production leaves them nil and execs `ip netns add/del`; tests stub them
+	// so unit tests need neither `ip` nor CAP_NET_ADMIN.
+	addNetns func(ctx context.Context, name string) error
+	delNetns func(ctx context.Context, name string) error
 }
 
 func (h *Host) Realize(ctx context.Context, slot Slot) (string, string, error) {
@@ -39,39 +43,75 @@ func (h *Host) Realize(ctx context.Context, slot Slot) (string, string, error) {
 		return "", "", errors.New("netns host: sandbox_id is required")
 	}
 	root := h.netnsRoot()
-	path := filepath.Join(root, slot.SandboxID)
 	if err := h.ensureDir(root); err != nil {
 		return "", "", err
 	}
-	// Touch path — production linux uses `ip netns add`; tests stub via mkdir.
-	if err := h.ensureDir(path); err != nil {
-		return "", "", fmt.Errorf("netns host: create %s: %w", path, err)
+	// Create a REAL network namespace, not just a directory: the CNI plugin and
+	// the containerd shim both open this path as a netns. `ip netns add` bind-
+	// mounts a fresh netns at /run/netns/<name>; a plain mkdir'd directory makes
+	// CNI ADD fail with a bare "exit status 1" (the plugin cannot enter a dir).
+	if err := h.createNetns(ctx, slot.SandboxID); err != nil {
+		return "", "", fmt.Errorf("netns host: create netns %s: %w", slot.SandboxID, err)
 	}
+	path := filepath.Join(root, slot.SandboxID)
 	res, err := h.Runner.Add(ctx, path, slot.SandboxID)
 	if err != nil {
-		_ = h.removePath(path)
+		_ = h.deleteNetns(ctx, slot.SandboxID)
 		return "", "", fmt.Errorf("netns host: cni add: %w", err)
 	}
 	return path, res.IP4, nil
+}
+
+// createNetns creates a persistent named netns (bind-mounted at
+// /run/netns/<name>). Idempotent: an already-present netns is not an error.
+func (h *Host) createNetns(ctx context.Context, name string) error {
+	if h.addNetns != nil {
+		return h.addNetns(ctx, name)
+	}
+	out, err := exec.CommandContext(ctx, "ip", "netns", "add", name).CombinedOutput()
+	if err != nil && !strings.Contains(strings.ToLower(string(out)), "file exists") {
+		return fmt.Errorf("ip netns add: %v: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// deleteNetns removes a named netns. Idempotent: a missing netns is not an error.
+func (h *Host) deleteNetns(ctx context.Context, name string) error {
+	if h.delNetns != nil {
+		return h.delNetns(ctx, name)
+	}
+	out, err := exec.CommandContext(ctx, "ip", "netns", "del", name).CombinedOutput()
+	if err != nil {
+		low := strings.ToLower(string(out))
+		if strings.Contains(low, "no such file") || strings.Contains(low, "cannot remove") {
+			return nil
+		}
+		return fmt.Errorf("ip netns del: %v: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
 }
 
 func (h *Host) Remove(ctx context.Context, slot Slot) error {
 	if h == nil || h.Runner == nil {
 		return nil
 	}
+	name := strings.TrimSpace(slot.SandboxID)
 	path := strings.TrimSpace(slot.NetnsPath)
-	if path == "" && strings.TrimSpace(slot.SandboxID) != "" {
-		path = filepath.Join(h.netnsRoot(), slot.SandboxID)
+	if name == "" && path != "" {
+		name = filepath.Base(path)
+	}
+	if name == "" {
+		return nil
 	}
 	if path == "" {
-		return nil
+		path = filepath.Join(h.netnsRoot(), name)
 	}
 	// Surface the CNI DEL error rather than swallowing it: a dropped DEL leaks
 	// the veth pair and the host-local IPAM lease with no process death to free
-	// them. Conntrack flush and netns unlink are still attempted regardless.
-	delErr := h.Runner.Del(ctx, path, slot.SandboxID)
+	// them. Conntrack flush and netns teardown are still attempted regardless.
+	delErr := h.Runner.Del(ctx, path, name)
 	_ = hostnet.FlushConntrackForIP(slot.ContainerIP)
-	rmErr := h.removePath(path)
+	rmErr := h.deleteNetns(ctx, name)
 	return errors.Join(delErr, rmErr)
 }
 
@@ -87,17 +127,6 @@ func (h *Host) ensureDir(path string) error {
 		return h.mkdir(path, 0o755)
 	}
 	return os.MkdirAll(path, 0o755)
-}
-
-func (h *Host) removePath(path string) error {
-	if h.unlink != nil {
-		return h.unlink(path)
-	}
-	err := os.Remove(path)
-	if os.IsNotExist(err) {
-		return nil
-	}
-	return err
 }
 
 // Builder sequences reserve → realize → adopt with LIFO teardown on failure.

--- a/internal/network/netns/host_extra_test.go
+++ b/internal/network/netns/host_extra_test.go
@@ -12,7 +12,12 @@ import (
 func TestHostRealizeRunnerErrorCleansUp(t *testing.T) {
 	runner := cni.NewFakeRunner()
 	runner.SetAddError(errors.New("cni add boom"))
-	h := &Host{Runner: runner, NetnsRoot: t.TempDir()}
+	h := &Host{
+		Runner:    runner,
+		NetnsRoot: t.TempDir(),
+		addNetns:  func(context.Context, string) error { return nil },
+		delNetns:  func(context.Context, string) error { return nil },
+	}
 	if _, _, err := h.Realize(context.Background(), Slot{SandboxID: "sb-x"}); err == nil {
 		t.Fatal("want realize error when CNI ADD fails")
 	}
@@ -21,10 +26,39 @@ func TestHostRealizeRunnerErrorCleansUp(t *testing.T) {
 func TestHostRemoveSurfacesDelError(t *testing.T) {
 	runner := cni.NewFakeRunner()
 	runner.SetDelError(errors.New("cni del boom"))
-	h := &Host{Runner: runner, NetnsRoot: t.TempDir(), unlink: func(string) error { return nil }}
+	h := &Host{
+		Runner:   runner,
+		delNetns: func(context.Context, string) error { return nil },
+	}
 	// Del error must surface (errors.Join), not be swallowed.
 	if err := h.Remove(context.Background(), Slot{SandboxID: "sb-x", NetnsPath: "/run/netns/sb-x", ContainerIP: "10.88.0.5"}); err == nil {
 		t.Fatal("want surfaced CNI DEL error")
+	}
+}
+
+func TestHostRealizeCreatesRealNetns(t *testing.T) {
+	// Realize must create a real netns (addNetns), not just mkdir a directory —
+	// the live regression that made CNI ADD fail with a bare "exit status 1".
+	var created, deleted string
+	runner := cni.NewFakeRunner()
+	h := &Host{
+		Runner:    runner,
+		NetnsRoot: t.TempDir(),
+		addNetns:  func(_ context.Context, name string) error { created = name; return nil },
+		delNetns:  func(_ context.Context, name string) error { deleted = name; return nil },
+	}
+	path, ip, err := h.Realize(context.Background(), Slot{SandboxID: "sb-real"})
+	if err != nil {
+		t.Fatalf("Realize: %v", err)
+	}
+	if created != "sb-real" {
+		t.Fatalf("expected a real netns to be created for sb-real, got %q", created)
+	}
+	if path == "" || ip == "" {
+		t.Fatalf("Realize returned path=%q ip=%q", path, ip)
+	}
+	if deleted != "" {
+		t.Fatalf("netns should not be deleted on success, deleted=%q", deleted)
 	}
 }
 

--- a/internal/network/netns/pool_test.go
+++ b/internal/network/netns/pool_test.go
@@ -127,6 +127,10 @@ func TestHostRealizeRemoveWithCNI(t *testing.T) {
 	h := &Host{
 		Runner:    runner,
 		NetnsRoot: t.TempDir(),
+		// Stub real netns create/delete so the unit test needs neither `ip` nor
+		// CAP_NET_ADMIN.
+		addNetns: func(context.Context, string) error { return nil },
+		delNetns: func(context.Context, string) error { return nil },
 	}
 	ctx := context.Background()
 	slot := Slot{SandboxID: "sb-h"}

--- a/internal/network/netns/refill_test.go
+++ b/internal/network/netns/refill_test.go
@@ -208,7 +208,12 @@ func TestTargetDepth(t *testing.T) {
 		t.Fatalf("need=%d err=%v", need, err)
 	}
 	runner := cni.NewFakeRunner()
-	_ = p.Prewarm(context.Background(), &Host{Runner: runner, NetnsRoot: t.TempDir()}, time.Now())
+	_ = p.Prewarm(context.Background(), &Host{
+		Runner:    runner,
+		NetnsRoot: t.TempDir(),
+		addNetns:  func(context.Context, string) error { return nil },
+		delNetns:  func(context.Context, string) error { return nil },
+	}, time.Now())
 	need, _ = p.TargetDepth(context.Background(), 2)
 	if need != 1 {
 		t.Fatalf("need=%d want 1", need)


### PR DESCRIPTION
Live single-node-containerd integration (real AWS t3.medium) surfaced three defects that the offline fakes structurally could not. All behind `SB_CONTAINER_ENGINE=containerd`; docker default path untouched.

## Bugs fixed
1. **netns `Host.Realize` created a plain directory, not a real netns.** `os.MkdirAll(/run/netns/<id>)` makes a directory; the CNI bridge plugin cannot enter a directory, so every create failed with a bare `exit status 1`. Now creates/deletes a real named netns via `ip netns add/del` (test seams keep unit tests off `ip`/CAP_NET_ADMIN). Masked offline because the real `Host` was only tested with the mkdir seam + a fake runner.
2. **`cni.ExecRunner` swallowed the real error.** CNI plugins report failures as JSON on **stdout**; `runPlugin` only surfaced stderr → empty `exit status 1:`. Now falls back to stdout.
3. **Terraform bootstrap never installed the CNI plugin binaries.** `/opt/cni/bin/bridge` was absent on provisioned containerd nodes (the comment deferred to Ansible/install.sh, but the integration path uses neither). `bootstrap.sh.tftpl` now installs bridge/host-local/loopback (v1.5.1) when the engine is containerd — gated + idempotent.

## Live-validated on the node (before this fix)
The Category-2 boot code all produced correct host state: conflist with **uplink MTU 9001** (not the hardcoded 1500), `br_netfilter` loaded, and the `AEROLVM-USER` chain + `FORWARD` jump created. A real netns + the bridge plugin allocate an IP (10.88.0.2). This PR closes the last gap so the driver itself creates that netns.

Follow-up: cut a release so `install.sh` (`--version latest`) pulls the fixed `sandboxd`, then re-run the single-node-containerd suite + UC-94 bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)