### PR TITLE
feat(wasm): resident-host egress isolation + migrate-on-expose + idle-TTL reaper (default-off)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -168,3 +168,20 @@ passed, zero-deployments premise re-verified in-tree). Branch
   cap. Defensive re-check at command encode + on the leader-forward path.
 - "No secrets in the Raft log" is now structural: no field exists to carry
   sealed bytes anywhere in cluster state.
+
+## Shard the WASM resident net-host mutex (performance, P3)
+
+- **What:** Shard `multiNetHost`'s single mutex (or split into per-map
+  RWMutexes) that guards the `hooks` / `conns` lookups in the resident
+  compile-once/instantiate-many WASM host (`pkg/wasm/engine_multi_network.go`,
+  shipped in PR-A of `plans/wasm-resident-module-host.md`, 2026-07-17).
+- **Why:** At very high co-tenant IO rates on one shared host process, the
+  single lock on every `tcp_dial`/`read`/`write`/`close` map lookup could show
+  up as contention.
+- **Caveat (why it's a TODO, not built now):** the design already releases the
+  lock BEFORE the blocking `conn.Read`/`Write`, so contention is only on
+  microsecond map lookups — adequate for correctness and the default-flag flip.
+  Building sharding now is premature optimization with no evidence it's needed.
+- **Depends on / start:** PR-A landed (done) + a profile (`go test -bench` or a
+  live cluster-3-mixed-wasm run) that actually shows lock contention. Eng-review
+  2026-07-17 (D9).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -556,6 +556,12 @@ type Config struct {
 	// process; when full the driver spills to a second host (<bucket>-2.sock).
 	// Default 32. SB_WASM_RESIDENT_HOST_MAX_INSTANCES.
 	WasmResidentHostMaxInstances int
+	// WasmResidentHostIdleTTL reaps a resident host process that has held zero
+	// instances for this long, reclaiming its compiled-module + runtime RAM.
+	// Pre-warmed standard-module hosts are pinned and never reaped. 0 disables
+	// the reaper (hosts live until daemon exit). Default 5m.
+	// SB_WASM_RESIDENT_HOST_IDLE_TTL.
+	WasmResidentHostIdleTTL time.Duration
 	// WasmDrainTimeout bounds graceful drain checkpoint per sandbox (§4.3).
 	// SB_WASM_DRAIN_TIMEOUT.
 	WasmDrainTimeout time.Duration
@@ -1541,6 +1547,7 @@ func Load() (Config, error) {
 		WasmCompileCacheDir:          getEnv("SB_WASM_COMPILE_CACHE_DIR", ""),
 		WasmResidentHostEnabled:      getEnvBool("SB_WASM_RESIDENT_HOST_ENABLED", false),
 		WasmResidentHostMaxInstances: getEnvInt("SB_WASM_RESIDENT_HOST_MAX_INSTANCES", 32),
+		WasmResidentHostIdleTTL:      getEnvDuration("SB_WASM_RESIDENT_HOST_IDLE_TTL", 5*time.Minute),
 		FirecrackerBinary:            getEnv("SB_FIRECRACKER_BINARY", "/usr/local/bin/firecracker"),
 		JailerBinary:                 getEnv("SB_JAILER_BINARY", "/usr/local/bin/jailer"),
 		FirecrackerKernelImage:       getEnv("SB_FIRECRACKER_KERNEL", "/var/lib/sandboxd/firecracker/vmlinux"),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -545,13 +545,17 @@ type Config struct {
 	// SB_WASM_COMPILE_CACHE_DIR.
 	WasmCompileCacheDir string
 	// WasmResidentHostEnabled routes non-listen wasm creates to a resident
-	// compile-once/instantiate-many host process per (module, memoryMB) bucket
-	// instead of a fresh per-sandbox worker (plans/wasm-resident-module-host.md).
+	// compile-once/instantiate-many host process per (ownerRef, module, memoryMB)
+	// bucket instead of a fresh per-sandbox worker (plans/wasm-resident-module-host.md).
 	// It collapses the ~2.8s cold CompileModule to a ~9ms Instantiate, but shares
 	// one process across co-tenant sandboxes — so it is DEFAULT OFF and remains
-	// operator opt-in until the per-instance egress-isolation work + eng-review
-	// land, exactly like SB_DOCKER_POOL_ENABLED. SB_WASM_RESIDENT_HOST_ENABLED.
+	// operator opt-in until PR-A/B/C land, exactly like SB_DOCKER_POOL_ENABLED.
+	// SB_WASM_RESIDENT_HOST_ENABLED.
 	WasmResidentHostEnabled bool
+	// WasmResidentHostMaxInstances caps co-tenant instances per resident host
+	// process; when full the driver spills to a second host (<bucket>-2.sock).
+	// Default 32. SB_WASM_RESIDENT_HOST_MAX_INSTANCES.
+	WasmResidentHostMaxInstances int
 	// WasmDrainTimeout bounds graceful drain checkpoint per sandbox (§4.3).
 	// SB_WASM_DRAIN_TIMEOUT.
 	WasmDrainTimeout time.Duration
@@ -1523,34 +1527,35 @@ func Load() (Config, error) {
 		// not to throttle normal durable workloads. Operators tune down for
 		// stricter boot-path protection or set 0 to disable. WASM durable is new
 		// in this release, so there are no existing guests this default can break.
-		WasmStateKVWritesPerSec: getEnvFloat("SB_WASM_STATEKV_WRITES_PER_SEC", 50),
-		WasmStateKVBurst:        getEnvInt("SB_WASM_STATEKV_BURST", 100),
-		WasmModuleGCEnabled:     getEnvBool("SB_WASM_MODULE_GC_ENABLED", true),
-		WasmModuleGCInterval:    getEnvDuration("SB_WASM_MODULE_GC_INTERVAL", 15*time.Minute),
-		WasmModuleGCTTL:         getEnvDuration("SB_WASM_MODULE_GC_TTL", 7*24*time.Hour),
-		WasmCacheGCTTL:          getEnvDuration("SB_WASM_CACHE_GC_TTL", 24*time.Hour),
-		WasmCacheMaxBytes:       getEnvInt64("SB_WASM_CACHE_MAX_BYTES", 0),
-		WasmPoolEnabled:         getEnvBool("SB_WASM_POOL_ENABLED", true),
-		WasmPoolDepthDefault:    getEnvInt("SB_WASM_POOL_DEPTH_DEFAULT", 2),
-		WasmPoolRefillInterval:  getEnvDuration("SB_WASM_POOL_REFILL_INTERVAL", 5*time.Second),
-		WasmModuleDigestMode:    strings.ToLower(getEnv("SB_WASM_MODULE_DIGEST_MODE", "once")),
-		WasmCompileCacheDir:     getEnv("SB_WASM_COMPILE_CACHE_DIR", ""),
-		WasmResidentHostEnabled: getEnvBool("SB_WASM_RESIDENT_HOST_ENABLED", false),
-		FirecrackerBinary:       getEnv("SB_FIRECRACKER_BINARY", "/usr/local/bin/firecracker"),
-		JailerBinary:            getEnv("SB_JAILER_BINARY", "/usr/local/bin/jailer"),
-		FirecrackerKernelImage:  getEnv("SB_FIRECRACKER_KERNEL", "/var/lib/sandboxd/firecracker/vmlinux"),
-		FirecrackerRunDir:       getEnv("SB_FIRECRACKER_RUN_DIR", "/run/sandboxd/firecracker"),
-		FirecrackerTemplatesDir: getEnv("SB_FIRECRACKER_TEMPLATES_DIR", "/var/lib/sandboxd/firecracker/templates"),
-		UseJailer:               getEnvBool("SB_FIRECRACKER_USE_JAILER", true),
-		JailerChrootBase:        getEnv("SB_JAILER_CHROOT_BASE", "/srv/jailer"),
-		JailerUID:               getEnvInt("SB_JAILER_UID", 1000),
-		JailerGID:               getEnvInt("SB_JAILER_GID", 1000),
-		FirecrackerTapBaseCIDR:  getEnv("SB_FIRECRACKER_TAP_BASE_CIDR", "172.16.0.0/20"),
-		FirecrackerTapPoolSize:  getEnvInt("SB_FIRECRACKER_TAP_POOL_SIZE", 256),
-		FirecrackerSkopeoBin:    getEnv("SB_FIRECRACKER_SKOPEO_BIN", "/usr/bin/skopeo"),
-		FirecrackerUmociBin:     getEnv("SB_FIRECRACKER_UMOCI_BIN", "/usr/bin/umoci"),
-		FirecrackerMkfs4Bin:     getEnv("SB_FIRECRACKER_MKFS_BIN", "/sbin/mkfs.ext4"),
-		FirecrackerIPBinary:     strings.TrimSpace(os.Getenv("SB_FIRECRACKER_IP_BINARY")),
+		WasmStateKVWritesPerSec:      getEnvFloat("SB_WASM_STATEKV_WRITES_PER_SEC", 50),
+		WasmStateKVBurst:             getEnvInt("SB_WASM_STATEKV_BURST", 100),
+		WasmModuleGCEnabled:          getEnvBool("SB_WASM_MODULE_GC_ENABLED", true),
+		WasmModuleGCInterval:         getEnvDuration("SB_WASM_MODULE_GC_INTERVAL", 15*time.Minute),
+		WasmModuleGCTTL:              getEnvDuration("SB_WASM_MODULE_GC_TTL", 7*24*time.Hour),
+		WasmCacheGCTTL:               getEnvDuration("SB_WASM_CACHE_GC_TTL", 24*time.Hour),
+		WasmCacheMaxBytes:            getEnvInt64("SB_WASM_CACHE_MAX_BYTES", 0),
+		WasmPoolEnabled:              getEnvBool("SB_WASM_POOL_ENABLED", true),
+		WasmPoolDepthDefault:         getEnvInt("SB_WASM_POOL_DEPTH_DEFAULT", 2),
+		WasmPoolRefillInterval:       getEnvDuration("SB_WASM_POOL_REFILL_INTERVAL", 5*time.Second),
+		WasmModuleDigestMode:         strings.ToLower(getEnv("SB_WASM_MODULE_DIGEST_MODE", "once")),
+		WasmCompileCacheDir:          getEnv("SB_WASM_COMPILE_CACHE_DIR", ""),
+		WasmResidentHostEnabled:      getEnvBool("SB_WASM_RESIDENT_HOST_ENABLED", false),
+		WasmResidentHostMaxInstances: getEnvInt("SB_WASM_RESIDENT_HOST_MAX_INSTANCES", 32),
+		FirecrackerBinary:            getEnv("SB_FIRECRACKER_BINARY", "/usr/local/bin/firecracker"),
+		JailerBinary:                 getEnv("SB_JAILER_BINARY", "/usr/local/bin/jailer"),
+		FirecrackerKernelImage:       getEnv("SB_FIRECRACKER_KERNEL", "/var/lib/sandboxd/firecracker/vmlinux"),
+		FirecrackerRunDir:            getEnv("SB_FIRECRACKER_RUN_DIR", "/run/sandboxd/firecracker"),
+		FirecrackerTemplatesDir:      getEnv("SB_FIRECRACKER_TEMPLATES_DIR", "/var/lib/sandboxd/firecracker/templates"),
+		UseJailer:                    getEnvBool("SB_FIRECRACKER_USE_JAILER", true),
+		JailerChrootBase:             getEnv("SB_JAILER_CHROOT_BASE", "/srv/jailer"),
+		JailerUID:                    getEnvInt("SB_JAILER_UID", 1000),
+		JailerGID:                    getEnvInt("SB_JAILER_GID", 1000),
+		FirecrackerTapBaseCIDR:       getEnv("SB_FIRECRACKER_TAP_BASE_CIDR", "172.16.0.0/20"),
+		FirecrackerTapPoolSize:       getEnvInt("SB_FIRECRACKER_TAP_POOL_SIZE", 256),
+		FirecrackerSkopeoBin:         getEnv("SB_FIRECRACKER_SKOPEO_BIN", "/usr/bin/skopeo"),
+		FirecrackerUmociBin:          getEnv("SB_FIRECRACKER_UMOCI_BIN", "/usr/bin/umoci"),
+		FirecrackerMkfs4Bin:          getEnv("SB_FIRECRACKER_MKFS_BIN", "/sbin/mkfs.ext4"),
+		FirecrackerIPBinary:          strings.TrimSpace(os.Getenv("SB_FIRECRACKER_IP_BINARY")),
 
 		FirecrackerTemplateGCEnabled:  getEnvBool("SB_FIRECRACKER_TEMPLATE_GC_ENABLED", true),
 		FirecrackerTemplateGCInterval: getEnvDuration("SB_FIRECRACKER_TEMPLATE_GC_INTERVAL", 1*time.Hour),

--- a/internal/runtime/wasm/config.go
+++ b/internal/runtime/wasm/config.go
@@ -14,20 +14,24 @@ type Config struct {
 	DefaultWallTimeout time.Duration
 	DrainTimeout       time.Duration
 	// ResidentHostEnabled routes non-listen creates to a shared resident
-	// compile-once/instantiate-many host per (digest, memoryMB) bucket instead of
-	// a fresh per-sandbox worker (plans/wasm-resident-module-host.md). Default
-	// false; requires a resident supervisor wired via SetResidentHostSupervisor.
+	// compile-once/instantiate-many host per (ownerRef, digest, memoryMB) bucket
+	// instead of a fresh per-sandbox worker (plans/wasm-resident-module-host.md).
+	// Default false; requires a resident supervisor wired via SetResidentHostSupervisor.
 	ResidentHostEnabled bool
+	// ResidentHostMaxInstances caps co-tenants per host process; 0 = unbounded.
+	// When full, the driver spills to <bucket>-2.sock (SB_WASM_RESIDENT_HOST_MAX_INSTANCES).
+	ResidentHostMaxInstances int
 }
 
 // FromDaemonConfig projects the WASM slice of daemon config into driver config.
 func FromDaemonConfig(cfg config.Config) Config {
 	return Config{
-		RunDir:              cfg.WasmRunDir,
-		ModulesDir:          cfg.WasmModulesDir,
-		DefaultMemoryMB:     cfg.WasmDefaultMemoryMB,
-		DefaultWallTimeout:  cfg.WasmDefaultTimeout,
-		DrainTimeout:        cfg.WasmDrainTimeout,
-		ResidentHostEnabled: cfg.WasmResidentHostEnabled,
+		RunDir:                   cfg.WasmRunDir,
+		ModulesDir:               cfg.WasmModulesDir,
+		DefaultMemoryMB:          cfg.WasmDefaultMemoryMB,
+		DefaultWallTimeout:       cfg.WasmDefaultTimeout,
+		DrainTimeout:             cfg.WasmDrainTimeout,
+		ResidentHostEnabled:      cfg.WasmResidentHostEnabled,
+		ResidentHostMaxInstances: cfg.WasmResidentHostMaxInstances,
 	}
 }

--- a/internal/runtime/wasm/config.go
+++ b/internal/runtime/wasm/config.go
@@ -21,6 +21,9 @@ type Config struct {
 	// ResidentHostMaxInstances caps co-tenants per host process; 0 = unbounded.
 	// When full, the driver spills to <bucket>-2.sock (SB_WASM_RESIDENT_HOST_MAX_INSTANCES).
 	ResidentHostMaxInstances int
+	// ResidentHostIdleTTL reaps a resident host holding zero instances for this
+	// long; 0 disables the reaper (SB_WASM_RESIDENT_HOST_IDLE_TTL).
+	ResidentHostIdleTTL time.Duration
 }
 
 // FromDaemonConfig projects the WASM slice of daemon config into driver config.
@@ -33,5 +36,6 @@ func FromDaemonConfig(cfg config.Config) Config {
 		DrainTimeout:             cfg.WasmDrainTimeout,
 		ResidentHostEnabled:      cfg.WasmResidentHostEnabled,
 		ResidentHostMaxInstances: cfg.WasmResidentHostMaxInstances,
+		ResidentHostIdleTTL:      cfg.WasmResidentHostIdleTTL,
 	}
 }

--- a/internal/runtime/wasm/driver.go
+++ b/internal/runtime/wasm/driver.go
@@ -131,10 +131,23 @@ func (d *Driver) refreshWorkerInstanceState(ctx context.Context, sandboxID strin
 	if inst == nil || strings.TrimSpace(inst.socketPath) == "" {
 		return inst
 	}
-	// Resident-hosted instances live on a shared process tracked by the resident
-	// supervisor, not the per-sandbox one — the spawn-count / InstanceLoaded
-	// liveness checks below don't apply, so report the instance as-is.
+	// Resident-hosted instances live on a shared process. Verify the host socket
+	// is still alive (D8) — after a host crash, Inspect/List must not report
+	// started for gone instances. Per-sandbox spawn-count does not apply.
 	if inst.fromResidentHost {
+		statusCtx := ctx
+		if statusCtx == nil {
+			statusCtx = context.Background()
+		}
+		if _, ok := statusCtx.Deadline(); !ok {
+			var cancel context.CancelFunc
+			statusCtx, cancel = context.WithTimeout(statusCtx, 2*time.Second)
+			defer cancel()
+		}
+		loaded, err := d.newWorkerClient(inst.socketPath).InstanceLoaded(statusCtx, sandboxID)
+		if err != nil || !loaded {
+			return d.markWorkerInstanceStopped(sandboxID, inst)
+		}
 		return inst
 	}
 	if count, ok := d.supervisorSpawnCount(d.workerKeyForInstance(sandboxID, inst)); ok {

--- a/internal/runtime/wasm/driver_test.go
+++ b/internal/runtime/wasm/driver_test.go
@@ -43,6 +43,7 @@ type recordingWorkerClient struct {
 	loadPath        string
 	stopped         bool
 	instantiateCaps []wasmengine.Capabilities
+	resolvedPort    int
 }
 
 func (c *recordingWorkerClient) Ping(string) error { return nil }
@@ -73,7 +74,9 @@ func (c *recordingWorkerClient) SetCapability(string, wasmengine.Capabilities) e
 func (c *recordingWorkerClient) NetstatsTick(string) (int64, int64, error)             { return 0, 0, nil }
 func (c *recordingWorkerClient) SetNetworkBlocks(string, bool, bool) error             { return nil }
 func (c *recordingWorkerClient) SetListenPort(string, int, string) error               { return nil }
-func (c *recordingWorkerClient) ResolvedListenPort(string) (int, error)                { return 0, nil }
+func (c *recordingWorkerClient) ResolvedListenPort(string) (int, error) {
+	return c.resolvedPort, nil
+}
 func (c *recordingWorkerClient) ProxyHTTP(string, int, http.ResponseWriter, *http.Request) error {
 	return nil
 }

--- a/internal/runtime/wasm/guest_http.go
+++ b/internal/runtime/wasm/guest_http.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/aerol-ai/microvm/pkg/models"
+	wasmengine "github.com/aerol-ai/microvm/pkg/wasm"
 )
 
 // GuestListenPortSyncer hot-updates wasip1 listener caps after expose_port.
@@ -25,8 +26,23 @@ func (d *Driver) SyncGuestListenPorts(ctx context.Context, sandboxID string, por
 	if inst.status != models.SandboxStatusStarted {
 		return nil
 	}
+	listenPort := wasip1ListenPort(ports)
+	if inst.fromResidentHost {
+		if listenPort == wasmengine.WASIListenPortDisabled {
+			// Resident sandboxes are non-listen by construction — there is no
+			// listener to disable, so an unexpose is a no-op (do not send a
+			// listener op to the shared host, which rejects them).
+			return nil
+		}
+		// expose_port needs a wasip1 listener the shared resident host cannot
+		// provide; migrate this sandbox onto a dedicated cold worker first
+		// (PR-B / plan D4-A), then install the listener on it below.
+		if err := d.migrateResidentToCold(ctx, inst); err != nil {
+			return fmt.Errorf("migrate resident sandbox %q for expose: %w", sandboxID, err)
+		}
+	}
 	client := d.newWorkerClient(inst.socketPath)
-	return d.syncGuestListenPort(ctx, inst, client, wasip1ListenPort(ports))
+	return d.syncGuestListenPort(ctx, inst, client, listenPort)
 }
 
 func (d *Driver) guestHTTPProxy(sandboxID string, guestPort int, w http.ResponseWriter, r *http.Request) error {

--- a/internal/runtime/wasm/instance.go
+++ b/internal/runtime/wasm/instance.go
@@ -32,6 +32,10 @@ type sandboxInstance struct {
 	// the shared process, and the per-sandbox supervisor spawn-count tracking does
 	// not apply.
 	fromResidentHost bool
+	// residentSlotHeld is true once this instance has reserved a live slot on its
+	// resident host; releaseResidentSlotFor clears it so the slot is freed exactly
+	// once (Finding P1-2). Meaningless unless fromResidentHost.
+	residentSlotHeld bool
 	status           models.SandboxStatus
 	entryExport      string
 	baseEnv          map[string]string

--- a/internal/runtime/wasm/lifecycle.go
+++ b/internal/runtime/wasm/lifecycle.go
@@ -228,6 +228,7 @@ func (d *Driver) Destroy(ctx context.Context, sandbox *models.Sandbox) error {
 		// process (co-tenants depend on it). Best-effort: a dead host already
 		// dropped the instance.
 		_ = d.newWorkerClient(inst.socketPath).StopInstance(sandboxID)
+		d.releaseResidentSlotFor(inst)
 	} else if d.supervisor != nil {
 		workerKey := sandboxID
 		if inst != nil && inst.workerKey != "" {

--- a/internal/runtime/wasm/resident.go
+++ b/internal/runtime/wasm/resident.go
@@ -398,3 +398,63 @@ func (d *Driver) createOnResidentHost(ctx context.Context, req models.CreateSand
 	d.mu.Unlock()
 	return d.runtimeState(inst), nil
 }
+
+// migrateResidentToCold moves a resident-hosted sandbox onto a dedicated cold
+// per-process worker WITH listener capability, so expose_port can install a
+// wasip1 listener the shared resident host cannot provide (PR-B / plan D4-A).
+//
+// Ordering is cold-up-then-stop-resident: the cold worker is spawned, compiled,
+// and the instance re-instantiated there FIRST; only once that succeeds is the
+// resident copy stopped and the instance's routing flipped. A failure in the
+// cold bring-up tears the half-spawned cold worker down and leaves the resident
+// copy serving (no zero-instance window; pr-review.md §4). The first expose pays
+// one cold LoadModule (~compile) — acceptable, since expose is off the
+// CreateSandbox boot path and not the hot create. Guest linear memory does not
+// survive (a fresh instance is created); /work persists (same workDir), and a
+// private sandbox has not run _start yet, so there is no in-flight state to lose.
+func (d *Driver) migrateResidentToCold(ctx context.Context, inst *sandboxInstance) error {
+	if d.supervisor == nil {
+		return fmt.Errorf("worker supervisor not configured")
+	}
+	residentSocket := inst.socketPath
+	coldSocket := filepath.Join(inst.workDir, "worker.sock")
+	client := d.newWorkerClient(coldSocket)
+
+	// 1) Bring up the dedicated cold worker + compile + instantiate (listener
+	//    disabled; the caller's syncGuestListenPort enables it right after).
+	if err := d.supervisor.Ensure(ctx, inst.sandboxID, coldSocket); err != nil {
+		return fmt.Errorf("start cold worker: %w", err)
+	}
+	if err := d.waitWorker(ctx, client, inst.sandboxID); err != nil {
+		_ = d.supervisor.Stop(inst.sandboxID)
+		return err
+	}
+	if _, err := client.LoadModule(inst.sandboxID, inst.modulePath, inst.memoryMB); err != nil {
+		_ = d.supervisor.Stop(inst.sandboxID)
+		return fmt.Errorf("cold load module: %w", err)
+	}
+	caps := wasmengine.CapsFromResourceLimits(wasmengine.Capabilities{
+		Env:            inst.baseEnv,
+		Args:           inst.baseArgs,
+		Preopens:       append([]wasmengine.Preopen(nil), inst.preopens...),
+		WASIListenPort: wasmengine.WASIListenPortDisabled,
+	}, inst.memoryMB, d.cfg.DefaultWallTimeout)
+	if err := client.Instantiate(inst.sandboxID, caps); err != nil {
+		_ = d.supervisor.Stop(inst.sandboxID)
+		return fmt.Errorf("cold instantiate: %w", err)
+	}
+
+	// 2) Cold copy is up — remove only this instance from the shared resident host
+	//    (never kill the host / co-tenants), release its slot, and flip routing.
+	_ = d.newWorkerClient(residentSocket).StopInstance(inst.sandboxID)
+	d.releaseResidentSlotFor(inst)
+	d.mu.Lock()
+	inst.socketPath = coldSocket
+	inst.workerKey = inst.sandboxID
+	inst.fromResidentHost = false
+	d.mu.Unlock()
+	// Track the cold worker's spawn count so refreshWorkerInstanceState detects a
+	// later respawn of THIS worker (uses the now-flipped per-sandbox workerKey).
+	d.noteWorkerSpawnCount(inst)
+	return nil
+}

--- a/internal/runtime/wasm/resident.go
+++ b/internal/runtime/wasm/resident.go
@@ -2,6 +2,8 @@ package wasm
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aerol-ai/microvm/pkg/controlplane"
 	"github.com/aerol-ai/microvm/pkg/createtiming"
 	"github.com/aerol-ai/microvm/pkg/models"
 	"github.com/aerol-ai/microvm/pkg/mounts"
@@ -16,15 +19,31 @@ import (
 	"github.com/aerol-ai/microvm/pkg/wasmmod"
 )
 
-// residentBucket tracks the shared resident-host process for one
-// (module digest, memoryMB) bucket. mu single-flights host spawn + host-level
-// LoadModule so concurrent creates for the same module neither spawn duplicate
-// hosts nor double-compile. See plans/wasm-resident-module-host.md.
+// residentBucket is one logical (ownerRef, digest, memoryMB) group. It may span
+// multiple host processes when MaxInstances is hit (spill to <bucket>-2.sock).
 type residentBucket struct {
-	id     string
+	id    string
+	mu    sync.Mutex
+	hosts []*residentHost
+}
+
+// residentHealthTTL bounds how stale a host's liveness proof may be before a
+// reuse re-probes it. Keeping the Ping+Loaded round-trips OFF the per-create hot
+// path (Finding B, eng-review 2026-07-17) protects the ~21ms warm-create win; a
+// host that dies inside the window is still caught reactively by the
+// Instantiate-failure rollback in createOnResidentHost (host.ready=false).
+const residentHealthTTL = 5 * time.Second
+
+// residentHost is one shared worker process inside a bucket.
+type residentHost struct {
 	socket string
-	mu     sync.Mutex
+	index  int
 	ready  bool
+	// live is Creating+Started instances routed here. Updated under the parent
+	// bucket's mu so MaxInstances is a hard cap under concurrent creates.
+	live int
+	// lastCheck is when readiness was last proven (bring-up or health-check).
+	lastCheck time.Time
 }
 
 // residentHostEnabled reports whether creates should route to a resident host.
@@ -39,31 +58,116 @@ func (d *Driver) residentHostEnabled() bool {
 // listener is added later by expose_port → SyncGuestListenPorts), so the only
 // create-time hint is AllowPublicTraffic. Public-intent creates route to the
 // per-sandbox cold path because the resident host rejects wasip1 listeners.
-// (Calling expose_port later on a private, resident-hosted sandbox is
-// unsupported in this cut and surfaces as an error — documented in the plan.)
 func createWantsPublicExpose(req models.CreateSandboxRequest) bool {
 	return req.AllowPublicTraffic != nil && *req.AllowPublicTraffic
 }
 
-// residentBucketID derives a filesystem-safe bucket id from the module digest
-// and memory limit — the two dimensions that must match for instances to share
-// one runtime + compiled module (wazero's memory limit is per-runtime).
-func residentBucketID(digest string, memoryMB int) string {
-	short := strings.ReplaceAll(digest, ":", "-")
-	if len(short) > 16 {
-		short = short[:16]
+// ownerRefFromCreateCtx mirrors service.ownerRefForCreate without importing
+// internal/service: non-operator Access → OwnerRef; operator/empty → "".
+func ownerRefFromCreateCtx(ctx context.Context) string {
+	access, ok := controlplane.AccessFromContext(ctx)
+	if !ok || access.Operator {
+		return ""
 	}
-	return fmt.Sprintf("%s-%dmb", short, memoryMB)
+	return strings.TrimSpace(access.Identity.OwnerRef)
 }
 
-func (d *Driver) residentSocketPath(bucketID string) string {
-	return filepath.Join(d.cfg.RunDir, "resident", bucketID+".sock")
+// residentBucketID derives a collision-free, filesystem-safe bucket id from
+// owner, digest, and memory limit. Owner and digest are HASHED, not truncated or
+// character-sanitized: truncation/sanitization could map two distinct owners
+// (long shared prefix) or `a/b` vs `a-b` to the same bucket, co-locating two
+// SaaS tenants in one process and breaking the isolation D7 exists for
+// (Finding P0-1). A non-empty ownerRef is mixed in per D7; empty/operator keeps
+// the global (owner-less) bucket for self-hosted compile amortization.
+func residentBucketID(ownerRef, digest string, memoryMB int) string {
+	modHash := shortHash(digest)
+	ownerRef = strings.TrimSpace(ownerRef)
+	if ownerRef == "" {
+		return fmt.Sprintf("%s-%dmb", modHash, memoryMB)
+	}
+	return fmt.Sprintf("o%s-%s-%dmb", shortHash(ownerRef), modHash, memoryMB)
 }
 
-// ensureResidentHost spawns (idempotently) the bucket's host process and loads
-// the module into it once, returning the bucket. Single-flighted per bucket.
-func (d *Driver) ensureResidentHost(ctx context.Context, digest, path string, memoryMB int) (*residentBucket, error) {
-	id := residentBucketID(digest, memoryMB)
+// shortHash is the first 16 hex chars (64 bits) of sha256(s) — a collision-free,
+// filesystem-safe fixed-width slug for bucket ids.
+func shortHash(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])[:16]
+}
+
+func (d *Driver) residentSocketPath(bucketID string, index int) string {
+	if index <= 0 {
+		return filepath.Join(d.cfg.RunDir, "resident", bucketID+".sock")
+	}
+	// Second host is <bucket>-2.sock (1-based display index = index+1).
+	return filepath.Join(d.cfg.RunDir, "resident", fmt.Sprintf("%s-%d.sock", bucketID, index+1))
+}
+
+func (d *Driver) residentHostKey(bucketID string, index int) string {
+	if index <= 0 {
+		return bucketID
+	}
+	return fmt.Sprintf("%s-%d", bucketID, index+1)
+}
+
+func (d *Driver) maxResidentInstances() int {
+	if d.cfg.ResidentHostMaxInstances > 0 {
+		return d.cfg.ResidentHostMaxInstances
+	}
+	// 0 / unset = unbounded (single host grows). Tests leave this at 0; prod
+	// config defaults to 32 via FromDaemonConfig.
+	return 0
+}
+
+// releaseResidentSlotFor decrements the host live count for a committed resident
+// instance exactly once, guarding against double release (e.g. Destroy after a
+// retry already cleaned up the old instance) via the inst.residentSlotHeld flag.
+func (d *Driver) releaseResidentSlotFor(inst *sandboxInstance) {
+	if inst == nil || !inst.fromResidentHost {
+		return
+	}
+	d.mu.Lock()
+	held := inst.residentSlotHeld
+	inst.residentSlotHeld = false
+	d.mu.Unlock()
+	if held {
+		d.releaseResidentSlot(inst.socketPath)
+	}
+}
+
+// releaseResidentSlot decrements the host live count after Destroy or a failed
+// create. Best-effort: looks up the host by socket under residentMu.
+func (d *Driver) releaseResidentSlot(socket string) {
+	if socket == "" {
+		return
+	}
+	d.residentMu.Lock()
+	buckets := d.residentBuckets
+	d.residentMu.Unlock()
+	for _, b := range buckets {
+		b.mu.Lock()
+		for _, h := range b.hosts {
+			if h.socket == socket {
+				if h.live > 0 {
+					h.live--
+				}
+				b.mu.Unlock()
+				return
+			}
+		}
+		b.mu.Unlock()
+	}
+}
+
+// ensureResidentHost picks (or spawns) a host under MaxInstances for the
+// (owner, digest, memoryMB) bucket, loads the module once, and returns it.
+// Single-flighted per bucket. Re-validates readiness (InstanceLoaded) on reuse
+// when the last proof is older than residentHealthTTL so a supervisor respawn
+// behind the same socket is detected (D8). When reserve is true the chosen
+// host's live count is incremented (caller releases it on failure/Destroy);
+// prewarm passes false since it brings up + compiles but instantiates nothing.
+func (d *Driver) ensureResidentHost(ctx context.Context, ownerRef, digest, path string, memoryMB int, reserve bool) (*residentBucket, *residentHost, error) {
+	id := residentBucketID(ownerRef, digest, memoryMB)
 
 	d.residentMu.Lock()
 	if d.residentBuckets == nil {
@@ -71,44 +175,103 @@ func (d *Driver) ensureResidentHost(ctx context.Context, digest, path string, me
 	}
 	b := d.residentBuckets[id]
 	if b == nil {
-		b = &residentBucket{id: id, socket: d.residentSocketPath(id)}
+		b = &residentBucket{id: id}
 		d.residentBuckets[id] = b
 	}
 	d.residentMu.Unlock()
 
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if b.ready {
-		return b, nil
+
+	max := d.maxResidentInstances()
+	take := func(h *residentHost) (*residentBucket, *residentHost, error) {
+		if reserve {
+			h.live++
+		}
+		return b, h, nil
 	}
-	if err := os.MkdirAll(filepath.Dir(b.socket), 0o700); err != nil {
-		return nil, fmt.Errorf("mkdir resident dir: %w", err)
+	for _, h := range b.hosts {
+		if max > 0 && h.live >= max {
+			continue
+		}
+		if h.ready {
+			// Lazy health-check (Finding B): skip the RPC when readiness was proven
+			// within residentHealthTTL so the common warm-create path stays RPC-free.
+			if time.Since(h.lastCheck) <= residentHealthTTL {
+				return take(h)
+			}
+			if err := d.healthCheckResidentHost(ctx, h, id); err != nil {
+				h.ready = false
+			} else {
+				h.lastCheck = time.Now()
+				return take(h)
+			}
+		}
+		if err := d.bringUpResidentHost(ctx, b, h, path, memoryMB); err != nil {
+			return nil, nil, err
+		}
+		return take(h)
 	}
-	if err := d.residentSupervisor.Ensure(ctx, id, b.socket); err != nil {
-		return nil, fmt.Errorf("start resident host: %w", err)
+
+	// All hosts full (or none yet) — spawn the next index.
+	index := len(b.hosts)
+	h := &residentHost{
+		socket: d.residentSocketPath(id, index),
+		index:  index,
 	}
-	client := d.newWorkerClient(b.socket)
-	if err := d.waitWorker(ctx, client, id); err != nil {
-		return nil, err
+	b.hosts = append(b.hosts, h)
+	if err := d.bringUpResidentHost(ctx, b, h, path, memoryMB); err != nil {
+		return nil, nil, err
 	}
-	// Host-level compile-once; the resident server dedups by path so a repeat
-	// call across buckets is a cheap no-op.
-	if _, err := client.LoadModule(id, path, memoryMB); err != nil {
-		return nil, fmt.Errorf("resident load module: %w", err)
+	return take(h)
+}
+
+func (d *Driver) healthCheckResidentHost(ctx context.Context, h *residentHost, _ string) error {
+	client := d.newWorkerClient(h.socket)
+	pingCtx := ctx
+	if _, ok := pingCtx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		pingCtx, cancel = context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
 	}
-	b.ready = true
-	return b, nil
+	// InstanceLoaded is a context-bounded round-trip that proves BOTH liveness and
+	// that the module is compiled, so it subsumes a Ping. A separate contextless
+	// client.Ping could block forever on a wedged host while bucket.mu is held
+	// (Finding P2), so it is intentionally not called here.
+	loaded, err := client.InstanceLoaded(pingCtx, "")
+	if err != nil {
+		return err
+	}
+	if !loaded {
+		return fmt.Errorf("resident host module not loaded")
+	}
+	return nil
+}
+
+func (d *Driver) bringUpResidentHost(ctx context.Context, b *residentBucket, h *residentHost, path string, memoryMB int) error {
+	if err := os.MkdirAll(filepath.Dir(h.socket), 0o700); err != nil {
+		return fmt.Errorf("mkdir resident dir: %w", err)
+	}
+	key := d.residentHostKey(b.id, h.index)
+	if err := d.residentSupervisor.Ensure(ctx, key, h.socket); err != nil {
+		return fmt.Errorf("start resident host: %w", err)
+	}
+	client := d.newWorkerClient(h.socket)
+	if err := d.waitWorker(ctx, client, key); err != nil {
+		return err
+	}
+	if _, err := client.LoadModule(key, path, memoryMB); err != nil {
+		return fmt.Errorf("resident load module: %w", err)
+	}
+	h.ready = true
+	h.lastCheck = time.Now()
+	return nil
 }
 
 // PrewarmResidentHosts brings up the resident host and compiles each ref's
 // module at daemon boot, so the FIRST create for a standard module is a ~ms
 // Instantiate instead of paying the one-time ~seconds CompileModule on the
-// create path. This is the fix for the lazy first-create-per-node tail measured
-// in the v0.7.10 A/B (resident server p99 ~1.7s = the un-amortized first
-// compile). Best-effort and meant to be backgrounded by the caller (compiling a
-// ~25MB module is slow — pr-review.md §2 keeps it off the boot-blocking path);
-// a ref that does not resolve or compile is logged and skipped. No-op unless
-// resident hosts are enabled.
+// create path. Best-effort and meant to be backgrounded by the caller.
 func (d *Driver) PrewarmResidentHosts(ctx context.Context, refs []string) {
 	if !d.residentHostEnabled() || d.resolver == nil {
 		return
@@ -124,7 +287,10 @@ func (d *Driver) PrewarmResidentHosts(ctx context.Context, refs []string) {
 			}
 			continue
 		}
-		if _, err := d.ensureResidentHost(ctx, resolved.Digest, resolved.Path, d.cfg.DefaultMemoryMB); err != nil {
+		// Prewarm the operator/global bucket (empty owner) at default memory.
+		// reserve=false: prewarm compiles the module on the host but instantiates
+		// no sandbox, so it must NOT hold a live slot (Finding P1-2).
+		if _, _, err := d.ensureResidentHost(ctx, "", resolved.Digest, resolved.Path, d.cfg.DefaultMemoryMB, false); err != nil {
 			if d.logger != nil {
 				d.logger.Warn("resident prewarm failed", "ref", ref, "error", err)
 			}
@@ -139,28 +305,45 @@ func (d *Driver) PrewarmResidentHosts(ctx context.Context, refs []string) {
 // createOnResidentHost is the resident-host create path: it instantiates an
 // isolated instance into the shared bucket host instead of spawning a
 // per-sandbox worker + compiling. Reached only when residentHostEnabled() and
-// the request is non-listen with a known digest. The existing per-sandbox
-// create path (Driver.Create) is left completely untouched.
+// the request is non-listen with a known digest.
 func (d *Driver) createOnResidentHost(ctx context.Context, req models.CreateSandboxRequest, sandboxID, ref string, resolved *wasmmod.ResolvedModule, memoryMB int, hostMounts []mounts.ContainerBind, timing *createtiming.CreateTiming) (*models.SandboxRuntimeState, error) {
-	bucket, err := d.ensureResidentHost(ctx, resolved.Digest, resolved.Path, memoryMB)
+	ownerRef := ownerRefFromCreateCtx(ctx)
+
+	// Idempotent retry (pr-review.md §1): if a prior attempt left an instance for
+	// this sandboxID, tear it down on ITS OWN host and release that slot BEFORE we
+	// reserve a fresh one. Doing it here (not after ensureResidentHost) means a
+	// retry that spills to a different host cannot orphan the old instance on the
+	// original host (Findings A + P0-2).
+	d.mu.Lock()
+	old := d.byID[sandboxID]
+	d.mu.Unlock()
+	if old != nil && old.fromResidentHost && old.socketPath != "" {
+		_ = d.newWorkerClient(old.socketPath).StopInstance(sandboxID)
+		d.releaseResidentSlotFor(old)
+	}
+
+	bucket, host, err := d.ensureResidentHost(ctx, ownerRef, resolved.Digest, resolved.Path, memoryMB, true)
 	if err != nil {
 		return nil, err
 	}
 
 	workDir := d.sandboxDir(sandboxID)
 	if err := os.MkdirAll(workDir, 0o700); err != nil {
+		// Release the slot ensureResidentHost just reserved (Finding P1-2).
+		d.releaseResidentSlot(host.socket)
 		return nil, fmt.Errorf("mkdir sandbox dir: %w", err)
 	}
 
+	workerKey := d.residentHostKey(bucket.id, host.index)
 	inst := &sandboxInstance{
 		sandboxID:        sandboxID,
 		moduleRef:        ref,
 		modulePath:       resolved.Path,
 		moduleSize:       resolved.SizeBytes,
 		moduleDigest:     resolved.Digest,
-		socketPath:       bucket.socket,
+		socketPath:       host.socket,
 		workDir:          workDir,
-		workerKey:        bucket.id,
+		workerKey:        workerKey,
 		fromResidentHost: true,
 		status:           models.SandboxStatusCreating,
 		entryExport:      entryExportFromRequest(req),
@@ -173,20 +356,13 @@ func (d *Driver) createOnResidentHost(ctx context.Context, req models.CreateSand
 		durability:       req.Durability,
 	}
 
+	// Commit the Creating instance (any prior attempt was already torn down +
+	// slot-released above, so no in-band retry handling is needed here).
 	d.mu.Lock()
-	_, retry := d.byID[sandboxID]
 	d.byID[sandboxID] = inst
 	d.mu.Unlock()
 
-	client := d.newWorkerClient(bucket.socket)
-	// Idempotency (pr-review.md §1): a retried create for the same sandboxID must
-	// not trip the resident engine's duplicate-instance guard. On a retry, drop
-	// any instance left by a prior attempt first (no-op if absent). Only on the
-	// retry path, so a first create pays no extra round-trip.
-	if retry {
-		_ = client.StopInstance(sandboxID)
-	}
-
+	client := d.newWorkerClient(host.socket)
 	caps := wasmengine.CapsFromResourceLimits(wasmengine.Capabilities{
 		Env:            req.Env,
 		Args:           wasmArgs(req),
@@ -196,10 +372,13 @@ func (d *Driver) createOnResidentHost(ctx context.Context, req models.CreateSand
 
 	instStart := time.Now()
 	if err := client.Instantiate(sandboxID, caps); err != nil {
-		// The host may have respawned empty (module dropped) — force a reload on
-		// the next create for this bucket, and roll this create back.
+		// The host may have respawned empty — force a reload on the next create
+		// for this host, and roll this create back.
 		bucket.mu.Lock()
-		bucket.ready = false
+		host.ready = false
+		if host.live > 0 {
+			host.live--
+		}
 		bucket.mu.Unlock()
 		d.mu.Lock()
 		delete(d.byID, sandboxID)
@@ -212,6 +391,9 @@ func (d *Driver) createOnResidentHost(ctx context.Context, req models.CreateSand
 	}
 	inst.status = models.SandboxStatusStarted
 	d.mu.Lock()
+	// The reserved slot is now owned by this committed instance; Destroy releases
+	// it exactly once via releaseResidentSlotFor (Finding P1-2).
+	inst.residentSlotHeld = true
 	d.byID[sandboxID] = inst
 	d.mu.Unlock()
 	return d.runtimeState(inst), nil

--- a/internal/runtime/wasm/resident.go
+++ b/internal/runtime/wasm/resident.go
@@ -25,6 +25,10 @@ type residentBucket struct {
 	id    string
 	mu    sync.Mutex
 	hosts []*residentHost
+	// nextIndex is a monotonic host-index counter. It never reuses an index even
+	// after the idle-TTL reaper removes a host, so a later spill cannot collide
+	// with a surviving host's socket path.
+	nextIndex int
 }
 
 // residentHealthTTL bounds how stale a host's liveness proof may be before a
@@ -44,6 +48,12 @@ type residentHost struct {
 	live int
 	// lastCheck is when readiness was last proven (bring-up or health-check).
 	lastCheck time.Time
+	// idleSince is when live last dropped to 0 (zero while live>0). The reaper
+	// tears the host down once idle for ResidentHostIdleTTL.
+	idleSince time.Time
+	// pinned hosts (brought up by boot pre-warm) are never reaped, so standard
+	// modules stay hot for everyone.
+	pinned bool
 }
 
 // residentHostEnabled reports whether creates should route to a resident host.
@@ -151,6 +161,10 @@ func (d *Driver) releaseResidentSlot(socket string) {
 				if h.live > 0 {
 					h.live--
 				}
+				if h.live == 0 {
+					// Start the idle clock; the reaper tears the host down after TTL.
+					h.idleSince = time.Now()
+				}
 				b.mu.Unlock()
 				return
 			}
@@ -187,6 +201,11 @@ func (d *Driver) ensureResidentHost(ctx context.Context, ownerRef, digest, path 
 	take := func(h *residentHost) (*residentBucket, *residentHost, error) {
 		if reserve {
 			h.live++
+			h.idleSince = time.Time{} // active again — cancel any pending reap
+		} else {
+			// A prewarm (reserve=false) pins the host so the idle-TTL reaper keeps
+			// standard-module hosts resident.
+			h.pinned = true
 		}
 		return b, h, nil
 	}
@@ -213,8 +232,10 @@ func (d *Driver) ensureResidentHost(ctx context.Context, ownerRef, digest, path 
 		return take(h)
 	}
 
-	// All hosts full (or none yet) — spawn the next index.
-	index := len(b.hosts)
+	// All hosts full (or none yet) — spawn the next (monotonic) index so a
+	// reaped-then-respawned bucket never collides sockets.
+	index := b.nextIndex
+	b.nextIndex++
 	h := &residentHost{
 		socket: d.residentSocketPath(id, index),
 		index:  index,
@@ -457,4 +478,114 @@ func (d *Driver) migrateResidentToCold(ctx context.Context, inst *sandboxInstanc
 	// later respawn of THIS worker (uses the now-flipped per-sandbox workerKey).
 	d.noteWorkerSpawnCount(inst)
 	return nil
+}
+
+// ResidentHostStats is a point-in-time snapshot of the resident-host footprint,
+// exposed via expvar (aerolvm_wasm_resident_hosts) so operators can size memory
+// headroom. Admission (pkg/capacity) counts each sandbox at its full memoryMB
+// (an over-count that cushions the guest's actual linear memory) but does NOT
+// see a host process's own RAM (the shared compiled module + runtime, ~the
+// module's on-disk size per bucket). PR-C keeps that accounting deliberately
+// conservative: Hosts here lets an operator reserve headroom via
+// MemoryFloorRatio / MemoryReservationRatio (roughly Hosts × module footprint).
+type ResidentHostStats struct {
+	Buckets   int `json:"buckets"`   // distinct (ownerRef, digest, memoryMB) groups
+	Hosts     int `json:"hosts"`     // resident host processes (base RAM ≈ Hosts × module size)
+	Instances int `json:"instances"` // live co-tenant instances across all hosts
+}
+
+// ResidentHostStats returns the current resident-host footprint (see the type
+// doc for how it relates to admission headroom).
+func (d *Driver) ResidentHostStats() ResidentHostStats {
+	d.residentMu.Lock()
+	buckets := make([]*residentBucket, 0, len(d.residentBuckets))
+	for _, b := range d.residentBuckets {
+		buckets = append(buckets, b)
+	}
+	d.residentMu.Unlock()
+
+	stats := ResidentHostStats{Buckets: len(buckets)}
+	for _, b := range buckets {
+		b.mu.Lock()
+		for _, h := range b.hosts {
+			stats.Hosts++
+			stats.Instances += h.live
+		}
+		b.mu.Unlock()
+	}
+	return stats
+}
+
+// RunResidentReaper periodically tears down resident host processes that have
+// held zero instances for at least ttl, reclaiming their compiled-module +
+// runtime RAM (PR-C). Pre-warmed standard-module hosts are pinned and never
+// reaped. ttl<=0 (or the flag off) disables it. Blocks until ctx is cancelled,
+// so the daemon runs it in a goroutine and shutdown stops it.
+func (d *Driver) RunResidentReaper(ctx context.Context, ttl time.Duration) {
+	if ttl <= 0 || !d.residentHostEnabled() {
+		return
+	}
+	// Scan a few times per TTL so an idle host is reclaimed within ~ttl of going
+	// idle, bounded to a sane [5s, 1m] tick.
+	interval := ttl / 4
+	if interval < 5*time.Second {
+		interval = 5 * time.Second
+	}
+	if interval > time.Minute {
+		interval = time.Minute
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			d.reapIdleResidentHosts(ttl)
+		}
+	}
+}
+
+// reapIdleResidentHosts removes every non-pinned host idle (live==0) for >= ttl.
+// Selection + removal from b.hosts happen under b.mu (so a concurrent create that
+// takes the host wins the race and the host is kept); the actual supervisor.Stop
+// runs OUTSIDE the lock so a slow stop never blocks creates for the bucket.
+func (d *Driver) reapIdleResidentHosts(ttl time.Duration) {
+	d.residentMu.Lock()
+	buckets := make([]*residentBucket, 0, len(d.residentBuckets))
+	for _, b := range d.residentBuckets {
+		buckets = append(buckets, b)
+	}
+	d.residentMu.Unlock()
+
+	now := time.Now()
+	type victim struct {
+		bucketID string
+		index    int
+		socket   string
+		idle     time.Duration
+	}
+	var victims []victim
+	for _, b := range buckets {
+		b.mu.Lock()
+		kept := make([]*residentHost, 0, len(b.hosts))
+		for _, h := range b.hosts {
+			if !h.pinned && h.live == 0 && !h.idleSince.IsZero() && now.Sub(h.idleSince) >= ttl {
+				victims = append(victims, victim{bucketID: b.id, index: h.index, socket: h.socket, idle: now.Sub(h.idleSince)})
+				continue
+			}
+			kept = append(kept, h)
+		}
+		b.hosts = kept
+		b.mu.Unlock()
+	}
+	for _, v := range victims {
+		if d.residentSupervisor != nil {
+			_ = d.residentSupervisor.Stop(d.residentHostKey(v.bucketID, v.index))
+		}
+		_ = os.Remove(v.socket)
+		if d.logger != nil {
+			d.logger.Info("reaped idle resident host", "bucket", v.bucketID, "socket", v.socket, "idle", v.idle.String())
+		}
+	}
 }

--- a/internal/runtime/wasm/resident_test.go
+++ b/internal/runtime/wasm/resident_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/aerol-ai/microvm/pkg/controlplane"
 	"github.com/aerol-ai/microvm/pkg/models"
@@ -435,6 +436,110 @@ type instantiateFailClient struct {
 
 func (c *instantiateFailClient) Instantiate(string, wasmengine.Capabilities) error {
 	return fmt.Errorf("cold instantiate boom")
+}
+
+// residentHostCount sums live resident host processes across all buckets.
+func residentHostCount(d *Driver) int {
+	var n int
+	d.residentMu.Lock()
+	buckets := d.residentBuckets
+	d.residentMu.Unlock()
+	for _, b := range buckets {
+		b.mu.Lock()
+		n += len(b.hosts)
+		b.mu.Unlock()
+	}
+	return n
+}
+
+// forceResidentHostsIdle backdates every idle (live==0) host's idle clock so the
+// reaper treats them as long-idle without a unit test having to wait.
+func forceResidentHostsIdle(d *Driver, at time.Time) {
+	d.residentMu.Lock()
+	buckets := d.residentBuckets
+	d.residentMu.Unlock()
+	for _, b := range buckets {
+		b.mu.Lock()
+		for _, h := range b.hosts {
+			if h.live == 0 {
+				h.idleSince = at
+			}
+		}
+		b.mu.Unlock()
+	}
+}
+
+// TestResidentHostStats proves the PR-C observability snapshot tracks the live
+// resident-host footprint (buckets / hosts / instances) the operator sizes
+// memory headroom against.
+func TestResidentHostStats(t *testing.T) {
+	d, _, _, _ := residentTestDriver(t, true)
+	if s := d.ResidentHostStats(); s.Hosts != 0 || s.Instances != 0 || s.Buckets != 0 {
+		t.Fatalf("empty stats = %+v, want all zero", s)
+	}
+	if _, err := d.Create(context.Background(), models.CreateSandboxRequest{Image: "demo.wasm"}, "sb-1", "tok", nil); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if s := d.ResidentHostStats(); s.Buckets != 1 || s.Hosts != 1 || s.Instances != 1 {
+		t.Fatalf("stats after 1 create = %+v, want buckets=1 hosts=1 instances=1", s)
+	}
+}
+
+// TestResidentReaperReapsIdleHost proves PR-C: a non-pinned resident host that
+// has held zero instances past the TTL is torn down (removed + supervisor.Stop).
+func TestResidentReaperReapsIdleHost(t *testing.T) {
+	d, _, resident, _ := residentTestDriver(t, true)
+	if _, err := d.Create(context.Background(), models.CreateSandboxRequest{Image: "demo.wasm"}, "sb-1", "tok", nil); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := d.Destroy(context.Background(), &models.Sandbox{ID: "sb-1"}); err != nil {
+		t.Fatalf("Destroy: %v", err)
+	}
+	if got := residentHostCount(d); got != 1 {
+		t.Fatalf("host count after destroy = %d, want 1 (idle, not yet reaped)", got)
+	}
+	forceResidentHostsIdle(d, time.Now().Add(-time.Hour))
+	stopsBefore := resident.stopCalls
+
+	d.reapIdleResidentHosts(time.Minute)
+
+	if got := residentHostCount(d); got != 0 {
+		t.Fatalf("host count after reap = %d, want 0 (idle host reaped)", got)
+	}
+	if resident.stopCalls <= stopsBefore {
+		t.Fatalf("reaper did not Stop the idle host (stopCalls %d -> %d)", stopsBefore, resident.stopCalls)
+	}
+}
+
+// TestResidentReaperKeepsPinnedAndActive proves the reaper never tears down a
+// pre-warmed (pinned) standard-module host, nor a host with live instances.
+func TestResidentReaperKeepsPinnedAndActive(t *testing.T) {
+	d, _, resident, _ := residentTestDriver(t, true)
+	// Pinned: pre-warmed standard host (operator/global bucket, live==0).
+	d.PrewarmResidentHosts(context.Background(), []string{"demo.wasm"})
+	// Active: an owner-scoped create that stays live (never destroyed).
+	userCtx := controlplane.ContextWithAccess(context.Background(), controlplane.Access{
+		Identity: controlplane.Identity{OwnerRef: "acme"},
+	})
+	if _, err := d.Create(userCtx, models.CreateSandboxRequest{Image: "demo.wasm"}, "sb-live", "tok", nil); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	before := residentHostCount(d)
+	if before != 2 {
+		t.Fatalf("precondition host count = %d, want 2 (pinned global + live tenant)", before)
+	}
+	// Backdate the pinned host's idle clock too — the pin, not idleness, must save it.
+	forceResidentHostsIdle(d, time.Now().Add(-time.Hour))
+	stopsBefore := resident.stopCalls
+
+	d.reapIdleResidentHosts(time.Minute)
+
+	if got := residentHostCount(d); got != before {
+		t.Fatalf("host count after reap = %d, want %d (pinned + active both kept)", got, before)
+	}
+	if resident.stopCalls != stopsBefore {
+		t.Fatalf("reaper stopped a pinned/active host (stopCalls %d -> %d)", stopsBefore, resident.stopCalls)
+	}
 }
 
 // TestExposeMigrationFailureLeavesResident proves the cold-up-then-stop ordering:

--- a/internal/runtime/wasm/resident_test.go
+++ b/internal/runtime/wasm/resident_test.go
@@ -2,11 +2,13 @@ package wasm
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 
 	"github.com/aerol-ai/microvm/pkg/controlplane"
 	"github.com/aerol-ai/microvm/pkg/models"
+	wasmengine "github.com/aerol-ai/microvm/pkg/wasm"
 	"github.com/aerol-ai/microvm/pkg/wasmmod"
 )
 
@@ -382,5 +384,93 @@ func TestPrewarmResidentHostDoesNotReserveSlot(t *testing.T) {
 	d.PrewarmResidentHosts(context.Background(), []string{"demo.wasm"})
 	if got := totalResidentLive(d); got != 0 {
 		t.Fatalf("prewarm reserved %d live slots, want 0", got)
+	}
+}
+
+// TestMigrateResidentToCold proves the PR-B core: migrating a private resident
+// sandbox brings up a dedicated cold worker, stops the resident copy, releases
+// its slot, and flips routing (workerKey + socket + fromResidentHost). The
+// SyncGuestListenPorts→migration wiring + failure ordering are covered by
+// TestExposeMigrationFailureLeavesResident (which reaches migration and errors
+// before the post-migration listener probe that needs a real guest).
+func TestMigrateResidentToCold(t *testing.T) {
+	d, perSandbox, _, client := residentTestDriver(t, true)
+	if _, err := d.Create(context.Background(), models.CreateSandboxRequest{Image: "demo.wasm"}, "sb-exp", "tok", nil); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	inst, _ := d.instance("sb-exp")
+	if !inst.fromResidentHost {
+		t.Fatal("precondition: create should route to the resident host")
+	}
+	if got := totalResidentLive(d); got != 1 {
+		t.Fatalf("resident live before migrate = %d, want 1", got)
+	}
+
+	if err := d.migrateResidentToCold(context.Background(), inst); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	if inst.fromResidentHost {
+		t.Fatal("still resident after migrate")
+	}
+	if inst.workerKey != "sb-exp" || filepath.Base(inst.socketPath) != "worker.sock" {
+		t.Fatalf("routing not flipped to cold worker: workerKey=%q socket=%q", inst.workerKey, inst.socketPath)
+	}
+	if !client.stopped {
+		t.Fatal("resident instance not StopInstance'd during migration")
+	}
+	if perSandbox.ensureCalls != 1 {
+		t.Fatalf("cold worker spawns = %d, want 1", perSandbox.ensureCalls)
+	}
+	if got := totalResidentLive(d); got != 0 {
+		t.Fatalf("resident live after migrate = %d, want 0 (slot not released)", got)
+	}
+}
+
+// instantiateFailClient fails Instantiate but is otherwise a normal recording
+// client, so a migration's cold bring-up fails at the instantiate step.
+type instantiateFailClient struct {
+	recordingWorkerClient
+}
+
+func (c *instantiateFailClient) Instantiate(string, wasmengine.Capabilities) error {
+	return fmt.Errorf("cold instantiate boom")
+}
+
+// TestExposeMigrationFailureLeavesResident proves the cold-up-then-stop ordering:
+// when the cold instantiate fails, the sandbox stays on the resident host (no
+// zero-instance window) and keeps its slot (PR-B failure path, pr-review.md §4).
+func TestExposeMigrationFailureLeavesResident(t *testing.T) {
+	dir := t.TempDir()
+	modPath := wasmmod.WriteMinimalWasm(t, dir, "demo.wasm")
+	perSandbox := &fakeSupervisor{}
+	resident := &fakeSupervisor{}
+	normal := &recordingWorkerClient{}
+	failing := &instantiateFailClient{}
+	d := New(Config{RunDir: filepath.Join(dir, "run"), ModulesDir: dir, ResidentHostEnabled: true}, nil)
+	d.SetModuleResolver(fakeResolver{path: modPath, digest: "deadbeef"})
+	d.SetWorkerSupervisor(perSandbox)
+	d.SetResidentHostSupervisor(resident)
+	// The cold worker socket ends in worker.sock — fail its Instantiate; the
+	// resident bucket socket uses the normal client so the create still succeeds.
+	d.SetWorkerClientFactory(func(socket string) WorkerClient {
+		if filepath.Base(socket) == "worker.sock" {
+			return failing
+		}
+		return normal
+	})
+
+	if _, err := d.Create(context.Background(), models.CreateSandboxRequest{Image: "demo.wasm"}, "sb-fail", "tok", nil); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := d.SyncGuestListenPorts(context.Background(), "sb-fail", []int{8080}); err == nil {
+		t.Fatal("expected migration failure to surface as an error")
+	}
+	inst, _ := d.instance("sb-fail")
+	if !inst.fromResidentHost {
+		t.Fatal("sandbox left the resident host despite cold-instantiate failure (zero-instance window)")
+	}
+	if got := totalResidentLive(d); got != 1 {
+		t.Fatalf("resident live = %d after failed migration, want 1 (slot wrongly released)", got)
 	}
 }

--- a/internal/runtime/wasm/resident_test.go
+++ b/internal/runtime/wasm/resident_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/aerol-ai/microvm/pkg/controlplane"
 	"github.com/aerol-ai/microvm/pkg/models"
 	"github.com/aerol-ai/microvm/pkg/wasmmod"
 )
@@ -59,8 +60,8 @@ func TestCreateRoutesToResidentHost(t *testing.T) {
 	if !inst.fromResidentHost {
 		t.Fatal("instance not marked fromResidentHost")
 	}
-	if inst.workerKey != residentBucketID("deadbeef", 0) {
-		t.Fatalf("workerKey=%q, want bucket %q", inst.workerKey, residentBucketID("deadbeef", 0))
+	if inst.workerKey != residentBucketID("", "deadbeef", 0) {
+		t.Fatalf("workerKey=%q, want bucket %q", inst.workerKey, residentBucketID("", "deadbeef", 0))
 	}
 
 	// Destroy must StopInstance (per-sandbox), NOT kill the shared host.
@@ -96,6 +97,21 @@ func TestCreateResidentRetryIsIdempotent(t *testing.T) {
 	}
 	if len(client.instantiateCaps) != 2 {
 		t.Fatalf("Instantiate calls = %d, want 2 (one per create)", len(client.instantiateCaps))
+	}
+	// Finding A: an idempotent retry must not inflate the host live count — the
+	// sandbox occupies exactly one slot no matter how many times create is retried.
+	var totalLive int
+	d.residentMu.Lock()
+	for _, b := range d.residentBuckets {
+		b.mu.Lock()
+		for _, h := range b.hosts {
+			totalLive += h.live
+		}
+		b.mu.Unlock()
+	}
+	d.residentMu.Unlock()
+	if totalLive != 1 {
+		t.Fatalf("host live count = %d after idempotent retry, want 1 (retry leaked a slot)", totalLive)
 	}
 }
 
@@ -186,5 +202,185 @@ func TestCreatePublicExposeUsesColdPath(t *testing.T) {
 	}
 	if inst.fromResidentHost {
 		t.Fatal("public-expose create wrongly routed to resident host")
+	}
+}
+
+// TestResidentBucketIDIncludesOwnerRef guards D7: a non-operator OwnerRef gets
+// its own bucket so SaaS tenants never co-locate; empty/operator stays global.
+func TestResidentBucketIDIncludesOwnerRef(t *testing.T) {
+	global := residentBucketID("", "deadbeef", 256)
+	tenant := residentBucketID("acme", "deadbeef", 256)
+	if global == tenant {
+		t.Fatalf("owner bucket collided with global: %q", global)
+	}
+	if residentBucketID("acme", "deadbeef", 256) != tenant {
+		t.Fatal("owner bucket not stable")
+	}
+	other := residentBucketID("globex", "deadbeef", 256)
+	if other == tenant {
+		t.Fatal("different owners share a bucket")
+	}
+}
+
+func TestCreateWithOwnerRefUsesDistinctResidentHost(t *testing.T) {
+	d, _, resident, _ := residentTestDriver(t, true)
+	opCtx := context.Background()
+	userCtx := controlplane.ContextWithAccess(context.Background(), controlplane.Access{
+		Identity: controlplane.Identity{OwnerRef: "acme"},
+	})
+
+	if _, err := d.Create(opCtx, models.CreateSandboxRequest{Image: "demo.wasm"}, "sb-op", "tok", nil); err != nil {
+		t.Fatalf("operator Create: %v", err)
+	}
+	if _, err := d.Create(userCtx, models.CreateSandboxRequest{Image: "demo.wasm"}, "sb-user", "tok", nil); err != nil {
+		t.Fatalf("user Create: %v", err)
+	}
+	if resident.ensureCalls != 2 {
+		t.Fatalf("resident ensure calls = %d, want 2 (distinct owner buckets)", resident.ensureCalls)
+	}
+	opInst, _ := d.instance("sb-op")
+	userInst, _ := d.instance("sb-user")
+	if opInst.workerKey == userInst.workerKey {
+		t.Fatalf("owner create reused operator bucket key %q", opInst.workerKey)
+	}
+}
+
+func TestResidentMaxInstancesSpillsToSecondHost(t *testing.T) {
+	d, _, resident, _ := residentTestDriver(t, true)
+	d.cfg.ResidentHostMaxInstances = 1
+
+	if _, err := d.Create(context.Background(), models.CreateSandboxRequest{Image: "demo.wasm"}, "sb-1", "tok", nil); err != nil {
+		t.Fatalf("Create 1: %v", err)
+	}
+	if _, err := d.Create(context.Background(), models.CreateSandboxRequest{Image: "demo.wasm"}, "sb-2", "tok", nil); err != nil {
+		t.Fatalf("Create 2: %v", err)
+	}
+	if resident.ensureCalls != 2 {
+		t.Fatalf("resident ensure calls = %d, want 2 (spill to second host)", resident.ensureCalls)
+	}
+	a, _ := d.instance("sb-1")
+	b, _ := d.instance("sb-2")
+	if a.socketPath == b.socketPath {
+		t.Fatalf("both instances on same socket %q under MaxInstances=1", a.socketPath)
+	}
+}
+
+func TestInspectMarksDeadResidentHostStopped(t *testing.T) {
+	d, _, _, _ := residentTestDriver(t, true)
+	client := &unloadedWorkerClient{}
+	d.SetWorkerClientFactory(func(string) WorkerClient { return client })
+	d.mu.Lock()
+	d.byID["sb-dead"] = &sandboxInstance{
+		sandboxID:        "sb-dead",
+		socketPath:       "/tmp/fake-resident.sock",
+		fromResidentHost: true,
+		status:           models.SandboxStatusStarted,
+	}
+	d.mu.Unlock()
+
+	state, err := d.Inspect(context.Background(), "sb-dead")
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	if state == nil || state.Status != models.SandboxStatusStopped {
+		t.Fatalf("state = %+v, want stopped after resident host gone", state)
+	}
+}
+
+func TestSetNetworkBlocksReachesResidentHost(t *testing.T) {
+	d, _, _, client := residentTestDriver(t, true)
+	netClient := &networkRecordingClient{recordingWorkerClient: *client}
+	d.SetWorkerClientFactory(func(string) WorkerClient { return netClient })
+
+	if _, err := d.Create(context.Background(), models.CreateSandboxRequest{Image: "demo.wasm"}, "sb-blocks", "tok", nil); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	d.SetNetworkBlocks("sb-blocks", false, true)
+	if !netClient.blocksSet {
+		t.Fatal("SetNetworkBlocks did not reach the resident host socket")
+	}
+}
+
+type networkRecordingClient struct {
+	recordingWorkerClient
+	blocksSet bool
+}
+
+func (c *networkRecordingClient) SetNetworkBlocks(string, bool, bool) error {
+	c.blocksSet = true
+	return nil
+}
+
+// totalResidentLive sums the live slot count across every resident host so tests
+// can assert MAX_INSTANCES accounting (Findings A / P0-2 / P1-2).
+func totalResidentLive(d *Driver) int {
+	var total int
+	d.residentMu.Lock()
+	buckets := d.residentBuckets
+	d.residentMu.Unlock()
+	for _, b := range buckets {
+		b.mu.Lock()
+		for _, h := range b.hosts {
+			total += h.live
+		}
+		b.mu.Unlock()
+	}
+	return total
+}
+
+// TestResidentBucketIDNoCollision proves the hashed bucket id (P0-1) does not
+// co-locate distinct owners/modules that the old truncate+sanitize scheme would
+// have collided into one shared host process.
+func TestResidentBucketIDNoCollision(t *testing.T) {
+	// Long owners sharing a >24-char prefix (old code truncated to 24).
+	if residentBucketID("customer-aaaaaaaaaaaaaaaaaaaaaaaaaaaa-1", "sha256:deadbeef", 256) ==
+		residentBucketID("customer-aaaaaaaaaaaaaaaaaaaaaaaaaaaa-2", "sha256:deadbeef", 256) {
+		t.Fatal("distinct long owners collided to one bucket")
+	}
+	// Sanitization collision: a/b vs a-b (old code mapped '/' -> '-').
+	if residentBucketID("a/b", "sha256:deadbeef", 256) == residentBucketID("a-b", "sha256:deadbeef", 256) {
+		t.Fatal("owners a/b and a-b collided")
+	}
+	// Modules sharing a 16-char digest prefix (old code truncated to 16).
+	if residentBucketID("", "sha256:0000000000000000aaaa", 256) ==
+		residentBucketID("", "sha256:0000000000000000bbbb", 256) {
+		t.Fatal("modules sharing a 16-char digest prefix collided")
+	}
+	// Operator/empty owner must not collide with any real owner.
+	if residentBucketID("", "sha256:deadbeef", 256) == residentBucketID("owner1", "sha256:deadbeef", 256) {
+		t.Fatal("operator (empty owner) and owner1 collided")
+	}
+}
+
+// TestResidentRetryNoOrphanOrLeak proves an idempotent retry under MAX_INSTANCES
+// tears down the prior instance on its own host and keeps the live count at 1 —
+// no orphaned instance on a spilled host, no slot leak (P0-2 + Finding A).
+func TestResidentRetryNoOrphanOrLeak(t *testing.T) {
+	d, _, _, client := residentTestDriver(t, true)
+	d.cfg.ResidentHostMaxInstances = 1
+	req := models.CreateSandboxRequest{Image: "demo.wasm"}
+	if _, err := d.Create(context.Background(), req, "sb-x", "tok", nil); err != nil {
+		t.Fatalf("Create #1: %v", err)
+	}
+	client.stopped = false
+	if _, err := d.Create(context.Background(), req, "sb-x", "tok", nil); err != nil {
+		t.Fatalf("Create #2 (retry): %v", err)
+	}
+	if !client.stopped {
+		t.Fatal("retry did not StopInstance the prior instance on its host")
+	}
+	if got := totalResidentLive(d); got != 1 {
+		t.Fatalf("total resident live = %d after idempotent retry under MAX=1, want 1", got)
+	}
+}
+
+// TestPrewarmResidentHostDoesNotReserveSlot proves boot pre-warm brings up +
+// compiles a host without holding a live slot (P1-2) — otherwise every prewarmed
+// module would permanently inflate the bucket's occupancy.
+func TestPrewarmResidentHostDoesNotReserveSlot(t *testing.T) {
+	d, _, _, _ := residentTestDriver(t, true)
+	d.PrewarmResidentHosts(context.Background(), []string{"demo.wasm"})
+	if got := totalResidentLive(d); got != 0 {
+		t.Fatalf("prewarm reserved %d live slots, want 0", got)
 	}
 }

--- a/pkg/daemon/wasm_wiring.go
+++ b/pkg/daemon/wasm_wiring.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"expvar"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -131,6 +132,22 @@ func wireWasmRuntime(ctx context.Context, cfg config.Config, logger *slog.Logger
 		}
 		go driver.PrewarmResidentHosts(ctx, refs)
 		logger.Info("wasm resident host prewarm scheduled", "modules", len(refs))
+		// Idle-TTL reaper: reclaim a resident host's RAM once it has held zero
+		// instances for the TTL (pre-warmed standard-module hosts are pinned and
+		// never reaped). Stops when ctx is cancelled on shutdown. No-op if the TTL
+		// is 0. See plans/wasm-resident-module-host.md PR-C.
+		go driver.RunResidentReaper(ctx, cfg.WasmResidentHostIdleTTL)
+		logger.Info("wasm resident host reaper scheduled", "idle_ttl", cfg.WasmResidentHostIdleTTL)
+		// Observability for the conservative capacity stance (PR-C): the admitter
+		// cannot see a resident host process's own RAM (shared compiled module +
+		// runtime), so expose the host footprint here and let operators reserve
+		// headroom via MemoryFloorRatio/MemoryReservationRatio. Guard the publish
+		// so a second wiring in-process (tests) doesn't panic on a duplicate name.
+		if expvar.Get("aerolvm_wasm_resident_hosts") == nil {
+			expvar.Publish("aerolvm_wasm_resident_hosts", expvar.Func(func() any {
+				return driver.ResidentHostStats()
+			}))
+		}
 	}
 
 	logger.Info("wasm runtime enabled",

--- a/pkg/wasm/engine_multi.go
+++ b/pkg/wasm/engine_multi.go
@@ -14,37 +14,38 @@ import (
 	"github.com/tetratelabs/wazero/sys"
 )
 
+// multiInstance is one co-tenant sandbox on a MultiInstanceEngine. mu serializes
+// Call vs Close so StopInstance/Run cannot Close a module under an in-flight
+// InvokeExport (D8 use-after-close).
+type multiInstance struct {
+	mod api.Module
+	mu  sync.Mutex
+}
+
 // MultiInstanceEngine holds one resident wazero runtime + one compiled module
 // and instantiates many isolated instances from it — compile-once,
 // instantiate-many. It is the Phase 1 primitive for the resident-module host
-// (plans/wasm-resident-module-host.md).
-//
-// Why it exists: the v0.7.9 cluster-3-mixed-wasm bench measured a cold create's
-// `wasm_load` at 2843ms p50, of which `wasm_load_compile` was 2768ms (~97%) —
-// and that is WITH the on-disk compile cache populated, so it is the per-process
-// deserialize of a 25MB CPython image, not a from-scratch compile. Reusing a
-// resident in-process CompiledModule skips that entirely: an Instantiate against
-// it measured 9ms. This type turns a "cold" create into an Instantiate.
+// (plans/wasm-resident-module-host.md), extended in Phase 2b PR-A with
+// per-instance network hooks (multiNetHost) and call/lifecycle locking.
 //
 // Bucketing constraint: wazero sets the memory limit at the runtime level and a
 // CompiledModule is bound to its runtime, so one MultiInstanceEngine serves a
-// single (module, memoryMB) bucket. MemoryMB is fixed at construction; the pool
-// (Phase 3) routes a create to an engine whose MemoryMB matches, else cold path.
+// single (module, memoryMB) bucket. MemoryMB is fixed at construction.
 //
-// Isolation: wazero gives every InstantiateModule its own linear memory, so
-// co-tenant instances cannot read each other's memory (proven in
-// engine_multi_test.go). Per-instance networking, snapshot/restore, IO-capturing
-// Run, and wasip1 listeners are deliberately NOT here yet — they are Phase 2,
-// wired when this engine is embedded in the worker (the worker's NetMediator is
-// already keyed by sandboxID). Phase 1 is the isolated-instance primitive only.
+// Isolation: wazero gives every InstantiateModule its own linear memory.
+// Networking is keyed by mod.Name() (= sandboxID) via multiNetHost so co-tenants
+// cannot share sockets. wasip1 listeners and checkpoint/restore remain out of
+// scope for resident hosts.
 type MultiInstanceEngine struct {
-	mu        sync.Mutex
-	runtime   wazero.Runtime
-	compiled  wazero.CompiledModule
-	memoryMB  int
-	pages     uint32
-	instances map[string]api.Module
-	lastLoad  LoadTimings
+	mu                sync.Mutex
+	runtime           wazero.Runtime
+	compiled          wazero.CompiledModule
+	memoryMB          int
+	pages             uint32
+	instances         map[string]*multiInstance
+	lastLoad          LoadTimings
+	netHost           *multiNetHost
+	netHostRegistered bool
 }
 
 // NewMultiInstanceEngine builds the resident runtime (memory-limited to memoryMB,
@@ -60,7 +61,7 @@ func NewMultiInstanceEngine(ctx context.Context, memoryMB int) (*MultiInstanceEn
 		runtime:   r,
 		memoryMB:  memoryMB,
 		pages:     pages,
-		instances: make(map[string]api.Module),
+		instances: make(map[string]*multiInstance),
 	}, nil
 }
 
@@ -110,6 +111,30 @@ func (m *MultiInstanceEngine) LastLoadTimings() LoadTimings {
 	return m.lastLoad
 }
 
+// SetNetworkHook binds a per-sandbox NetworkHook for mediated egress. The hook
+// is looked up at host-fn call time by mod.Name() (= sandboxID).
+func (m *MultiInstanceEngine) SetNetworkHook(sandboxID string, hook *NetworkHook) {
+	if sandboxID == "" {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.netHost == nil {
+		m.netHost = newMultiNetHost()
+	}
+	m.netHost.setHook(sandboxID, hook)
+}
+
+// ClearNetworkHook drops the sandbox's hook and closes every conn it owns.
+func (m *MultiInstanceEngine) ClearNetworkHook(sandboxID string) {
+	m.mu.Lock()
+	host := m.netHost
+	m.mu.Unlock()
+	if host != nil {
+		host.clearSandbox(sandboxID)
+	}
+}
+
 // Instantiate creates an isolated instance keyed by sandboxID from the resident
 // compiled module. This is the fast path the whole design exists for: it costs
 // an Instantiate (~9ms), not a CompileModule (~2.8s). _start is NOT run here
@@ -126,6 +151,11 @@ func (m *MultiInstanceEngine) Instantiate(ctx context.Context, sandboxID string,
 	if _, ok := m.instances[sandboxID]; ok {
 		return fmt.Errorf("instance %q already exists", sandboxID)
 	}
+	// Register aerol/vm/net before guest Instantiate so modules that import it
+	// resolve; dials fail closed until SetNetworkHook binds a per-sandbox hook.
+	if err := m.ensureNetworkHostLocked(ctx); err != nil {
+		return err
+	}
 	// wazero rejects two instances sharing a module name on one runtime, so key
 	// the instance name by sandboxID to keep co-tenants distinct.
 	cfg := moduleConfigFor(caps).WithName(sandboxID)
@@ -136,7 +166,7 @@ func (m *MultiInstanceEngine) Instantiate(ctx context.Context, sandboxID string,
 	if err != nil {
 		return fmt.Errorf("instantiate module: %w", err)
 	}
-	m.instances[sandboxID] = mod
+	m.instances[sandboxID] = &multiInstance{mod: mod}
 	return nil
 }
 
@@ -159,14 +189,30 @@ func (m *MultiInstanceEngine) Run(ctx context.Context, sandboxID string, caps Ca
 		m.mu.Unlock()
 		return RunResult{}, fmt.Errorf("no compiled module loaded")
 	}
-	// Re-instantiate semantics: drop any prior instance for this sandbox first.
-	if old, ok := m.instances[sandboxID]; ok {
-		_ = old.Close(ctx)
-		delete(m.instances, sandboxID)
+	if err := m.ensureNetworkHostLocked(ctx); err != nil {
+		m.mu.Unlock()
+		return RunResult{}, err
 	}
+	// Re-instantiate semantics: drop any prior instance for this sandbox first.
+	old := m.instances[sandboxID]
+	delete(m.instances, sandboxID)
 	compiled := m.compiled
 	runtime := m.runtime
+	host := m.netHost
 	m.mu.Unlock()
+
+	if host != nil {
+		// Close owned sockets BEFORE waiting on old.mu: a guest blocked in a host
+		// tcp_read/write holds old.mu and wazero cannot preempt it, so closing the
+		// conn first makes the blocked Read return and the call unwind (Finding
+		// P1-1). The hook stays so the next Exec still has a dialer.
+		host.closeConns(sandboxID)
+	}
+	if old != nil {
+		old.mu.Lock()
+		_ = old.mod.Close(ctx)
+		old.mu.Unlock()
+	}
 
 	invokeCtx, cancel := WithInvocationDeadline(ctx, caps)
 	defer cancel()
@@ -181,19 +227,23 @@ func (m *MultiInstanceEngine) Run(ctx context.Context, sandboxID string, caps Ca
 	if err != nil {
 		return RunResult{}, fmt.Errorf("instantiate module: %w", err)
 	}
+	inst := &multiInstance{mod: mod}
 	m.mu.Lock()
-	m.instances[sandboxID] = mod
+	m.instances[sandboxID] = inst
 	m.mu.Unlock()
 
 	result := RunResult{}
+	inst.mu.Lock()
 	fn := mod.ExportedFunction(export)
 	if fn == nil {
+		inst.mu.Unlock()
 		result.ExitCode = 1
 		result.Stdout = stdout.String()
 		result.Stderr = stderr.String()
 		return result, fmt.Errorf("export %q not found", export)
 	}
 	_, callErr := fn.Call(invokeCtx)
+	inst.mu.Unlock()
 	result.ExitCode = exitCodeFromInvoke(callErr)
 	result.Stdout = stdout.String()
 	result.Stderr = stderr.String()
@@ -210,16 +260,19 @@ func (m *MultiInstanceEngine) Run(ctx context.Context, sandboxID string, caps Ca
 	return result, nil
 }
 
-// InvokeExport calls an exported function on one instance. The lock is released
-// before the call so a long-running export does not serialize co-tenants.
+// InvokeExport calls an exported function on one instance. The engine lock is
+// released before the call so a long-running export does not serialize
+// co-tenants; the per-instance lock keeps StopInstance from Closing underfoot.
 func (m *MultiInstanceEngine) InvokeExport(ctx context.Context, sandboxID, name string) error {
 	m.mu.Lock()
-	mod, ok := m.instances[sandboxID]
+	inst, ok := m.instances[sandboxID]
 	m.mu.Unlock()
 	if !ok {
 		return fmt.Errorf("no instance %q", sandboxID)
 	}
-	fn := mod.ExportedFunction(name)
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+	fn := inst.mod.ExportedFunction(name)
 	if fn == nil {
 		return fmt.Errorf("export %q not found", name)
 	}
@@ -228,18 +281,36 @@ func (m *MultiInstanceEngine) InvokeExport(ctx context.Context, sandboxID, name 
 }
 
 // StopInstance closes one instance and leaves every co-tenant running.
-// Idempotent: stopping an unknown sandboxID is a no-op.
+// Idempotent: stopping an unknown sandboxID is a no-op. Waits for in-flight
+// InvokeExport/Run calls on that instance, then closes owned network conns.
 func (m *MultiInstanceEngine) StopInstance(ctx context.Context, sandboxID string) error {
 	m.mu.Lock()
-	mod, ok := m.instances[sandboxID]
+	inst, ok := m.instances[sandboxID]
 	if ok {
 		delete(m.instances, sandboxID)
 	}
+	host := m.netHost
 	m.mu.Unlock()
+	// Close owned sockets BEFORE taking inst.mu: a guest blocked in a host
+	// tcp_read/write (which wazero cannot preempt) holds inst.mu, so waiting on it
+	// first would deadlock — closing the conn makes the blocked Read return and
+	// the guest call unwind (Finding P1-1).
+	if host != nil {
+		host.closeConns(sandboxID)
+	}
 	if !ok {
+		if host != nil {
+			host.clearSandbox(sandboxID)
+		}
 		return nil
 	}
-	return mod.Close(ctx)
+	inst.mu.Lock()
+	err := inst.mod.Close(ctx)
+	inst.mu.Unlock()
+	if host != nil {
+		host.clearSandbox(sandboxID)
+	}
+	return err
 }
 
 // HasInstance reports whether sandboxID has a live instance.
@@ -258,28 +329,43 @@ func (m *MultiInstanceEngine) InstanceCount() int {
 }
 
 // instanceModule returns the raw wazero module for one sandbox (nil if absent).
-// Package-internal: used by tests and by future per-instance snapshot/network
-// wiring in Phase 2.
+// Package-internal: used by tests and by per-instance snapshot/network wiring.
 func (m *MultiInstanceEngine) instanceModule(sandboxID string) api.Module {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.instances[sandboxID]
+	inst := m.instances[sandboxID]
+	if inst == nil {
+		return nil
+	}
+	return inst.mod
 }
 
 // Close tears down every instance, the compiled module, and the runtime.
 func (m *MultiInstanceEngine) Close(ctx context.Context) error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-	for id, mod := range m.instances {
-		_ = mod.Close(ctx)
-		delete(m.instances, id)
+	instances := m.instances
+	m.instances = make(map[string]*multiInstance)
+	host := m.netHost
+	m.netHost = nil
+	m.netHostRegistered = false
+	compiled := m.compiled
+	m.compiled = nil
+	runtime := m.runtime
+	m.mu.Unlock()
+
+	if host != nil {
+		host.closeAll()
 	}
-	if m.compiled != nil {
-		_ = m.compiled.Close(ctx)
-		m.compiled = nil
+	for _, inst := range instances {
+		inst.mu.Lock()
+		_ = inst.mod.Close(ctx)
+		inst.mu.Unlock()
 	}
-	if m.runtime != nil {
-		return m.runtime.Close(ctx)
+	if compiled != nil {
+		_ = compiled.Close(ctx)
+	}
+	if runtime != nil {
+		return runtime.Close(ctx)
 	}
 	return nil
 }

--- a/pkg/wasm/engine_multi_network.go
+++ b/pkg/wasm/engine_multi_network.go
@@ -1,0 +1,273 @@
+package wasm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+
+	"github.com/tetratelabs/wazero/api"
+)
+
+// multiNetHost is the co-tenant aerol/vm/net host module for MultiInstanceEngine.
+// Hooks and connections are keyed by mod.Name() (= sandboxID, set via WithName at
+// Instantiate), so guest B cannot resolve guest A's conn_id — ownership is
+// structural (nested map), not a check that can be forgotten.
+// See plans/wasm-resident-module-host.md Phase 2b / PR-A.
+type multiNetHost struct {
+	mu     sync.Mutex
+	hooks  map[string]*NetworkHook
+	conns  map[string]map[uint64]net.Conn
+	nextID atomic.Uint64
+	closed bool
+}
+
+func newMultiNetHost() *multiNetHost {
+	return &multiNetHost{
+		hooks: make(map[string]*NetworkHook),
+		conns: make(map[string]map[uint64]net.Conn),
+	}
+}
+
+func (h *multiNetHost) setHook(sandboxID string, hook *NetworkHook) {
+	if sandboxID == "" {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if hook == nil {
+		delete(h.hooks, sandboxID)
+		return
+	}
+	h.hooks[sandboxID] = hook
+}
+
+// closeConns closes and deletes every conn owned by sandboxID, leaving the hook
+// in place (used by Run's re-instantiate so the next Exec still has a dialer).
+// Closing unblocks a pinned tcp_read/tcp_write (the conn's Read/Write returns).
+func (h *multiNetHost) closeConns(sandboxID string) {
+	if h == nil || sandboxID == "" {
+		return
+	}
+	h.mu.Lock()
+	owned := h.conns[sandboxID]
+	delete(h.conns, sandboxID)
+	h.mu.Unlock()
+	for _, c := range owned {
+		if c != nil {
+			_ = c.Close()
+		}
+	}
+}
+
+// clearSandbox drops the hook and closes every conn owned by sandboxID.
+func (h *multiNetHost) clearSandbox(sandboxID string) {
+	if h == nil || sandboxID == "" {
+		return
+	}
+	h.mu.Lock()
+	delete(h.hooks, sandboxID)
+	owned := h.conns[sandboxID]
+	delete(h.conns, sandboxID)
+	h.mu.Unlock()
+	for _, c := range owned {
+		if c != nil {
+			_ = c.Close()
+		}
+	}
+}
+
+func (h *multiNetHost) closeAll() {
+	h.mu.Lock()
+	h.closed = true
+	h.hooks = make(map[string]*NetworkHook)
+	all := h.conns
+	h.conns = make(map[string]map[uint64]net.Conn)
+	h.mu.Unlock()
+	for _, owned := range all {
+		for _, c := range owned {
+			if c != nil {
+				_ = c.Close()
+			}
+		}
+	}
+}
+
+func (h *multiNetHost) resolveHook(sandboxID string) *NetworkHook {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return nil
+	}
+	return h.hooks[sandboxID]
+}
+
+func (h *multiNetHost) takeConn(sandboxID string, id uint64) (net.Conn, ByteMeter) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	owned := h.conns[sandboxID]
+	if owned == nil {
+		return nil, nil
+	}
+	conn := owned[id]
+	var meter ByteMeter
+	if hook := h.hooks[sandboxID]; hook != nil {
+		meter = hook.Meter
+	}
+	return conn, meter
+}
+
+func (h *multiNetHost) popConn(sandboxID string, id uint64) net.Conn {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	owned := h.conns[sandboxID]
+	if owned == nil {
+		return nil
+	}
+	conn := owned[id]
+	delete(owned, id)
+	if len(owned) == 0 {
+		delete(h.conns, sandboxID)
+	}
+	return conn
+}
+
+func (h *multiNetHost) putConn(sandboxID string, id uint64, conn net.Conn) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.conns[sandboxID] == nil {
+		h.conns[sandboxID] = make(map[uint64]net.Conn)
+	}
+	h.conns[sandboxID][id] = conn
+}
+
+func (h *multiNetHost) tcpDial(ctx context.Context, mod api.Module, stack []uint64) {
+	const (
+		errInvalid = int32(1)
+		errDial    = int32(2)
+		errBlocked = int32(3)
+	)
+	addrPtr := uint32(stack[0])
+	addrLen := uint32(stack[1])
+	stack[0] = uint64(errInvalid)
+
+	sid := mod.Name()
+	hook := h.resolveHook(sid)
+	if hook == nil || hook.Dial == nil {
+		// Fail closed: never fall through to another tenant's dialer.
+		stack[0] = uint64(errBlocked)
+		return
+	}
+	addr, ok := mod.Memory().Read(addrPtr, addrLen)
+	if !ok {
+		return
+	}
+	// Honor the invocation deadline (D6-A): dial is bounded by min(ctx, dialer timeout).
+	conn, err := hook.Dial.DialContext(ctx, "tcp", string(addr))
+	if err != nil {
+		if errors.Is(err, ErrNetworkEgressBlocked) {
+			stack[0] = uint64(errBlocked)
+			return
+		}
+		stack[0] = uint64(errDial)
+		return
+	}
+	id := h.nextID.Add(1)
+	h.putConn(sid, id, conn)
+	stack[0] = uint64(int32(id))
+}
+
+func (h *multiNetHost) tcpClose(_ context.Context, mod api.Module, stack []uint64) {
+	id := uint64(stack[0])
+	conn := h.popConn(mod.Name(), id)
+	if conn != nil {
+		_ = conn.Close()
+	}
+	stack[0] = 0
+}
+
+func (h *multiNetHost) tcpRead(_ context.Context, mod api.Module, stack []uint64) {
+	const (
+		errInvalid = int32(1)
+		errClosed  = int32(2)
+	)
+	connID := uint64(stack[0])
+	bufPtr := uint32(stack[1])
+	bufLen := uint32(stack[2])
+	stack[0] = uint64(errInvalid)
+
+	conn, meter := h.takeConn(mod.Name(), connID)
+	if conn == nil {
+		stack[0] = uint64(errClosed)
+		return
+	}
+	buf, ok := mod.Memory().Read(bufPtr, bufLen)
+	if !ok {
+		return
+	}
+	stack[0] = uint64(netConnRead(conn, meter, buf))
+}
+
+func (h *multiNetHost) tcpWrite(_ context.Context, mod api.Module, stack []uint64) {
+	const (
+		errInvalid = int32(1)
+		errClosed  = int32(2)
+	)
+	connID := uint64(stack[0])
+	bufPtr := uint32(stack[1])
+	bufLen := uint32(stack[2])
+	stack[0] = uint64(errInvalid)
+
+	conn, meter := h.takeConn(mod.Name(), connID)
+	if conn == nil {
+		stack[0] = uint64(errClosed)
+		return
+	}
+	buf, ok := mod.Memory().Read(bufPtr, bufLen)
+	if !ok {
+		return
+	}
+	stack[0] = uint64(netConnWrite(conn, meter, buf))
+}
+
+// ensureNetworkHostLocked registers aerol/vm/net once on the shared runtime.
+// Caller must hold m.mu.
+func (m *MultiInstanceEngine) ensureNetworkHostLocked(ctx context.Context) error {
+	if m.netHost != nil && m.netHostRegistered {
+		return nil
+	}
+	if m.runtime == nil {
+		return fmt.Errorf("runtime not initialized")
+	}
+	if m.netHost == nil {
+		m.netHost = newMultiNetHost()
+	}
+	if m.netHostRegistered {
+		return nil
+	}
+	host := m.netHost
+	builder := m.runtime.NewHostModuleBuilder("aerol/vm/net")
+	builder.NewFunctionBuilder().
+		WithGoModuleFunction(api.GoModuleFunc(host.tcpDial), []api.ValueType{api.ValueTypeI32, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
+		WithParameterNames("addr_ptr", "addr_len").
+		Export("tcp_dial")
+	builder.NewFunctionBuilder().
+		WithGoModuleFunction(api.GoModuleFunc(host.tcpClose), []api.ValueType{api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
+		WithParameterNames("conn_id").
+		Export("tcp_close")
+	builder.NewFunctionBuilder().
+		WithGoModuleFunction(api.GoModuleFunc(host.tcpRead), []api.ValueType{api.ValueTypeI32, api.ValueTypeI32, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
+		WithParameterNames("conn_id", "buf_ptr", "buf_len").
+		Export("tcp_read")
+	builder.NewFunctionBuilder().
+		WithGoModuleFunction(api.GoModuleFunc(host.tcpWrite), []api.ValueType{api.ValueTypeI32, api.ValueTypeI32, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
+		WithParameterNames("conn_id", "buf_ptr", "buf_len").
+		Export("tcp_write")
+	if _, err := builder.Instantiate(ctx); err != nil {
+		return fmt.Errorf("aerol/vm/net host module: %w", err)
+	}
+	m.netHostRegistered = true
+	return nil
+}

--- a/pkg/wasm/engine_multi_network_test.go
+++ b/pkg/wasm/engine_multi_network_test.go
@@ -1,0 +1,287 @@
+package wasm
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/pkg/wasmmod"
+)
+
+// TestMultiNetHost_CrossTenantConnDenied is the IRON-RULE isolation regression:
+// guest B must not read/write/close guest A's conn_id. Conn ownership is the
+// nested map; a foreign id is unresolvable → errClosed, and A's conn stays usable.
+func TestMultiNetHost_CrossTenantConnDenied(t *testing.T) {
+	ctx := context.Background()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_, _ = c.Write([]byte("ok"))
+			_ = c.Close()
+		}
+	}()
+
+	host := newMultiNetHost()
+	meterA, meterB := &mockMeter{}, &mockMeter{}
+	host.setHook("sbx-A", &NetworkHook{SandboxID: "sbx-A", Dial: &countingDialer{}, Meter: meterA})
+	host.setHook("sbx-B", &NetworkHook{SandboxID: "sbx-B", Dial: &countingDialer{}, Meter: meterB})
+
+	addr := []byte(ln.Addr().String())
+	modA := &mockModule{name: "sbx-A", mem: &mockMemory{buf: append([]byte{}, addr...)}}
+	stack := []uint64{0, uint64(len(addr))}
+	host.tcpDial(ctx, modA, stack)
+	connID := stack[0]
+	if int32(connID) <= 0 {
+		t.Fatalf("A dial failed: %v", int32(connID))
+	}
+
+	modB := &mockModule{name: "sbx-B", mem: &mockMemory{buf: make([]byte, 8)}}
+	// B tries to use A's conn_id → errClosed (2).
+	readStack := []uint64{connID, 0, 2}
+	host.tcpRead(ctx, modB, readStack)
+	if readStack[0] != 2 {
+		t.Fatalf("B tcp_read with A's id: got %v, want errClosed(2)", readStack[0])
+	}
+	writeStack := []uint64{connID, 0, 2}
+	host.tcpWrite(ctx, modB, writeStack)
+	if writeStack[0] != 2 {
+		t.Fatalf("B tcp_write with A's id: got %v, want errClosed(2)", writeStack[0])
+	}
+	closeStack := []uint64{connID}
+	host.tcpClose(ctx, modB, closeStack) // B's close is a no-op on unknown id
+	if closeStack[0] != 0 {
+		t.Fatalf("B tcp_close: got %v", closeStack[0])
+	}
+
+	// A's conn still works.
+	modA.mem.buf = make([]byte, 2)
+	readStack = []uint64{connID, 0, 2}
+	host.tcpRead(ctx, modA, readStack)
+	if int32(readStack[0]) <= 0 {
+		t.Fatalf("A read after B's attempt failed: %v", int32(readStack[0]))
+	}
+	if meterB.in.Load() != 0 || meterB.out.Load() != 0 {
+		t.Fatalf("B meter moved on A's traffic: in=%d out=%d", meterB.in.Load(), meterB.out.Load())
+	}
+}
+
+func TestMultiNetHost_PerTenantMeterAndBlocks(t *testing.T) {
+	ctx := context.Background()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			buf := make([]byte, 8)
+			_, _ = c.Read(buf)
+			_, _ = c.Write([]byte("xy"))
+			_ = c.Close()
+		}
+	}()
+
+	host := newMultiNetHost()
+	meterA, meterB := &mockMeter{}, &mockMeter{}
+	host.setHook("a", &NetworkHook{Dial: &countingDialer{}, Meter: meterA})
+	host.setHook("b", &NetworkHook{Dial: &countingDialer{}, Meter: meterB})
+
+	addr := []byte(ln.Addr().String())
+	dial := func(sid string) uint64 {
+		mod := &mockModule{name: sid, mem: &mockMemory{buf: append([]byte{}, addr...)}}
+		stack := []uint64{0, uint64(len(addr))}
+		host.tcpDial(ctx, mod, stack)
+		if int32(stack[0]) <= 0 {
+			t.Fatalf("%s dial failed", sid)
+		}
+		return stack[0]
+	}
+	idA := dial("a")
+	idB := dial("b")
+
+	modA := &mockModule{name: "a", mem: &mockMemory{buf: []byte("hi????")}}
+	host.tcpWrite(ctx, modA, []uint64{idA, 0, 2})
+	host.tcpRead(ctx, modA, []uint64{idA, 2, 2})
+	if meterA.out.Load() != 2 {
+		t.Fatalf("A out=%d, want 2", meterA.out.Load())
+	}
+	if meterB.in.Load() != 0 || meterB.out.Load() != 0 {
+		t.Fatalf("B meter polluted: in=%d out=%d", meterB.in.Load(), meterB.out.Load())
+	}
+	_ = idB
+
+	// Fail-closed: no hook → errBlocked.
+	host.clearSandbox("a")
+	modGone := &mockModule{name: "a", mem: &mockMemory{buf: append([]byte{}, addr...)}}
+	stack := []uint64{0, uint64(len(addr))}
+	host.tcpDial(ctx, modGone, stack)
+	if stack[0] != 3 {
+		t.Fatalf("cleared hook dial: got %v, want errBlocked(3)", stack[0])
+	}
+
+	// Blocked dialer → errBlocked; sibling still dials.
+	host.setHook("a", &NetworkHook{Dial: &mockBlockedDialer{}})
+	host.setHook("b", &NetworkHook{Dial: &countingDialer{}})
+	stack = []uint64{0, uint64(len(addr))}
+	host.tcpDial(ctx, &mockModule{name: "a", mem: &mockMemory{buf: append([]byte{}, addr...)}}, stack)
+	if stack[0] != 3 {
+		t.Fatalf("blocked A: got %v, want 3", stack[0])
+	}
+	stack = []uint64{0, uint64(len(addr))}
+	host.tcpDial(ctx, &mockModule{name: "b", mem: &mockMemory{buf: append([]byte{}, addr...)}}, stack)
+	if int32(stack[0]) <= 0 {
+		t.Fatalf("B dial under A's block failed: %v", int32(stack[0]))
+	}
+}
+
+func TestMultiNetHost_DialHonorsInvocationDeadline(t *testing.T) {
+	host := newMultiNetHost()
+	var sawCancel atomic.Bool
+	host.setHook("a", &NetworkHook{Dial: &contextAwareDialer{sawCancel: &sawCancel}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	addr := []byte("127.0.0.1:9")
+	mod := &mockModule{name: "a", mem: &mockMemory{buf: addr}}
+	stack := []uint64{0, uint64(len(addr))}
+	host.tcpDial(ctx, mod, stack)
+	if stack[0] != 2 { // errDial
+		t.Fatalf("canceled dial: got %v, want errDial(2)", stack[0])
+	}
+	if !sawCancel.Load() {
+		t.Fatal("dialer did not observe canceled context")
+	}
+}
+
+func TestMultiNetHost_StopClosesOwnedConns(t *testing.T) {
+	ctx := context.Background()
+	c1, c2 := net.Pipe()
+	defer c2.Close()
+
+	host := newMultiNetHost()
+	host.setHook("a", &NetworkHook{Dial: &pipeDialer{c: c1}})
+	mod := &mockModule{name: "a", mem: &mockMemory{buf: []byte("x")}}
+	stack := []uint64{0, 1}
+	host.tcpDial(ctx, mod, stack)
+	if int32(stack[0]) <= 0 {
+		t.Fatalf("dial: %v", int32(stack[0]))
+	}
+
+	blocked := make(chan struct{})
+	go func() {
+		buf := make([]byte, 1)
+		_, _ = c2.Read(buf) // blocks until peer closed
+		close(blocked)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	host.clearSandbox("a")
+	select {
+	case <-blocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("clearSandbox did not unblock peer Read")
+	}
+}
+
+type contextAwareDialer struct {
+	sawCancel *atomic.Bool
+}
+
+func (d *contextAwareDialer) DialContext(ctx context.Context, _, _ string) (net.Conn, error) {
+	<-ctx.Done()
+	d.sawCancel.Store(true)
+	return nil, ctx.Err()
+}
+
+type pipeDialer struct{ c net.Conn }
+
+func (d *pipeDialer) DialContext(context.Context, string, string) (net.Conn, error) {
+	return d.c, nil
+}
+
+// TestMultiInstanceEngine_ParallelCallAcrossModules stress-tests the core
+// assumption that wazero permits parallel Call across different modules on one
+// runtime, and that StopInstance waits for in-flight calls (D8).
+func TestMultiInstanceEngine_ParallelCallAcrossModules(t *testing.T) {
+	dir := t.TempDir()
+	modPath := wasmmod.WriteMinimalWasm(t, dir, "demo.wasm")
+	ctx := context.Background()
+	eng, err := NewMultiInstanceEngine(ctx, 0)
+	if err != nil {
+		t.Fatalf("NewMultiInstanceEngine: %v", err)
+	}
+	t.Cleanup(func() { _ = eng.Close(ctx) })
+	if err := eng.LoadModule(ctx, modPath); err != nil {
+		t.Fatalf("LoadModule: %v", err)
+	}
+
+	const n = 8
+	caps := Capabilities{Args: []string{"wasm"}, WallTimeoutNs: int64(time.Minute)}
+	ids := make([]string, n)
+	for i := 0; i < n; i++ {
+		ids[i] = fmt.Sprintf("sb-%d", i)
+		if err := eng.Instantiate(ctx, ids[i], caps); err != nil {
+			t.Fatalf("Instantiate %s: %v", ids[i], err)
+		}
+	}
+
+	// Parallel Call across distinct modules — the design's core unproven assumption.
+	var wg sync.WaitGroup
+	errCh := make(chan error, n)
+	for _, id := range ids {
+		wg.Add(1)
+		go func(sid string) {
+			defer wg.Done()
+			if err := eng.InvokeExport(ctx, sid, "_start"); err != nil {
+				errCh <- err
+			}
+		}(id)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatalf("parallel InvokeExport: %v", err)
+	}
+
+	// Re-instantiate via Run so each sandbox has a fresh module, then Stop under
+	// concurrent Invoke (Stop must wait for the per-instance lock, not UAF).
+	for _, id := range ids {
+		if _, err := eng.Run(ctx, id, caps, "_start"); err != nil {
+			t.Fatalf("Run %s: %v", id, err)
+		}
+	}
+	errCh = make(chan error, n)
+	var stopWG sync.WaitGroup
+	for _, id := range ids {
+		stopWG.Add(1)
+		go func(sid string) {
+			defer stopWG.Done()
+			if err := eng.StopInstance(ctx, sid); err != nil {
+				errCh <- err
+			}
+		}(id)
+	}
+	stopWG.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatalf("Stop under load: %v", err)
+	}
+	if got := eng.InstanceCount(); got != 0 {
+		t.Fatalf("InstanceCount=%d after stop-all, want 0", got)
+	}
+}

--- a/pkg/wasm/mock_wazero_test.go
+++ b/pkg/wasm/mock_wazero_test.go
@@ -33,7 +33,9 @@ func (m *mockMemory) Write(offset uint32, v []byte) bool {
 
 type mockModule struct {
 	api.Module
-	mem *mockMemory
+	mem  *mockMemory
+	name string
 }
 
 func (m *mockModule) Memory() api.Memory { return m.mem }
+func (m *mockModule) Name() string       { return m.name }

--- a/pkg/wasm/net_conn_io.go
+++ b/pkg/wasm/net_conn_io.go
@@ -1,0 +1,26 @@
+package wasm
+
+import "net"
+
+// netConnRead performs a conn.Read, meters inbound bytes, and returns the
+// guest-facing int32 result. Shared by the single-instance wazeroNetHost and
+// the co-tenant multiNetHost so the socket body stays single-sourced (D5-A).
+func netConnRead(conn net.Conn, meter ByteMeter, buf []byte) int32 {
+	n, err := conn.Read(buf)
+	if n > 0 && meter != nil {
+		meter.AddIn(int64(n))
+	}
+	_ = err // guest sees short/EOF as a non-positive or short read; match prior host behavior
+	return int32(n)
+}
+
+// netConnWrite performs a conn.Write, meters outbound bytes, and returns the
+// guest-facing int32 result. Shared by both net hosts (D5-A).
+func netConnWrite(conn net.Conn, meter ByteMeter, buf []byte) int32 {
+	n, err := conn.Write(buf)
+	if n > 0 && meter != nil {
+		meter.AddOut(int64(n))
+	}
+	_ = err
+	return int32(n)
+}

--- a/pkg/wasm/wazero_network.go
+++ b/pkg/wasm/wazero_network.go
@@ -79,7 +79,7 @@ func (e *wazeroEngine) ensureNetworkHost(ctx context.Context) error {
 	return nil
 }
 
-func (h *wazeroNetHost) tcpDial(_ context.Context, mod api.Module, stack []uint64) {
+func (h *wazeroNetHost) tcpDial(ctx context.Context, mod api.Module, stack []uint64) {
 	const (
 		errInvalid = int32(1)
 		errDial    = int32(2)
@@ -103,7 +103,10 @@ func (h *wazeroNetHost) tcpDial(_ context.Context, mod api.Module, stack []uint6
 	if !ok {
 		return
 	}
-	conn, err := hook.Dial.DialContext(context.Background(), "tcp", string(addr))
+	// Honor the invocation deadline (D6-A): previously dialed with
+	// context.Background(), which ignored caps wall timeout under co-tenancy
+	// and the single-instance path alike.
+	conn, err := hook.Dial.DialContext(ctx, "tcp", string(addr))
 	if err != nil {
 		if errors.Is(err, ErrNetworkEgressBlocked) {
 			stack[0] = uint64(errBlocked)
@@ -160,15 +163,7 @@ func (h *wazeroNetHost) tcpRead(_ context.Context, mod api.Module, stack []uint6
 	if !ok {
 		return
 	}
-	n, err := conn.Read(buf)
-	if n > 0 && meter != nil {
-		meter.AddIn(int64(n))
-	}
-	if err != nil {
-		stack[0] = uint64(int32(n))
-		return
-	}
-	stack[0] = uint64(int32(n))
+	stack[0] = uint64(netConnRead(conn, meter, buf))
 }
 
 func (h *wazeroNetHost) tcpWrite(_ context.Context, mod api.Module, stack []uint64) {
@@ -193,13 +188,5 @@ func (h *wazeroNetHost) tcpWrite(_ context.Context, mod api.Module, stack []uint
 	if !ok {
 		return
 	}
-	n, err := conn.Write(buf)
-	if n > 0 && meter != nil {
-		meter.AddOut(int64(n))
-	}
-	if err != nil {
-		stack[0] = uint64(int32(n))
-		return
-	}
-	stack[0] = uint64(int32(n))
+	stack[0] = uint64(netConnWrite(conn, meter, buf))
 }

--- a/pkg/wasm/worker/resident_server.go
+++ b/pkg/wasm/worker/resident_server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 	"sync"
 
 	wasmengine "github.com/aerol-ai/microvm/pkg/wasm"
@@ -12,34 +13,79 @@ import (
 
 // ResidentServer serves the worker protocol backed by a MultiInstanceEngine:
 // one resident process compiles a module once and hosts many isolated sandbox
-// instances (compile-once, instantiate-many). It is the Phase 2 host process
-// for plans/wasm-resident-module-host.md, spawned via `--wasm-resident-host`.
+// instances (compile-once, instantiate-many). Spawned via `--wasm-resident-host`.
 //
-// Scope (initial cut, default-off): non-listen, non-networking sandboxes —
-// LoadModule (once, host-level), Instantiate/Exec/Invoke/StopInstance keyed by
-// sandboxID. Listener (expose_port/HTTP), checkpoint/restore, and per-instance
-// egress mediation are rejected here on purpose; the driver routes those to the
-// per-sandbox cold path. Per-instance egress isolation on a shared runtime
-// (name-keyed hooks + conn ownership) is the eng-review-gated Phase 2 remainder.
+// Phase 2b PR-A: per-instance egress via MultiInstanceEngine.SetNetworkHook
+// (name-keyed hooks + conn ownership) and a shared NetMediator. Listener
+// (expose_port/HTTP) and checkpoint/restore remain rejected — those stay on the
+// per-sandbox cold path (migrate-on-expose is PR-B).
 type ResidentServer struct {
 	mu         sync.Mutex
 	eng        *wasmengine.MultiInstanceEngine
 	loadedPath string
+	net        *NetMediator
+	workerNet  map[string]*workerNetUsage
+	lastCaps   map[string]wasmengine.Capabilities
 }
 
-// ensureEngine lazily builds the MultiInstanceEngine on the first LoadModule,
-// fixing the runtime memory limit to the bucket's memoryMB.
-func (s *ResidentServer) ensureEngine(ctx context.Context, memoryMB int) (*wasmengine.MultiInstanceEngine, error) {
+func (s *ResidentServer) mediator() *NetMediator {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.eng == nil {
-		eng, err := wasmengine.NewMultiInstanceEngine(ctx, memoryMB)
-		if err != nil {
-			return nil, err
-		}
-		s.eng = eng
+	if s.net == nil {
+		s.net = newNetMediator()
 	}
-	return s.eng, nil
+	return s.net
+}
+
+func (s *ResidentServer) netUsageFor(sandboxID string) *workerNetUsage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.workerNet == nil {
+		s.workerNet = make(map[string]*workerNetUsage)
+	}
+	if s.workerNet[sandboxID] == nil {
+		s.workerNet[sandboxID] = &workerNetUsage{}
+	}
+	return s.workerNet[sandboxID]
+}
+
+func (s *ResidentServer) bindNetworkHook(eng *wasmengine.MultiInstanceEngine, sandboxID string) {
+	if eng == nil || sandboxID == "" {
+		return
+	}
+	m := s.mediator()
+	usage := s.netUsageFor(sandboxID)
+	eng.SetNetworkHook(sandboxID, &wasmengine.NetworkHook{
+		SandboxID: sandboxID,
+		Dial:      mediatorDialer{m: m, sandboxID: sandboxID},
+		Meter:     &workerByteMeter{u: usage},
+	})
+}
+
+func (s *ResidentServer) clearNetworkHook(eng *wasmengine.MultiInstanceEngine, sandboxID string) {
+	if eng == nil {
+		return
+	}
+	eng.ClearNetworkHook(sandboxID)
+	s.mu.Lock()
+	delete(s.workerNet, sandboxID)
+	delete(s.lastCaps, sandboxID)
+	s.mu.Unlock()
+}
+
+func (s *ResidentServer) storeCaps(sandboxID string, caps wasmengine.Capabilities) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.lastCaps == nil {
+		s.lastCaps = make(map[string]wasmengine.Capabilities)
+	}
+	s.lastCaps[sandboxID] = caps
+}
+
+func (s *ResidentServer) capsFor(sandboxID string) wasmengine.Capabilities {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastCaps[sandboxID]
 }
 
 func (s *ResidentServer) engine() *wasmengine.MultiInstanceEngine {
@@ -88,6 +134,11 @@ func (s *ResidentServer) Serve(conn net.Conn) error {
 		case MsgInstanceStatus:
 			eng := s.engine()
 			loaded := eng != nil && eng.Loaded()
+			if eng != nil && env.SandboxID != "" {
+				// Prefer per-sandbox liveness when a sandboxID is supplied so
+				// Inspect can detect a gone instance after host respawn.
+				loaded = eng.HasInstance(env.SandboxID)
+			}
 			body, encErr := encodePayload(instanceStatusPayload{Loaded: loaded})
 			if encErr != nil {
 				return encErr
@@ -105,38 +156,45 @@ func (s *ResidentServer) Serve(conn net.Conn) error {
 				}
 				continue
 			}
-			eng, err := s.ensureEngine(ctx, p.MemoryMB)
-			if err != nil {
-				if replyErr(env.SandboxID, err) != nil {
-					return err
-				}
-				continue
-			}
-			// A resident host is one (module, memoryMB) bucket. Loading a second,
-			// different module into it is a routing bug — reject rather than blow
-			// away the compiled module other live instances depend on.
+			// Hold the server lock across check+load so two concurrent
+			// different-path loads cannot both pass prev=="" (D8).
 			s.mu.Lock()
 			prev := s.loadedPath
-			s.mu.Unlock()
 			if prev != "" && prev != p.Path {
+				s.mu.Unlock()
 				if replyErr(env.SandboxID, fmt.Errorf("resident host already bound to %q, refusing to load %q", prev, p.Path)) != nil {
 					return err
 				}
 				continue
 			}
+			var eng *wasmengine.MultiInstanceEngine
+			var ensureErr error
+			if s.eng == nil {
+				eng, ensureErr = wasmengine.NewMultiInstanceEngine(ctx, p.MemoryMB)
+				if ensureErr != nil {
+					s.mu.Unlock()
+					if replyErr(env.SandboxID, ensureErr) != nil {
+						return err
+					}
+					continue
+				}
+				s.eng = eng
+			} else {
+				eng = s.eng
+			}
 			var timings wasmengine.LoadTimings
 			if prev != p.Path {
-				if err := eng.LoadModule(ctx, p.Path); err != nil {
-					if replyErr(env.SandboxID, err) != nil {
+				if loadErr := eng.LoadModule(ctx, p.Path); loadErr != nil {
+					s.mu.Unlock()
+					if replyErr(env.SandboxID, loadErr) != nil {
 						return err
 					}
 					continue
 				}
 				timings = eng.LastLoadTimings()
-				s.mu.Lock()
 				s.loadedPath = p.Path
-				s.mu.Unlock()
 			}
+			s.mu.Unlock()
 			body, encErr := encodePayload(loadModuleResultPayload{Timings: timings})
 			if encErr != nil {
 				return encErr
@@ -165,12 +223,15 @@ func (s *ResidentServer) Serve(conn net.Conn) error {
 				}
 				continue
 			}
+			s.bindNetworkHook(eng, env.SandboxID)
 			if err := eng.Instantiate(ctx, env.SandboxID, p.Caps); err != nil {
+				s.clearNetworkHook(eng, env.SandboxID)
 				if replyErr(env.SandboxID, err) != nil {
 					return err
 				}
 				continue
 			}
+			s.storeCaps(env.SandboxID, p.Caps)
 			if err := replyOK(env.SandboxID); err != nil {
 				return err
 			}
@@ -189,6 +250,8 @@ func (s *ResidentServer) Serve(conn net.Conn) error {
 				}
 				continue
 			}
+			s.bindNetworkHook(eng, env.SandboxID)
+			s.storeCaps(env.SandboxID, p.Caps)
 			result, runErr := eng.Run(ctx, env.SandboxID, p.Caps, p.Export)
 			if runErr != nil && result.ExitCode == 0 && result.Stderr == "" {
 				if replyErr(env.SandboxID, runErr) != nil {
@@ -216,6 +279,9 @@ func (s *ResidentServer) Serve(conn net.Conn) error {
 				}
 				continue
 			}
+			if p.Export == "" {
+				p.Export = "_start"
+			}
 			eng := s.engine()
 			if eng == nil {
 				if replyErr(env.SandboxID, fmt.Errorf("engine not loaded")) != nil {
@@ -223,8 +289,13 @@ func (s *ResidentServer) Serve(conn net.Conn) error {
 				}
 				continue
 			}
-			if err := eng.InvokeExport(ctx, env.SandboxID, p.Export); err != nil {
-				if replyErr(env.SandboxID, err) != nil {
+			s.bindNetworkHook(eng, env.SandboxID)
+			// Honor caps wall timeout (D8) — previously invoked with Background.
+			invokeCtx, cancel := wasmengine.WithInvocationDeadline(ctx, s.capsFor(env.SandboxID))
+			invokeErr := eng.InvokeExport(invokeCtx, env.SandboxID, p.Export)
+			cancel()
+			if invokeErr != nil {
+				if replyErr(env.SandboxID, invokeErr) != nil {
 					return err
 				}
 				continue
@@ -241,13 +312,40 @@ func (s *ResidentServer) Serve(conn net.Conn) error {
 					}
 					continue
 				}
+				s.clearNetworkHook(eng, env.SandboxID)
+				_, _ = s.mediator().DrainUsage(env.SandboxID)
 			}
 			if err := replyOK(env.SandboxID); err != nil {
 				return err
 			}
+		case MsgSetNetworkBlocks:
+			var p setNetworkBlocksPayload
+			if err := decodePayload(env.Payload, &p); err != nil {
+				if replyErr(env.SandboxID, err) != nil {
+					return err
+				}
+				continue
+			}
+			s.mediator().SetBlocks(env.SandboxID, p.BlockIngress, p.BlockEgress)
+			if err := replyOK(env.SandboxID); err != nil {
+				return err
+			}
+		case MsgNetstatsTick:
+			sandboxID := strings.TrimSpace(env.SandboxID)
+			u := s.netUsageFor(sandboxID)
+			sockIn, sockOut := s.mediator().DrainUsage(sandboxID)
+			body, encErr := encodePayload(netstatsResultPayload{
+				BytesIn:  u.bytesIn.Swap(0) + sockIn,
+				BytesOut: u.bytesOut.Swap(0) + sockOut,
+			})
+			if encErr != nil {
+				return encErr
+			}
+			if err := writeFrame(conn, Envelope{Type: MsgOK, SandboxID: sandboxID, Payload: body}); err != nil {
+				return err
+			}
 		default:
-			// Checkpoint/Restore, listener, network, and netstats ops are not
-			// served by a resident host in this cut.
+			// Checkpoint/Restore and listener ops are not served by a resident host.
 			if unsupported(env.SandboxID, string(env.Type)) != nil {
 				return err
 			}

--- a/pkg/wasm/worker/resident_server_test.go
+++ b/pkg/wasm/worker/resident_server_test.go
@@ -112,3 +112,57 @@ func TestResidentServer_RejectsListener(t *testing.T) {
 	}
 	time.Sleep(10 * time.Millisecond)
 }
+
+// TestResidentServer_NetworkBlocksAndNetstats confirms MsgSetNetworkBlocks /
+// MsgNetstatsTick are keyed per-sandbox (were rejected before PR-A) and that
+// Instantiate binds a hook so mediated dial works.
+func TestResidentServer_NetworkBlocksAndNetstats(t *testing.T) {
+	dir := t.TempDir()
+	modPath := wasmmod.WriteMinimalWasm(t, dir, "demo.wasm")
+	client, _ := serveResident(t)
+	if _, err := client.LoadModule("host", modPath, 0); err != nil {
+		t.Fatalf("LoadModule: %v", err)
+	}
+	caps := nonListenCaps("wasm")
+	if err := client.Instantiate("sb-net", caps); err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	if err := client.SetNetworkBlocks("sb-net", false, true); err != nil {
+		t.Fatalf("SetNetworkBlocks: %v", err)
+	}
+	in, out, err := client.NetstatsTick("sb-net")
+	if err != nil {
+		t.Fatalf("NetstatsTick: %v", err)
+	}
+	if in != 0 || out != 0 {
+		t.Fatalf("netstats = (%d,%d), want (0,0)", in, out)
+	}
+	if err := client.StopInstance("sb-net"); err != nil {
+		t.Fatalf("StopInstance: %v", err)
+	}
+}
+
+// TestResidentServer_LoadModuleConcurrentDistinctPathsKeepsOneModule guards the
+// D8 check-then-load race: two concurrent different-path loads must not both
+// pass prev=="" — one wins, the other is refused.
+func TestResidentServer_LoadModuleConcurrentDistinctPathsKeepsOneModule(t *testing.T) {
+	dir := t.TempDir()
+	a := wasmmod.WriteMinimalWasm(t, dir, "a.wasm")
+	b := wasmmod.WriteMinimalWasm(t, dir, "b.wasm")
+	client, _ := serveResident(t)
+
+	errCh := make(chan error, 2)
+	go func() { _, err := client.LoadModule("host", a, 0); errCh <- err }()
+	go func() { _, err := client.LoadModule("host", b, 0); errCh <- err }()
+	var ok, fail int
+	for i := 0; i < 2; i++ {
+		if err := <-errCh; err != nil {
+			fail++
+		} else {
+			ok++
+		}
+	}
+	if ok != 1 || fail != 1 {
+		t.Fatalf("concurrent distinct loads: ok=%d fail=%d, want 1/1", ok, fail)
+	}
+}

--- a/plans/wasm-resident-module-host.md
+++ b/plans/wasm-resident-module-host.md
@@ -480,6 +480,30 @@ compile.
   conservative over-count (treat each resident instance as full `memoryMB`) and
   refine later.
 
+**IMPLEMENTED 2026-07-17 (PR-C).**
+- **Idle-TTL reaper** — `Driver.RunResidentReaper` (daemon goroutine, gated by
+  the flag; stops on ctx cancel) scans every `SB_WASM_RESIDENT_HOST_IDLE_TTL/4`
+  (clamped 5s–1m; default TTL 5m, 0 disables) and `reapIdleResidentHosts` tears
+  down any host with `live==0` idle ≥ TTL. Pre-warmed standard-module hosts are
+  `pinned` (set when `ensureResidentHost` runs with `reserve=false`) and never
+  reaped. Idle tracking: `residentHost.idleSince` set when `releaseResidentSlot`
+  drops `live` to 0, cleared on the next reserve. Buckets use a **monotonic
+  `nextIndex`** so a reaped-then-respawned host can't collide sockets. Selection
+  is under `bucket.mu` (a concurrent create that takes the host wins and it's
+  kept); `supervisor.Stop` runs outside the lock. Tests:
+  `TestResidentReaperReapsIdleHost`, `TestResidentReaperKeepsPinnedAndActive`.
+- **`MAX_INSTANCES`** — shipped in PR-A (`SB_WASM_RESIDENT_HOST_MAX_INSTANCES`,
+  default 32, spill-to-second-host).
+- **Capacity — conservative + observability** (D-decision 2026-07-17). No
+  admission-path change: each sandbox is already admitted at full `memoryMB` (an
+  over-count that cushions the guest's actual linear memory), and the shared
+  per-bucket base (compiled image + runtime) is treated as uncounted headroom
+  operators reserve via `MemoryFloorRatio`/`MemoryReservationRatio`. To make that
+  sizeable, `Driver.ResidentHostStats` (buckets/hosts/instances) is published as
+  the `aerolvm_wasm_resident_hosts` expvar (test `TestResidentHostStats`). Exact
+  per-bucket-base reservation via a driver→`pkg/capacity` seam is deferred until
+  a real deployment shows the base RAM bites.
+
 ### Test plan (eng-review 2026-07-17)
 
 **PR-A (egress isolation) — offline, 100% of new branches:**
@@ -530,9 +554,11 @@ resident instance's host-shared cost.
   (default 32; spill to `<bucket>-2.sock` when full). Still default-off after this.
 - **PR-B — migrate-on-expose.** `internal/runtime/wasm/guest_http.go` +
   `resident.go` + tests.
-- **PR-C — host lifecycle + capacity.** idle-TTL reaper + `pkg/capacity`
-  host-shared RAM accounting + `internal/config/config.go` (idle-TTL env) + tests.
-  (`MAX_INSTANCES` shipped in PR-A.)
+- **PR-C — host lifecycle + capacity. DONE 2026-07-17.** idle-TTL reaper
+  (`RunResidentReaper` + `SB_WASM_RESIDENT_HOST_IDLE_TTL`, pinned prewarm hosts,
+  monotonic host index) + conservative capacity stance with the
+  `aerolvm_wasm_resident_hosts` expvar footprint metric + tests.
+  (`MAX_INSTANCES` shipped in PR-A; exact Admitter reservation deferred.)
 - **Flag flip** (`SB_WASM_RESIDENT_HOST_ENABLED` default → true) is a **4th,
   separate** change, only after A+B+C land and the live CPython bench is green.
 

--- a/plans/wasm-resident-module-host.md
+++ b/plans/wasm-resident-module-host.md
@@ -446,6 +446,20 @@ window + a rollback that can itself fail), and routing every possibly-exposing
 create to cold up front (defeats the latency win — private-by-default means
 almost everything could expose).
 
+**IMPLEMENTED 2026-07-17.** `Driver.migrateResidentToCold` (`resident.go`) does
+the cold-up-then-stop dance (spawn dedicated worker → waitWorker → LoadModule →
+Instantiate listener-disabled → then StopInstance on the resident host +
+`releaseResidentSlotFor` + flip `socketPath`/`workerKey`/`fromResidentHost` +
+`noteWorkerSpawnCount`); a cold-bring-up failure Stops the half-spawned worker
+and leaves the sandbox resident. `SyncGuestListenPorts` (`guest_http.go`) calls
+it before the listener sync when the sandbox is `fromResidentHost` and the
+request enables a listener (an unexpose on a still-resident sandbox is a no-op).
+Tests: `resident_test.go` `TestMigrateResidentToCold` (routing flip + slot
+release + resident stop) and `TestExposeMigrationFailureLeavesResident`
+(cold-instantiate failure keeps the sandbox resident, slot retained, error
+surfaced). Not on the `CreateSandbox` boot path; first expose pays one cold
+compile.
+
 ### 3. Host lifecycle + capacity (PR-C)
 
 - **Idle-TTL reaper.** A resident host with `InstanceCount()==0` for

--- a/plans/wasm-resident-module-host.md
+++ b/plans/wasm-resident-module-host.md
@@ -128,8 +128,12 @@ process." What still isolates co-tenants:
 
 - **Per-instance linear memory** — wazero gives each `InstantiateModule` its own
   memory; no shared memory unless explicitly configured (we don't).
-- **Per-instance memory cap** (`MemoryLimitPages`) and **fuel metering** bound a
-  single instance's resource use.
+- **Per-instance memory cap** (`MemoryLimitPages`) bounds a single instance's
+  memory. CPU-bound guests are bounded by **wall-clock cancellation**
+  (`WithInvocationDeadline`), NOT fuel — fuel accounting is wasmtime-only in this
+  codebase (Codex, eng-review 2026-07-17), so the resident (wazero) host relies
+  on the invocation deadline for CPU bounding. See the co-tenancy deadline
+  hardening in Phase 2b.
 - **Bounded instances per host** (`SB_WASM_RESIDENT_HOST_MAX_INSTANCES`) caps the
   blast radius and lets the pool spread load across host processes.
 
@@ -200,23 +204,19 @@ listener Instantiate is rejected.
 **Scope limit (unchanged):** resident-host mode serves **non-listen** sandboxes
 only; `expose_port`/HTTP guests fall back to the cold per-process path.
 
-**Remaining Phase 2 (eng-review-gated): per-instance egress isolation.** The
-engine's `wazeroNetHost` (`wazero_network.go`) holds ONE hook + a GLOBAL conn
-table, read by all three WASI host modules at call time. Co-tenancy needs it
-keyed by `mod.Name()` (= sandboxID, since instances are named) plus conn
-ownership so guest B can't touch guest A's socket. Until that lands, resident
-instances get base WASI + FS only (no mediated egress), so networking modules
-are not yet served here. This is the security-sensitive change that must go
-through review.
+**Phase 2 remainder (per-instance egress isolation) — IMPLEMENTED 2026-07-17
+(PR-A).** `multiNetHost` keys hooks + conns by `mod.Name()`; ResidentServer binds
+a per-sandbox `NetworkHook` via `NetMediator`. See Phase 2b §1.
 
 ### Config (Phase 3) — flag IMPLEMENTED 2026-07-15
 
 - `SB_WASM_RESIDENT_HOST_ENABLED` (bool, **default false**) → `cfg.WasmResidentHostEnabled`
   (`internal/config/config.go`). Gates the whole path; false = today's behavior
   exactly. **DONE.**
-- `SB_WASM_RESIDENT_HOST_MAX_INSTANCES` (int, per-host cap) — TODO with the
-  routing below.
-- Interplay with `SB_WASM_POOL_ENABLED` + `setup/config-defaults.md` — TODO.
+- `SB_WASM_RESIDENT_HOST_MAX_INSTANCES` (int, per-host cap, default 32) —
+  **DONE in PR-A** (spill to `<bucket>-2.sock` when full).
+- Interplay with `SB_WASM_POOL_ENABLED` + `setup/config-defaults.md` — TODO
+  (PR-C / docs).
 
 ### Pool + driver routing (Phase 3b) — IMPLEMENTED 2026-07-15 (gated, offline-tested)
 
@@ -255,16 +255,272 @@ takes the cold path.
 This also sidesteps the miss/refill race in `project_wasm_create_latency`: no
 separate per-sandbox cold spawn to race — creates instantiate into a resident host.
 
-**Remaining before the flag can flip ON (eng-review-gated):**
-- **Per-instance egress isolation** — resident instances currently get base
-  WASI + FS only; wasi-sockets/http egress needs the net host keyed by
-  `mod.Name()` + conn ownership (see Phase 2 note). Until then, networking
-  modules (likely CPython) aren't served by the resident host, so the live
-  CPython cold-load win still can't be benched.
-- **expose_port after create** on a private resident sandbox errors (resident
-  host rejects listeners). Document, or migrate-to-cold-on-expose.
-- **Host lifecycle**: idle-TTL teardown of resident hosts, capacity/admission
-  accounting for host-shared RAM, `SB_WASM_RESIDENT_HOST_MAX_INSTANCES` cap.
+**Remaining before the flag can flip ON (eng-review-gated) — designed in Phase 2b below:**
+- **Per-instance egress isolation** — **DONE (PR-A, 2026-07-17).**
+- **expose_port after create** on a private resident sandbox — PR-B (migrate-on-expose).
+- **Host lifecycle**: idle-TTL teardown + capacity/admission accounting — PR-C
+  (`SB_WASM_RESIDENT_HOST_MAX_INSTANCES` shipped in PR-A).
+
+## Phase 2b — egress isolation + expose + capacity (design, 2026-07-17, eng-review)
+
+The three items above are what stand between "shipped, default-off" and "safe to
+flip the default on." They are independent workstreams and ship as **three
+stacked PRs** (see staging at the end). Item 1 is the only security-sensitive
+one and gates the other two.
+
+### 1. Per-instance egress isolation (PR-A, the blocker)
+
+**The gap.** Outbound TCP for a wasip1 guest goes through the custom
+`aerol/vm/net` host module (`tcp_dial`/`tcp_read`/`tcp_write`/`tcp_close`) — NOT
+wasip1 sockets (wasi-preview1 has no outbound `sock_connect`; only
+accept/recv/send on an already-listening fd, which resident-host mode doesn't
+serve). That host module lives in `wazeroNetHost` (`pkg/wasm/wazero_network.go`),
+which today holds **one** `hook *NetworkHook` and **one global**
+`conns map[uint64]net.Conn`. It is correct for the single-instance engine (one
+sandbox per process) and is **not instantiated at all** on `MultiInstanceEngine`,
+so resident instances get base WASI + FS only.
+
+Two things break if we naively instantiate the existing host on the shared
+runtime: (a) one hook can't represent N co-tenant sandboxes' dialers/meters, and
+(b) a global conn table lets guest B pass a `conn_id` that belongs to guest A and
+read/write A's socket — a cross-tenant data leak.
+
+**The fix — key everything by `mod.Name()`.** `MultiInstanceEngine.Instantiate`
+already sets `WithName(sandboxID)` (engine_multi.go:131), so every host-function
+call carries the caller's identity in `mod.Name()`. A new multi-tenant net host:
+
+```
+                     one resident runtime, one "aerol/vm/net" host module
+                     ┌───────────────────────────────────────────────────┐
+ guest A (mod.Name   │  tcp_dial(mod, addr):                              │
+   = "sbx-A") ───────┼─►  sid := mod.Name()          // "sbx-A"           │
+                     │    hook := hooks[sid]          // A's dialer+meter  │
+ guest B (mod.Name   │    if hook==nil||blocked → errBlocked              │
+   = "sbx-B") ───────┼─►  conn := hook.Dial(addr)     // A's NetMediator   │
+                     │    id := nextID++                                  │
+                     │    conns[sid][id] = conn      // OWNED by sbx-A     │
+                     │                                                     │
+                     │  tcp_read(mod, id, buf):                           │
+                     │    sid := mod.Name()                               │
+                     │    conn := conns[sid][id]     // B can't see A's id │
+                     │    if conn==nil → errClosed                        │
+                     │    n := conn.Read(buf); hooks[sid].Meter.AddIn(n)  │
+                     └───────────────────────────────────────────────────┘
+   hooks:  map[sandboxID]*NetworkHook          (per-tenant dialer + meter)
+   conns:  map[sandboxID]map[uint64]net.Conn   (per-tenant conn table = ownership)
+```
+
+- `hooks map[string]*NetworkHook` replaces the single `hook`. Every host fn reads
+  `mod.Name()` and looks up that sandbox's hook; a missing hook → `errBlocked`
+  (fail closed, never fall through to another tenant's dialer).
+- `conns map[string]map[uint64]net.Conn` replaces the global table. A `conn_id`
+  is only resolvable inside its owner's inner map, so B passing A's id finds
+  nothing → `errClosed`. This is the conn-ownership guarantee, enforced by data
+  structure, not by a check that can be forgotten.
+- Bytes meter through `hooks[sid].Meter` (per-tenant), so `NetstatsTick` stays
+  per-sandbox.
+
+The single-instance `wazeroEngine` keeps its existing one-hook host untouched
+(it is correct there and flag-off must stay byte-for-byte identical). The
+multi-tenant host is a **new type** (`multiNetHost` in a new
+`pkg/wasm/engine_multi_network.go`), instantiated lazily on the resident runtime
+the first time any instance binds a hook. `MultiInstanceEngine` gains
+`SetNetworkHook(sandboxID, *NetworkHook)` / `ClearNetworkHook(sandboxID)`
+mirroring `NetworkAwareEngine`.
+
+**Decisions locked (eng-review 2026-07-17):**
+- **Bucket by `(ownerRef, digest, memoryMB)`, not just `(digest, memoryMB)`**
+  (D7 — AerolVM is SaaS + multi-tenant, [[project_saas_multitenant]], not only
+  self-hosted). When a create carries a **non-operator `OwnerRef`** (control-plane
+  resolved — `models.Sandbox.OwnerRef` / `ownerRefForCreate(ctx)`), the owner is
+  mixed into `residentBucketID`, so a customer's sandboxes never co-locate in one
+  process with another customer's — no cross-customer socket/blast-radius sharing.
+  An **empty/operator `OwnerRef`** (the only case on the open-source build) keeps
+  today's fully-shared global bucket, preserving max compile amortization for the
+  self-hosted case. This is **in code, not docs** — `ownerRef` is a real
+  dimension of `residentBucketID`. Wiring: thread `ownerRef` into the wasm
+  `Driver.Create` path (the 4th `Create` arg is currently unused `_ string`, or
+  read it from the create ctx as `ownerRefForCreate` does).
+- **Conn ownership = structural nested map** `conns map[sandboxID]map[uint64]net.Conn`
+  (D3-A). A `conn_id` is unresolvable outside its owner's inner map, so a
+  cross-tenant read is unrepresentable, not merely guarded. `nextID` stays a
+  global atomic (ids are unscoped-unusable, need not be secret).
+- **DRY the socket body** (D5-A): factor `conn.Read`/`Write` + meter +
+  error-mapping into a helper taking an already-resolved `(conn, meter)`; the
+  single-instance host and `multiNetHost` differ ONLY in the resolve step
+  (one field vs `mod.Name()` lookup). Security logic stays single-sourced.
+- **Thread the invocation deadline into the dial** (D6-A): pass the host-fn
+  call's ctx into `DialContext` instead of `context.Background()`, in BOTH the
+  multi host and the existing single host (`wazero_network.go:106`, same one-line
+  bug). Bounds a dial by min(invocation deadline, 30s dialer timeout).
+- Missing hook or blocked egress → `errBlocked` (**fail closed**); never fall
+  through to another tenant's dialer.
+
+**Worker wiring** (`resident_server.go`) mirrors the single-instance `Server`,
+which already has all the per-sandbox pieces:
+- `ResidentServer` gets its own `*NetMediator` (already sandboxID-keyed:
+  `SetBlocks`/`DrainUsage`/`DialContext` all take a sandboxID).
+- `MsgInstantiate` → after `eng.Instantiate`, bind
+  `eng.SetNetworkHook(sandboxID, &NetworkHook{SandboxID: sandboxID,
+  Dial: mediatorDialer{m, sandboxID}, Meter: workerByteMeter{usageFor(sandboxID)}})`
+  — identical to `Server.bindNetworkHook`, just keyed.
+- `MsgSetNetworkBlocks` → `mediator().SetBlocks(sandboxID, …)` (was rejected).
+- `MsgNetstatsTick` → `mediator().DrainUsage(sandboxID)` (was rejected).
+- `MsgStopInstance` → `eng.ClearNetworkHook(sandboxID)` + drop mediator usage.
+
+Once wired, the driver's existing egress-policy plumbing (the service layer
+sends `SetNetworkBlocks` after create) flows to resident sandboxes unchanged, so
+the `createOnResidentHost` caps no longer need to be networking-stripped.
+
+**Residual co-tenancy risk to enumerate:** a single mutex guards `hooks`/`conns`
+lookups (released before the blocking `conn.Read`/`Write`, so no head-of-line
+blocking across tenants). A panic inside a host fn still runs on the shared
+process (existing co-tenancy risk, already documented). A hung dial is bounded
+by `NetMediator`'s 30s dialer timeout, but note `tcp_dial` currently dials with
+`context.Background()` (wazero_network.go:106) — it ignores the invocation
+deadline. Pre-existing, but worth fixing under co-tenancy so one tenant's slow
+dial can't pin a goroutine indefinitely.
+
+### 1b. Co-tenancy correctness hardening (PR-A, D8 — from Codex outside voice)
+
+Shared-process correctness that a naive multi-tenant net host would miss. All in
+PR-A because the flag flip depends on them.
+
+- **Per-instance call/lifecycle lock or refcount.** `MultiInstanceEngine.InvokeExport`
+  (engine_multi.go:215) releases the engine lock before `fn.Call`, while
+  `StopInstance`/`Run` can `Close`/replace the same `api.Module` concurrently →
+  use-after-close. Add a per-instance guard (refcount or per-instance mutex) so a
+  Stop waits for in-flight calls (or cancels them) and a call sees a stable
+  module. **Plus a stress test** proving wazero permits parallel `Call` across
+  *different* modules on one runtime under load (the design's core unproven
+  assumption).
+- **Connection cleanup on teardown.** `StopInstance`, `Run` (which drops+replaces
+  the module at engine_multi.go:162), and `ClearNetworkHook(sid)` must **close +
+  delete `conns[sid]`**. This frees sockets AND is the lever that unblocks a
+  pinned `tcp_read`/`tcp_write` (closing the conn makes the blocked Read return)
+  — so it doubles as the fix for reads/writes having no deadline (D6 only covered
+  dial).
+- **Resident `MsgInvoke` invocation deadline.** `resident_server.go` calls
+  `eng.InvokeExport(ctx, …)` with `ctx=context.Background()` (resident_server.go:56)
+  — no deadline, unlike the single-instance `Server` which wraps invoke with
+  `WithInvocationDeadline`. Bug in already-merged code; fix here. (`MsgExec` is
+  fine — `Run` wraps it internally.)
+- **Respawn / idempotency hardening (P2, merged-code gaps):**
+  - `refreshWorkerInstanceState` short-circuits `fromResidentHost` instances
+    without checking host liveness (driver.go:137) → after a host crash,
+    `Inspect`/`List` report `started` for gone instances. Verify the host socket
+    (or a generation token) for resident instances.
+  - `ensureResidentHost` skips health/load when `bucket.ready` (resident.go:81);
+    if the supervisor restarted the host behind the same socket, `ready` is stale
+    until an instantiate fails. Health-check (Ping + `InstanceStatus.Loaded`) on
+    reuse, or track a host generation.
+  - `ResidentServer.LoadModule` reads `loadedPath` unlocked then loads then writes
+    it — two concurrent different-path loads can both pass `prev==""`. Hold the
+    lock across check+load (or single-flight per path in the server), so the
+    one-module-per-host invariant holds even without the driver single-flight.
+
+### 2. expose_port after create (PR-B)
+
+With private-by-default (`project_private_by_default`), a normal create is
+private → routes to the resident host, and the caller exposes a port **later**.
+The resident host can't add a wasip1 listener to an already-instantiated shared
+runtime (the listener is configured per-instance via `experimentalsock.WithConfig`
+at instantiate time, engine_wazero.go withNetworkContext). So expose-after-create
+on a resident sandbox is **the normal flow now, not a rare edge** — a plain error
+is not acceptable.
+
+**Design: migrate-on-expose, cold-up-then-stop-resident (D4-A, eng-review
+2026-07-17).** When `expose_port` (→ `SyncGuestListenPorts`,
+`internal/runtime/wasm/guest_http.go:20`) hits a `fromResidentHost` sandbox:
+1. Instantiate the sandbox on a **fresh cold per-process worker WITH** the
+   listener config, preserving sandboxID + workDir + env + digest.
+2. Only after the cold instance is confirmed up, `StopInstance` on the resident
+   host and flip `inst.fromResidentHost=false` + `inst.socketPath` to the cold
+   worker.
+There is **no window with zero instances**: if step 1 fails, the resident copy
+is still serving and expose returns an error (failure-path consistency,
+pr-review §4). Costs a bit of transient RAM during the swap. The first expose
+pays a cold `wasm_load` once (acceptable — expose is not the hot create path);
+subsequent traffic is normal. Rejected: stop-then-recreate (real zero-instance
+window + a rollback that can itself fail), and routing every possibly-exposing
+create to cold up front (defeats the latency win — private-by-default means
+almost everything could expose).
+
+### 3. Host lifecycle + capacity (PR-C)
+
+- **Idle-TTL reaper.** A resident host with `InstanceCount()==0` for
+  `SB_WASM_RESIDENT_HOST_IDLE_TTL` (default e.g. 5m) is torn down to reclaim RAM
+  (a bucket holds the ~25MB compiled image + runtime resident). Boot pre-warm
+  re-creates standard-module hosts, so the reaper must not fight pre-warm — skip
+  reaping pre-warmed standard-module buckets, or let pre-warm re-spawn on next
+  demand. Reaper is a ticker goroutine on the driver, gated by the flag.
+- **`SB_WASM_RESIDENT_HOST_MAX_INSTANCES`.** Cap instances per host process; when
+  a bucket's host is full, spawn a second host for the same bucket
+  (`<bucket>-2.sock`) and route there. Bounds blast radius per the isolation
+  section.
+- **Capacity/admission.** `pkg/capacity` Admitter models per-sandbox RAM. A
+  resident bucket's cost is `compiled image + runtime` **once per bucket** plus
+  per-instance linear memory (≤ `memoryMB`). The admitter needs a host-shared
+  cost model so it doesn't over- or under-count resident instances. This is the
+  fuzziest item; if it can't be made correct quickly, gate the flag flip on a
+  conservative over-count (treat each resident instance as full `memoryMB`) and
+  refine later.
+
+### Test plan (eng-review 2026-07-17)
+
+**PR-A (egress isolation) — offline, 100% of new branches:**
+- `pkg/wasm/engine_multi_network_test.go`:
+  - **★★★ IRON-RULE isolation regression (security boundary + fragile area):**
+    two co-tenant instances on one `MultiInstanceEngine`; A dials → conn_id; B
+    `tcp_read`/`tcp_write`/`tcp_close` with A's conn_id → `errClosed`, A's conn
+    stays usable. Proves the cross-tenant deny the whole PR exists for.
+  - per-tenant metering attribution (A's bytes ≠ B's bytes);
+  - `SetBlocks(A)` blocks A's egress, B still dials (per-tenant policy);
+  - fail-closed: no hook / blocked → `errBlocked`;
+  - `ClearNetworkHook(A)` leaves B's networking live;
+  - dial honors the invocation deadline (D6-A) — a canceled ctx aborts the dial.
+- `pkg/wasm/worker/resident_server_test.go` (extend): `MsgSetNetworkBlocks` /
+  `MsgNetstatsTick` now succeed keyed per-sandbox (were rejected);
+  `MsgInstantiate` binds a hook so a dial works; `MsgStopInstance` clears it.
+- `internal/runtime/wasm/resident_test.go` (extend): `createOnResidentHost` caps
+  no longer strip networking; `Driver.SetNetworkBlocks` on a `fromResidentHost`
+  sandbox reaches the bucket socket and is honored; a **non-operator `OwnerRef`
+  buckets to a distinct host** from the operator/empty case (D7); host-crash →
+  `refreshWorkerInstanceState` no longer reports a gone instance as `started`.
+- Correctness cluster (D8): **concurrency stress test** — N goroutines
+  Instantiate/Invoke/StopInstance across distinct sandboxIDs on one
+  `MultiInstanceEngine` with `-race`, asserting no use-after-close and that
+  parallel `Call`s across modules actually run; conn cleanup — `StopInstance`
+  closes owned conns and a blocked `tcp_read` returns; `MsgInvoke` respects the
+  invocation deadline; `LoadModule` two-concurrent-different-paths keeps one
+  module.
+- **Live (Phase 4, `[→E2E]`):** CPython egress on the resident host,
+  `make integration-benchmark-wasm` on `cluster-3-mixed-wasm` — the win that
+  couldn't be benched until egress works.
+
+**PR-B (migrate-on-expose):** `expose_port` on a `fromResidentHost` sandbox
+migrates to cold + listener works; cold-create failure leaves the resident copy
+serving + returns an error (no zero-instance window); idempotent re-expose.
+
+**PR-C (lifecycle):** idle-TTL reaps a 0-instance host but NOT a pre-warmed
+standard bucket; `MAX_INSTANCES` spills to a second host; admitter counts a
+resident instance's host-shared cost.
+
+### Staging (3 stacked PRs)
+
+- **PR-A — egress isolation + hard cap** — **IMPLEMENTED 2026-07-17**.
+  `pkg/wasm/engine_multi_network.go` (new), `engine_multi.go`,
+  `wazero_network.go` (shared helper + dial-ctx), `worker/resident_server.go`,
+  `internal/runtime/wasm/resident.go` (+ owner bucketing + max-instances spill +
+  host liveness) + tests. **Includes `SB_WASM_RESIDENT_HOST_MAX_INSTANCES`**
+  (default 32; spill to `<bucket>-2.sock` when full). Still default-off after this.
+- **PR-B — migrate-on-expose.** `internal/runtime/wasm/guest_http.go` +
+  `resident.go` + tests.
+- **PR-C — host lifecycle + capacity.** idle-TTL reaper + `pkg/capacity`
+  host-shared RAM accounting + `internal/config/config.go` (idle-TTL env) + tests.
+  (`MAX_INSTANCES` shipped in PR-A.)
+- **Flag flip** (`SB_WASM_RESIDENT_HOST_ENABLED` default → true) is a **4th,
+  separate** change, only after A+B+C land and the live CPython bench is green.
 
 ### Validation (Phase 4)
 
@@ -295,3 +551,19 @@ enumeration gate the default flip.
 - Memory accounting for admission control (`pkg/capacity`) — a resident host's
   RAM is shared across instances; the admitter's per-sandbox model needs to
   understand host-shared cost.
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | — |
+| Codex Review | `/codex review` | Independent 2nd opinion | 1 | issues_found | 13 findings, all folded/resolved |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | clean | 6 issues, 0 critical gaps |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | — |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | — |
+
+- **CODEX:** 13 findings. P1 cluster (per-instance call/lifecycle lock + refcount + parallel-call stress test, conn cleanup on teardown, `MsgInvoke` invocation deadline) + P2 respawn hardening (host-liveness in `refreshWorkerInstanceState`, `bucket.ready` health-check, `LoadModule` check-then-load race) all folded into PR-A (D8). Fuel-framing doc corrected (wazero = wall-time only).
+- **CROSS-MODEL:** two tensions, both resolved. Sharing granularity → bucket by `(ownerRef, digest, memoryMB)` (multi-tenant SaaS isolation, operator/empty keeps global bucket). Capacity sequencing → `MAX_INSTANCES` moved from PR-C into PR-A. No residual disagreement.
+- **VERDICT:** ENG CLEARED — design locked across PR-A (egress isolation + hard cap + co-tenancy correctness), PR-B (migrate-on-expose), PR-C (idle-TTL + capacity), then a separate flag flip. **PR-A implemented 2026-07-17;** next is PR-B.
+
+NO UNRESOLVED DECISIONS


### PR DESCRIPTION
## What this does (in plain terms)

AerolVM runs code sandboxes. For WASM sandboxes (e.g. Python), the slow part is
the **first start** — preparing the code image takes ~2.5 seconds. We built a
faster mode ("resident host") that prepares the image **once** and reuses it, so
a sandbox starts in **~20ms instead of ~2.5s (roughly 100× faster)**.

The catch: that fast mode packs **many sandboxes into one shared process** to get
the reuse. Before we can safely turn it on — especially for our **multi-tenant
SaaS**, where different customers' sandboxes could land on the same shared host —
we had to make that sharing safe and self-managing. **This PR is that safety +
lifecycle work.**

## Why it matters

- **Speed:** ~2.5s → ~20ms cold starts → a much snappier experience for AI agents
  and CI workloads.
- **Cost:** one prepared image serves many sandboxes → far lower cost per
  sandbox, which is central to the SaaS unit economics.
- **Trust:** different customers never share a process, and no sandbox can see
  another's network traffic.

## Is anything changing for users right now?

**No.** This ships **turned OFF**. Current behavior is untouched. It only takes
effect after two later, deliberate steps: a live test, then flipping the switch.
So this PR is zero-risk to merge.

## What we made safe / self-managing (three pieces)

1. **Network isolation between neighbors.** On a shared host, each sandbox's
   internet access is kept separate, measured, and policy-controlled — one
   sandbox cannot touch another's connections. (This also unblocks running
   Python, which needs networking, in the fast mode.)
2. **"Expose a port" keeps working.** If a sandbox on the shared host later needs
   its own public port/URL, we seamlessly move it onto its own dedicated process
   with **no moment where it's down**. If that move ever fails, the sandbox keeps
   running where it was.
3. **Automatic cleanup + visibility.** A shared host that goes idle frees its
   memory automatically after a timeout; the always-hot standard languages
   (Python, etc.) stay ready. Operators get a metric showing how many shared
   hosts are running so they can size memory.

## What's left before it's actually on

1. **Merge this PR.**
2. **Run one live performance/safety test** in the cloud (confirms the speed win
   holds and networking is safe). Uses real infrastructure, so it's a deliberate,
   cost-aware step.
3. **Flip the switch** (a one-line default change) once the test passes.

---

## Engineering details

Implements PR-A/B/C of `plans/wasm-resident-module-host.md` (Phase 2b). Three
commits: egress isolation, migrate-on-expose, idle-TTL reaper + capacity.
Default-off (`SB_WASM_RESIDENT_HOST_ENABLED` unchanged); flag-off is a
byte-for-byte no-op on the existing per-sandbox path.

### Code-path diagrams (pr-review §8)

**Create routing (delta + rollback branch):**

```mermaid
flowchart TD
    C["CreateSandbox (wasm)"] --> F{"resident flag ON<br/>AND not public-expose<br/>AND digest known?"}
    F -->|"no — default / flag OFF (UNCHANGED)"| COLD["per-sandbox cold worker:<br/>spawn + compile + instantiate"]
    F -->|"yes — NEW"| OWN["ownerRef from ctx<br/>bucket = hash(ownerRef, digest, memoryMB)"]
    OWN --> H{"host in bucket<br/>under MAX_INSTANCES?"}
    H -->|"reuse (lazy health-check)"| INST["Instantiate(sandboxID)<br/>+ bind per-tenant net hook<br/>+ reserve live slot"]
    H -->|"full / none — spawn (monotonic index) + compile once"| INST
    INST --> OK{"instantiate ok?"}
    OK -->|yes| STARTED["Started · slot held"]
    OK -->|"no — FAILURE"| RB["rollback: host.ready=false ·<br/>release slot · delete byID · rm workDir"]
```

**Migrate-on-expose (cold-up-then-stop; failure keeps sandbox resident):**

```mermaid
flowchart TD
    E["expose_port → SyncGuestListenPorts"] --> R{"fromResidentHost?"}
    R -->|"no — already cold (UNCHANGED)"| SYNC["install wasip1 listener"]
    R -->|"yes — NEW"| CU["1) cold worker: spawn → compile →<br/>Instantiate (listener-disabled)"]
    CU --> CUOK{"cold instance up?"}
    CUOK -->|"no — FAILURE"| STAY["Stop the half-spawned cold worker ·<br/>sandbox STAYS resident · return error<br/>(no zero-instance window)"]
    CUOK -->|yes| SW["2) StopInstance on resident host ·<br/>release slot · flip socket/workerKey/<br/>fromResidentHost=false"]
    SW --> SYNC
```

**Per-tenant egress on the shared host (cross-tenant deny + fail-closed):**

```mermaid
sequenceDiagram
    participant A as Guest A (mod.Name=sbx-A)
    participant H as multiNetHost (shared process)
    participant B as Guest B (mod.Name=sbx-B)
    A->>H: tcp_dial(addr)
    Note over H: hook = hooks[sbx-A]<br/>nil → errBlocked (fail closed)
    H-->>A: conn_id=id (stored in conns[sbx-A][id])
    B->>H: tcp_read(id)  [B guesses A's conn_id]
    Note over H: conns[sbx-B][id] not found
    H-->>B: errClosed — cross-tenant DENY
```

**Idle-TTL reaper (keep-branches shown):**

```mermaid
flowchart TD
    T["reaper tick (every TTL/4)"] --> L{"per host"}
    L -->|"!pinned AND live==0 AND idle ≥ TTL"| REAP["remove from bucket ·<br/>supervisor.Stop · rm socket"]
    L -->|"pinned (pre-warmed)"| K1["keep — always hot"]
    L -->|"live > 0"| K2["keep — active"]
```

**Isolation mechanism:** co-tenant net host keyed by `mod.Name()` with a
structural nested conn map (a tenant can't resolve another's conn_id); buckets
keyed by hashed `(ownerRef, digest, memoryMB)` so distinct owners never co-locate;
fail-closed egress; per-instance call/lifecycle lock (no use-after-close);
conn-cleanup unblocks a pinned read; `SB_WASM_RESIDENT_HOST_MAX_INSTANCES` cap +
spill. Incorporates 7 fixes from the eng-review + Codex adversarial pass.

**pr-review.md axes:** §1 idempotency — resident create is retry-safe (old
instance torn down on its own host before re-reserve) and expose is idempotent;
§2 boot-path latency — no new work on `CreateSandbox` for the default path
(byte-for-byte unchanged); migrate adds one compile at expose (off the create
path); prewarm/reaper are backgrounded goroutines; §4 failure-path — migrate is
cold-up-then-stop (cold failure leaves the resident copy serving), create rolls
back slot + `byID` + workDir on failure; cluster — node-local, no FSM/gossip
change, no-op when `EnableCluster` is false.

**Testing:** `make test` (offline) green across `internal/runtime/wasm`,
`internal/config`, `pkg/daemon`, `pkg/wasm`; resident/engine code `-race` clean;
fragile-area regression tests added (cross-tenant isolation, parallel-call race
stress, conn cleanup, LoadModule race, bucket no-collision, retry-no-orphan, MAX
spill, migrate happy + failure, reaper reaps-idle/keeps-pinned, stats). Two
pre-existing `-race` failures (`TestClient_ContextErrors_Blocks`,
`TestTinygoHTTPModuleRequest`) are unrelated to this diff.

**Follow-ups (not in this PR):** flip the flag after the live CPython egress bench
(`make integration-benchmark-wasm` on `cluster-3-mixed-wasm`); exact per-bucket
memory-admission reservation (conservative accounting + the
`aerolvm_wasm_resident_hosts` metric ship here; the exact model is deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
