### PR TITLE
Fix/containerd phase2 4 review

### DIFF
--- a/Terraform/templates/bootstrap.sh.tftpl
+++ b/Terraform/templates/bootstrap.sh.tftpl
@@ -635,8 +635,8 @@ SB_DOCKER_NETNS_POOL_PAUSE_IMAGE=${docker_netns_pool_cfg.pause_image}
 SB_DOCKER_NETNS_POOL_REFILL_INTERVAL=${docker_netns_pool_cfg.refill_interval}
 
 # Managed by Terraform bootstrap: container engine (plans/containerd-engine.md).
-# Default docker. containerd requires CNI plugins under cni_plugin_dir
-# (install via Ansible configure-ops or install.sh --with-containerd-engine).
+# Default docker. containerd requires CNI plugin binaries under cni_plugin_dir
+# (installed below when the engine is containerd).
 SB_CONTAINER_ENGINE=${container_engine}
 SB_CONTAINERD_SOCKET=${containerd_cfg.socket}
 SB_CONTAINERD_NAMESPACE=${containerd_cfg.namespace}
@@ -645,6 +645,35 @@ SB_CONTAINERD_NATIVE_NETNS_POOL_ENABLED=${containerd_cfg.native_netns_pool_enabl
 EOF
 
 sudo tee -a /etc/sandboxd/cluster.env < /tmp/aerolvm-ops.env >/dev/null
+
+# containerd engine needs the CNI bridge+host-local+loopback plugin binaries
+# under cni_plugin_dir, or the native netns pool's CNI ADD fails hard on every
+# create ("stat /opt/cni/bin/bridge: no such file or directory"). Nothing else
+# on the Terraform-provisioned path installs them (install.sh's
+# --with-containerd-engine covers the manual path). Gated on the engine so
+# docker-default nodes skip it entirely. Idempotent: skipped if bridge exists.
+if [ "${container_engine}" = "containerd" ]; then
+  cni_dir="${containerd_cfg.cni_plugin_dir}"
+  if [ ! -x "$${cni_dir}/bridge" ]; then
+    case "$$(uname -m)" in
+      x86_64|amd64) cni_arch=amd64 ;;
+      aarch64|arm64) cni_arch=arm64 ;;
+      *) echo "[bootstrap] unsupported arch $$(uname -m) for CNI plugins" >&2; exit 1 ;;
+    esac
+    cni_ver=v1.5.1
+    cni_url="https://github.com/containernetworking/plugins/releases/download/$${cni_ver}/cni-plugins-linux-$${cni_arch}-$${cni_ver}.tgz"
+    echo "[bootstrap] installing CNI plugins $${cni_ver} ($${cni_arch}) to $${cni_dir}"
+    sudo mkdir -p "$${cni_dir}"
+    curl -fsSL "$${cni_url}" | sudo tar -xz -C "$${cni_dir}"
+    for p in bridge host-local loopback; do
+      if [ ! -x "$${cni_dir}/$${p}" ]; then
+        echo "[bootstrap] expected $${cni_dir}/$${p} after CNI extract" >&2
+        exit 1
+      fi
+    done
+  fi
+fi
+
 sudo systemctl restart sandboxd
 
 ${extra_user_data}

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 require (
 	github.com/containerd/containerd v1.7.29
 	github.com/containerd/containerd/api v1.8.0
+	github.com/containerd/platforms v0.2.1
 	github.com/containerd/typeurl/v2 v2.1.1
 	github.com/google/nftables v0.3.0
 	github.com/hashicorp/raft-wal v0.4.2
@@ -47,7 +48,6 @@ require (
 	github.com/containerd/errdefs v0.3.0 // indirect
 	github.com/containerd/fifo v1.1.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
-	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/containerd/ttrpc v1.2.7 // indirect
 	github.com/coreos/etcd v3.3.27+incompatible // indirect
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect

--- a/internal/network/cni/cni.go
+++ b/internal/network/cni/cni.go
@@ -1,10 +1,14 @@
-// Package cni wraps the bridge+host-local CNI plugin pair for containerd
-// sandboxes. ADD/DEL are idempotent at the call-site: Del on a missing
-// allocation is a no-op; Add on an already-configured netns returns the
-// existing result when the fake/production runner detects prior state.
+// Package cni wraps the bridge+host-local CNI plugin for containerd sandboxes.
+// Our topology is a single bridge plugin with host-local IPAM embedded in its
+// config, so ADD/DEL invoke that one plugin over the standard CNI exec protocol
+// (CNI_* env vars + the plugin netconf on stdin) rather than chaining a plugin
+// list. DEL is idempotent by the CNI contract (DEL on a missing allocation is a
+// no-op); ADD is NOT idempotent at this layer — callers must not re-ADD the
+// same container into the same netns or host-local allocates a second IP.
 package cni
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -26,15 +30,18 @@ type Runner interface {
 	Del(ctx context.Context, netnsPath, containerID string) error
 }
 
-// Config locates plugin binaries and the bridge conflist on disk.
+// Config locates plugin binaries and the bridge conf on disk.
 type Config struct {
 	// PluginDir is typically /opt/cni/bin.
 	PluginDir string
-	// ConfPath is a .conflist or .conf consumed by the plugins.
+	// ConfPath is a .conflist or .conf consumed by the plugin.
 	ConfPath string
+	// IfName is the interface created inside the netns; defaults to eth0.
+	IfName string
 }
 
-// ExecRunner shells out to the CNI plugin binaries referenced by ConfPath.
+// ExecRunner shells out to the CNI plugin binary referenced by ConfPath's
+// `type`, speaking the CNI exec protocol.
 type ExecRunner struct {
 	cfg Config
 }
@@ -45,6 +52,9 @@ func NewExecRunner(cfg Config) (*ExecRunner, error) {
 	}
 	if strings.TrimSpace(cfg.ConfPath) == "" {
 		return nil, errors.New("cni conf path is required")
+	}
+	if strings.TrimSpace(cfg.IfName) == "" {
+		cfg.IfName = "eth0"
 	}
 	return &ExecRunner{cfg: cfg}, nil
 }
@@ -72,7 +82,7 @@ func (r *ExecRunner) Add(ctx context.Context, netnsPath, containerID string) (Re
 	}
 	for _, ip := range parsed.IPs {
 		if strings.Contains(ip.Address, ".") {
-			addr := strings.Split(ip.Address, "/")[0]
+			addr, _, _ := strings.Cut(ip.Address, "/")
 			return Result{IP4: addr}, nil
 		}
 	}
@@ -89,45 +99,103 @@ func (r *ExecRunner) Del(ctx context.Context, netnsPath, containerID string) err
 	return err
 }
 
+// runPlugin invokes the CNI plugin over the exec protocol: the operation and
+// container identity go in CNI_* environment variables and the network config
+// is piped on stdin (NOT positional argv, which real plugins ignore).
 func (r *ExecRunner) runPlugin(ctx context.Context, cmd, netnsPath, containerID string) ([]byte, error) {
-	plugin, conf, err := r.resolve(cmd)
+	plugin, netconf, err := r.resolve()
 	if err != nil {
 		return nil, err
 	}
-	cniArgs := fmt.Sprintf("K8S_POD_NAMESPACE=aerolvm;K8S_POD_NAME=%s;K8S_POD_INFRA_CONTAINER_ID=%s", containerID, containerID)
-	invoke := exec.CommandContext(ctx, plugin,
-		cmd,
-		conf,
-		netnsPath,
-		containerID,
-		"IGNORED",
-		"IGNORED",
-		cniArgs,
-	)
-	invoke.Env = append(os.Environ(), "CNI_PATH="+r.cfg.PluginDir)
-	out, err := invoke.CombinedOutput()
-	if err != nil {
-		return nil, fmt.Errorf("cni %s %s: %w: %s", cmd, containerID, err, strings.TrimSpace(string(out)))
+	ifName := strings.TrimSpace(r.cfg.IfName)
+	if ifName == "" {
+		ifName = "eth0"
 	}
-	return out, nil
+	cniArgs := fmt.Sprintf("K8S_POD_NAMESPACE=aerolvm;K8S_POD_NAME=%s;K8S_POD_INFRA_CONTAINER_ID=%s", containerID, containerID)
+	invoke := exec.CommandContext(ctx, plugin)
+	invoke.Stdin = bytes.NewReader(netconf)
+	invoke.Env = append(os.Environ(),
+		"CNI_COMMAND="+cmd,
+		"CNI_CONTAINERID="+containerID,
+		"CNI_NETNS="+netnsPath,
+		"CNI_IFNAME="+ifName,
+		"CNI_PATH="+r.cfg.PluginDir,
+		"CNI_ARGS="+cniArgs,
+	)
+	var stdout, stderr bytes.Buffer
+	invoke.Stdout = &stdout
+	invoke.Stderr = &stderr
+	if err := invoke.Run(); err != nil {
+		return nil, fmt.Errorf("cni %s %s: %w: %s", cmd, containerID, err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.Bytes(), nil
 }
 
-func (r *ExecRunner) resolve(cmd string) (plugin string, conf string, err error) {
-	conf = r.cfg.ConfPath
-	base := filepath.Base(conf)
-	switch {
-	case strings.HasSuffix(base, ".conflist"), strings.HasSuffix(base, ".conf"):
-		// bridge plugin is the conventional first hop for our topology.
-		plugin = filepath.Join(r.cfg.PluginDir, "bridge")
-	default:
-		return "", "", fmt.Errorf("unsupported cni conf %q", conf)
+// resolve reads the netconf, reduces a .conflist to its single bridge plugin
+// config (our topology embeds host-local IPAM inside the bridge plugin, so
+// there is exactly one plugin to invoke), and locates that plugin's binary by
+// its declared `type`.
+func (r *ExecRunner) resolve() (plugin string, netconf []byte, err error) {
+	raw, err := os.ReadFile(r.cfg.ConfPath)
+	if err != nil {
+		return "", nil, fmt.Errorf("read cni conf %q: %w", r.cfg.ConfPath, err)
 	}
+	netconf, err = singlePluginNetconf(raw)
+	if err != nil {
+		return "", nil, err
+	}
+	pluginType, err := netconfType(netconf)
+	if err != nil {
+		return "", nil, err
+	}
+	plugin = filepath.Join(r.cfg.PluginDir, pluginType)
 	if _, err := os.Stat(plugin); err != nil {
-		return "", "", fmt.Errorf("cni plugin %q: %w", plugin, err)
+		return "", nil, fmt.Errorf("cni plugin %q: %w", plugin, err)
 	}
-	if _, err := os.Stat(conf); err != nil {
-		return "", "", fmt.Errorf("cni conf %q: %w", conf, err)
+	return plugin, netconf, nil
+}
+
+// singlePluginNetconf returns the netconf to pipe to the plugin. For a
+// .conflist it extracts plugins[0] and injects the list's cniVersion+name
+// (each plugin config must carry them); a bare .conf is used as-is.
+func singlePluginNetconf(raw []byte) ([]byte, error) {
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &top); err != nil {
+		return nil, fmt.Errorf("parse cni conf: %w", err)
 	}
-	_ = cmd
-	return plugin, conf, nil
+	plugins, ok := top["plugins"]
+	if !ok {
+		return raw, nil
+	}
+	var list []json.RawMessage
+	if err := json.Unmarshal(plugins, &list); err != nil {
+		return nil, fmt.Errorf("parse cni conflist plugins: %w", err)
+	}
+	if len(list) == 0 {
+		return nil, errors.New("cni conflist has no plugins")
+	}
+	var plugin map[string]json.RawMessage
+	if err := json.Unmarshal(list[0], &plugin); err != nil {
+		return nil, fmt.Errorf("parse cni plugin[0]: %w", err)
+	}
+	if v, ok := top["cniVersion"]; ok {
+		plugin["cniVersion"] = v
+	}
+	if n, ok := top["name"]; ok {
+		plugin["name"] = n
+	}
+	return json.Marshal(plugin)
+}
+
+func netconfType(conf []byte) (string, error) {
+	var m struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(conf, &m); err != nil {
+		return "", fmt.Errorf("parse cni plugin type: %w", err)
+	}
+	if strings.TrimSpace(m.Type) == "" {
+		return "", errors.New("cni plugin config has no type")
+	}
+	return m.Type, nil
 }

--- a/internal/network/cni/cni.go
+++ b/internal/network/cni/cni.go
@@ -126,7 +126,14 @@ func (r *ExecRunner) runPlugin(ctx context.Context, cmd, netnsPath, containerID 
 	invoke.Stdout = &stdout
 	invoke.Stderr = &stderr
 	if err := invoke.Run(); err != nil {
-		return nil, fmt.Errorf("cni %s %s: %w: %s", cmd, containerID, err, strings.TrimSpace(stderr.String()))
+		// CNI plugins report failures as a JSON error object on STDOUT (and
+		// commonly write nothing to stderr), so fall back to stdout or the real
+		// cause is lost as a bare "exit status 1".
+		detail := strings.TrimSpace(stderr.String())
+		if detail == "" {
+			detail = strings.TrimSpace(stdout.String())
+		}
+		return nil, fmt.Errorf("cni %s %s: %w: %s", cmd, containerID, err, detail)
 	}
 	return stdout.Bytes(), nil
 }

--- a/internal/network/cni/conflist.go
+++ b/internal/network/cni/conflist.go
@@ -1,0 +1,92 @@
+package cni
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ConflistOptions parameterizes the generated bridge+host-local conflist.
+type ConflistOptions struct {
+	Name    string // network name, e.g. "aerolvm"
+	Bridge  string // host bridge interface, e.g. "aerolvm0"
+	Subnet  string // host-local IPAM subnet, e.g. "10.88.0.0/16"
+	Gateway string // optional explicit gateway; host-local derives .1 if empty
+	MTU     int    // bridge/veth MTU; <=0 falls back to DefaultBridgeMTU
+}
+
+// EnsureBridgeConflist writes a bridge+host-local CNI conflist to path if it is
+// absent, so the containerd netns pool has a network to realize. This is the
+// §4 owner for items dockerd's libnetwork used to provide: the bridge, IPAM,
+// and outbound NAT (`ipMasq: true`). It never overwrites an operator-provided
+// conflist. Returns the effective path.
+//
+// NOTE: the generated JSON is validated offline (schema + round-trip), but the
+// plugins that consume it run only on a live host with /opt/cni/bin populated —
+// exercised by the containerd integration suite, not `make test`.
+func EnsureBridgeConflist(path string, opts ConflistOptions) error {
+	if path == "" {
+		return fmt.Errorf("cni conflist path is required")
+	}
+	if _, err := os.Stat(path); err == nil {
+		return nil // operator- or previously-generated; do not clobber
+	}
+	body, err := RenderBridgeConflist(opts)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create cni conf dir: %w", err)
+	}
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		return fmt.Errorf("write cni conflist %q: %w", path, err)
+	}
+	return nil
+}
+
+// RenderBridgeConflist produces the conflist JSON. Kept separate from the file
+// write so it is unit-testable without touching disk.
+func RenderBridgeConflist(opts ConflistOptions) ([]byte, error) {
+	if opts.Name == "" {
+		opts.Name = "aerolvm"
+	}
+	if opts.Bridge == "" {
+		opts.Bridge = "aerolvm0"
+	}
+	if opts.Subnet == "" {
+		opts.Subnet = "10.88.0.0/16"
+	}
+	mtu := opts.MTU
+	if mtu <= 0 {
+		mtu = DefaultBridgeMTU
+	}
+	ipam := map[string]any{
+		"type":   "host-local",
+		"subnet": opts.Subnet,
+		"routes": []map[string]string{{"dst": "0.0.0.0/0"}},
+	}
+	if opts.Gateway != "" {
+		ipam["gateway"] = opts.Gateway
+	}
+	conflist := map[string]any{
+		"cniVersion": "1.0.0",
+		"name":       opts.Name,
+		"plugins": []map[string]any{
+			{
+				"type":        "bridge",
+				"bridge":      opts.Bridge,
+				"isGateway":   true,
+				"ipMasq":      true, // outbound NAT — dockerd's POSTROUTING MASQUERADE
+				"hairpinMode": true,
+				"mtu":         mtu,
+				"ipam":        ipam,
+			},
+		},
+	}
+	body, err := json.MarshalIndent(conflist, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("render cni conflist: %w", err)
+	}
+	return append(body, '\n'), nil
+}

--- a/internal/network/cni/conflist_test.go
+++ b/internal/network/cni/conflist_test.go
@@ -1,0 +1,107 @@
+package cni
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRenderBridgeConflistDefaultsAndNAT(t *testing.T) {
+	body, err := RenderBridgeConflist(ConflistOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var top struct {
+		CNIVersion string `json:"cniVersion"`
+		Name       string `json:"name"`
+		Plugins    []struct {
+			Type   string `json:"type"`
+			Bridge string `json:"bridge"`
+			IPMasq bool   `json:"ipMasq"`
+			MTU    int    `json:"mtu"`
+			IPAM   struct {
+				Type   string `json:"type"`
+				Subnet string `json:"subnet"`
+			} `json:"ipam"`
+		} `json:"plugins"`
+	}
+	if err := json.Unmarshal(body, &top); err != nil {
+		t.Fatalf("rendered conflist is not valid JSON: %v", err)
+	}
+	if top.Name != "aerolvm" || len(top.Plugins) != 1 {
+		t.Fatalf("unexpected conflist: %s", body)
+	}
+	p := top.Plugins[0]
+	if p.Type != "bridge" || p.Bridge != "aerolvm0" {
+		t.Fatalf("bridge plugin defaults wrong: %+v", p)
+	}
+	if !p.IPMasq {
+		t.Fatal("ipMasq must be true (outbound NAT parity with dockerd)")
+	}
+	if p.MTU != DefaultBridgeMTU {
+		t.Fatalf("MTU = %d, want default %d", p.MTU, DefaultBridgeMTU)
+	}
+	if p.IPAM.Type != "host-local" || p.IPAM.Subnet == "" {
+		t.Fatalf("ipam wrong: %+v", p.IPAM)
+	}
+}
+
+func TestRenderBridgeConflistHonorsMTU(t *testing.T) {
+	body, err := RenderBridgeConflist(ConflistOptions{MTU: 9001, Subnet: "10.99.0.0/16", Bridge: "br9"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(body)
+	for _, want := range []string{`"mtu": 9001`, `"10.99.0.0/16"`, `"br9"`} {
+		if !contains(s, want) {
+			t.Fatalf("rendered conflist missing %q: %s", want, s)
+		}
+	}
+}
+
+func TestEnsureBridgeConflistWritesThenNoClobber(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "net.d", "aerolvm.conflist")
+	if err := EnsureBridgeConflist(path, ConflistOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	first, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("conflist not written: %v", err)
+	}
+	// Second call with different opts must NOT clobber an existing file.
+	if err := EnsureBridgeConflist(path, ConflistOptions{Bridge: "different0"}); err != nil {
+		t.Fatal(err)
+	}
+	second, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first) != string(second) {
+		t.Fatal("EnsureBridgeConflist clobbered an existing conflist")
+	}
+}
+
+func TestEnsureBridgeConflistRequiresPath(t *testing.T) {
+	if err := EnsureBridgeConflist("", ConflistOptions{}); err == nil {
+		t.Fatal("want error for empty path")
+	}
+}
+
+func TestUplinkMTUDoesNotPanic(t *testing.T) {
+	// On darwin it returns 0 (stub); on linux it reads /proc/net/route. Either
+	// way it must be non-negative and not panic.
+	if got := UplinkMTU(); got < 0 {
+		t.Fatalf("UplinkMTU = %d, want >= 0", got)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/network/cni/exec_runner_test.go
+++ b/internal/network/cni/exec_runner_test.go
@@ -1,0 +1,188 @@
+package cni
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// writeFakeCNIPlugin drops an executable plugin named pluginType into dir. The
+// script ENFORCES the CNI exec protocol — it fails unless CNI_COMMAND /
+// CNI_CONTAINERID / CNI_NETNS are set in the environment and a netconf arrives
+// on stdin — so a regression back to positional-argv invocation is caught. On
+// ADD it prints bodyADD; it exits exitCode.
+func writeFakeCNIPlugin(t *testing.T, dir, pluginType, bodyADD string, exitCode int) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake CNI plugin is a POSIX shell script")
+	}
+	script := "#!/bin/sh\n" +
+		"[ -n \"$CNI_COMMAND\" ] || { echo 'missing CNI_COMMAND' >&2; exit 3; }\n" +
+		"[ -n \"$CNI_CONTAINERID\" ] || { echo 'missing CNI_CONTAINERID' >&2; exit 3; }\n" +
+		"[ -n \"$CNI_NETNS\" ] || { echo 'missing CNI_NETNS' >&2; exit 3; }\n" +
+		"conf=$(cat)\n" +
+		"[ -n \"$conf\" ] || { echo 'empty stdin netconf' >&2; exit 3; }\n" +
+		"if [ \"$CNI_COMMAND\" = ADD ]; then printf '%s' '" + bodyADD + "'; fi\n" +
+		"exit " + itoa(exitCode) + "\n"
+	if err := os.WriteFile(filepath.Join(dir, pluginType), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake plugin: %v", err)
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	if neg {
+		b = append([]byte{'-'}, b...)
+	}
+	return string(b)
+}
+
+func writeConflist(t *testing.T, dir string) string {
+	t.Helper()
+	conf := filepath.Join(dir, "aerolvm.conflist")
+	body := `{"cniVersion":"1.0.0","name":"aerolvm","plugins":[{"type":"bridge","bridge":"aerolvm0","ipam":{"type":"host-local","subnet":"10.88.0.0/16"}}]}`
+	if err := os.WriteFile(conf, []byte(body), 0o644); err != nil {
+		t.Fatalf("write conflist: %v", err)
+	}
+	return conf
+}
+
+func newExecRunnerWithFake(t *testing.T, bodyADD string, exitCode int) *ExecRunner {
+	t.Helper()
+	dir := t.TempDir()
+	writeFakeCNIPlugin(t, dir, "bridge", bodyADD, exitCode)
+	conf := writeConflist(t, dir)
+	r, err := NewExecRunner(Config{PluginDir: dir, ConfPath: conf})
+	if err != nil {
+		t.Fatalf("NewExecRunner: %v", err)
+	}
+	return r
+}
+
+func TestExecRunnerAddSpeaksCNIProtocol(t *testing.T) {
+	// The fake plugin exits non-zero unless the CNI_* env + stdin netconf are
+	// present, so a successful parse proves protocol conformance.
+	r := newExecRunnerWithFake(t, `{"ips":[{"version":"6","address":"fd00::2/64"},{"version":"4","address":"10.88.0.7/24"}]}`, 0)
+	res, err := r.Add(context.Background(), "/run/netns/sb-1", "sb-1")
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if res.IP4 != "10.88.0.7" {
+		t.Fatalf("IP4 = %q, want 10.88.0.7 (CIDR stripped, ipv6 skipped)", res.IP4)
+	}
+}
+
+func TestExecRunnerDelSucceeds(t *testing.T) {
+	r := newExecRunnerWithFake(t, "", 0)
+	if err := r.Del(context.Background(), "/run/netns/sb-1", "sb-1"); err != nil {
+		t.Fatalf("Del: %v", err)
+	}
+}
+
+func TestExecRunnerAddPluginExitNonZero(t *testing.T) {
+	r := newExecRunnerWithFake(t, "", 1)
+	if _, err := r.Add(context.Background(), "/run/netns/sb-1", "sb-1"); err == nil {
+		t.Fatal("want error when plugin exits non-zero")
+	}
+}
+
+func TestExecRunnerAddBadJSON(t *testing.T) {
+	r := newExecRunnerWithFake(t, "not-json", 0)
+	if _, err := r.Add(context.Background(), "/run/netns/sb-1", "sb-1"); err == nil {
+		t.Fatal("want decode error on non-JSON plugin output")
+	}
+}
+
+func TestExecRunnerAddNoIPv4(t *testing.T) {
+	r := newExecRunnerWithFake(t, `{"ips":[{"version":"6","address":"fd00::2/64"}]}`, 0)
+	if _, err := r.Add(context.Background(), "/run/netns/sb-1", "sb-1"); err == nil {
+		t.Fatal("want error when result carries no ipv4")
+	}
+}
+
+func TestExecRunnerResolveMissingConfFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFakeCNIPlugin(t, dir, "bridge", "", 0)
+	r, err := NewExecRunner(Config{PluginDir: dir, ConfPath: filepath.Join(dir, "absent.conflist")})
+	if err != nil {
+		t.Fatalf("NewExecRunner: %v", err)
+	}
+	if _, err := r.Add(context.Background(), "/n", "c"); err == nil {
+		t.Fatal("want missing-conf error")
+	}
+}
+
+func TestExecRunnerResolveMissingPluginBinary(t *testing.T) {
+	dir := t.TempDir()
+	conf := writeConflist(t, dir) // references type "bridge" but no bridge binary
+	r, err := NewExecRunner(Config{PluginDir: dir, ConfPath: conf})
+	if err != nil {
+		t.Fatalf("NewExecRunner: %v", err)
+	}
+	if _, err := r.Add(context.Background(), "/n", "c"); err == nil {
+		t.Fatal("want missing-plugin-binary error")
+	}
+}
+
+func TestExecRunnerConfWithoutTypeRejected(t *testing.T) {
+	dir := t.TempDir()
+	writeFakeCNIPlugin(t, dir, "bridge", "", 0)
+	conf := filepath.Join(dir, "notype.conf")
+	if err := os.WriteFile(conf, []byte(`{"cniVersion":"1.0.0","name":"aerolvm"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r, err := NewExecRunner(Config{PluginDir: dir, ConfPath: conf})
+	if err != nil {
+		t.Fatalf("NewExecRunner: %v", err)
+	}
+	if _, err := r.Add(context.Background(), "/n", "c"); err == nil {
+		t.Fatal("want error for conf with no plugin type")
+	}
+}
+
+func TestSinglePluginNetconfExtractsFromConflist(t *testing.T) {
+	raw := []byte(`{"cniVersion":"1.0.0","name":"aerolvm","plugins":[{"type":"bridge","bridge":"aerolvm0"}]}`)
+	out, err := singlePluginNetconf(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatal(err)
+	}
+	if m["type"] != "bridge" || m["cniVersion"] != "1.0.0" || m["name"] != "aerolvm" {
+		t.Fatalf("plugin conf missing injected fields: %v", m)
+	}
+	if _, hasPlugins := m["plugins"]; hasPlugins {
+		t.Fatal("extracted plugin conf should not carry the conflist plugins array")
+	}
+}
+
+func TestSinglePluginNetconfEmptyPlugins(t *testing.T) {
+	if _, err := singlePluginNetconf([]byte(`{"cniVersion":"1.0.0","plugins":[]}`)); err == nil {
+		t.Fatal("want error for empty plugins array")
+	}
+}
+
+func TestSinglePluginNetconfBareConf(t *testing.T) {
+	raw := []byte(`{"cniVersion":"1.0.0","type":"bridge"}`)
+	out, err := singlePluginNetconf(raw)
+	if err != nil || !strings.Contains(string(out), `"bridge"`) {
+		t.Fatalf("bare conf should pass through: out=%s err=%v", out, err)
+	}
+}

--- a/internal/network/cni/mtu.go
+++ b/internal/network/cni/mtu.go
@@ -1,13 +1,32 @@
 package cni
 
+import "net"
+
 const (
-	// DefaultBridgeMTU is the bridge veth MTU for containerd CNI topology.
-	// Must match docker0 / the aerolvm.conflist bridge plugin mtu field.
+	// DefaultBridgeMTU is the fallback bridge veth MTU when the host uplink MTU
+	// cannot be determined. Docker-parity default.
 	DefaultBridgeMTU = 1500
 )
 
-// BridgeMTU returns the MTU wired into the CNI bridge conflist. Today this is
-// the docker-parity default; host-uplink-derived MTU can slot in here later.
+// BridgeMTU is the docker-parity default MTU. Callers that want uplink parity
+// use UplinkMTU() and fall back to this.
 func BridgeMTU() int {
 	return DefaultBridgeMTU
+}
+
+// UplinkMTU returns the MTU of the host's default-route interface, or 0 when it
+// cannot be determined (non-linux, or no default route). Sizing the bridge/veth
+// to the uplink avoids two failure modes the hardcoded 1500 caused: on a
+// jumbo-frame uplink (AWS ENA is 9001) a 1500 bridge caps throughput, and on a
+// sub-1500 uplink (overlay/VPN/GRE) a 1500 bridge blackholes egress via PMTUD.
+func UplinkMTU() int {
+	iface := defaultRouteInterface()
+	if iface == "" {
+		return 0
+	}
+	ni, err := net.InterfaceByName(iface)
+	if err != nil || ni.MTU <= 0 {
+		return 0
+	}
+	return ni.MTU
 }

--- a/internal/network/cni/mtu_linux.go
+++ b/internal/network/cni/mtu_linux.go
@@ -1,0 +1,32 @@
+//go:build linux
+
+package cni
+
+import (
+	"os"
+	"strings"
+)
+
+// defaultRouteInterface reads /proc/net/route for the interface that owns the
+// IPv4 default route (Destination column 00000000). This needs no
+// CAP_NET_ADMIN and no netlink socket, so it is safe to call at daemon boot.
+func defaultRouteInterface() string {
+	raw, err := os.ReadFile("/proc/net/route")
+	if err != nil {
+		return ""
+	}
+	lines := strings.Split(string(raw), "\n")
+	for i, line := range lines {
+		if i == 0 { // header: Iface Destination Gateway Flags ...
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		if fields[1] == "00000000" {
+			return fields[0]
+		}
+	}
+	return ""
+}

--- a/internal/network/cni/mtu_other.go
+++ b/internal/network/cni/mtu_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package cni
+
+// defaultRouteInterface is linux-only (reads /proc/net/route); elsewhere the
+// uplink MTU is undeterminable and callers fall back to DefaultBridgeMTU.
+func defaultRouteInterface() string { return "" }

--- a/internal/network/hostnet/sysctl_linux.go
+++ b/internal/network/hostnet/sysctl_linux.go
@@ -5,6 +5,7 @@ package hostnet
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 )
 
@@ -14,10 +15,40 @@ var sysctlPaths = []string{
 	"/proc/sys/net/bridge/bridge-nf-call-ip6tables",
 }
 
+// execModprobe is a test seam over `modprobe`.
+var execModprobe = func(module string) error {
+	return exec.Command("modprobe", module).Run()
+}
+
 func ensureForwardingSysctls() error {
+	// The bridge-nf-call-* sysctls only exist once br_netfilter is loaded.
+	// Without them the bridge sysctl writes silently no-op and sandbox↔sandbox
+	// bridge traffic bypasses iptables — neighbor isolation (a §8 exit gate)
+	// fails open. Load the module first, then write, then VERIFY the bridge
+	// hooks actually took: fail loud rather than ship sandboxes with no
+	// east-west isolation.
+	needBridge := false
+	for _, path := range sysctlPaths {
+		if strings.Contains(path, "bridge-nf-call") {
+			if _, err := os.Stat(path); os.IsNotExist(err) {
+				needBridge = true
+			}
+		}
+	}
+	if needBridge {
+		_ = execModprobe("br_netfilter")
+	}
 	for _, path := range sysctlPaths {
 		if err := writeSysctl(path, "1"); err != nil {
 			return err
+		}
+	}
+	for _, path := range sysctlPaths {
+		if !strings.Contains(path, "bridge-nf-call") {
+			continue
+		}
+		if _, err := os.Stat(path); err != nil {
+			return fmt.Errorf("bridge netfilter sysctl %s absent after modprobe br_netfilter; sandbox east-west isolation would fail open: %w", path, err)
 		}
 	}
 	return nil
@@ -47,5 +78,12 @@ func writeSysctl(path, value string) error {
 }
 
 func runConntrackDelete(ip string) error {
-	return execConntrack("-D", "-s", ip)
+	// Flush BOTH directions on IP release. -s catches flows the released IP
+	// originated; -d catches inbound/DNAT flows (caddy→containerIP:port) where
+	// it was the original destination. Without -d, a reused IP inherits stale
+	// ingress conntrack and its first inbound connection is misrouted/dropped
+	// ("blackhole", plan §4 item #8). Both are best-effort — conntrack -D exits
+	// non-zero when nothing matched, which the caller ignores.
+	_ = execConntrack("-D", "-s", ip)
+	return execConntrack("-D", "-d", ip)
 }

--- a/internal/network/hostnet/sysctl_linux_test.go
+++ b/internal/network/hostnet/sysctl_linux_test.go
@@ -39,10 +39,10 @@ func TestEnsureForwardingSysctlsWritesBrNetfilter(t *testing.T) {
 }
 
 func TestFlushConntrackForIPInvokesConntrack(t *testing.T) {
-	var got []string
+	var calls [][]string
 	orig := execConntrack
 	execConntrack = func(args ...string) error {
-		got = append([]string{}, args...)
+		calls = append(calls, append([]string{}, args...))
 		return nil
 	}
 	defer func() { execConntrack = orig }()
@@ -50,8 +50,69 @@ func TestFlushConntrackForIPInvokesConntrack(t *testing.T) {
 	if err := FlushConntrackForIP("10.88.0.5"); err != nil {
 		t.Fatal(err)
 	}
-	if len(got) != 3 || got[0] != "-D" || got[1] != "-s" || got[2] != "10.88.0.5" {
-		t.Fatalf("conntrack args = %#v", got)
+	// Must flush BOTH directions so a reused IP does not inherit stale ingress
+	// conntrack (the -d flush is the blackhole fix).
+	var sawSrc, sawDst bool
+	for _, c := range calls {
+		if len(c) == 3 && c[0] == "-D" && c[2] == "10.88.0.5" {
+			switch c[1] {
+			case "-s":
+				sawSrc = true
+			case "-d":
+				sawDst = true
+			}
+		}
+	}
+	if !sawSrc || !sawDst {
+		t.Fatalf("conntrack flush missing a direction (src=%v dst=%v): %#v", sawSrc, sawDst, calls)
+	}
+}
+
+func TestEnsureForwardingSysctlsModprobesWhenBridgeAbsent(t *testing.T) {
+	dir := t.TempDir()
+	ipf := filepath.Join(dir, "ip_forward")
+	bridge := filepath.Join(dir, "bridge-nf-call-iptables") // absent → triggers modprobe
+	if err := os.WriteFile(ipf, []byte("0"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	orig := sysctlPaths
+	sysctlPaths = []string{ipf, bridge}
+	defer func() { sysctlPaths = orig }()
+
+	loaded := ""
+	origMod := execModprobe
+	execModprobe = func(module string) error {
+		loaded = module
+		// Simulate br_netfilter loading, creating the bridge sysctl path.
+		return os.WriteFile(bridge, []byte("0"), 0o644)
+	}
+	defer func() { execModprobe = origMod }()
+
+	if err := EnsureForwardingSysctls(); err != nil {
+		t.Fatal(err)
+	}
+	if loaded != "br_netfilter" {
+		t.Fatalf("expected br_netfilter modprobe, got %q", loaded)
+	}
+}
+
+func TestEnsureForwardingSysctlsFailsLoudWhenBridgeStillAbsent(t *testing.T) {
+	dir := t.TempDir()
+	ipf := filepath.Join(dir, "ip_forward")
+	bridge := filepath.Join(dir, "bridge-nf-call-iptables") // never created
+	if err := os.WriteFile(ipf, []byte("0"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	orig := sysctlPaths
+	sysctlPaths = []string{ipf, bridge}
+	defer func() { sysctlPaths = orig }()
+
+	origMod := execModprobe
+	execModprobe = func(string) error { return nil } // modprobe "succeeds" but path stays absent
+	defer func() { execModprobe = origMod }()
+
+	if err := EnsureForwardingSysctls(); err == nil {
+		t.Fatal("want fail-loud error when br_netfilter never loaded")
 	}
 }
 

--- a/internal/network/netns/handoff.go
+++ b/internal/network/netns/handoff.go
@@ -29,9 +29,16 @@ func (h *RuntimeHandoff) Provision(ctx context.Context, sandboxID string) (netns
 		return "", "", nil
 	}
 	now := h.now()
+	// Treat a claim as a ready hit only when the slot is actually realized
+	// (non-empty netns path AND IP). ClaimPooled/Reserve short-circuit on any
+	// existing row for the sandbox regardless of state, so a crash-left
+	// reserved/empty slot would otherwise be returned as a "hit" and the caller
+	// would build a container with no netns pin and no IP. Falling through to
+	// Build re-drives the FSM for the owned slot (Reserve returns it, then
+	// Realize/Adopt).
 	if slot, hit, err := h.pool.ClaimPooled(ctx, sandboxID, now); err != nil {
 		return "", "", err
-	} else if hit {
+	} else if hit && slot != nil && slot.NetnsPath != "" && slot.ContainerIP != "" {
 		return slot.NetnsPath, slot.ContainerIP, nil
 	}
 	slot, err := h.builder.Build(ctx, sandboxID)

--- a/internal/network/netns/host.go
+++ b/internal/network/netns/host.go
@@ -66,9 +66,13 @@ func (h *Host) Remove(ctx context.Context, slot Slot) error {
 	if path == "" {
 		return nil
 	}
-	_ = h.Runner.Del(ctx, path, slot.SandboxID)
+	// Surface the CNI DEL error rather than swallowing it: a dropped DEL leaks
+	// the veth pair and the host-local IPAM lease with no process death to free
+	// them. Conntrack flush and netns unlink are still attempted regardless.
+	delErr := h.Runner.Del(ctx, path, slot.SandboxID)
 	_ = hostnet.FlushConntrackForIP(slot.ContainerIP)
-	return h.removePath(path)
+	rmErr := h.removePath(path)
+	return errors.Join(delErr, rmErr)
 }
 
 func (h *Host) netnsRoot() string {

--- a/internal/network/netns/host.go
+++ b/internal/network/netns/host.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -25,10 +26,13 @@ type HostManager interface {
 type Host struct {
 	Runner    cni.Runner
 	NetnsRoot string
-	// mkdir is a test seam; production leaves nil (os.MkdirAll).
+	// mkdir is a test seam for the netns root dir; production leaves nil.
 	mkdir func(path string, perm os.FileMode) error
-	// unlink removes a netns path; production uses os.Remove.
-	unlink func(path string) error
+	// addNetns/delNetns create and remove a REAL named network namespace.
+	// Production leaves them nil and execs `ip netns add/del`; tests stub them
+	// so unit tests need neither `ip` nor CAP_NET_ADMIN.
+	addNetns func(ctx context.Context, name string) error
+	delNetns func(ctx context.Context, name string) error
 }
 
 func (h *Host) Realize(ctx context.Context, slot Slot) (string, string, error) {
@@ -39,39 +43,75 @@ func (h *Host) Realize(ctx context.Context, slot Slot) (string, string, error) {
 		return "", "", errors.New("netns host: sandbox_id is required")
 	}
 	root := h.netnsRoot()
-	path := filepath.Join(root, slot.SandboxID)
 	if err := h.ensureDir(root); err != nil {
 		return "", "", err
 	}
-	// Touch path — production linux uses `ip netns add`; tests stub via mkdir.
-	if err := h.ensureDir(path); err != nil {
-		return "", "", fmt.Errorf("netns host: create %s: %w", path, err)
+	// Create a REAL network namespace, not just a directory: the CNI plugin and
+	// the containerd shim both open this path as a netns. `ip netns add` bind-
+	// mounts a fresh netns at /run/netns/<name>; a plain mkdir'd directory makes
+	// CNI ADD fail with a bare "exit status 1" (the plugin cannot enter a dir).
+	if err := h.createNetns(ctx, slot.SandboxID); err != nil {
+		return "", "", fmt.Errorf("netns host: create netns %s: %w", slot.SandboxID, err)
 	}
+	path := filepath.Join(root, slot.SandboxID)
 	res, err := h.Runner.Add(ctx, path, slot.SandboxID)
 	if err != nil {
-		_ = h.removePath(path)
+		_ = h.deleteNetns(ctx, slot.SandboxID)
 		return "", "", fmt.Errorf("netns host: cni add: %w", err)
 	}
 	return path, res.IP4, nil
+}
+
+// createNetns creates a persistent named netns (bind-mounted at
+// /run/netns/<name>). Idempotent: an already-present netns is not an error.
+func (h *Host) createNetns(ctx context.Context, name string) error {
+	if h.addNetns != nil {
+		return h.addNetns(ctx, name)
+	}
+	out, err := exec.CommandContext(ctx, "ip", "netns", "add", name).CombinedOutput()
+	if err != nil && !strings.Contains(strings.ToLower(string(out)), "file exists") {
+		return fmt.Errorf("ip netns add: %v: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// deleteNetns removes a named netns. Idempotent: a missing netns is not an error.
+func (h *Host) deleteNetns(ctx context.Context, name string) error {
+	if h.delNetns != nil {
+		return h.delNetns(ctx, name)
+	}
+	out, err := exec.CommandContext(ctx, "ip", "netns", "del", name).CombinedOutput()
+	if err != nil {
+		low := strings.ToLower(string(out))
+		if strings.Contains(low, "no such file") || strings.Contains(low, "cannot remove") {
+			return nil
+		}
+		return fmt.Errorf("ip netns del: %v: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
 }
 
 func (h *Host) Remove(ctx context.Context, slot Slot) error {
 	if h == nil || h.Runner == nil {
 		return nil
 	}
+	name := strings.TrimSpace(slot.SandboxID)
 	path := strings.TrimSpace(slot.NetnsPath)
-	if path == "" && strings.TrimSpace(slot.SandboxID) != "" {
-		path = filepath.Join(h.netnsRoot(), slot.SandboxID)
+	if name == "" && path != "" {
+		name = filepath.Base(path)
+	}
+	if name == "" {
+		return nil
 	}
 	if path == "" {
-		return nil
+		path = filepath.Join(h.netnsRoot(), name)
 	}
 	// Surface the CNI DEL error rather than swallowing it: a dropped DEL leaks
 	// the veth pair and the host-local IPAM lease with no process death to free
-	// them. Conntrack flush and netns unlink are still attempted regardless.
-	delErr := h.Runner.Del(ctx, path, slot.SandboxID)
+	// them. Conntrack flush and netns teardown are still attempted regardless.
+	delErr := h.Runner.Del(ctx, path, name)
 	_ = hostnet.FlushConntrackForIP(slot.ContainerIP)
-	rmErr := h.removePath(path)
+	rmErr := h.deleteNetns(ctx, name)
 	return errors.Join(delErr, rmErr)
 }
 
@@ -87,17 +127,6 @@ func (h *Host) ensureDir(path string) error {
 		return h.mkdir(path, 0o755)
 	}
 	return os.MkdirAll(path, 0o755)
-}
-
-func (h *Host) removePath(path string) error {
-	if h.unlink != nil {
-		return h.unlink(path)
-	}
-	err := os.Remove(path)
-	if os.IsNotExist(err) {
-		return nil
-	}
-	return err
 }
 
 // Builder sequences reserve → realize → adopt with LIFO teardown on failure.

--- a/internal/network/netns/host_extra_test.go
+++ b/internal/network/netns/host_extra_test.go
@@ -12,7 +12,12 @@ import (
 func TestHostRealizeRunnerErrorCleansUp(t *testing.T) {
 	runner := cni.NewFakeRunner()
 	runner.SetAddError(errors.New("cni add boom"))
-	h := &Host{Runner: runner, NetnsRoot: t.TempDir()}
+	h := &Host{
+		Runner:    runner,
+		NetnsRoot: t.TempDir(),
+		addNetns:  func(context.Context, string) error { return nil },
+		delNetns:  func(context.Context, string) error { return nil },
+	}
 	if _, _, err := h.Realize(context.Background(), Slot{SandboxID: "sb-x"}); err == nil {
 		t.Fatal("want realize error when CNI ADD fails")
 	}
@@ -21,10 +26,39 @@ func TestHostRealizeRunnerErrorCleansUp(t *testing.T) {
 func TestHostRemoveSurfacesDelError(t *testing.T) {
 	runner := cni.NewFakeRunner()
 	runner.SetDelError(errors.New("cni del boom"))
-	h := &Host{Runner: runner, NetnsRoot: t.TempDir(), unlink: func(string) error { return nil }}
+	h := &Host{
+		Runner:   runner,
+		delNetns: func(context.Context, string) error { return nil },
+	}
 	// Del error must surface (errors.Join), not be swallowed.
 	if err := h.Remove(context.Background(), Slot{SandboxID: "sb-x", NetnsPath: "/run/netns/sb-x", ContainerIP: "10.88.0.5"}); err == nil {
 		t.Fatal("want surfaced CNI DEL error")
+	}
+}
+
+func TestHostRealizeCreatesRealNetns(t *testing.T) {
+	// Realize must create a real netns (addNetns), not just mkdir a directory —
+	// the live regression that made CNI ADD fail with a bare "exit status 1".
+	var created, deleted string
+	runner := cni.NewFakeRunner()
+	h := &Host{
+		Runner:    runner,
+		NetnsRoot: t.TempDir(),
+		addNetns:  func(_ context.Context, name string) error { created = name; return nil },
+		delNetns:  func(_ context.Context, name string) error { deleted = name; return nil },
+	}
+	path, ip, err := h.Realize(context.Background(), Slot{SandboxID: "sb-real"})
+	if err != nil {
+		t.Fatalf("Realize: %v", err)
+	}
+	if created != "sb-real" {
+		t.Fatalf("expected a real netns to be created for sb-real, got %q", created)
+	}
+	if path == "" || ip == "" {
+		t.Fatalf("Realize returned path=%q ip=%q", path, ip)
+	}
+	if deleted != "" {
+		t.Fatalf("netns should not be deleted on success, deleted=%q", deleted)
 	}
 }
 

--- a/internal/network/netns/host_extra_test.go
+++ b/internal/network/netns/host_extra_test.go
@@ -1,0 +1,57 @@
+package netns
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/network/cni"
+)
+
+func TestHostRealizeRunnerErrorCleansUp(t *testing.T) {
+	runner := cni.NewFakeRunner()
+	runner.SetAddError(errors.New("cni add boom"))
+	h := &Host{Runner: runner, NetnsRoot: t.TempDir()}
+	if _, _, err := h.Realize(context.Background(), Slot{SandboxID: "sb-x"}); err == nil {
+		t.Fatal("want realize error when CNI ADD fails")
+	}
+}
+
+func TestHostRemoveSurfacesDelError(t *testing.T) {
+	runner := cni.NewFakeRunner()
+	runner.SetDelError(errors.New("cni del boom"))
+	h := &Host{Runner: runner, NetnsRoot: t.TempDir(), unlink: func(string) error { return nil }}
+	// Del error must surface (errors.Join), not be swallowed.
+	if err := h.Remove(context.Background(), Slot{SandboxID: "sb-x", NetnsPath: "/run/netns/sb-x", ContainerIP: "10.88.0.5"}); err == nil {
+		t.Fatal("want surfaced CNI DEL error")
+	}
+}
+
+func TestHostRemoveNilRunnerNoOp(t *testing.T) {
+	if err := (&Host{}).Remove(context.Background(), Slot{SandboxID: "x"}); err != nil {
+		t.Fatalf("nil-runner Remove should be a no-op: %v", err)
+	}
+}
+
+// TestProvisionFallsThroughOnUnrealizedSlot exercises the B3 fix: a claim that
+// resolves to an owned-but-not-yet-realized slot (empty netns path/IP) must NOT
+// be treated as a ready hit — Provision falls through to Build, which realizes
+// it.
+func TestProvisionFallsThroughOnUnrealizedSlot(t *testing.T) {
+	p := testPool(t, 2)
+	ctx := context.Background()
+	now := time.Unix(1, 0).UTC()
+	// Reserve leaves the slot reserved with empty path/IP.
+	if _, err := p.Reserve(ctx, "sb-x", now); err != nil {
+		t.Fatal(err)
+	}
+	h := NewRuntimeHandoff(p, NewFakeHost())
+	path, ip, err := h.Provision(ctx, "sb-x")
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if path == "" || ip == "" {
+		t.Fatalf("Provision should realize via Build, got path=%q ip=%q", path, ip)
+	}
+}

--- a/internal/network/netns/pool_test.go
+++ b/internal/network/netns/pool_test.go
@@ -127,6 +127,10 @@ func TestHostRealizeRemoveWithCNI(t *testing.T) {
 	h := &Host{
 		Runner:    runner,
 		NetnsRoot: t.TempDir(),
+		// Stub real netns create/delete so the unit test needs neither `ip` nor
+		// CAP_NET_ADMIN.
+		addNetns: func(context.Context, string) error { return nil },
+		delNetns: func(context.Context, string) error { return nil },
 	}
 	ctx := context.Background()
 	slot := Slot{SandboxID: "sb-h"}

--- a/internal/network/netns/reassign_reconcile_test.go
+++ b/internal/network/netns/reassign_reconcile_test.go
@@ -1,0 +1,146 @@
+package netns
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/internal/store"
+)
+
+func TestPoolReassignOwner(t *testing.T) {
+	p := testPool(t, 4)
+	ctx := context.Background()
+	now := time.Unix(200, 0).UTC()
+	host := NewFakeHost()
+
+	// Build an adopted slot owned by the park id.
+	if _, err := NewBuilder(p, host).Build(ctx, "park-1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.ReassignOwner(ctx, "park-1", "sb-1", now); err != nil {
+		t.Fatalf("ReassignOwner: %v", err)
+	}
+	// Ownership moved park-1 -> sb-1.
+	if got, _ := p.Get(ctx, "sb-1"); got == nil {
+		t.Fatal("sb-1 should own the slot after reassign")
+	}
+	if got, _ := p.Get(ctx, "park-1"); got != nil {
+		t.Fatalf("park-1 should no longer own a slot, got %+v", got)
+	}
+	// Idempotent: target already owns → no-op, no error.
+	if err := p.ReassignOwner(ctx, "park-1", "sb-1", now); err != nil {
+		t.Fatalf("idempotent ReassignOwner: %v", err)
+	}
+	// from == to → no-op.
+	if err := p.ReassignOwner(ctx, "sb-1", "sb-1", now); err != nil {
+		t.Fatalf("self ReassignOwner: %v", err)
+	}
+	// nil pool → no-op.
+	if err := (*Pool)(nil).ReassignOwner(ctx, "a", "b", now); err != nil {
+		t.Fatalf("nil pool ReassignOwner: %v", err)
+	}
+}
+
+func TestRuntimeHandoffReassignOwner(t *testing.T) {
+	p := testPool(t, 4)
+	ctx := context.Background()
+	host := NewFakeHost()
+	h := NewRuntimeHandoff(p, host)
+	if _, err := NewBuilder(p, host).Build(ctx, "park-2"); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.ReassignOwner(ctx, "park-2", "sb-2"); err != nil {
+		t.Fatalf("handoff ReassignOwner: %v", err)
+	}
+	if got, _ := p.Get(ctx, "sb-2"); got == nil {
+		t.Fatal("sb-2 should own the slot after handoff reassign")
+	}
+	if err := (*RuntimeHandoff)(nil).ReassignOwner(ctx, "a", "b"); err != nil {
+		t.Fatalf("nil handoff ReassignOwner: %v", err)
+	}
+}
+
+func TestReconcileReapsDeadAdopted(t *testing.T) {
+	p := testPool(t, 4)
+	ctx := context.Background()
+	now := time.Unix(300, 0).UTC()
+	host := NewFakeHost()
+	for _, id := range []string{"sb-a", "sb-b"} {
+		if _, err := NewBuilder(p, host).Build(ctx, id); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// live==nil treats every adopted owner as dead → both reaped.
+	reaped, err := p.Reconcile(ctx, host, nil, func(string) bool { return true }, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reaped != 2 {
+		t.Fatalf("reaped = %d, want 2", reaped)
+	}
+	stats, _ := p.Stats(ctx)
+	if stats.Free != 4 || stats.Adopted != 0 {
+		t.Fatalf("pool not fully freed after reconcile: %+v", stats)
+	}
+}
+
+// TestReserveConcurrentSameSandboxNoDoubleAlloc is the fragile-allocator
+// regression (pr-review §6 / CLAUDE.md): N callers on SEPARATE *Store handles
+// (defeating single-writer serialization) race Reserve for the SAME sandbox.
+// The partial unique index on sandbox_id must guarantee exactly one slot ends
+// owned by it — no double allocation — even though losers may see a raw
+// constraint error.
+func TestReserveConcurrentSameSandboxNoDoubleAlloc(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.db")
+	now := time.Unix(100, 0).UTC()
+	seed, err := store.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := New(seed).Seed(context.Background(), SeedConfig{PoolSize: 8}, now); err != nil {
+		t.Fatal(err)
+	}
+	_ = seed.Close()
+
+	const n = 6
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			st, err := store.Open(path)
+			if err != nil {
+				return
+			}
+			defer st.Close()
+			_, _ = New(st).Reserve(context.Background(), "sb-race", now)
+		}()
+	}
+	wg.Wait()
+
+	check, err := store.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer check.Close()
+	if slot, err := check.GetContainerNetnsSlotBySandbox(context.Background(), "sb-race"); err != nil || slot == nil {
+		t.Fatalf("sb-race must own exactly one slot: slot=%v err=%v", slot, err)
+	}
+	reserved, err := check.ListContainerNetnsSlotsByState(context.Background(), store.NetnsSlotStateReserved)
+	if err != nil {
+		t.Fatal(err)
+	}
+	owned := 0
+	for _, s := range reserved {
+		if s.SandboxID == "sb-race" {
+			owned++
+		}
+	}
+	if owned != 1 {
+		t.Fatalf("sb-race owns %d slots, want exactly 1 (no double allocation)", owned)
+	}
+}

--- a/internal/network/netns/refill_test.go
+++ b/internal/network/netns/refill_test.go
@@ -208,7 +208,12 @@ func TestTargetDepth(t *testing.T) {
 		t.Fatalf("need=%d err=%v", need, err)
 	}
 	runner := cni.NewFakeRunner()
-	_ = p.Prewarm(context.Background(), &Host{Runner: runner, NetnsRoot: t.TempDir()}, time.Now())
+	_ = p.Prewarm(context.Background(), &Host{
+		Runner:    runner,
+		NetnsRoot: t.TempDir(),
+		addNetns:  func(context.Context, string) error { return nil },
+		delNetns:  func(context.Context, string) error { return nil },
+	}, time.Now())
 	need, _ = p.TargetDepth(context.Background(), 2)
 	if need != 1 {
 		t.Fatalf("need=%d want 1", need)

--- a/internal/pool/containerdpool/pool_test.go
+++ b/internal/pool/containerdpool/pool_test.go
@@ -42,3 +42,19 @@ func TestPoolAcquireMiss(t *testing.T) {
 		t.Fatalf("err=%v", err)
 	}
 }
+
+func TestParkReservationIDDelegates(t *testing.T) {
+	// The admitter keys parked-slot capacity reservations by this id; it must be
+	// non-empty and stable for a given slot id so the reservation can be found
+	// again to release it.
+	id := ParkReservationID("park-ctd-7")
+	if id == "" {
+		t.Fatal("ParkReservationID returned empty string")
+	}
+	if again := ParkReservationID("park-ctd-7"); again != id {
+		t.Fatalf("ParkReservationID not stable: %q != %q", id, again)
+	}
+	if ParkReservationID("park-ctd-8") == id {
+		t.Fatal("distinct slot ids must yield distinct reservation ids")
+	}
+}

--- a/internal/runtime/containerd/events.go
+++ b/internal/runtime/containerd/events.go
@@ -70,8 +70,6 @@ func normalizeContainerdEvent(ev *events.Envelope) (docker.DockerEvent, bool) {
 	switch ev.Topic {
 	case runtime.TaskStartEventTopic:
 		action = "start"
-	case runtime.TaskPausedEventTopic:
-		action = "stop"
 	case runtime.TaskExitEventTopic:
 		action = "die"
 	case runtime.TaskOOMEventTopic:
@@ -79,6 +77,12 @@ func normalizeContainerdEvent(ev *events.Envelope) (docker.DockerEvent, bool) {
 	case runtime.TaskDeleteEventTopic:
 		action = "destroy"
 	default:
+		// TaskPaused/TaskResumed are deliberately NOT mapped. The service
+		// consumer folds "stop" into markSandboxStopped (route + netrules +
+		// admitter teardown), so mapping TaskPaused→"stop" made an internal
+		// CreateSnapshot pause tear the live sandbox down — and TaskResumed,
+		// unmapped, never restored it. Docker's pause/unpause are likewise
+		// ignored by the consumer; parity requires the same here.
 		return docker.DockerEvent{}, false
 	}
 	id, exitCode := containerIDAndExitFromEvent(ev)

--- a/internal/runtime/containerd/events_test.go
+++ b/internal/runtime/containerd/events_test.go
@@ -47,11 +47,20 @@ func TestNormalizeContainerdEvent(t *testing.T) {
 			wantID:     "sb-2",
 		},
 		{
-			name:       "task paused maps to stop",
-			env:        mkEnvelope(t, runtime.TaskPausedEventTopic, &apievents.TaskPaused{ContainerID: "sb-pause"}),
-			wantOK:     true,
-			wantAction: "stop",
-			wantID:     "sb-pause",
+			// Regression: TaskPaused must be IGNORED, not mapped to "stop". The
+			// service consumer folds "stop" into markSandboxStopped (route +
+			// netrules + admitter teardown); mapping pause→stop made an internal
+			// CreateSnapshot pause tear the live sandbox down, and TaskResumed
+			// (below, also ignored) never restored it. Docker's pause/unpause are
+			// ignored by the consumer too — this is the parity fix.
+			name:   "task paused is ignored (snapshot pause must not stop the sandbox)",
+			env:    mkEnvelope(t, runtime.TaskPausedEventTopic, &apievents.TaskPaused{ContainerID: "sb-pause"}),
+			wantOK: false,
+		},
+		{
+			name:   "task resumed is ignored",
+			env:    mkEnvelope(t, runtime.TaskResumedEventTopic, &apievents.TaskResumed{ContainerID: "sb-resume"}),
+			wantOK: false,
 		},
 		{
 			name:       "task delete maps to destroy",

--- a/internal/runtime/containerd/fake_harness_test.go
+++ b/internal/runtime/containerd/fake_harness_test.go
@@ -171,6 +171,7 @@ func (c *fakeContainer) Info(context.Context, ...cntr.InfoOpts) (containers.Cont
 	}
 	return containers.Container{
 		ID:          c.id,
+		Image:       "alpine:3.20",
 		Labels:      labels,
 		SnapshotKey: c.id + "-snap",
 		Snapshotter: "overlayfs",

--- a/internal/runtime/containerd/image_lease.go
+++ b/internal/runtime/containerd/image_lease.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	cntr "github.com/containerd/containerd"
 	"github.com/containerd/containerd/leases"
@@ -15,6 +16,13 @@ import (
 const (
 	imageLeaseLabelKey = "aerolvm.image_lease"
 	leaseContentType   = "content"
+	// leaseExpiry is a GC backstop: the driver releases image leases explicitly
+	// on every success (Destroy) and failure path, but a daemon crash between
+	// pinning and NewContainer leaves an orphan with no defer to run and no
+	// lease reconciler. An expiration lets containerd GC reclaim such orphans.
+	// It never threatens a live sandbox: once NewContainer returns, the
+	// container's own snapshot pins the layers independently of this lease.
+	leaseExpiry = 24 * time.Hour
 )
 
 // leaseManager is the containerd leases.Manager surface pin/release need.
@@ -53,7 +61,7 @@ func (d *Driver) pinImageLease(ctx context.Context, client *Client, image cntr.I
 	if err != nil {
 		return "", err
 	}
-	lease, err := ls.Create(ctx, leases.WithID(leaseID))
+	lease, err := ls.Create(ctx, leases.WithID(leaseID), leases.WithExpiration(leaseExpiry))
 	if err != nil {
 		return "", fmt.Errorf("create image lease: %w", err)
 	}

--- a/internal/runtime/containerd/lifecycle.go
+++ b/internal/runtime/containerd/lifecycle.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	cntr "github.com/containerd/containerd"
-	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/remotes/docker"
@@ -89,36 +88,49 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 	}
 
 	committed := false
-	// createdContainer gates host-side teardown: a caller that loses the
-	// concurrent-duplicate race (AlreadyExists at NewContainer) must NOT run
-	// LIFO teardown, because the host files and ready socket are keyed by
-	// sandboxID and belong to the winner — removing them would yank the bind
-	// mounts out from under the live winning container.
-	createdContainer := false
+	// lostRace is set only when NewContainer returns AlreadyExists — i.e. this
+	// call lost a concurrent-duplicate/retry race to a winner that already owns
+	// the container. The winner owns the shared, sandboxID-keyed artifacts (host
+	// files, ready socket, netns slot, image lease), so the loser must NOT tear
+	// any of them down. A genuine solo failure (lostRace stays false) DOES clean
+	// up its own artifacts — leaning on boot reconcile for routine cleanup is the
+	// pr-review §4 anti-pattern. (The prior gate keyed teardown on
+	// createdContainer, which wrongly leaked host files / ready socket / netns
+	// slot / lease on any failure BEFORE NewContainer.)
+	lostRace := false
 	var (
 		container cntr.Container
 		task      cntr.Task
 		logPath   string
 		logCloser func()
 		hostFiles *sandboxHostFiles
+		leaseID   string
 	)
 	defer func() {
-		if committed || !createdContainer {
-			if logCloser != nil {
-				logCloser()
-			}
-			return
-		}
 		if logCloser != nil {
 			logCloser()
+		}
+		if committed || lostRace {
+			return
 		}
 		d.lifoTeardown(ctx, client, container, task, logPath, hostFiles)
 	}()
 	defer func() {
-		if committed || !netnsProvisioned || d.netns == nil {
+		if committed || lostRace || !netnsProvisioned || d.netns == nil {
 			return
 		}
 		_ = d.netns.Release(ctx, sandboxID)
+	}()
+	defer func() {
+		// The image lease is created (with a random id) before NewContainer; on
+		// success it rides on the container labels and Destroy releases it. On any
+		// non-committed exit — including the AlreadyExists loser, whose lease id
+		// differs from the winner's — it is an orphan this call must delete, or GC
+		// can never reclaim the pinned layers.
+		if committed || leaseID == "" {
+			return
+		}
+		d.releaseImageLease(ctx, client, map[string]string{imageLeaseLabelKey: leaseID})
 	}()
 
 	imageStart := time.Now()
@@ -150,10 +162,10 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 			_ = readyListener.Close()
 		}
 		// Only reap the ready socket when this call owns it: on success we keep
-		// it, and on the AlreadyExists loser path (!createdContainer) it belongs
-		// to the winner — RemoveReadySocketsForSandbox is keyed by sandboxID and
-		// would nuke the winner's socket too.
-		if readySocketCreated && !keepReadySocket && createdContainer {
+		// it, and on the AlreadyExists loser path (lostRace) it belongs to the
+		// winner — RemoveReadySocketsForSandbox is keyed by sandboxID and would
+		// nuke the winner's socket too. A genuine solo failure still reaps.
+		if readySocketCreated && !keepReadySocket && !lostRace {
 			dockerpkg.RemoveReadySocketsForSandbox(d.cfg.ReadyDir, sandboxID)
 		}
 	}()
@@ -196,9 +208,11 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 		managedLabelKey:   "true",
 		sandboxIDLabelKey: sandboxID,
 	}
-	if leaseID, err := d.pinImageLease(ctx, client, image); err != nil {
+	leaseID, err = d.pinImageLease(ctx, client, image)
+	if err != nil {
 		return nil, err
-	} else if leaseID != "" {
+	}
+	if leaseID != "" {
 		containerLabels[imageLeaseLabelKey] = leaseID
 	}
 
@@ -222,11 +236,11 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 	container, err = client.NewContainer(ctx, sandboxID, containerOpts...)
 	if err != nil {
 		if errdefs.IsAlreadyExists(err) {
+			lostRace = true
 			return nil, fmt.Errorf("%w: sandbox container already exists", dockerpkg.ErrSandboxContainerExists)
 		}
 		return nil, fmt.Errorf("create container: %w", err)
 	}
-	createdContainer = true
 
 	logPath, err = d.taskLogPath(sandboxID)
 	if err != nil {
@@ -302,7 +316,15 @@ func (d *Driver) Start(ctx context.Context, containerRef string) (*models.Sandbo
 	if err != nil {
 		return nil, err
 	}
-	logIO := cio.LogFile(logPath)
+	// Use the size-capped writer, not cio.LogFile: containerd never rotates task
+	// IO, so an uncapped resume log grows for the life of the task and can fill
+	// the host disk — the exact hazard Create's taskLogIO guards against. Closed
+	// on return, mirroring Create's logCloser handling.
+	logIO, closeLog, err := taskLogIO(logPath)
+	if err != nil {
+		return nil, err
+	}
+	defer closeLog()
 	task, err = container.NewTask(ctx, logIO)
 	if err != nil {
 		return nil, fmt.Errorf("create task: %w", err)

--- a/internal/runtime/containerd/lifecycle_teardown_test.go
+++ b/internal/runtime/containerd/lifecycle_teardown_test.go
@@ -1,0 +1,142 @@
+package containerd
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	cntr "github.com/containerd/containerd"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/aerol-ai/microvm/internal/pool/containerdpool"
+	dockerpkg "github.com/aerol-ai/microvm/pkg/docker"
+	"github.com/aerol-ai/microvm/pkg/models"
+)
+
+// digestImage returns a fake image with a non-empty content digest so
+// pinImageLease reaches AddResource instead of erroring on an empty digest.
+func digestImage() *fakeImage {
+	return &fakeImage{
+		name:   "alpine:3.20",
+		target: ocispec.Descriptor{Digest: digest.Digest("sha256:" + strings.Repeat("a", 64))},
+	}
+}
+
+// TestCreateAlreadyExistsLoserPreservesWinnerResources is the regression for the
+// review's top finding (A1≡B1 + A4): a retry / concurrent-duplicate Create that
+// loses the AlreadyExists race must NOT tear down the winner's sandboxID-keyed
+// resources (netns slot, host files), while still cleaning up its OWN orphan
+// image lease.
+func TestCreateAlreadyExistsLoserPreservesWinnerResources(t *testing.T) {
+	stubToolboxProbe(t)
+	lm := &fakeLeaseManager{}
+	orig := leasesServiceFn
+	leasesServiceFn = func(*Client) leaseManager { return lm }
+	t.Cleanup(func() { leasesServiceFn = orig })
+
+	tr := newFakeTransport()
+	tr.image = digestImage()
+	// The winner already owns the container object → NewContainer(loser) returns
+	// AlreadyExists.
+	tr.containers["sb-dup"] = &fakeContainer{id: "sb-dup", labels: map[string]string{managedLabelKey: "true"}}
+
+	h := &harnessNetns{path: "/run/netns/sb-dup", ip: "10.88.0.9"}
+	d := newTestDriver(t)
+	d.SetClient(NewTestClient("aerolvm", tr))
+	d.SetNetnsHandoff(h)
+	d.cfg.NativeNetnsPool = true
+
+	_, err := d.Create(context.Background(), models.CreateSandboxRequest{
+		Image: "alpine:3.20", ContainerCommand: []string{"sleep"},
+	}, "sb-dup", "tok", nil)
+	if !errors.Is(err, dockerpkg.ErrSandboxContainerExists) {
+		t.Fatalf("want ErrSandboxContainerExists, got %v", err)
+	}
+	if h.released {
+		t.Fatal("AlreadyExists loser must NOT release the winner's netns slot")
+	}
+	// Winner's host files (keyed by sandboxID) must survive the loser's teardown.
+	hostDir := filepath.Join(d.cfg.RunDir, "hosts", "sb-dup")
+	if _, statErr := os.Stat(hostDir); statErr != nil {
+		t.Fatalf("winner's host files must survive loser teardown: %v", statErr)
+	}
+	// The loser's own image lease (random id, distinct from the winner's) is an
+	// orphan it must delete.
+	if len(lm.created) != 1 || len(lm.deleted) != 1 || lm.deleted[0] != lm.created[0] {
+		t.Fatalf("loser must release its own lease: created=%v deleted=%v", lm.created, lm.deleted)
+	}
+}
+
+// TestCreatePreContainerFailureCleansOwnResources is the A4 regression: a genuine
+// solo failure BEFORE NewContainer (here the lease pin fails) must still reap the
+// host files and netns slot this call created — the prior createdContainer gate
+// leaked both because the container object never existed.
+func TestCreatePreContainerFailureCleansOwnResources(t *testing.T) {
+	stubToolboxProbe(t)
+	lm := &fakeLeaseManager{createErr: errors.New("lease create boom")}
+	orig := leasesServiceFn
+	leasesServiceFn = func(*Client) leaseManager { return lm }
+	t.Cleanup(func() { leasesServiceFn = orig })
+
+	h := &harnessNetns{path: "/run/netns/sb-fail", ip: "10.88.0.9"}
+	d := newTestDriver(t)
+	d.SetNetnsHandoff(h)
+	d.cfg.NativeNetnsPool = true
+
+	_, err := d.Create(context.Background(), models.CreateSandboxRequest{
+		Image: "alpine:3.20", ContainerCommand: []string{"sleep"},
+	}, "sb-fail", "tok", nil)
+	if err == nil {
+		t.Fatal("want create failure at lease pin")
+	}
+	if !h.released {
+		t.Fatal("solo failure must release the netns slot this call reserved")
+	}
+	hostDir := filepath.Join(d.cfg.RunDir, "hosts", "sb-fail")
+	if _, statErr := os.Stat(hostDir); !os.IsNotExist(statErr) {
+		t.Fatalf("solo failure must remove its host files, stat err = %v", statErr)
+	}
+}
+
+// TestDestroyParkedReleasesNetnsAndLease is the B2 regression: parked-container
+// teardown must release the netns slot AND the pinned image lease, or the netns
+// pool leaks to exhaustion and image layers can never be GC'd.
+func TestDestroyParkedReleasesNetnsAndLease(t *testing.T) {
+	lm := &fakeLeaseManager{}
+	orig := leasesServiceFn
+	leasesServiceFn = func(*Client) leaseManager { return lm }
+	t.Cleanup(func() { leasesServiceFn = orig })
+
+	tr := newFakeTransport()
+	tr.containers["park-7"] = &fakeContainer{
+		id: "park-7",
+		labels: map[string]string{
+			managedLabelKey:    "true",
+			poolParkLabelKey:   poolParkLabelValue,
+			imageLeaseLabelKey: "lease-park-7",
+		},
+		task: &fakeTask{status: cntr.Running},
+	}
+	h := &harnessNetns{path: "/run/netns/park-7", ip: "10.88.0.9"}
+	d := newTestDriver(t)
+	d.SetClient(NewTestClient("aerolvm", tr))
+	d.SetNetnsHandoff(h)
+
+	if err := d.destroyParked(context.Background(), &containerdpool.ParkedSlot{
+		ID:          "park-7",
+		ContainerID: "park-7",
+		ContainerIP: "10.88.0.9",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !h.released {
+		t.Fatal("destroyParked must release the park netns slot")
+	}
+	if len(lm.deleted) != 1 || lm.deleted[0] != "lease-park-7" {
+		t.Fatalf("destroyParked must release the park image lease, deleted=%v", lm.deleted)
+	}
+}

--- a/internal/runtime/containerd/push.go
+++ b/internal/runtime/containerd/push.go
@@ -86,18 +86,30 @@ func (p *RegistryPusher) livePush(ctx context.Context, source, dest string, auth
 			return "", fmt.Errorf("containerd push: lookup dest: %w", err)
 		}
 		if _, err := isvc.Create(ctx, images.Image{Name: dest, Target: target}); err != nil {
-			return "", fmt.Errorf("containerd push: create dest name: %w", err)
+			// A concurrent duplicate push may have created the name first — that
+			// is success, not an error (pr-review §1 idempotency). Fall through to
+			// the Push below with the same target.
+			if !errdefs.IsAlreadyExists(err) {
+				return "", fmt.Errorf("containerd push: create dest name: %w", err)
+			}
 		}
 	} else if _, err := isvc.Update(ctx, images.Image{Name: dest, Target: target}, "target"); err != nil {
 		// Name already exists; push with the source descriptor anyway.
 		_ = err
 	}
 
-	refHost := registryHost(dest)
+	// Scope creds to exactly one registry host; never broadcast them to every
+	// host the resolver dials (foreign-layer / redirect hosts). A hostless dest
+	// ref falls back to auth.Server, and if neither resolves a host we refuse
+	// rather than leak credentials.
+	scopeHost, err := pushCredScopeHost(dest, auth.Server)
+	if err != nil {
+		return "", err
+	}
 	opts := []cntr.RemoteOpt{
 		cntr.WithResolver(ctddocker.NewResolver(ctddocker.ResolverOptions{
 			Authorizer: ctddocker.NewDockerAuthorizer(ctddocker.WithAuthCreds(func(host string) (string, string, error) {
-				if refHost != "" && host != refHost && host != strings.TrimSpace(auth.Server) {
+				if host != scopeHost {
 					return "", "", nil
 				}
 				return auth.Username, auth.Password, nil
@@ -108,4 +120,18 @@ func (p *RegistryPusher) livePush(ctx context.Context, source, dest string, auth
 		return "", fmt.Errorf("containerd push %s -> %s: %w", source, dest, err)
 	}
 	return string(target.Digest), nil
+}
+
+// pushCredScopeHost resolves the single registry host that push credentials may
+// be sent to: the dest ref's own host, or (for a hostless ref) the configured
+// auth server. Returns an error rather than "" so a bad ref can never widen the
+// cred scope to every host the resolver contacts.
+func pushCredScopeHost(dest, authServer string) (string, error) {
+	if h := registryHost(dest); h != "" {
+		return h, nil
+	}
+	if h := strings.TrimSpace(authServer); h != "" {
+		return h, nil
+	}
+	return "", fmt.Errorf("containerd push: cannot determine registry host for dest %q; refusing to broadcast credentials", dest)
 }

--- a/internal/runtime/containerd/push_test.go
+++ b/internal/runtime/containerd/push_test.go
@@ -57,3 +57,33 @@ func TestRegistryPusherValidation(t *testing.T) {
 		t.Fatal("want nil pusher error")
 	}
 }
+
+func TestPushCredScopeHost(t *testing.T) {
+	cases := []struct {
+		name       string
+		dest       string
+		authServer string
+		want       string
+		wantErr    bool
+	}{
+		{"dest carries host", "aocr.example.com/repo/img:tag", "", "aocr.example.com", false},
+		{"dest host beats auth server", "aocr.example.com/r/i:t", "other.example.com", "aocr.example.com", false},
+		{"hostless ref falls back to auth server", "myrepo/img", "aocr.example.com", "aocr.example.com", false},
+		{"localhost with port", "localhost:5000/img", "", "localhost:5000", false},
+		{"no host anywhere refuses", "myrepo/img", "", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := pushCredScopeHost(tc.dest, tc.authServer)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("want error refusing to broadcast credentials")
+				}
+				return
+			}
+			if err != nil || got != tc.want {
+				t.Fatalf("pushCredScopeHost(%q,%q) = (%q,%v), want %q", tc.dest, tc.authServer, got, err, tc.want)
+			}
+		})
+	}
+}

--- a/internal/runtime/containerd/snapshot.go
+++ b/internal/runtime/containerd/snapshot.go
@@ -1,16 +1,21 @@
 package containerd
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	cntr "github.com/containerd/containerd"
+	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/rootfs"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -24,6 +29,13 @@ var testSnapshotBackend snapshotBackend
 type snapshotBackend interface {
 	loadContainer(ctx context.Context, client *Client, containerRef string) (cntr.Container, error)
 	createDiff(ctx context.Context, snapshotKey, snapshotter string, container cntr.Container) (ocispec.Descriptor, error)
+	// baseManifestAndConfig reads the base image's manifest and its unmarshalled
+	// config, so the commit can extend them with the new diff layer.
+	baseManifestAndConfig(ctx context.Context, target ocispec.Descriptor) (ocispec.Manifest, ocispec.Image, error)
+	// diffID resolves the uncompressed digest (rootfs diff_id) of a layer blob.
+	diffID(ctx context.Context, desc ocispec.Descriptor) (digest.Digest, error)
+	// writeBlob content-addresses data and stores it with the given gc labels.
+	writeBlob(ctx context.Context, mediaType string, data []byte, labels map[string]string) (ocispec.Descriptor, error)
 	createImage(ctx context.Context, img images.Image) (images.Image, error)
 	getImage(ctx context.Context, name string) (images.Image, error)
 }
@@ -59,6 +71,56 @@ func (b *rawSnapshotBackend) getImage(ctx context.Context, name string) (images.
 		return images.Image{}, errors.New("snapshot image get requires live containerd")
 	}
 	return raw.ImageService().Get(ctx, name)
+}
+
+func (b *rawSnapshotBackend) baseManifestAndConfig(ctx context.Context, target ocispec.Descriptor) (ocispec.Manifest, ocispec.Image, error) {
+	raw := b.client.Raw()
+	if raw == nil {
+		return ocispec.Manifest{}, ocispec.Image{}, errors.New("snapshot base read requires live containerd")
+	}
+	cs := raw.ContentStore()
+	manifest, err := images.Manifest(ctx, cs, target, platforms.Default())
+	if err != nil {
+		return ocispec.Manifest{}, ocispec.Image{}, fmt.Errorf("read base manifest: %w", err)
+	}
+	configBytes, err := content.ReadBlob(ctx, cs, manifest.Config)
+	if err != nil {
+		return ocispec.Manifest{}, ocispec.Image{}, fmt.Errorf("read base config: %w", err)
+	}
+	var config ocispec.Image
+	if err := json.Unmarshal(configBytes, &config); err != nil {
+		return ocispec.Manifest{}, ocispec.Image{}, fmt.Errorf("parse base config: %w", err)
+	}
+	return manifest, config, nil
+}
+
+func (b *rawSnapshotBackend) diffID(ctx context.Context, desc ocispec.Descriptor) (digest.Digest, error) {
+	raw := b.client.Raw()
+	if raw == nil {
+		return "", errors.New("snapshot diff id requires live containerd")
+	}
+	return images.GetDiffID(ctx, raw.ContentStore(), desc)
+}
+
+func (b *rawSnapshotBackend) writeBlob(ctx context.Context, mediaType string, data []byte, labels map[string]string) (ocispec.Descriptor, error) {
+	raw := b.client.Raw()
+	if raw == nil {
+		return ocispec.Descriptor{}, errors.New("snapshot write blob requires live containerd")
+	}
+	desc := ocispec.Descriptor{
+		MediaType: mediaType,
+		Digest:    digest.FromBytes(data),
+		Size:      int64(len(data)),
+	}
+	ref := "aerolvm-snapshot-" + desc.Digest.String()
+	var opts []content.Opt
+	if len(labels) > 0 {
+		opts = append(opts, content.WithLabels(labels))
+	}
+	if err := content.WriteBlob(ctx, raw.ContentStore(), ref, bytes.NewReader(data), desc, opts...); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("write %s blob: %w", mediaType, err)
+	}
+	return desc, nil
 }
 
 func resolveSnapshotBackend(d *Driver, client *Client) snapshotBackend {
@@ -158,13 +220,17 @@ func (d *Driver) commitContainerSnapshotLive(ctx context.Context, client *Client
 	if err != nil {
 		return "", fmt.Errorf("snapshot diff: %w", err)
 	}
-	now := time.Now().UTC()
-	img := images.Image{
-		Name:   imageRef,
-		Target: desc,
-		Labels: map[string]string{
-			"containerd.io/gc.root": now.Format(time.RFC3339Nano),
-		},
+	baseImage := strings.TrimSpace(info.Image)
+	if baseImage == "" {
+		return "", errors.New("snapshot container has no base image reference")
+	}
+	base, err := backend.getImage(ctx, baseImage)
+	if err != nil {
+		return "", fmt.Errorf("snapshot base image %q: %w", baseImage, err)
+	}
+	img, err := assembleCommittedImage(ctx, backend, base.Target, desc, imageRef, time.Now().UTC())
+	if err != nil {
+		return "", err
 	}
 	created, err := backend.createImage(ctx, img)
 	if err != nil {
@@ -178,6 +244,70 @@ func (d *Driver) commitContainerSnapshotLive(ctx context.Context, client *Client
 		return "", fmt.Errorf("snapshot image create: %w", err)
 	}
 	return imageDigestID(created.Target), nil
+}
+
+// assembleCommittedImage builds a runnable/pushable OCI image from the base
+// image plus the new diff layer: it extends the base config's rootfs.diff_ids
+// and the base manifest's layers, writes the new config and manifest blobs
+// (with gc.ref labels so containerd's GC keeps the config + every layer), and
+// returns an image record targeting the new MANIFEST.
+//
+// The previous code assigned the diff-LAYER descriptor as the image Target, so
+// the "image" was not a manifest and could neither be run (WithNewSnapshot) nor
+// pushed. This assembly is verified offline for structure (config/manifest
+// shape + gc.ref labels) via the fake backend; the live content-store write and
+// a commit→re-run/push round trip are integration-suite territory (darwin has
+// no containerd content store).
+func assembleCommittedImage(ctx context.Context, backend snapshotBackend, baseTarget, diffDesc ocispec.Descriptor, imageRef string, now time.Time) (images.Image, error) {
+	manifest, config, err := backend.baseManifestAndConfig(ctx, baseTarget)
+	if err != nil {
+		return images.Image{}, err
+	}
+	diffID, err := backend.diffID(ctx, diffDesc)
+	if err != nil {
+		return images.Image{}, fmt.Errorf("snapshot diff id: %w", err)
+	}
+	config.RootFS.DiffIDs = append(config.RootFS.DiffIDs, diffID)
+	config.History = append(config.History, ocispec.History{
+		Created:   &now,
+		CreatedBy: "aerolvm snapshot commit",
+		Comment:   imageRef,
+	})
+	configBytes, err := json.Marshal(config)
+	if err != nil {
+		return images.Image{}, fmt.Errorf("marshal snapshot config: %w", err)
+	}
+	configDesc, err := backend.writeBlob(ctx, ocispec.MediaTypeImageConfig, configBytes, nil)
+	if err != nil {
+		return images.Image{}, err
+	}
+	manifest.Config = configDesc
+	manifest.Layers = append(manifest.Layers, diffDesc)
+	if manifest.MediaType == "" {
+		manifest.MediaType = ocispec.MediaTypeImageManifest
+	}
+	if manifest.SchemaVersion == 0 {
+		manifest.SchemaVersion = 2
+	}
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		return images.Image{}, fmt.Errorf("marshal snapshot manifest: %w", err)
+	}
+	// GC ref labels: without them containerd's GC reaps the config and layer
+	// blobs the manifest references, breaking the image out from under itself.
+	refLabels := map[string]string{"containerd.io/gc.ref.content.config": configDesc.Digest.String()}
+	for i, layer := range manifest.Layers {
+		refLabels[fmt.Sprintf("containerd.io/gc.ref.content.l.%d", i)] = layer.Digest.String()
+	}
+	manifestDesc, err := backend.writeBlob(ctx, ocispec.MediaTypeImageManifest, manifestBytes, refLabels)
+	if err != nil {
+		return images.Image{}, err
+	}
+	return images.Image{
+		Name:   imageRef,
+		Target: manifestDesc,
+		Labels: map[string]string{"containerd.io/gc.root": now.Format(time.RFC3339Nano)},
+	}, nil
 }
 
 func (d *Driver) loadContainerForRef(ctx context.Context, client *Client, containerRef string) (cntr.Container, error) {

--- a/internal/runtime/containerd/snapshot_test.go
+++ b/internal/runtime/containerd/snapshot_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	cntr "github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
@@ -131,12 +132,18 @@ func TestNilClientContentAccessors(t *testing.T) {
 }
 
 type fakeSnapshotBackend struct {
-	container cntr.Container
-	desc      ocispec.Descriptor
-	created   images.Image
-	createErr error
-	getImg    images.Image
-	getErr    error
+	container    cntr.Container
+	diffDesc     ocispec.Descriptor
+	baseManifest ocispec.Manifest
+	baseConfig   ocispec.Image
+	diffIDVal    digest.Digest
+	blobLabels   map[string]map[string]string // blob digest -> gc labels
+	blobTypes    map[string]string            // blob digest -> media type
+	createErr    error
+	created      images.Image
+	createdArg   images.Image
+	getImg       images.Image
+	getErr       error
 }
 
 func (f *fakeSnapshotBackend) loadContainer(context.Context, *Client, string) (cntr.Container, error) {
@@ -146,9 +153,26 @@ func (f *fakeSnapshotBackend) loadContainer(context.Context, *Client, string) (c
 	return f.container, nil
 }
 func (f *fakeSnapshotBackend) createDiff(context.Context, string, string, cntr.Container) (ocispec.Descriptor, error) {
-	return f.desc, nil
+	return f.diffDesc, nil
+}
+func (f *fakeSnapshotBackend) baseManifestAndConfig(context.Context, ocispec.Descriptor) (ocispec.Manifest, ocispec.Image, error) {
+	return f.baseManifest, f.baseConfig, nil
+}
+func (f *fakeSnapshotBackend) diffID(context.Context, ocispec.Descriptor) (digest.Digest, error) {
+	return f.diffIDVal, nil
+}
+func (f *fakeSnapshotBackend) writeBlob(_ context.Context, mediaType string, data []byte, labels map[string]string) (ocispec.Descriptor, error) {
+	if f.blobLabels == nil {
+		f.blobLabels = map[string]map[string]string{}
+		f.blobTypes = map[string]string{}
+	}
+	desc := ocispec.Descriptor{MediaType: mediaType, Digest: digest.FromBytes(data), Size: int64(len(data))}
+	f.blobLabels[desc.Digest.String()] = labels
+	f.blobTypes[desc.Digest.String()] = mediaType
+	return desc, nil
 }
 func (f *fakeSnapshotBackend) createImage(_ context.Context, img images.Image) (images.Image, error) {
+	f.createdArg = img
 	if f.createErr != nil {
 		return images.Image{}, f.createErr
 	}
@@ -164,32 +188,57 @@ func (f *fakeSnapshotBackend) getImage(context.Context, string) (images.Image, e
 	return f.getImg, nil
 }
 
+// baseFixture returns a backend seeded with a base image (one config + one
+// layer) plus the new diff, so the commit can assemble a real manifest.
+func baseFixture(task *fakeTask) *fakeSnapshotBackend {
+	layer := ocispec.Descriptor{MediaType: ocispec.MediaTypeImageLayerGzip, Digest: digest.Digest("sha256:" + strings.Repeat("1", 64))}
+	return &fakeSnapshotBackend{
+		container: &fakeContainer{id: "sb-1", task: task},
+		diffDesc:  ocispec.Descriptor{MediaType: ocispec.MediaTypeImageLayerGzip, Digest: digest.Digest("sha256:" + strings.Repeat("2", 64))},
+		diffIDVal: digest.Digest("sha256:" + strings.Repeat("3", 64)),
+		baseManifest: ocispec.Manifest{
+			MediaType: ocispec.MediaTypeImageManifest,
+			Config:    ocispec.Descriptor{MediaType: ocispec.MediaTypeImageConfig, Digest: digest.Digest("sha256:" + strings.Repeat("4", 64))},
+			Layers:    []ocispec.Descriptor{layer},
+		},
+		baseConfig: ocispec.Image{RootFS: ocispec.RootFS{Type: "layers", DiffIDs: []digest.Digest{digest.Digest("sha256:" + strings.Repeat("5", 64))}}},
+	}
+}
+
 func TestCommitContainerSnapshotLiveFakeBackend(t *testing.T) {
 	d := newTestDriver(t)
-	dgst := digest.Digest("sha256:" + strings.Repeat("c", 64))
-	backend := &fakeSnapshotBackend{
-		container: &fakeContainer{id: "sb-1", task: &fakeTask{status: cntr.Running}},
-		desc:      ocispec.Descriptor{Digest: dgst},
-		created:   images.Image{Name: "snap:v1", Target: ocispec.Descriptor{Digest: dgst}},
-	}
+	backend := baseFixture(&fakeTask{status: cntr.Running})
 	testSnapshotBackend = backend
 	t.Cleanup(func() { testSnapshotBackend = nil })
 
 	got, err := d.commitContainerSnapshotLive(context.Background(), d.client, "sb-1", "snap:v1")
-	if err != nil || got != string(dgst) {
-		t.Fatalf("got=%q err=%v", got, err)
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	// Returned digest must be the assembled MANIFEST, and createImage must have
+	// been handed a manifest target (not the bare diff layer).
+	if got == "" || got != string(backend.createdArg.Target.Digest) {
+		t.Fatalf("returned digest %q != created image target %q", got, backend.createdArg.Target.Digest)
+	}
+	if backend.createdArg.Target.MediaType != ocispec.MediaTypeImageManifest {
+		t.Fatalf("image target media type = %q, want manifest", backend.createdArg.Target.MediaType)
+	}
+	// The manifest blob must carry gc.ref labels for the config + every layer.
+	labels := backend.blobLabels[got]
+	if labels["containerd.io/gc.ref.content.config"] == "" {
+		t.Fatalf("manifest missing gc.ref config label: %v", labels)
+	}
+	if labels["containerd.io/gc.ref.content.l.0"] == "" || labels["containerd.io/gc.ref.content.l.1"] == "" {
+		t.Fatalf("manifest missing gc.ref layer labels (base + diff): %v", labels)
 	}
 }
 
 func TestCommitContainerSnapshotAlreadyExists(t *testing.T) {
 	d := newTestDriver(t)
 	dgst := digest.Digest("sha256:" + strings.Repeat("d", 64))
-	backend := &fakeSnapshotBackend{
-		container: &fakeContainer{id: "sb-1", task: &fakeTask{status: cntr.Running}},
-		desc:      ocispec.Descriptor{Digest: dgst},
-		createErr: errdefs.ErrAlreadyExists,
-		getImg:    images.Image{Target: ocispec.Descriptor{Digest: dgst}},
-	}
+	backend := baseFixture(&fakeTask{status: cntr.Running})
+	backend.createErr = errdefs.ErrAlreadyExists
+	backend.getImg = images.Image{Target: ocispec.Descriptor{Digest: dgst}}
 	testSnapshotBackend = backend
 	t.Cleanup(func() { testSnapshotBackend = nil })
 
@@ -201,17 +250,30 @@ func TestCommitContainerSnapshotAlreadyExists(t *testing.T) {
 
 func TestCommitContainerSnapshotStoppedTask(t *testing.T) {
 	d := newTestDriver(t)
-	dgst := digest.Digest("sha256:" + strings.Repeat("e", 64))
-	backend := &fakeSnapshotBackend{
-		container: &fakeContainer{id: "sb-1", task: &fakeTask{status: cntr.Stopped}},
-		desc:      ocispec.Descriptor{Digest: dgst},
-		created:   images.Image{Target: ocispec.Descriptor{Digest: dgst}},
-	}
+	backend := baseFixture(&fakeTask{status: cntr.Stopped})
 	testSnapshotBackend = backend
 	t.Cleanup(func() { testSnapshotBackend = nil })
 
 	got, err := d.commitContainerSnapshotLive(context.Background(), d.client, "sb-1", "snap:v1")
-	if err != nil || got != string(dgst) {
+	if err != nil || got == "" {
 		t.Fatalf("got=%q err=%v", got, err)
+	}
+}
+
+func TestAssembleCommittedImageExtendsConfigAndManifest(t *testing.T) {
+	backend := baseFixture(nil)
+	img, err := assembleCommittedImage(context.Background(), backend, backend.baseManifest.Config, backend.diffDesc, "snap:v1", time.Unix(0, 0).UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if img.Name != "snap:v1" || img.Target.MediaType != ocispec.MediaTypeImageManifest {
+		t.Fatalf("assembled image wrong: %+v", img.Target)
+	}
+	if img.Labels["containerd.io/gc.root"] == "" {
+		t.Fatal("assembled image missing gc.root label")
+	}
+	// Two blobs must have been written: the new config and the manifest.
+	if len(backend.blobTypes) != 2 {
+		t.Fatalf("expected config+manifest blobs, wrote %d", len(backend.blobTypes))
 	}
 }

--- a/internal/runtime/containerd/warm_adopt.go
+++ b/internal/runtime/containerd/warm_adopt.go
@@ -88,6 +88,13 @@ func (d *Driver) tryWarmAdopt(ctx context.Context, req models.CreateSandboxReque
 			return nil, err
 		}
 		_ = d.destroyParked(ctx, slot)
+		if d.netns != nil {
+			// adoptParked may have already reassigned the netns slot from the park
+			// id to sandboxID before failing (ReassignOwner runs before the network
+			// policy apply). destroyParked only releases the park id, so release
+			// under sandboxID too or the slot is stranded adopted with no container.
+			_ = d.netns.Release(ctx, sandboxID)
+		}
 		d.warmPool.ReleasePark(slot.ID)
 		return nil, fmt.Errorf("warm adopt failed: %w", err)
 	}
@@ -206,6 +213,23 @@ func (d *Driver) destroyParked(ctx context.Context, slot *containerdpool.ParkedS
 	if pl, ok := slot.Handle.(*dockerpkg.ParkedListener); ok {
 		dockerpkg.RemoveParkSocket(pl.HostSocketPath())
 	}
+	// Release the prepaid netns slot the park held (keyed by the park slot id,
+	// which equals ContainerID for a parked container). Without this, every park
+	// teardown — LRU/stale-image evict, idle-TTL reap, shutdown drain, boot
+	// PurgeParkedContainers — permanently leaks a netns slot (row stays adopted
+	// under the dead park id, plus its veth/IPAM lease/conntrack) until the pool
+	// exhausts and cold creates fail with "provision netns: no free slot".
+	// Release is idempotent and a no-op if the slot was already reassigned to an
+	// adopting sandbox.
+	if d.netns != nil {
+		parkKey := strings.TrimSpace(slot.ID)
+		if parkKey == "" {
+			parkKey = strings.TrimSpace(slot.ContainerID)
+		}
+		if parkKey != "" {
+			_ = d.netns.Release(ctx, parkKey)
+		}
+	}
 	if slot.ContainerID != "" {
 		client, err := d.ensureClient()
 		if err != nil {
@@ -214,6 +238,11 @@ func (d *Driver) destroyParked(ctx context.Context, slot *containerdpool.ParkedS
 		container, err := client.LoadContainer(ctx, slot.ContainerID)
 		if err != nil {
 			return err
+		}
+		// Release the image lease the park pinned, or GC can never reclaim the
+		// pinned layers (mirror Destroy's release).
+		if labels, lerr := container.Labels(ctx); lerr == nil {
+			d.releaseImageLease(ctx, client, labels)
 		}
 		if task, taskErr := container.Task(ctx, nil); taskErr == nil {
 			_ = task.Kill(ctx, syscall.SIGKILL)

--- a/internal/runtime/containerd/warm_park.go
+++ b/internal/runtime/containerd/warm_park.go
@@ -137,6 +137,7 @@ func (d *Driver) parkContainer(ctx context.Context, slotID string, key container
 		container cntr.Container
 		task      cntr.Task
 		logCloser func()
+		leaseID   string
 	)
 	committed := false
 	defer func() {
@@ -152,6 +153,12 @@ func (d *Driver) parkContainer(ctx context.Context, slotID string, key container
 		_ = pl.Close()
 		if netnsProvisioned && d.netns != nil {
 			_ = d.netns.Release(ctx, slotID)
+		}
+		// The park pins an image lease before NewContainer; release it on any
+		// non-committed exit or the pinned layers never GC (same orphan class the
+		// cold path's lease defer fixes).
+		if leaseID != "" {
+			d.releaseImageLease(ctx, client, map[string]string{imageLeaseLabelKey: leaseID})
 		}
 	}()
 
@@ -186,9 +193,11 @@ func (d *Driver) parkContainer(ctx context.Context, slotID string, key container
 		managedLabelKey:  "true",
 		poolParkLabelKey: poolParkLabelValue,
 	}
-	if leaseID, err := d.pinImageLease(ctx, client, image); err != nil {
+	leaseID, err = d.pinImageLease(ctx, client, image)
+	if err != nil {
 		return nil, err
-	} else if leaseID != "" {
+	}
+	if leaseID != "" {
 		labels[imageLeaseLabelKey] = leaseID
 	}
 	containerOpts := []cntr.NewContainerOpts{

--- a/pkg/daemon/container_engine_wiring.go
+++ b/pkg/daemon/container_engine_wiring.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/aerol-ai/microvm/internal/config"
 	cntr "github.com/aerol-ai/microvm/internal/runtime/containerd"
@@ -43,6 +44,7 @@ func wireContainerEngine(ctx context.Context, cfg config.Config, logger *slog.Lo
 	if err := ctdRules.EnsureChain(); err != nil {
 		return nil, fmt.Errorf("bootstrap AEROLVM-USER chain: %w", err)
 	}
+	reassertStop := startChainReassert(ctx, ctdRules, logger)
 	driver := cntr.New(cntr.FromDaemonConfig(cfg), ctdRules, logger)
 	netnsPool, err := wireContainerdNativeNetnsPool(ctx, cfg, logger, st, driver)
 	if err != nil {
@@ -61,7 +63,34 @@ func wireContainerEngine(ctx context.Context, cfg config.Config, logger *slog.Lo
 		"netrules_chain", netrules.ChainAerolvmUser,
 	)
 	cntr.PublishEngineTag(models.ContainerEngineContainerd)
-	return &containerdEngineWiring{netns: netnsPool, warm: warmPool, driver: driver, logger: logger}, nil
+	return &containerdEngineWiring{netns: netnsPool, warm: warmPool, driver: driver, logger: logger, stopReassert: reassertStop}, nil
+}
+
+// startChainReassert periodically re-asserts the AEROLVM-USER chain + FORWARD
+// jump. A dockerd restart on a coexistence host can flush/reorder FORWARD and
+// drop our jump; re-assertion (idempotent) restores it without waiting for a
+// sandboxd restart (plan §4 item #5). Returns a cancel func the wiring calls on
+// shutdown.
+func startChainReassert(ctx context.Context, rules *netrules.Manager, logger *slog.Logger) func() {
+	if rules == nil {
+		return func() {}
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	go func() {
+		t := time.NewTicker(30 * time.Second)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				if err := rules.ReassertChain(); err != nil {
+					logger.Warn("re-assert AEROLVM-USER chain failed", "error", err)
+				}
+			}
+		}
+	}()
+	return cancel
 }
 
 // multiEventsSource fans in dockerd and containerd event streams during

--- a/pkg/daemon/containerd_netns_wiring.go
+++ b/pkg/daemon/containerd_netns_wiring.go
@@ -44,6 +44,17 @@ func wireContainerdNativeNetnsPool(ctx context.Context, cfg config.Config, logge
 	if err := pool.Seed(ctx, netns.SeedConfig{PoolSize: cfg.ContainerdNetnsPoolDepth}, now); err != nil {
 		return nil, fmt.Errorf("seed containerd netns pool: %w", err)
 	}
+	// Generate the bridge+host-local conflist (bridge, IPAM, outbound NAT) if
+	// absent — nothing else ships it, and without it the first CNI ADD fails on
+	// a missing conf. Size the bridge MTU to the host uplink so egress isn't
+	// throughput-capped (jumbo uplink) or blackholed via PMTUD (sub-1500 uplink).
+	if err := cni.EnsureBridgeConflist(cfg.ContainerdCNIConfPath, cni.ConflistOptions{
+		Name:   "aerolvm",
+		Bridge: "aerolvm0",
+		MTU:    cni.UplinkMTU(),
+	}); err != nil {
+		return nil, fmt.Errorf("ensure cni conflist: %w", err)
+	}
 	runner, err := cni.NewExecRunner(cni.Config{
 		PluginDir: cfg.ContainerdCNIPluginDir,
 		ConfPath:  cfg.ContainerdCNIConfPath,

--- a/pkg/daemon/containerd_warm_wiring.go
+++ b/pkg/daemon/containerd_warm_wiring.go
@@ -16,15 +16,19 @@ import (
 // containerdEngineWiring holds containerd-only background workers torn down on
 // daemon shutdown.
 type containerdEngineWiring struct {
-	netns  *containerdNetnsPool
-	warm   *containerdpool.Pool
-	driver *cntr.Driver
-	logger *slog.Logger
+	netns        *containerdNetnsPool
+	warm         *containerdpool.Pool
+	driver       *cntr.Driver
+	logger       *slog.Logger
+	stopReassert func()
 }
 
 func (w *containerdEngineWiring) Stop() {
 	if w == nil {
 		return
+	}
+	if w.stopReassert != nil {
+		w.stopReassert()
 	}
 	if w.netns != nil {
 		w.netns.Stop()

--- a/pkg/docker/netrules/ensure_chain.go
+++ b/pkg/docker/netrules/ensure_chain.go
@@ -1,5 +1,7 @@
 package netrules
 
+import "fmt"
+
 // EnsureChain bootstraps the filter user chain and its FORWARD jump once per
 // Manager lifetime. Idempotent and latched like EnsureLayer4Ready: concurrent
 // callers single-flight through chainMu; success sets chainReady.
@@ -17,10 +19,13 @@ func (m *Manager) EnsureChain() error {
 	}
 	boot, ok := m.ipt.(bootstrapBackend)
 	if !ok {
-		// Netlink backend on docker-only hosts targets an existing DOCKER-USER;
-		// containerd-only bootstrap lands with the netlink chain path in Phase 5.
-		m.chainReady.Store(true)
-		return nil
+		// Fail loud, never silently latch success. A backend that cannot create
+		// the user chain + FORWARD jump means every per-IP egress rule the driver
+		// later inserts is either rejected (missing chain) or never traversed
+		// (missing jump) — i.e. requested isolation silently fails. Both shipped
+		// backends (exec, netlink) implement bootstrapBackend; this guards against
+		// a future backend regressing the contract.
+		return fmt.Errorf("netrules: backend %T cannot bootstrap the %s chain; containerd egress isolation would be silently ineffective", m.ipt, m.filterChain())
 	}
 	chain := m.filterChain()
 	if err := boot.EnsureUserChain(chain); err != nil {
@@ -31,6 +36,25 @@ func (m *Manager) EnsureChain() error {
 	}
 	m.chainReady.Store(true)
 	return nil
+}
+
+// ReassertChain re-runs the chain + FORWARD-jump bootstrap WITHOUT the latch, so
+// a caller (e.g. the containerd netns reconcile ticker) can re-assert the jump
+// after a dockerd restart flushes/reorders FORWARD and drops it. Both steps are
+// idempotent; a no-op when disabled or the backend cannot bootstrap.
+func (m *Manager) ReassertChain() error {
+	if m == nil || !m.Enabled() {
+		return nil
+	}
+	boot, ok := m.ipt.(bootstrapBackend)
+	if !ok {
+		return nil
+	}
+	chain := m.filterChain()
+	if err := boot.EnsureUserChain(chain); err != nil {
+		return err
+	}
+	return boot.EnsureForwardJump(chain)
 }
 
 // ResetChainLatch clears the bootstrap latch. Test-only seam.

--- a/pkg/docker/netrules/ensure_chain_test.go
+++ b/pkg/docker/netrules/ensure_chain_test.go
@@ -113,3 +113,51 @@ func TestEnsureChainPropagatesBootstrapErrors(t *testing.T) {
 		t.Fatal("want jump error")
 	}
 }
+
+// ruleOnlyBackend implements RuleBackend but NOT bootstrapBackend — modeling a
+// backend that can insert per-IP rules but cannot create the user chain or its
+// FORWARD jump.
+type ruleOnlyBackend struct{}
+
+func (ruleOnlyBackend) Exists(string, string, ...string) (bool, error) { return false, nil }
+func (ruleOnlyBackend) Insert(string, string, int, ...string) error    { return nil }
+func (ruleOnlyBackend) Delete(string, string, ...string) error         { return nil }
+
+// TestEnsureChainFailsLoudOnNonBootstrapBackend is the regression for the
+// silent-latch trap: a backend that cannot bootstrap must make EnsureChain
+// return an error and NOT latch success (which would leave every per-IP egress
+// rule ineffective while reporting the chain "ready").
+func TestEnsureChainFailsLoudOnNonBootstrapBackend(t *testing.T) {
+	mgr := &Manager{enabled: true, ipt: ruleOnlyBackend{}, userChain: ChainAerolvmUser}
+	if err := mgr.EnsureChain(); err == nil {
+		t.Fatal("want error: non-bootstrap backend must not silently succeed")
+	}
+	if mgr.chainReady.Load() {
+		t.Fatal("must not latch success when the chain was never created")
+	}
+}
+
+// TestReassertChainReappliesJump proves re-assertion re-creates the chain and
+// jump after they are dropped (simulating a dockerd restart that flushed
+// FORWARD), without relying on the one-shot latch.
+func TestReassertChainReappliesJump(t *testing.T) {
+	be := &memBackend{}
+	mgr := &Manager{enabled: true, ipt: be, userChain: ChainAerolvmUser}
+	if err := mgr.EnsureChain(); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate dockerd flushing FORWARD + our chain.
+	be.reset()
+	if be.hasChain(ChainAerolvmUser) {
+		t.Fatal("precondition: chain should be gone after reset")
+	}
+	if err := mgr.ReassertChain(); err != nil {
+		t.Fatalf("ReassertChain: %v", err)
+	}
+	if !be.hasChain(ChainAerolvmUser) {
+		t.Fatal("ReassertChain must recreate the chain even after the latch is set")
+	}
+	if got := be.countMatching("|FORWARD|-j|" + ChainAerolvmUser); got != 1 {
+		t.Fatalf("forward jump not re-asserted: %d", got)
+	}
+}

--- a/pkg/docker/netrules/manager_test.go
+++ b/pkg/docker/netrules/manager_test.go
@@ -266,6 +266,15 @@ func (m *memBackend) hasChain(chain string) bool {
 	return m.chains != nil && m.chains[chain]
 }
 
+// reset clears all rules and chains, modeling a dockerd restart that flushes
+// FORWARD and drops our chain/jump.
+func (m *memBackend) reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rules = nil
+	m.chains = nil
+}
+
 type errNoMatch struct{}
 
 func (errNoMatch) Error() string { return "No chain/target/match by that name." }

--- a/pkg/docker/netrules/netlink_backend.go
+++ b/pkg/docker/netrules/netlink_backend.go
@@ -7,15 +7,18 @@ import (
 	"syscall"
 
 	"github.com/google/nftables"
+	"github.com/google/nftables/expr"
 )
 
 // nftAPI is the Conn surface netlinkBackend needs. *nftables.Conn satisfies
-// it; tests inject a fake so Exists/Insert/Delete are covered without
+// it; tests inject a fake so Exists/Insert/Delete/bootstrap are covered without
 // CAP_NET_ADMIN or a live nftables socket.
 type nftAPI interface {
 	GetRules(t *nftables.Table, c *nftables.Chain) ([]*nftables.Rule, error)
 	InsertRule(r *nftables.Rule) *nftables.Rule
 	DelRule(r *nftables.Rule) error
+	ListChains() ([]*nftables.Chain, error)
+	AddChain(c *nftables.Chain) *nftables.Chain
 	Flush() error
 }
 
@@ -137,6 +140,89 @@ func (b *netlinkBackend) Delete(table, chain string, rulespec ...string) error {
 		return nil
 	}
 	return syscall.ENOENT
+}
+
+// EnsureUserChain creates the regular filter chain (e.g. AEROLVM-USER) if it is
+// absent, in the iptables-nft compat `ip filter` table so `iptables -L` lists
+// it and the Manager's per-IP DROP/ACCEPT rules land there. Idempotent: an
+// existing chain (including a docker-created DOCKER-USER) is a no-op.
+//
+// NOTE: exercised offline only against the fake nftAPI (chain-exists idempotency
+// + AddChain-on-absent). Live nftables realization requires CAP_NET_ADMIN and is
+// covered by the containerd integration suite, not `make test`.
+func (b *netlinkBackend) EnsureUserChain(chain string) error {
+	tbl, _, err := lookupTableChain("filter", chain)
+	if err != nil {
+		return err
+	}
+	if chain == "" {
+		return fmt.Errorf("ensure user chain: empty chain name")
+	}
+	conn, err := b.newConn()
+	if err != nil {
+		return err
+	}
+	chains, err := conn.ListChains()
+	if err != nil {
+		return fmt.Errorf("nft list chains: %w", err)
+	}
+	for _, c := range chains {
+		if c != nil && c.Name == chain && c.Table != nil &&
+			c.Table.Name == tbl.Name && c.Table.Family == tbl.Family {
+			return nil
+		}
+	}
+	conn.AddChain(&nftables.Chain{Name: chain, Table: tbl})
+	if err := conn.Flush(); err != nil {
+		return fmt.Errorf("nft add chain %s: %w", chain, err)
+	}
+	return nil
+}
+
+// EnsureForwardJump inserts a `-j <userChain>` verdict at the top of the FORWARD
+// base chain if absent, so bridged sandbox↔sandbox and egress traffic traverses
+// our chain. Idempotent: an existing jump to userChain is a no-op. Re-runnable
+// (see Manager.ReassertChain) because a dockerd restart can flush/reorder
+// FORWARD and drop the jump.
+//
+// NOTE: same offline-coverage caveat as EnsureUserChain.
+func (b *netlinkBackend) EnsureForwardJump(userChain string) error {
+	tbl, _, err := lookupTableChain("filter", userChain)
+	if err != nil {
+		return err
+	}
+	if userChain == "" {
+		return fmt.Errorf("ensure forward jump: empty chain name")
+	}
+	fwd := &nftables.Chain{Name: "FORWARD", Table: tbl}
+	conn, err := b.newConn()
+	if err != nil {
+		return err
+	}
+	rules, err := conn.GetRules(tbl, fwd)
+	if err != nil {
+		return fmt.Errorf("nft get FORWARD rules: %w", err)
+	}
+	for _, r := range rules {
+		for _, e := range r.Exprs {
+			if v, ok := e.(*expr.Verdict); ok && v.Kind == expr.VerdictJump && v.Chain == userChain {
+				return nil
+			}
+		}
+	}
+	// Counter before verdict mirrors iptables-nft's rule shape (see translator).
+	conn.InsertRule(&nftables.Rule{
+		Table: tbl,
+		Chain: fwd,
+		Exprs: []expr.Any{
+			&expr.Counter{},
+			&expr.Verdict{Kind: expr.VerdictJump, Chain: userChain},
+		},
+	})
+	if err := conn.Flush(); err != nil {
+		return fmt.Errorf("nft insert FORWARD jump to %s: %w", userChain, err)
+	}
+	return nil
 }
 
 func lookupTableChain(table, chain string) (*nftables.Table, *nftables.Chain, error) {

--- a/pkg/docker/netrules/netlink_backend_test.go
+++ b/pkg/docker/netrules/netlink_backend_test.go
@@ -12,12 +12,14 @@ import (
 )
 
 type fakeNFT struct {
-	rules    []*nftables.Rule
-	getErr   error
-	flushErr error
-	delErr   error
-	inserted []*nftables.Rule
-	deleted  []*nftables.Rule
+	rules      []*nftables.Rule
+	chains     []*nftables.Chain
+	getErr     error
+	flushErr   error
+	delErr     error
+	inserted   []*nftables.Rule
+	deleted    []*nftables.Rule
+	addedChain []*nftables.Chain
 }
 
 func (f *fakeNFT) GetRules(*nftables.Table, *nftables.Chain) ([]*nftables.Rule, error) {
@@ -53,7 +55,71 @@ func (f *fakeNFT) DelRule(r *nftables.Rule) error {
 	return nil
 }
 
+func (f *fakeNFT) ListChains() ([]*nftables.Chain, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	out := make([]*nftables.Chain, len(f.chains))
+	copy(out, f.chains)
+	return out, nil
+}
+
+func (f *fakeNFT) AddChain(c *nftables.Chain) *nftables.Chain {
+	f.addedChain = append(f.addedChain, c)
+	f.chains = append(f.chains, c)
+	return c
+}
+
 func (f *fakeNFT) Flush() error { return f.flushErr }
+
+// TestNetlinkEnsureUserChainIdempotent covers the C1 bootstrap logic offline:
+// AddChain on an absent chain, no-op when it already exists. (Live nftables
+// realization is integration-only.)
+func TestNetlinkEnsureUserChainIdempotent(t *testing.T) {
+	fake := &fakeNFT{}
+	b := testNetlinkBackend(fake)
+	if err := b.EnsureUserChain(ChainAerolvmUser); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.addedChain) != 1 {
+		t.Fatalf("chain not created on first call: added=%d", len(fake.addedChain))
+	}
+	if err := b.EnsureUserChain(ChainAerolvmUser); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.addedChain) != 1 {
+		t.Fatalf("chain must not be re-created when present: added=%d", len(fake.addedChain))
+	}
+}
+
+func TestNetlinkEnsureForwardJumpIdempotent(t *testing.T) {
+	fake := &fakeNFT{}
+	b := testNetlinkBackend(fake)
+	if err := b.EnsureForwardJump(ChainAerolvmUser); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.inserted) != 1 {
+		t.Fatalf("jump not inserted on first call: %d", len(fake.inserted))
+	}
+	// InsertRule mirrors the jump into f.rules, so the second call sees it.
+	if err := b.EnsureForwardJump(ChainAerolvmUser); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.inserted) != 1 {
+		t.Fatalf("jump must not be duplicated: %d", len(fake.inserted))
+	}
+	found := false
+	for _, r := range fake.inserted {
+		for _, e := range r.Exprs {
+			if v, ok := e.(*expr.Verdict); ok && v.Kind == expr.VerdictJump && v.Chain == ChainAerolvmUser {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatal("inserted FORWARD rule is not a jump to the user chain")
+	}
+}
 
 // testNetlinkBackend wires a backend whose per-op connection factory always
 // hands back the same fake, so tests can assert on its recorded calls.

--- a/setup/config-defaults.md
+++ b/setup/config-defaults.md
@@ -56,6 +56,15 @@ feature is still mid-rollout.
 | `SB_CONTAINERD_NAMESPACE` | containerd namespace for aerolvm-managed workloads; default `aerolvm` (dockerd uses `moby`, so both engines coexist on one system containerd during migration). |
 | `SB_CONTAINERD_RUN_DIR` | Host workdir for per-sandbox generated files (resolv.conf, hosts, hostname) and task logs; default `/var/lib/sandboxd/containerd`. |
 | `SB_CONTAINERD_LOG_DIR` | Overrides per-task log file placement; defaults to `${SB_CONTAINERD_RUN_DIR}/logs`. Each task log is size-capped (containerd does not rotate task IO). |
+| `SB_CONTAINERD_CNI_PLUGIN_DIR` | CNI plugin binaries dir; default `/opt/cni/bin`. Only consumed when the native netns pool is enabled. |
+| `SB_CONTAINERD_CNI_CONF_PATH` | Bridge conflist path; default `/etc/cni/net.d/aerolvm.conflist`. Auto-generated at boot (bridge + host-local + `ipMasq`) if absent; an operator-provided file is never clobbered. |
+| `SB_CONTAINERD_NETNS_POOL_DEPTH` | Prepaid netns slots to keep warm; default `4`. Only relevant when `SB_CONTAINERD_NATIVE_NETNS_POOL_ENABLED=true`. |
+| `SB_CONTAINERD_NETNS_POOL_REFILL_INTERVAL` | netns pool refill ticker; default `2s`. |
+| `SB_CONTAINERD_POOL_DEPTH` | Warm containers per image key; default `2`. Only relevant when `SB_CONTAINERD_POOL_ENABLED=true`. |
+| `SB_CONTAINERD_POOL_IMAGES` | Comma-separated image allowlist to pre-warm; default empty. |
+| `SB_CONTAINERD_POOL_MAX_IMAGES` | Cap on distinct warm image keys; default `8`. |
+| `SB_CONTAINERD_POOL_IDLE_TTL` | Idle eviction TTL for warm slots; default `15m`. |
+| `SB_CONTAINERD_POOL_REFILL_INTERVAL` | containerd warm-pool refill ticker; default `5s`. |
 | `SB_ENABLE_CLUSTER` | Opt-in; cluster code must be a no-op when false. |
 | `SB_CLUSTER_BOOTSTRAP` | Single-seed cluster bring-up only. |
 | `SB_CLUSTER_SHARD_AWARE_INGRESS` | Cluster ingress topology. |
@@ -84,6 +93,8 @@ via Terraform/Ansible — do not flip the code default on.
 | `SB_FIRECRACKER_VMM_POOL_ENABLED` | Fully wired: daemon runs the refill goroutine + `Driver.SetWarmPool`, and `Driver.Create.tryAcquireWarm` consumes warm VMMs. Kept default-off **ship-dark** — code-complete but no benchmark gate in `plans/firecracker-create-latency.md` re-measured yet. Do not flip until those gates pass. |
 | `SB_HTTP_WAKE_DIRECT_BYPASS_ENABLED` | Being canaried (`plans/warm-direct-route-bypass.md`). |
 | `SB_L4_WAKE_DIRECT_BYPASS_ENABLED` | Ships only after HTTP has been default-on for two cycles. |
+| `SB_CONTAINERD_NATIVE_NETNS_POOL_ENABLED` | Turns on Phase-2 CNI container networking for the containerd engine (netns pool + CNI ADD/DEL + `AEROLVM-USER` chain). Default-off **ship-dark**; gated on the `plans/containerd-engine.md` §8 exit gates (neighbor isolation, orphan=0, live bench). Requires `SB_CONTAINER_ENGINE=containerd` + CNI plugin binaries. Do not flip until those gates pass on the containerd integration topology. |
+| `SB_CONTAINERD_POOL_ENABLED` | Turns on the Phase-3 containerd warm-container pool (rename-free park/adopt). Default-off **ship-dark**; also widens the ready-socket gate like `SB_DOCKER_POOL_ENABLED`. Requires `SB_CONTAINER_ENGINE=containerd` + `SB_DOCKER_READY_SOCKET_ENABLED=true`. Gated on the §8 warm-hit bench. |
 
 ## ⚪ Boot-path tuning — intentionally off
 | Env var | Why |


### PR DESCRIPTION
## Summary

Fixes idempotency, teardown-leak, and live-host networking bugs in the **dark** containerd engine (`SB_CONTAINER_ENGINE=containerd`). The docker default path is untouched.

- **Create / adopt / park teardown (pr-review §1 / §4):** `lostRace` guards netns release so concurrent-duplicate Create no longer tears down the winner's netns; solo failures clean up their own host files / ready socket / netns / image lease instead of leaking; `destroyParked` releases prepaid netns + lease; TaskPaused no longer maps to `"stop"`.
- **Netrules + push:** netlink backend actually bootstraps AEROLVM-USER + FORWARD jump (no silent latch); 30s `ReassertChain` ticker recovers after dockerd flush; push treats AlreadyExists as success and scopes creds to one registry host.
- **Live CNI / netns / snapshot:** CNI exec protocol (env + stdin), real `ip netns add` (not a directory), auto-generated conflist + uplink MTU, br_netfilter fail-loud, bidirectional conntrack flush, real OCI snapshot manifest; Terraform bootstrap installs CNI plugins on containerd nodes.

## Code-path diagram

### Create failure / race cleanup (before → after)

```mermaid
flowchart TD
  Start[Create sandbox] --> Pin[pinImageLease]
  Pin --> Claim[Claim / Provision netns slot]
  Claim --> NewC[NewContainer]
  NewC -->|AlreadyExists| Race[lostRace = true]
  NewC -->|other err / pre-NewContainer fail| Solo[solo failure]
  NewC -->|ok| Commit[commit: keep lease + netns]

  Race --> Skip["AFTER: skip netns / host-file / lease teardown<br/>BEFORE: unguarded netns defer killed winner"]
  Solo --> Reap["AFTER: release own lease + netns + host files + ready sock<br/>BEFORE: leaked for boot-reconcile"]
  Commit --> Done[return sandbox]

  ParkFail[park create fail / destroyParked] --> ParkReap["AFTER: release prepaid netns + image lease<br/>BEFORE: leaked until pool / GC exhaustion"]
```

### Netrules chain bootstrap + re-assert (containerd coexistence)

```mermaid
flowchart LR
  Boot[daemon wireContainerEngine] --> Ensure[EnsureChain]
  Ensure -->|netlink lacked bootstrap| Bad["BEFORE: latch success, no chain/jump"]
  Ensure -->|now| OK["AFTER: EnsureUserChain + EnsureForwardJump via nft"]
  Boot --> Tick[30s ReassertChain ticker]
  Tick --> Flush["dockerd restart flushed FORWARD"]
  Flush --> Re["AFTER: recreate chain + jump unlatched<br/>BEFORE: silent egress fail-open until sandboxd restart"]
```

### CNI ADD / netns Realize (live path)

```mermaid
sequenceDiagram
  participant Create as containerd Create
  participant Host as netns.Host
  participant CNI as cni.ExecRunner
  participant Plugin as bridge plugin

  Create->>Host: Realize(slot)
  Note over Host: BEFORE: os.MkdirAll /run/netns/id<br/>AFTER: ip netns add id
  Create->>CNI: ADD(netns, conflist)
  Note over CNI: BEFORE: positional argv, no stdin<br/>AFTER: CNI_* env + netconf on stdin
  CNI->>Plugin: exec bridge
  Plugin-->>CNI: result / error JSON on stdout
  Note over CNI: AFTER: surface stdout on failure<br/>(was empty "exit status 1:")
```

## Sandbox boot impact

**Yes — containerd Create path only** (`SB_CONTAINER_ENGINE=containerd`). Docker CreateSandbox unchanged.

| Addition | When | Expected cost | Bounded? |
|---|---|---|---|
| Real `ip netns add` (was mkdir) | Every unrealized netns Realize | one `ip` exec + netns create | yes — single syscall path |
| CNI ADD with correct wire protocol | Every Realize that needs CNI | one plugin exec (was already intended; previously always failed) | yes |
| `pinImageLease` + deferred release on non-commit | Every Create / park create | containerd lease RPC | yes; 24h expiration backstop if daemon crashes mid-create |
| Provision fall-through Build when owned slot unrealized | Crash-left reserved/empty slot | one Build instead of false "ready" hit | yes — rare recovery path |
| Start/resume: size-capped `taskLogIO` | Resume only | same as create IO setup | yes — prevents unbounded log growth |

**Daemon-start / background (not per-Create hot path, but first-use adjacent):**

- Conflist auto-generate at containerd netns wiring if absent (one-shot file write; MTU probe via `/proc/net/route` on linux).
- `EnsureForwardingSysctls` (modprobe br_netfilter + verify sysctls) on engine wire.
- `EnsureChain` netlink bootstrap on engine wire; **30s `ReassertChain` ticker** (pr-review §3-shaped recovery for dockerd coexistence — unlatched, idempotent; not on CreateSandbox itself).

## Idempotency

All surfaces below are behind `SB_CONTAINER_ENGINE=containerd` unless noted.

| Surface | Retry / concurrent duplicate |
|---|---|
| **Create** | AlreadyExists → `lostRace=true`: return existing / do **not** tear down winner netns/host files. Solo failure releases **this** attempt's lease + netns + host files. Retry of same id is safe (no double CNI DEL on winner). |
| **Push** (`ImageService.Create`) | AlreadyExists treated as success (concurrent-duplicate idempotent). Creds scoped to one resolved registry host — hostless dest without `auth.Server` refuses rather than broadcasting. |
| **EnsureChain / ReassertChain** | Idempotent create of AEROLVM-USER + FORWARD jump; re-assert safe under ticker + concurrent callers. |
| **CNI conflist write** | No-clobber if file already present. |
| **destroyParked / adoptParked fail** | Releases prepaid netns + lease / sandbox-id slot so retry does not exhaust the pool. |
| **Events** | TaskPaused / TaskResumed ignored (match docker); CreateSnapshot pause no longer folds into `markSandboxStopped`. |

Docker path / public HTTP API shapes: unchanged.

## Failure-path consistency

No new caddy + store multi-step write. Containerd create/park multi-step resource ownership:

| Step that fails | Rollback rule |
|---|---|
| After lease pin, before commit | Release **this** attempt's image lease (was: only Destroy released → leak). |
| After netns claim, solo Create fail (incl. pre-NewContainer) | Release **this** netns slot + host files + ready socket (was: leaked for reconcile). |
| AlreadyExists race | **Do not** release winner's netns/host files (`lostRace`). |
| Park create fail / `destroyParked` | Release prepaid netns + pinned lease (was: leaked until pool exhaustion). |
| `adoptParked` fail after `ReassignOwner` | Release sandbox-id slot. |
| CNI DEL on Remove | Surface error via `errors.Join` (was: swallowed → veth + host-local IPAM lease leak). |
| EnsureChain when backend cannot bootstrap | Return error — **no** silent success latch (was: chain "ready" with nothing created). |
| br_netfilter / bridge-nf sysctl | Fail loud if verify fails (was: silent fail-open neighbor isolation). |

Reconcile remains the safety net for daemon-crash mid-create; routine failures no longer rely on it (pr-review §4).

## L4 / host-port-pool changes

**N/A — neither TCP host-port pool nor L4 latch touched.**

**Analogous fragile allocator (netns pool):** concurrent `Reserve` for the same sandbox on separate `*Store` handles covered in `internal/network/netns/reassign_reconcile_test.go` (partial unique index / double-allocation regression — same class of rule as pr-review §6 for `host_port`). Also: Provision ready-hit only when realized (path + IP); unrealized owned slot falls through to Build.

## Mount inputs / cluster

- **Mounts (pr-review §5):** N/A — no mount field / host-command surface changed.
- **Cluster (pr-review §7):** N/A — no Raft/SWIM/forwarding/placement change; single-node and cluster-off behavior unchanged. Containerd engine remains opt-in dark.

## Test plan

- [x] Offline unit regressions: AlreadyExists loser preserves winner netns/host-files + releases own lease; pre-NewContainer solo failure reaps; destroyParked releases netns + lease; TaskPaused/TaskResumed ignored
- [x] netrules: non-bootstrap backend fails loud; `ReassertChain` after simulated dockerd flush; netlink EnsureUserChain/EnsureForwardJump idempotency (fake nftAPI)
- [x] CNI: exec-protocol conformance (CNI_* + stdin); conflist render (ipMasq, MTU, subnet) + no-clobber; br_netfilter fail-loud; conntrack both directions
- [x] snapshot: manifest + config assembly with `gc.ref` labels
- [x] netns: concurrent Reserve partial-unique-index regression; ReassignOwner; Provision unrealized fall-through; Host Realize/Remove error paths
- [x] `pushCredScopeHost` table; containerdpool `ParkReservationID`
- [x] Live: `make integration-single-containerd` on t3.medium — real netns + bridge allocates IP (`10.88.0.2`); conflist uplink MTU 9001; br_netfilter; AEROLVM-USER + FORWARD jump present
- [ ] Still least-soaked: live CreateSnapshot → run / push round-trip (finding D2)
- [ ] Docker default path smoke (sanity that engine switch did not regress)