### PR TITLE
fix(firecracker): stop post_resume waiting out its 2s timeout every create (60× create latency)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BIN_DIR ?= bin
 	integration-benchmark-fc integration-benchmark-fc-only \
 	integration-benchmark-wasm integration-benchmark-wasm-only \
 	integration-benchmark-gvisor integration-benchmark-gvisor-only \
-	integration-single-fc integration-arm64 integration-arm64-single integration-arm64-cluster integration-all integration-collect-logs integration-destroy integration-reap \
+	integration-single-fc integration-benchmark-fc-single integration-arm64 integration-arm64-single integration-arm64-cluster integration-all integration-collect-logs integration-destroy integration-reap \
 	integration-cert-store-init integration-clear-lease
 
 fmt:
@@ -313,6 +313,27 @@ integration-benchmark-gvisor-only:
 # cluster. On-Demand only (the metal box exceeds the Spot vCPU quota).
 integration-single-fc:
 	integration-tests/run.sh single-node-fc $(RUN_FLAGS)
+
+# Firecracker create-latency benchmark on ONE c5.metal box (single-node-fc).
+# The cheap diagnostic: cluster-hetero costs 8 nodes, this costs one, and being
+# single-node it isolates the FC DRIVER cost — no Raft placement or cross-node
+# forward hop in the number, so the per-stage Server-Timing breakdown
+# (fc_verify / fc_spawn / fc_load / fc_resume / fc_handshake / fc_post_resume)
+# attributes cleanly to the driver. UC-94 firecracker only (UC-95 density skips
+# because AEROL_BENCH_RUNTIMES=firecracker). Measures the COLD path (warm-VMM
+# pool stays default-off); enable SB_FIRECRACKER_VMM_POOL_ENABLED on the box to
+# also measure warm. Provisions On-Demand (metal exceeds Spot quota) and tears
+# down on exit unless you pass `keep`.
+#   make integration-benchmark-fc-single
+#   make integration-benchmark-fc-single keep
+#   make integration-benchmark-fc-single FC_SINGLE_BENCH_OUT=/tmp/fc-single.json
+FC_SINGLE_BENCH_OUT ?= integration-tests/reports/single-node-fc-bench.json
+FC_SINGLE_BENCH_SAMPLES ?= 10
+integration-benchmark-fc-single:
+	AEROL_BENCH=1 AEROL_BENCH_OUT=$(FC_SINGLE_BENCH_OUT) \
+	AEROL_BENCH_SAMPLES=$(FC_SINGLE_BENCH_SAMPLES) \
+	AEROL_BENCH_RUNTIMES=firecracker \
+		integration-tests/run.sh single-node-fc $(RUN_FLAGS)
 
 integration-arm64-single:
 	integration-tests/run.sh single-node-fc-arm64 $(RUN_FLAGS)

--- a/integration-tests/scenarios/single-node-fc.caps.yml
+++ b/integration-tests/scenarios/single-node-fc.caps.yml
@@ -1,10 +1,23 @@
 # Capabilities the single-node x86 Firecracker scenario can satisfy. The suite
 # skips any use case whose required capabilities aren't all present here. Mirror
 # of single-node-fc-arm64 but on an x86 bare-metal host.
+#
+# benchmark: opts in UC-94 (create latency) so `make integration-benchmark-fc-single`
+# can measure the firecracker create path on ONE c5.metal box — far cheaper than
+# the 8-node cluster-hetero, and single-node isolates the FC driver cost (no Raft
+# placement / cross-node forward in the number).
+#
+# docker-engine: keep this metal FC box on the proven dockerd bootstrap. containerd
+# is the harness default now, but the container engine is irrelevant to firecracker
+# latency (FC bypasses it via Jailer + TAP + vsock), and containerd-on-c5.metal is
+# not yet live-verified — so for an expensive one-shot metal bench we do NOT want
+# the containerd CNI bootstrap as a provisioning variable.
 name: single-node-fc
 capabilities:
   - docker
+  - docker-engine
   - platform-volumes
   - firecracker
   - domain
   - custom-domains
+  - benchmark

--- a/integration-tests/suite/harness/usecases.go
+++ b/integration-tests/suite/harness/usecases.go
@@ -280,7 +280,12 @@ var Registry = []UseCase{
 	// running) over a sample, reporting p50/p90/p99. UC-95 probes effective
 	// fleet density by creating sandboxes until the API rejects on capacity,
 	// then tears them all down. Both reuse the hetero cluster substrate.
-	{ID: "UC-94", Title: "Benchmark: per-runtime sandbox create latency", Requires: []Capability{CapCluster, CapBenchmark}, Implemented: true},
+	// UC-94 needs only CapBenchmark, not CapCluster: create latency is meaningful
+	// single-node too (the single-node-fc c5.metal box is the cheap way to profile
+	// the firecracker driver in isolation — no Raft/placement/forward in the
+	// number). The bench body already handles the no-cluster case: waitBenchmarkReady
+	// early-returns when CapCluster is absent, so it skips the members/leader wait.
+	{ID: "UC-94", Title: "Benchmark: per-runtime sandbox create latency", Requires: []Capability{CapBenchmark}, Implemented: true},
 	{ID: "UC-95", Title: "Benchmark: fleet density to capacity rejection", Requires: []Capability{CapCluster, CapBenchmark}, Implemented: true},
 	{ID: "UC-96", Title: "Docker create readiness delivered via unix-socket push", Requires: []Capability{CapCluster, CapDocker}, Implemented: true},
 	{ID: "UC-96b", Title: "Docker socket push works for non-root container images", Requires: []Capability{CapCluster, CapDocker}, Implemented: true},

--- a/internal/runtime/firecracker/snapshot.go
+++ b/internal/runtime/firecracker/snapshot.go
@@ -14,6 +14,7 @@ package firecracker
 // the Driver's per-sandbox registry maps.
 
 import (
+	"bufio"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -414,9 +415,19 @@ func (d *Driver) sendVsockOp(ctx context.Context, socketPath string, guestCID ui
 	if _, err := conn.Write(append(line, '\n')); err != nil {
 		return fmt.Errorf("write: %w", err)
 	}
-	// Discard the ack. A short read budget keeps a hung guest from
-	// pinning the snapshot pipeline.
-	_, _ = io.CopyN(io.Discard, conn, 256)
+	// Read the single newline-delimited JSON ack the guest writes, and STOP at
+	// the newline. The guest (cmd/toolboxd handleVsockConn) keeps the
+	// connection open to serve further ops, so it never sends EOF after the
+	// ack. The previous `io.CopyN(io.Discard, conn, 256)` demanded 256 bytes:
+	// it read the ~12-byte ack, then blocked waiting for 244 bytes that never
+	// arrive until the conn's read deadline fired — burning the full
+	// PostResumeTimeout (~2s) on EVERY post_resume. That single stall was
+	// ~98% of firecracker snapshot-clone create latency (server p50 2030ms,
+	// fc_post_resume 2000ms, measured single-node-fc). The conn already carries
+	// the dial-context read deadline (vsock_dial_linux.go SetDeadline), so a
+	// genuinely hung guest still bails at the bound instead of hanging forever.
+	// We only care that the ack arrived; its content is discarded.
+	_, _ = bufio.NewReader(conn).ReadString('\n')
 	return nil
 }
 

--- a/internal/runtime/firecracker/snapshot_vsock_ack_test.go
+++ b/internal/runtime/firecracker/snapshot_vsock_ack_test.go
@@ -1,0 +1,77 @@
+package firecracker
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+)
+
+// ackThenHoldConn mimics the real in-guest vsock server (cmd/toolboxd
+// handleVsockConn): it returns the single newline-delimited JSON ack on the
+// first read, then HOLDS the connection open to serve further ops — it never
+// sends EOF. It counts reads so a test can prove sendVsockOp stops at the ack's
+// newline rather than reading toward a fixed byte budget.
+type ackThenHoldConn struct {
+	ack   []byte
+	pos   int
+	reads int
+	wrote [][]byte
+}
+
+func (c *ackThenHoldConn) Read(p []byte) (int, error) {
+	c.reads++
+	if c.pos < len(c.ack) {
+		n := copy(p, c.ack[c.pos:])
+		c.pos += n
+		return n, nil
+	}
+	// No EOF: the real guest keeps the connection open. Any read past the ack
+	// is the pre-fix over-read; against the real guest it blocked here until
+	// the connection's read deadline (~2s). Return an error so a regression
+	// fails fast instead of hanging the suite.
+	return 0, errors.New("guest sent only the ack line and is holding the connection open")
+}
+
+func (c *ackThenHoldConn) Write(p []byte) (int, error) {
+	b := make([]byte, len(p))
+	copy(b, p)
+	c.wrote = append(c.wrote, b)
+	return len(p), nil
+}
+
+func (c *ackThenHoldConn) Close() error { return nil }
+
+type ackHoldDialer struct{ conn *ackThenHoldConn }
+
+func (d ackHoldDialer) Dial(_ context.Context, _ string, _, _ uint32) (io.ReadWriteCloser, error) {
+	return d.conn, nil
+}
+
+// TestSendVsockOp_StopsAtAckNewline is the regression guard for the firecracker
+// post_resume create-latency fix. sendVsockOp must return as soon as it has
+// read the guest's single-line ack and NOT keep reading toward a fixed byte
+// budget: the guest holds the connection open (no EOF), so over-reading blocked
+// for the full PostResumeTimeout (~2s) on every create — the fc_post_resume
+// stage that measured 2000ms and was ~98% of firecracker create p50
+// (2030ms server p50, single-node-fc). See snapshot.go sendVsockOp.
+func TestSendVsockOp_StopsAtAckNewline(t *testing.T) {
+	conn := &ackThenHoldConn{ack: []byte(`{"ok":true}` + "\n")}
+	d := &Driver{vsockDial: ackHoldDialer{conn: conn}}
+
+	err := d.sendVsockOp(context.Background(), "/run/vsock.sock", 3, "post_resume",
+		map[string]any{"wallclock_unix_ns": int64(1)})
+	if err != nil {
+		t.Fatalf("sendVsockOp returned error: %v", err)
+	}
+	// Exactly one read: consume the ack line, stop at its newline. A second read
+	// is the pre-fix io.CopyN(_, 256) over-read — against the real (open,
+	// EOF-less) guest that read blocked for the full ~2s deadline on every
+	// post_resume.
+	if conn.reads != 1 {
+		t.Fatalf("read the guest connection %d times, want exactly 1 (stop at the ack newline; do not read toward a byte budget)", conn.reads)
+	}
+	if len(conn.wrote) != 1 {
+		t.Fatalf("wrote %d messages, want exactly 1 (the op line)", len(conn.wrote))
+	}
+}


### PR DESCRIPTION
## Summary

- **Firecracker snapshot-clone create latency: server p50 2029 ms → 34 ms (60×), zero failures**, validated as a same-hardware before/after A/B on one `c5.metal` (single-node-fc, v0.7.7).
- Root cause: `sendVsockOp` read the guest's `post_resume` ack with `io.CopyN(io.Discard, conn, 256)`. The in-guest vsock server (`cmd/toolboxd` `handleVsockConn`) writes a ~12-byte `{"ok":true}` ack then **keeps the connection open** for more ops — no EOF. So `CopyN` read the ack, then blocked waiting for 244 bytes that never arrive until the conn's read deadline fired, **burning the full `PostResumeTimeout` (~2 s) on every create**.
- Fix: read the single newline-delimited ack line (`bufio…ReadString('\n')`) and stop at the newline. The conn already carries the dial-context read deadline (`vsock_dial_linux.go` `SetDeadline`), so a genuinely hung guest still bails at the bound. Also fixes the snapshot-start and warm-acquire paths (same helper).

## Code-path diagram

```mermaid
flowchart TD
    W[conn.Write op] --> R{read ack}
    R -->|"BEFORE: io.CopyN(_, 256)"| B["read 12B ack, then block for 244 more<br/>→ conn read-deadline fires at ~2s<br/>fc_post_resume = 2000ms EVERY create"]
    R -->|"AFTER: bufio ReadString('\n')"| A["read the one ack line, return<br/>fc_post_resume ≈ 6ms (a normal vsock round-trip)"]
    B --> Done[return nil; sandbox works either way<br/>the ack content was always discarded]
    A --> Done
```

## Sandbox boot impact

Yes — this is on `CreateSandbox`'s firecracker snapshot-clone path (and the snapshot-start + warm-acquire paths). It **removes** ~2 s of fixed latency per create; it adds nothing. Per-stage measured single-node-fc: `fc_post_resume` 2000 ms → 6 ms; everything else was already trivial (`fc_spawn` 7, `fc_load` 3, `fc_verify` 0). This beats `plans/firecracker-create-latency.md`'s Phase-3 warm-VMM-pool target (≤700 ms) by ~20×, and shows that pool targets the wrong stage (`fc_spawn`+`fc_load` ≈ 10 ms here) — recommend keeping it shelved.

## Idempotency

N/A — `sendVsockOp` is a best-effort post-resume signal (RNG reseed / wallclock / eth0), not an API surface. Retry and concurrent-create behavior are unchanged; only the ack-read loop changed.

## Failure-path consistency

N/A — no multi-step write touching both caddy and the store changed. A failed/hung ack read is still non-fatal (logged, create proceeds), exactly as before — the deadline remains the hung-guest bound.

## L4 / host-port-pool changes

N/A — neither `TryReserveHostPort`, the `host_port` index, `allocateHostPort`, `EnsureLayer4(Ready)`, nor the `l4Ready` latch is touched. (The TAP allocator is also untouched — this is a vsock read fix, not an allocation change.)

## Test plan

- **Regression test** `internal/runtime/firecracker/snapshot_vsock_ack_test.go`: a fake guest that acks then holds the connection open (no EOF, like the real guest); asserts `sendVsockOp` reads the connection **exactly once** — i.e. stops at the ack newline rather than reading toward a byte budget. Reverting to the 256-byte read fails it. (The pre-existing fakes EOF'd after the ack, which is why they never caught this.)
- `go test ./internal/runtime/firecracker/...` green; `make test` green; `go vet -tags=integration ./integration-tests/...` clean.
- **Live A/B** on single-node-fc (one c5.metal): provisioned released v0.7.7 (before = server p50 2029 ms, `fc_post_resume` 2000 ms), `scp` + `systemctl`-swapped the fixed binary (API confirmed the `-fcfix` version), re-benched (after = server p50 **34 ms**, `fc_post_resume` **6 ms**, 0/10 failures). Box torn down, no leaked infra.
- Enables that cheap diagnostic: `make integration-benchmark-fc-single` (one c5.metal, isolates the driver — no cluster forward); UC-94 dropped its `CapCluster` gate (create latency is single-node-meaningful; `waitBenchmarkReady` already early-returns without a cluster); single-node-fc advertises `benchmark` + `docker-engine` (keeps the metal box on the proven docker bootstrap — the container engine is irrelevant to FC latency, and containerd-on-metal is unverified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
