### PR TITLE
docs: quote containerd UC-94 latency as the default OCI path

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 &nbsp;
 
-AerolVM is open-source sandbox infrastructure for running isolated code environments - self-host it on your own Linux host, or run it as a managed, multi-tenant service. Each sandbox is a fully isolated compute unit with its own filesystem, network stack, and allocated resources - create latency as low as **4ms server-side** (V8 isolate warm path) and supporting Docker, gVisor, Firecracker, WASM, and V8-isolate runtimes. Built for AI agent pipelines and ephemeral CI, it ships as a single Go binary backed by Caddy for TLS routing and SQLite for state, with no external dependencies and a one-line installer.
+AerolVM is open-source sandbox infrastructure for running isolated code environments - self-host it on your own Linux host, or run it as a managed, multi-tenant service. Each sandbox is a fully isolated compute unit with its own filesystem, network stack, and allocated resources - create latency as low as **4ms server-side** (V8 isolate warm path) and supporting OCI containers on **containerd** (default), gVisor, Firecracker, WASM, and V8-isolate runtimes. Built for AI agent pipelines and ephemeral CI, it ships as a single Go binary backed by Caddy for TLS routing and SQLite for state, with no external dependencies and a one-line installer.
 
 ## Features
 
@@ -40,7 +40,7 @@ AerolVM provides a complete surface for building sandbox-backed products and age
 | [Lifecycle (create / start / stop / destroy)](https://microvm.aerol.ai/sandboxes) | [Streaming exec & PTY](https://microvm.aerol.ai/exec-streaming) | [HTTP preview URLs](https://microvm.aerol.ai/preview) | [External storage (S3, NFS, SSHFS, rclone)](https://microvm.aerol.ai/external-storage) | [Raft-coordinated cluster](https://microvm.aerol.ai/cluster-setup) |
 | [Environment & resource limits](https://microvm.aerol.ai/environment) | [Persistent PTY sessions w/ replay](https://microvm.aerol.ai/sessions) | [TCP port exposure](https://microvm.aerol.ai/tcp-ports) | [Encrypted sandbox secrets](https://microvm.aerol.ai/environment) | [HA failover & durability](https://microvm.aerol.ai/durability) |
 | [Snapshots (stop-start persistence)](https://microvm.aerol.ai/snapshots) | [SSH access per sandbox](https://microvm.aerol.ai/ssh-access) | [TLS + SNI port routing](https://microvm.aerol.ai/tcp-vs-tls-ports) | [Custom domains](https://microvm.aerol.ai/custom-domains) | [Cluster ingress topology](https://microvm.aerol.ai/cluster-ingress) |
-| [Multi-runtime (Docker / gVisor / Firecracker / WASM / Isolate)](https://microvm.aerol.ai/sandboxes) | [File system operations](https://microvm.aerol.ai/file-system) | [Per-sandbox egress control](https://microvm.aerol.ai/network-isolation) | [Sandbox tags & tenant scoping](https://microvm.aerol.ai/sandbox-tags) | [Reconciler & self-healing](https://microvm.aerol.ai/reconcile) |
+| [Multi-runtime (containerd OCI / gVisor / Firecracker / WASM / Isolate)](https://microvm.aerol.ai/sandboxes) | [File system operations](https://microvm.aerol.ai/file-system) | [Per-sandbox egress control](https://microvm.aerol.ai/network-isolation) | [Sandbox tags & tenant scoping](https://microvm.aerol.ai/sandbox-tags) | [Reconciler & self-healing](https://microvm.aerol.ai/reconcile) |
 | [GPU sandboxes](https://microvm.aerol.ai/gpu-sandboxes) | [Port allowlist](https://microvm.aerol.ai/port-allowlist) | [Per-sandbox network quotas](https://microvm.aerol.ai/network-usage) | [Dashboard](https://microvm.aerol.ai/dashboard) | [Operational runbooks](https://microvm.aerol.ai/operational-runbooks) |
 
 ## Why AerolVM
@@ -51,8 +51,8 @@ AerolVM beats the two most common alternatives on the axes that matter most for 
 | :--- | :--- | :--- | :--- |
 | **Deployment** | ✅ Self-host (single binary, one-line install) or managed multi-tenant SaaS | ✗ Cloud only | ✅ Self-host (complex multi-component setup) |
 | **Runs locally** | ✅ `--local` flag, no DNS needed | ✗ | ✗ |
-| **Sandbox startup (server p50)** | Isolate ~4ms · WASM ~22ms · Docker ~30ms · Firecracker ~34ms | ~200ms | < 90ms |
-| **Runtime isolation** | ✅ Docker, gVisor, Firecracker (microVM), WASM, V8 isolate (workerd) | Firecracker (microVM) | Docker only |
+| **Sandbox startup (server p50)** | Isolate ~4ms · WASM ~22ms · Firecracker ~34ms · containerd ~189ms | ~200ms | < 90ms |
+| **Runtime isolation** | ✅ OCI (containerd default) / gVisor / Firecracker / WASM / V8 isolate | Firecracker (microVM) | Docker only |
 | **Sandbox lifetime** | Unlimited | 1 day | Unlimited |
 | **Serverless / Workers-style sandboxes** | ✅ WASM + V8 isolate | ✗ | ✗ |
 | **TCP + TLS port routing** | ✅ | ✗ | ✗ |
@@ -69,7 +69,7 @@ AerolVM beats the two most common alternatives on the axes that matter most for 
 
 ### vs e2b
 
-e2b is the fastest managed path if you want zero infrastructure, but it means your code runs on someone else's hardware with no self-hosting option, per-sandbox-hour billing that compounds fast at scale, a hard 1-day sandbox lifetime cap, and a single isolation model. AerolVM covers the same AI execution use case on infrastructure you own — pick Docker, gVisor, Firecracker, WASM, or V8 isolates — with predictable fixed-cost pricing.
+e2b is the fastest managed path if you want zero infrastructure, but it means your code runs on someone else's hardware with no self-hosting option, per-sandbox-hour billing that compounds fast at scale, a hard 1-day sandbox lifetime cap, and a single isolation model. AerolVM covers the same AI execution use case on infrastructure you own — pick OCI on containerd, gVisor, Firecracker, WASM, or V8 isolates — with predictable fixed-cost pricing.
 
 > **Already on the e2b SDK?** AerolVM's `/e2b` API facade means your existing code keeps working - just point `E2B_API_URL` at your AerolVM host.
 
@@ -84,7 +84,7 @@ Daytona targets long-lived developer workspaces, not high-frequency ephemeral ag
 AerolVM is a single Go binary (`sandboxd`) wired to three components:
 
 - **Caddy** - handles wildcard TLS via DNS-01, L7 HTTP routing (`<sandbox-id>.<domain>`), and L4 TCP SNI routing (`<sandbox-id>-<port>.<domain>`). The daemon talks to the Caddy admin API; no config files are reloaded at runtime.
-- **Runtimes** - Docker (`runc`), gVisor (`runsc`), Firecracker (microVM), WASM (WASI workers / resident host), and V8 isolate (`workerd`). OCI runtimes share the Docker/containerd path; WASM and isolate are host-mediated and Runtime-only.
+- **Runtimes** - OCI containers (`runtime: "docker"` on the **containerd** engine by default; dockerd optional), gVisor (`runsc`), Firecracker (microVM), WASM (WASI workers / resident host), and V8 isolate (`workerd`). WASM and isolate are host-mediated and Runtime-only.
 - **SQLite (WAL mode, single-writer)** - stores sandbox state, the TCP host-port pool, exposed-port intents, and sealed secrets. Single-writer means no contention; WAL mode means reads never block writes.
 
 For multi-host deployments, `sandboxd` nodes form a cluster using **Raft** (FSM-replicated placement state) and **SWIM gossip** (membership + capacity heartbeats). Nodes take `server`, `worker`, or `ingress` roles. The Raft voter count stays fixed at 3 or 5 regardless of how many workers you add - the same topology Kubernetes uses for control-plane vs. data-plane scaling. See [Cluster Setup](https://microvm.aerol.ai/cluster-setup).
@@ -100,8 +100,8 @@ For multi-host deployments, `sandboxd` nodes form a cluster using **Raft** (FSM-
 │                      │                              │
 │          ┌───────────┼───────────┐                  │
 │          ▼           ▼           ▼                  │
-│   Docker/gVisor   Caddy      SSH gateway            │
-│   FC/WASM/isolate admin API  (Ed25519)              │
+│  containerd/gVisor  Caddy      SSH gateway            │
+│  FC/WASM/isolate  admin API  (Ed25519)              │
 └─────────────────────────────────────────────────────┘
 ```
 
@@ -109,7 +109,7 @@ For multi-host deployments, `sandboxd` nodes form a cluster using **Raft** (FSM-
 
 | Runtime | Status | Install / enable | Use case |
 | :--- | :--- | :--- | :--- |
-| Docker (`runc`) | ✅ Available | Default | Broadest OCI image compatibility. |
+| OCI / `docker` API (`runc` via **containerd**) | ✅ Available | Default engine (`SB_CONTAINER_ENGINE=containerd`) | Broadest OCI image compatibility. |
 | gVisor (`runsc`) | ✅ Available | `--with-gvisor` | User-space kernel for untrusted LLM code. |
 | Firecracker | ✅ Available | `--with-firecracker` (bare metal / KVM) | MicroVM - dedicated kernel per sandbox. |
 | WASM | ✅ Available | Config / cluster wasm workers | WASI modules; resident host ~22ms warm create. |
@@ -117,17 +117,17 @@ For multi-host deployments, `sandboxd` nodes form a cluster using **Raft** (FSM-
 
 ## Create latency (live UC-94)
 
-Server-side create from `Server-Timing` (excludes client↔cluster WAN). Artifacts under `integration-tests/reports/`.
+Server-side create from `Server-Timing` (excludes client↔cluster WAN). Artifacts under `integration-tests/reports/`. Production deployments use the **containerd** engine for OCI sandboxes (`runtime: "docker"` on the wire).
 
-| Runtime | Server p50 | Server p90 | Server p99 | Topology | Notes |
+| Runtime / engine | Server p50 | Server p90 | Server p99 | Topology | Notes |
 | :--- | ---: | ---: | ---: | :--- | :--- |
 | **Isolate** | **4ms** | 6ms | 19ms | `single-node-isolate` · t3.medium | Warm path (same tenant group); API p50 266ms is WAN |
 | **WASM** (resident host) | **22ms** | 46ms | 50ms | `cluster-3-mixed-wasm` · t3.large | Flag-on resident host; no cold-compile tail |
-| **Docker** (sparse / warm) | **28–30ms** | 29–332ms | 30–373ms | `cluster-3-mixed-docker` · t3.medium | Sparse bench holds ~28ms; burst p90 can include image/netrule work |
 | **Firecracker** (warm pool) | **34ms** | 36ms | 37ms | `single-node-fc` · c5.metal | Post warm-pool path; cold/template builds are higher |
+| **containerd** (OCI default) | **189ms** | 225ms | 233ms | `cluster-3-mixed-containerd` · t3.medium | Default host engine; API runtime remains `docker` |
 | **gVisor** | **284ms** | 330ms | 346ms | `cluster-3-mixed-gvisor` · t3.medium | User-space kernel boot cost |
 
-Reproduce: `make integration-benchmark-isolate`, `integration-benchmark-wasm`, `integration-benchmark-docker`, `integration-benchmark-fc`, `integration-benchmark-gvisor`.
+Reproduce: `make integration-benchmark-isolate`, `integration-benchmark-wasm`, `integration-benchmark-containerd`, `integration-benchmark-fc`, `integration-benchmark-gvisor`.
 
 ## SDKs
 

--- a/docs/src/content/docs/comparison.md
+++ b/docs/src/content/docs/comparison.md
@@ -13,8 +13,8 @@ A side-by-side look at how AerolVM compares to the two most common alternatives 
 | **Can run locally** | ✅ | ✗ | ✗ |
 | **Open source** | ✅ | ✗ | ✅ |
 | **Primary use case** | AI agents + ephemeral CI | AI agent code execution | Developer workspaces |
-| **Sandbox startup (server p50)** | Isolate ~4ms · WASM ~22ms · Docker ~30ms · Firecracker ~34ms | ~200ms | <90ms |
-| **Runtime isolation** | Docker, gVisor, Firecracker (microVM), WASM, V8 isolate (workerd) | Firecracker | Docker |
+| **Sandbox startup (server p50)** | Isolate ~4ms · WASM ~22ms · Firecracker ~34ms · containerd ~189ms | ~200ms | <90ms |
+| **Runtime isolation** | OCI (containerd default), gVisor, Firecracker (microVM), WASM, V8 isolate (workerd) | Firecracker | Docker |
 | **Serverless / Workers-style sandboxes** | ✅ WASM + V8 isolate (Lambda / Workers model) | ✗ | ✗ |
 | **Security** | gVisor + Firecracker + isolate jail / WASM sandboxing | Firecracker | ✗ |
 | **Port Isolation** | ✅ | ✗ | ✗ |
@@ -81,7 +81,7 @@ AerolVM covers the same AI execution use case while running entirely on your own
 
 **Daytona** targets persistent developer workspaces - IDE integration, git-based environments, long-lived dev containers. It is not designed for ephemeral, high-frequency sandbox creation that AI agents need.
 
-- **Slow lifecycle.** Daytona workspaces take seconds to start because they're full persistent VMs. AerolVM warm-creates Docker/Firecracker sandboxes in ~30ms server-side (V8 isolates in ~4ms) - the difference between an agent waiting on infrastructure and an agent running code.
+- **Slow lifecycle.** Daytona workspaces take seconds to start because they're full persistent VMs. AerolVM warm-creates Firecracker sandboxes in ~34ms server-side and V8 isolates in ~4ms (default OCI/containerd path ~189ms) - the difference between an agent waiting on infrastructure and an agent running code.
 - **Setup complexity.** Daytona is genuinely difficult to self-host: multiple components, infrastructure dependencies, and ongoing operational overhead. AerolVM is a single-binary install with a one-line script.
 - **No kernel-level isolation, no per-sandbox egress control, no port allowlist.** Daytona assumes you trust the people using your workspaces. AerolVM assumes you don't trust the code running inside the sandbox.
 - **Workspace ergonomics over agent ergonomics.** Daytona's SDK and feature surface are built for humans editing code in an IDE. AerolVM's SDKs (TS, Python, Go, Rust, Java) are built for programmatic, high-throughput use.

--- a/docs/src/content/docs/engineering-runtime-layers.mdx
+++ b/docs/src/content/docs/engineering-runtime-layers.mdx
@@ -64,17 +64,18 @@ they're spread across two different layers:
 
 | Runtime | Layer | Isolation mechanism |
 |---|---|---|
-| **Docker** (`runtime: "docker"`) | OCI runtime (`runc`) | Linux namespaces + cgroups |
+| **OCI / Docker API** (`runtime: "docker"`) | OCI runtime (`runc`) on **containerd** (default host engine) | Linux namespaces + cgroups |
 | **gVisor** (`runtime: "gvisor"`) | OCI runtime (`runsc`) | Userspace kernel intercepting syscalls |
 | **Firecracker** (`runtime: "firecracker"`) | Our own OCI-runtime-equivalent → VMM | Hardware VM (KVM) |
 | **WASM** (`runtime: "wasm"`) | Language VM / sandboxed bytecode | Host-mediated WASI workers (optional resident host) |
 | **Isolate** (`runtime: "isolate"`) | Language VM (V8 / workerd) | Per-tenant workerd group + host-mediated egress; off by default |
 
-Docker and gVisor are drop-in OCI runtimes — the container ecosystem handed
-them to us. WASM and isolate are off the OCI diagram: they isolate at the
-language-VM layer, not the container layer, so they trade syscall compatibility
-for density and create latency (see [WASM Architecture](/wasm-architecture/) and
-[Isolate Sandbox](/isolate-sandbox/)).
+The API still says `runtime: "docker"` for OCI sandboxes; production nodes
+realize them with the native **containerd** driver (`SB_CONTAINER_ENGINE=containerd`).
+gVisor is a drop-in OCI runtime beside that path. WASM and isolate are off the
+OCI diagram: they isolate at the language-VM layer, not the container layer, so
+they trade syscall compatibility for density and create latency (see
+[WASM Architecture](/wasm-architecture/) and [Isolate Sandbox](/isolate-sandbox/)).
 
 Firecracker is the interesting one. There is no off-the-shelf OCI runtime in
 that row, because **we wrote it ourselves.**
@@ -285,9 +286,9 @@ layer is a VM, pick which engine.
 
 | You want | Pick this layer | Notes |
 |---|---|---|
-| Max compatibility, lowest overhead, trusted-ish code | `runc` (Docker) | Namespaces. Fast OCI path (~30ms warm server create). |
+| Max compatibility, lowest overhead, trusted-ish code | `runc` via containerd (`runtime: "docker"`) | Namespaces. Default OCI engine (~189ms server create on live UC-94). |
 | Untrusted code, container UX, no VM cost | gVisor (`runsc`) | Userspace kernel. Strong boundary, some syscall-compat gaps. |
-| Hardware-VM isolation with ~30ms warm boot | Firecracker | Our hand-rolled driver + snapshot warm pool. Default microVM. |
+| Hardware-VM isolation with ~34ms warm boot | Firecracker | Our hand-rolled driver + snapshot warm pool. Default microVM. |
 | GPU passthrough / confidential VMs / hotplug | Cloud Hypervisor *(candidate engine)* | Same layer as Firecracker; swap the engine, reuse the chassis. |
 | Smallest possible footprint, WASI modules | WASM | Language-VM layer; resident host ~22ms warm create. |
 | JS/TS `fetch` handlers, Workers density | Isolate (V8 / workerd) | Language-VM layer; ~4ms warm server create; off by default. |

--- a/docs/src/content/docs/getting-started/single-node-setup.md
+++ b/docs/src/content/docs/getting-started/single-node-setup.md
@@ -61,7 +61,7 @@ Caddy issues exactly two certificates, `<domain>` and `*.<domain>`, then renews 
 
 | Runtime | Installer flag | Notes |
 |---|---|---|
-| Docker | Default | Lowest overhead. Best for trusted workloads. |
+| OCI (`runtime: "docker"`) on **containerd** | Default engine | Production default (`SB_CONTAINER_ENGINE=containerd`). Broadest image compatibility. |
 | gVisor | `--with-gvisor` | Adds a user-space kernel boundary for untrusted code. |
 | Firecracker | `--with-firecracker` | MicroVM runtime; needs KVM / bare metal. |
 | WASM | Config (`SB_ENABLE_WASM` / wasm workers) | WASI modules; no separate installer flag on single-node by default. See [WASM Sandbox](/wasm-sandbox). |

--- a/docs/src/content/docs/quick-start.md
+++ b/docs/src/content/docs/quick-start.md
@@ -4,11 +4,13 @@ title: Quick Start
 
 **AerolVM** is open-source infrastructure for running isolated code environments.
 Self-host it or run it as managed multi-tenant SaaS. Each sandbox is a fully
-isolated compute unit — Docker/gVisor containers, Firecracker microVMs, WASM
-modules, or V8 isolates — with its own network policy and allocated resources.
+isolated compute unit — OCI containers on containerd, gVisor, Firecracker
+microVMs, WASM modules, or V8 isolates — with its own network policy and
+allocated resources.
 
 Warm create latency (server-side) ranges from **~4ms** (V8 isolate) through
-**~30ms** (Docker / Firecracker warm pool) depending on runtime. See the
+**~34ms** (Firecracker warm pool) and **~189ms** (default OCI on containerd)
+depending on runtime. See the
 [README benchmark table](https://github.com/aerol-ai/microvm#create-latency-live-uc-94)
 for the latest UC-94 numbers.
 
@@ -21,15 +23,16 @@ environment snapshots enable persistent agent operations across sessions.
 
 | Runtime | Status | Use case |
 |---|---|---|
-| Docker | ✅ | Fast OCI images, broadest compatibility (default) |
+| OCI (`runtime: "docker"` on **containerd**) | ✅ | Fast OCI images, broadest compatibility (default engine) |
 | gVisor | ✅ | User-space kernel isolation for untrusted code (`--with-gvisor`) |
 | Firecracker | ✅ | Hardware microVM isolation; warm pool ~34ms server create |
 | WebAssembly | ✅ | WASI modules; resident host ~22ms warm create |
 | Isolate (V8 / workerd) | ✅ (off by default) | JS/TS `fetch` handlers; **~4ms** warm server create (`--with-isolate`) |
 
 Kata Containers is not implemented — create requests with `runtime: "kata"`
-return not-implemented. Docker is the default. Enable the others in server
-config or installer flags as needed.
+return not-implemented. The default API runtime is `docker` (OCI); production
+hosts run it on the **containerd** engine (`SB_CONTAINER_ENGINE=containerd`).
+Enable the other runtimes in server config or installer flags as needed.
 
 ## Use Cases
 

--- a/docs/src/content/docs/sandboxes.mdx
+++ b/docs/src/content/docs/sandboxes.mdx
@@ -11,14 +11,14 @@ disk. WASM and isolate sandboxes are host-mediated (no guest filesystem) and
 opt into a different create shape (`module_ref` instead of `image`).
 
 Warm server-side create is roughly **~4ms** (isolate), **~22ms** (WASM resident
-host), **~30ms** (Docker / Firecracker warm pool) — see the live UC-94 table in
-the repository README.
+host), **~34ms** (Firecracker warm pool), **~189ms** (default OCI on
+containerd) — see the live UC-94 table in the repository README.
 
 ## Sandbox types
 
 | Type | Runtime value | Description |
 |---|---|---|
-| Docker | `docker` (default) | Standard runc-backed containers. Works on any node. |
+| OCI / Docker API | `docker` (default) | Standard runc-backed containers on the **containerd** host engine by default (`SB_CONTAINER_ENGINE=containerd`). Works on any node. |
 | gVisor | `gvisor` | User-space kernel - intercepts syscalls. Better isolation, same hardware requirements. See [gVisor Sandbox](/gvisor-sandbox). |
 | Firecracker | `firecracker` | Full microVM - warm-pool create ~34ms server-side. Requires bare-metal / KVM nodes. See [Firecracker Sandbox](/firecracker-sandbox). |
 | WASM | `wasm` | WASI modules in host workers; optional durable checkpoints. See [WASM Sandbox](/wasm-sandbox). |


### PR DESCRIPTION
Replace dockerd warm/sparse (~30ms) headlines with the live cluster-3-mixed-containerd bench (server p50 189ms) and clarify that production uses SB_CONTAINER_ENGINE=containerd for runtime:"docker".

<!--
GitHub auto-fills new PR descriptions with this template. Fill in EVERY
section below. "N/A - <one-line reason>" is a valid answer; an empty answer
is not. See pr-review.md at the repo root for what each section is asking.
-->

## Summary

<!-- 1-3 bullets: what changed and why. -->

## Code-path diagram

<!--
REQUIRED for any change to runtime behavior (see pr-review.md §8): at least
one ```mermaid``` diagram of the changed code path, annotated with what
changed on each branch (before -> after).

- sequenceDiagram for protocol / handshake / cross-process changes
- flowchart for control-flow, lifecycle, or cleanup-path changes
- every failure/cleanup branch the diff touches must appear as a branch

Reference example: PR #289 "What changed, visually".
Only valid opt-out: "N/A - docs/comment-only change."
-->

## Sandbox boot impact

<!--
Did this PR add ANY work - DB query, HTTP round-trip, file I/O, lock
acquisition - to CreateSandbox or anything it calls?

If yes: state what was added, expected added latency, when it fires, and
whether it's bounded. "Only on the first call" is still impact and must be
called out.

If no: write "N/A - no work added to sandbox boot path."
-->

## Idempotency

<!--
For every API surface this PR touches, describe behavior under retry and
under concurrent calls with the same inputs. Sandbox APIs MUST be
idempotent (see pr-review.md §1).

If no API surface changed: write "N/A - no API surface changed."
-->

## Failure-path consistency

<!--
For any multi-step write that touches BOTH caddy and the store: what is the
rollback rule on partial failure? Who cleans up if step 2 of 3 fails?

If no multi-step write path was changed: write "N/A - no multi-step write
path changed."
-->

## L4 / host-port-pool changes

<!--
Did this PR touch TryReserveHostPort, the partial unique index on
host_port, allocateHostPort, EnsureLayer4, EnsureLayer4Ready, or the
l4Ready latch? If yes, link the regression test that covers the change.

If no: write "N/A - neither touched."
-->

## Test plan

<!-- Bulleted checklist of how this was verified. -->
