### PR TITLE
feat(containerd): real BuildKit builds + readiness Server-Timing + live fast-loop fixes

### DIFF
--- a/Terraform/templates/bootstrap.sh.tftpl
+++ b/Terraform/templates/bootstrap.sh.tftpl
@@ -655,10 +655,10 @@ sudo tee -a /etc/sandboxd/cluster.env < /tmp/aerolvm-ops.env >/dev/null
 if [ "${container_engine}" = "containerd" ]; then
   cni_dir="${containerd_cfg.cni_plugin_dir}"
   if [ ! -x "$${cni_dir}/bridge" ]; then
-    case "$$(uname -m)" in
+    case "$(uname -m)" in
       x86_64|amd64) cni_arch=amd64 ;;
       aarch64|arm64) cni_arch=arm64 ;;
-      *) echo "[bootstrap] unsupported arch $$(uname -m) for CNI plugins" >&2; exit 1 ;;
+      *) echo "[bootstrap] unsupported arch $(uname -m) for CNI plugins" >&2; exit 1 ;;
     esac
     cni_ver=v1.5.1
     cni_url="https://github.com/containernetworking/plugins/releases/download/$${cni_ver}/cni-plugins-linux-$${cni_arch}-$${cni_ver}.tgz"

--- a/Terraform/templates/bootstrap.sh.tftpl
+++ b/Terraform/templates/bootstrap.sh.tftpl
@@ -672,6 +672,49 @@ if [ "${container_engine}" = "containerd" ]; then
       fi
     done
   fi
+
+  # buildkitd powers image builds on the containerd engine (POST /v1/images/build
+  # + snapshot-from-Dockerfile). buildctl talks to buildkitd over its default
+  # socket (/run/buildkit/buildkitd.sock = SB_CONTAINERD_BUILDKIT_ADDR default);
+  # buildkitd's containerd worker writes built images into the aerolvm namespace
+  # so the driver runs them directly with no extra pull. docker-default nodes
+  # never reach here. Idempotent: install skipped when buildkitd already present.
+  if ! command -v buildkitd >/dev/null 2>&1; then
+    case "$(uname -m)" in
+      x86_64|amd64) bk_arch=amd64 ;;
+      aarch64|arm64) bk_arch=arm64 ;;
+      *) echo "[bootstrap] unsupported arch $(uname -m) for buildkit" >&2; exit 1 ;;
+    esac
+    bk_ver=v0.17.2
+    bk_url="https://github.com/moby/buildkit/releases/download/$${bk_ver}/buildkit-$${bk_ver}.linux-$${bk_arch}.tar.gz"
+    echo "[bootstrap] installing buildkit $${bk_ver} ($${bk_arch})"
+    bk_tmp="$(mktemp -d)"
+    curl -fsSL "$${bk_url}" | sudo tar -xz -C "$${bk_tmp}"
+    sudo install -m 0755 "$${bk_tmp}/bin/buildkitd" /usr/local/bin/buildkitd
+    sudo install -m 0755 "$${bk_tmp}/bin/buildctl" /usr/local/bin/buildctl
+    rm -rf "$${bk_tmp}"
+  fi
+  # containerd worker only (no oci worker), pinned to the aerolvm namespace + our
+  # containerd socket so builds share the driver's image store. Host networking
+  # for RUN steps avoids needing a separate buildkit CNI config.
+  if [ ! -f /etc/systemd/system/buildkit.service ]; then
+    sudo tee /etc/systemd/system/buildkit.service >/dev/null <<UNIT
+[Unit]
+Description=BuildKit (aerolvm containerd worker)
+Requires=containerd.service
+After=containerd.service
+
+[Service]
+ExecStart=/usr/local/bin/buildkitd --oci-worker=false --containerd-worker=true --containerd-worker-addr=${containerd_cfg.socket} --containerd-worker-namespace=${containerd_cfg.namespace} --containerd-worker-net=host
+Restart=on-failure
+Delegate=yes
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+    sudo systemctl daemon-reload
+  fi
+  sudo systemctl enable --now buildkit.service || echo "[bootstrap] warning: buildkit.service failed to start" >&2
 fi
 
 sudo systemctl restart sandboxd

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/containerd/containerd/api v1.8.0
 	github.com/containerd/platforms v0.2.1
 	github.com/containerd/typeurl/v2 v2.1.1
+	github.com/distribution/reference v0.6.0
 	github.com/google/nftables v0.3.0
 	github.com/hashicorp/raft-wal v0.4.2
 	github.com/opencontainers/go-digest v1.0.0
@@ -52,7 +53,6 @@ require (
 	github.com/coreos/etcd v3.3.27+incompatible // indirect
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
 	github.com/coreos/pkg v0.0.0-20220810130054-c7d1c02cb6cf // indirect
-	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -153,6 +153,11 @@ type Config struct {
 	ContainerdCNIPluginDir string
 	// ContainerdCNIConfPath is the bridge conflist used for ADD/DEL.
 	ContainerdCNIConfPath string
+	// ContainerdBuildKitAddr is the buildkitd control socket used for image
+	// builds on the containerd engine (buildctl --addr). The bootstrap installs
+	// buildkitd at the default socket with a containerd worker on the aerolvm
+	// namespace. SB_CONTAINERD_BUILDKIT_ADDR.
+	ContainerdBuildKitAddr string
 	// ContainerdNetnsPoolRefillInterval drives native netns pool refill.
 	ContainerdNetnsPoolRefillInterval time.Duration
 	// ContainerdPoolEnabled gates the warm containerd task pool (Phase 3).
@@ -1301,6 +1306,7 @@ func Load() (Config, error) {
 		ContainerdNetnsPoolDepth:          getEnvInt("SB_CONTAINERD_NETNS_POOL_DEPTH", 4),
 		ContainerdCNIPluginDir:            getEnv("SB_CONTAINERD_CNI_PLUGIN_DIR", "/opt/cni/bin"),
 		ContainerdCNIConfPath:             getEnv("SB_CONTAINERD_CNI_CONF_PATH", "/etc/cni/net.d/aerolvm.conflist"),
+		ContainerdBuildKitAddr:            getEnv("SB_CONTAINERD_BUILDKIT_ADDR", "unix:///run/buildkit/buildkitd.sock"),
 		ContainerdNetnsPoolRefillInterval: getEnvDuration("SB_CONTAINERD_NETNS_POOL_REFILL_INTERVAL", 2*time.Second),
 		ContainerdPoolEnabled:             getEnvBool("SB_CONTAINERD_POOL_ENABLED", false),
 		ContainerdPoolDepth:               getEnvInt("SB_CONTAINERD_POOL_DEPTH", 2),

--- a/internal/network/cni/cni.go
+++ b/internal/network/cni/cni.go
@@ -111,7 +111,12 @@ func (r *ExecRunner) runPlugin(ctx context.Context, cmd, netnsPath, containerID 
 	if ifName == "" {
 		ifName = "eth0"
 	}
-	cniArgs := fmt.Sprintf("K8S_POD_NAMESPACE=aerolvm;K8S_POD_NAME=%s;K8S_POD_INFRA_CONTAINER_ID=%s", containerID, containerID)
+	// IgnoreUnknown=true is mandatory: plugins parse CNI_ARGS via types.LoadArgs,
+	// which ERRORS on any key it does not define ("unknown args [...]"). The
+	// bridge/host-local plugins do not define the K8S_POD_* keys, so without this
+	// prefix every ADD fails with code 999. Kubernetes passes IgnoreUnknown=1 for
+	// exactly this reason.
+	cniArgs := fmt.Sprintf("IgnoreUnknown=true;K8S_POD_NAMESPACE=aerolvm;K8S_POD_NAME=%s;K8S_POD_INFRA_CONTAINER_ID=%s", containerID, containerID)
 	invoke := exec.CommandContext(ctx, plugin)
 	invoke.Stdin = bytes.NewReader(netconf)
 	invoke.Env = append(os.Environ(),

--- a/internal/network/cni/conflist.go
+++ b/internal/network/cni/conflist.go
@@ -7,6 +7,11 @@ import (
 	"path/filepath"
 )
 
+// DefaultBridgeSubnet is the host-local IPAM subnet for the aerolvm0 bridge.
+// Shared so the netrules FORWARD-accept rules target the same CIDR the conflist
+// hands out.
+const DefaultBridgeSubnet = "10.88.0.0/16"
+
 // ConflistOptions parameterizes the generated bridge+host-local conflist.
 type ConflistOptions struct {
 	Name    string // network name, e.g. "aerolvm"
@@ -55,7 +60,7 @@ func RenderBridgeConflist(opts ConflistOptions) ([]byte, error) {
 		opts.Bridge = "aerolvm0"
 	}
 	if opts.Subnet == "" {
-		opts.Subnet = "10.88.0.0/16"
+		opts.Subnet = DefaultBridgeSubnet
 	}
 	mtu := opts.MTU
 	if mtu <= 0 {

--- a/internal/network/cni/exec_runner_test.go
+++ b/internal/network/cni/exec_runner_test.go
@@ -24,6 +24,9 @@ func writeFakeCNIPlugin(t *testing.T, dir, pluginType, bodyADD string, exitCode 
 		"[ -n \"$CNI_COMMAND\" ] || { echo 'missing CNI_COMMAND' >&2; exit 3; }\n" +
 		"[ -n \"$CNI_CONTAINERID\" ] || { echo 'missing CNI_CONTAINERID' >&2; exit 3; }\n" +
 		"[ -n \"$CNI_NETNS\" ] || { echo 'missing CNI_NETNS' >&2; exit 3; }\n" +
+		// Real plugins reject unknown CNI_ARGS keys unless IgnoreUnknown is set;
+		// the K8S_POD_* keys we pass are unknown to bridge/host-local.
+		"case \"$CNI_ARGS\" in IgnoreUnknown=true*) ;; *) echo 'CNI_ARGS missing IgnoreUnknown=true' >&2; exit 3;; esac\n" +
 		"conf=$(cat)\n" +
 		"[ -n \"$conf\" ] || { echo 'empty stdin netconf' >&2; exit 3; }\n" +
 		"if [ \"$CNI_COMMAND\" = ADD ]; then printf '%s' '" + bodyADD + "'; fi\n" +

--- a/internal/runtime/containerd/buildkit.go
+++ b/internal/runtime/containerd/buildkit.go
@@ -1,0 +1,198 @@
+package containerd
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/aerol-ai/microvm/pkg/docker"
+)
+
+// DefaultBuildKitAddr is the buildkitd control socket the bootstrap installs.
+const DefaultBuildKitAddr = "unix:///run/buildkit/buildkitd.sock"
+
+// BuildKitBuilder builds images for the containerd engine by shelling out to
+// `buildctl` against a local buildkitd whose containerd worker writes into the
+// aerolvm namespace. It satisfies the same ImageBuilder seam as the dockerd
+// build path (BuildImage(ctx, docker.BuildImageRequest)), so the v1/daytona
+// build handlers work unchanged once the engine-gate is lifted.
+//
+// buildctl is used instead of the moby/buildkit Go client to avoid pulling
+// buildkit's large dependency tree into the daemon; buildctl ships alongside
+// buildkitd from the same release.
+type BuildKitBuilder struct {
+	addr    string // BUILDKIT_HOST
+	buildct string // buildctl binary path
+	logger  *slog.Logger
+}
+
+// NewBuildKitBuilder returns a builder targeting addr (default
+// DefaultBuildKitAddr). buildctlPath defaults to "buildctl" on PATH.
+func NewBuildKitBuilder(addr, buildctlPath string, logger *slog.Logger) *BuildKitBuilder {
+	if strings.TrimSpace(addr) == "" {
+		addr = DefaultBuildKitAddr
+	}
+	if strings.TrimSpace(buildctlPath) == "" {
+		buildctlPath = "buildctl"
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &BuildKitBuilder{addr: addr, buildct: buildctlPath, logger: logger}
+}
+
+// BuildImage builds req.DockerfileContent (+ optional context tar) into an image
+// tagged req.Tag, exported and unpacked into the containerd image store so a
+// later create can run it directly.
+func (b *BuildKitBuilder) BuildImage(ctx context.Context, req docker.BuildImageRequest) error {
+	tag := strings.TrimSpace(req.Tag)
+	if tag == "" {
+		return errors.New("build image: tag is required")
+	}
+	dockerfile := strings.TrimRight(req.DockerfileContent, "\n") + "\n"
+	if strings.TrimSpace(dockerfile) == "" {
+		return errors.New("build image: dockerfile content is required")
+	}
+
+	dir, err := os.MkdirTemp("", "aerolvm-buildkit-")
+	if err != nil {
+		return fmt.Errorf("build image: temp dir: %w", err)
+	}
+	defer os.RemoveAll(dir)
+
+	if len(req.ContextTar) > 0 {
+		if err := extractTar(req.ContextTar, dir); err != nil {
+			return fmt.Errorf("build image: extract context: %w", err)
+		}
+	}
+	// The Dockerfile is authoritative even if a context tar also carried one.
+	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte(dockerfile), 0o644); err != nil {
+		return fmt.Errorf("build image: write dockerfile: %w", err)
+	}
+
+	// unpack=true realizes the image's layers in the snapshotter so a subsequent
+	// WithNewSnapshot create can use it without an extra pull/unpack.
+	args := []string{
+		"--addr", b.addr,
+		"build",
+		"--frontend", "dockerfile.v0",
+		"--local", "context=" + dir,
+		"--local", "dockerfile=" + dir,
+		"--output", "type=image,name=" + tag + ",unpack=true",
+	}
+	cmd := exec.CommandContext(ctx, b.buildct, args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if req.OnLog != nil {
+		// buildctl writes progress to stderr; tee it to the caller's log sink.
+		cmd.Stderr = io.MultiWriter(&stderr, logLineWriter(req.OnLog))
+	}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("buildctl build %s: %w: %s", tag, err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+// ImageBuilder is the full image-builder surface the v1 / daytona build
+// handlers require for the containerd engine. It composes the buildctl-backed
+// BuildImage with the driver's containerd-native image operations
+// (ImageExists / RemoveImage) and the registry pusher, so it is a drop-in for
+// the same seam the dockerd path satisfies with *pkg/docker.Client.
+type ImageBuilder struct {
+	build  *BuildKitBuilder
+	driver *Driver
+	pusher *RegistryPusher
+}
+
+// NewImageBuilder wires a containerd image builder from a driver (image store
+// + registry push) and a buildkit builder (Dockerfile compile).
+func NewImageBuilder(driver *Driver, build *BuildKitBuilder) *ImageBuilder {
+	return &ImageBuilder{build: build, driver: driver, pusher: NewRegistryPusher(driver)}
+}
+
+func (b *ImageBuilder) BuildImage(ctx context.Context, req docker.BuildImageRequest) error {
+	return b.build.BuildImage(ctx, req)
+}
+
+func (b *ImageBuilder) ImageExists(ctx context.Context, imageRef string) (bool, error) {
+	return b.driver.ImageExists(ctx, imageRef)
+}
+
+func (b *ImageBuilder) PushImage(ctx context.Context, req docker.PushImageRequest) (string, error) {
+	return b.pusher.PushImage(ctx, req)
+}
+
+func (b *ImageBuilder) RemoveImage(ctx context.Context, imageRef string) error {
+	return b.driver.RemoveImage(ctx, imageRef)
+}
+
+// RefreshTag is a no-op on containerd. The dockerd builder bumps
+// Metadata.LastTagTime so its built-image janitor doesn't GC a cache-hit tag;
+// containerd's built-image lifecycle is snapshot/lease-driven, not tag-time
+// metadata, so there is nothing to refresh.
+func (b *ImageBuilder) RefreshTag(ctx context.Context, fullRef string) error {
+	return nil
+}
+
+// logLineWriter adapts a line callback to an io.Writer, flushing per newline.
+type logLineWriter func(string)
+
+func (w logLineWriter) Write(p []byte) (int, error) {
+	for _, line := range strings.Split(strings.TrimRight(string(p), "\n"), "\n") {
+		if line != "" {
+			w(line)
+		}
+	}
+	return len(p), nil
+}
+
+func extractTar(data []byte, dir string) error {
+	tr := tar.NewReader(bytes.NewReader(data))
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		// Reject path traversal: an entry whose joined path lands outside dir
+		// (e.g. "../escape") must not be written. filepath.Join cleans the
+		// result, so a traversing name resolves above dir and fails the prefix
+		// check rather than being silently written elsewhere.
+		target := filepath.Join(dir, hdr.Name)
+		cleanDir := filepath.Clean(dir)
+		if target != cleanDir && !strings.HasPrefix(target, cleanDir+string(os.PathSeparator)) {
+			return fmt.Errorf("tar entry escapes context dir: %q", hdr.Name)
+		}
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(hdr.Mode)&0o777)
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(f, tr); err != nil { //nolint:gosec // bounded by build context size
+				_ = f.Close()
+				return err
+			}
+			if err := f.Close(); err != nil {
+				return err
+			}
+		}
+	}
+}

--- a/internal/runtime/containerd/buildkit_test.go
+++ b/internal/runtime/containerd/buildkit_test.go
@@ -1,0 +1,235 @@
+package containerd
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	cntr "github.com/containerd/containerd"
+
+	"github.com/aerol-ai/microvm/pkg/docker"
+)
+
+func TestNewBuildKitBuilderDefaults(t *testing.T) {
+	b := NewBuildKitBuilder("", "", nil)
+	if b.addr != DefaultBuildKitAddr {
+		t.Fatalf("addr = %q, want default %q", b.addr, DefaultBuildKitAddr)
+	}
+	if b.buildct != "buildctl" {
+		t.Fatalf("buildctl path = %q, want buildctl", b.buildct)
+	}
+	if b.logger == nil {
+		t.Fatal("logger must default to slog.Default()")
+	}
+	custom := NewBuildKitBuilder("unix:///tmp/x.sock", "/opt/buildctl", nil)
+	if custom.addr != "unix:///tmp/x.sock" || custom.buildct != "/opt/buildctl" {
+		t.Fatalf("custom addr/path not honored: %q %q", custom.addr, custom.buildct)
+	}
+}
+
+func TestBuildKitBuilderValidatesInput(t *testing.T) {
+	b := NewBuildKitBuilder("", "", nil)
+	if err := b.BuildImage(context.Background(), docker.BuildImageRequest{DockerfileContent: "FROM alpine"}); err == nil {
+		t.Fatal("empty tag must error")
+	}
+	if err := b.BuildImage(context.Background(), docker.BuildImageRequest{Tag: "x:1"}); err == nil {
+		t.Fatal("empty dockerfile must error")
+	}
+}
+
+// writeFakeBuildctl writes an executable stand-in for buildctl that emits the
+// given stderr lines and exits with code. Lets BuildImage's exec path (arg
+// assembly, stderr tee, error wrapping) be exercised without a real buildkitd.
+func writeFakeBuildctl(t *testing.T, stderr string, code int) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "buildctl")
+	script := "#!/bin/sh\n"
+	if stderr != "" {
+		script += "printf '%s\\n' \"" + stderr + "\" 1>&2\n"
+	}
+	script += "exit " + strconv.Itoa(code) + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake buildctl: %v", err)
+	}
+	return path
+}
+
+func TestBuildKitBuilderRunsBuildctl(t *testing.T) {
+	path := writeFakeBuildctl(t, "resolving dockerfile\nbuilding", 0)
+	b := NewBuildKitBuilder("unix:///run/buildkit/buildkitd.sock", path, nil)
+	var lines []string
+	err := b.BuildImage(context.Background(), docker.BuildImageRequest{
+		Tag:               "built:abc",
+		DockerfileContent: "FROM alpine\nRUN true",
+		OnLog:             func(l string) { lines = append(lines, l) },
+	})
+	if err != nil {
+		t.Fatalf("BuildImage: %v", err)
+	}
+	if len(lines) == 0 {
+		t.Fatal("OnLog should have received buildctl progress lines")
+	}
+}
+
+func TestBuildKitBuilderReportsBuildctlFailure(t *testing.T) {
+	path := writeFakeBuildctl(t, "frontend error: something broke", 1)
+	b := NewBuildKitBuilder("", path, nil)
+	err := b.BuildImage(context.Background(), docker.BuildImageRequest{
+		Tag:               "built:def",
+		DockerfileContent: "FROM alpine",
+	})
+	if err == nil {
+		t.Fatal("expected error on buildctl exit 1")
+	}
+	if !strings.Contains(err.Error(), "something broke") {
+		t.Fatalf("error should carry buildctl stderr, got: %v", err)
+	}
+}
+
+func TestBuildKitBuilderExtractsContextTar(t *testing.T) {
+	// A context tar should be materialized into the build dir and the build
+	// should still run (fake buildctl). Prove extractTar is on the path.
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	_ = tw.WriteHeader(&tar.Header{Name: "app/main.go", Mode: 0o644, Size: 5, Typeflag: tar.TypeReg})
+	_, _ = tw.Write([]byte("hello"))
+	_ = tw.Close()
+
+	path := writeFakeBuildctl(t, "", 0)
+	b := NewBuildKitBuilder("", path, nil)
+	err := b.BuildImage(context.Background(), docker.BuildImageRequest{
+		Tag:               "built:ctx",
+		DockerfileContent: "FROM scratch\nCOPY app/main.go /",
+		ContextTar:        buf.Bytes(),
+	})
+	if err != nil {
+		t.Fatalf("BuildImage with context: %v", err)
+	}
+}
+
+func TestExtractTarRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	_ = tw.WriteHeader(&tar.Header{Name: "dir/", Mode: 0o755, Typeflag: tar.TypeDir})
+	_ = tw.WriteHeader(&tar.Header{Name: "dir/file.txt", Mode: 0o644, Size: 3, Typeflag: tar.TypeReg})
+	_, _ = tw.Write([]byte("abc"))
+	_ = tw.Close()
+
+	dir := t.TempDir()
+	if err := extractTar(buf.Bytes(), dir); err != nil {
+		t.Fatalf("extractTar: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "dir", "file.txt"))
+	if err != nil || string(got) != "abc" {
+		t.Fatalf("extracted file = %q err=%v, want abc", got, err)
+	}
+}
+
+func TestExtractTarRejectsTraversal(t *testing.T) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	_ = tw.WriteHeader(&tar.Header{Name: "../escape.txt", Mode: 0o644, Size: 1, Typeflag: tar.TypeReg})
+	_, _ = tw.Write([]byte("x"))
+	_ = tw.Close()
+
+	if err := extractTar(buf.Bytes(), t.TempDir()); err == nil {
+		t.Fatal("path traversal entry must be rejected")
+	}
+}
+
+func TestLogLineWriter(t *testing.T) {
+	var got []string
+	w := logLineWriter(func(l string) { got = append(got, l) })
+	n, err := w.Write([]byte("line1\nline2\n\n"))
+	if err != nil || n != len("line1\nline2\n\n") {
+		t.Fatalf("Write n=%d err=%v", n, err)
+	}
+	if len(got) != 2 || got[0] != "line1" || got[1] != "line2" {
+		t.Fatalf("lines = %v, want [line1 line2]", got)
+	}
+}
+
+func TestImageBuilderComposite(t *testing.T) {
+	d := newTestDriver(t)
+	tr := newFakeTransport()
+	tr.getImageFn = func(_ context.Context, ref string) (cntr.Image, error) {
+		if ref == "built:xyz" {
+			return &fakeImage{name: ref}, nil
+		}
+		return nil, errors.New("missing")
+	}
+	d.SetClient(NewTestClient("aerolvm", tr))
+	b := NewImageBuilder(d, NewBuildKitBuilder("", writeFakeBuildctl(t, "", 0), nil))
+
+	// RefreshTag is a no-op on containerd.
+	if err := b.RefreshTag(context.Background(), "anything"); err != nil {
+		t.Fatalf("RefreshTag must be a no-op, got %v", err)
+	}
+
+	// ImageExists delegates to the driver's containerd store lookup.
+	ok, err := b.ImageExists(context.Background(), "built:xyz")
+	if err != nil || !ok {
+		t.Fatalf("ImageExists(built:xyz) = %v,%v; want true,nil", ok, err)
+	}
+	if ok, _ := b.ImageExists(context.Background(), "absent:1"); ok {
+		t.Fatal("ImageExists(absent) should be false")
+	}
+
+	// PushImage delegates to the pusher, whose validation rejects an empty req.
+	if _, err := b.PushImage(context.Background(), docker.PushImageRequest{}); err == nil {
+		t.Fatal("PushImage with empty request must error via the pusher")
+	}
+
+	// BuildImage delegates to the buildkit builder (fake buildctl exit 0).
+	if err := b.BuildImage(context.Background(), docker.BuildImageRequest{Tag: "built:new", DockerfileContent: "FROM alpine"}); err != nil {
+		t.Fatalf("BuildImage delegation: %v", err)
+	}
+
+	// RemoveImage delegates to the driver's image-delete seam.
+	orig := removeImageFn
+	t.Cleanup(func() { removeImageFn = orig })
+	var removed string
+	removeImageFn = func(_ context.Context, _ *Client, ref string) error {
+		removed = ref
+		return nil
+	}
+	if err := b.RemoveImage(context.Background(), "built:xyz"); err != nil {
+		t.Fatalf("RemoveImage delegation: %v", err)
+	}
+	if removed != "built:xyz" {
+		t.Fatalf("RemoveImage delegated ref = %q, want built:xyz", removed)
+	}
+}
+
+func TestDriverImageExists(t *testing.T) {
+	d := newTestDriver(t)
+	tr := newFakeTransport()
+	tr.getImageFn = func(_ context.Context, ref string) (cntr.Image, error) {
+		// Only "snap:latest" resolves — proves tagless resolution via :latest.
+		if ref == "snap:latest" {
+			return &fakeImage{name: ref}, nil
+		}
+		return nil, errors.New("missing")
+	}
+	d.SetClient(NewTestClient("aerolvm", tr))
+
+	if ok, _ := d.ImageExists(context.Background(), "snap:latest"); !ok {
+		t.Fatal("exact ref should resolve")
+	}
+	if ok, _ := d.ImageExists(context.Background(), "snap"); !ok {
+		t.Fatal("tagless ref should resolve via :latest")
+	}
+	if ok, _ := d.ImageExists(context.Background(), "nope:1"); ok {
+		t.Fatal("absent ref should be false")
+	}
+	if ok, _ := d.ImageExists(context.Background(), "  "); ok {
+		t.Fatal("blank ref should be false")
+	}
+}

--- a/internal/runtime/containerd/image_config.go
+++ b/internal/runtime/containerd/image_config.go
@@ -7,7 +7,6 @@ import (
 
 	cntr "github.com/containerd/containerd"
 	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/images"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -19,11 +18,12 @@ func imageDefaultCommand(ctx context.Context, client *Client, image cntr.Image) 
 }
 
 func imageConfigCommand(ctx context.Context, provider content.Provider, image cntr.Image) ([]string, error) {
-	desc, err := image.Config(ctx)
-	if err != nil {
-		return nil, err
-	}
-	cfgDesc, err := images.Config(ctx, provider, desc, nil)
+	// Image.Config returns the config descriptor directly — containerd already
+	// resolves index→manifest→config for the client platform. Read it straight
+	// from the content store. Do NOT feed it back through images.Config, which
+	// expects a manifest/index and fails with "unexpected media type
+	// application/vnd.oci.image.config.v1+json" on the config descriptor.
+	cfgDesc, err := image.Config(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runtime/containerd/image_config_test.go
+++ b/internal/runtime/containerd/image_config_test.go
@@ -41,6 +41,7 @@ func (r *memReaderAt) Close() error { return nil }
 
 type configFakeImage struct {
 	manifestDesc ocispec.Descriptor
+	configDesc   ocispec.Descriptor
 }
 
 func (c *configFakeImage) Name() string               { return "cfg:test" }
@@ -55,7 +56,9 @@ func (c *configFakeImage) Usage(context.Context, ...cntr.UsageOpt) (int64, error
 	return 0, nil
 }
 func (c *configFakeImage) Config(context.Context) (ocispec.Descriptor, error) {
-	return c.manifestDesc, nil
+	// Real containerd returns the CONFIG descriptor here (index→manifest→config
+	// already resolved), not the manifest.
+	return c.configDesc, nil
 }
 func (c *configFakeImage) IsUnpacked(context.Context, string) (bool, error) { return true, nil }
 func (c *configFakeImage) ContentStore() content.Store                      { return nil }
@@ -91,11 +94,18 @@ func newTestImageProvider(t *testing.T) (*memProvider, *configFakeImage) {
 		cfgDigest:      cfgBody,
 		manifestDigest: manifestBody,
 	}}
-	img := &configFakeImage{manifestDesc: ocispec.Descriptor{
-		MediaType: ocispec.MediaTypeImageManifest,
-		Digest:    manifestDigest,
-		Size:      int64(len(manifestBody)),
-	}}
+	img := &configFakeImage{
+		manifestDesc: ocispec.Descriptor{
+			MediaType: ocispec.MediaTypeImageManifest,
+			Digest:    manifestDigest,
+			Size:      int64(len(manifestBody)),
+		},
+		configDesc: ocispec.Descriptor{
+			MediaType: ocispec.MediaTypeImageConfig,
+			Digest:    cfgDigest,
+			Size:      int64(len(cfgBody)),
+		},
+	}
 	return provider, img
 }
 

--- a/internal/runtime/containerd/imageref_test.go
+++ b/internal/runtime/containerd/imageref_test.go
@@ -1,0 +1,56 @@
+package containerd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	cntr "github.com/containerd/containerd"
+)
+
+// TestEnsureImageNormalizesShortRef is the regression for the live pull failure
+// `parse "dummy://alpine:3.20": invalid port ":3.20"`: containerd's resolver
+// cannot handle a bare docker ref, so ensureImage must normalize it to a
+// fully-qualified name (as `ctr` does) before GetImage/Pull.
+func TestEnsureImageNormalizesShortRef(t *testing.T) {
+	d := newTestDriver(t)
+	tr := newFakeTransport()
+	var pulledRef string
+	tr.getImageFn = func(context.Context, string) (cntr.Image, error) {
+		return nil, errors.New("not present")
+	}
+	tr.pullImageFn = func(_ context.Context, ref string, _ ...cntr.RemoteOpt) (cntr.Image, error) {
+		pulledRef = ref
+		return &fakeImage{name: ref}, nil
+	}
+	d.SetClient(NewTestClient("aerolvm", tr))
+
+	if _, err := d.ensureImage(context.Background(), d.client, "alpine:3.20", nil); err != nil {
+		t.Fatalf("ensureImage: %v", err)
+	}
+	if pulledRef != "docker.io/library/alpine:3.20" {
+		t.Fatalf("pull ref = %q, want normalized docker.io/library/alpine:3.20", pulledRef)
+	}
+}
+
+func TestEnsureImageKeepsFullyQualifiedRef(t *testing.T) {
+	d := newTestDriver(t)
+	tr := newFakeTransport()
+	var pulledRef string
+	tr.getImageFn = func(context.Context, string) (cntr.Image, error) {
+		return nil, errors.New("not present")
+	}
+	tr.pullImageFn = func(_ context.Context, ref string, _ ...cntr.RemoteOpt) (cntr.Image, error) {
+		pulledRef = ref
+		return &fakeImage{name: ref}, nil
+	}
+	d.SetClient(NewTestClient("aerolvm", tr))
+
+	const full = "aocr.example.com/team/img:v1"
+	if _, err := d.ensureImage(context.Background(), d.client, full, nil); err != nil {
+		t.Fatalf("ensureImage: %v", err)
+	}
+	if pulledRef != full {
+		t.Fatalf("pull ref = %q, want unchanged %q", pulledRef, full)
+	}
+}

--- a/internal/runtime/containerd/imageref_test.go
+++ b/internal/runtime/containerd/imageref_test.go
@@ -33,6 +33,33 @@ func TestEnsureImageNormalizesShortRef(t *testing.T) {
 	}
 }
 
+func TestEnsureImageFindsLocalRefBeforeNormalizing(t *testing.T) {
+	// A committed snapshot / custom-named local image is stored under the exact
+	// ref; it must be found as-is, not normalized to docker.io/... and pulled
+	// from Docker Hub (the UC-21 regression).
+	d := newTestDriver(t)
+	tr := newFakeTransport()
+	pulled := false
+	tr.getImageFn = func(_ context.Context, ref string) (cntr.Image, error) {
+		if ref == "myapp-snap:latest" {
+			return &fakeImage{name: ref}, nil
+		}
+		return nil, errors.New("not present")
+	}
+	tr.pullImageFn = func(context.Context, string, ...cntr.RemoteOpt) (cntr.Image, error) {
+		pulled = true
+		return nil, errors.New("should not pull a local ref")
+	}
+	d.SetClient(NewTestClient("aerolvm", tr))
+	img, err := d.ensureImage(context.Background(), d.client, "myapp-snap:latest", nil)
+	if err != nil || img == nil {
+		t.Fatalf("ensureImage local ref: img=%v err=%v", img, err)
+	}
+	if pulled {
+		t.Fatal("local snapshot ref must not trigger a Docker Hub pull")
+	}
+}
+
 func TestEnsureImageKeepsFullyQualifiedRef(t *testing.T) {
 	d := newTestDriver(t)
 	tr := newFakeTransport()

--- a/internal/runtime/containerd/imageref_test.go
+++ b/internal/runtime/containerd/imageref_test.go
@@ -60,6 +60,33 @@ func TestEnsureImageFindsLocalRefBeforeNormalizing(t *testing.T) {
 	}
 }
 
+func TestEnsureImageFindsTaglessLocalRefViaLatest(t *testing.T) {
+	// A snapshot referenced without a tag ("myapp-snap") is stored as
+	// "myapp-snap:latest"; containerd needs the exact tag, so it must resolve
+	// locally via :latest, not fall through to a Docker Hub pull (UC-21).
+	d := newTestDriver(t)
+	tr := newFakeTransport()
+	pulled := false
+	tr.getImageFn = func(_ context.Context, ref string) (cntr.Image, error) {
+		if ref == "myapp-snap:latest" {
+			return &fakeImage{name: ref}, nil
+		}
+		return nil, errors.New("not present")
+	}
+	tr.pullImageFn = func(context.Context, string, ...cntr.RemoteOpt) (cntr.Image, error) {
+		pulled = true
+		return nil, errors.New("should not pull")
+	}
+	d.SetClient(NewTestClient("aerolvm", tr))
+	img, err := d.ensureImage(context.Background(), d.client, "myapp-snap", nil)
+	if err != nil || img == nil {
+		t.Fatalf("tagless local ref: img=%v err=%v", img, err)
+	}
+	if pulled {
+		t.Fatal("tagless local snapshot must resolve via :latest, not a pull")
+	}
+}
+
 func TestEnsureImageKeepsFullyQualifiedRef(t *testing.T) {
 	d := newTestDriver(t)
 	tr := newFakeTransport()

--- a/internal/runtime/containerd/lifecycle.go
+++ b/internal/runtime/containerd/lifecycle.go
@@ -601,6 +601,15 @@ func (d *Driver) ensureImage(ctx context.Context, client *Client, ref string, au
 	if image, err := client.GetImage(ctx, ref); err == nil {
 		return image, nil
 	}
+	// A tagless local ref (e.g. a committed snapshot "myapp-snap", stored by the
+	// driver as "myapp-snap:latest") needs an exact tag for containerd's
+	// GetImage. Try :latest locally before the registry-normalized pull, or a
+	// snapshot referenced without a tag is mistaken for a Docker Hub image.
+	if !refHasTag(ref) {
+		if image, err := client.GetImage(ctx, ref+":latest"); err == nil {
+			return image, nil
+		}
+	}
 	// Normalize for the registry pull path, exactly as `ctr` does: containerd's
 	// resolver cannot parse a bare "alpine:3.20" — it reads it as host "alpine"
 	// with an invalid port ":3.20" ("dummy://alpine:3.20"). ParseDockerRef →
@@ -665,6 +674,16 @@ func (d *Driver) ensureImage(ctx context.Context, client *Client, ref string, au
 		return nil, err
 	}
 	return res.(cntr.Image), nil
+}
+
+// refHasTag reports whether the ref's final path component carries a :tag or
+// @digest (a host:port prefix does not count as a tag).
+func refHasTag(ref string) bool {
+	last := ref
+	if i := strings.LastIndex(ref, "/"); i >= 0 {
+		last = ref[i+1:]
+	}
+	return strings.ContainsAny(last, ":@")
 }
 
 // registryHost extracts the registry hostname from an image ref. Docker Hub

--- a/internal/runtime/containerd/lifecycle.go
+++ b/internal/runtime/containerd/lifecycle.go
@@ -472,7 +472,48 @@ func (d *Driver) ListManaged(ctx context.Context) (map[string]*models.SandboxRun
 }
 
 func (d *Driver) Resize(ctx context.Context, containerRef string, req models.ResizeSandboxRequest) error {
-	return fmt.Errorf("containerd live resize is not implemented yet")
+	if d.cfg.ResourceLimitsOff {
+		return nil
+	}
+	client, err := d.ensureClient()
+	if err != nil {
+		return err
+	}
+	container, err := client.LoadContainer(ctx, containerRef)
+	if err != nil {
+		return fmt.Errorf("load container: %w", err)
+	}
+	task, err := container.Task(ctx, nil)
+	if err != nil {
+		// Stopped sandbox: the store holds the new size and it takes effect via
+		// the spec on next start; there is no live cgroup to update.
+		if errdefs.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("resize task: %w", err)
+	}
+	res := &specs.LinuxResources{}
+	if req.MemoryMB > 0 {
+		limit := int64(req.MemoryMB) * 1024 * 1024
+		res.Memory = &specs.LinuxMemory{Limit: &limit}
+	}
+	if req.CPU > 0 {
+		// Fractional CPU is a CFS quota/period (mirrors resourceSpecOpts + dockerd
+		// --cpus), not a cpuset.
+		const cpuPeriod uint64 = 100000
+		quota := int64(req.CPU * float64(cpuPeriod))
+		if quota < 1000 {
+			quota = 1000
+		}
+		period := cpuPeriod
+		res.CPU = &specs.LinuxCPU{Quota: &quota, Period: &period}
+	}
+	if res.Memory == nil && res.CPU == nil {
+		return nil
+	}
+	// DiskGB is soft-ignored (containerd overlayfs has no live quota; same as
+	// create — plans/containerd-engine-phase0-decisions.md DiskGB row).
+	return task.Update(ctx, cntr.WithResources(res))
 }
 
 func (d *Driver) RemoveImage(ctx context.Context, imageRef string) error {
@@ -540,11 +581,18 @@ func (d *Driver) ensureImage(ctx context.Context, client *Client, ref string, au
 	if ref == "" {
 		return nil, errors.New("image reference is required")
 	}
-	// Normalize short/docker refs to a fully-qualified name, exactly as `ctr`
-	// does. containerd's resolver cannot parse a bare "alpine:3.20" — it reads
-	// it as host "alpine" with an invalid port ":3.20" ("dummy://alpine:3.20").
-	// dockerd's libnetwork normalized this for the docker driver; the containerd
-	// driver must do it itself. ParseDockerRef → docker.io/library/alpine:3.20.
+	// Local images (committed snapshots, custom-named builds) are stored under
+	// the EXACT ref given — look that up FIRST. Normalizing a bare local name
+	// like "myapp-snap:latest" to docker.io/library/myapp-snap:latest would miss
+	// the local image and try to pull it from Docker Hub (the UC-21
+	// create-from-snapshot failure).
+	if image, err := client.GetImage(ctx, ref); err == nil {
+		return image, nil
+	}
+	// Normalize for the registry pull path, exactly as `ctr` does: containerd's
+	// resolver cannot parse a bare "alpine:3.20" — it reads it as host "alpine"
+	// with an invalid port ":3.20" ("dummy://alpine:3.20"). ParseDockerRef →
+	// docker.io/library/alpine:3.20.
 	if named, nerr := refdocker.ParseDockerRef(ref); nerr == nil {
 		ref = named.String()
 	}

--- a/internal/runtime/containerd/lifecycle.go
+++ b/internal/runtime/containerd/lifecycle.go
@@ -326,6 +326,18 @@ func (d *Driver) Start(ctx context.Context, containerRef string) (*models.Sandbo
 		return nil, err
 	}
 	defer closeLog()
+	// Resume re-creates the task from the stored spec, which bind-mounts the
+	// create-time ready socket. That socket was closed+unlinked after Create, so
+	// runc's mount fails ("open .../ready/<id>.<nonce>.sock: no such file"). Recreate
+	// the exact socket (nonce from the spec mount path, token from the spec env)
+	// so the mount succeeds and the restarted toolbox can re-signal readiness.
+	if d.cfg.ReadyEnabled {
+		if spec, serr := container.Spec(ctx); serr == nil {
+			if rl := d.recreateResumeReadySocket(spec); rl != nil {
+				defer func() { _ = rl.Close() }()
+			}
+		}
+	}
 	task, err = container.NewTask(ctx, logIO)
 	if err != nil {
 		return nil, fmt.Errorf("create task: %w", err)
@@ -701,6 +713,49 @@ func (d *Driver) setupReadySocket(env *[]string, mountSpecs *[]specs.Mount, sand
 		Type: "bind", Source: readyListener.HostSocketPath(), Destination: dockerpkg.GuestReadySocketPath, Options: []string{"rbind"},
 	})
 	return readyListener, nil
+}
+
+// recreateResumeReadySocket recreates the create-time ready socket that a
+// stored spec bind-mounts, so a resumed task's runc mount does not fail on the
+// unlinked socket. The socket path encodes <sandboxID>.<nonce>; the token comes
+// from the spec env. Returns nil (caller proceeds without it) when the spec has
+// no ready mount or the token/nonce can't be recovered.
+func (d *Driver) recreateResumeReadySocket(spec *specs.Spec) *dockerpkg.ReadyListener {
+	if spec == nil || spec.Process == nil {
+		return nil
+	}
+	var source string
+	for _, m := range spec.Mounts {
+		if m.Destination == dockerpkg.GuestReadySocketPath {
+			source = m.Source
+			break
+		}
+	}
+	if source == "" {
+		return nil
+	}
+	// source is <ReadyDir>/<sandboxID>.<nonce>.sock
+	name := strings.TrimSuffix(filepath.Base(source), ".sock")
+	dot := strings.LastIndex(name, ".")
+	if dot <= 0 {
+		return nil
+	}
+	sandboxID, nonce := name[:dot], name[dot+1:]
+	var token string
+	for _, e := range spec.Process.Env {
+		if v, ok := strings.CutPrefix(e, "SB_TOOLBOX_TOKEN="); ok {
+			token = v
+			break
+		}
+	}
+	if token == "" || nonce == "" {
+		return nil
+	}
+	rl, err := dockerpkg.NewReadyListener(d.cfg.ReadyDir, sandboxID, token, nonce)
+	if err != nil {
+		return nil
+	}
+	return rl
 }
 
 func (d *Driver) lifoTeardown(ctx context.Context, client *Client, container cntr.Container, task cntr.Task, logPath string, hostFiles *sandboxHostFiles) {

--- a/internal/runtime/containerd/lifecycle.go
+++ b/internal/runtime/containerd/lifecycle.go
@@ -270,7 +270,14 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 		return nil, err
 	}
 
+	// Attribute the readiness wait for Server-Timing (parity with the docker
+	// driver): the ready socket is the fast path ("socket"); the HTTP health
+	// poll is the fallback ("health"). Without this the create Server-Timing
+	// header carries no readiness source on containerd hosts (UC-11).
+	readyStart := time.Now()
+	readinessSource := "health"
 	if d.cfg.ReadyEnabled && readyListener != nil {
+		readinessSource = "socket"
 		if err := readyListener.Wait(ctx); err != nil {
 			return nil, fmt.Errorf("ready socket: %w", err)
 		}
@@ -278,6 +285,7 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 	} else if err := d.waitToolboxHTTP(ctx, state.ContainerIP, toolboxToken); err != nil {
 		return nil, err
 	}
+	createtiming.From(ctx).RecordReadinessWaits(0, time.Since(readyStart), readinessSource)
 
 	if req.NetworkBlockAll && state.ContainerIP != "" {
 		netrulesStart := time.Now()
@@ -538,6 +546,31 @@ func (d *Driver) RemoveImage(ctx context.Context, imageRef string) error {
 		return nil
 	}
 	return removeImageFn(ctx, client, imageRef)
+}
+
+// ImageExists reports whether imageRef resolves to a local image in the
+// containerd store WITHOUT pulling. Used by the build handlers' cache
+// short-circuit (a freshly built tag) and mirrors ensureImage's local-ref
+// resolution (exact ref first, then :latest for a tagless local ref) so a
+// tag committed as "name:latest" is recognised when referenced as "name".
+func (d *Driver) ImageExists(ctx context.Context, imageRef string) (bool, error) {
+	client, err := d.ensureClient()
+	if err != nil {
+		return false, err
+	}
+	imageRef = strings.TrimSpace(imageRef)
+	if imageRef == "" {
+		return false, nil
+	}
+	if _, err := client.GetImage(ctx, imageRef); err == nil {
+		return true, nil
+	}
+	if !refHasTag(imageRef) {
+		if _, err := client.GetImage(ctx, imageRef+":latest"); err == nil {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // removeImageFn deletes an image from the containerd image store. Tests stub it.

--- a/internal/runtime/containerd/lifecycle.go
+++ b/internal/runtime/containerd/lifecycle.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/remotes/docker"
+	refdocker "github.com/distribution/reference"
 	"github.com/opencontainers/runtime-spec/specs-go"
 
 	"github.com/aerol-ai/microvm/internal/pool/containerdpool"
@@ -538,6 +539,14 @@ func (d *Driver) ensureImage(ctx context.Context, client *Client, ref string, au
 	ref = strings.TrimSpace(ref)
 	if ref == "" {
 		return nil, errors.New("image reference is required")
+	}
+	// Normalize short/docker refs to a fully-qualified name, exactly as `ctr`
+	// does. containerd's resolver cannot parse a bare "alpine:3.20" — it reads
+	// it as host "alpine" with an invalid port ":3.20" ("dummy://alpine:3.20").
+	// dockerd's libnetwork normalized this for the docker driver; the containerd
+	// driver must do it itself. ParseDockerRef → docker.io/library/alpine:3.20.
+	if named, nerr := refdocker.ParseDockerRef(ref); nerr == nil {
+		ref = named.String()
 	}
 	if image, err := client.GetImage(ctx, ref); err == nil {
 		return image, nil

--- a/internal/runtime/containerd/lifecycle_test.go
+++ b/internal/runtime/containerd/lifecycle_test.go
@@ -57,7 +57,7 @@ func TestBuildMountsIncludesToolboxAndHostFilesAndUserBinds(t *testing.T) {
 	}
 }
 
-func TestUnimplementedPhaseMethods(t *testing.T) {
+func TestCreateSnapshotRequiresLiveContainerd(t *testing.T) {
 	d := newTestDriver(t)
 	tr := newFakeTransport()
 	tr.containers["c"] = &fakeContainer{id: "c", task: &fakeTask{status: cntr.Running}}
@@ -65,7 +65,19 @@ func TestUnimplementedPhaseMethods(t *testing.T) {
 	if _, err := d.CreateSnapshot(t.Context(), "c", "img:latest"); err == nil || !strings.Contains(err.Error(), "live containerd") {
 		t.Fatalf("CreateSnapshot should require live containerd, got %v", err)
 	}
-	if err := d.Resize(t.Context(), "c", models.ResizeSandboxRequest{}); err == nil {
-		t.Fatal("Resize should report not implemented")
+}
+
+func TestResizeUpdatesRunningTask(t *testing.T) {
+	d := newTestDriver(t)
+	tr := newFakeTransport()
+	tr.containers["c"] = &fakeContainer{id: "c", task: &fakeTask{status: cntr.Running}}
+	d.SetClient(NewTestClient("aerolvm", tr))
+	// Resize is implemented (task.Update): a CPU/mem change against a running
+	// task succeeds, and an empty request is a no-op.
+	if err := d.Resize(t.Context(), "c", models.ResizeSandboxRequest{CPU: 2, MemoryMB: 512}); err != nil {
+		t.Fatalf("Resize should succeed against a running task, got %v", err)
+	}
+	if err := d.Resize(t.Context(), "c", models.ResizeSandboxRequest{}); err != nil {
+		t.Fatalf("empty Resize should be a no-op, got %v", err)
 	}
 }

--- a/internal/runtime/containerd/snapshot.go
+++ b/internal/runtime/containerd/snapshot.go
@@ -38,6 +38,9 @@ type snapshotBackend interface {
 	writeBlob(ctx context.Context, mediaType string, data []byte, labels map[string]string) (ocispec.Descriptor, error)
 	createImage(ctx context.Context, img images.Image) (images.Image, error)
 	getImage(ctx context.Context, name string) (images.Image, error)
+	// unpack realizes the image's layers in the snapshotter so it can back a new
+	// container via WithNewSnapshot.
+	unpack(ctx context.Context, name, snapshotter string) error
 }
 
 type rawSnapshotBackend struct {
@@ -63,6 +66,14 @@ func (b *rawSnapshotBackend) createImage(ctx context.Context, img images.Image) 
 		return images.Image{}, errors.New("snapshot image create requires live containerd")
 	}
 	return raw.ImageService().Create(ctx, img)
+}
+
+func (b *rawSnapshotBackend) unpack(ctx context.Context, name, snapshotter string) error {
+	img, err := b.client.GetImage(ctx, name)
+	if err != nil {
+		return err
+	}
+	return img.Unpack(ctx, snapshotter)
 }
 
 func (b *rawSnapshotBackend) getImage(ctx context.Context, name string) (images.Image, error) {
@@ -239,9 +250,18 @@ func (d *Driver) commitContainerSnapshotLive(ctx context.Context, client *Client
 			if getErr != nil {
 				return "", fmt.Errorf("snapshot image exists: %w", err)
 			}
+			if uerr := backend.unpack(ctx, imageRef, info.Snapshotter); uerr != nil {
+				return "", fmt.Errorf("snapshot unpack (existing): %w", uerr)
+			}
 			return imageDigestID(existing.Target), nil
 		}
 		return "", fmt.Errorf("snapshot image create: %w", err)
+	}
+	// Unpack so the committed image's layers are realized in the snapshotter and
+	// it can back a new container via WithNewSnapshot — without this,
+	// create-from-snapshot fails with "parent snapshot ... does not exist".
+	if err := backend.unpack(ctx, imageRef, info.Snapshotter); err != nil {
+		return "", fmt.Errorf("snapshot unpack: %w", err)
 	}
 	return imageDigestID(created.Target), nil
 }

--- a/internal/runtime/containerd/snapshot_test.go
+++ b/internal/runtime/containerd/snapshot_test.go
@@ -144,6 +144,8 @@ type fakeSnapshotBackend struct {
 	createdArg   images.Image
 	getImg       images.Image
 	getErr       error
+	unpacked     bool
+	unpackErr    error
 }
 
 func (f *fakeSnapshotBackend) loadContainer(context.Context, *Client, string) (cntr.Container, error) {
@@ -187,6 +189,10 @@ func (f *fakeSnapshotBackend) getImage(context.Context, string) (images.Image, e
 	}
 	return f.getImg, nil
 }
+func (f *fakeSnapshotBackend) unpack(context.Context, string, string) error {
+	f.unpacked = true
+	return f.unpackErr
+}
 
 // baseFixture returns a backend seeded with a base image (one config + one
 // layer) plus the new diff, so the commit can assemble a real manifest.
@@ -214,6 +220,9 @@ func TestCommitContainerSnapshotLiveFakeBackend(t *testing.T) {
 	got, err := d.commitContainerSnapshotLive(context.Background(), d.client, "sb-1", "snap:v1")
 	if err != nil {
 		t.Fatalf("err=%v", err)
+	}
+	if !backend.unpacked {
+		t.Fatal("committed snapshot image must be unpacked so it can back a new container")
 	}
 	// Returned digest must be the assembled MANIFEST, and createImage must have
 	// been handed a manifest target (not the bare diff layer).

--- a/pkg/api/daytona/handlers.go
+++ b/pkg/api/daytona/handlers.go
@@ -1160,9 +1160,6 @@ func (h *handlers) resolveBuildInfo(ctx context.Context, info *buildInfoRequest)
 		// their COPY/ADD steps silently no-op.
 		return "", "", errors.New("buildInfo.contextHashes is enabled but no context resolver is configured on this daemon")
 	}
-	if h.deps.ContainerEngine == models.ContainerEngineContainerd {
-		return "", "", models.ErrBuildKitUnavailable
-	}
 	if h.deps.Builder == nil {
 		return "", "", errors.New("multi-line buildInfo Dockerfiles require an image builder; daemon was started without one")
 	}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -28,7 +28,7 @@ import (
 type Server struct {
 	logger          *slog.Logger
 	service         *service.Service
-	builder         *docker.Client
+	builder         apiv1.ImageBuilder
 	build           daytona.BuildConfig
 	containerEngine string
 	patToken        string
@@ -40,14 +40,26 @@ type Server struct {
 // validation path; pass controlplane.Noop().Validator (or any rejecting
 // validator) for the open-source PAT-only behavior. A nil validator is treated
 // as reject-all so callers can't accidentally open the door by omission.
-func NewServer(logger *slog.Logger, service *service.Service, dockerClient *docker.Client, cfg config.Config, patToken string, validator controlplane.Validator) *Server {
+//
+// builder is the image-builder the /images/build + snapshot-from-Dockerfile
+// paths use. On the dockerd engine this is the *docker.Client; on the
+// containerd engine the daemon passes a buildkit-backed builder. A nil builder
+// falls back to dockerClient so existing docker-only callers are unaffected;
+// when both are nil the build endpoints return 503 (builder not configured).
+func NewServer(logger *slog.Logger, service *service.Service, dockerClient *docker.Client, builder apiv1.ImageBuilder, cfg config.Config, patToken string, validator controlplane.Validator) *Server {
 	if validator == nil {
 		validator = controlplane.Noop().Validator
+	}
+	// A nil *docker.Client wrapped in the interface would be a non-nil
+	// interface holding a nil pointer, defeating the handlers' `Builder == nil`
+	// guard. Only fall back when we actually have a docker client.
+	if builder == nil && dockerClient != nil {
+		builder = dockerClient
 	}
 	s := &Server{
 		logger:          logger,
 		service:         service,
-		builder:         dockerClient,
+		builder:         builder,
 		build:           daytona.BuildConfig{ContextEnabled: cfg.ImageBuildContextEnabled, Timeout: cfg.ImageBuildTimeout},
 		containerEngine: cfg.ContainerEngine,
 		patToken:        patToken,

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -93,7 +93,7 @@ func TestRequireAuthCases(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			server := NewServer(slog.New(slog.NewTextHandler(io.Discard, nil)), nil, nil, config.Config{}, "pat-token", nil)
+			server := NewServer(slog.New(slog.NewTextHandler(io.Discard, nil)), nil, nil, nil, config.Config{}, "pat-token", nil)
 			request := httptest.NewRequest(http.MethodPost, tc.path, strings.NewReader(tc.body))
 			if tc.authorization != "" {
 				request.Header.Set("Authorization", tc.authorization)
@@ -123,7 +123,7 @@ func TestRequireAuthCases(t *testing.T) {
 //  3. GET /v1/metrics is PAT-gated and renders aerolvm_* expvars in
 //     Prometheus text format for production scrapers.
 func TestDashboardEndpoints(t *testing.T) {
-	server := NewServer(slog.New(slog.NewTextHandler(io.Discard, nil)), nil, nil, config.Config{}, "pat-token", nil)
+	server := NewServer(slog.New(slog.NewTextHandler(io.Discard, nil)), nil, nil, nil, config.Config{}, "pat-token", nil)
 
 	t.Run("ui_is_served_unauthenticated_as_html", func(t *testing.T) {
 		request := httptest.NewRequest(http.MethodGet, "/ui", nil)
@@ -222,7 +222,7 @@ func keysOf(m map[string]any) []string {
 func TestHandleHealth(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	svc := service.New(config.Config{}, logger, nil, nil, nil, nil, nil, nil, nil)
-	server := NewServer(logger, svc, nil, config.Config{}, "pat-token", nil)
+	server := NewServer(logger, svc, nil, nil, config.Config{}, "pat-token", nil)
 
 	request := httptest.NewRequest(http.MethodGet, "/health", nil)
 	response := httptest.NewRecorder()

--- a/pkg/api/v1/build.go
+++ b/pkg/api/v1/build.go
@@ -193,10 +193,6 @@ func (h *handlers) buildImage(w http.ResponseWriter, r *http.Request) {
 		apihttp.WriteError(w, http.StatusBadRequest, "dockerfile_content is required")
 		return
 	}
-	if h.deps.ContainerEngine == models.ContainerEngineContainerd {
-		apihttp.WriteError(w, http.StatusServiceUnavailable, models.ErrBuildKitUnavailable.Error())
-		return
-	}
 	if h.deps.Builder == nil {
 		apihttp.WriteError(w, http.StatusServiceUnavailable, "image builder is not configured on this daemon")
 		return

--- a/pkg/api/v1/build_test.go
+++ b/pkg/api/v1/build_test.go
@@ -306,8 +306,11 @@ func TestBuildImageRejectsMissingBuilder(t *testing.T) {
 	}
 }
 
-func TestBuildImageContainerdBuildKitAbsent(t *testing.T) {
-	// Phase 3 named test: buildkitd-absent → clear error, not a hang.
+func TestBuildImageContainerdRoutesThroughBuilder(t *testing.T) {
+	// Phase 3: on containerd the daemon wires a buildkit-backed builder, so a
+	// build request must flow THROUGH to that builder (no engine gate). The
+	// earlier "BuildKit unavailable" 503 gate is gone; buildkitd absence now
+	// surfaces as a builder error, not a blanket engine rejection.
 	builder := &fakeImageBuilder{}
 	mux := http.NewServeMux()
 	RegisterRoutes(mux, Deps{
@@ -319,14 +322,30 @@ func TestBuildImageContainerdBuildKitAbsent(t *testing.T) {
 	body, _ := json.Marshal(buildImageRequest{DockerfileContent: "FROM alpine"})
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/v1/images/build", strings.NewReader(string(body))))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	if len(builder.builds) != 1 {
+		t.Fatalf("containerd build must invoke the wired builder once, got %d", len(builder.builds))
+	}
+}
+
+func TestBuildImageContainerdNoBuilder(t *testing.T) {
+	// Containerd host started without a builder (buildkit wiring skipped): the
+	// generic "builder not configured" 503 fires — the same guard the dockerd
+	// path uses — rather than a hang or panic.
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, Deps{
+		Builder:         nil,
+		Build:           BuildConfig{},
+		Auth:            func(h http.Handler) http.Handler { return h },
+		ContainerEngine: models.ContainerEngineContainerd,
+	})
+	body, _ := json.Marshal(buildImageRequest{DockerfileContent: "FROM alpine"})
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/v1/images/build", strings.NewReader(string(body))))
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status = %d, want 503; body=%s", rr.Code, rr.Body.String())
-	}
-	if !strings.Contains(rr.Body.String(), "BuildKit") {
-		t.Fatalf("body should mention BuildKit: %s", rr.Body.String())
-	}
-	if len(builder.builds) != 0 {
-		t.Fatalf("must not invoke builder on containerd: %d builds", len(builder.builds))
 	}
 }
 

--- a/pkg/api/v1/snapshot.go
+++ b/pkg/api/v1/snapshot.go
@@ -122,9 +122,6 @@ func (h *handlers) resolveSnapshotImage(ctx context.Context, dockerfile string, 
 		// silently no-op.
 		return "", "", errBuildNotImplemented
 	}
-	if h.deps.ContainerEngine == models.ContainerEngineContainerd {
-		return "", "", models.ErrBuildKitUnavailable
-	}
 	if h.deps.Builder == nil {
 		return "", "", errors.New("multi-line dockerfile_content requires an image builder; daemon was started without one")
 	}

--- a/pkg/createtiming/createtiming.go
+++ b/pkg/createtiming/createtiming.go
@@ -64,15 +64,25 @@ func From(ctx context.Context) *CreateTiming {
 	return timing
 }
 
-// RecordDockerWaits sets the docker runtime's readiness attribution.
-// Nil-safe so the runtime can call it unconditionally.
-func (t *CreateTiming) RecordDockerWaits(runtimeWait, toolboxWait time.Duration, source string) {
+// RecordReadinessWaits sets a runtime's readiness attribution: how long the
+// container runtime and toolbox waits took, and which signal proved readiness
+// ("socket" or "health"). Nil-safe so a driver can call it unconditionally.
+// setCreateServerTiming renders Source as the "readiness;desc=" entry, so a
+// driver that omits this leaves the create Server-Timing without a readiness
+// source (the containerd UC-11 gap).
+func (t *CreateTiming) RecordReadinessWaits(runtimeWait, toolboxWait time.Duration, source string) {
 	if t == nil {
 		return
 	}
 	t.RuntimeWaitMS = float64(runtimeWait.Microseconds()) / 1000
 	t.ToolboxWaitMS = float64(toolboxWait.Microseconds()) / 1000
 	t.Source = source
+}
+
+// RecordDockerWaits is the docker driver's original name for
+// RecordReadinessWaits, kept so existing docker callers are untouched.
+func (t *CreateTiming) RecordDockerWaits(runtimeWait, toolboxWait time.Duration, source string) {
+	t.RecordReadinessWaits(runtimeWait, toolboxWait, source)
 }
 
 // RecordStage appends a duration stage. Nil-safe; negative durations

--- a/pkg/createtiming/createtiming_test.go
+++ b/pkg/createtiming/createtiming_test.go
@@ -70,6 +70,19 @@ func TestRecordDockerWaits(t *testing.T) {
 	}
 }
 
+func TestRecordReadinessWaits(t *testing.T) {
+	timing := &CreateTiming{}
+	timing.RecordReadinessWaits(0, 44*time.Millisecond, "health")
+	if timing.RuntimeWaitMS != 0 || timing.ToolboxWaitMS != 44 || timing.Source != "health" {
+		t.Fatalf("readiness waits = %+v, want 0/44/health", timing)
+	}
+	// RecordDockerWaits is the docker-named alias and must set the same fields.
+	timing.RecordDockerWaits(10*time.Millisecond, 20*time.Millisecond, "socket")
+	if timing.RuntimeWaitMS != 10 || timing.ToolboxWaitMS != 20 || timing.Source != "socket" {
+		t.Fatalf("alias waits = %+v, want 10/20/socket", timing)
+	}
+}
+
 func TestNilRecorderIsSafe(t *testing.T) {
 	var timing *CreateTiming
 	timing.RecordStage("fc_driver", time.Second)

--- a/pkg/daemon/container_engine_wiring.go
+++ b/pkg/daemon/container_engine_wiring.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aerol-ai/microvm/internal/config"
+	"github.com/aerol-ai/microvm/internal/network/cni"
 	cntr "github.com/aerol-ai/microvm/internal/runtime/containerd"
 	"github.com/aerol-ai/microvm/internal/service"
 	"github.com/aerol-ai/microvm/internal/store"
@@ -41,6 +42,10 @@ func wireContainerEngine(ctx context.Context, cfg config.Config, logger *slog.Lo
 	if err != nil {
 		return nil, fmt.Errorf("create containerd netrules manager: %w", err)
 	}
+	// dockerd sets FORWARD policy to DROP and only ACCEPTs docker0; our aerolvm0
+	// bridge needs its own FORWARD ACCEPTs or all sandbox egress + peer traffic
+	// is dropped. EnsureChain installs them (below per-IP DROPs) for this subnet.
+	ctdRules.SetBridgeSubnet(cni.DefaultBridgeSubnet)
 	if err := ctdRules.EnsureChain(); err != nil {
 		return nil, fmt.Errorf("bootstrap AEROLVM-USER chain: %w", err)
 	}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aerol-ai/microvm/internal/version"
 	api "github.com/aerol-ai/microvm/pkg/api"
 	"github.com/aerol-ai/microvm/pkg/api/ingressproxy"
+	apiv1 "github.com/aerol-ai/microvm/pkg/api/v1"
 	"github.com/aerol-ai/microvm/pkg/caddy"
 	"github.com/aerol-ai/microvm/pkg/capacity"
 	"github.com/aerol-ai/microvm/pkg/controlplane"
@@ -749,10 +750,22 @@ func Run(ctx context.Context, logger *slog.Logger, makeProvider ProviderFactory)
 		}()
 	}
 
+	// On the containerd engine, image builds run through buildkitd (buildctl)
+	// against the aerolvm namespace instead of the dockerd builder. Wire the
+	// composite builder so /images/build + snapshot-from-Dockerfile work; the
+	// dockerd path passes nil and NewServer falls back to the docker client.
+	var apiBuilder *cntr.ImageBuilder
+	if ctdWiring != nil {
+		apiBuilder = cntr.NewImageBuilder(ctdWiring.driver, cntr.NewBuildKitBuilder(cfg.ContainerdBuildKitAddr, "", logger))
+	}
 	// cp.Validator is the second-token (non-PAT) validation path. Under
 	// controlplane.Noop() it rejects every non-PAT token, so the server
 	// behaves exactly as the PAT-only build did before this seam existed.
-	server := api.NewServer(logger, svc, dockerClient, cfg, cfg.PATToken, cp.Validator)
+	var builder apiv1.ImageBuilder
+	if apiBuilder != nil {
+		builder = apiBuilder
+	}
+	server := api.NewServer(logger, svc, dockerClient, builder, cfg, cfg.PATToken, cp.Validator)
 	logger.Info("dashboard available", "url", "http://"+cfg.ListenAddr()+"/ui")
 	// Mount the same API handler onto the cluster-internal mTLS listener so
 	// peers can reverse-proxy owner API calls over the cert-pinned channel

--- a/pkg/docker/netrules/ensure_chain.go
+++ b/pkg/docker/netrules/ensure_chain.go
@@ -1,6 +1,9 @@
 package netrules
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // EnsureChain bootstraps the filter user chain and its FORWARD jump once per
 // Manager lifetime. Idempotent and latched like EnsureLayer4Ready: concurrent
@@ -34,7 +37,40 @@ func (m *Manager) EnsureChain() error {
 	if err := boot.EnsureForwardJump(chain); err != nil {
 		return err
 	}
+	if err := m.ensureBridgeForwardAccept(); err != nil {
+		return err
+	}
 	m.chainReady.Store(true)
+	return nil
+}
+
+// ensureBridgeForwardAccept installs subnet-scoped FORWARD ACCEPT rules for the
+// sandbox bridge so its traffic survives dockerd's FORWARD DROP policy. They go
+// in the user chain BELOW any per-IP DROP (which Insert at position 1), so a
+// blocked/egress-policied sandbox is still dropped while an unrestricted
+// sandbox gets egress + sandbox↔sandbox connectivity. Idempotent; no-op when no
+// bridge subnet is set (dockerd path). Uses only -s/-d matches so it is
+// expressible on both the exec and netlink backends.
+func (m *Manager) ensureBridgeForwardAccept() error {
+	if m == nil || strings.TrimSpace(m.bridgeSubnet) == "" {
+		return nil
+	}
+	chain := m.filterChain()
+	for _, spec := range [][]string{
+		{"-s", m.bridgeSubnet, "-j", "ACCEPT"},
+		{"-d", m.bridgeSubnet, "-j", "ACCEPT"},
+	} {
+		exists, err := m.ipt.Exists("filter", chain, spec...)
+		if err != nil {
+			return fmt.Errorf("check bridge forward accept: %w", err)
+		}
+		if exists {
+			continue
+		}
+		if err := m.ipt.Insert("filter", chain, 1, spec...); err != nil {
+			return fmt.Errorf("insert bridge forward accept: %w", err)
+		}
+	}
 	return nil
 }
 
@@ -54,7 +90,10 @@ func (m *Manager) ReassertChain() error {
 	if err := boot.EnsureUserChain(chain); err != nil {
 		return err
 	}
-	return boot.EnsureForwardJump(chain)
+	if err := boot.EnsureForwardJump(chain); err != nil {
+		return err
+	}
+	return m.ensureBridgeForwardAccept()
 }
 
 // ResetChainLatch clears the bootstrap latch. Test-only seam.

--- a/pkg/docker/netrules/ensure_chain_test.go
+++ b/pkg/docker/netrules/ensure_chain_test.go
@@ -31,6 +31,47 @@ func TestEnsureChainIdempotentLatch(t *testing.T) {
 	}
 }
 
+func TestEnsureChainInstallsBridgeForwardAccept(t *testing.T) {
+	be := &memBackend{}
+	mgr := &Manager{enabled: true, ipt: be, userChain: ChainAerolvmUser}
+	mgr.SetBridgeSubnet("10.88.0.0/16")
+	if err := mgr.EnsureChain(); err != nil {
+		t.Fatal(err)
+	}
+	// Subnet-scoped FORWARD ACCEPTs (both directions) survive dockerd's DROP.
+	if be.countMatching("|-s|10.88.0.0/16|-j|ACCEPT") != 1 {
+		t.Fatalf("missing -s subnet accept: %v", be.rules)
+	}
+	if be.countMatching("|-d|10.88.0.0/16|-j|ACCEPT") != 1 {
+		t.Fatalf("missing -d subnet accept: %v", be.rules)
+	}
+	// Idempotent — re-assert does not duplicate.
+	if err := mgr.ReassertChain(); err != nil {
+		t.Fatal(err)
+	}
+	if be.countMatching("|-s|10.88.0.0/16|-j|ACCEPT") != 1 {
+		t.Fatalf("subnet accept duplicated on reassert: %v", be.rules)
+	}
+	// A per-IP block coexists (isolation still enforced via the DROP).
+	if err := mgr.BlockAllEgress("10.88.0.5"); err != nil {
+		t.Fatal(err)
+	}
+	if be.countMatching("|-s|10.88.0.5|-j|DROP") != 1 {
+		t.Fatalf("per-IP block missing alongside bridge accept: %v", be.rules)
+	}
+}
+
+func TestEnsureChainNoBridgeAcceptWithoutSubnet(t *testing.T) {
+	be := &memBackend{}
+	mgr := &Manager{enabled: true, ipt: be, userChain: ChainAerolvmUser}
+	if err := mgr.EnsureChain(); err != nil {
+		t.Fatal(err)
+	}
+	if be.countMatching("ACCEPT") != 0 {
+		t.Fatalf("no bridge subnet set: expected no ACCEPT rules, got %v", be.rules)
+	}
+}
+
 func TestEnsureChainDisabledNoOp(t *testing.T) {
 	mgr := &Manager{enabled: false, userChain: ChainAerolvmUser}
 	if err := mgr.EnsureChain(); err != nil {

--- a/pkg/docker/netrules/manager.go
+++ b/pkg/docker/netrules/manager.go
@@ -67,6 +67,23 @@ type Manager struct {
 	// Service.EnsureLayer4Ready.
 	chainReady atomic.Bool
 	chainMu    sync.Mutex
+	// bridgeSubnet, when set (containerd engine, e.g. 10.88.0.0/16), makes
+	// EnsureChain also install subnet-scoped FORWARD ACCEPT rules for our
+	// bridge. dockerd sets the FORWARD policy to DROP and only ACCEPTs docker0
+	// traffic; without our own ACCEPTs, all aerolvm0 egress and sandbox↔sandbox
+	// traffic is dropped by that policy. The CNI bridge plugin sets up the
+	// bridge + NAT but not FORWARD ACCEPTs (libnetwork did that for docker0),
+	// so it is ours (plan §4 item #5).
+	bridgeSubnet string
+}
+
+// SetBridgeSubnet records the sandbox bridge subnet whose forwarded traffic
+// EnsureChain/ReassertChain must ACCEPT (below any per-IP DROP). Empty = no-op.
+func (m *Manager) SetBridgeSubnet(subnet string) {
+	if m == nil {
+		return
+	}
+	m.bridgeSubnet = strings.TrimSpace(subnet)
 }
 
 // ipLock is a refcounted per-IP mutex. Refs track in-flight holders so idle

--- a/setup/config-defaults.md
+++ b/setup/config-defaults.md
@@ -58,6 +58,7 @@ feature is still mid-rollout.
 | `SB_CONTAINERD_LOG_DIR` | Overrides per-task log file placement; defaults to `${SB_CONTAINERD_RUN_DIR}/logs`. Each task log is size-capped (containerd does not rotate task IO). |
 | `SB_CONTAINERD_CNI_PLUGIN_DIR` | CNI plugin binaries dir; default `/opt/cni/bin`. Only consumed when the native netns pool is enabled. |
 | `SB_CONTAINERD_CNI_CONF_PATH` | Bridge conflist path; default `/etc/cni/net.d/aerolvm.conflist`. Auto-generated at boot (bridge + host-local + `ipMasq`) if absent; an operator-provided file is never clobbered. |
+| `SB_CONTAINERD_BUILDKIT_ADDR` | buildkitd control socket for image builds on the containerd engine; default `unix:///run/buildkit/buildkitd.sock`. The bootstrap installs buildkitd with a containerd worker pinned to the aerolvm namespace, so built images land where the driver can run them. Only used when `SB_CONTAINER_ENGINE=containerd`. |
 | `SB_CONTAINERD_NETNS_POOL_DEPTH` | Prepaid netns slots to keep warm; default `4`. Only relevant when `SB_CONTAINERD_NATIVE_NETNS_POOL_ENABLED=true`. |
 | `SB_CONTAINERD_NETNS_POOL_REFILL_INTERVAL` | netns pool refill ticker; default `2s`. |
 | `SB_CONTAINERD_POOL_DEPTH` | Warm containers per image key; default `2`. Only relevant when `SB_CONTAINERD_POOL_ENABLED=true`. |


### PR DESCRIPTION
## What & why

Lands the remaining `SB_CONTAINER_ENGINE=containerd` fixes surfaced by the live
`single-node-containerd` integration run (the 8 fast-loop commits after PR #329,
which drove the suite from 13/105 → 55/105), **plus** the last two dark features:

- **BuildKit image builds** on the containerd engine (UC-46 build, UC-74
  create-with-image, UC-76 build+push) — previously gated with a 503
  "BuildKit unavailable".
- **Readiness Server-Timing** on the containerd create path (UC-11).

The containerd engine remains **dark** (default `docker`); every change here is
gated on the engine and is a no-op for docker hosts.

### Fast-loop fixes included (already live-validated on the reaped node)
- normalize image refs before pull (`docker.io/library/...`) + local-ref-first / `:latest` resolution for snapshots
- read image default command from the config descriptor directly
- FORWARD ACCEPT for the aerolvm0 bridge subnet (egress + peer traffic)
- live `Resize` via `task.Update`
- recreate the ready socket on resume so runc mount succeeds
- unpack committed snapshot images so they can back new containers

### New in this PR (offline-tested; live validation pending a fresh provision)
- `BuildKitBuilder` (buildctl shell-out) + `ImageBuilder` composite (BuildImage / ImageExists / RemoveImage / PushImage / RefreshTag-noop)
- `Driver.ImageExists` (pure local-store lookup, no pull)
- daemon wires the composite as the API builder when engine=containerd
- removed the `ContainerEngine==containerd` 503 gate in build.go / snapshot.go / daytona handlers (the generic `Builder == nil` guard remains)
- `SB_CONTAINERD_BUILDKIT_ADDR` config knob + buildkitd install in `bootstrap.sh.tftpl`
- containerd create records the readiness source (`socket`/`health`) via new `createtiming.RecordReadinessWaits`

## Code-path diagram (§8)

```mermaid
flowchart TB
    subgraph build["POST /v1/images/build (containerd)"]
        B0["buildImage handler"]
        B0 --> Bgate{"Builder == nil?"}
        Bgate -->|"nil (was: engine==containerd → 503)"| B503["503 not configured"]
        Bgate -->|wired composite| BExist{"ImageExists(tag)?"}
        BExist -->|hit| BRefresh["RefreshTag (no-op on ctd)"]
        BExist -->|miss| BBuild["buildctl build --output type=image,name=tag,unpack=true"]
        BBuild --> BWorker["buildkitd containerd worker → aerolvm ns"]
        BWorker --> BPush{"push requested?"}
        BRefresh --> BPush
        BPush -->|yes| BP["RegistryPusher.PushImage"]
        BPush -->|no| BOK["200"]
        BP --> BOK
    end

    subgraph create["containerd Create readiness (UC-11 delta)"]
        C0["task.Start"] --> Cready{"ReadyEnabled && listener?"}
        Cready -->|yes| Csock["readyListener.Wait — source=socket"]
        Cready -->|no| Chealth["waitToolboxHTTP — source=health"]
        Csock --> Crec["RecordReadinessWaits(source)  &lt;- NEW"]
        Chealth --> Crec
        Crec --> Cdone["setCreateServerTiming emits readiness;desc=source"]
    end
```

## pr-review axes

**§1 Idempotency** — Build tag is content-addressed (`docker.BuildTagFor`); a retry
re-runs `buildctl` and re-exports the same `name:tag` (buildkit is idempotent on an
identical Dockerfile/context). `ImageExists` short-circuits a cache hit. No host-port
pool involvement. `PushImage` treats `AlreadyExists` as success. `ImageExists` /
`RemoveImage` operate on the containerd image store and are safe under retry.

**§2 Boot-path latency** — The BuildKit wiring is **not** on `CreateSandbox` (it is the
separate `/images/build` endpoint). The UC-11 change adds to the containerd create
path exactly: one `time.Now()`, one string assignment, and one nil-safe
`RecordReadinessWaits` struct write — **no I/O, no lock, no allocation of note**;
negligible and bounded. The 8 fast-loop create-path fixes (image-ref resolution,
ready-socket recreation on resume) were already live-validated. Docker create path is
byte-identical (builder wiring gated on `ctdWiring != nil`).

**§3 Bootstrap** — buildkitd is installed at **daemon provisioning** (Terraform
bootstrap), not via a hot-API lazy bootstrap; no `atomic.Bool`/single-flight pattern
needed. N/A for the EnsureLayer4Ready shape.

**§4 Failure-path consistency** — Build failure (`buildctl` non-zero) happens before any
caddy/store write; nothing to roll back. The existing snapshot-register rollback
(`RemoveImage` on downstream failure) is unchanged and now backed by the containerd
image delete. N/A for new caddy+store multi-step writes.

**§5 Mount inputs** — N/A.

**§6 TCP host-port pool & L4 bootstrap** — N/A (untouched).

**§7 Cluster** — N/A for correctness: containerd is single-node/dark; the existing
`clusterBuildImageWrap` fanout path is unchanged. Containerd builder wiring is gated on
`ctdWiring != nil` so it is a no-op when `EnableCluster` is false or the engine is
docker. No FSM / placement / forwarding changes.

## Testing

- `make test` green. New/updated: `buildkit_test.go` (validation, fake-buildctl
  success/failure exec, context-tar extraction + traversal rejection, composite
  delegation, `Driver.ImageExists`), `createtiming` `RecordReadinessWaits`, v1
  `build_test.go` rewritten (containerd now routes through the wired builder; nil-builder
  503), `server_test.go` signature fix.
- Live: `make integration-single-containerd` on a fresh provision validates UC-46/74/76
  (build) + UC-11 (readiness) + the fast-loop fixes end-to-end. **Pending** — the prior
  node was TTL-reaped; a fresh provision is queued after merge+release.

## Known follow-ups
- **UC-43** (ssh `echo ssh-ok` exits 1) still needs live repro on the ssh-gateway
  session path; not addressed here.
- buildkitd version pin (`v0.17.2`) + systemd flags are validated offline only until the
  fresh provision runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
