### PR TITLE
docs: position AerolVM as self-hosted or managed multi-tenant SaaS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # AerolVM — Claude Code Instructions
 
-Self-hosted Docker-backed sandbox platform. Go daemon + 5 SDKs + Astro docs site.
+Self-hosted or managed multi-tenant Docker-backed sandbox platform. Go daemon + 5 SDKs + Astro docs site.
 For non-trivial changes, invoke the matching project skill before coding (they live in
 [`.claude/skills/`](./.claude/skills/) — see the "Project skills" table below).
 Read [`pr-review.md`](./pr-review.md) before opening any PR that touches the server.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <h3 align="center">
   Run Untrusted Code Safely.<br/>
-  Self-Hosted Sandbox Infrastructure for AI Agents and Ephemeral Workloads.
+  Self-Hosted or Fully-Managed Sandbox Infrastructure for AI Agents and Ephemeral Workloads.
 </h3>
 
 <p align="center">
@@ -29,7 +29,7 @@
 
 &nbsp;
 
-AerolVM is open-source, self-hosted sandbox infrastructure for running isolated code environments on your own Linux host. Each sandbox is a fully isolated compute unit with its own filesystem, network namespace, and allocated vCPU, RAM, and disk - spinning up in **under 60ms** and supporting Docker, gVisor, and Firecracker runtimes. Built for AI agent pipelines and ephemeral CI, it ships as a single Go binary backed by Caddy for TLS routing and SQLite for state, with no external dependencies and a one-line installer.
+AerolVM is open-source sandbox infrastructure for running isolated code environments - self-host it on your own Linux host, or run it as a managed, multi-tenant service. Each sandbox is a fully isolated compute unit with its own filesystem, network namespace, and allocated vCPU, RAM, and disk - spinning up in **under 60ms** and supporting Docker, gVisor, and Firecracker runtimes. Built for AI agent pipelines and ephemeral CI, it ships as a single Go binary backed by Caddy for TLS routing and SQLite for state, with no external dependencies and a one-line installer.
 
 ## Features
 
@@ -49,7 +49,7 @@ AerolVM beats the two most common alternatives on the axes that matter most for 
 
 | | AerolVM | e2b | Daytona |
 | :--- | :--- | :--- | :--- |
-| **Self-hosted** | ✅ Single binary, one-line install | ✗ Cloud only | ✅ Complex multi-component setup |
+| **Deployment** | ✅ Self-host (single binary, one-line install) or managed multi-tenant SaaS | ✗ Cloud only | ✅ Self-host (complex multi-component setup) |
 | **Runs locally** | ✅ `--local` flag, no DNS needed | ✗ | ✗ |
 | **Sandbox startup** | < 90ms | ~200ms | < 90ms |
 | **Runtime isolation** | ✅ Docker, gVisor (user-space kernel), Firecracker (microVM) | Firecracker (microVM) | Docker only |

--- a/docs/src/content/docs/comparison.md
+++ b/docs/src/content/docs/comparison.md
@@ -8,7 +8,7 @@ A side-by-side look at how AerolVM compares to the two most common alternatives 
 
 | | AerolVM | e2b | Daytona |
 |---|---|---|---|
-| **Hosting** | Self-hosted on your infra | Cloud (managed, no self-host) | Self-hosted |
+| **Hosting** | Self-host on your infra, or managed multi-tenant SaaS | Cloud (managed, no self-host) | Self-hosted |
 | **Set Up Complexity** | Easy for Single Node | No self-host | Extremely Complex for Single Node |
 | **Can run locally** | ✅ | ✗ | ✗ |
 | **Open source** | ✅ | ✗ | ✅ |

--- a/docs/src/content/docs/engineering-distributed-sandbox-runtime.mdx
+++ b/docs/src/content/docs/engineering-distributed-sandbox-runtime.mdx
@@ -247,7 +247,7 @@ On top of the native SDKs, AerolVM exposes two compatibility facades:
 
 This is not a differentiator in the same league as "HA stateful
 sandboxes." It is a migration story. If you're already on E2B or Daytona
-and want to move to self-hosted, you change one URL.
+and want to move to AerolVM — self-hosted or managed — you change one URL.
 
 See [Using Daytona SDK](/using-daytona-sdk) and
 [Using E2B SDK](/using-e2b-sdk).

--- a/plans/readme-rewrite-plan.md
+++ b/plans/readme-rewrite-plan.md
@@ -56,11 +56,11 @@ Reference: [Daytona README](https://github.com/daytonaio/daytona/blob/main/READM
 
 1. **Add an HTML-centered logo block** with `<picture>` + `srcset` for dark/light mode. Use `docs/public/aerol-logo.svg` via GitHub raw URL.
 
-2. **Write a 2-line tagline** under the logo: first line is action ("Run Untrusted Code Safely."), second line expands ("Self-Hosted Sandbox Infrastructure for AI Agents and Ephemeral Workloads.").
+2. **Write a 2-line tagline** under the logo: first line is action ("Run Untrusted Code Safely."), second line expands ("Self-Hosted or Fully-Managed Sandbox Infrastructure for AI Agents and Ephemeral Workloads.").
 
 3. **Add a centered nav-links paragraph** under the tagline: Documentation · Quick Start · Report Bug · Request Feature. Gives every visitor a clear next action.
 
-4. **Write a 3-sentence intro paragraph** that names: what it is (self-hosted Docker sandbox platform), what makes it different (single-binary, sub-90ms cold start, gVisor isolation, Raft cluster mode), who it is for (AI agent pipelines and ephemeral CI).
+4. **Write a 3-sentence intro paragraph** that names: what it is (self-hosted or managed multi-tenant Docker sandbox platform), what makes it different (single-binary, sub-90ms cold start, gVisor isolation, Raft cluster mode), who it is for (AI agent pipelines and ephemeral CI).
 
 5. **Add a Features table with 4–5 columns** mapping capability areas to linked docs pages. Categories: Sandboxes · Execution · Networking & Ports · Storage & Secrets · Platform & Cluster. Each cell is a link.
 

--- a/plans/sandbox-platform-issues-2026.md
+++ b/plans/sandbox-platform-issues-2026.md
@@ -217,7 +217,7 @@ Legend: ✅ **Not present** · ⚠️ **Partial / risk** · ❌ **Present (real 
 | E2B-2 | NFS / persistent volume instability | ⚠️ Inherited risk | AerolVM delegates to host tools (`mount.nfs`, `mountpoint-s3`, etc.) per `pkg/mounts/manager.go:2`. The Manager correctly rolls back failed mounts (`pkg/mounts/manager.go`), but cannot shield against an unstable NFS server. |
 | E2B-3 | Cold start ~150ms | ✅ Runtime-dependent | Docker, gVisor, Firecracker, WASM runtimes all configurable. Firecracker templates (`SB_ENABLE_FIRECRACKER`) allow snapshot-restore paths. Operators choose the trade-off. |
 | E2B-4 | Hard runtime ceilings (1h / 24h) | ✅ Not present | No platform-enforced ceiling. `Lifecycle.StopAtAge` / `DestroyAtAge` are optional and user-set. Unset = runs indefinitely (`internal/service/service.go:3784-3791`). |
-| E2B-5 | Pricing cliffs at scale | ✅ Not applicable | Self-hosted. Operator owns infrastructure costs. |
+| E2B-5 | Pricing cliffs at scale | ⚠️ Applies to the managed offering | Self-hosted: the operator owns infrastructure costs, no vendor cliff. The managed multi-tenant SaaS must price to avoid recreating the same cliffs. |
 | E2B-6 | Port-not-open race on boot | ❌ Present | `ExposePort()` (`internal/service/service.go:2164`) calls `s.installHTTPPortRoute` and `s.store.UpsertPort` without first probing whether the container port is actually listening. There is no `WaitForPort` before route installation. Only the SSH gateway has a probe (`probeSSHGateway`, `service.go:4627`), and it's daemon-level only, not per-port. Caddy will route traffic to the port immediately — clients that race `ExposePort` with container startup will get connection refused. |
 | E2B-7 | Silent template deprecation / 504 | ✅ Not present | Firecracker templates have explicit GC via `FirecrackerTemplateGCTTL` (`internal/config/config.go:516`). Deletion while a sandbox references the template returns `ErrTemplateInUse` → 409 (`pkg/api/apihttp/apihttp.go:89-90`). No silent removal. |
 | E2B-8 | API ConnectTimeout under burst creates | ⚠️ Infrastructure risk | SQLite single-writer with 5s busy timeout (`internal/store/store.go:23`, `sqliteBusyTimeoutMS=5000`). Under extreme burst, SQLite write queue saturation could produce context deadlines before the busy timeout expires. WAL mode mitigates reads. |
@@ -250,7 +250,7 @@ Legend: ✅ **Not present** · ⚠️ **Partial / risk** · ❌ **Present (real 
 |---|-------|---------|----------|
 | M-1 | gVisor `/proc/self/root` sandbox escape | ⚠️ Inherited if gVisor used | AerolVM supports gVisor via `runtime=gvisor` (`pkg/docker/client.go:300-318`). The escape class (`/proc/self/root` path rewriting bypassing deny patterns) is a gVisor kernel issue, not an AerolVM issue. If operators deploy gVisor, they inherit the class of risk until gVisor patches it. AerolVM itself has no deny-pattern enforcement that could be bypassed. |
 | M-2 | gVisor ≠ microVM isolation | ⚠️ Architecture-dependent | AerolVM exposes both: `runtime=gvisor` (user-space kernel, shared host kernel) and `runtime=firecracker` (full microVM, separate kernel). The choice is per-sandbox. Operators using Firecracker get full isolation; operators defaulting to Docker/gVisor do not. |
-| M-3 | Cost significantly higher than alternatives | ✅ Not applicable | Self-hosted. |
+| M-3 | Cost significantly higher than alternatives | ⚠️ Applies to the managed offering | Self-hosted: operator owns costs. The managed multi-tenant SaaS must keep unit economics competitive. |
 
 ---
 
@@ -268,7 +268,7 @@ Legend: ✅ **Not present** · ⚠️ **Partial / risk** · ❌ **Present (real 
 
 ### Fly.io Sprites Issues vs AerolVM
 
-Sprites issues are mostly managed-cloud reliability issues (control plane down, 500 on create, non-responsive after use). AerolVM is self-hosted. The structural equivalents are addressed as follows:
+Sprites issues are mostly managed-cloud reliability issues (control plane down, 500 on create, non-responsive after use). Self-hosted AerolVM avoids them structurally; the managed multi-tenant offering owns these concerns directly. The structural equivalents are addressed as follows:
 
 | Sprites Issue | AerolVM Equivalent |
 |---|---|


### PR DESCRIPTION
## Summary

AerolVM is **both** self-hosted **and** a managed, multi-tenant SaaS — not self-hosted only. Several docs still framed it as self-hosted-exclusive; this corrects the framing wherever that was a factual claim.

## Changes (docs/positioning only — no code)

- **README.md** — tagline (`Self-Hosted` → `Self-Hosted or Fully-Managed`), intro paragraph (self-host on your own host **or** run it as a managed multi-tenant service), and the comparison row (`Self-hosted` → `Deployment: self-host or managed multi-tenant SaaS`).
- **docs/src/content/docs/comparison.md** — Hosting row now shows self-host **or** managed multi-tenant SaaS.
- **docs/src/content/docs/engineering-distributed-sandbox-runtime.mdx** — migration line now reads "move to AerolVM (self-hosted or managed)". The technical failure-domain argument (self-hosted multi-node) is left intact — it's an engineering claim, not a product-identity one.
- **CLAUDE.md** — project descriptor → "Self-hosted or managed multi-tenant Docker-backed sandbox platform".
- **plans/sandbox-platform-issues-2026.md** — competitive verdicts that dismissed pricing/cost/reliability as "✅ Not applicable / self-hosted" (E2B-5, M-3, Sprites §) now read "⚠️ applies to the managed offering", since those concerns are real for the SaaS.
- **plans/readme-rewrite-plan.md** — tagline + intro prescriptions kept in sync with the README.

## Scope

Docs/positioning only. **No code, no behavior change.** Deliberately excludes the in-flight WASM resident-host egress-isolation implementation and its eng-review plan/TODOS, which are separate changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)