### PR TITLE
feat(wasm): split wasm_load into Server-Timing sub-stages (Phase 0)

### DIFF
--- a/internal/pool/wasm/spawner.go
+++ b/internal/pool/wasm/spawner.go
@@ -56,7 +56,7 @@ func (s *SupervisorSpawner) Warm(ctx context.Context, slotID, socketPath, module
 		worker.ReadyPollSleep(ctx, attempt)
 		attempt++
 	}
-	if err := client.LoadModule(slotID, modulePath, memoryMB); err != nil {
+	if _, err := client.LoadModule(slotID, modulePath, memoryMB); err != nil {
 		_ = s.Supervisor.Stop(slotID)
 		return fmt.Errorf("load module: %w", err)
 	}

--- a/internal/runtime/wasm/create.go
+++ b/internal/runtime/wasm/create.go
@@ -136,12 +136,17 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 		}
 		d.noteWorkerSpawnCount(inst)
 		loadStart := time.Now()
-		if err := client.LoadModule(sandboxID, resolved.Path, memoryMB); err != nil {
+		loadTimings, err := client.LoadModule(sandboxID, resolved.Path, memoryMB)
+		if err != nil {
 			cleanup()
 			return nil, fmt.Errorf("load module: %w", err)
 		}
 		if timing != nil {
 			timing.RecordStage("wasm_load", time.Since(loadStart))
+			// Sub-stages of wasm_load, reported by the worker, so the create-latency
+			// bench can see which step owns the ~2.8s cold load (compile dominates
+			// for CPython) — the measurement that gates plans/wasm-resident-module-host.md.
+			recordLoadSubStages(timing, loadTimings)
 		}
 	} else {
 		if err := d.waitWorker(ctx, client, sandboxID); err != nil {
@@ -173,6 +178,24 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 	d.mu.Unlock()
 
 	return d.runtimeState(inst), nil
+}
+
+// recordLoadSubStages emits the wasm_load breakdown as separate Server-Timing
+// entries. Only non-zero stages are recorded so a warm-hit create (which never
+// calls LoadModule) and engines that don't report timings stay silent.
+func recordLoadSubStages(timing *createtiming.CreateTiming, t wasmengine.LoadTimings) {
+	if t.NewEngine > 0 {
+		timing.RecordStage("wasm_load_newengine", t.NewEngine)
+	}
+	if t.RuntimeInit > 0 {
+		timing.RecordStage("wasm_load_runtime", t.RuntimeInit)
+	}
+	if t.Read > 0 {
+		timing.RecordStage("wasm_load_read", t.Read)
+	}
+	if t.Compile > 0 {
+		timing.RecordStage("wasm_load_compile", t.Compile)
+	}
 }
 
 func preopensFromBinds(workDir string, binds []mounts.ContainerBind) []wasmengine.Preopen {

--- a/internal/runtime/wasm/driver_test.go
+++ b/internal/runtime/wasm/driver_test.go
@@ -49,9 +49,9 @@ func (c *recordingWorkerClient) Ping(string) error { return nil }
 func (c *recordingWorkerClient) InstanceLoaded(context.Context, string) (bool, error) {
 	return true, nil
 }
-func (c *recordingWorkerClient) LoadModule(_, path string, _ int) error {
+func (c *recordingWorkerClient) LoadModule(_, path string, _ int) (wasmengine.LoadTimings, error) {
 	c.loadPath = path
-	return nil
+	return wasmengine.LoadTimings{}, nil
 }
 func (c *recordingWorkerClient) Instantiate(_ string, caps wasmengine.Capabilities) error {
 	c.instantiateCaps = append(c.instantiateCaps, caps)

--- a/internal/runtime/wasm/gaps_test.go
+++ b/internal/runtime/wasm/gaps_test.go
@@ -74,8 +74,8 @@ type failLoadClient struct {
 	recordingWorkerClient
 }
 
-func (c *failLoadClient) LoadModule(string, string, int) error {
-	return fmt.Errorf("load failed")
+func (c *failLoadClient) LoadModule(string, string, int) (wasmengine.LoadTimings, error) {
+	return wasmengine.LoadTimings{}, fmt.Errorf("load failed")
 }
 
 type failEnsureSupervisor struct {

--- a/internal/runtime/wasm/guest_http_integration_test.go
+++ b/internal/runtime/wasm/guest_http_integration_test.go
@@ -147,7 +147,7 @@ func TestWorkerClientWasip1HTTPBaseline(t *testing.T) {
 		t.Fatal(err)
 	}
 	wc := driver.newWorkerClient(sock)
-	if err := wc.LoadModule(sandboxID, absMod, 0); err != nil {
+	if _, err := wc.LoadModule(sandboxID, absMod, 0); err != nil {
 		t.Fatalf("LoadModule: %v", err)
 	}
 	caps := wasmengine.Capabilities{
@@ -201,7 +201,7 @@ func TestSetListenPortAfterColdInstantiate(t *testing.T) {
 		t.Fatal(err)
 	}
 	wc := driver.newWorkerClient(sock)
-	if err := wc.LoadModule(sandboxID, absMod, 0); err != nil {
+	if _, err := wc.LoadModule(sandboxID, absMod, 0); err != nil {
 		t.Fatal(err)
 	}
 	cold := wasmengine.Capabilities{

--- a/internal/runtime/wasm/lifecycle.go
+++ b/internal/runtime/wasm/lifecycle.go
@@ -116,7 +116,7 @@ func (d *Driver) Start(ctx context.Context, sandboxID string) (*models.SandboxRu
 		return nil, err
 	}
 	d.noteWorkerSpawnCount(inst)
-	if err := client.LoadModule(sandboxID, inst.modulePath, inst.memoryMB); err != nil {
+	if _, err := client.LoadModule(sandboxID, inst.modulePath, inst.memoryMB); err != nil {
 		return nil, fmt.Errorf("load module: %w", err)
 	}
 	caps := wasmengine.CapsFromResourceLimits(wasmengine.Capabilities{

--- a/internal/runtime/wasm/network_policy_test.go
+++ b/internal/runtime/wasm/network_policy_test.go
@@ -19,8 +19,8 @@ func (c *stubWorkerNetstatsClient) Ping(string) error { return nil }
 func (c *stubWorkerNetstatsClient) InstanceLoaded(context.Context, string) (bool, error) {
 	return true, nil
 }
-func (c *stubWorkerNetstatsClient) LoadModule(string, string, int) error {
-	return nil
+func (c *stubWorkerNetstatsClient) LoadModule(string, string, int) (wasmengine.LoadTimings, error) {
+	return wasmengine.LoadTimings{}, nil
 }
 func (c *stubWorkerNetstatsClient) Instantiate(string, wasmengine.Capabilities) error {
 	return nil

--- a/internal/runtime/wasm/passivate.go
+++ b/internal/runtime/wasm/passivate.go
@@ -87,7 +87,7 @@ func (d *Driver) RehydrateSandbox(ctx context.Context, sandbox *models.Sandbox, 
 	if memoryMB <= 0 {
 		memoryMB = d.cfg.DefaultMemoryMB
 	}
-	if err := client.LoadModule(sandbox.ID, modulePath, memoryMB); err != nil {
+	if _, err := client.LoadModule(sandbox.ID, modulePath, memoryMB); err != nil {
 		return nil, fmt.Errorf("load module: %w", err)
 	}
 

--- a/internal/runtime/wasm/seams.go
+++ b/internal/runtime/wasm/seams.go
@@ -28,7 +28,7 @@ type WorkerSupervisorSpawnCounter interface {
 type WorkerClient interface {
 	Ping(sandboxID string) error
 	InstanceLoaded(ctx context.Context, sandboxID string) (bool, error)
-	LoadModule(sandboxID, path string, memoryMB int) error
+	LoadModule(sandboxID, path string, memoryMB int) (wasmengine.LoadTimings, error)
 	Instantiate(sandboxID string, caps wasmengine.Capabilities) error
 	Invoke(sandboxID, export string) error
 	Exec(sandboxID string, caps wasmengine.Capabilities, export string) (wasmengine.RunResult, error)
@@ -62,7 +62,7 @@ func (a workerClientAdapter) InstanceLoaded(ctx context.Context, sandboxID strin
 	return a.client.InstanceLoaded(ctx, sandboxID)
 }
 
-func (a workerClientAdapter) LoadModule(sandboxID, path string, memoryMB int) error {
+func (a workerClientAdapter) LoadModule(sandboxID, path string, memoryMB int) (wasmengine.LoadTimings, error) {
 	return a.client.LoadModule(sandboxID, path, memoryMB)
 }
 

--- a/pkg/wasm/engine_wazero.go
+++ b/pkg/wasm/engine_wazero.go
@@ -31,6 +31,9 @@ type wazeroEngine struct {
 	netHook     *NetworkHook
 	netHost     *wazeroNetHost
 	wasiCompat  bool
+	// lastLoad is the sub-stage breakdown of the most recent LoadModule, read
+	// back by the worker via LastLoadTimings() (LoadTimingReporter).
+	lastLoad LoadTimings
 }
 
 func newWazeroEngine(ctx context.Context) (*wazeroEngine, error) {
@@ -126,20 +129,34 @@ func (e *wazeroEngine) LoadModule(ctx context.Context, path string, opts LoadOpt
 	// rebuilding the runtime (ensureMemoryLimit path), and a failed prior load
 	// must not poison the next path.
 	e.moduleBytes = nil
+	e.lastLoad = LoadTimings{}
+	initStart := time.Now()
 	if err := e.initRuntime(ctx, opts.MemoryMB); err != nil {
 		return err
 	}
+	e.lastLoad.RuntimeInit = time.Since(initStart)
+	readStart := time.Now()
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
+	e.lastLoad.Read = time.Since(readStart)
+	compileStart := time.Now()
 	compiled, err := compileModule(e.runtime, ctx, b)
 	if err != nil {
 		return fmt.Errorf("compile module: %w", err)
 	}
+	e.lastLoad.Compile = time.Since(compileStart)
 	e.moduleBytes = append([]byte(nil), b...)
 	e.compiled = compiled
 	return nil
+}
+
+// LastLoadTimings returns the sub-stage breakdown of the most recent LoadModule
+// (LoadTimingReporter). NewEngine is left zero here — it is filled in by the
+// worker, which owns the NewEngineFor call that precedes LoadModule.
+func (e *wazeroEngine) LastLoadTimings() LoadTimings {
+	return e.lastLoad
 }
 
 func (e *wazeroEngine) Instantiate(ctx context.Context, caps Capabilities) error {

--- a/pkg/wasm/load_timings.go
+++ b/pkg/wasm/load_timings.go
@@ -1,0 +1,39 @@
+package wasm
+
+import "time"
+
+// LoadTimings breaks the cold-create wasm_load stage into its sub-costs. It
+// exists because a single wasm_load timer told us the stage was ~2.8s p50 for
+// CPython on t3.medium but not WHICH step owned it — and the firecracker
+// create-latency episode proved that guessing the dominant sub-cost before
+// measuring it burns effort on the wrong lever. Splitting the timer lets the
+// create path emit per-step Server-Timing entries so the resident-module work
+// (plans/wasm-resident-module-host.md) targets the real bottleneck.
+//
+// The fields mirror the cold LoadModule sequence in the worker:
+//
+//	NewEngine   — worker: NewEngineFor builds the first wazero runtime + WASI.
+//	RuntimeInit — engine: LoadModule rebuilds the runtime at the target memory
+//	              limit (+ WASI + compile-cache open). This is a second runtime
+//	              build today; see the plan's "redundant double init" note.
+//	Read        — engine: os.ReadFile of the module bytes (25MB for CPython).
+//	Compile     — engine: wazero CompileModule (compile-cache assisted; a full
+//	              cold compile is ~10s, a cache hit ~seconds of deserialize).
+//
+// Durations marshal to JSON as their nanosecond integer (time.Duration is
+// int64), so they cross the worker IPC boundary losslessly.
+type LoadTimings struct {
+	NewEngine   time.Duration `json:"new_engine_ns,omitempty"`
+	RuntimeInit time.Duration `json:"runtime_init_ns,omitempty"`
+	Read        time.Duration `json:"read_ns,omitempty"`
+	Compile     time.Duration `json:"compile_ns,omitempty"`
+}
+
+// LoadTimingReporter is an optional engine capability: an engine that
+// implements it exposes the sub-stage breakdown of its most recent LoadModule.
+// It is type-asserted by the worker (like NetworkAwareEngine) so the base
+// Engine interface — and the wasmtime backend and the test mocks that
+// implement it — stay untouched.
+type LoadTimingReporter interface {
+	LastLoadTimings() LoadTimings
+}

--- a/pkg/wasm/worker/client.go
+++ b/pkg/wasm/worker/client.go
@@ -141,17 +141,27 @@ func (c *Client) InstanceLoaded(ctx context.Context, sandboxID string) (bool, er
 	return p.Loaded, nil
 }
 
-// LoadModule compiles the module at path inside the worker process.
-func (c *Client) LoadModule(sandboxID, path string, memoryMB int) error {
+// LoadModule compiles the module at path inside the worker process and returns
+// the sub-stage timing breakdown (best-effort; zero-valued if the worker did
+// not report it) so the host create path can emit wasm_load Server-Timing subs.
+func (c *Client) LoadModule(sandboxID, path string, memoryMB int) (wasmengine.LoadTimings, error) {
 	body, err := encodePayload(loadModulePayload{Path: path, MemoryMB: memoryMB})
 	if err != nil {
-		return err
+		return wasmengine.LoadTimings{}, err
 	}
 	reply, err := c.roundTrip(Envelope{Type: MsgLoadModule, SandboxID: sandboxID, Payload: body})
 	if err != nil {
-		return err
+		return wasmengine.LoadTimings{}, err
 	}
-	return c.expectOK(reply)
+	if err := c.expectOK(reply); err != nil {
+		return wasmengine.LoadTimings{}, err
+	}
+	var p loadModuleResultPayload
+	if len(reply.Payload) > 0 {
+		// Timings are diagnostic only; a decode failure must not fail the load.
+		_ = decodePayload(reply.Payload, &p)
+	}
+	return p.Timings, nil
 }
 
 // Instantiate creates a WASI instance with the given capabilities.

--- a/pkg/wasm/worker/client_encode_test.go
+++ b/pkg/wasm/worker/client_encode_test.go
@@ -32,7 +32,7 @@ func TestClient_EncodeDecodeErrors(t *testing.T) {
 		return nil, errors.New("mock encode error")
 	}
 
-	_ = c.LoadModule(sb, "path", 0)
+	_, _ = c.LoadModule(sb, "path", 0)
 	_ = c.Instantiate(sb, wasmengine.Capabilities{})
 	_, _ = c.Exec(sb, wasmengine.Capabilities{}, "")
 	_ = c.Invoke(sb, "")

--- a/pkg/wasm/worker/client_extra_test.go
+++ b/pkg/wasm/worker/client_extra_test.go
@@ -17,7 +17,7 @@ func TestClient_ConnectionClosed_AllMethods(t *testing.T) {
 	ctx := context.Background()
 	sb := "sb"
 
-	if err := client.LoadModule(sb, "path", 0); err == nil {
+	if _, err := client.LoadModule(sb, "path", 0); err == nil {
 		t.Error("expected error")
 	}
 	if err := client.Instantiate(sb, wasmengine.Capabilities{}); err == nil {
@@ -179,7 +179,7 @@ func TestClient_AllMethods_Success(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	_ = c.LoadModule("sb", "path", 0)
+	_, _ = c.LoadModule("sb", "path", 0)
 	_ = c.Instantiate("sb", wasmengine.Capabilities{})
 	_, _ = c.Exec("sb", wasmengine.Capabilities{}, "export")
 	_ = c.Invoke("sb", "export")
@@ -204,7 +204,7 @@ func TestClient_AllMethods_Error(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	_ = c.LoadModule("sb", "path", 0)
+	_, _ = c.LoadModule("sb", "path", 0)
 	_ = c.Instantiate("sb", wasmengine.Capabilities{})
 	_, _ = c.Exec("sb", wasmengine.Capabilities{}, "export")
 	_ = c.Invoke("sb", "export")

--- a/pkg/wasm/worker/client_test.go
+++ b/pkg/wasm/worker/client_test.go
@@ -151,7 +151,8 @@ func TestClient_MoreMethods(t *testing.T) {
 			name: "LoadModule_OK",
 			run: func(c *Client) error {
 				c.dial = mockDialer(t, Envelope{Type: MsgOK})
-				return c.LoadModule(sb, "path/to/module", 0)
+				_, err := c.LoadModule(sb, "path/to/module", 0)
+				return err
 			},
 		},
 		{
@@ -159,7 +160,8 @@ func TestClient_MoreMethods(t *testing.T) {
 			run: func(c *Client) error {
 				payload, _ := encodePayload(errorPayload{Message: "boom"})
 				c.dial = mockDialer(t, Envelope{Type: MsgError, Payload: payload})
-				return c.LoadModule(sb, "path/to/module", 0)
+				_, err := c.LoadModule(sb, "path/to/module", 0)
+				return err
 			},
 			wantErr: true,
 		},

--- a/pkg/wasm/worker/cold_path_test.go
+++ b/pkg/wasm/worker/cold_path_test.go
@@ -41,7 +41,7 @@ func TestWorkerColdPathLoadInstantiateInvoke(t *testing.T) {
 	if err := client.Ping(sandboxID); err != nil {
 		t.Fatalf("Ping: %v", err)
 	}
-	if err := client.LoadModule(sandboxID, modPath, 0); err != nil {
+	if _, err := client.LoadModule(sandboxID, modPath, 0); err != nil {
 		t.Fatalf("LoadModule: %v", err)
 	}
 	if err := client.Instantiate(sandboxID, wasmengine.Capabilities{Args: []string{"test"}}); err != nil {

--- a/pkg/wasm/worker/guest_wasip1_http_test.go
+++ b/pkg/wasm/worker/guest_wasip1_http_test.go
@@ -57,7 +57,7 @@ func TestGuestWasip1HTTPServerEndToEnd(t *testing.T) {
 	defer cleanup()
 
 	sandboxID := "sb-wasip1-http"
-	if err := client.LoadModule(sandboxID, modPath, 0); err != nil {
+	if _, err := client.LoadModule(sandboxID, modPath, 0); err != nil {
 		t.Fatalf("LoadModule: %v", err)
 	}
 	caps := wasmengine.Capabilities{

--- a/pkg/wasm/worker/load_timings_test.go
+++ b/pkg/wasm/worker/load_timings_test.go
@@ -1,0 +1,71 @@
+package worker
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/wasmmod"
+)
+
+// TestLoadModuleReportsSubStageTimings is the regression guard for the
+// wasm_load sub-stage instrumentation: a real wazero worker must return a
+// populated LoadTimings so the create path can emit wasm_load_newengine /
+// _runtime / _read / _compile Server-Timing entries. Without this, wasm_load
+// stays a single opaque ~2.8s number and the resident-module work
+// (plans/wasm-resident-module-host.md) can't target the dominant sub-cost.
+func TestLoadModuleReportsSubStageTimings(t *testing.T) {
+	dir := t.TempDir()
+	modPath := wasmmod.WriteMinimalWasm(t, dir, "demo.wasm")
+	// macOS sun_path caps at 104 bytes — keep the socket under /tmp.
+	socketPath := filepath.Join(os.TempDir(), fmt.Sprintf("aerol-wasm-lt-%d.sock", time.Now().UnixNano()))
+	t.Cleanup(func() { _ = os.Remove(socketPath) })
+
+	_ = os.Remove(socketPath)
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	srv := &Server{}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) { _ = srv.Serve(c) }(conn)
+		}
+	}()
+
+	client := NewClient(socketPath)
+	if err := client.Ping("sb-lt"); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+	timings, err := client.LoadModule("sb-lt", modPath, 0)
+	if err != nil {
+		t.Fatalf("LoadModule: %v", err)
+	}
+
+	// NewEngine (worker builds the first runtime), RuntimeInit (LoadModule
+	// rebuilds it at the memory limit), and Compile (wazero CompileModule) all
+	// do real work, so each must register a positive duration once the timings
+	// survive the IPC round-trip. Read is asserted non-negative only — a tiny
+	// module file can round toward zero on a warm page cache.
+	if timings.NewEngine <= 0 {
+		t.Errorf("NewEngine timing not reported: %v", timings.NewEngine)
+	}
+	if timings.RuntimeInit <= 0 {
+		t.Errorf("RuntimeInit timing not reported: %v", timings.RuntimeInit)
+	}
+	if timings.Compile <= 0 {
+		t.Errorf("Compile timing not reported: %v", timings.Compile)
+	}
+	if timings.Read < 0 {
+		t.Errorf("Read timing negative: %v", timings.Read)
+	}
+	time.Sleep(10 * time.Millisecond)
+}

--- a/pkg/wasm/worker/payload.go
+++ b/pkg/wasm/worker/payload.go
@@ -40,6 +40,13 @@ type okPayload struct {
 	OK bool `json:"ok"`
 }
 
+// loadModuleResultPayload rides the MsgLoadModule OK reply so the host create
+// path can emit the wasm_load sub-stage breakdown (Server-Timing). Old clients
+// that decode only okPayload keep working — expectOK ignores the payload.
+type loadModuleResultPayload struct {
+	Timings wasmengine.LoadTimings `json:"timings"`
+}
+
 type instanceStatusPayload struct {
 	Loaded bool `json:"loaded"`
 }

--- a/pkg/wasm/worker/proxy_http_test.go
+++ b/pkg/wasm/worker/proxy_http_test.go
@@ -70,7 +70,7 @@ func TestProxyHTTPForwardsToGuestBackend(t *testing.T) {
 
 	sandboxID := "sb-proxy"
 	modPath := writeMinimalModule(t, t.TempDir())
-	if err := client.LoadModule(sandboxID, modPath, 0); err != nil {
+	if _, err := client.LoadModule(sandboxID, modPath, 0); err != nil {
 		t.Fatalf("LoadModule: %v", err)
 	}
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -131,7 +131,7 @@ func TestSetListenPortDisabled(t *testing.T) {
 
 	sandboxID := "sb-listen"
 	modPath := writeMinimalModule(t, t.TempDir())
-	if err := client.LoadModule(sandboxID, modPath, 0); err != nil {
+	if _, err := client.LoadModule(sandboxID, modPath, 0); err != nil {
 		t.Fatalf("LoadModule: %v", err)
 	}
 	if err := client.Instantiate(sandboxID, wasmengine.Capabilities{

--- a/pkg/wasm/worker/server.go
+++ b/pkg/wasm/worker/server.go
@@ -166,7 +166,9 @@ func (s *Server) Serve(conn net.Conn) error {
 				_ = s.eng.Close(ctx)
 				s.eng = nil
 			}
+			newEngStart := time.Now()
 			s.eng, err = wasmengine.NewEngineFor(ctx, workerEngineName())
+			newEngDur := time.Since(newEngStart)
 			if err != nil {
 				s.mu.Unlock()
 				if replyErr(env.SandboxID, err) != nil {
@@ -175,6 +177,13 @@ func (s *Server) Serve(conn net.Conn) error {
 				continue
 			}
 			err = s.eng.LoadModule(ctx, p.Path, wasmengine.LoadOptions{MemoryMB: p.MemoryMB})
+			// Read the engine's sub-stage breakdown before releasing the lock; the
+			// worker owns the NewEngineFor cost, so we splice it in here.
+			var timings wasmengine.LoadTimings
+			if r, ok := s.eng.(wasmengine.LoadTimingReporter); ok {
+				timings = r.LastLoadTimings()
+			}
+			timings.NewEngine = newEngDur
 			s.mu.Unlock()
 			if err != nil {
 				if replyErr(env.SandboxID, err) != nil {
@@ -182,7 +191,11 @@ func (s *Server) Serve(conn net.Conn) error {
 				}
 				continue
 			}
-			if err := replyOK(env.SandboxID); err != nil {
+			body, encErr := encodePayload(loadModuleResultPayload{Timings: timings})
+			if encErr != nil {
+				return encErr
+			}
+			if err := writeFrame(conn, Envelope{Type: MsgOK, SandboxID: env.SandboxID, Payload: body}); err != nil {
 				return err
 			}
 		case MsgInstantiate:

--- a/pkg/wasm/worker/server_netstats_test.go
+++ b/pkg/wasm/worker/server_netstats_test.go
@@ -98,7 +98,7 @@ func TestServerExecColdPathPreservesNetstatsTick(t *testing.T) {
 
 	client := NewClient(socketPath)
 	const sandboxID = "sb-exec"
-	if err := client.LoadModule(sandboxID, modPath, 0); err != nil {
+	if _, err := client.LoadModule(sandboxID, modPath, 0); err != nil {
 		t.Fatalf("LoadModule: %v", err)
 	}
 	if err := client.Instantiate(sandboxID, wasmengine.Capabilities{}); err != nil {

--- a/pkg/wasm/worker/server_test.go
+++ b/pkg/wasm/worker/server_test.go
@@ -60,7 +60,7 @@ func TestServeSocketPath(t *testing.T) {
 	wasmPath := filepath.Join(t.TempDir(), "test.wasm")
 	_ = os.WriteFile(wasmPath, wasmBytes, 0644)
 
-	_ = client.LoadModule(sb, wasmPath, 0)
+	_, _ = client.LoadModule(sb, wasmPath, 0)
 
 	conn, _ := net.Dial("unix", sock)
 	if conn != nil {

--- a/plans/wasm-resident-module-host.md
+++ b/plans/wasm-resident-module-host.md
@@ -1,0 +1,217 @@
+# WASM cold-load: resident compiled-module host (compile-once, instantiate-many)
+
+Status: **Proposed / design** (2026-07-15). Phase 0 (measurement) is implemented;
+Phases 1–4 are unbuilt and gated on the Phase 0 numbers + an eng-review, because
+this changes the WASM isolation model.
+
+Owner rules that apply: this plan changes `CreateSandbox` callees
+(`/touch-create-sandbox`) and the WASM warm-worker pool (`internal/pool/wasm/` —
+regression tests mandatory next to the file, same bar as the TCP host-port
+pool), and it needs a boot-path latency call-out in every PR per `pr-review.md`
+§2. The worker wire protocol (`pkg/wasm/worker/`) changes in Phase 2 — both ends
+ship in the same binary (`sandboxd --wasm-worker` re-execs the daemon), so there
+is no cross-version window, but say so in the PR. **It also changes the process
+isolation model (co-tenancy), so it MUST ship behind a default-off flag and go
+through `/plan-eng-review` before the default flips** — same discipline the
+docker warm pool (`SB_DOCKER_POOL_ENABLED`) and pause-netns pool used.
+
+Sibling plans: `plans/wasm-create-latency.md` (the warm-pool work that already
+put warm creates in the 23ms class), `plans/firecracker-create-latency.md` (the
+"measure the stage before you build the lever" lesson this plan opens with).
+
+---
+
+## Problem
+
+The 2026-07-15 `cluster-3-mixed-wasm` bench (release v0.7.8, warm depth 2, 10
+samples, 0 failures) measured:
+
+| metric | value |
+|---|---|
+| server p50 (warm hit) | **23ms** |
+| server p90 / p99 | 2633ms / 2862ms |
+| `wasm_load` p50 (cold miss) | **2814ms** (2 of 10 samples) |
+| `wasm_instantiate` p50 | 10ms |
+| `wasm_warm` p50 | 0ms (pool hit) |
+
+The warm path is already best-in-class (23ms — beats docker warm 43ms and
+firecracker 34ms). The entire tail is the handful of creates that MISS the warm
+pool and fall through to the cold `wasm_load` path. That path
+(`internal/runtime/wasm/create.go:124-145` → worker `MsgLoadModule`
+`pkg/wasm/worker/server.go` → `pkg/wasm/engine_wazero.go:116`) rebuilds
+everything from scratch in a **fresh per-sandbox worker process**:
+
+1. `NewEngineFor` — build a wazero runtime + instantiate WASI.
+2. `initRuntime` (again, at the target memory limit) — a second runtime build.
+3. `os.ReadFile` — read the module bytes (~25MB for CPython).
+4. `CompileModule` — turn bytes into an executable image (compile-cache
+   assisted: a full cold compile is ~10s, a cache hit ~seconds of deserialize).
+
+None of this is shared: every cold create pays it in full.
+
+## Phase 0 — measure which sub-step owns the 2.8s (IMPLEMENTED 2026-07-15)
+
+Before building any lever, split the single `wasm_load` timer. The firecracker
+episode proved that guessing the dominant sub-cost (there: the hash / the warm
+pool) wastes effort — the real cost (a vsock over-read) only showed up once the
+stage was instrumented per-step.
+
+Shipped: `pkg/wasm/load_timings.go` (`LoadTimings` + optional
+`LoadTimingReporter`), sub-stage timing inside `wazeroEngine.LoadModule`, the
+worker measuring `NewEngineFor` and returning `LoadTimings` over the
+`MsgLoadModule` reply, and `create.go` emitting `wasm_load_newengine`,
+`wasm_load_runtime`, `wasm_load_read`, `wasm_load_compile` Server-Timing
+entries. Regression test:
+`pkg/wasm/worker/load_timings_test.go`.
+
+**Gate:** the next `cluster-3-mixed-wasm` bench (or a local Docker cold create)
+must show the breakdown before Phase 1 starts. Interpretation → lever:
+
+| dominant sub-stage | correct lever |
+|---|---|
+| `wasm_load_compile` | resident **compiled module** (this plan) |
+| `wasm_load_runtime` + `_newengine` | resident **runtime** (a lighter variant of this plan — reuse the runtime, still re-`InstantiateModule`) |
+| `wasm_load_read` | mmap / keep module bytes resident (small, separate change) |
+
+The config note (`~10s` cold compile vs `~2.8s` cached) strongly implies
+`_compile` dominates, i.e. this plan is the right lever — but confirm, don't
+assume.
+
+## Core insight
+
+wazero is **compile-once, instantiate-many**: `CompileModule` returns a
+`CompiledModule` that `InstantiateModule` can turn into many independent
+instances, each with its own linear memory. The engine already instantiates
+from a resident `e.compiled` (`engine_wazero.go:167`), and `wasm_instantiate` is
+only ~10ms. The 2.8s exists purely because the cold path **rebuilds** the
+compiled module per sandbox instead of instantiating a resident one.
+
+The compiled module cannot be shared cheaply **across processes** — the on-disk
+compile cache is the cross-process mechanism, and its deserialize IS the 2.8s.
+So the fast path requires reusing the compiled module **in-process**: a
+long-lived worker process holds the resident runtime + compiled module and
+services many instantiate requests. Ceiling: **`wasm_load` 2814ms → ~10ms** for
+any create that lands on a host already holding the module.
+
+## The hard constraint: memory limit is per-runtime, so bucket by (digest, memoryMB)
+
+wazero sets the memory limit at the **runtime** level
+(`WithMemoryLimitPages`, `engine_wazero.go:57-61`), and a `CompiledModule` is
+bound to the runtime it was compiled in. Therefore all co-tenant instances
+sharing one compiled module share one memory limit. A resident host is keyed by
+**(module digest, memoryMB)**, not digest alone. In practice standard modules
+all use `SB_WASM_DEFAULT_MEMORY_MB` (256), so they bucket together; a create
+with a non-default `memory_mb` that has no matching host falls back to the cold
+path (correct, and rare). This is also why `ensureMemoryLimit`
+(`engine_wazero.go:108`) rebuilds the runtime today — the resident-host design
+makes that rebuild impossible for co-tenants, which is fine because the bucket
+key guarantees a matching limit.
+
+## Isolation tradeoff (why this is default-off + eng-review-gated)
+
+Today: one sandbox per worker process → OS-level crash/OOM isolation. Co-tenancy
+shrinks the blast radius from "one sandbox" to "the co-tenants on one host
+process." What still isolates co-tenants:
+
+- **Per-instance linear memory** — wazero gives each `InstantiateModule` its own
+  memory; no shared memory unless explicitly configured (we don't).
+- **Per-instance memory cap** (`MemoryLimitPages`) and **fuel metering** bound a
+  single instance's resource use.
+- **Bounded instances per host** (`SB_WASM_RESIDENT_HOST_MAX_INSTANCES`) caps the
+  blast radius and lets the pool spread load across host processes.
+
+Residual risk to enumerate in the eng-review: a panic in a host function (or a
+wazero bug) runs on a shared process and takes down all co-tenants; a runaway
+guest that exhausts host RAM (not guest linear memory) affects co-tenants. These
+are why the default stays process-per-sandbox and this mode is strictly opt-in.
+
+## Design
+
+A **resident module host** is a long-lived worker process that:
+
+1. On first use for a (digest, memoryMB) bucket, loads + compiles the module
+   once (pays `wasm_load` once).
+2. Holds the resident runtime + `CompiledModule`.
+3. Services many `Instantiate` requests, each creating an isolated instance
+   keyed by `sandboxID`; a create that routes here costs ~`wasm_instantiate`.
+
+### Engine (Phase 1)
+
+Add a multi-instance capability WITHOUT touching the base `Engine` interface
+(which `wasmtime` + several mocks implement). Preferred: a new
+`MultiInstanceEngine` in `pkg/wasm` wrapping `{runtime, compiled,
+map[sandboxID]api.Module}` with per-instance `Instantiate/StopInstance/Run/
+CaptureSnapshot/RestoreSnapshot/ResolvedListenPort`. The existing
+single-instance `wazeroEngine` stays the default path untouched. Offline unit
+tests: two instances of the same compiled module cannot read each other's
+linear memory; StopInstance on one leaves the other running; compile happens
+exactly once across N instantiates.
+
+### Worker protocol (Phase 2)
+
+The worker `Server` today holds one `s.eng` + one `s.lastCaps`
+(`server.go:16-24`). Make instance state per-`sandboxID` (the network mediator
+and byte counters are **already** keyed by sandboxID — `netUsageFor`,
+`mediator()` — so that half is done). Split the messages:
+
+- `MsgLoadModule` → load/compile the host's shared module once (idempotent per
+  bucket); returns the existing `LoadTimings`.
+- `MsgInstantiate` / `MsgStopInstance` / `MsgCheckpoint` / `MsgRestore` /
+  `MsgSetListenPort` → operate on the per-`sandboxID` instance.
+
+**Scope limit for Phase 2:** wasip1 TCP listeners (`expose_port` / HTTP guests)
+resolve one listener fd per instance and the server tracks a single
+`lastCaps.WASIListenPort`. Multiplexing many listeners in one process is extra
+complexity, so the first cut supports resident-host mode **only for
+non-listen sandboxes** (one-shot exec / no `expose_port`); HTTP guests fall back
+to the cold per-process path. Lift this in a later phase if the bench shows
+HTTP guests need it.
+
+### Pool + routing (Phase 3)
+
+`internal/pool/wasm` shifts from "pool of pre-instantiated slots" to "pool of
+resident hosts per (digest, memoryMB)." `Acquire` returns a host to instantiate
+into rather than a slot to adopt. Refill keeps `min` hosts compiled per hot
+bucket. This also naturally fixes the miss/refill race noted in
+`project_wasm_create_latency` — there is no separate per-sandbox cold spawn to
+race, because the create instantiates into a resident host.
+
+### Config (Phase 3)
+
+- `SB_WASM_RESIDENT_HOST_ENABLED` (bool, **default false**) — gates the whole
+  path; when false, behavior is exactly today's.
+- `SB_WASM_RESIDENT_HOST_MAX_INSTANCES` (int, default e.g. 32) — per-host
+  instance cap (blast-radius bound + load spreading).
+- Interplay: when enabled, the resident host is the warm mechanism, so
+  `SB_WASM_POOL_ENABLED` semantics fold into host pre-compilation. Document
+  which wins in `setup/config-defaults.md`.
+
+### Validation (Phase 4)
+
+`make integration-benchmark-wasm` on `cluster-3-mixed-wasm` with the flag on:
+target is cold-miss `wasm_load` collapsing toward `wasm_instantiate` (~10ms) and
+the p99 tail flattening. Stays default-off; eng-review + the isolation risk
+enumeration gate the default flip.
+
+## Expected outcome
+
+- Cold-miss `wasm_load`: **2814ms → ~10ms** on a host already holding the module
+  (first create per bucket still pays one compile, amortized across all later
+  instances).
+- p99 tail (2.6–2.9s) flattens because burst creates instantiate into resident
+  hosts instead of each forking + compiling.
+- Warm p50 (23ms) unchanged — this is about the tail, not the median.
+
+## Risks / open questions
+
+- Per-instance invocation deadline / fuel cancellation inside a shared runtime
+  (today `WithInvocationDeadline` is per-call; verify it cancels only the target
+  instance's call).
+- Checkpoint/restore + clone-generation fencing (`pkg/wasm/snapshot_codec.go`
+  `FenceCloneGeneration`) under co-tenancy — snapshots are per-instance; confirm
+  the fence still keys correctly.
+- Host-process lifecycle: when do resident hosts get torn down (idle TTL?),
+  and how does drain/passivate interact with co-tenants still live on the host.
+- Memory accounting for admission control (`pkg/capacity`) — a resident host's
+  RAM is shared across instances; the admitter's per-sandbox model needs to
+  understand host-shared cost.


### PR DESCRIPTION
## Summary

- Instrument the cold WASM `LoadModule` path so `wasm_load` breaks into `wasm_load_newengine` / `wasm_load_runtime` / `wasm_load_read` / `wasm_load_compile` Server-Timing entries.
- Return `LoadTimings` over the worker `MsgLoadModule` reply (optional `LoadTimingReporter` on the wazero engine) so the next bench can show which sub-step owns the ~2.8s CPython cold miss.
- Add the resident compiled-module host design plan (`plans/wasm-resident-module-host.md`); Phases 1–4 stay gated on these measurements.

## Code-path diagram

```mermaid
sequenceDiagram
  participant Create as runtime/wasm Create
  participant Client as worker.Client
  participant Worker as wasm-worker
  participant Eng as wazeroEngine

  Note over Create: cold miss (warm pool miss)
  Create->>Client: LoadModule(id, path, mem)
  Client->>Worker: MsgLoadModule
  Worker->>Worker: time NewEngineFor
  Worker->>Eng: LoadModule(path, mem)
  Eng->>Eng: time RuntimeInit / Read / Compile
  Eng-->>Worker: ok (+ LastLoadTimings)
  Worker-->>Client: reply{timings}
  Client-->>Create: LoadTimings
  Create->>Create: RecordStage wasm_load_*
  Note over Create: before: opaque wasm_load only<br/>after: sub-stages when non-zero
```

## Sandbox boot impact

Yes — cold WASM create path only (warm-pool miss → `LoadModule`):

- Worker now measures and serializes `LoadTimings` on the `MsgLoadModule` reply (tiny JSON fields; nanoseconds).
- Create path records up to 4 additional Server-Timing stages when durations are non-zero.
- No extra DB / HTTP / lock work. Warm-hit creates never call `LoadModule` and stay silent.
- Expected added latency: measurement overhead only (negligible vs ~2.8s load).

## Idempotency

N/A - no API surface changed. Internal worker wire reply gains an optional `timings` field; both ends ship in the same binary (`sandboxd --wasm-worker` re-exec).

## Failure-path consistency

N/A - no multi-step write path changed. Load failure still cleans up the same way; timings are only returned on success.

## L4 / host-port-pool changes

N/A - neither touched.

## Test plan

- [x] `pkg/wasm/worker/load_timings_test.go` — LoadModule reply carries populated timings
- [x] Existing worker/runtime mocks updated for `LoadModule` → `(LoadTimings, error)`
- [ ] Next `cluster-3-mixed-wasm` (or local Docker cold create) reads the new Server-Timing breakdown before Phase 1


Made with [Cursor](https://cursor.com)