### PR TITLE
docs: refresh README and MDX for isolate runtime + UC-94 latency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,8 +101,9 @@ internal/
   observability/ OTEL traces + expvar metrics exporter for sandboxd.
   pool/          Warm pools for fast boot. pool/vmm/ holds pre-booted
                  Firecracker snapshots (snapshot-load fast-boot); pool/wasm/
-                 holds pre-spawned WASM workers. Both publish expvar
-                 hit/miss/orphan metrics and refill on a ticker.
+                 holds pre-spawned WASM workers; pool/isolate/ holds blank
+                 workerd hosts. Publish expvar hit/miss/orphan metrics and
+                 refill on a ticker.
   runtime/       Runtime.Runtime interface + drivers. runtime.go defines
                  Runtime (Create/Start/Stop/Destroy/Snapshot/Inspect/…) and
                  ContainerRuntime (adds the network-rule methods); use
@@ -112,8 +113,10 @@ internal/
                  wasm/ (Runtime only — host-mediated networking, no per-IP
                  iptables; wasm/toolhost/ is the host-side file/exec/sessions
                  HTTP handler, wasm/statekv/ is the durable per-sandbox KV
-                 store backed by the wasm_state_kv table). See "Runtime
-                 drivers" below.
+                 store backed by the wasm_state_kv table),
+                 isolate/ (Runtime only — V8/workerd Workers model, off by
+                 default behind SB_ENABLE_ISOLATE; per-tenant group + host-
+                 mediated egress). See "Runtime drivers" below.
   scaleobs/      Scale-out observability metrics (admission / placement).
   service/       Business logic. Version-agnostic. Owns Service struct,
                  CreateSandbox / CreateSandboxWithID / RecreateSandbox entry
@@ -166,6 +169,8 @@ pkg/
   wasmmod/       WASM module resolver + OCI registry (ORAS push/pull/delete).
                  Resolves a ref (path, file://, bare name) → local .wasm and
                  validates the artifact.
+  isolate/       workerd engine host (pkg/isolate) — group supervisor, jail
+                 spec, per-slot egress pool. Driven by internal/runtime/isolate.
 sdk/
   typescript/    @aerol-ai/aerolvm-sdk. src/MicroVM.ts + Sandbox.ts; transport
                  in src/internal/api/v1/.
@@ -274,6 +279,7 @@ For changes that don't match a skill, the file-level "where to look" map is:
 | Add server business logic | `internal/service/service.go` (or new file in same package) |
 | Firecracker VM runtime / Jailer / snapshots | `internal/runtime/firecracker/driver.go`, REST client `pkg/firecracker/client.go`, warm pool `internal/pool/vmm/`, rootfs `pkg/oci/`, TAP `internal/network/tap/` |
 | WASM runtime / engine / modules | `internal/runtime/wasm/driver.go`, host handler `internal/runtime/wasm/toolhost/`, KV `internal/runtime/wasm/statekv/`, engine `pkg/wasm/`, modules `pkg/wasmmod/`, warm pool `internal/pool/wasm/` |
+| V8-isolate runtime (workerd) | `internal/runtime/isolate/`, `pkg/isolate/`, warm pool `internal/pool/isolate/`, docs `docs/.../isolate-sandbox.mdx`, plan `plans/isolate-runtime.md` |
 | Add/run a runtime driver (the interface itself) | `internal/runtime/runtime.go` (Runtime + ContainerRuntime) |
 | Daemon boot wiring (new subsystem into Run) | `pkg/daemon/` |
 | Managed control-plane seam | `pkg/controlplane/` (keep open-source build a no-op) |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 &nbsp;
 
-AerolVM is open-source sandbox infrastructure for running isolated code environments - self-host it on your own Linux host, or run it as a managed, multi-tenant service. Each sandbox is a fully isolated compute unit with its own filesystem, network namespace, and allocated vCPU, RAM, and disk - spinning up in **under 60ms** and supporting Docker, gVisor, and Firecracker runtimes. Built for AI agent pipelines and ephemeral CI, it ships as a single Go binary backed by Caddy for TLS routing and SQLite for state, with no external dependencies and a one-line installer.
+AerolVM is open-source sandbox infrastructure for running isolated code environments - self-host it on your own Linux host, or run it as a managed, multi-tenant service. Each sandbox is a fully isolated compute unit with its own filesystem, network stack, and allocated resources - create latency as low as **4ms server-side** (V8 isolate warm path) and supporting Docker, gVisor, Firecracker, WASM, and V8-isolate runtimes. Built for AI agent pipelines and ephemeral CI, it ships as a single Go binary backed by Caddy for TLS routing and SQLite for state, with no external dependencies and a one-line installer.
 
 ## Features
 
@@ -40,7 +40,7 @@ AerolVM provides a complete surface for building sandbox-backed products and age
 | [Lifecycle (create / start / stop / destroy)](https://microvm.aerol.ai/sandboxes) | [Streaming exec & PTY](https://microvm.aerol.ai/exec-streaming) | [HTTP preview URLs](https://microvm.aerol.ai/preview) | [External storage (S3, NFS, SSHFS, rclone)](https://microvm.aerol.ai/external-storage) | [Raft-coordinated cluster](https://microvm.aerol.ai/cluster-setup) |
 | [Environment & resource limits](https://microvm.aerol.ai/environment) | [Persistent PTY sessions w/ replay](https://microvm.aerol.ai/sessions) | [TCP port exposure](https://microvm.aerol.ai/tcp-ports) | [Encrypted sandbox secrets](https://microvm.aerol.ai/environment) | [HA failover & durability](https://microvm.aerol.ai/durability) |
 | [Snapshots (stop-start persistence)](https://microvm.aerol.ai/snapshots) | [SSH access per sandbox](https://microvm.aerol.ai/ssh-access) | [TLS + SNI port routing](https://microvm.aerol.ai/tcp-vs-tls-ports) | [Custom domains](https://microvm.aerol.ai/custom-domains) | [Cluster ingress topology](https://microvm.aerol.ai/cluster-ingress) |
-| [Multi-runtime (Docker / gVisor / Firecracker)](https://microvm.aerol.ai/sandboxes) | [File system operations](https://microvm.aerol.ai/file-system) | [Per-sandbox egress control](https://microvm.aerol.ai/network-isolation) | [Sandbox tags & tenant scoping](https://microvm.aerol.ai/sandbox-tags) | [Reconciler & self-healing](https://microvm.aerol.ai/reconcile) |
+| [Multi-runtime (Docker / gVisor / Firecracker / WASM / Isolate)](https://microvm.aerol.ai/sandboxes) | [File system operations](https://microvm.aerol.ai/file-system) | [Per-sandbox egress control](https://microvm.aerol.ai/network-isolation) | [Sandbox tags & tenant scoping](https://microvm.aerol.ai/sandbox-tags) | [Reconciler & self-healing](https://microvm.aerol.ai/reconcile) |
 | [GPU sandboxes](https://microvm.aerol.ai/gpu-sandboxes) | [Port allowlist](https://microvm.aerol.ai/port-allowlist) | [Per-sandbox network quotas](https://microvm.aerol.ai/network-usage) | [Dashboard](https://microvm.aerol.ai/dashboard) | [Operational runbooks](https://microvm.aerol.ai/operational-runbooks) |
 
 ## Why AerolVM
@@ -51,10 +51,10 @@ AerolVM beats the two most common alternatives on the axes that matter most for 
 | :--- | :--- | :--- | :--- |
 | **Deployment** | ✅ Self-host (single binary, one-line install) or managed multi-tenant SaaS | ✗ Cloud only | ✅ Self-host (complex multi-component setup) |
 | **Runs locally** | ✅ `--local` flag, no DNS needed | ✗ | ✗ |
-| **Sandbox startup** | < 90ms | ~200ms | < 90ms |
-| **Runtime isolation** | ✅ Docker, gVisor (user-space kernel), Firecracker (microVM) | Firecracker (microVM) | Docker only |
+| **Sandbox startup (server p50)** | Isolate ~4ms · WASM ~22ms · Docker ~30ms · Firecracker ~34ms | ~200ms | < 90ms |
+| **Runtime isolation** | ✅ Docker, gVisor, Firecracker (microVM), WASM, V8 isolate (workerd) | Firecracker (microVM) | Docker only |
 | **Sandbox lifetime** | Unlimited | 1 day | Unlimited |
-| **Serveless Sandbox(based on Lambda Arch)** | ✅ | ✗ | ✗ |
+| **Serverless / Workers-style sandboxes** | ✅ WASM + V8 isolate | ✗ | ✗ |
 | **TCP + TLS port routing** | ✅ | ✗ | ✗ |
 | **Per-sandbox egress control** | ✅ | ✗ | ✗ |
 | **External storage** | ✅ S3 / NFS / SSHFS / rclone | ✗ | ✗ |
@@ -69,7 +69,7 @@ AerolVM beats the two most common alternatives on the axes that matter most for 
 
 ### vs e2b
 
-e2b is the fastest managed path if you want zero infrastructure, but it means your code runs on someone else's hardware with no self-hosting option, per-sandbox-hour billing that compounds fast at scale, a hard 1-day sandbox lifetime cap, and no kernel-level isolation for untrusted LLM-generated code. AerolVM covers the same AI execution use case on infrastructure you own, with gVisor isolation and predictable fixed-cost pricing.
+e2b is the fastest managed path if you want zero infrastructure, but it means your code runs on someone else's hardware with no self-hosting option, per-sandbox-hour billing that compounds fast at scale, a hard 1-day sandbox lifetime cap, and a single isolation model. AerolVM covers the same AI execution use case on infrastructure you own — pick Docker, gVisor, Firecracker, WASM, or V8 isolates — with predictable fixed-cost pricing.
 
 > **Already on the e2b SDK?** AerolVM's `/e2b` API facade means your existing code keeps working - just point `E2B_API_URL` at your AerolVM host.
 
@@ -84,7 +84,7 @@ Daytona targets long-lived developer workspaces, not high-frequency ephemeral ag
 AerolVM is a single Go binary (`sandboxd`) wired to three components:
 
 - **Caddy** - handles wildcard TLS via DNS-01, L7 HTTP routing (`<sandbox-id>.<domain>`), and L4 TCP SNI routing (`<sandbox-id>-<port>.<domain>`). The daemon talks to the Caddy admin API; no config files are reloaded at runtime.
-- **Docker / gVisor / Firecracker** - the container runtimes. gVisor runs as an OCI-compatible runtime (`runsc`) so the same Docker API creates a kernel-isolated container with one extra flag.
+- **Runtimes** - Docker (`runc`), gVisor (`runsc`), Firecracker (microVM), WASM (WASI workers / resident host), and V8 isolate (`workerd`). OCI runtimes share the Docker/containerd path; WASM and isolate are host-mediated and Runtime-only.
 - **SQLite (WAL mode, single-writer)** - stores sandbox state, the TCP host-port pool, exposed-port intents, and sealed secrets. Single-writer means no contention; WAL mode means reads never block writes.
 
 For multi-host deployments, `sandboxd` nodes form a cluster using **Raft** (FSM-replicated placement state) and **SWIM gossip** (membership + capacity heartbeats). Nodes take `server`, `worker`, or `ingress` roles. The Raft voter count stays fixed at 3 or 5 regardless of how many workers you add - the same topology Kubernetes uses for control-plane vs. data-plane scaling. See [Cluster Setup](https://microvm.aerol.ai/cluster-setup).
@@ -100,18 +100,34 @@ For multi-host deployments, `sandboxd` nodes form a cluster using **Raft** (FSM-
 │                      │                              │
 │          ┌───────────┼───────────┐                  │
 │          ▼           ▼           ▼                  │
-│       Docker      Caddy      SSH gateway            │
-│    gVisor/FC    admin API    (Ed25519)              │
+│   Docker/gVisor   Caddy      SSH gateway            │
+│   FC/WASM/isolate admin API  (Ed25519)              │
 └─────────────────────────────────────────────────────┘
 ```
 
 ## Runtimes
 
-| Runtime | Status | Use Case |
-| :--- | :--- | :--- |
-| Docker (`runc`) | ✅ Available | Default. Lowest overhead, broadest image compatibility. |
-| gVisor (`runsc`) | ✅ Available | User-space kernel isolation for untrusted LLM-generated code. Install with `--with-gvisor`. |
-| Firecracker | ✅ Available | MicroVM isolation - dedicated kernel per sandbox for maximum security. |
+| Runtime | Status | Install / enable | Use case |
+| :--- | :--- | :--- | :--- |
+| Docker (`runc`) | ✅ Available | Default | Broadest OCI image compatibility. |
+| gVisor (`runsc`) | ✅ Available | `--with-gvisor` | User-space kernel for untrusted LLM code. |
+| Firecracker | ✅ Available | `--with-firecracker` (bare metal / KVM) | MicroVM - dedicated kernel per sandbox. |
+| WASM | ✅ Available | Config / cluster wasm workers | WASI modules; resident host ~22ms warm create. |
+| Isolate (V8 / workerd) | ✅ Available (off by default) | `--with-isolate` / `SB_ENABLE_ISOLATE` | JS/TS `fetch` handlers; **~4ms** warm server create. |
+
+## Create latency (live UC-94)
+
+Server-side create from `Server-Timing` (excludes client↔cluster WAN). Artifacts under `integration-tests/reports/`.
+
+| Runtime | Server p50 | Server p90 | Server p99 | Topology | Notes |
+| :--- | ---: | ---: | ---: | :--- | :--- |
+| **Isolate** | **4ms** | 6ms | 19ms | `single-node-isolate` · t3.medium | Warm path (same tenant group); API p50 266ms is WAN |
+| **WASM** (resident host) | **22ms** | 46ms | 50ms | `cluster-3-mixed-wasm` · t3.large | Flag-on resident host; no cold-compile tail |
+| **Docker** (sparse / warm) | **28–30ms** | 29–332ms | 30–373ms | `cluster-3-mixed-docker` · t3.medium | Sparse bench holds ~28ms; burst p90 can include image/netrule work |
+| **Firecracker** (warm pool) | **34ms** | 36ms | 37ms | `single-node-fc` · c5.metal | Post warm-pool path; cold/template builds are higher |
+| **gVisor** | **284ms** | 330ms | 346ms | `cluster-3-mixed-gvisor` · t3.medium | User-space kernel boot cost |
+
+Reproduce: `make integration-benchmark-isolate`, `integration-benchmark-wasm`, `integration-benchmark-docker`, `integration-benchmark-fc`, `integration-benchmark-gvisor`.
 
 ## SDKs
 

--- a/docs/src/content/docs/cluster-setup.md
+++ b/docs/src/content/docs/cluster-setup.md
@@ -185,7 +185,27 @@ Set the `*_url` fields to download locations for the binaries and kernel artifac
 
 After deployment, you register container images as Firecracker templates and then create sandboxes using the `firecracker` runtime. See [Firecracker Templates](/firecracker-templates) for the step-by-step workflow.
 
-## Step 7 - Enable GPU support (optional)
+## Step 7 - Enable Isolate (optional)
+
+The V8-isolate runtime runs JS/TS `fetch` handlers inside Cloudflare `workerd`
+(Workers model). It is off by default. Enabling it on a worker installs a
+version-pinned, SHA-256-verified `workerd` binary and sets `SB_ENABLE_ISOLATE=true`.
+
+```hcl
+nodes = {
+  srv1 = { role = "server", seed = true, instance_type = "t3.small" }
+  wrk1 = { role = "worker", with_isolate = true, instance_type = "t3.large" }
+  wrk2 = { role = "worker", with_isolate = true, instance_type = "t3.large" }
+  ing1 = { role = "ingress",                     instance_type = "t3.medium" }
+}
+```
+
+Or set `default_with_isolate = true` for every node. After deploy, create with
+`runtime: "isolate"` and a `module_ref` pointing at an uploaded JS bundle
+(`POST /v1/js-bundles`). See [Isolate Sandbox](/isolate-sandbox) for egress
+attribution, residual limits, and the ~4ms warm create path.
+
+## Step 8 - Enable GPU support (optional)
 
 AerolVM can pass through physical GPUs to sandboxes. NVIDIA and AMD GPUs are both supported. GPU-enabled worker nodes run alongside regular workers - the cluster placement engine automatically routes GPU sandbox requests to nodes that have the right hardware.
 
@@ -228,7 +248,7 @@ GPU passthrough is not compatible with gVisor. A sandbox can use either a GPU or
 
 After deployment, see [GPU Sandboxes](/gpu-sandboxes) for the full sandbox creation flow.
 
-## Step 8 - Deploy
+## Step 9 - Deploy
 
 Initialize the Terraform providers (only needed once per machine):
 
@@ -256,7 +276,7 @@ ssh ubuntu@<seed-ip> sudo tail -f /var/log/aerolvm-bootstrap.log
 
 Wait until you see `[bootstrap] complete`. The seed takes a few minutes to start the cluster; other nodes join after the seed finishes and uploads its configuration to S3.
 
-## Step 9 - Verify
+## Step 10 - Verify
 
 Once bootstrap is complete, check that all nodes joined:
 

--- a/docs/src/content/docs/comparison.md
+++ b/docs/src/content/docs/comparison.md
@@ -13,10 +13,10 @@ A side-by-side look at how AerolVM compares to the two most common alternatives 
 | **Can run locally** | ✅ | ✗ | ✗ |
 | **Open source** | ✅ | ✗ | ✅ |
 | **Primary use case** | AI agents + ephemeral CI | AI agent code execution | Developer workspaces |
-| **Sandbox startup** | <70ms | ~200s | <90ms |
-| **Runtime isolation** | Docker, gVisor (kernel-level), Firecracker (microVM) | Kata | Docker |
-| **Serveless Sandbox(based on Lambda Arch)** | ✅ | ✗ | ✗ |
-| **Security** | gVisor + FireCracker (Extremely secure) | FireCracker(Extremely secure) | ✗ |
+| **Sandbox startup (server p50)** | Isolate ~4ms · WASM ~22ms · Docker ~30ms · Firecracker ~34ms | ~200ms | <90ms |
+| **Runtime isolation** | Docker, gVisor, Firecracker (microVM), WASM, V8 isolate (workerd) | Firecracker | Docker |
+| **Serverless / Workers-style sandboxes** | ✅ WASM + V8 isolate (Lambda / Workers model) | ✗ | ✗ |
+| **Security** | gVisor + Firecracker + isolate jail / WASM sandboxing | Firecracker | ✗ |
 | **Port Isolation** | ✅ | ✗ | ✗ |
 | **Persistent** | ✅ | ✗ | ✅ |
 | **Sandbox Lifecycle** | Infinite | 1 day | Infinite |
@@ -81,7 +81,7 @@ AerolVM covers the same AI execution use case while running entirely on your own
 
 **Daytona** targets persistent developer workspaces - IDE integration, git-based environments, long-lived dev containers. It is not designed for ephemeral, high-frequency sandbox creation that AI agents need.
 
-- **Slow lifecycle.** Daytona workspaces take seconds to start because they're full persistent VMs. AerolVM boots a sandbox in under 90ms - the difference between an agent waiting on infrastructure and an agent running code.
+- **Slow lifecycle.** Daytona workspaces take seconds to start because they're full persistent VMs. AerolVM warm-creates Docker/Firecracker sandboxes in ~30ms server-side (V8 isolates in ~4ms) - the difference between an agent waiting on infrastructure and an agent running code.
 - **Setup complexity.** Daytona is genuinely difficult to self-host: multiple components, infrastructure dependencies, and ongoing operational overhead. AerolVM is a single-binary install with a one-line script.
 - **No kernel-level isolation, no per-sandbox egress control, no port allowlist.** Daytona assumes you trust the people using your workspaces. AerolVM assumes you don't trust the code running inside the sandbox.
 - **Workspace ergonomics over agent ergonomics.** Daytona's SDK and feature surface are built for humans editing code in an IDE. AerolVM's SDKs (TS, Python, Go, Rust, Java) are built for programmatic, high-throughput use.

--- a/docs/src/content/docs/engineering-runtime-layers.mdx
+++ b/docs/src/content/docs/engineering-runtime-layers.mdx
@@ -14,7 +14,7 @@ stack, and picking one means not picking the others.
 They are not at the same layer. **Firecracker and Cloud Hypervisor are engines.
 Kata is a chassis you drop an engine into.** Asking "Firecracker or Kata" is
 like asking "a V8 or a sedan" — the sedan *has* a V8. This page lays out the
-layer cake, shows exactly where AerolVM's four runtimes sit in it, and explains
+layer cake, shows exactly where AerolVM's five runtimes sit in it, and explains
 why AerolVM ended up writing its own chassis instead of adopting one off the
 shelf.
 
@@ -57,9 +57,9 @@ Firecracker. Kata runs *on top of* Firecracker.** The moment you internalize
 that, "Firecracker vs Kata" dissolves — they're answering questions one layer
 apart.
 
-## Where AerolVM's four runtimes actually sit
+## Where AerolVM's five runtimes actually sit
 
-AerolVM ships four runtimes today. They do not line up in a single row —
+AerolVM ships five runtimes today. They do not line up in a single row —
 they're spread across two different layers:
 
 | Runtime | Layer | Isolation mechanism |
@@ -67,12 +67,14 @@ they're spread across two different layers:
 | **Docker** (`runtime: "docker"`) | OCI runtime (`runc`) | Linux namespaces + cgroups |
 | **gVisor** (`runtime: "gvisor"`) | OCI runtime (`runsc`) | Userspace kernel intercepting syscalls |
 | **Firecracker** (`runtime: "firecracker"`) | Our own OCI-runtime-equivalent → VMM | Hardware VM (KVM) |
-| **WASM** (`runtime: "wasm"`) | A different axis entirely | Language VM / sandboxed bytecode |
+| **WASM** (`runtime: "wasm"`) | Language VM / sandboxed bytecode | Host-mediated WASI workers (optional resident host) |
+| **Isolate** (`runtime: "isolate"`) | Language VM (V8 / workerd) | Per-tenant workerd group + host-mediated egress; off by default |
 
 Docker and gVisor are drop-in OCI runtimes — the container ecosystem handed
-them to us. WASM is off the diagram: it isolates at the language-VM layer, not
-the container layer, so it trades syscall compatibility for the smallest
-possible footprint (see [WASM Architecture](/wasm-architecture/)).
+them to us. WASM and isolate are off the OCI diagram: they isolate at the
+language-VM layer, not the container layer, so they trade syscall compatibility
+for density and create latency (see [WASM Architecture](/wasm-architecture/) and
+[Isolate Sandbox](/isolate-sandbox/)).
 
 Firecracker is the interesting one. There is no off-the-shelf OCI runtime in
 that row, because **we wrote it ourselves.**
@@ -155,8 +157,8 @@ snapshots, the fast-boot trick carries over intact.
 
 Critically, none of this touches the SDK. Runtime selection is one string in
 the create call — the same field that already distinguishes Docker, gVisor,
-Firecracker, and WASM. A new engine slots in behind it without changing a line
-of client code:
+Firecracker, WASM, and isolate. A new engine slots in behind it without changing
+a line of client code:
 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">
@@ -168,7 +170,7 @@ of client code:
       patToken: process.env.SB_PAT_TOKEN,
     })
 
-    // Runtime is a string. Today it selects docker | gvisor | firecracker | wasm.
+    // Runtime is a string. Today it selects docker | gvisor | firecracker | wasm | isolate.
     // A new VMM (e.g. cloud-hypervisor) would slot in behind this same field
     // without any SDK change.
     const sbx = await client.create({
@@ -283,11 +285,12 @@ layer is a VM, pick which engine.
 
 | You want | Pick this layer | Notes |
 |---|---|---|
-| Max compatibility, lowest overhead, trusted-ish code | `runc` (Docker) | Namespaces. Fastest, weakest boundary. |
+| Max compatibility, lowest overhead, trusted-ish code | `runc` (Docker) | Namespaces. Fast OCI path (~30ms warm server create). |
 | Untrusted code, container UX, no VM cost | gVisor (`runsc`) | Userspace kernel. Strong boundary, some syscall-compat gaps. |
-| Hardware-VM isolation with sub-100ms boot | Firecracker | Our hand-rolled driver + snapshot warm pool. Default microVM. |
+| Hardware-VM isolation with ~30ms warm boot | Firecracker | Our hand-rolled driver + snapshot warm pool. Default microVM. |
 | GPU passthrough / confidential VMs / hotplug | Cloud Hypervisor *(candidate engine)* | Same layer as Firecracker; swap the engine, reuse the chassis. |
-| Smallest possible footprint, per-request isolation | WASM | Language-VM layer. Different tradeoff axis entirely. |
+| Smallest possible footprint, WASI modules | WASM | Language-VM layer; resident host ~22ms warm create. |
+| JS/TS `fetch` handlers, Workers density | Isolate (V8 / workerd) | Language-VM layer; ~4ms warm server create; off by default. |
 
 The mental model to walk away with: **Firecracker and Cloud Hypervisor are
 engines; Docker/gVisor/Kata are chassis; AerolVM built its own chassis so it

--- a/docs/src/content/docs/firecracker-sandbox.mdx
+++ b/docs/src/content/docs/firecracker-sandbox.mdx
@@ -5,7 +5,12 @@ description: Create sandboxes backed by Firecracker microVMs for full kernel iso
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-Firecracker sandboxes run inside lightweight virtual machines instead of containers. Each sandbox boots its own Linux kernel in under 100ms and is completely isolated from the host and from other sandboxes at the hardware level. There is no shared kernel - a vulnerability in one sandbox cannot affect another.
+Firecracker sandboxes run inside lightweight virtual machines instead of
+containers. Each sandbox boots its own Linux kernel and is completely isolated
+from the host and from other sandboxes at the hardware level. There is no shared
+kernel - a vulnerability in one sandbox cannot affect another. With the snapshot
+warm pool, live UC-94 on `single-node-fc` (`c5.metal`) measures **~34ms** server
+create p50 (API ~300ms includes client WAN).
 
 Use Firecracker when:
 - You are running untrusted or LLM-generated code that should not have any path to the host kernel

--- a/docs/src/content/docs/getting-started/single-node-setup.md
+++ b/docs/src/content/docs/getting-started/single-node-setup.md
@@ -57,16 +57,20 @@ Cloudflare is the current documented DNS-01 provider. Create a scoped API token 
 
 Caddy issues exactly two certificates, `<domain>` and `*.<domain>`, then renews them on a schedule.
 
-## Container Runtimes
+## Container and language runtimes
 
 | Runtime | Installer flag | Notes |
 |---|---|---|
 | Docker | Default | Lowest overhead. Best for trusted workloads. |
 | gVisor | `--with-gvisor` | Adds a user-space kernel boundary for untrusted code. |
-| Firecracker | `--with-firecracker` | MicroVM runtime for fast, secure isolation. |
-| Kata Containers | Not available yet | Create requests return `runtime not yet implemented`. |
+| Firecracker | `--with-firecracker` | MicroVM runtime; needs KVM / bare metal. |
+| WASM | Config (`SB_ENABLE_WASM` / wasm workers) | WASI modules; no separate installer flag on single-node by default. See [WASM Sandbox](/wasm-sandbox). |
+| Isolate (V8 / workerd) | `--with-isolate` | Downloads pinned `workerd`, sets `SB_ENABLE_ISOLATE=true`. Off by default. See [Isolate Sandbox](/isolate-sandbox). |
+| Kata Containers | Not available | Create requests return `runtime not yet implemented`. |
 
 If you want gVisor on the host, add `--with-gvisor` to the install command above. gVisor is not compatible with `--privileged` containers, ignores `disk_gb`, requires cgroupv2 plus systemd, and does not support GPU passthrough.
+
+For V8 isolates, add `--with-isolate`. Until full jail chroot-populate lands, operators may need `SB_ISOLATE_USE_JAIL=false` for end-to-end creates (the live integration scenario does this).
 
 ## GPU Support
 

--- a/docs/src/content/docs/isolate-sandbox.mdx
+++ b/docs/src/content/docs/isolate-sandbox.mdx
@@ -1,6 +1,6 @@
 ---
 title: Isolate Sandbox
-description: Deploy a JS/TS fetch handler as a V8 isolate — no image, no registry, host-mediated HTTP.
+description: Deploy a JS/TS fetch handler as a V8 isolate — no image, no registry, host-mediated HTTP with per-sandbox egress.
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
@@ -9,17 +9,38 @@ Isolate sandboxes run a JavaScript/TypeScript `fetch` handler inside a V8
 isolate (Cloudflare's `workerd` engine). Push a bundle, get an HTTP entrypoint
 with capability-scoped egress — no Dockerfile, no container image, no shell or
 filesystem. This is the Workers-model tier that complements Firecracker
-microVMs.
+microVMs and WASM modules.
 
 Requires `SB_ENABLE_ISOLATE=true` and a pinned `workerd` binary on the host
-(`install.sh --with-isolate`).
+(`install.sh --with-isolate`, or Terraform `with_isolate = true` /
+`default_with_isolate = true`). Off by default.
+
+## Create latency
+
+Warm create (bundle already uploaded, tenant group already running) is the
+steady-state path. Live UC-94 on `single-node-isolate` (`t3.medium`, jail off,
+10 samples, 0 failures):
+
+| Metric | p50 | p90 | p99 |
+|---|---|---|---|
+| **Server create** | **4ms** | 6ms | 19ms |
+| Client API round-trip | 266ms | 269ms | 289ms |
+
+The API figure includes laptop → region WAN; quote **server** latency for
+create cost. Cold first-create for a tenant also pays one workerd group spawn;
+subsequent creates in that tenant inject into the resident group.
 
 ## Create an isolate sandbox
 
 Pass `runtime: "isolate"` and a `module_ref` pointing at a JS/TS bundle —
-an uploaded catalogue name/digest, or a `file://` path for operators. Isolates
+an uploaded catalogue digest/name, or a `file://` path for operators. Isolates
 default to `durability: "ephemeral"`; `passivatable` is rejected and `durable`
 is not yet enabled.
+
+Upload the bundle once with `POST /v1/js-bundles` (experimental catalogue),
+then create with the returned digest as `module_ref`. Same-tenant sandboxes
+share one workerd group process (server-authorized `tenant_id`); the group key
+is never client-chosen for forced co-residency.
 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">
@@ -66,22 +87,23 @@ is not yet enabled.
         "context"
         "fmt"
         "log"
+        "os"
 
-        "github.com/aerol-ai/microvm/pkg/microvm"
-        "github.com/aerol-ai/microvm/pkg/types"
+        microvm  "github.com/aerol-ai/microvm/sdk/go/pkg/microvm"
+        sdktypes "github.com/aerol-ai/microvm/sdk/go/pkg/types"
     )
 
-    client, err := microvm.New(microvm.Config{
-        APIURL:   "https://sandbox.example.com",
-        PATToken: "your-token",
+    client, err := microvm.NewClientWithConfig(&sdktypes.MicroVMConfig{
+        APIUrl:   os.Getenv("SB_API_URL"),
+        PATToken: os.Getenv("SB_PAT_TOKEN"),
     })
     if err != nil {
         log.Fatal(err)
     }
 
-    sb, err := client.Create(context.Background(), types.CreateSandboxOptions{
+    sb, err := client.Create(context.Background(), sdktypes.CreateSandboxOptions{
         ModuleRef:       "sha256:…",
-        Runtime:         types.RuntimeIsolate,
+        Runtime:         sdktypes.RuntimeIsolate,
         MemoryMB:        128,
         NetworkAllowOut: []string{"api.example.com"},
     })
@@ -97,12 +119,16 @@ is not yet enabled.
 
     #[tokio::main]
     async fn main() -> Result<(), Box<dyn std::error::Error>> {
-        let client = Client::new("https://sandbox.example.com", "your-token")?;
+        let client = Client::new(
+            Some("https://sandbox.example.com"),
+            Some("your-token"),
+        )?;
         let sandbox = client
             .create(CreateOptions {
                 module_ref: Some("sha256:…".into()),
                 runtime: Some("isolate".into()),
                 memory_mb: Some(128),
+                network_allow_out: Some(vec!["api.example.com".into()]),
                 ..Default::default()
             })
             .await?;
@@ -125,17 +151,57 @@ is not yet enabled.
     Sandbox sandbox = client.create(new CreateOptions()
         .setModuleRef("sha256:…")
         .setRuntime("isolate")
-        .setMemoryMb(128));
+        .setMemoryMb(128)
+        .setNetworkAllowOut(java.util.List.of("api.example.com")));
 
     System.out.println(sandbox.id);
     ```
   </TabItem>
 </Tabs>
 
+## Per-sandbox egress
+
+Outbound `fetch` is host-mediated. Each sandbox binds a dedicated egress slot
+in the workerd group config — attribution is structural (which static egress
+service the worker can reach), not a forgeable header. Within one tenant group
+you can mix:
+
+- `networkAllowOut: ['api.example.com']` — only listed hosts
+- `networkBlockAll: true` — fail-closed deny (same as an empty allowlist with no opens)
+- allow-all with SSRF guards still blocking link-local / EC2 metadata / loopback
+
+`SB_ISOLATE_EGRESS_POOL_SIZE` (default 64) caps concurrently egressing sandboxes
+per group. Pool exhaustion binds a deny service and logs spill — never silent
+open egress.
+
+Public HTTP ingress is opt-in with `exposePort` (HTTP only — the TCP host-port
+pool is never walked for isolates).
+
 ## Residual limits
 
 Isolates have **no shell, no filesystem, and no arbitrary binary**. Toolbox
-`exec` invokes the `fetch` handler; other toolbox verbs return 501. Upload
-bundles via `POST /v1/js-bundles` (experimental until the demand checkpoint
-lands). Public HTTP is opt-in with `expose_port` (HTTP only — the TCP host-port
-pool is never walked).
+`exec` invokes the `fetch` handler; other toolbox verbs return 501. Platform
+volumes and OCI images are rejected. SSH is not available.
+
+The outer jail (chroot + seccomp) defaults on in config; full chroot populate
+with the workerd binary is still landing — deploy with
+`SB_ISOLATE_USE_JAIL=false` until that follow-up ships (the live integration
+scenario does this today). Cross-tenant isolation remains one OS process per
+tenant group regardless.
+
+## Operator setup
+
+| Knob | Default | Purpose |
+|---|---|---|
+| `SB_ENABLE_ISOLATE` | `false` | Advertise + accept `runtime: "isolate"` |
+| `SB_ISOLATE_WORKERD_PATH` | install path | Pinned workerd binary |
+| `SB_ISOLATE_GROUP_GRANULARITY` | `per-tenant` | Or `per-sandbox` for stronger isolation / lower density |
+| `SB_ISOLATE_EGRESS_POOL_SIZE` | `64` | Concurrent egress slots per group |
+| `SB_ISOLATE_USE_JAIL` | `true` | Outer jail; set `false` until chroot-populate lands |
+
+Installer: `install.sh --with-isolate`. Cluster Terraform:
+`with_isolate = true` on workers (or `default_with_isolate`). Operators upgrade
+the pinned workerd via `setup/runbooks/isolate-workerd-upgrade.md`.
+
+Live coverage: `make integration-single-isolate` (UC-103/104/105) and
+`make integration-benchmark-isolate` (UC-94 create latency).

--- a/docs/src/content/docs/platform-volumes.mdx
+++ b/docs/src/content/docs/platform-volumes.mdx
@@ -31,7 +31,8 @@ A platform volume:
 Platform volumes must be **enabled by the operator** (see [Operator
 setup](#operator-setup)). If they are not configured, every volume request is
 rejected with **412 Precondition Failed**. Volumes are supported on the
-`docker` and `gvisor` runtimes only — `firecracker` and `wasm` reject them.
+`docker` and `gvisor` runtimes only — `firecracker`, `wasm`, and `isolate`
+reject them.
 Platform volumes count against the same per-sandbox cap as external mounts (8
 total).
 

--- a/docs/src/content/docs/quick-start.md
+++ b/docs/src/content/docs/quick-start.md
@@ -2,26 +2,34 @@
 title: Quick Start
 ---
 
-**AerolVM** is open-source infrastructure for running isolated code environments. Each sandbox is a fully isolated compute unit with its own filesystem, network stack, and allocated vCPU, RAM, and disk with a support of Docker, GVisor, Kata and Wasm.
+**AerolVM** is open-source infrastructure for running isolated code environments.
+Self-host it or run it as managed multi-tenant SaaS. Each sandbox is a fully
+isolated compute unit — Docker/gVisor containers, Firecracker microVMs, WASM
+modules, or V8 isolates — with its own network policy and allocated resources.
 
-The idea is to provide a seamless, secure sandbox experience that can start in under 50ms to 1s.
+Warm create latency (server-side) ranges from **~4ms** (V8 isolate) through
+**~30ms** (Docker / Firecracker warm pool) depending on runtime. See the
+[README benchmark table](https://github.com/aerol-ai/microvm#create-latency-live-uc-94)
+for the latest UC-94 numbers.
 
-Sandboxes are the core component of the [Aerol.ai](https://aerol.ai) platform, spinning up in under 70ms from code to execution and running any code in Python, TypeScript, and JavaScript. Built on OCI/Docker compatibility, massive parallelization, and unlimited persistence, sandboxes deliver consistent, predictable environments for agent workflows.
-
-Agents and developers interact with sandboxes programmatically using the AerolVM SDKs, API, and CLI. Operations span sandbox lifecycle management, filesystem operations, process and code execution, and runtime configuration. Our stateful environment snapshots enable persistent agent operations across sessions, making AerolVM the ideal foundation for AI agent architectures.
+Agents and developers interact with sandboxes programmatically using the AerolVM
+SDKs, API, and CLI. Operations span sandbox lifecycle management, filesystem
+operations, process and code execution, and runtime configuration. Stateful
+environment snapshots enable persistent agent operations across sessions.
 
 ## Runtimes
 
-AerolVM supports multiple container runtimes, giving you a choice between security and compatibility:
-
-| Runtime | Status | Use Case |
+| Runtime | Status | Use case |
 |---|---|---|
-| Docker | ✅ | Fast startup, broad image compatibility, standard workloads |
-| GVisor | ✅ | Kernel-level isolation without a full VM - ideal for untrusted code |
-| Firecracker | ✅ | Kernel-level isolation Full VM isolation with hardware virtualization |
-| WebAssembly | ✅ | Ultra-lightweight WASI workloads with optional durable checkpoints |
+| Docker | ✅ | Fast OCI images, broadest compatibility (default) |
+| gVisor | ✅ | User-space kernel isolation for untrusted code (`--with-gvisor`) |
+| Firecracker | ✅ | Hardware microVM isolation; warm pool ~34ms server create |
+| WebAssembly | ✅ | WASI modules; resident host ~22ms warm create |
+| Isolate (V8 / workerd) | ✅ (off by default) | JS/TS `fetch` handlers; **~4ms** warm server create (`--with-isolate`) |
 
-Docker is the default runtime today. GVisor, Firecracker, and WebAssembly are also available when enabled in server config.
+Kata Containers is not implemented — create requests with `runtime: "kata"`
+return not-implemented. Docker is the default. Enable the others in server
+config or installer flags as needed.
 
 ## Use Cases
 
@@ -29,6 +37,7 @@ Docker is the default runtime today. GVisor, Firecracker, and WebAssembly are al
 - **CI / ephemeral build agents** - spin up a fresh environment per job, destroy when done
 - **Interactive developer environments** - persistent workspaces with SSH, port previews, and file sync
 - **Data processing pipelines** - attach cloud storage, run transforms, and extract results
+- **Edge-style JS handlers** - deploy a V8 isolate with per-sandbox egress, no container image
 
 ## Next Steps
 
@@ -38,3 +47,4 @@ Docker is the default runtime today. GVisor, Firecracker, and WebAssembly are al
 - [Streaming Exec](/exec-streaming) - stream stdout/stderr live and use interactive PTY sessions
 - [Sessions](/sessions) - persistent terminal sessions that survive reconnects
 - [WebAssembly Sandboxes](/wasm-sandbox) - create and run WASI modules with durable checkpoints
+- [Isolate Sandboxes](/isolate-sandbox) - push a JS/TS fetch handler as a V8 isolate

--- a/docs/src/content/docs/sandboxes.mdx
+++ b/docs/src/content/docs/sandboxes.mdx
@@ -5,7 +5,14 @@ description: Create, manage, and resize standard Docker sandboxes.
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-A sandbox is an isolated compute environment. Each sandbox has its own filesystem, network namespace, and configurable vCPU, memory, and disk. Sandboxes spin up in under 90ms and run any OCI-compatible image.
+A sandbox is an isolated compute environment. Container and microVM sandboxes
+have their own filesystem, network namespace, and configurable vCPU, memory, and
+disk. WASM and isolate sandboxes are host-mediated (no guest filesystem) and
+opt into a different create shape (`module_ref` instead of `image`).
+
+Warm server-side create is roughly **~4ms** (isolate), **~22ms** (WASM resident
+host), **~30ms** (Docker / Firecracker warm pool) — see the live UC-94 table in
+the repository README.
 
 ## Sandbox types
 
@@ -13,7 +20,9 @@ A sandbox is an isolated compute environment. Each sandbox has its own filesyste
 |---|---|---|
 | Docker | `docker` (default) | Standard runc-backed containers. Works on any node. |
 | gVisor | `gvisor` | User-space kernel - intercepts syscalls. Better isolation, same hardware requirements. See [gVisor Sandbox](/gvisor-sandbox). |
-| Firecracker | `firecracker` | Full microVM - each sandbox boots its own kernel in under 100ms. Requires bare-metal nodes. See [Firecracker Sandbox](/firecracker-sandbox). |
+| Firecracker | `firecracker` | Full microVM - warm-pool create ~34ms server-side. Requires bare-metal / KVM nodes. See [Firecracker Sandbox](/firecracker-sandbox). |
+| WASM | `wasm` | WASI modules in host workers; optional durable checkpoints. See [WASM Sandbox](/wasm-sandbox). |
+| Isolate | `isolate` | V8 isolate (`workerd`) running a JS/TS `fetch` handler — no image. Off by default (`--with-isolate`). See [Isolate Sandbox](/isolate-sandbox). |
 | GPU | `docker` + `gpus` field | Standard Docker with direct GPU passthrough. See [GPU Sandbox](/gpu-sandboxes). |
 
 ## Lifecycle states

--- a/docs/src/content/docs/wasm-sandbox.mdx
+++ b/docs/src/content/docs/wasm-sandbox.mdx
@@ -5,7 +5,12 @@ description: Run WebAssembly/WASI workloads with optional checkpoint durability 
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-WASM sandboxes run guest modules inside isolated worker processes on the host. They boot quickly, share the same toolbox and routing model as Docker sandboxes, and support optional checkpoint durability for daemon restarts and cluster failover.
+WASM sandboxes run guest modules inside isolated worker processes on the host.
+They boot quickly, share the same toolbox and routing model as Docker sandboxes,
+and support optional checkpoint durability for daemon restarts and cluster
+failover. With the resident host enabled (default on recent releases), warm
+create is ~**22ms** server p50 on `cluster-3-mixed-wasm` (flat ~20–50ms; the
+multi-second cold-compile tail is gone).
 
 ## Create a WASM sandbox
 

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -9,12 +9,13 @@ matrix. Full design + decisions: [`../plans/integration-tests.md`](../plans/inte
 > key + separate `TF_DATA_DIR`) so production state is never touched. Spot
 > instances + auto-teardown + `make integration-reap` keep cost down.
 
-## Status: Phase 0 (walking skeleton)
+## Status
 
-Implemented end-to-end on the `single-node` scenario: UC-10 (auth), UC-11
-(create), UC-16 (delete), UC-29 (expose), UC-30 (reachable). Everything else is
-in the registry as **pending** and shows up that way in the report. Cluster
-scenarios land in Phase 2.
+Live scenarios cover single-node (docker / containerd / fc / wasm / isolate),
+3× mixed clusters (docker, containerd, gvisor, wasm, fc), hetero, local-mode,
+and arm64. Reports and the coverage matrix live in `reports/`. Isolate is
+exercised by `make integration-single-isolate` (UC-103/104/105) and
+`make integration-benchmark-isolate` (UC-94).
 
 ## Prerequisites
 
@@ -27,13 +28,15 @@ scenarios land in Phase 2.
 ## Run
 
 ```bash
-make integration-single                 # single-node scenario (Phase 0)
+make integration-single                 # single-node scenario
+make integration-single-isolate         # single-node + V8-isolate (workerd); UC-103/104/105
 make integration-local                  # local-mode (--local install on a throwaway box)
 integration-tests/run.sh single-node --keep        # leave infra up for debugging
 integration-tests/run.sh single-node --prod-tls    # use real Let's Encrypt instead of staging
 make integration-cluster-hetero           # 8-node heterogeneous cluster (x86 fc)
 make integration-cluster-mixed-fc         # 3× mixed cluster, FC on seed c5.metal
 make integration-cluster-mixed-gvisor       # 3× mixed cluster, gVisor on every node
+make integration-cluster-mixed-wasm         # 3× mixed cluster, WASM workers
 make integration-single-fc                # single-node-fc (x86 firecracker, c5.metal)
 make integration-arm64                    # arm64 firecracker single + cluster scenarios
 make integration-arm64-single             # single-node-fc-arm64 (Graviton metal)
@@ -107,17 +110,19 @@ every stored cert. See [`setup/multi-node-cert-sharing.md`](../setup/multi-node-
 deployment to measure sandbox creation. It only runs where the scenario
 advertises the `benchmark` capability — **`cluster-hetero`** (every runtime),
 **`cluster-3-mixed-docker`** (docker only), **`cluster-3-mixed-fc`** (docker +
-firecracker), **`cluster-3-mixed-gvisor`** (docker + gvisor), and
-**`cluster-3-mixed-wasm`** (docker + wasm) in 3-node mixed clusters — because
-it is slow and provisions many sandboxes. Everywhere else UC-94/UC-95 skip (not-applicable).
+firecracker), **`cluster-3-mixed-gvisor`** (docker + gvisor),
+**`cluster-3-mixed-wasm`** (docker + wasm), and **`single-node-isolate`**
+(isolate) — because it is slow and provisions many sandboxes. Everywhere else
+UC-94/UC-95 skip (not-applicable).
 
 - **UC-94 — create latency:** for each runtime the scenario has (docker,
-  firecracker, gvisor, wasm) it creates `AEROL_BENCH_SAMPLES` sandboxes
+  firecracker, gvisor, wasm, isolate) it creates `AEROL_BENCH_SAMPLES` sandboxes
   serially, reporting p50/p90/p99 + mean for three timings: **api** (the
   `Create()` client round-trip), **server** (the API's own `Server-Timing`
   header for the create — client↔cluster network excluded), and **running**
   (create→`started`). `api − server` is that network overhead, so you can tell a
-  slow create from a slow link.
+  slow create from a slow link. For isolate, the bench uploads one JS bundle and
+  pins a shared `tenant_id` so samples hit the warm group path.
 - **UC-95 — fleet density:** creates docker sandboxes until the fleet rejects on
   capacity (HTTP 503 `capacity exceeded`), reports how many landed, then tears
   them all down. `AEROL_BENCH_MAX` bounds cost if admission never trips.
@@ -153,6 +158,10 @@ make integration-benchmark-wasm
 # gVisor-focused 3× mixed cluster (docker + gvisor only; cheap t3 spot boxes):
 make integration-benchmark-gvisor
 
+# V8-isolate (workerd) create-latency on single-node-isolate (t3.medium):
+# AEROL_BENCH_RUNTIMES=isolate; UC-95 skipped (no CapCluster).
+make integration-benchmark-isolate
+
 # Manual env form (hetero):
 AEROL_BENCH=1 \
 AEROL_BENCH_OUT=integration-tests/reports/cluster-hetero-bench.json \
@@ -180,11 +189,14 @@ make integration-benchmark-wasm-only       # re-run wasm bench against kept clus
 make integration-cluster-mixed-gvisor keep # 3× mixed gVisor cluster
 make integration-benchmark-gvisor-only     # re-run UC-94/UC-95 against it
 
+make integration-single-isolate keep       # single-node isolate (functional UCs)
+make integration-benchmark-isolate-only    # re-run UC-94 isolate latency
+
 # Narrow the UC-94 sweep on hetero / mixed-fc / mixed-gvisor benches:
 AEROL_BENCH_RUNTIMES=docker,gvisor,wasm make integration-benchmark-only
-# …or isolate firecracker latency (UC-95 skips when docker is excluded):
+# …or firecracker-only latency (UC-95 skips when docker is excluded):
 AEROL_BENCH_RUNTIMES=firecracker make integration-benchmark-fc-only
-# …or isolate gvisor latency (UC-95 skips when docker is excluded):
+# …or gvisor-only latency (UC-95 skips when docker is excluded):
 AEROL_BENCH_RUNTIMES=gvisor make integration-benchmark-gvisor-only
 # …or add docker density/latency back on the wasm cluster:
 AEROL_BENCH_RUNTIMES=docker,wasm make integration-benchmark-wasm-only
@@ -194,6 +206,7 @@ make integration-destroy SCENARIO=cluster-3-mixed-docker
 make integration-destroy SCENARIO=cluster-3-mixed-fc
 make integration-destroy SCENARIO=cluster-3-mixed-gvisor
 make integration-destroy SCENARIO=cluster-3-mixed-wasm
+make integration-destroy SCENARIO=single-node-isolate
 ```
 
 Percentiles + the density ceiling also print as `bench[...]` log lines (captured

--- a/plans/isolate-runtime.md
+++ b/plans/isolate-runtime.md
@@ -1,6 +1,6 @@
 # V8-Isolate Sandboxes (Deno/Workers model) — Design & Implementation Plan
 
-Status: **In progress — Phases 1–3 landed (cold path, /v1/js-bundles, idle-TTL, bundle GC, guest HTTP, attributed egress, expose_port, warm pool, P0 gate, docs + SDK constants); §10.1 demand pitch still open (gates Phase 4)** · Owner: TBD · Created: 2026-07-10 · Amended: 2026-07-18
+Status: **In progress — Phases 1–3 landed + live harness (cold path, /v1/js-bundles, idle-TTL, bundle GC, guest HTTP, attributed egress, expose_port, warm pool, P0 gate, docs + SDK constants, `single-node-isolate` UC-103/104/105, UC-94 bench); §10.1 demand pitch still open (gates Phase 4)** · Owner: TBD · Created: 2026-07-10 · Amended: 2026-07-18
 
 This plan adds a **fifth runtime** to AerolVM — **V8 isolates** (the
 Deno-Deploy / Cloudflare-Workers model) — as a peer to `docker`, `gvisor`,
@@ -15,8 +15,10 @@ bundle instead of a `.wasm`.
 The isolate runtime is the **Workers-model tier**: push a JS/TS bundle, get a
 `fetch` handler with capability-scoped grants — no image build, no external
 registry, near-zero per-sandbox footprint, thousands of sandboxes per host.
-Create latency (~5ms warm target) is a supporting stat, not the headline: the
-resident-WASM host already creates at a flat ~21ms, so what this tier uniquely
+Create latency is a supporting stat, not the headline: live UC-94 on
+`single-node-isolate` (t3.medium, jail off, 10 samples) measured **warm server
+p50=4ms / p90=6ms / p99=19ms** (API p50=266ms is laptop→region WAN). The
+resident-WASM host already creates at a flat ~22ms, so what this tier uniquely
 adds is the **deployment model and density economics**, not raw speed. It is
 the complement to the Firecracker tier (arbitrary binaries, real VM isolation)
 — the same two-tier split Deno arrived at when it paired Workers (isolates)
@@ -26,6 +28,13 @@ with Deno Sandbox (microVMs).
 
 ## 0. Review history
 
+- **2026-07-18 — Live integration + UC-94 bench.** `single-node-isolate`
+  scenario (`make integration-single-isolate`): UC-103 (runs), UC-104
+  (per-sandbox egress allowlist in one tenant group), UC-105 (js-bundle
+  catalogue CRUD) green on released v0.7.16 + workerd. UC-94 via
+  `make integration-benchmark-isolate`: warm isolate server p50=4ms (artifact
+  `reports/single-node-isolate-bench.{json,md}`). Jail left off until
+  chroot-populate lands.
 - **2026-07-18 — Phases 2 leftovers + Phase 3 landed.** Idle-TTL reaper;
   unreferenced bundle GC; guest HTTP PortGateway + expose_port (HTTP-only,
   no TCP pool); per-sandbox attributed egress (per-slot egress-service pool —


### PR DESCRIPTION
## Summary
- Refresh README with all five runtimes (Docker / gVisor / Firecracker / WASM / Isolate) and a live UC-94 create-latency table (isolate 4ms, WASM 22ms, Docker ~30ms, Firecracker 34ms, gVisor 284ms server p50).
- Expand isolate docs for Phases 1–3: warm create numbers, per-sandbox egress attribution, js-bundles, jail caveat, operator knobs, and integration make targets.
- Bring outdated MDX/setup pages in line (quick-start, comparison, sandboxes, runtime-layers, single-node + cluster `--with-isolate`, wasm/fc latency claims, integration-tests README, plan status).

## Code-path diagram
N/A - docs/comment-only change.

## Sandbox boot impact
N/A - no work added to sandbox boot path.

## Idempotency
N/A - no API surface changed.

## Failure-path consistency
N/A - no multi-step write path changed.

## L4 / host-port-pool changes
N/A - neither touched.

## Test plan
- [ ] Skim README runtimes + UC-94 table against `integration-tests/reports/*-bench.md`
- [ ] Preview isolate page: `make docs-dev` → `/isolate-sandbox`
- [ ] Confirm sidebar still links Isolate under Sandboxes (`content.config.ts` unchanged)
- [ ] Spot-check quick-start / comparison / cluster-setup for Kata removal and `with_isolate` step


Made with [Cursor](https://cursor.com)