### PR TITLE
feat(wasm): resident compile-once/instantiate-many host (default-off)

### DIFF
--- a/cmd/sandboxd/main.go
+++ b/cmd/sandboxd/main.go
@@ -12,9 +12,10 @@ import (
 )
 
 var (
-	runDaemon        = daemon.Run
-	runWasmWorkerCLI = worker.RunCLI
-	osExit           = os.Exit
+	runDaemon              = daemon.Run
+	runWasmWorkerCLI       = worker.RunCLI
+	runWasmResidentHostCLI = worker.RunCLIResident
+	osExit                 = os.Exit
 )
 
 func run(ctx context.Context, logger *slog.Logger) error {
@@ -29,6 +30,17 @@ func run(ctx context.Context, logger *slog.Logger) error {
 func main() {
 	if len(os.Args) >= 2 && os.Args[1] == "--wasm-worker" {
 		if err := runWasmWorkerCLI(os.Args[2:]); err != nil {
+			os.Stderr.WriteString(err.Error() + "\n")
+			osExit(1)
+		}
+		return
+	}
+
+	// Resident-module host: one process compiles a module once and hosts many
+	// isolated sandbox instances (plans/wasm-resident-module-host.md). Spawned
+	// only when SB_WASM_RESIDENT_HOST_ENABLED routes a create here.
+	if len(os.Args) >= 2 && os.Args[1] == "--wasm-resident-host" {
+		if err := runWasmResidentHostCLI(os.Args[2:]); err != nil {
 			os.Stderr.WriteString(err.Error() + "\n")
 			osExit(1)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -544,6 +544,14 @@ type Config struct {
 	// Default <WasmCacheDir>/wazero-compile. Empty disables the cache.
 	// SB_WASM_COMPILE_CACHE_DIR.
 	WasmCompileCacheDir string
+	// WasmResidentHostEnabled routes non-listen wasm creates to a resident
+	// compile-once/instantiate-many host process per (module, memoryMB) bucket
+	// instead of a fresh per-sandbox worker (plans/wasm-resident-module-host.md).
+	// It collapses the ~2.8s cold CompileModule to a ~9ms Instantiate, but shares
+	// one process across co-tenant sandboxes — so it is DEFAULT OFF and remains
+	// operator opt-in until the per-instance egress-isolation work + eng-review
+	// land, exactly like SB_DOCKER_POOL_ENABLED. SB_WASM_RESIDENT_HOST_ENABLED.
+	WasmResidentHostEnabled bool
 	// WasmDrainTimeout bounds graceful drain checkpoint per sandbox (§4.3).
 	// SB_WASM_DRAIN_TIMEOUT.
 	WasmDrainTimeout time.Duration
@@ -1527,6 +1535,7 @@ func Load() (Config, error) {
 		WasmPoolRefillInterval:  getEnvDuration("SB_WASM_POOL_REFILL_INTERVAL", 5*time.Second),
 		WasmModuleDigestMode:    strings.ToLower(getEnv("SB_WASM_MODULE_DIGEST_MODE", "once")),
 		WasmCompileCacheDir:     getEnv("SB_WASM_COMPILE_CACHE_DIR", ""),
+		WasmResidentHostEnabled: getEnvBool("SB_WASM_RESIDENT_HOST_ENABLED", false),
 		FirecrackerBinary:       getEnv("SB_FIRECRACKER_BINARY", "/usr/local/bin/firecracker"),
 		JailerBinary:            getEnv("SB_JAILER_BINARY", "/usr/local/bin/jailer"),
 		FirecrackerKernelImage:  getEnv("SB_FIRECRACKER_KERNEL", "/var/lib/sandboxd/firecracker/vmlinux"),

--- a/internal/runtime/wasm/config.go
+++ b/internal/runtime/wasm/config.go
@@ -13,15 +13,21 @@ type Config struct {
 	DefaultMemoryMB    int
 	DefaultWallTimeout time.Duration
 	DrainTimeout       time.Duration
+	// ResidentHostEnabled routes non-listen creates to a shared resident
+	// compile-once/instantiate-many host per (digest, memoryMB) bucket instead of
+	// a fresh per-sandbox worker (plans/wasm-resident-module-host.md). Default
+	// false; requires a resident supervisor wired via SetResidentHostSupervisor.
+	ResidentHostEnabled bool
 }
 
 // FromDaemonConfig projects the WASM slice of daemon config into driver config.
 func FromDaemonConfig(cfg config.Config) Config {
 	return Config{
-		RunDir:             cfg.WasmRunDir,
-		ModulesDir:         cfg.WasmModulesDir,
-		DefaultMemoryMB:    cfg.WasmDefaultMemoryMB,
-		DefaultWallTimeout: cfg.WasmDefaultTimeout,
-		DrainTimeout:       cfg.WasmDrainTimeout,
+		RunDir:              cfg.WasmRunDir,
+		ModulesDir:          cfg.WasmModulesDir,
+		DefaultMemoryMB:     cfg.WasmDefaultMemoryMB,
+		DefaultWallTimeout:  cfg.WasmDefaultTimeout,
+		DrainTimeout:        cfg.WasmDrainTimeout,
+		ResidentHostEnabled: cfg.WasmResidentHostEnabled,
 	}
 }

--- a/internal/runtime/wasm/create.go
+++ b/internal/runtime/wasm/create.go
@@ -59,6 +59,14 @@ func (d *Driver) Create(ctx context.Context, req models.CreateSandboxRequest, sa
 
 	memoryMB := effectiveMemoryMB(req, d.cfg.DefaultMemoryMB)
 
+	// Resident-host fast path (opt-in, non-listen, known digest): instantiate
+	// into a shared compile-once/instantiate-many host instead of spawning a
+	// per-sandbox worker + compiling. Everything below is the untouched
+	// per-sandbox path used when the flag is off (the default).
+	if d.residentHostEnabled() && !createWantsPublicExpose(req) && resolved.Digest != "" {
+		return d.createOnResidentHost(ctx, req, sandboxID, ref, resolved, memoryMB, hostMounts, timing)
+	}
+
 	warmStart := time.Now()
 	warmSlot, err := d.tryAcquireWarm(ctx, resolved.Digest, resolved.Path, memoryMB)
 	if timing != nil {

--- a/internal/runtime/wasm/driver.go
+++ b/internal/runtime/wasm/driver.go
@@ -30,6 +30,13 @@ type Driver struct {
 	// waitListenReady overrides guest TCP readiness polling (tests).
 	waitListenReady func(host string, port int) error
 
+	// residentSupervisor spawns/owns shared resident-host processes
+	// (--wasm-resident-host), one per (digest, memoryMB) bucket. Nil unless
+	// cfg.ResidentHostEnabled and wired via SetResidentHostSupervisor.
+	residentSupervisor WorkerSupervisor
+	residentMu         sync.Mutex
+	residentBuckets    map[string]*residentBucket
+
 	mu   sync.Mutex
 	byID map[string]*sandboxInstance
 
@@ -67,6 +74,13 @@ func (d *Driver) SetWorkerClientFactory(f WorkerClientFactory) {
 	if f != nil {
 		d.newWorkerClient = f
 	}
+}
+
+// SetResidentHostSupervisor wires the supervisor that owns shared resident-host
+// processes. Only consulted when cfg.ResidentHostEnabled; leaving it nil (the
+// default) keeps every create on the per-sandbox worker path.
+func (d *Driver) SetResidentHostSupervisor(s WorkerSupervisor) {
+	d.residentSupervisor = s
 }
 
 // SetStateKV wires the durable host-KV store (§4.6).
@@ -115,6 +129,12 @@ func (d *Driver) ListManaged(ctx context.Context) (map[string]*models.SandboxRun
 
 func (d *Driver) refreshWorkerInstanceState(ctx context.Context, sandboxID string, inst *sandboxInstance) *sandboxInstance {
 	if inst == nil || strings.TrimSpace(inst.socketPath) == "" {
+		return inst
+	}
+	// Resident-hosted instances live on a shared process tracked by the resident
+	// supervisor, not the per-sandbox one — the spawn-count / InstanceLoaded
+	// liveness checks below don't apply, so report the instance as-is.
+	if inst.fromResidentHost {
 		return inst
 	}
 	if count, ok := d.supervisorSpawnCount(d.workerKeyForInstance(sandboxID, inst)); ok {

--- a/internal/runtime/wasm/instance.go
+++ b/internal/runtime/wasm/instance.go
@@ -26,6 +26,12 @@ type sandboxInstance struct {
 	// driver must not keep reporting the sandbox as live.
 	workerSpawnCount int
 	fromWarmPool     bool
+	// fromResidentHost marks a sandbox instantiated into a shared resident host
+	// process (compile-once/instantiate-many). Its socketPath is the bucket host
+	// socket and workerKey is the bucket id — destroy must StopInstance, NOT kill
+	// the shared process, and the per-sandbox supervisor spawn-count tracking does
+	// not apply.
+	fromResidentHost bool
 	status           models.SandboxStatus
 	entryExport      string
 	baseEnv          map[string]string

--- a/internal/runtime/wasm/lifecycle.go
+++ b/internal/runtime/wasm/lifecycle.go
@@ -223,7 +223,12 @@ func (d *Driver) Destroy(ctx context.Context, sandbox *models.Sandbox) error {
 	if d.net != nil {
 		d.net.ReleaseSandbox(sandboxID)
 	}
-	if d.supervisor != nil {
+	if inst != nil && inst.fromResidentHost {
+		// Shared resident host — remove only this instance; NEVER kill the
+		// process (co-tenants depend on it). Best-effort: a dead host already
+		// dropped the instance.
+		_ = d.newWorkerClient(inst.socketPath).StopInstance(sandboxID)
+	} else if d.supervisor != nil {
 		workerKey := sandboxID
 		if inst != nil && inst.workerKey != "" {
 			workerKey = inst.workerKey

--- a/internal/runtime/wasm/resident.go
+++ b/internal/runtime/wasm/resident.go
@@ -1,0 +1,182 @@
+package wasm
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/createtiming"
+	"github.com/aerol-ai/microvm/pkg/models"
+	"github.com/aerol-ai/microvm/pkg/mounts"
+	wasmengine "github.com/aerol-ai/microvm/pkg/wasm"
+	"github.com/aerol-ai/microvm/pkg/wasmmod"
+)
+
+// residentBucket tracks the shared resident-host process for one
+// (module digest, memoryMB) bucket. mu single-flights host spawn + host-level
+// LoadModule so concurrent creates for the same module neither spawn duplicate
+// hosts nor double-compile. See plans/wasm-resident-module-host.md.
+type residentBucket struct {
+	id     string
+	socket string
+	mu     sync.Mutex
+	ready  bool
+}
+
+// residentHostEnabled reports whether creates should route to a resident host.
+// Requires both the opt-in config flag and a wired resident supervisor, so a
+// misconfiguration degrades to the per-sandbox path rather than erroring.
+func (d *Driver) residentHostEnabled() bool {
+	return d.cfg.ResidentHostEnabled && d.residentSupervisor != nil
+}
+
+// createWantsPublicExpose reports whether a create signals intent to expose an
+// HTTP port. wasm creates are always non-listen AT create time (the wasip1
+// listener is added later by expose_port → SyncGuestListenPorts), so the only
+// create-time hint is AllowPublicTraffic. Public-intent creates route to the
+// per-sandbox cold path because the resident host rejects wasip1 listeners.
+// (Calling expose_port later on a private, resident-hosted sandbox is
+// unsupported in this cut and surfaces as an error — documented in the plan.)
+func createWantsPublicExpose(req models.CreateSandboxRequest) bool {
+	return req.AllowPublicTraffic != nil && *req.AllowPublicTraffic
+}
+
+// residentBucketID derives a filesystem-safe bucket id from the module digest
+// and memory limit — the two dimensions that must match for instances to share
+// one runtime + compiled module (wazero's memory limit is per-runtime).
+func residentBucketID(digest string, memoryMB int) string {
+	short := strings.ReplaceAll(digest, ":", "-")
+	if len(short) > 16 {
+		short = short[:16]
+	}
+	return fmt.Sprintf("%s-%dmb", short, memoryMB)
+}
+
+func (d *Driver) residentSocketPath(bucketID string) string {
+	return filepath.Join(d.cfg.RunDir, "resident", bucketID+".sock")
+}
+
+// ensureResidentHost spawns (idempotently) the bucket's host process and loads
+// the module into it once, returning the bucket. Single-flighted per bucket.
+func (d *Driver) ensureResidentHost(ctx context.Context, digest, path string, memoryMB int) (*residentBucket, error) {
+	id := residentBucketID(digest, memoryMB)
+
+	d.residentMu.Lock()
+	if d.residentBuckets == nil {
+		d.residentBuckets = make(map[string]*residentBucket)
+	}
+	b := d.residentBuckets[id]
+	if b == nil {
+		b = &residentBucket{id: id, socket: d.residentSocketPath(id)}
+		d.residentBuckets[id] = b
+	}
+	d.residentMu.Unlock()
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.ready {
+		return b, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(b.socket), 0o700); err != nil {
+		return nil, fmt.Errorf("mkdir resident dir: %w", err)
+	}
+	if err := d.residentSupervisor.Ensure(ctx, id, b.socket); err != nil {
+		return nil, fmt.Errorf("start resident host: %w", err)
+	}
+	client := d.newWorkerClient(b.socket)
+	if err := d.waitWorker(ctx, client, id); err != nil {
+		return nil, err
+	}
+	// Host-level compile-once; the resident server dedups by path so a repeat
+	// call across buckets is a cheap no-op.
+	if _, err := client.LoadModule(id, path, memoryMB); err != nil {
+		return nil, fmt.Errorf("resident load module: %w", err)
+	}
+	b.ready = true
+	return b, nil
+}
+
+// createOnResidentHost is the resident-host create path: it instantiates an
+// isolated instance into the shared bucket host instead of spawning a
+// per-sandbox worker + compiling. Reached only when residentHostEnabled() and
+// the request is non-listen with a known digest. The existing per-sandbox
+// create path (Driver.Create) is left completely untouched.
+func (d *Driver) createOnResidentHost(ctx context.Context, req models.CreateSandboxRequest, sandboxID, ref string, resolved *wasmmod.ResolvedModule, memoryMB int, hostMounts []mounts.ContainerBind, timing *createtiming.CreateTiming) (*models.SandboxRuntimeState, error) {
+	bucket, err := d.ensureResidentHost(ctx, resolved.Digest, resolved.Path, memoryMB)
+	if err != nil {
+		return nil, err
+	}
+
+	workDir := d.sandboxDir(sandboxID)
+	if err := os.MkdirAll(workDir, 0o700); err != nil {
+		return nil, fmt.Errorf("mkdir sandbox dir: %w", err)
+	}
+
+	inst := &sandboxInstance{
+		sandboxID:        sandboxID,
+		moduleRef:        ref,
+		modulePath:       resolved.Path,
+		moduleSize:       resolved.SizeBytes,
+		moduleDigest:     resolved.Digest,
+		socketPath:       bucket.socket,
+		workDir:          workDir,
+		workerKey:        bucket.id,
+		fromResidentHost: true,
+		status:           models.SandboxStatusCreating,
+		entryExport:      entryExportFromRequest(req),
+		baseEnv:          copyStringMap(req.Env),
+		baseArgs:         wasmArgs(req),
+		preopens:         preopensFromBinds(workDir, hostMounts),
+		cpu:              req.CPU,
+		memoryMB:         memoryMB,
+		diskGB:           req.DiskGB,
+		durability:       req.Durability,
+	}
+
+	d.mu.Lock()
+	_, retry := d.byID[sandboxID]
+	d.byID[sandboxID] = inst
+	d.mu.Unlock()
+
+	client := d.newWorkerClient(bucket.socket)
+	// Idempotency (pr-review.md §1): a retried create for the same sandboxID must
+	// not trip the resident engine's duplicate-instance guard. On a retry, drop
+	// any instance left by a prior attempt first (no-op if absent). Only on the
+	// retry path, so a first create pays no extra round-trip.
+	if retry {
+		_ = client.StopInstance(sandboxID)
+	}
+
+	caps := wasmengine.CapsFromResourceLimits(wasmengine.Capabilities{
+		Env:            req.Env,
+		Args:           wasmArgs(req),
+		Preopens:       append([]wasmengine.Preopen(nil), inst.preopens...),
+		WASIListenPort: wasmengine.WASIListenPortDisabled,
+	}, memoryMB, d.cfg.DefaultWallTimeout)
+
+	instStart := time.Now()
+	if err := client.Instantiate(sandboxID, caps); err != nil {
+		// The host may have respawned empty (module dropped) — force a reload on
+		// the next create for this bucket, and roll this create back.
+		bucket.mu.Lock()
+		bucket.ready = false
+		bucket.mu.Unlock()
+		d.mu.Lock()
+		delete(d.byID, sandboxID)
+		d.mu.Unlock()
+		_ = os.RemoveAll(workDir)
+		return nil, fmt.Errorf("instantiate module: %w", err)
+	}
+	if timing != nil {
+		timing.RecordStage("wasm_instantiate", time.Since(instStart))
+	}
+	inst.status = models.SandboxStatusStarted
+	d.mu.Lock()
+	d.byID[sandboxID] = inst
+	d.mu.Unlock()
+	return d.runtimeState(inst), nil
+}

--- a/internal/runtime/wasm/resident_test.go
+++ b/internal/runtime/wasm/resident_test.go
@@ -1,0 +1,146 @@
+package wasm
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/aerol-ai/microvm/pkg/models"
+	"github.com/aerol-ai/microvm/pkg/wasmmod"
+)
+
+// residentTestDriver builds a driver wired for both the per-sandbox and the
+// resident-host paths, sharing one recording client, so a test can assert which
+// path a create took.
+func residentTestDriver(t *testing.T, enabled bool) (*Driver, *fakeSupervisor, *fakeSupervisor, *recordingWorkerClient) {
+	t.Helper()
+	dir := t.TempDir()
+	modPath := wasmmod.WriteMinimalWasm(t, dir, "demo.wasm")
+	runDir := filepath.Join(dir, "run")
+
+	perSandbox := &fakeSupervisor{}
+	resident := &fakeSupervisor{}
+	client := &recordingWorkerClient{}
+	d := New(Config{RunDir: runDir, ModulesDir: dir, ResidentHostEnabled: enabled}, nil)
+	d.SetModuleResolver(fakeResolver{path: modPath, digest: "deadbeef"})
+	d.SetWorkerSupervisor(perSandbox)
+	d.SetResidentHostSupervisor(resident)
+	d.SetWorkerClientFactory(func(string) WorkerClient { return client })
+	return d, perSandbox, resident, client
+}
+
+// TestCreateRoutesToResidentHost is the Phase 3b routing guard: with the flag on
+// and a non-public create, the sandbox instantiates into the shared resident
+// host (resident supervisor ensured, per-sandbox supervisor untouched), and
+// Destroy removes just the instance without killing the shared host.
+func TestCreateRoutesToResidentHost(t *testing.T) {
+	d, perSandbox, resident, client := residentTestDriver(t, true)
+
+	if _, err := d.Create(context.Background(), models.CreateSandboxRequest{Image: "demo.wasm"}, "sb-res", "tok", nil); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if resident.ensureCalls != 1 {
+		t.Fatalf("resident ensure calls = %d, want 1", resident.ensureCalls)
+	}
+	if perSandbox.ensureCalls != 0 {
+		t.Fatalf("per-sandbox ensure calls = %d, want 0 (routed to resident host)", perSandbox.ensureCalls)
+	}
+	if client.loadPath == "" {
+		t.Fatal("expected host-level LoadModule on the resident path")
+	}
+	if len(client.instantiateCaps) != 1 {
+		t.Fatalf("Instantiate calls = %d, want 1", len(client.instantiateCaps))
+	}
+	inst, err := d.instance("sb-res")
+	if err != nil {
+		t.Fatalf("instance: %v", err)
+	}
+	if !inst.fromResidentHost {
+		t.Fatal("instance not marked fromResidentHost")
+	}
+	if inst.workerKey != residentBucketID("deadbeef", 0) {
+		t.Fatalf("workerKey=%q, want bucket %q", inst.workerKey, residentBucketID("deadbeef", 0))
+	}
+
+	// Destroy must StopInstance (per-sandbox), NOT kill the shared host.
+	if err := d.Destroy(context.Background(), &models.Sandbox{ID: "sb-res"}); err != nil {
+		t.Fatalf("Destroy: %v", err)
+	}
+	if !client.stopped {
+		t.Fatal("Destroy did not StopInstance on the resident host")
+	}
+	if resident.stopCalls != 0 {
+		t.Fatalf("resident supervisor Stop called %d times — must never kill the shared host", resident.stopCalls)
+	}
+	if perSandbox.stopCalls != 0 {
+		t.Fatalf("per-sandbox supervisor Stop called %d times for a resident instance", perSandbox.stopCalls)
+	}
+}
+
+// TestCreateResidentRetryIsIdempotent guards pr-review.md §1: re-creating the
+// same sandboxID on the resident path drops the prior instance first
+// (StopInstance) so it does not trip the engine's duplicate-instance guard.
+func TestCreateResidentRetryIsIdempotent(t *testing.T) {
+	d, _, _, client := residentTestDriver(t, true)
+	req := models.CreateSandboxRequest{Image: "demo.wasm"}
+	if _, err := d.Create(context.Background(), req, "sb-retry", "tok", nil); err != nil {
+		t.Fatalf("Create #1: %v", err)
+	}
+	client.stopped = false
+	if _, err := d.Create(context.Background(), req, "sb-retry", "tok", nil); err != nil {
+		t.Fatalf("Create #2 (retry): %v", err)
+	}
+	if !client.stopped {
+		t.Fatal("retry did not StopInstance the prior instance before re-instantiating")
+	}
+	if len(client.instantiateCaps) != 2 {
+		t.Fatalf("Instantiate calls = %d, want 2 (one per create)", len(client.instantiateCaps))
+	}
+}
+
+// TestCreateResidentDisabledUsesColdPath confirms the flag-off default is
+// untouched: creates take the per-sandbox worker path.
+func TestCreateResidentDisabledUsesColdPath(t *testing.T) {
+	d, perSandbox, resident, _ := residentTestDriver(t, false)
+	if _, err := d.Create(context.Background(), models.CreateSandboxRequest{Image: "demo.wasm"}, "sb-cold", "tok", nil); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if perSandbox.ensureCalls != 1 {
+		t.Fatalf("per-sandbox ensure calls = %d, want 1 with resident disabled", perSandbox.ensureCalls)
+	}
+	if resident.ensureCalls != 0 {
+		t.Fatalf("resident ensure calls = %d, want 0 with flag off", resident.ensureCalls)
+	}
+	inst, err := d.instance("sb-cold")
+	if err != nil {
+		t.Fatalf("instance: %v", err)
+	}
+	if inst.fromResidentHost {
+		t.Fatal("instance wrongly marked fromResidentHost with flag off")
+	}
+}
+
+// TestCreatePublicExposeUsesColdPath confirms a public-intent create bypasses
+// the resident host (which cannot serve wasip1 listeners) even when enabled.
+func TestCreatePublicExposeUsesColdPath(t *testing.T) {
+	d, perSandbox, resident, _ := residentTestDriver(t, true)
+	pub := true
+	req := models.CreateSandboxRequest{Image: "demo.wasm", AllowPublicTraffic: &pub}
+	if _, err := d.Create(context.Background(), req, "sb-pub", "tok", nil); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if resident.ensureCalls != 0 {
+		t.Fatalf("resident ensure calls = %d, want 0 for a public-expose create", resident.ensureCalls)
+	}
+	if perSandbox.ensureCalls != 1 {
+		t.Fatalf("per-sandbox ensure calls = %d, want 1 (cold path for public expose)", perSandbox.ensureCalls)
+	}
+	inst, err := d.instance("sb-pub")
+	if err != nil {
+		t.Fatalf("instance: %v", err)
+	}
+	if inst.fromResidentHost {
+		t.Fatal("public-expose create wrongly routed to resident host")
+	}
+}

--- a/pkg/daemon/wasm_wiring.go
+++ b/pkg/daemon/wasm_wiring.go
@@ -59,6 +59,14 @@ func wireWasmRuntime(ctx context.Context, cfg config.Config, logger *slog.Logger
 	supervisor := worker.NewSupervisor(worker.DefaultSpawner)
 	driver.SetModuleResolver(resolver)
 	driver.SetWorkerSupervisor(supervisor)
+	// Resident-module host (compile-once/instantiate-many): opt-in, default off.
+	// A second supervisor owns the shared host processes so their lifecycle is
+	// independent of per-sandbox workers. Wired only when enabled — otherwise the
+	// driver's residentHostEnabled() stays false and every create takes the
+	// per-sandbox path. See plans/wasm-resident-module-host.md.
+	if cfg.WasmResidentHostEnabled {
+		driver.SetResidentHostSupervisor(worker.NewSupervisor(worker.DefaultResidentSpawner))
+	}
 	if st != nil {
 		// Wrap the durable host-KV store in a per-sandbox write limiter so a
 		// chatty guest cannot starve the single-writer boot path (§4.6).

--- a/pkg/wasm/engine_multi.go
+++ b/pkg/wasm/engine_multi.go
@@ -1,0 +1,285 @@
+package wasm
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/sys"
+)
+
+// MultiInstanceEngine holds one resident wazero runtime + one compiled module
+// and instantiates many isolated instances from it — compile-once,
+// instantiate-many. It is the Phase 1 primitive for the resident-module host
+// (plans/wasm-resident-module-host.md).
+//
+// Why it exists: the v0.7.9 cluster-3-mixed-wasm bench measured a cold create's
+// `wasm_load` at 2843ms p50, of which `wasm_load_compile` was 2768ms (~97%) —
+// and that is WITH the on-disk compile cache populated, so it is the per-process
+// deserialize of a 25MB CPython image, not a from-scratch compile. Reusing a
+// resident in-process CompiledModule skips that entirely: an Instantiate against
+// it measured 9ms. This type turns a "cold" create into an Instantiate.
+//
+// Bucketing constraint: wazero sets the memory limit at the runtime level and a
+// CompiledModule is bound to its runtime, so one MultiInstanceEngine serves a
+// single (module, memoryMB) bucket. MemoryMB is fixed at construction; the pool
+// (Phase 3) routes a create to an engine whose MemoryMB matches, else cold path.
+//
+// Isolation: wazero gives every InstantiateModule its own linear memory, so
+// co-tenant instances cannot read each other's memory (proven in
+// engine_multi_test.go). Per-instance networking, snapshot/restore, IO-capturing
+// Run, and wasip1 listeners are deliberately NOT here yet — they are Phase 2,
+// wired when this engine is embedded in the worker (the worker's NetMediator is
+// already keyed by sandboxID). Phase 1 is the isolated-instance primitive only.
+type MultiInstanceEngine struct {
+	mu        sync.Mutex
+	runtime   wazero.Runtime
+	compiled  wazero.CompiledModule
+	memoryMB  int
+	pages     uint32
+	instances map[string]api.Module
+	lastLoad  LoadTimings
+}
+
+// NewMultiInstanceEngine builds the resident runtime (memory-limited to memoryMB,
+// sharing the on-disk compile cache + base wasip1 host) with no module compiled
+// yet. Call LoadModule once, then Instantiate per sandbox.
+func NewMultiInstanceEngine(ctx context.Context, memoryMB int) (*MultiInstanceEngine, error) {
+	pages := MemoryLimitPages(memoryMB)
+	r, err := newBaseRuntime(ctx, pages)
+	if err != nil {
+		return nil, err
+	}
+	return &MultiInstanceEngine{
+		runtime:   r,
+		memoryMB:  memoryMB,
+		pages:     pages,
+		instances: make(map[string]api.Module),
+	}, nil
+}
+
+// MemoryMB is the fixed memory limit (MB) this engine's runtime + compiled
+// module are built for. The pool routes only matching-memory creates here.
+func (m *MultiInstanceEngine) MemoryMB() int { return m.memoryMB }
+
+// Loaded reports whether a module has been compiled into the resident runtime.
+func (m *MultiInstanceEngine) Loaded() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.compiled != nil
+}
+
+// LoadModule compiles the module at path once; every later Instantiate reuses
+// the resident CompiledModule. A repeat call recompiles (e.g. module upgrade)
+// and closes the previous compiled module — existing live instances keep
+// running on their own already-instantiated code.
+func (m *MultiInstanceEngine) LoadModule(ctx context.Context, path string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.lastLoad = LoadTimings{}
+	readStart := time.Now()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	m.lastLoad.Read = time.Since(readStart)
+	compileStart := time.Now()
+	compiled, err := compileModule(m.runtime, ctx, b)
+	if err != nil {
+		return fmt.Errorf("compile module: %w", err)
+	}
+	m.lastLoad.Compile = time.Since(compileStart)
+	if m.compiled != nil {
+		_ = m.compiled.Close(ctx)
+	}
+	m.compiled = compiled
+	return nil
+}
+
+// LastLoadTimings satisfies LoadTimingReporter. NewEngine/RuntimeInit are left
+// zero — this engine builds its runtime once at construction, not per load.
+func (m *MultiInstanceEngine) LastLoadTimings() LoadTimings {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastLoad
+}
+
+// Instantiate creates an isolated instance keyed by sandboxID from the resident
+// compiled module. This is the fast path the whole design exists for: it costs
+// an Instantiate (~9ms), not a CompileModule (~2.8s). _start is NOT run here
+// (deferred, matching the single-instance engine); callers invoke it explicitly.
+func (m *MultiInstanceEngine) Instantiate(ctx context.Context, sandboxID string, caps Capabilities) error {
+	if sandboxID == "" {
+		return fmt.Errorf("sandboxID required")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.compiled == nil {
+		return fmt.Errorf("no compiled module loaded")
+	}
+	if _, ok := m.instances[sandboxID]; ok {
+		return fmt.Errorf("instance %q already exists", sandboxID)
+	}
+	// wazero rejects two instances sharing a module name on one runtime, so key
+	// the instance name by sandboxID to keep co-tenants distinct.
+	cfg := moduleConfigFor(caps).WithName(sandboxID)
+	if fsCfg := fsConfigFor(caps); fsCfg != nil {
+		cfg = cfg.WithFSConfig(fsCfg)
+	}
+	mod, err := m.runtime.InstantiateModule(ctx, m.compiled, cfg)
+	if err != nil {
+		return fmt.Errorf("instantiate module: %w", err)
+	}
+	m.instances[sandboxID] = mod
+	return nil
+}
+
+// Run (re-)instantiates the sandbox's instance with stdout/stderr capture and
+// invokes export (default _start), returning the captured output — the one-shot
+// Exec path for a resident-hosted sandbox. It mirrors the single-instance
+// engine's Run (re-instantiate per call so a fresh Exec starts clean), but
+// keyed by sandboxID and reusing the resident compiled module, so it costs an
+// Instantiate (~9ms), not a compile. A non-zero guest exit is returned in the
+// RunResult (not as a Go error), matching the single-instance engine.
+func (m *MultiInstanceEngine) Run(ctx context.Context, sandboxID string, caps Capabilities, export string) (RunResult, error) {
+	if sandboxID == "" {
+		return RunResult{}, fmt.Errorf("sandboxID required")
+	}
+	if export == "" {
+		export = "_start"
+	}
+	m.mu.Lock()
+	if m.compiled == nil {
+		m.mu.Unlock()
+		return RunResult{}, fmt.Errorf("no compiled module loaded")
+	}
+	// Re-instantiate semantics: drop any prior instance for this sandbox first.
+	if old, ok := m.instances[sandboxID]; ok {
+		_ = old.Close(ctx)
+		delete(m.instances, sandboxID)
+	}
+	compiled := m.compiled
+	runtime := m.runtime
+	m.mu.Unlock()
+
+	invokeCtx, cancel := WithInvocationDeadline(ctx, caps)
+	defer cancel()
+
+	var stdout, stderr bytes.Buffer
+	cfg := moduleConfigFor(caps).WithName(sandboxID).WithStdout(&stdout).WithStderr(&stderr)
+	if fsCfg := fsConfigFor(caps); fsCfg != nil {
+		cfg = cfg.WithFSConfig(fsCfg)
+	}
+	start := time.Now()
+	mod, err := runtime.InstantiateModule(invokeCtx, compiled, cfg)
+	if err != nil {
+		return RunResult{}, fmt.Errorf("instantiate module: %w", err)
+	}
+	m.mu.Lock()
+	m.instances[sandboxID] = mod
+	m.mu.Unlock()
+
+	result := RunResult{}
+	fn := mod.ExportedFunction(export)
+	if fn == nil {
+		result.ExitCode = 1
+		result.Stdout = stdout.String()
+		result.Stderr = stderr.String()
+		return result, fmt.Errorf("export %q not found", export)
+	}
+	_, callErr := fn.Call(invokeCtx)
+	result.ExitCode = exitCodeFromInvoke(callErr)
+	result.Stdout = stdout.String()
+	result.Stderr = stderr.String()
+	result.Usage = UsageStats{WallDurationMs: time.Since(start).Milliseconds()}
+	if callErr != nil {
+		var exitErr *sys.ExitError
+		if errors.As(callErr, &exitErr) {
+			// A guest exit(code) is a normal result, not a host error.
+			return result, nil
+		}
+		result.Stderr = stringsTrimJoin(result.Stderr, callErr.Error())
+		return result, callErr
+	}
+	return result, nil
+}
+
+// InvokeExport calls an exported function on one instance. The lock is released
+// before the call so a long-running export does not serialize co-tenants.
+func (m *MultiInstanceEngine) InvokeExport(ctx context.Context, sandboxID, name string) error {
+	m.mu.Lock()
+	mod, ok := m.instances[sandboxID]
+	m.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("no instance %q", sandboxID)
+	}
+	fn := mod.ExportedFunction(name)
+	if fn == nil {
+		return fmt.Errorf("export %q not found", name)
+	}
+	_, err := fn.Call(ctx)
+	return err
+}
+
+// StopInstance closes one instance and leaves every co-tenant running.
+// Idempotent: stopping an unknown sandboxID is a no-op.
+func (m *MultiInstanceEngine) StopInstance(ctx context.Context, sandboxID string) error {
+	m.mu.Lock()
+	mod, ok := m.instances[sandboxID]
+	if ok {
+		delete(m.instances, sandboxID)
+	}
+	m.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	return mod.Close(ctx)
+}
+
+// HasInstance reports whether sandboxID has a live instance.
+func (m *MultiInstanceEngine) HasInstance(sandboxID string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.instances[sandboxID]
+	return ok
+}
+
+// InstanceCount is the number of live instances (for pool accounting + tests).
+func (m *MultiInstanceEngine) InstanceCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.instances)
+}
+
+// instanceModule returns the raw wazero module for one sandbox (nil if absent).
+// Package-internal: used by tests and by future per-instance snapshot/network
+// wiring in Phase 2.
+func (m *MultiInstanceEngine) instanceModule(sandboxID string) api.Module {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.instances[sandboxID]
+}
+
+// Close tears down every instance, the compiled module, and the runtime.
+func (m *MultiInstanceEngine) Close(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for id, mod := range m.instances {
+		_ = mod.Close(ctx)
+		delete(m.instances, id)
+	}
+	if m.compiled != nil {
+		_ = m.compiled.Close(ctx)
+		m.compiled = nil
+	}
+	if m.runtime != nil {
+		return m.runtime.Close(ctx)
+	}
+	return nil
+}

--- a/pkg/wasm/engine_multi_test.go
+++ b/pkg/wasm/engine_multi_test.go
@@ -1,0 +1,185 @@
+package wasm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aerol-ai/microvm/pkg/wasmmod"
+)
+
+// TestMultiInstanceEngine_CompileOnceInstantiateManyIsolated is the Phase 1
+// regression guard for the resident-module host: one compiled module must serve
+// many isolated instances (compile-once, instantiate-many), stopping one must
+// leave co-tenants running, and duplicate sandbox IDs must be rejected. This is
+// the primitive that turns a cold create's 2.8s CompileModule into a ~9ms
+// Instantiate (plans/wasm-resident-module-host.md).
+func TestMultiInstanceEngine_CompileOnceInstantiateManyIsolated(t *testing.T) {
+	dir := t.TempDir()
+	// A module with exported linear memory, so we can prove instance isolation.
+	modPath := wasmmod.WriteCheckpointWasm(t, dir, "mem.wasm")
+	ctx := context.Background()
+
+	eng, err := NewMultiInstanceEngine(ctx, 0)
+	if err != nil {
+		t.Fatalf("NewMultiInstanceEngine: %v", err)
+	}
+	t.Cleanup(func() { _ = eng.Close(ctx) })
+
+	if err := eng.LoadModule(ctx, modPath); err != nil {
+		t.Fatalf("LoadModule: %v", err)
+	}
+	// Compile-once: capture the resident compiled module; it must not change as
+	// we instantiate many times below.
+	compiledAfterLoad := eng.compiled
+	if compiledAfterLoad == nil {
+		t.Fatal("LoadModule left no compiled module")
+	}
+
+	caps := Capabilities{Args: []string{"wasm"}}
+	if err := eng.Instantiate(ctx, "a", caps); err != nil {
+		t.Fatalf("Instantiate a: %v", err)
+	}
+	if err := eng.Instantiate(ctx, "b", caps); err != nil {
+		t.Fatalf("Instantiate b: %v", err)
+	}
+	if got := eng.InstanceCount(); got != 2 {
+		t.Fatalf("InstanceCount=%d, want 2", got)
+	}
+	if eng.compiled != compiledAfterLoad {
+		t.Fatal("compiled module changed across Instantiate — expected compile-once, instantiate-many")
+	}
+
+	// Isolation: each instance has its own linear memory. A write to A must not
+	// be visible in B.
+	memA := eng.instanceModule("a").Memory()
+	memB := eng.instanceModule("b").Memory()
+	if memA == nil || memB == nil {
+		t.Fatal("instances missing linear memory")
+	}
+	if !memA.WriteByte(0, 0x42) {
+		t.Fatal("write to instance A memory failed")
+	}
+	if got, ok := memB.ReadByte(0); !ok || got != 0 {
+		t.Fatalf("instance B memory saw A's write: got %#x (ok=%v), want 0 — instances not isolated", got, ok)
+	}
+	if got, _ := memA.ReadByte(0); got != 0x42 {
+		t.Fatalf("instance A memory readback = %#x, want 0x42", got)
+	}
+
+	// Duplicate sandboxID must be rejected (idempotency is the caller's job via
+	// HasInstance; the engine refuses to silently replace a live instance).
+	if err := eng.Instantiate(ctx, "b", caps); err == nil {
+		t.Fatal("expected error instantiating a duplicate sandboxID")
+	}
+
+	// Stop-one: closing A leaves B alive and uncorrupted.
+	if err := eng.StopInstance(ctx, "a"); err != nil {
+		t.Fatalf("StopInstance a: %v", err)
+	}
+	if eng.HasInstance("a") {
+		t.Fatal("instance a still present after StopInstance")
+	}
+	if !eng.HasInstance("b") {
+		t.Fatal("stopping a removed instance b")
+	}
+	if got := eng.InstanceCount(); got != 1 {
+		t.Fatalf("InstanceCount=%d after stopping a, want 1", got)
+	}
+	if got, ok := memB.ReadByte(0); !ok || got != 0 {
+		t.Fatalf("instance B memory corrupted after stopping A: got %#x (ok=%v)", got, ok)
+	}
+
+	// Stopping an unknown instance is a no-op, not an error.
+	if err := eng.StopInstance(ctx, "does-not-exist"); err != nil {
+		t.Fatalf("StopInstance unknown: %v", err)
+	}
+}
+
+// TestMultiInstanceEngine_InstantiateBeforeLoad guards the ordering contract:
+// Instantiate before LoadModule must fail cleanly rather than panic.
+func TestMultiInstanceEngine_InstantiateBeforeLoad(t *testing.T) {
+	ctx := context.Background()
+	eng, err := NewMultiInstanceEngine(ctx, 0)
+	if err != nil {
+		t.Fatalf("NewMultiInstanceEngine: %v", err)
+	}
+	t.Cleanup(func() { _ = eng.Close(ctx) })
+
+	if err := eng.Instantiate(ctx, "a", Capabilities{}); err == nil {
+		t.Fatal("expected error instantiating before LoadModule")
+	}
+	if err := eng.Instantiate(ctx, "", Capabilities{}); err == nil {
+		t.Fatal("expected error for empty sandboxID")
+	}
+}
+
+// TestMultiInstanceEngine_RunPerInstance confirms the one-shot Exec path works
+// per sandbox on the resident compiled module and returns a clean exit for the
+// empty _start module — without a second compile.
+func TestMultiInstanceEngine_RunPerInstance(t *testing.T) {
+	dir := t.TempDir()
+	modPath := wasmmod.WriteMinimalWasm(t, dir, "demo.wasm")
+	ctx := context.Background()
+	eng, err := NewMultiInstanceEngine(ctx, 0)
+	if err != nil {
+		t.Fatalf("NewMultiInstanceEngine: %v", err)
+	}
+	t.Cleanup(func() { _ = eng.Close(ctx) })
+	if err := eng.LoadModule(ctx, modPath); err != nil {
+		t.Fatalf("LoadModule: %v", err)
+	}
+	compiledAfterLoad := eng.compiled
+
+	caps := Capabilities{Args: []string{"wasm"}}
+	for _, id := range []string{"run-a", "run-b"} {
+		res, err := eng.Run(ctx, id, caps, "_start")
+		if err != nil {
+			t.Fatalf("Run %s: %v", id, err)
+		}
+		if res.ExitCode != 0 {
+			t.Fatalf("Run %s exit=%d stderr=%q", id, res.ExitCode, res.Stderr)
+		}
+	}
+	if eng.compiled != compiledAfterLoad {
+		t.Fatal("Run recompiled the module — expected reuse of the resident compiled module")
+	}
+	if got := eng.InstanceCount(); got != 2 {
+		t.Fatalf("InstanceCount=%d after two Runs, want 2", got)
+	}
+
+	// Run before load must fail cleanly, and empty sandboxID is rejected.
+	fresh, err := NewMultiInstanceEngine(ctx, 0)
+	if err != nil {
+		t.Fatalf("NewMultiInstanceEngine: %v", err)
+	}
+	t.Cleanup(func() { _ = fresh.Close(ctx) })
+	if _, err := fresh.Run(ctx, "x", caps, "_start"); err == nil {
+		t.Fatal("expected error running before LoadModule")
+	}
+	if _, err := eng.Run(ctx, "", caps, "_start"); err == nil {
+		t.Fatal("expected error for empty sandboxID")
+	}
+}
+
+// TestMultiInstanceEngine_ReportsLoadTimings confirms the engine satisfies
+// LoadTimingReporter so the resident-host path keeps emitting the wasm_load
+// breakdown once wired into the worker (Phase 2).
+func TestMultiInstanceEngine_ReportsLoadTimings(t *testing.T) {
+	dir := t.TempDir()
+	modPath := wasmmod.WriteMinimalWasm(t, dir, "demo.wasm")
+	ctx := context.Background()
+	eng, err := NewMultiInstanceEngine(ctx, 0)
+	if err != nil {
+		t.Fatalf("NewMultiInstanceEngine: %v", err)
+	}
+	t.Cleanup(func() { _ = eng.Close(ctx) })
+
+	var _ LoadTimingReporter = eng // compile-time: implements the reporter
+
+	if err := eng.LoadModule(ctx, modPath); err != nil {
+		t.Fatalf("LoadModule: %v", err)
+	}
+	if got := eng.LastLoadTimings().Compile; got <= 0 {
+		t.Fatalf("Compile timing not reported: %v", got)
+	}
+}

--- a/pkg/wasm/engine_wazero.go
+++ b/pkg/wasm/engine_wazero.go
@@ -58,21 +58,9 @@ func (e *wazeroEngine) initRuntime(ctx context.Context, memoryMB int) error {
 		e.runtime = nil
 	}
 	pages := MemoryLimitPages(memoryMB)
-	cfg := wazero.NewRuntimeConfig()
-	if pages > 0 {
-		cfg = cfg.WithMemoryLimitPages(pages)
-	}
-	if dir := wazeroCompileCacheDir(); dir != "" {
-		cache, err := wazero.NewCompilationCacheWithDir(dir)
-		if err != nil {
-			return fmt.Errorf("compilation cache: %w", err)
-		}
-		cfg = cfg.WithCompilationCache(cache)
-	}
-	r := wazero.NewRuntimeWithConfig(ctx, cfg)
-	if _, err := wasi_snapshot_preview1.Instantiate(ctx, r); err != nil {
-		_ = r.Close(ctx)
-		return fmt.Errorf("wasi instantiate: %w", err)
+	r, err := newBaseRuntime(ctx, pages)
+	if err != nil {
+		return err
 	}
 	e.runtime = r
 	e.wasiCompat = false
@@ -89,6 +77,31 @@ func (e *wazeroEngine) initRuntime(ctx context.Context, memoryMB int) error {
 
 func wazeroCompileCacheDir() string {
 	return strings.TrimSpace(os.Getenv("AEROL_WASM_COMPILE_CACHE_DIR"))
+}
+
+// newBaseRuntime builds a wazero runtime at the given memory-limit pages with
+// the shared on-disk compilation cache and the base wasip1 host, but no guest
+// module compiled. Shared by the single-instance engine (initRuntime) and the
+// MultiInstanceEngine (engine_multi.go) so both get identical runtime config —
+// notably the same compilation cache, which is what makes a warm compile cheap.
+func newBaseRuntime(ctx context.Context, pages uint32) (wazero.Runtime, error) {
+	cfg := wazero.NewRuntimeConfig()
+	if pages > 0 {
+		cfg = cfg.WithMemoryLimitPages(pages)
+	}
+	if dir := wazeroCompileCacheDir(); dir != "" {
+		cache, err := wazero.NewCompilationCacheWithDir(dir)
+		if err != nil {
+			return nil, fmt.Errorf("compilation cache: %w", err)
+		}
+		cfg = cfg.WithCompilationCache(cache)
+	}
+	r := wazero.NewRuntimeWithConfig(ctx, cfg)
+	if _, err := wasi_snapshot_preview1.Instantiate(ctx, r); err != nil {
+		_ = r.Close(ctx)
+		return nil, fmt.Errorf("wasi instantiate: %w", err)
+	}
+	return r, nil
 }
 
 func (e *wazeroEngine) ensureWasiCompatHosts(ctx context.Context) error {
@@ -211,6 +224,14 @@ func (e *wazeroEngine) InvokeExport(ctx context.Context, name string) error {
 }
 
 func (e *wazeroEngine) moduleConfig(caps Capabilities) wazero.ModuleConfig {
+	return moduleConfigFor(caps)
+}
+
+// moduleConfigFor builds the wazero ModuleConfig for a set of capabilities. It
+// is a pure function of caps (no engine state), so both the single-instance
+// engine and the MultiInstanceEngine share it — the latter additionally sets a
+// per-instance WithName so many instances can coexist on one runtime.
+func moduleConfigFor(caps Capabilities) wazero.ModuleConfig {
 	cfg := wazero.NewModuleConfig().WithArgs(caps.Args...)
 	// Driver/worker invoke _start explicitly (background on create; after listen for HTTP).
 	cfg = cfg.WithSysWalltime().WithSysNanotime().WithStartFunctions()
@@ -305,6 +326,12 @@ func (e *wazeroEngine) instantiateWithIO(ctx context.Context, caps Capabilities,
 // fd (3 + len(preopens)) rather than fd 3 — guests learn the right fd from the
 // AEROL_WASM_LISTEN_FD env var injected by moduleConfig (see listenerFD).
 func (e *wazeroEngine) fsConfigForCaps(caps Capabilities) wazero.FSConfig {
+	return fsConfigFor(caps)
+}
+
+// fsConfigFor builds directory preopens for a set of capabilities. Pure function
+// of caps (no engine state); shared with the MultiInstanceEngine.
+func fsConfigFor(caps Capabilities) wazero.FSConfig {
 	preopens := caps.Preopens
 	if len(preopens) == 0 {
 		return nil

--- a/pkg/wasm/worker/resident_server.go
+++ b/pkg/wasm/worker/resident_server.go
@@ -1,0 +1,285 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"sync"
+
+	wasmengine "github.com/aerol-ai/microvm/pkg/wasm"
+)
+
+// ResidentServer serves the worker protocol backed by a MultiInstanceEngine:
+// one resident process compiles a module once and hosts many isolated sandbox
+// instances (compile-once, instantiate-many). It is the Phase 2 host process
+// for plans/wasm-resident-module-host.md, spawned via `--wasm-resident-host`.
+//
+// Scope (initial cut, default-off): non-listen, non-networking sandboxes —
+// LoadModule (once, host-level), Instantiate/Exec/Invoke/StopInstance keyed by
+// sandboxID. Listener (expose_port/HTTP), checkpoint/restore, and per-instance
+// egress mediation are rejected here on purpose; the driver routes those to the
+// per-sandbox cold path. Per-instance egress isolation on a shared runtime
+// (name-keyed hooks + conn ownership) is the eng-review-gated Phase 2 remainder.
+type ResidentServer struct {
+	mu         sync.Mutex
+	eng        *wasmengine.MultiInstanceEngine
+	loadedPath string
+}
+
+// ensureEngine lazily builds the MultiInstanceEngine on the first LoadModule,
+// fixing the runtime memory limit to the bucket's memoryMB.
+func (s *ResidentServer) ensureEngine(ctx context.Context, memoryMB int) (*wasmengine.MultiInstanceEngine, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.eng == nil {
+		eng, err := wasmengine.NewMultiInstanceEngine(ctx, memoryMB)
+		if err != nil {
+			return nil, err
+		}
+		s.eng = eng
+	}
+	return s.eng, nil
+}
+
+func (s *ResidentServer) engine() *wasmengine.MultiInstanceEngine {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.eng
+}
+
+// Serve accepts framed control messages on conn until EOF or an unrecoverable
+// error. Multiple connections may be served concurrently; the MultiInstanceEngine
+// is internally synchronized.
+func (s *ResidentServer) Serve(conn net.Conn) error {
+	defer conn.Close()
+	ctx := context.Background()
+
+	replyOK := func(sandboxID string) error {
+		body, err := encodePayload(okPayload{OK: true})
+		if err != nil {
+			return err
+		}
+		return writeFrame(conn, Envelope{Type: MsgOK, SandboxID: sandboxID, Payload: body})
+	}
+	replyErr := func(sandboxID string, err error) error {
+		body, encErr := encodePayload(errorPayload{Message: err.Error()})
+		if encErr != nil {
+			return encErr
+		}
+		return writeFrame(conn, Envelope{Type: MsgError, SandboxID: sandboxID, Payload: body})
+	}
+	// unsupported rejects a message type that resident-host mode does not serve
+	// in this cut, so a misrouted request fails loudly instead of hanging.
+	unsupported := func(sandboxID, op string) error {
+		return replyErr(sandboxID, fmt.Errorf("%s not supported in resident-host mode (route to per-sandbox worker)", op))
+	}
+
+	for {
+		env, err := readFrame(conn)
+		if err != nil {
+			return err
+		}
+		switch env.Type {
+		case MsgHealthPing:
+			if err := writeFrame(conn, Envelope{Type: MsgPong, SandboxID: env.SandboxID}); err != nil {
+				return err
+			}
+		case MsgInstanceStatus:
+			eng := s.engine()
+			loaded := eng != nil && eng.Loaded()
+			body, encErr := encodePayload(instanceStatusPayload{Loaded: loaded})
+			if encErr != nil {
+				return encErr
+			}
+			if err := writeFrame(conn, Envelope{Type: MsgOK, SandboxID: env.SandboxID, Payload: body}); err != nil {
+				return err
+			}
+		case MsgTriggerPanic:
+			panic("wasm resident worker test panic")
+		case MsgLoadModule:
+			var p loadModulePayload
+			if err := decodePayload(env.Payload, &p); err != nil {
+				if replyErr(env.SandboxID, err) != nil {
+					return err
+				}
+				continue
+			}
+			eng, err := s.ensureEngine(ctx, p.MemoryMB)
+			if err != nil {
+				if replyErr(env.SandboxID, err) != nil {
+					return err
+				}
+				continue
+			}
+			// A resident host is one (module, memoryMB) bucket. Loading a second,
+			// different module into it is a routing bug — reject rather than blow
+			// away the compiled module other live instances depend on.
+			s.mu.Lock()
+			prev := s.loadedPath
+			s.mu.Unlock()
+			if prev != "" && prev != p.Path {
+				if replyErr(env.SandboxID, fmt.Errorf("resident host already bound to %q, refusing to load %q", prev, p.Path)) != nil {
+					return err
+				}
+				continue
+			}
+			var timings wasmengine.LoadTimings
+			if prev != p.Path {
+				if err := eng.LoadModule(ctx, p.Path); err != nil {
+					if replyErr(env.SandboxID, err) != nil {
+						return err
+					}
+					continue
+				}
+				timings = eng.LastLoadTimings()
+				s.mu.Lock()
+				s.loadedPath = p.Path
+				s.mu.Unlock()
+			}
+			body, encErr := encodePayload(loadModuleResultPayload{Timings: timings})
+			if encErr != nil {
+				return encErr
+			}
+			if err := writeFrame(conn, Envelope{Type: MsgOK, SandboxID: env.SandboxID, Payload: body}); err != nil {
+				return err
+			}
+		case MsgInstantiate:
+			var p instantiatePayload
+			if err := decodePayload(env.Payload, &p); err != nil {
+				if replyErr(env.SandboxID, err) != nil {
+					return err
+				}
+				continue
+			}
+			if p.Caps.ListenEnabled() {
+				if unsupported(env.SandboxID, "wasip1 listener (expose_port/HTTP)") != nil {
+					return err
+				}
+				continue
+			}
+			eng := s.engine()
+			if eng == nil {
+				if replyErr(env.SandboxID, fmt.Errorf("engine not loaded")) != nil {
+					return err
+				}
+				continue
+			}
+			if err := eng.Instantiate(ctx, env.SandboxID, p.Caps); err != nil {
+				if replyErr(env.SandboxID, err) != nil {
+					return err
+				}
+				continue
+			}
+			if err := replyOK(env.SandboxID); err != nil {
+				return err
+			}
+		case MsgExec:
+			var p execPayload
+			if err := decodePayload(env.Payload, &p); err != nil {
+				if replyErr(env.SandboxID, err) != nil {
+					return err
+				}
+				continue
+			}
+			eng := s.engine()
+			if eng == nil {
+				if replyErr(env.SandboxID, fmt.Errorf("engine not loaded")) != nil {
+					return err
+				}
+				continue
+			}
+			result, runErr := eng.Run(ctx, env.SandboxID, p.Caps, p.Export)
+			if runErr != nil && result.ExitCode == 0 && result.Stderr == "" {
+				if replyErr(env.SandboxID, runErr) != nil {
+					return err
+				}
+				continue
+			}
+			body, encErr := encodePayload(execResultPayload{
+				ExitCode: result.ExitCode,
+				Stdout:   result.Stdout,
+				Stderr:   result.Stderr,
+				Usage:    result.Usage,
+			})
+			if encErr != nil {
+				return encErr
+			}
+			if err := writeFrame(conn, Envelope{Type: MsgInvokeResult, SandboxID: env.SandboxID, Payload: body}); err != nil {
+				return err
+			}
+		case MsgInvoke:
+			var p invokePayload
+			if err := decodePayload(env.Payload, &p); err != nil {
+				if replyErr(env.SandboxID, err) != nil {
+					return err
+				}
+				continue
+			}
+			eng := s.engine()
+			if eng == nil {
+				if replyErr(env.SandboxID, fmt.Errorf("engine not loaded")) != nil {
+					return err
+				}
+				continue
+			}
+			if err := eng.InvokeExport(ctx, env.SandboxID, p.Export); err != nil {
+				if replyErr(env.SandboxID, err) != nil {
+					return err
+				}
+				continue
+			}
+			if err := replyOK(env.SandboxID); err != nil {
+				return err
+			}
+		case MsgStopInstance:
+			eng := s.engine()
+			if eng != nil {
+				if err := eng.StopInstance(ctx, env.SandboxID); err != nil {
+					if replyErr(env.SandboxID, err) != nil {
+						return err
+					}
+					continue
+				}
+			}
+			if err := replyOK(env.SandboxID); err != nil {
+				return err
+			}
+		default:
+			// Checkpoint/Restore, listener, network, and netstats ops are not
+			// served by a resident host in this cut.
+			if unsupported(env.SandboxID, string(env.Type)) != nil {
+				return err
+			}
+		}
+	}
+}
+
+// ServeSocketPathResident listens on a Unix socket and serves each connection
+// with a shared ResidentServer (one MultiInstanceEngine per process).
+func ServeSocketPathResident(socketPath string) error {
+	_ = os.Remove(socketPath)
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return err
+	}
+	defer ln.Close()
+	srv := &ResidentServer{}
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			return err
+		}
+		go func(c net.Conn) {
+			_ = srv.Serve(c)
+		}(conn)
+	}
+}
+
+// RunCLIResident is the `--wasm-resident-host <socket>` entrypoint.
+func RunCLIResident(args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("usage: --wasm-resident-host <socket-path>")
+	}
+	return ServeSocketPathResident(args[0])
+}

--- a/pkg/wasm/worker/resident_server_test.go
+++ b/pkg/wasm/worker/resident_server_test.go
@@ -1,0 +1,114 @@
+package worker
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	wasmengine "github.com/aerol-ai/microvm/pkg/wasm"
+	"github.com/aerol-ai/microvm/pkg/wasmmod"
+)
+
+// serveResident starts a ResidentServer on a fresh unix socket and returns a
+// client + the socket path. Mirrors the cold_path_test harness.
+func serveResident(t *testing.T) (*Client, string) {
+	t.Helper()
+	socketPath := filepath.Join(os.TempDir(), fmt.Sprintf("aerol-wasm-res-%d.sock", time.Now().UnixNano()))
+	t.Cleanup(func() { _ = os.Remove(socketPath) })
+	_ = os.Remove(socketPath)
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	srv := &ResidentServer{}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) { _ = srv.Serve(c) }(conn)
+		}
+	}()
+	return NewClient(socketPath), socketPath
+}
+
+// nonListenCaps builds caps that are explicitly NOT a wasip1 listener. The zero
+// value of WASIListenPort is 0, which ListenEnabled() treats as ephemeral-listen
+// ENABLED, so a resident host would (correctly) reject it — the driver sets
+// WASIListenPortDisabled for non-HTTP sandboxes, and so must this test.
+func nonListenCaps(args ...string) wasmengine.Capabilities {
+	return wasmengine.Capabilities{Args: args, WASIListenPort: wasmengine.WASIListenPortDisabled}
+}
+
+// TestResidentServer_LoadOnceInstantiateManyExec is the Phase 2 regression guard
+// for the resident-host worker: one LoadModule compiles once, many sandboxes
+// Instantiate + Exec against the resident module, the bucket refuses a second
+// distinct module, and StopInstance is per-sandbox.
+func TestResidentServer_LoadOnceInstantiateManyExec(t *testing.T) {
+	dir := t.TempDir()
+	modPath := wasmmod.WriteMinimalWasm(t, dir, "demo.wasm")
+	client, _ := serveResident(t)
+
+	if err := client.Ping("host"); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+	if _, err := client.LoadModule("host", modPath, 0); err != nil {
+		t.Fatalf("LoadModule: %v", err)
+	}
+
+	caps := nonListenCaps("wasm")
+	for _, id := range []string{"sb-1", "sb-2"} {
+		if err := client.Instantiate(id, caps); err != nil {
+			t.Fatalf("Instantiate %s: %v", id, err)
+		}
+	}
+	for _, id := range []string{"sb-1", "sb-2"} {
+		res, err := client.Exec(id, caps, "_start")
+		if err != nil {
+			t.Fatalf("Exec %s: %v", id, err)
+		}
+		if res.ExitCode != 0 {
+			t.Fatalf("Exec %s exit=%d stderr=%q", id, res.ExitCode, res.Stderr)
+		}
+	}
+
+	// Re-loading the same module is idempotent (same bucket).
+	if _, err := client.LoadModule("host", modPath, 0); err != nil {
+		t.Fatalf("re-LoadModule same path: %v", err)
+	}
+	// A different module is refused — a resident host is one (module, memoryMB)
+	// bucket, and swapping it would pull the compiled code out from under live
+	// instances.
+	other := wasmmod.WriteMinimalWasm(t, dir, "other.wasm")
+	if _, err := client.LoadModule("host", other, 0); err == nil {
+		t.Fatal("expected error loading a second distinct module into a bound resident host")
+	}
+
+	// Per-sandbox stop.
+	if err := client.StopInstance("sb-1"); err != nil {
+		t.Fatalf("StopInstance sb-1: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+}
+
+// TestResidentServer_RejectsListener confirms a listener (expose_port/HTTP)
+// Instantiate is rejected — the driver routes those to the per-sandbox cold path.
+func TestResidentServer_RejectsListener(t *testing.T) {
+	dir := t.TempDir()
+	modPath := wasmmod.WriteMinimalWasm(t, dir, "demo.wasm")
+	client, _ := serveResident(t)
+	if _, err := client.LoadModule("host", modPath, 0); err != nil {
+		t.Fatalf("LoadModule: %v", err)
+	}
+	// WASIListenPort 0 = ephemeral listen enabled → must be rejected here.
+	listenCaps := wasmengine.Capabilities{Args: []string{"wasm"}, WASIListenPort: 0}
+	if err := client.Instantiate("sb-listen", listenCaps); err == nil {
+		t.Fatal("expected resident host to reject a wasip1-listener Instantiate")
+	}
+	time.Sleep(10 * time.Millisecond)
+}

--- a/pkg/wasm/worker/supervisor.go
+++ b/pkg/wasm/worker/supervisor.go
@@ -26,6 +26,21 @@ func DefaultSpawner(ctx context.Context, socketPath string) (*exec.Cmd, error) {
 	return cmd, nil
 }
 
+// DefaultResidentSpawner runs the current executable as a resident-module host
+// (--wasm-resident-host → RunCLIResident): one process compiles a module once
+// and hosts many isolated sandbox instances. Used by the driver's resident-host
+// supervisor when SB_WASM_RESIDENT_HOST_ENABLED is set.
+func DefaultResidentSpawner(ctx context.Context, socketPath string) (*exec.Cmd, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.CommandContext(ctx, exe, "--wasm-resident-host", socketPath)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd, nil
+}
+
 // Slot tracks one sandbox worker subprocess.
 type Slot struct {
 	SandboxID  string

--- a/plans/wasm-resident-module-host.md
+++ b/plans/wasm-resident-module-host.md
@@ -73,9 +73,22 @@ must show the breakdown before Phase 1 starts. Interpretation → lever:
 | `wasm_load_runtime` + `_newengine` | resident **runtime** (a lighter variant of this plan — reuse the runtime, still re-`InstantiateModule`) |
 | `wasm_load_read` | mmap / keep module bytes resident (small, separate change) |
 
-The config note (`~10s` cold compile vs `~2.8s` cached) strongly implies
-`_compile` dominates, i.e. this plan is the right lever — but confirm, don't
-assume.
+**Gate result — GREEN (2026-07-15, `cluster-3-mixed-wasm`, v0.7.9, 10 samples,
+0 failures).** The breakdown of the cold miss (`wasm_load` p50 2843ms, n=2):
+
+| sub-stage | p50 | share |
+|---|---|---|
+| `wasm_load_compile` | **2768ms** | **~97%** |
+| `wasm_load_read` (25MB ReadFile) | 56ms | ~2% |
+| `wasm_load_newengine` | 1ms | ~0% |
+| `wasm_load_runtime` | 1ms | ~0% |
+
+`CompileModule` owns the cold load almost entirely — and note this is *with* the
+on-disk compile cache populated, so 2.77s is the cache-hit **deserialize** cost
+of a 25MB CPython image per fresh process, not a from-scratch 10s compile. A
+resident in-process `CompiledModule` skips even the deserialize, so a cold
+create collapses to `wasm_instantiate` (**9ms** in the same run). This plan (the
+resident compiled module) is confirmed the right lever; Phase 1 may start.
 
 ## Core insight
 
@@ -135,56 +148,123 @@ A **resident module host** is a long-lived worker process that:
 3. Services many `Instantiate` requests, each creating an isolated instance
    keyed by `sandboxID`; a create that routes here costs ~`wasm_instantiate`.
 
-### Engine (Phase 1)
+### Engine (Phase 1) — IMPLEMENTED 2026-07-15
 
-Add a multi-instance capability WITHOUT touching the base `Engine` interface
-(which `wasmtime` + several mocks implement). Preferred: a new
-`MultiInstanceEngine` in `pkg/wasm` wrapping `{runtime, compiled,
-map[sandboxID]api.Module}` with per-instance `Instantiate/StopInstance/Run/
-CaptureSnapshot/RestoreSnapshot/ResolvedListenPort`. The existing
-single-instance `wazeroEngine` stays the default path untouched. Offline unit
-tests: two instances of the same compiled module cannot read each other's
-linear memory; StopInstance on one leaves the other running; compile happens
-exactly once across N instantiates.
+`pkg/wasm/engine_multi.go`: `MultiInstanceEngine` wraps `{runtime, compiled,
+map[sandboxID]api.Module}` — compile-once (`LoadModule`), instantiate-many
+(`Instantiate(sandboxID, caps)` with a per-instance `WithName(sandboxID)` so
+co-tenants don't collide on one runtime), plus `StopInstance`, `InvokeExport`,
+`HasInstance`, `InstanceCount`, `Close`, and `LastLoadTimings`
+(`LoadTimingReporter`). MemoryMB is fixed at construction (the bucketing
+constraint above). The base `Engine` interface is untouched — `wasmtime` and the
+mocks are unaffected; the runtime builder + module/fs config helpers were
+extracted to free functions (`newBaseRuntime`, `moduleConfigFor`, `fsConfigFor`)
+so both engines share identical config (notably the compile cache), and the
+single-instance `wazeroEngine` delegates to them unchanged.
 
-### Worker protocol (Phase 2)
+Tests (`pkg/wasm/engine_multi_test.go`, offline): compile happens once across N
+instantiates (resident `compiled` pointer unchanged); two instances of the same
+module cannot read each other's linear memory (write to A, B stays zero);
+StopInstance on one leaves the co-tenant running and uncorrupted; duplicate
+sandboxID rejected; Instantiate-before-Load and empty-ID fail cleanly;
+`LoadTimingReporter` satisfied. Full `pkg/wasm` + driver + pool suites still
+green (the extraction did not disturb the single-instance path).
 
-The worker `Server` today holds one `s.eng` + one `s.lastCaps`
-(`server.go:16-24`). Make instance state per-`sandboxID` (the network mediator
-and byte counters are **already** keyed by sandboxID — `netUsageFor`,
-`mediator()` — so that half is done). Split the messages:
+**Deferred to Phase 2 (worker wiring), NOT in the Phase 1 engine:** per-instance
+networking (the worker's `NetMediator` is already sandboxID-keyed), IO-capturing
+`Run`, snapshot/restore, and wasip1 listeners (`expose_port`/HTTP — resident-host
+mode initially serves non-listen sandboxes; HTTP falls back to the cold path).
 
-- `MsgLoadModule` → load/compile the host's shared module once (idempotent per
-  bucket); returns the existing `LoadTimings`.
-- `MsgInstantiate` / `MsgStopInstance` / `MsgCheckpoint` / `MsgRestore` /
-  `MsgSetListenPort` → operate on the per-`sandboxID` instance.
+### Worker protocol (Phase 2) — IMPLEMENTED 2026-07-15
 
-**Scope limit for Phase 2:** wasip1 TCP listeners (`expose_port` / HTTP guests)
-resolve one listener fd per instance and the server tracks a single
-`lastCaps.WASIListenPort`. Multiplexing many listeners in one process is extra
-complexity, so the first cut supports resident-host mode **only for
-non-listen sandboxes** (one-shot exec / no `expose_port`); HTTP guests fall back
-to the cold per-process path. Lift this in a later phase if the bench shows
-HTTP guests need it.
+`pkg/wasm/worker/resident_server.go`: `ResidentServer` backed by a
+`MultiInstanceEngine`, spawned via `--wasm-resident-host <socket>`
+(`RunCLIResident` → `cmd/sandboxd/main.go`). It reuses the existing wire
+protocol + `Client` unchanged — only the server interprets the messages
+multi-instance:
 
-### Pool + routing (Phase 3)
+- `MsgLoadModule` → lazily builds the engine at the payload's `memoryMB` on
+  first call, compiles once, returns the existing `LoadTimings`; idempotent for
+  the same path; **refuses a second distinct module** (a bucket is one module).
+- `MsgInstantiate` / `MsgExec` / `MsgInvoke` / `MsgStopInstance` → per-`sandboxID`
+  on the resident engine (`MultiInstanceEngine.{Instantiate,Run,InvokeExport,
+  StopInstance}`).
+- Listener (`caps.ListenEnabled()`), checkpoint/restore, network/netstats →
+  **rejected** with a clear error, so a misrouted request fails loudly.
 
-`internal/pool/wasm` shifts from "pool of pre-instantiated slots" to "pool of
-resident hosts per (digest, memoryMB)." `Acquire` returns a host to instantiate
-into rather than a slot to adopt. Refill keeps `min` hosts compiled per hot
-bucket. This also naturally fixes the miss/refill race noted in
-`project_wasm_create_latency` — there is no separate per-sandbox cold spawn to
-race, because the create instantiates into a resident host.
+Tests (`pkg/wasm/worker/resident_server_test.go`, offline): load-once →
+instantiate+exec two sandboxes on the resident module; re-load same path is a
+no-op; a second distinct module is refused; per-sandbox StopInstance; a
+listener Instantiate is rejected.
 
-### Config (Phase 3)
+**Scope limit (unchanged):** resident-host mode serves **non-listen** sandboxes
+only; `expose_port`/HTTP guests fall back to the cold per-process path.
 
-- `SB_WASM_RESIDENT_HOST_ENABLED` (bool, **default false**) — gates the whole
-  path; when false, behavior is exactly today's.
-- `SB_WASM_RESIDENT_HOST_MAX_INSTANCES` (int, default e.g. 32) — per-host
-  instance cap (blast-radius bound + load spreading).
-- Interplay: when enabled, the resident host is the warm mechanism, so
-  `SB_WASM_POOL_ENABLED` semantics fold into host pre-compilation. Document
-  which wins in `setup/config-defaults.md`.
+**Remaining Phase 2 (eng-review-gated): per-instance egress isolation.** The
+engine's `wazeroNetHost` (`wazero_network.go`) holds ONE hook + a GLOBAL conn
+table, read by all three WASI host modules at call time. Co-tenancy needs it
+keyed by `mod.Name()` (= sandboxID, since instances are named) plus conn
+ownership so guest B can't touch guest A's socket. Until that lands, resident
+instances get base WASI + FS only (no mediated egress), so networking modules
+are not yet served here. This is the security-sensitive change that must go
+through review.
+
+### Config (Phase 3) — flag IMPLEMENTED 2026-07-15
+
+- `SB_WASM_RESIDENT_HOST_ENABLED` (bool, **default false**) → `cfg.WasmResidentHostEnabled`
+  (`internal/config/config.go`). Gates the whole path; false = today's behavior
+  exactly. **DONE.**
+- `SB_WASM_RESIDENT_HOST_MAX_INSTANCES` (int, per-host cap) — TODO with the
+  routing below.
+- Interplay with `SB_WASM_POOL_ENABLED` + `setup/config-defaults.md` — TODO.
+
+### Pool + driver routing (Phase 3b) — IMPLEMENTED 2026-07-15 (gated, offline-tested)
+
+Gated by `cfg.WasmResidentHostEnabled` (default false) so flag-off is a
+byte-for-byte no-op — the existing per-sandbox `Driver.Create` path is left
+completely untouched (verified: full `internal/runtime/wasm` suite still green).
+Shipped (`internal/runtime/wasm/resident.go` + edits to `driver.go`,
+`create.go`, `lifecycle.go`, `config.go`, `pkg/daemon/wasm_wiring.go`,
+`pkg/wasm/worker/supervisor.go`):
+
+1. Resident-host state on the driver + `SetResidentHostSupervisor` (a second
+   supervisor using `worker.DefaultResidentSpawner` → `--wasm-resident-host`),
+   `ensureResidentHost` keyed by bucket `residentBucketID(digest, memoryMB)`
+   with per-bucket single-flight (`residentBucket.mu`) on host spawn + one
+   host-level `LoadModule`.
+2. `create.go`: an early branch — when `residentHostEnabled()`, the create is
+   not public-expose (`createWantsPublicExpose`), and the digest is known —
+   returns `createOnResidentHost` (Ensure → waitWorker → host LoadModule →
+   `Instantiate(sandboxID)`), setting `fromResidentHost`, `socketPath`=bucket
+   socket, `workerKey`=bucket. Instantiate failure resets the bucket (respawn
+   safety) and rolls back.
+3. `lifecycle.go` Destroy: `fromResidentHost` → `client.StopInstance(sandboxID)`,
+   never `supervisor.Stop` (the shared host stays up). (Stop already calls
+   StopInstance, so it was already correct.)
+4. `driver.go` `refreshWorkerInstanceState`: short-circuits for
+   `fromResidentHost` (per-sandbox spawn-count liveness doesn't apply).
+5. Daemon wiring: the resident supervisor is constructed only when the flag is
+   set; nil/no-op otherwise.
+
+Tests (`internal/runtime/wasm/resident_test.go`, offline): create routes to the
+resident host (resident supervisor ensured, per-sandbox untouched, host-level
+load + instantiate, `fromResidentHost` + bucket workerKey); Destroy StopInstances
+without killing the host; flag-off takes the cold path; public-expose create
+takes the cold path.
+
+This also sidesteps the miss/refill race in `project_wasm_create_latency`: no
+separate per-sandbox cold spawn to race — creates instantiate into a resident host.
+
+**Remaining before the flag can flip ON (eng-review-gated):**
+- **Per-instance egress isolation** — resident instances currently get base
+  WASI + FS only; wasi-sockets/http egress needs the net host keyed by
+  `mod.Name()` + conn ownership (see Phase 2 note). Until then, networking
+  modules (likely CPython) aren't served by the resident host, so the live
+  CPython cold-load win still can't be benched.
+- **expose_port after create** on a private resident sandbox errors (resident
+  host rejects listeners). Document, or migrate-to-cold-on-expose.
+- **Host lifecycle**: idle-TTL teardown of resident hosts, capacity/admission
+  accounting for host-shared RAM, `SB_WASM_RESIDENT_HOST_MAX_INSTANCES` cap.
 
 ### Validation (Phase 4)
 


### PR DESCRIPTION
## Summary

Phases 1–3b of [`plans/wasm-resident-module-host.md`](plans/wasm-resident-module-host.md): a **resident compile-once / instantiate-many host** for WASM sandboxes.

The v0.7.9 `cluster-3-mixed-wasm` bench (10 samples, 0 failures) — using the `wasm_load` sub-stage timing merged in #335 — pinned the WASM cold-create cost:

| `wasm_load` sub-stage | p50 | share |
|---|---|---|
| **`wasm_load_compile`** | **2768 ms** | **~97%** |
| `wasm_load_read` (25 MB) | 56 ms | ~2% |
| `wasm_load_runtime` / `_newengine` | 1 ms / 1 ms | ~0% |

That 2.77 s is the wazero `CompileModule` cost **with the on-disk cache already populated** — i.e. the per-process deserialize of a 25 MB CPython image. A resident in-process `CompiledModule` skips it entirely: an `Instantiate` measured **9 ms** in the same run. This PR builds the mechanism to reach that ceiling.

**Gated by `SB_WASM_RESIDENT_HOST_ENABLED` (default `false`). Flag-off is a byte-for-byte no-op** — the existing per-sandbox `Driver.Create` path is untouched.

- **Phase 1** — `MultiInstanceEngine` (`pkg/wasm/engine_multi.go`): compile-once, instantiate-many, per-instance linear-memory isolation. Base `Engine` interface untouched; runtime/module/fs config extracted to free functions shared with the single-instance engine.
- **Phase 2** — `ResidentServer` (`--wasm-resident-host`) reuses the wire protocol multi-instance; non-listen scope.
- **Phase 3a** — `SB_WASM_RESIDENT_HOST_ENABLED` config flag.
- **Phase 3b** — driver create/lifecycle routing behind the flag; a second supervisor owns the shared hosts.

## Code-path diagram (§8)

```mermaid
flowchart TD
    C["Driver.Create"] --> G{"residentHostEnabled()<br/>&& !public-expose<br/>&& digest != ''"}
    G -->|"no (default / flag off)"| COLD["UNCHANGED per-sandbox path:<br/>tryAcquireWarm → spawn worker →<br/>LoadModule (compile) → Instantiate"]
    G -->|"yes (NEW)"| EH["ensureResidentHost(digest, memoryMB)<br/>single-flight per bucket"]
    EH --> EHR{"bucket ready?"}
    EHR -->|no| SPAWN["resident supervisor Ensure →<br/>waitWorker → host LoadModule (compile ONCE)"]
    EHR -->|yes| SKIP["reuse resident host"]
    SPAWN --> INST
    SKIP --> INST
    INST{"retry?<br/>(sandboxID in byID)"}
    INST -->|yes| STOP["StopInstance (drop stale) — idempotency §1"]
    INST -->|no| I2
    STOP --> I2["Instantiate(sandboxID) ~9ms"]
    I2 -->|ok| DONE["status=Started"]
    I2 -->|err| RB["reset bucket.ready + delete byID +<br/>RemoveAll(workDir) — failure-path §4"]

    D["Driver.Destroy"] --> DG{"inst.fromResidentHost?"}
    DG -->|"yes (NEW)"| DS["client.StopInstance — NEVER kill shared host"]
    DG -->|no| DK["UNCHANGED: supervisor.Stop(workerKey)"]
```

## pr-review axes

This PR touches `internal/runtime/wasm` (a `CreateSandbox` callee), `pkg/wasm`, `internal/config`, `pkg/daemon`, `cmd/sandboxd`. It does **not** touch `internal/service`, `internal/store`, `pkg/caddy`, `pkg/api`, or the SDKs.

**§1 Idempotency** — The resident engine rejects a duplicate `sandboxID` (a loud routing-bug guard, asserted in `engine_multi_test.go`). Retry-safety is handled one layer up: `createOnResidentHost` detects a retry (sandboxID already in `byID`) and `StopInstance`s the stale instance before re-`Instantiate` — matching the single-instance engine's re-instantiate-on-Exec semantics. Regression test: `TestCreateResidentRetryIsIdempotent`. First-create pays no extra round-trip.

**§2 `CreateSandbox` boot latency** — Adds a branch to `Driver.Create`. **When the flag is off (default), zero added work** — the branch condition is a bool load + nil check and falls straight through to the untouched path. **When on**, a resident create *replaces* per-sandbox spawn+compile with: (bucket-cached, single-flighted) host `Ensure` + host `LoadModule` (compile once per bucket, amortized across all its instances) + `Instantiate` (~9 ms). The host `LoadModule` on a warm bucket is a dedup no-op. Net: strictly *less* work than the cold path it replaces. The one added round-trip (`StopInstance`) is retry-path only.

**§3 Bootstrap** — The resident host spawn is a lazy, single-flighted per-bucket bring-up on the create path (`residentBucket.mu` guards spawn+load so a concurrent burst for one module spawns one host, not N) — the same shape as the L4 latch's intent. It is *not* daemon-start bootstrap; nothing is added to daemon boot.

**§4 Failure-path consistency** — `createOnResidentHost` is the only new multi-step path and touches no caddy/store. On `Instantiate` failure it rolls back atomically: reset `bucket.ready` (so the next create reloads a possibly-respawned empty host), delete the `byID` entry, `RemoveAll(workDir)`. No shared-host teardown on a single instance failure.

**§5 Mount inputs** — N/A (no change to mount handling).

**§6 TCP host-port pool & L4** — N/A (untouched).

**§7 Cluster** — N/A for placement/forwarding: resident routing is node-local and happens on the worker *after* placement, orthogonal to who-runs-what. Default-off, so no cluster behavior change. (A resident-hosted sandbox is not cluster-recovery/snapshot-eligible — noted in the plan as part of the eng-review-gated remainder.)

**§8 Diagram** — above.

## Testing (all offline, `make test`)

- `pkg/wasm/engine_multi_test.go` — compile-once across N instantiates; two instances' linear memory isolated; stop-one leaves co-tenant running; duplicate/empty-ID/before-load rejected; per-instance `Run`; `LoadTimingReporter`.
- `pkg/wasm/worker/resident_server_test.go` — load-once → instantiate+exec two sandboxes; re-load no-op; second distinct module refused; per-sandbox stop; listener Instantiate rejected.
- `internal/runtime/wasm/resident_test.go` — create routes to resident host (per-sandbox supervisor untouched); Destroy StopInstances without killing the host; **flag-off → cold path**; **public-expose → cold path**; retry idempotent.
- Full `internal/runtime/wasm` + `pkg/daemon` + `cmd/sandboxd` + `internal/config` suites green (no regression on the fragile create/lifecycle path). `go build`/`vet`/`gofmt` clean.

## Not in this PR — before the flag can flip ON (eng-review-gated)

1. **Per-instance egress isolation** — resident instances currently get base WASI + FS only; wasi-sockets/http egress needs the net host keyed by `mod.Name()` (= sandboxID) + conn ownership. **Until this lands, networking modules (likely CPython) aren't served by the resident host, so the live CPython cold-load win can't yet be benched.**
2. `expose_port` after create on a private resident sandbox errors (host rejects listeners) — needs documenting or migrate-to-cold.
3. Resident-host idle-TTL teardown + capacity/admission accounting for shared RAM + `SB_WASM_RESIDENT_HOST_MAX_INSTANCES` cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
