### PR TITLE
test(isolate): AWS integration-harness coverage + create-latency benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GO ?= go
 BIN_DIR ?= bin
 
 .PHONY: fmt install-git-hooks test test-acme-e2e build build-sandboxd build-toolboxd docs-install docs-dev docs-build clean \
-	integration-local integration-single integration-single-containerd integration-single-wasm integration-cluster-mixed integration-cluster-mixed-docker integration-cluster-mixed-containerd integration-cluster-mixed-wasm \
+	integration-local integration-single integration-single-containerd integration-single-wasm integration-single-isolate integration-cluster-mixed integration-cluster-mixed-docker integration-cluster-mixed-containerd integration-cluster-mixed-wasm \
 	integration-cluster-mixed-fc integration-cluster-mixed-gvisor integration-cluster-hetero integration-cluster-hetero-safe \
 	integration-benchmark integration-benchmark-only integration-benchmark-docker integration-benchmark-docker-only \
 	integration-benchmark-docker-sparse \
@@ -105,6 +105,14 @@ integration-single-containerd:
 # Smallest scenario that exercises the wasm-runtime use cases.
 integration-single-wasm:
 	integration-tests/run.sh single-node-wasm $(RUN_FLAGS)
+
+# Single-node with the V8-isolate (workerd) runtime enabled. Driven entirely by
+# default_with_isolate=true in single-node-isolate.tfvars (install.sh
+# --with-isolate downloads workerd + writes SB_ENABLE_ISOLATE=true) — no config
+# overlay, no node-side staging. Exercises the isolate-runtime use cases
+# (UC-103..105), including the per-sandbox egress-attribution proof.
+integration-single-isolate:
+	integration-tests/run.sh single-node-isolate $(RUN_FLAGS)
 
 integration-cluster-mixed:
 	integration-tests/run.sh cluster-3-mixed $(RUN_FLAGS)

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ BIN_DIR ?= bin
 	integration-benchmark-containerd integration-benchmark-containerd-only \
 	integration-benchmark-fc integration-benchmark-fc-only \
 	integration-benchmark-wasm integration-benchmark-wasm-only \
+	integration-benchmark-isolate integration-benchmark-isolate-only \
 	integration-benchmark-gvisor integration-benchmark-gvisor-only \
 	integration-benchmark-gvisor-docker integration-benchmark-gvisor-docker-only \
 	integration-single-fc integration-benchmark-fc-single integration-arm64 integration-arm64-single integration-arm64-cluster integration-all integration-collect-logs integration-destroy integration-reap \
@@ -299,6 +300,33 @@ integration-benchmark-wasm-only:
 	AEROL_BENCH_SAMPLES=$(WASM_BENCH_SAMPLES) \
 	AEROL_BENCH_RUNTIMES=$(WASM_BENCH_RUNTIMES) \
 		integration-tests/run.sh cluster-3-mixed-wasm --bench-only
+
+# V8-isolate (workerd) create-latency benchmark on the single-node-isolate box.
+# Provisions single-node-isolate (t3.medium, jail off) and runs UC-94 isolate
+# latency only (AEROL_BENCH_RUNTIMES=isolate). warmBenchmarkRuntimes spawns the
+# tenant's workerd group once, so the samples measure the warm create path
+# (isolate loaded into an already-running group). UC-95 (density) is skipped: it
+# needs CapCluster, which a single node lacks. UC-94 is meaningful single-node
+# (no Raft/placement/forward in the number). Add docker with
+# AEROL_BENCH_RUNTIMES=docker,isolate.
+#   make integration-benchmark-isolate
+#   make integration-benchmark-isolate keep
+#   make integration-benchmark-isolate ISOLATE_BENCH_OUT=/tmp/isolate-bench.json
+ISOLATE_BENCH_OUT ?= integration-tests/reports/single-node-isolate-bench.json
+ISOLATE_BENCH_SAMPLES ?= 10
+ISOLATE_BENCH_RUNTIMES ?= isolate
+integration-benchmark-isolate:
+	AEROL_BENCH=1 AEROL_BENCH_OUT=$(ISOLATE_BENCH_OUT) \
+	AEROL_BENCH_SAMPLES=$(ISOLATE_BENCH_SAMPLES) \
+	AEROL_BENCH_RUNTIMES=$(ISOLATE_BENCH_RUNTIMES) \
+		integration-tests/run.sh single-node-isolate --bench-only $(RUN_FLAGS)
+
+# Re-run UC-94 against a single-node-isolate left up with `keep`.
+integration-benchmark-isolate-only:
+	AEROL_BENCH=1 AEROL_BENCH_OUT=$(ISOLATE_BENCH_OUT) \
+	AEROL_BENCH_SAMPLES=$(ISOLATE_BENCH_SAMPLES) \
+	AEROL_BENCH_RUNTIMES=$(ISOLATE_BENCH_RUNTIMES) \
+		integration-tests/run.sh single-node-isolate --bench-only
 
 # gVisor create-latency benchmark on the 3× mixed-gvisor cluster (containerd
 # engine — the harness default; the scenario has no docker-engine cap, so

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -8,7 +8,8 @@
 #   integration-tests/run.sh <scenario> [--bench-only]    # UC-94/UC-95 only (provision if needed)
 #   integration-tests/run.sh all       [flags]
 #
-# Scenarios: single-node | single-node-containerd | local-mode | cluster-3-mixed |
+# Scenarios: single-node | single-node-containerd | single-node-wasm |
+#            single-node-isolate | local-mode | cluster-3-mixed |
 #            cluster-3-mixed-docker | cluster-3-mixed-containerd | cluster-3-mixed-fc |
 #            cluster-3-mixed-gvisor | cluster-3-mixed-gvisor-docker |
 #            cluster-3-mixed-wasm | cluster-hetero |
@@ -1013,7 +1014,7 @@ elif [[ "$BENCH_ONLY" == "1" ]]; then
     run_one "$SCENARIO"
   fi
 elif [[ "$SCENARIO" == "all" ]]; then
-  for s in local-mode single-node single-node-wasm cluster-3-mixed cluster-3-mixed-docker cluster-3-mixed-wasm cluster-3-mixed-fc cluster-3-mixed-gvisor cluster-hetero single-node-fc single-node-fc-arm64 cluster-arm64; do
+  for s in local-mode single-node single-node-wasm single-node-isolate cluster-3-mixed cluster-3-mixed-docker cluster-3-mixed-wasm cluster-3-mixed-fc cluster-3-mixed-gvisor cluster-hetero single-node-fc single-node-fc-arm64 cluster-arm64; do
     ( run_one "$s" )
   done
 else

--- a/integration-tests/scenarios/single-node-isolate.caps.yml
+++ b/integration-tests/scenarios/single-node-isolate.caps.yml
@@ -18,3 +18,9 @@ capabilities:
   - docker
   - isolate
   - domain
+  # Opt UC-94 in for `make integration-benchmark-isolate` (isolate create latency
+  # only; the make target passes AEROL_BENCH_RUNTIMES=isolate + --bench-only).
+  # UC-94 is dormant unless AEROL_BENCH=1, so the functional
+  # `make integration-single-isolate` run skips it. UC-95 (density) stays skipped
+  # here — it also needs CapCluster, which a single node lacks.
+  - benchmark

--- a/integration-tests/scenarios/single-node-isolate.caps.yml
+++ b/integration-tests/scenarios/single-node-isolate.caps.yml
@@ -1,0 +1,20 @@
+# Single-node scenario with the V8-isolate (workerd) runtime turned on. Same
+# topology as single-node (one mixed box + public domain/TLS) but advertises
+# `isolate`, which gates the isolate use cases (UC-103..105) in the suite. The
+# runtime itself is enabled purely by provisioning: single-node-isolate.tfvars
+# sets default_with_isolate=true → install.sh --with-isolate downloads workerd +
+# writes SB_ENABLE_ISOLATE=true. Unlike wasm there is NO run.sh overlay flip and
+# no node-side staging (the UCs upload JS bundles over the API), so `isolate` is
+# an advertisement-only capability — the same shape as `gvisor`.
+#
+# `docker` is advertised too because the mixed node also runs the docker runtime;
+# it gives the isolate scenario free base-lifecycle regression coverage and
+# proves isolate coexists with docker on one host. `domain` gives a public
+# base_url + TLS the UCs talk to.
+#
+# This is the smallest scenario that exercises the isolate-runtime use cases.
+name: single-node-isolate
+capabilities:
+  - docker
+  - isolate
+  - domain

--- a/integration-tests/scenarios/single-node-isolate.tfvars
+++ b/integration-tests/scenarios/single-node-isolate.tfvars
@@ -1,0 +1,67 @@
+# Single-node V8-isolate (workerd) integration scenario: one mixed node with a
+# public domain + TLS and the isolate runtime installed at bootstrap. Topology is
+# identical to single-node.tfvars / single-node-wasm.tfvars; the only difference
+# is default_with_isolate = true, which Terraform threads into install.sh's
+# --with-isolate flag (downloads the SHA-256-pinned workerd release to
+# /usr/local/bin/workerd and writes SB_ENABLE_ISOLATE=true). Unlike wasm there
+# is NO run.sh config-overlay flip and no node-side module staging — the isolate
+# runtime is entirely provisioning-driven (same shape as gvisor's
+# default_with_gvisor), and its JS bundles are uploaded by the UCs over the API.
+#
+# A single "mixed" node is both ingress and worker, so IsWorker() is true and
+# supportedRuntimesForConfig advertises "isolate" (EnableIsolate && IsWorker) —
+# without that, admission would reject every isolate create with
+# ErrNoPlacementTarget (the gvisor UC-87 class of bug). isolate runs in-process
+# via workerd (host-mediated, no KVM / bare metal), so the cheap t3.medium
+# suffices.
+#
+# AWS access (aws_profile, aws_region, ssh_key_name, ...) is INHERITED from the
+# operator's config/terraform.tfvars, which run.sh chains as the first
+# -var-file. This file is chained second and overrides only the prod-specific
+# bits below. Ops + secrets come from the runtime config overlay (run.sh) +
+# config/secrets.yml.
+cluster_name = "aerolvm-itest-single-node-isolate"
+
+# Override prod's extra_tags entirely (a map override replaces it). The itest
+# marker is required by the safety tripwire; ttl drives scripts/integration-reap.sh.
+extra_tags = {
+  itest = "true"
+  ttl   = "4" # hours; reaper terminates older instances
+}
+
+default_instance_type  = "t3.medium"
+default_volume_size_gb = 40 # override prod's 128 — throwaway box, keep cost down
+
+# Install Cloudflare workerd (SHA-256-pinned) + SB_ENABLE_ISOLATE=true on the
+# node at bootstrap. This is the isolate analog of default_with_gvisor=true.
+default_with_isolate = true
+
+# A single node has nothing to share certs WITH; disable the prod-inherited
+# managed S3 cert bucket so the run doesn't create one. Cluster scenarios re-enable it.
+caddy_shared_cert_storage = {
+  enabled = false
+}
+
+# extra_user_data runs AFTER install.sh writes the env + starts sandboxd, so it
+# is the append-and-restart hook (same one the wasm/gvisor scenarios use). We
+# turn the isolate jail OFF for the test: SB_ISOLATE_USE_JAIL defaults to true,
+# but the jail's chroot is not yet populated with the workerd binary (the
+# chroot-populate step is the tracked "full jail realization" follow-up in
+# plans/isolate-runtime.md). With the jail on, workerd is exec'd inside an empty
+# chroot and every create fails with "fork/exec /usr/local/bin/workerd: no such
+# file or directory" — even though the binary is installed on the host and health
+# reports isolate:ok. Jail-off is how the runtime is currently deployable end to
+# end (it is what the manual live validation used), and it is orthogonal to the
+# per-sandbox egress attribution UC-104 proves. A jail-ON isolate scenario is a
+# follow-up gated on the chroot-populate work.
+nodes = {
+  node1 = {
+    role = "mixed"
+    seed = true
+    spot = true
+    extra_user_data = <<-EOT
+      echo 'SB_ISOLATE_USE_JAIL=false' | sudo tee -a /etc/sandboxd/sandboxd.env >/dev/null
+      sudo systemctl restart sandboxd
+    EOT
+  }
+}

--- a/integration-tests/suite/benchmark_test.go
+++ b/integration-tests/suite/benchmark_test.go
@@ -24,9 +24,9 @@ import (
 // benchmark_test.go holds the opt-in create benchmarks (UC-94/UC-95). They run
 // only where the scenario advertises CapBenchmark — cluster-hetero (every
 // runtime), cluster-3-mixed-docker (docker only), cluster-3-mixed-fc (docker +
-// firecracker), cluster-3-mixed-gvisor (docker + gvisor), and cluster-3-mixed-wasm
-// (docker + wasm) — because they
-// many sandboxes. They reuse the same SDK client + cleanup contract as every
+// firecracker), cluster-3-mixed-gvisor (docker + gvisor), cluster-3-mixed-wasm
+// (docker + wasm), and single-node-isolate (docker + isolate) — because they
+// provision many sandboxes. They reuse the same SDK client + cleanup contract as every
 // other use case; the only difference is they record timings instead of
 // asserting a single create.
 //
@@ -60,6 +60,11 @@ var benchRuntimes = []struct {
 	{"firecracker", harness.CapFirecracker},
 	{"gvisor", harness.CapGvisor},
 	{"wasm", harness.CapWasm},
+	// isolate (V8/workerd) measures the warm create path: warmBenchmarkRuntimes
+	// spawns the tenant's workerd group once, then every sample is an isolate
+	// loaded into that already-running group (compile-once / instantiate-many).
+	// A bundle is uploaded once in selectedBenchRuntimes and reused as ModuleRef.
+	{"isolate", harness.CapIsolate},
 }
 
 type benchRuntimeSpec struct {
@@ -67,6 +72,11 @@ type benchRuntimeSpec struct {
 	image      string
 	wasmRef    string
 	templateID string
+	// bundleRef + tenantID configure an isolate create: the JS bundle uploaded
+	// once for the sweep, and the shared workerd group key so samples reuse one
+	// warm group. Unused by other runtimes.
+	bundleRef string
+	tenantID  string
 }
 
 // requireBenchEnabled is a second gate on top of the CapBenchmark capability.
@@ -169,6 +179,15 @@ func selectedBenchRuntimes(t *testing.T) []benchRuntimeSpec {
 				continue
 			}
 		}
+		if br.runtime == "isolate" {
+			// Upload the bench bundle once (content-addressed + idempotent) and
+			// reference it by name on every create. A single shared tenant keeps
+			// all samples in one warm workerd group so the numbers reflect the
+			// steady-state create path, not a group cold-spawn per sample.
+			spec.bundleRef = uploadBundle(t, client(t), "itest-isolate-bench",
+				`export default { async fetch() { return new Response("bench"); } };`)
+			spec.tenantID = "bench-isolate"
+		}
 		selected = append(selected, spec)
 	}
 	return selected
@@ -184,6 +203,12 @@ func benchCreateOptions(t *testing.T, spec benchRuntimeSpec) sdktypes.CreateSand
 	case "wasm":
 		opts.Image = spec.wasmRef
 		opts.ModuleRef = spec.wasmRef
+	case "isolate":
+		// The bundle IS the image; ModuleRef references it and TenantID keeps
+		// every sample in one warm workerd group.
+		opts.ModuleRef = spec.bundleRef
+		opts.TenantID = spec.tenantID
+		opts.MemoryMB = 128
 	case "firecracker":
 		opts.Image = spec.image
 		if opts.Image == "" {

--- a/integration-tests/suite/harness/http.go
+++ b/integration-tests/suite/harness/http.go
@@ -46,6 +46,28 @@ func (c *Client) rawPost(ctx context.Context, path string, body any) (*http.Resp
 	return http.DefaultClient.Do(req)
 }
 
+// Delete issues an authenticated DELETE and returns an error on any non-2xx.
+// Used by the isolate js-bundle catalogue UC, whose delete verb the Go SDK does
+// not wrap. 204 No Content (the catalogue's success status) and any 2xx count as
+// success; the body snippet on failure surfaces what the server said.
+func (c *Client) Delete(ctx context.Context, path string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.sc.BaseURL+path, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.sc.PAT)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("DELETE %s: status %d: %s", path, resp.StatusCode, snippet(b))
+	}
+	return nil
+}
+
 // GetJSON GETs path and decodes a 2xx JSON body into out. Any non-2xx is an
 // error carrying the status and a snippet of the body, so a failing use case
 // reports what the server actually said.

--- a/integration-tests/suite/harness/skip_test.go
+++ b/integration-tests/suite/harness/skip_test.go
@@ -78,7 +78,7 @@ func TestRegistryWellFormed(t *testing.T) {
 		seen[uc.ID] = true
 		for _, c := range uc.Requires {
 			switch c {
-			case CapDocker, CapFirecracker, CapGvisor, CapWasm, CapGPU, CapDomain, CapCluster, CapCustomDomains, CapExternalDNSZone, CapMixedArchNegative, CapPlatformVolumes, CapBenchmark, CapDockerPool, CapDockerNetnsPool, CapDockerEngine, CapContainerdEngine:
+			case CapDocker, CapFirecracker, CapGvisor, CapWasm, CapIsolate, CapGPU, CapDomain, CapCluster, CapCustomDomains, CapExternalDNSZone, CapMixedArchNegative, CapPlatformVolumes, CapBenchmark, CapDockerPool, CapDockerNetnsPool, CapDockerEngine, CapContainerdEngine:
 			default:
 				t.Fatalf("%s requires unknown capability %q", uc.ID, c)
 			}

--- a/integration-tests/suite/harness/usecases.go
+++ b/integration-tests/suite/harness/usecases.go
@@ -19,9 +19,18 @@ const (
 	CapFirecracker Capability = "firecracker" // a firecracker-capable worker
 	CapGvisor      Capability = "gvisor"      // a gvisor-capable worker
 	CapWasm        Capability = "wasm"        // wasm runtime + staged module
-	CapGPU         Capability = "gpu"         // a GPU worker
-	CapDomain      Capability = "domain"      // public domain + TLS (not local-mode)
-	CapCluster     Capability = "cluster"     // multi-node cluster (raft/forwarding)
+	// CapIsolate gates the V8-isolate (workerd) use cases (UC-103..105). Like
+	// CapGvisor it is advertisement-only: the runtime is enabled purely by
+	// provisioning (default_with_isolate=true → install.sh --with-isolate writes
+	// SB_ENABLE_ISOLATE=true + installs workerd), not by any run.sh config-overlay
+	// flip. A scenario advertises it when its node was provisioned --with-isolate;
+	// where the runtime is off, the isolate UCs skip (not-applicable) rather than
+	// hard-fail. Unlike CapWasm it needs no node-side module staging — the UCs
+	// upload JS bundles over POST /v1/js-bundles at runtime.
+	CapIsolate Capability = "isolate" // V8-isolate (workerd) runtime available
+	CapGPU     Capability = "gpu"     // a GPU worker
+	CapDomain  Capability = "domain"  // public domain + TLS (not local-mode)
+	CapCluster Capability = "cluster" // multi-node cluster (raft/forwarding)
 	// CapMixedArchNegative gates UC-79: inject a foreign-arch snapshot ref and
 	// assert the arm64 cluster refuses to resume it.
 	CapMixedArchNegative Capability = "mixed-arch-negative"
@@ -299,6 +308,32 @@ var Registry = []UseCase{
 	{ID: "UC-100", Title: "sandboxd restart reconcile: live sandboxes + parked + netns slots survive", Requires: []Capability{CapContainerdEngine}, Implemented: true},
 	{ID: "UC-101", Title: "containerd restart: shims survive and events resubscribe", Requires: []Capability{CapContainerdEngine}, Implemented: true},
 	{ID: "UC-102", Title: "dockerd coexistence: AEROLVM-USER jump survives dockerd restart", Requires: []Capability{CapContainerdEngine}, Implemented: true},
+
+	// L. V8-isolate runtime (workerd) — plans/isolate-runtime.md. Gated on
+	// CapIsolate, which a scenario advertises only when its node was provisioned
+	// --with-isolate (SB_ENABLE_ISOLATE=true + a workerd binary). These are the
+	// repeatable live coverage for the isolate runtime — before them the only
+	// isolate validation on real infra was an ad-hoc manual recipe.
+	//
+	// UC-103 is the end-to-end "isolate runs": upload a JS bundle over
+	// POST /v1/js-bundles, create a runtime=isolate sandbox referencing it, and
+	// drive its fetch handler via toolbox exec (the isolate driver maps an exec
+	// command to a fetch on that URL path). Proves workerd installed, the group
+	// spawned, the bundle loaded, and the fetch handler served.
+	{ID: "UC-103", Title: "Isolate-runtime sandbox runs (upload bundle + create + exec-fetch)", Requires: []Capability{CapIsolate}, Implemented: true},
+	// UC-104 is the per-sandbox egress-attribution proof (the §4 redesign shipped
+	// in v0.7.16 / PR #340). Two isolate sandboxes in the SAME tenant group get
+	// DIFFERENT egress policies enforced: an allow-listed sandbox reaches its
+	// allowed host but is refused a non-allowed one, while a block-all sandbox in
+	// the same group is refused everything. Attribution is the egress slot socket,
+	// not a forgeable header — so this is what turns "egress works" from an
+	// offline claim into a live, multi-tenant guarantee.
+	{ID: "UC-104", Title: "Isolate per-sandbox egress allowlist enforced (block-all + allow differ in one tenant)", Requires: []Capability{CapIsolate}, Implemented: true},
+	// UC-105 exercises the js-bundle catalogue CRUD the isolate runtime uploads
+	// through (POST/GET/DELETE /v1/js-bundles): upload returns a digest, list/get
+	// surface it, delete removes it. The owner-scoping + in-use-refusal edges are
+	// covered offline; this is the live round-trip.
+	{ID: "UC-105", Title: "Isolate js-bundle catalogue CRUD (upload/list/get/delete)", Requires: []Capability{CapIsolate}, Implemented: true},
 }
 
 // byID is a lookup built once for the report generator.

--- a/integration-tests/suite/isolate_test.go
+++ b/integration-tests/suite/isolate_test.go
@@ -1,0 +1,225 @@
+//go:build integration
+
+package suite
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aerol-ai/microvm/integration-tests/suite/harness"
+	"github.com/aerol-ai/microvm/pkg/models"
+	microvm "github.com/aerol-ai/microvm/sdk/go/pkg/microvm"
+	sdktypes "github.com/aerol-ai/microvm/sdk/go/pkg/types"
+)
+
+// The isolate runtime (plans/isolate-runtime.md) has no image and no registry —
+// a sandbox references a JS/TS bundle uploaded to the /v1/js-bundles catalogue,
+// and its fetch handler is driven by mapping a toolbox exec command to a fetch
+// URL path (internal/runtime/isolate/exec.go). These UCs are the repeatable live
+// coverage that make the runtime — and specifically the per-sandbox egress
+// attribution shipped in v0.7.16 — non-experimental. They gate on CapIsolate, so
+// they skip (not-applicable) on any scenario whose node was not provisioned
+// --with-isolate.
+
+// uploadBundle uploads a JS bundle to the owner-scoped catalogue and returns the
+// reference the create path accepts (the bundle name). Upload is content-
+// addressed and idempotent, so re-running with the same name+source resolves to
+// the same digest rather than accumulating bundles.
+func uploadBundle(t *testing.T, c *harness.Client, name, source string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	var out models.JSBundle
+	if err := c.PostJSON(ctx, "/v1/js-bundles", models.CreateJSBundleRequest{
+		Name:   name,
+		Source: source,
+	}, &out); err != nil {
+		t.Fatalf("upload bundle %q: %v", name, err)
+	}
+	if out.Digest == "" {
+		t.Fatalf("upload bundle %q: empty digest in response", name)
+	}
+	return name
+}
+
+// newIsolateSandbox creates a runtime=isolate sandbox referencing a bundle and
+// registers cleanup. It deliberately does NOT go through harness.NewSandbox:
+// that helper injects a default docker Image and flips AllowPublicTraffic on,
+// neither of which fits the host-mediated isolate boot path (the bundle IS the
+// image; ingress is a separate expose_port call). Mirrors the proven API recipe
+// in pkg/daemon/isolate_api_integration_test.go.
+func newIsolateSandbox(t *testing.T, c *harness.Client, moduleRef, tenant string, opts sdktypes.CreateSandboxOptions) *microvm.Sandbox {
+	t.Helper()
+	opts.Runtime = models.RuntimeIsolate
+	opts.ModuleRef = moduleRef
+	opts.TenantID = tenant
+	if opts.Name == "" {
+		opts.Name = harness.UniqueName(sc, t)
+	}
+	if opts.MemoryMB == 0 {
+		opts.MemoryMB = 128
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	sb, err := c.SDK().Create(ctx, opts)
+	if err != nil {
+		t.Fatalf("create isolate sandbox: %v", err)
+	}
+	t.Cleanup(func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), time.Minute)
+		defer ccancel()
+		if derr := c.SDK().Destroy(cctx, sb.ID); derr != nil {
+			t.Logf("cleanup: destroy isolate sandbox %s: %v", sb.ID, derr)
+		}
+	})
+	return sb
+}
+
+// execFetch drives the sandbox's fetch handler: the isolate driver maps an exec
+// command to a GET on http://isolate<command>, returning the handler's response
+// body as stdout. Returns the stdout.
+func execFetch(t *testing.T, sb *microvm.Sandbox, urlPath string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	res, err := sb.ExecCommand(ctx, urlPath)
+	if err != nil {
+		t.Fatalf("exec-fetch %q on %s: %v", urlPath, sb.ID, err)
+	}
+	return res.Stdout
+}
+
+// UC-103 — an isolate sandbox runs end-to-end: upload a bundle, create a
+// runtime=isolate sandbox referencing it, and confirm its fetch handler serves
+// via toolbox exec. Proves workerd installed + group spawned + bundle loaded.
+func TestIsolateRuntimeRuns(t *testing.T) {
+	harness.Require(t, sc, "UC-103")
+	c := client(t)
+
+	ref := uploadBundle(t, c, "itest-isolate-hello",
+		`export default { async fetch() { return new Response("isolate-ok"); } };`)
+
+	sb := newIsolateSandbox(t, c, ref, "itest-runs", sdktypes.CreateSandboxOptions{})
+	waitRunning(t, sb)
+
+	if got := execFetch(t, sb, "/"); got != "isolate-ok" {
+		t.Fatalf("fetch handler = %q, want %q", got, "isolate-ok")
+	}
+}
+
+// egressProbeBundle returns the searchParam target ("t") and reports the inner
+// fetch's HTTP status (or the thrown error). A policy denial surfaces as an
+// upstream 403 from the egress proxy → body "status=403"; an allowed fetch is
+// 200 (reachable) or a throw/502 (allowed but unreachable), never 403.
+const egressProbeBundle = `export default { async fetch(req) {
+  const u = new URL(req.url);
+  try {
+    const r = await fetch(u.searchParams.get("t"));
+    return new Response("status=" + r.status);
+  } catch (e) {
+    return new Response("throw=" + (e && e.message ? e.message : String(e)));
+  }
+}};`
+
+// UC-104 — per-sandbox egress attribution (the §4 redesign, v0.7.16 / PR #340).
+// Two isolate sandboxes in the SAME tenant group get DIFFERENT egress policies
+// enforced: an allow-listed sandbox reaches its allowed host but is refused a
+// non-allowed one, while a block-all sandbox in the same group is refused
+// everything. Attribution is the egress slot socket — a forged header on the
+// outbound is irrelevant — so this is the live proof that egress is enforced
+// per sandbox, not group-wide, and is no longer deny-all.
+func TestIsolatePerSandboxEgress(t *testing.T) {
+	harness.Require(t, sc, "UC-104")
+	c := client(t)
+
+	ref := uploadBundle(t, c, "itest-isolate-egress", egressProbeBundle)
+
+	const tenant = "itest-egress" // both sandboxes share ONE workerd group
+	allow := newIsolateSandbox(t, c, ref, tenant, sdktypes.CreateSandboxOptions{
+		NetworkAllowOut: []string{"example.com"},
+	})
+	block := newIsolateSandbox(t, c, ref, tenant, sdktypes.CreateSandboxOptions{
+		NetworkBlockAll: true,
+	})
+	waitRunning(t, allow)
+	waitRunning(t, block)
+
+	probe := func(sb *microvm.Sandbox, target string) string {
+		return execFetch(t, sb, "/?t="+url.QueryEscape(target))
+	}
+
+	// Allow-listed sandbox → allowed host: PERMITTED (never a 403 policy denial).
+	if got := probe(allow, "https://example.com/"); strings.Contains(got, "status=403") {
+		t.Fatalf("allow→example.com = %q, want permitted (not a 403 policy denial)", got)
+	}
+	// Allow-listed sandbox → NON-allowed host: DENIED by its own allowlist.
+	if got := probe(allow, "https://not-allowed.example/"); !strings.Contains(got, "status=403") {
+		t.Fatalf("allow→not-allowed = %q, want status=403 (allowlist enforced)", got)
+	}
+	// Block-all sandbox in the SAME group → allowed host still DENIED, proving
+	// the policy is attributed per sandbox, not applied group-wide.
+	if got := probe(block, "https://example.com/"); !strings.Contains(got, "status=403") {
+		t.Fatalf("block→example.com = %q, want status=403 (block-all)", got)
+	}
+}
+
+// UC-105 — the js-bundle catalogue CRUD the isolate runtime uploads through:
+// upload returns a digest, list + get surface it, delete removes it (and a
+// follow-up get 404s). Owner-scoping + in-use-refusal edges are covered offline;
+// this is the live round-trip.
+func TestIsolateJSBundleCatalogue(t *testing.T) {
+	harness.Require(t, sc, "UC-105")
+	c := client(t)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	// Unique name so the delete at the end is unconditional (no live sandbox
+	// pins it) and repeated runs don't fight over one catalogue entry.
+	name := harness.UniqueName(sc, t)
+	var created models.JSBundle
+	if err := c.PostJSON(ctx, "/v1/js-bundles", models.CreateJSBundleRequest{
+		Name:   name,
+		Source: `export default { async fetch() { return new Response("catalogue"); } };`,
+	}, &created); err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if created.Digest == "" {
+		t.Fatal("upload returned empty digest")
+	}
+
+	// List includes it.
+	var list []models.JSBundle
+	if err := c.GetJSON(ctx, "/v1/js-bundles", &list); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	found := false
+	for _, b := range list {
+		if b.Digest == created.Digest {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("list %d bundles, none matched digest %s", len(list), created.Digest)
+	}
+
+	// Get by digest round-trips.
+	var got models.JSBundle
+	if err := c.GetJSON(ctx, "/v1/js-bundles/"+created.Digest, &got); err != nil {
+		t.Fatalf("get %s: %v", created.Digest, err)
+	}
+	if got.Digest != created.Digest {
+		t.Fatalf("get digest = %s, want %s", got.Digest, created.Digest)
+	}
+
+	// Delete removes it; a follow-up get must 404.
+	if err := c.Delete(ctx, "/v1/js-bundles/"+created.Digest); err != nil {
+		t.Fatalf("delete %s: %v", created.Digest, err)
+	}
+	if err := c.GetJSON(ctx, "/v1/js-bundles/"+created.Digest, &models.JSBundle{}); err == nil {
+		t.Fatalf("get after delete succeeded; want not-found for %s", created.Digest)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds the **first AWS integration-harness coverage for the V8-isolate (workerd) runtime**: a `single-node-isolate` scenario, `CapIsolate` + UC-103/104/105, `make integration-single-isolate`, and a UC-94 isolate create-latency benchmark (`make integration-benchmark-isolate`). Before this, isolate — and the per-sandbox egress attribution shipped in v0.7.16 / #340 — was only ever validated by an ad-hoc manual recipe, so it left no `reports/*.md` and had no `make` target.
- **Test-harness only** — no runtime, server, `pkg/`, or SDK code changes. The isolate provisioning layer already existed (`install.sh --with-isolate` downloads a SHA-pinned workerd + writes `SB_ENABLE_ISOLATE=true`; Terraform `default_with_isolate`; `bootstrap.sh.tftpl` emits the flag), so this is purely the harness layer, mirroring how gvisor is wired (advertisement-only capability, provisioning-driven, no config-overlay flip and no node-side staging — the UCs upload JS bundles over `POST /v1/js-bundles` at runtime).
- **Live-validated end to end** on real AWS with the released **v0.7.16** binary + workerd (no scp/cross-compile — a vanilla provision is production-faithful).

## Code-path diagram

```mermaid
flowchart TB
  subgraph provision["make integration-single-isolate → run.sh single-node-isolate"]
    TF["Terraform apply<br/>default_with_isolate = true"] --> INS["install.sh --with-isolate<br/>SHA-pinned workerd → /usr/local/bin/workerd<br/>+ SB_ENABLE_ISOLATE=true"]
    INS --> EUD["extra_user_data (NEW)<br/>SB_ISOLATE_USE_JAIL=false + restart sandboxd"]
    EUD --> HEALTH["wait DNS/TLS/health → isolate:ok<br/>supported_runtimes=[docker,isolate]"]
  end
  subgraph suite["integration suite — CapIsolate gates (NEW)"]
    HEALTH --> U103["UC-103 upload bundle → create isolate → exec-fetch"]
    HEALTH --> U105["UC-105 js-bundle catalogue CRUD"]
    HEALTH --> U104["UC-104 two sandboxes / one tenant:<br/>allow-list vs block-all egress differ"]
    HEALTH --> U94["UC-94 (bench, AEROL_BENCH=1 only)<br/>warm create latency, 10 samples"]
  end
  U103 --> RPT["report matrix + auto-teardown"]
  U104 --> RPT
  U105 --> RPT
  U94 --> RPT
```

Before → after: before this PR there was no isolate scenario/UC/target and no isolate row in any report; after, `single-node-isolate` provisions the runtime through the existing `--with-isolate` path and the suite exercises create/exec, per-sandbox egress, the bundle catalogue, and create latency.

## Sandbox boot impact

**N/A — test harness only; no work added to `CreateSandbox` or any callee.** The one node-side change the scenario makes is appending `SB_ISOLATE_USE_JAIL=false` to `sandboxd.env` via `extra_user_data` (a provisioning-time env write + restart, the same hook the wasm/gvisor scenarios use), not a code path in the boot sequence.

## Idempotency

**N/A — no API surface changed.** The UCs are clients of existing endpoints: js-bundle upload is content-addressed and idempotent (re-upload of the same name+source resolves to the same digest), and sandbox create/destroy are unchanged. The bench reuses one uploaded bundle + one shared tenant across all samples precisely because upload is idempotent.

## Failure-path consistency

**N/A — no multi-step caddy+store write path changed.** Isolate is HTTP-only / host-mediated and the change is test-only. The harness's own hygiene is unchanged: every created sandbox registers a `t.Cleanup` destroy, and `run.sh` (no `--keep`) tears the deployment down on `EXIT/INT/TERM` and collects `reports/<scenario>-failure-logs.txt` before teardown on any failure.

## L4 / host-port-pool changes

**N/A — neither touched.** Isolate never calls `TryReserveHostPort` / `allocateHostPort` / `EnsureLayer4` / the `l4Ready` latch; the harness adds no L4 code.

## Test plan

- **Offline:** `go vet -tags=integration ./integration-tests/suite/...` (exit 0); `go test ./integration-tests/suite/harness/...` (green — includes the known-capability check extended with `CapIsolate`); `go test ./integration-tests/report/...` (green — registry-driven, classifies the new UCs); `make fmt` clean.
- **Live functional** (`make integration-single-isolate`, fresh t3.medium, released v0.7.16 + workerd): **pass 57 · fail 0 · skip 51 · inconclusive 0**. UC-103/104/105 all green. UC-104 proved per-sandbox egress attribution on real infra — an allow-listed sandbox reached `example.com` (200) but 403'd a non-allowed host, while a **block-all sandbox in the same tenant group 403'd everything**. Torn down clean (34 resources destroyed, no leak).
- **Live benchmark** (`make integration-benchmark-isolate`, 10 samples): warm isolate create **server p50 = 4 ms / p90 = 6 ms / p99 = 19 ms**, 0 failures (stages: create 6 ms mean, cluster_promote 4 ms, create_with_id 1 ms, cluster_seal 0 ms). The ~262 ms api↔server gap is laptop→`us-east-1` WAN, not create cost. Torn down clean (34 resources destroyed, no leak).

### Deliberate scope note

The scenario runs the isolate **jail off** (`SB_ISOLATE_USE_JAIL=false`). The jail defaults on, but its chroot is not yet populated with the workerd binary (chroot-populate is the tracked "full jail realization" follow-up in `plans/isolate-runtime.md`); with the jail on, workerd is exec'd inside an empty chroot and every create fails `no such file or directory` even though the binary is installed and health reports `isolate:ok`. Jail-off is how the runtime is currently deployable end to end, and is orthogonal to the egress attribution UC-104 proves. **Follow-ups:** a jail-ON isolate scenario once chroot-populate lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
