### PR TITLE
fix(containerd): land remaining live fixes (ssh exec, snapshot lease, UC-11, report parser)

### DIFF
--- a/integration-tests/report/gen.go
+++ b/integration-tests/report/gen.go
@@ -14,6 +14,8 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -224,14 +226,33 @@ func summarize(rs []Result) Summary {
 }
 
 func parseEvents(r io.Reader) ([]testEvent, error) {
-	dec := json.NewDecoder(r)
+	// `go test -json` is line-delimited JSON. Parse line-by-line and skip a
+	// torn line rather than aborting the whole report: when a test writes to
+	// os.Stdout concurrently with the test framework, the -json stream can
+	// splice two records and corrupt one line. A streaming json.Decoder cannot
+	// resync past that; a Scanner just drops the bad line and keeps going.
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024) // test output lines can be large
 	var events []testEvent
-	for dec.More() {
+	skipped := 0
+	for sc.Scan() {
+		line := bytes.TrimSpace(sc.Bytes())
+		if len(line) == 0 || line[0] != '{' {
+			skipped++
+			continue
+		}
 		var ev testEvent
-		if err := dec.Decode(&ev); err != nil {
-			return nil, err
+		if err := json.Unmarshal(line, &ev); err != nil {
+			skipped++
+			continue
 		}
 		events = append(events, ev)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	if skipped > 0 {
+		fmt.Fprintf(os.Stderr, "parseEvents: skipped %d malformed line(s) in the go test -json stream\n", skipped)
 	}
 	return events, nil
 }

--- a/integration-tests/suite/docker_readiness_test.go
+++ b/integration-tests/suite/docker_readiness_test.go
@@ -134,14 +134,24 @@ func TestDockerReadinessSocketImpliesServingAgent(t *testing.T) {
 }
 
 // UC-97 is covered by pkg/docker unit tests (push disabled → health poll).
-// Non-cluster scenarios (local-mode, single-node) exercise the fallback on
-// live infra because EnableCluster=false keeps the push path off.
+// The health-poll fallback only applies on a node with EnableCluster=false;
+// push-based readiness ("socket") is correct whenever EnableCluster is true.
 func TestDockerReadinessFallbackOnNonCluster(t *testing.T) {
 	if sc.Satisfies(harness.UseCase{Requires: []harness.Capability{harness.CapCluster}}) {
 		t.Skip("cluster scenario uses socket push; fallback covered elsewhere")
 	}
 	harness.Require(t, sc, "UC-11")
 	c := client(t)
+	// The scenario capability tags this as "non-cluster", but single-node
+	// scenarios still run sandboxd as a 1-node cluster (seed → cluster-init sets
+	// SB_ENABLE_CLUSTER=true), which turns push-based readiness ON — so "socket"
+	// is correct there. DockerReadySocketEffective() gates on EnableCluster, not
+	// on node count, so key the fallback assertion off the node's ACTUAL mode
+	// (via /health) rather than the scenario tag. Only a truly non-cluster node
+	// (local-mode, EnableCluster=false) exercises the health-poll fallback.
+	if h, err := c.SDK().Health(context.Background()); err == nil && (h.ClusterTopology != "" || h.ClusterNodes > 0) {
+		t.Skip("node runs EnableCluster=true (1-node cluster); push readiness is on, socket is correct")
+	}
 	sb := c.NewSandbox(t, sdktypes.CreateSandboxOptions{
 		Image: harness.DefaultImage,
 		Name:  harness.UniqueName(sc, t),

--- a/internal/runtime/containerd/snapshot.go
+++ b/internal/runtime/containerd/snapshot.go
@@ -199,6 +199,22 @@ func (d *Driver) commitContainerSnapshotLive(ctx context.Context, client *Client
 	if backend == nil {
 		return "", errors.New("containerd snapshot commit requires live containerd")
 	}
+	// Hold a lease across the whole commit. createDiff writes the diff content
+	// to the store with NO gc reference — it only becomes GC-protected once the
+	// committed image's gc.ref.content.l.* labels land at createImage. Without a
+	// lease, a GC sweep in that window collects the diff (and its layers),
+	// surfacing intermittently as "content digest <x>: not found" at diff-id or
+	// unpack. The lease pins everything created here until it is released (by
+	// which point the image labels protect the content). WithDefaultNamespace on
+	// the raw client scopes the lease to the aerolvm namespace.
+	if raw := client.Raw(); raw != nil {
+		leasedCtx, release, lerr := raw.WithLease(ctx)
+		if lerr != nil {
+			return "", fmt.Errorf("snapshot lease: %w", lerr)
+		}
+		ctx = leasedCtx
+		defer func() { _ = release(ctx) }()
+	}
 	container, err := backend.loadContainer(ctx, client, containerRef)
 	if err != nil {
 		return "", err

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -726,9 +726,10 @@ func Run(ctx context.Context, logger *slog.Logger, makeProvider ProviderFactory)
 
 	if shouldStartSSHGateway(cfg) {
 		sshCfg := sshgateway.Config{
-			ListenAddr:  cfg.SSHListenAddr,
-			HostKeyPath: cfg.SSHHostKeyPath,
-			ToolboxPort: cfg.ToolboxPort,
+			ListenAddr:      cfg.SSHListenAddr,
+			HostKeyPath:     cfg.SSHHostKeyPath,
+			ToolboxPort:     cfg.ToolboxPort,
+			ContainerEngine: cfg.ContainerEngine,
 		}
 		// In cluster mode an SSH connection can land on a node that does not own
 		// the target sandbox. Point the gateway at this node's own v1 API

--- a/pkg/sshgateway/forward_test.go
+++ b/pkg/sshgateway/forward_test.go
@@ -386,3 +386,76 @@ func TestHTTPToWS(t *testing.T) {
 		}
 	}
 }
+
+// TestHandleSession_ContainerdExecViaToolbox is the UC-43 regression: on the
+// containerd engine a one-shot ssh `exec` request must run through the
+// in-container toolbox session (POST /sessions carrying Command) rather than
+// the docker-exec path, which cannot reach a containerd task (echo would come
+// back exit 1). The command's exit status must propagate over the SSH channel.
+func TestHandleSession_ContainerdExecViaToolbox(t *testing.T) {
+	var posted *models.CreateSessionRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/sessions":
+			body, _ := io.ReadAll(r.Body)
+			var cr models.CreateSessionRequest
+			_ = json.Unmarshal(body, &cr)
+			posted = &cr
+			_, _ = w.Write([]byte(`{"id":"sess-local","name":"exec","status":"running"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/sessions/sess-local/attach":
+			up := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+			conn, err := up.Upgrade(w, r, nil)
+			if err != nil {
+				return
+			}
+			defer conn.Close()
+			_ = conn.WriteMessage(websocket.BinaryMessage, append([]byte{streamFramePrefixStdout}, []byte("ssh-ok")...))
+			_ = conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"exit","code":0}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	host, portStr, err := net.SplitHostPort(srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("SplitHostPort: %v", err)
+	}
+	port, _ := strconv.Atoi(portStr)
+
+	g := &Gateway{
+		logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+		containerEngine: models.ContainerEngineContainerd,
+		toolboxPort:     port,
+		svc: &fakeLookup{sandbox: &models.Sandbox{
+			ID:           "sb-ctd",
+			Status:       models.SandboxStatusStarted,
+			ContainerID:  "ctr-1",
+			ContainerIP:  host,
+			ToolboxToken: "tok",
+		}},
+	}
+	channel := &fakeChannel{stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}}
+	requests := make(chan *ssh.Request, 2)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		g.handleSession(context.Background(), "sb-ctd", "session", "default", false, channel, requests)
+	}()
+	requests <- &ssh.Request{Type: "exec", Payload: encodeString("echo ssh-ok")}
+	close(requests)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleSession did not return")
+	}
+
+	if posted == nil {
+		t.Fatal("containerd exec must POST a toolbox session; the docker-exec path was taken instead")
+	}
+	if posted.Command != "echo ssh-ok" {
+		t.Fatalf("toolbox session command = %q, want echo ssh-ok", posted.Command)
+	}
+	if got := channel.exitStatus(); got != 0 {
+		t.Fatalf("exit status = %d, want 0", got)
+	}
+}

--- a/pkg/sshgateway/gateway.go
+++ b/pkg/sshgateway/gateway.go
@@ -60,6 +60,12 @@ type Config struct {
 	// RemoteAPIToken is the PAT presented on the loopback v1 call. Only used
 	// when RemoteAPIBaseURL is set.
 	RemoteAPIToken string
+	// ContainerEngine is the host runtime engine ("docker" | "containerd").
+	// On containerd, sandboxes are containerd tasks (not docker containers), so
+	// the docker-exec one-shot path cannot reach them — the gateway runs the
+	// command through the in-container toolbox session instead. Empty defaults
+	// to the docker behaviour.
+	ContainerEngine string
 }
 
 // Gateway terminates SSH connections on the host and bridges accepted shell /
@@ -82,6 +88,9 @@ type Gateway struct {
 	// remote branch is never taken.
 	remoteBaseURL string
 	remotePAT     string
+
+	// containerEngine gates the containerd one-shot-exec-via-toolbox path.
+	containerEngine string
 }
 
 // New constructs a Gateway. It loads or generates the host key. Returns an
@@ -106,8 +115,9 @@ func New(logger *slog.Logger, cfg Config, svc SandboxLookup, dockerCli DockerExe
 		dockerCli:   dockerCli,
 		toolboxPort: cfg.ToolboxPort,
 
-		remoteBaseURL: strings.TrimRight(strings.TrimSpace(cfg.RemoteAPIBaseURL), "/"),
-		remotePAT:     strings.TrimSpace(cfg.RemoteAPIToken),
+		remoteBaseURL:   strings.TrimRight(strings.TrimSpace(cfg.RemoteAPIBaseURL), "/"),
+		remotePAT:       strings.TrimSpace(cfg.RemoteAPIToken),
+		containerEngine: strings.TrimSpace(cfg.ContainerEngine),
 	}, nil
 }
 
@@ -366,8 +376,20 @@ func (g *Gateway) handleSession(ctx context.Context, sandboxID, mode, sessionNam
 				replyRequest(req, false)
 				continue
 			}
-			cmd := []string{"sh", "-c", command}
 			replyRequest(req, true)
+			// Containerd sandboxes are containerd tasks, not docker containers, so
+			// the docker-exec path (runExec) cannot reach them (echo would come
+			// back exit 1). Run the one-shot command as its own short-lived
+			// toolbox session — the same engine-agnostic path the cross-node exec
+			// uses — so its exact exit status propagates. Docker is unchanged.
+			if g.containerEngine == models.ContainerEngineContainerd && g.toolboxPort > 0 && sandbox.ContainerIP != "" {
+				state.execCommand = command
+				ep := localSessionEndpoint(sandbox.ContainerIP, g.toolboxPort, sandbox.ToolboxToken)
+				exitCode := g.attachToSession(ctx, channel, ep, "exec-"+newForwardID(), state, nil)
+				_ = sendExitStatus(channel, uint32(exitCode))
+				return
+			}
+			cmd := []string{"sh", "-c", command}
 			g.runExec(ctx, channel, sandboxID, containerID, cmd, state)
 			return
 


### PR DESCRIPTION
## What & why

Follow-up to #330, which merged only the BuildKit commit (the merge queue picked
up an early branch tip before these two commits landed). This lands the rest of
the live-validated containerd fixes so main matches what was validated on the
single-node-containerd node.

- **ssh one-shot exec via toolbox (UC-43)** — `sess.Output(...)` returned exit 1
  on containerd because the gateway's `exec` request used the docker-exec path,
  which can't reach a containerd task. Route the one-shot command through the
  in-container toolbox session (same engine-agnostic path the cross-node exec
  uses); docker unchanged. Gateway is engine-aware via `Config.ContainerEngine`.
- **readiness Server-Timing (UC-11)** — test keyed off the stale scenario cap;
  single-node runs `EnableCluster=true` (1-node cluster) so `"socket"` is
  correct. Skip the health-fallback assertion when `/health` reports cluster mode.
- **report/gen.go** — parse `go test -json` line-by-line, skipping a torn line
  instead of failing the whole report.
- **snapshot commit lease (UC-20/21)** — `commitContainerSnapshotLive` created
  the diff content with no gc reference until `createImage`; a GC sweep in that
  window intermittently collected it ("content digest … not found"). Wrap the
  commit in a lease. Live: 8/8 stable (was ~1/3 flaky).

## Testing
- Offline `make test` green.
- Live single-node-containerd: 101–102 pass / 43 skip / 0 deterministic fails.
  UC-43, UC-20/21 (8/8), BuildKit UC-46/74/76 all pass; UC-11 skips correctly.
- New unit test: `sshgateway.TestHandleSession_ContainerdExecViaToolbox`.

## pr-review axes
- **§1 Idempotency**: snapshot commit is idempotent (AlreadyExists → unpack existing); ssh exec creates a fresh short-lived toolbox session per request.
- **§2 Boot path**: no change to `CreateSandbox`. Snapshot lease is on the commit path only.
- **§4 Failure path**: lease auto-releases on return; on failure the diff content is GC-eligible again (no leak).
- **§7 Cluster**: gateway containerd-exec routing is engine-gated + no-op on docker; UC-11 skip reads runtime cluster state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
