### PR TITLE
fix(containerd): CNI_ARGS IgnoreUnknown + bootstrap uname escaping (live-validated)

### DIFF
--- a/Terraform/templates/bootstrap.sh.tftpl
+++ b/Terraform/templates/bootstrap.sh.tftpl
@@ -655,10 +655,10 @@ sudo tee -a /etc/sandboxd/cluster.env < /tmp/aerolvm-ops.env >/dev/null
 if [ "${container_engine}" = "containerd" ]; then
   cni_dir="${containerd_cfg.cni_plugin_dir}"
   if [ ! -x "$${cni_dir}/bridge" ]; then
-    case "$$(uname -m)" in
+    case "$(uname -m)" in
       x86_64|amd64) cni_arch=amd64 ;;
       aarch64|arm64) cni_arch=arm64 ;;
-      *) echo "[bootstrap] unsupported arch $$(uname -m) for CNI plugins" >&2; exit 1 ;;
+      *) echo "[bootstrap] unsupported arch $(uname -m) for CNI plugins" >&2; exit 1 ;;
     esac
     cni_ver=v1.5.1
     cni_url="https://github.com/containernetworking/plugins/releases/download/$${cni_ver}/cni-plugins-linux-$${cni_arch}-$${cni_ver}.tgz"

--- a/internal/network/cni/cni.go
+++ b/internal/network/cni/cni.go
@@ -111,7 +111,12 @@ func (r *ExecRunner) runPlugin(ctx context.Context, cmd, netnsPath, containerID 
 	if ifName == "" {
 		ifName = "eth0"
 	}
-	cniArgs := fmt.Sprintf("K8S_POD_NAMESPACE=aerolvm;K8S_POD_NAME=%s;K8S_POD_INFRA_CONTAINER_ID=%s", containerID, containerID)
+	// IgnoreUnknown=true is mandatory: plugins parse CNI_ARGS via types.LoadArgs,
+	// which ERRORS on any key it does not define ("unknown args [...]"). The
+	// bridge/host-local plugins do not define the K8S_POD_* keys, so without this
+	// prefix every ADD fails with code 999. Kubernetes passes IgnoreUnknown=1 for
+	// exactly this reason.
+	cniArgs := fmt.Sprintf("IgnoreUnknown=true;K8S_POD_NAMESPACE=aerolvm;K8S_POD_NAME=%s;K8S_POD_INFRA_CONTAINER_ID=%s", containerID, containerID)
 	invoke := exec.CommandContext(ctx, plugin)
 	invoke.Stdin = bytes.NewReader(netconf)
 	invoke.Env = append(os.Environ(),

--- a/internal/network/cni/exec_runner_test.go
+++ b/internal/network/cni/exec_runner_test.go
@@ -24,6 +24,9 @@ func writeFakeCNIPlugin(t *testing.T, dir, pluginType, bodyADD string, exitCode 
 		"[ -n \"$CNI_COMMAND\" ] || { echo 'missing CNI_COMMAND' >&2; exit 3; }\n" +
 		"[ -n \"$CNI_CONTAINERID\" ] || { echo 'missing CNI_CONTAINERID' >&2; exit 3; }\n" +
 		"[ -n \"$CNI_NETNS\" ] || { echo 'missing CNI_NETNS' >&2; exit 3; }\n" +
+		// Real plugins reject unknown CNI_ARGS keys unless IgnoreUnknown is set;
+		// the K8S_POD_* keys we pass are unknown to bridge/host-local.
+		"case \"$CNI_ARGS\" in IgnoreUnknown=true*) ;; *) echo 'CNI_ARGS missing IgnoreUnknown=true' >&2; exit 3;; esac\n" +
 		"conf=$(cat)\n" +
 		"[ -n \"$conf\" ] || { echo 'empty stdin netconf' >&2; exit 3; }\n" +
 		"if [ \"$CNI_COMMAND\" = ADD ]; then printf '%s' '" + bodyADD + "'; fi\n" +


### PR DESCRIPTION
Two more defects found running the live single-node-containerd suite (behind `SB_CONTAINER_ENGINE=containerd`; docker path untouched).

1. **`cni.ExecRunner` CNI_ARGS missing `IgnoreUnknown=true`.** Plugins parse CNI_ARGS via `types.LoadArgs`, which errors on any key it doesn't define; bridge/host-local don't define the `K8S_POD_*` keys, so every ADD failed with `code 999: unknown args`. Now prepends `IgnoreUnknown=true` (as Kubernetes does). Manually verified: `bridge` ADD allocates `10.88.0.2/16`.
2. **`bootstrap.sh.tftpl` `$(uname -m)` escaping.** The CNI-install block used `$$(uname -m)`, but Terraform `templatefile` only collapses `$$` before `{`, so it rendered literally → the shell read `$$` as its PID → arch never matched → `exit 1` aborted the whole bootstrap *before* `systemctl restart sandboxd`. That single bug caused BOTH run-2 symptoms: no CNI plugins installed AND the daemon stuck on the docker engine (never restarted into the containerd env). One-char-class fix.

Together with v0.7.3 (real netns + stdout error surfacing), this should make a freshly-provisioned containerd node boot the engine, install CNI plugins, and create sandboxes on the aerolvm0 bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)