### PR TITLE
fix(sims): serverless-wake http-echo needs binary in argv[0] (SLESS-01)

### DIFF
--- a/integration-tests/suite/sims/workloads.go
+++ b/integration-tests/suite/sims/workloads.go
@@ -118,9 +118,15 @@ func runServerlessWakeSim(ctx *RunContext) Result {
 	}
 	trueVal := true
 	sb, err := ctx.Client.SDK().Create(context.Background(), sdktypes.CreateSandboxOptions{
-		Name:               harness.UniqueName(ctx.Scenario, ctx.T),
-		Image:              "hashicorp/http-echo:1.0",
-		ContainerCommand:   []string{"-text=awake", "-listen=:8080"},
+		Name:  harness.UniqueName(ctx.Scenario, ctx.T),
+		Image: "hashicorp/http-echo:1.0",
+		// ContainerCommand is the FULL argv the toolbox execs — it replaces the
+		// image ENTRYPOINT (both docker and containerd drivers set the container
+		// entrypoint to the toolbox shim and pass this as the argv it runs). So
+		// argv[0] must be the http-echo binary, not a bare flag; passing just
+		// "-text=..." makes the toolbox try to exec "-text=awake" → the main
+		// process never starts and :8080 gets connection-refused.
+		ContainerCommand:   []string{"/http-echo", "-text=awake", "-listen=:8080"},
 		AllowPublicTraffic: &trueVal,
 		Lifecycle: &sdktypes.Lifecycle{
 			StopIfIdleFor: 30 * time.Second,


### PR DESCRIPTION
## Summary

- `runServerlessWakeSim` (SLESS-01) passed `ContainerCommand: ["-text=awake", "-listen=:8080"]` — bare flags with **no binary**. AerolVM's `ContainerCommand` is the FULL argv the toolbox shim execs; it replaces the image `ENTRYPOINT` (both the docker and containerd drivers set the container entrypoint to the toolbox and pass `ContainerCommand` as its argv, only falling back to the image entrypoint+cmd when the command is empty). So the container tried to exec `-text=awake` as the program, the workload never started, `http-echo` never bound `:8080`, and every proxy hop got `connection refused`. The sim polled 30s and failed (`initial hit: status 404/503` — teardown-timing noise).
- **Not** a serverless / wake / cluster defect. The live failure logs show the cross-node SNI passthrough, the owner wake route, and the ingress proxy all worked; only the upstream container was missing.
- Fix: prefix the binary → `["/http-echo", "-text=awake", "-listen=:8080"]`. Every other sim that sets `ContainerCommand` already includes the binary as argv[0] (`sh`, `sleep`, `redis-server`, `start-notebook.sh`); only this one didn't.

## Code-path diagram

N/A - test-harness-only change (integration sim). No runtime/server behavior changed.

## Sandbox boot impact

N/A - no work added to sandbox boot path (test harness only).

## Idempotency

N/A - no API surface changed.

## Failure-path consistency

N/A - no multi-step write path changed.

## L4 / host-port-pool changes

N/A - neither touched.

## Test plan

- Root-caused from the live `cluster-mixed-benchmark-with-obs` run failure logs: owner node logged `expose_port: container port not yet accepting connections` then `proxy to sandbox upstream failed ... dial tcp <ip>:8080: connect: connection refused` every ~3s for the sandbox's whole life.
- Ruled out infra: the postgres sim (real listening upstream, TCP expose, cross-node) passed on the same run.
- Local `docker` A/B (definitive):
  - exec-ing the bare flags reproduces the exact failure: `OCI runtime create failed: exec: "-text=awake": executable file not found in $PATH`.
  - `/http-echo -text=awake -listen=:8080` → `server is listening on :8080`, `curl → "awake"`, `http=200`.
- `go vet -tags=integration ./integration-tests/suite/sims/` and `go build -tags=integration ./integration-tests/...` clean; `gofmt` clean.
- Confirms green on the next live integration run (SLESS-01).

🤖 Generated with [Claude Code](https://claude.com/claude-code)