### PR TITLE
feat(wasm): pre-warm resident hosts at boot (follow-up to #336)

### DIFF
--- a/internal/runtime/wasm/resident.go
+++ b/internal/runtime/wasm/resident.go
@@ -100,6 +100,42 @@ func (d *Driver) ensureResidentHost(ctx context.Context, digest, path string, me
 	return b, nil
 }
 
+// PrewarmResidentHosts brings up the resident host and compiles each ref's
+// module at daemon boot, so the FIRST create for a standard module is a ~ms
+// Instantiate instead of paying the one-time ~seconds CompileModule on the
+// create path. This is the fix for the lazy first-create-per-node tail measured
+// in the v0.7.10 A/B (resident server p99 ~1.7s = the un-amortized first
+// compile). Best-effort and meant to be backgrounded by the caller (compiling a
+// ~25MB module is slow — pr-review.md §2 keeps it off the boot-blocking path);
+// a ref that does not resolve or compile is logged and skipped. No-op unless
+// resident hosts are enabled.
+func (d *Driver) PrewarmResidentHosts(ctx context.Context, refs []string) {
+	if !d.residentHostEnabled() || d.resolver == nil {
+		return
+	}
+	for _, ref := range refs {
+		if ctx.Err() != nil {
+			return
+		}
+		resolved, err := d.resolver.Resolve(ctx, ref)
+		if err != nil || resolved == nil || resolved.Digest == "" {
+			if d.logger != nil {
+				d.logger.Warn("resident prewarm skipped: ref did not resolve", "ref", ref, "error", err)
+			}
+			continue
+		}
+		if _, err := d.ensureResidentHost(ctx, resolved.Digest, resolved.Path, d.cfg.DefaultMemoryMB); err != nil {
+			if d.logger != nil {
+				d.logger.Warn("resident prewarm failed", "ref", ref, "error", err)
+			}
+			continue
+		}
+		if d.logger != nil {
+			d.logger.Info("resident host prewarmed", "ref", ref, "digest", resolved.Digest, "memory_mb", d.cfg.DefaultMemoryMB)
+		}
+	}
+}
+
 // createOnResidentHost is the resident-host create path: it instantiates an
 // isolated instance into the shared bucket host instead of spawning a
 // per-sandbox worker + compiling. Reached only when residentHostEnabled() and

--- a/internal/runtime/wasm/resident_test.go
+++ b/internal/runtime/wasm/resident_test.go
@@ -99,6 +99,50 @@ func TestCreateResidentRetryIsIdempotent(t *testing.T) {
 	}
 }
 
+// TestPrewarmResidentHostsSkipsFirstCreateBringup guards the boot-time pre-warm:
+// after PrewarmResidentHosts brings up + compiles a module's host, the first
+// create for that module must NOT re-spawn or re-compile — it's a cached
+// (ready) bucket, so the create is instantiate-only. This is what moves the
+// one-time compile off the create path (the v0.7.10 tail fix).
+func TestPrewarmResidentHostsSkipsFirstCreateBringup(t *testing.T) {
+	d, _, resident, client := residentTestDriver(t, true)
+
+	d.PrewarmResidentHosts(context.Background(), []string{"demo.wasm"})
+	if resident.ensureCalls != 1 {
+		t.Fatalf("prewarm resident ensure calls = %d, want 1", resident.ensureCalls)
+	}
+	if client.loadPath == "" {
+		t.Fatal("prewarm did not LoadModule (compile) the resident host")
+	}
+
+	// First create for the same (digest, memoryMB) bucket must reuse the
+	// pre-warmed host: no additional Ensure, no additional LoadModule.
+	client.loadPath = ""
+	if _, err := d.Create(context.Background(), models.CreateSandboxRequest{Image: "demo.wasm"}, "sb-pw", "tok", nil); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if resident.ensureCalls != 1 {
+		t.Fatalf("create re-brought-up the host: resident ensure calls = %d, want 1 (reuse pre-warmed)", resident.ensureCalls)
+	}
+	if client.loadPath != "" {
+		t.Fatalf("create re-compiled (LoadModule) despite pre-warm: loadPath=%q", client.loadPath)
+	}
+	inst, err := d.instance("sb-pw")
+	if err != nil || !inst.fromResidentHost {
+		t.Fatalf("create did not use the resident host (inst=%v err=%v)", inst, err)
+	}
+}
+
+// TestPrewarmResidentHostsDisabledNoop confirms pre-warm does nothing when the
+// flag is off (no resident supervisor consulted).
+func TestPrewarmResidentHostsDisabledNoop(t *testing.T) {
+	d, _, resident, _ := residentTestDriver(t, false)
+	d.PrewarmResidentHosts(context.Background(), []string{"demo.wasm"})
+	if resident.ensureCalls != 0 {
+		t.Fatalf("prewarm ran with flag off: resident ensure calls = %d, want 0", resident.ensureCalls)
+	}
+}
+
 // TestCreateResidentDisabledUsesColdPath confirms the flag-off default is
 // untouched: creates take the per-sandbox worker path.
 func TestCreateResidentDisabledUsesColdPath(t *testing.T) {

--- a/pkg/daemon/wasm_wiring.go
+++ b/pkg/daemon/wasm_wiring.go
@@ -119,6 +119,20 @@ func wireWasmRuntime(ctx context.Context, cfg config.Config, logger *slog.Logger
 			"refill_interval", cfg.WasmPoolRefillInterval)
 	}
 
+	// Boot-time resident-host pre-warm: bring up + compile the standard-module
+	// resident hosts ahead of demand so the first create is an Instantiate, not a
+	// cold compile. Backgrounded (compiling ~25MB modules is slow) so it never
+	// blocks daemon boot (hard rule 2 / pr-review.md §2). No-op unless the flag
+	// is set and a resident supervisor was wired above.
+	if cfg.WasmResidentHostEnabled {
+		refs := make([]string, 0, len(cfg.WasmStandardModules))
+		for alias := range cfg.WasmStandardModules {
+			refs = append(refs, alias)
+		}
+		go driver.PrewarmResidentHosts(ctx, refs)
+		logger.Info("wasm resident host prewarm scheduled", "modules", len(refs))
+	}
+
 	logger.Info("wasm runtime enabled",
 		"run_dir", cfg.WasmRunDir,
 		"modules_dir", cfg.WasmModulesDir,


### PR DESCRIPTION
## Summary

Follow-up to #336. The resident host (compile-once/instantiate-many) shipped in #336 compiled a module **lazily on the first create per node** — so that one create paid the ~2.5 s `CompileModule` while every later create on that node was a ~ms `Instantiate`. On the v0.7.10 live A/B this showed as a stubborn **~1.7 s server p90/p99 tail**: one un-amortized first-compile per cluster node.

This PR moves that one-time compile **off the create path to daemon boot**. `Driver.PrewarmResidentHosts` resolves each standard module and brings up + compiles its resident host ahead of demand, so the first create is already a ~ms `Instantiate`. Backgrounded so it never blocks boot (hard rule 2 / pr-review §2). No-op unless `SB_WASM_RESIDENT_HOST_ENABLED` is set (default off).

## Live A/B re-bench (real t3.medium, `cluster-3-mixed-wasm`, 10 samples, 0 failures)

| config | server p50 | server p90 | server p99 | mean | cold compiles |
|---|---|---|---|---|---|
| flag OFF (warm-pool baseline) | 28 ms | 2722 ms | 3042 ms | 596 ms | 2–3 × ~3 s |
| flag ON, **lazy** (no pre-warm, = #336) | 20 ms | 1718 ms | 1745 ms | 361 ms | 1 per node |
| flag ON **+ boot pre-warm** (this PR) | **21 ms** | **27 ms** | **28 ms** | **22 ms** | **0** |

**p99 3042 → 28 ms (−99%), mean 596 → 22 ms (−96%).** Every create is now flat ~21 ms (instantiate ~9 ms + `cluster_promote` ~10 ms), tail included. Pre-warm confirmed in node logs: `resident host prewarmed ref=python … memory_mb=256` on all 3 nodes at boot.

## Code-path diagram (§8)

```mermaid
flowchart TD
    subgraph boot["daemon boot (NEW, backgrounded)"]
      B1{"SB_WASM_RESIDENT_HOST_ENABLED?"}
      B1 -->|no default| B2["nothing — per-sandbox path"]
      B1 -->|yes| B3["go PrewarmResidentHosts(standard modules)"]
      B3 --> B4["for each module: resolve → ensureResidentHost<br/>(spawn host + compile ONCE) → bucket.ready=true"]
    end
    subgraph create["first create for module X"]
      C1["createOnResidentHost → ensureResidentHost"]
      C1 --> C2{"bucket.ready?"}
      C2 -->|"BEFORE this PR: no → spawn+compile ~2.5s"| C3["slow first create"]
      C2 -->|"AFTER: yes (pre-warmed at boot)"| C4["Instantiate ~9ms"]
    end
    B4 -.pre-warms the bucket the create reuses.-> C2
```

## pr-review axes

Touches `internal/runtime/wasm` (a `CreateSandbox`-adjacent driver) + `pkg/daemon` wiring. Not `internal/service`/`store`/`caddy`/`pkg/api`/SDKs.

**§1 Idempotency** — `PrewarmResidentHosts` calls the same `ensureResidentHost` used by create, which is single-flighted per `(digest, memoryMB)` bucket. Running it repeatedly (e.g. a daemon restart) is a no-op on an already-`ready` bucket. A module that fails to resolve/compile is logged and skipped — it does not fail boot, and its first create falls back to the lazy path.

**§2 `CreateSandbox` boot latency** — This PR *reduces* create-path work: it removes the one-time compile from the first create (moving it to daemon boot). No new work is added to the create path. The added work is at **daemon startup**, backgrounded (a goroutine), so it does not block boot — compiling the standard modules (~2–3 s each) runs off the boot-blocking path.

**§3 Bootstrap** — This is best-effort daemon-start work, backgrounded, flag-gated, and idempotent via the per-bucket single-flight — the shape hard rule 3 prescribes. Failure is logged and the lazy path still works; it does not fail the daemon.

**§4 Failure-path consistency** — No caddy/store writes. A failed pre-warm leaves the bucket not-`ready`; the first create then brings it up lazily (existing #336 path). No partial state.

**§5 / §6 / §7** — N/A (no mount inputs, no TCP/L4 pool, no placement/forwarding change; resident routing is node-local and default-off).

**§8 Diagram** — above.

## Testing

- Offline (`internal/runtime/wasm/resident_test.go`): `TestPrewarmResidentHostsSkipsFirstCreateBringup` — after pre-warm, the first create for the same bucket does **not** re-Ensure or re-LoadModule (proves the compile moved off the create path); `TestPrewarmResidentHostsDisabledNoop` — no-op when the flag is off.
- `go build` / `go vet` / `gofmt` clean; `internal/runtime/wasm` + `pkg/daemon` suites green.
- **Live-validated** on real t3.medium (A/B table above), cluster torn down clean.

## Deploy note (for the record)

During the live re-bench, rolling-restarting all 3 SWIM nodes to pick up the new binary + flag split the cluster 2+1 — the seed was restarted **last**, orphaning the joiners (a SWIM restart-ordering artifact, **not** this code, and not OOM: nodes sat at 1.3/3.8 GB). Recovered by restarting the two joiners to rejoin the seed → 3 members → clean bench. In production this feature ships in the binary from first boot, so this rolling-restart hazard doesn't apply.

## Still eng-review-gated before the flag flips on (unchanged from #336)

Per-instance egress isolation (net host keyed by `mod.Name()` + conn ownership), `expose_port`-after-create handling, and resident-host idle-TTL/capacity accounting. Note: pre-warming N standard modules holds N resident host processes resident (memory cost) — factor into the capacity work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
