### PR TITLE
fix(containerd): snapshot push resolves the :latest-tagged local image (UC-21)

### DIFF
--- a/internal/runtime/containerd/push.go
+++ b/internal/runtime/containerd/push.go
@@ -71,7 +71,19 @@ func (p *RegistryPusher) livePush(ctx context.Context, source, dest string, auth
 	if err != nil {
 		return "", fmt.Errorf("containerd push: %w", err)
 	}
-	img, err := client.GetImage(ctx, source)
+	// Snapshots are committed locally as "<name>:latest" (formatSnapshotImageRef
+	// normalizes a tagless name), but the snapshot-push reconciler passes the
+	// bare "<name>". GetImage is exact-match, so a single bare lookup missed and
+	// every containerd snapshot push failed "image not found" — the image never
+	// reached AOCR and cross-node create-from-snapshot broke (single-node found
+	// it locally and never needed the push). Try the exact ref, then
+	// "<name>:latest", mirroring the create/pull path (ImageExists / ensureImage).
+	var img cntr.Image
+	for _, candidate := range pushSourceCandidates(source) {
+		if img, err = client.GetImage(ctx, candidate); err == nil {
+			break
+		}
+	}
 	if err != nil {
 		return "", fmt.Errorf("containerd push: get %s: %w", source, err)
 	}
@@ -120,6 +132,21 @@ func (p *RegistryPusher) livePush(ctx context.Context, source, dest string, auth
 		return "", fmt.Errorf("containerd push %s -> %s: %w", source, dest, err)
 	}
 	return string(target.Digest), nil
+}
+
+// pushSourceCandidates lists the local image refs livePush tries, in order, to
+// resolve the source image to upload. Snapshots are committed as "<name>:latest"
+// (formatSnapshotImageRef normalizes a tagless name), but the snapshot-push
+// reconciler passes the bare "<name>"; containerd's GetImage is exact-match, so
+// without the ":latest" fallback the push failed "image not found" and the
+// snapshot never reached AOCR, breaking cross-node create-from-snapshot. Mirrors
+// the create/pull path's exact-then-":latest" resolution (see ImageExists). A
+// ref that already carries a tag or digest is used as-is.
+func pushSourceCandidates(source string) []string {
+	if refHasTag(source) {
+		return []string{source}
+	}
+	return []string{source, source + ":latest"}
 }
 
 // pushCredScopeHost resolves the single registry host that push credentials may

--- a/internal/runtime/containerd/push_test.go
+++ b/internal/runtime/containerd/push_test.go
@@ -3,11 +3,63 @@ package containerd
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/aerol-ai/microvm/pkg/docker"
 	"github.com/aerol-ai/microvm/pkg/models"
 )
+
+// TestPushSourceCandidatesLatestFallback locks in the snapshot-push fix: a
+// tagless source (the bare snapshot name the reconciler passes) must fall back
+// to "<name>:latest", because CreateSnapshot commits the local image as
+// "<name>:latest". Without the fallback, livePush's exact-match GetImage failed
+// "image not found", the snapshot never reached AOCR, and cross-node
+// create-from-snapshot broke (UC-21). An already-tagged/digested ref is used
+// as-is so we never invent a spurious ":latest" candidate.
+func TestPushSourceCandidatesLatestFallback(t *testing.T) {
+	cases := []struct {
+		name   string
+		source string
+		want   []string
+	}{
+		{
+			name:   "tagless snapshot name falls back to :latest",
+			source: "cluster-x-testsnap-1700000000-snap",
+			want:   []string{"cluster-x-testsnap-1700000000-snap", "cluster-x-testsnap-1700000000-snap:latest"},
+		},
+		{
+			name:   "already-tagged ref used as-is",
+			source: "cluster-x-testsnap-1700000000-snap:latest",
+			want:   []string{"cluster-x-testsnap-1700000000-snap:latest"},
+		},
+		{
+			name:   "versioned tag used as-is",
+			source: "repo/app:v1",
+			want:   []string{"repo/app:v1"},
+		},
+		{
+			// The registry host:port colon must NOT be mistaken for a tag, so a
+			// tagless AOCR-style repo still gets the :latest fallback.
+			source: "aocr.aerol.ai:443/cluster/prod/snapshots/s-snap",
+			name:   "registry host:port with tagless repo still falls back",
+			want:   []string{"aocr.aerol.ai:443/cluster/prod/snapshots/s-snap", "aocr.aerol.ai:443/cluster/prod/snapshots/s-snap:latest"},
+		},
+		{
+			name:   "digest ref used as-is",
+			source: "repo/app@sha256:abc123",
+			want:   []string{"repo/app@sha256:abc123"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := pushSourceCandidates(tc.source)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("pushSourceCandidates(%q) = %v, want %v", tc.source, got, tc.want)
+			}
+		})
+	}
+}
 
 func TestRegistryPusherPushImage(t *testing.T) {
 	p := NewRegistryPusher(nil)


### PR DESCRIPTION
## Summary

- The containerd snapshot **push** to AOCR failed on every attempt with `containerd push: get <name>: image "<name>": not found`, so snapshots never reached the registry and **cross-node create-from-snapshot broke** (UC-21, `TestRegisterSnapshotAndCreateFrom`).
- Root cause: `CreateSnapshot` commits a tagless snapshot name as `<name>:latest` (`formatSnapshotImageRef`), but the snapshot-push reconciler passes the **bare** `<name>` to `livePush`, whose `GetImage` is exact-match with **no `:latest` fallback** — unlike the create/pull path (`ImageExists` / `ensureImage`), which try bare then `<name>:latest`.
- Not a registry/auth/network issue: other snapshot pulls from `aocr.aerol.ai` succeeded in the same run. Single-node is unaffected (the derived create finds the image locally and never pushes); this only bites the containerd engine (now the default) in cluster mode when the derived create lands on a non-source node.
- Fix: `pushSourceCandidates(source)` returns `[source, source+":latest"]` for a tagless ref (and `[source]` when it already carries a tag/digest, via `refHasTag`, which ignores the registry `host:port` colon); `livePush` tries the candidates in order.

## Code-path diagram

```mermaid
flowchart TD
    A[CreateSnapshot name] -->|formatSnapshotImageRef| B["commit local image as name:latest"]
    C[snapshot push reconciler] -->|source = bare name| D[livePush]
    D --> E{GetImage lookup}
    E -->|before: exact-match name only| F["not found -> push fails -> never reaches AOCR"]
    E -->|after: pushSourceCandidates = name, name:latest| G["finds name:latest -> pushes to AOCR"]
    F --> H[cross-node create-from-snapshot 404s -> UC-21 fail]
    G --> I[cross-node create-from-snapshot pulls -> UC-21 pass]
```

## Sandbox boot impact

N/A - no work added to the sandbox boot path. This is the snapshot-push reconciler path, not `CreateSandbox`.

## Idempotency

Unchanged. Only the *local source-image resolution* changed (which name `GetImage` looks up). The push/create-dest logic is untouched and remains idempotent: `ImageService.Get(dest)` then `Create`/`Update`, with `AlreadyExists` treated as success. Retried/concurrent pushes converge on the same dest target.

## Failure-path consistency

N/A - no multi-step caddy+store write changed. `livePush` is a read (local image) + push; a failed candidate lookup falls through to the next candidate, and a genuine miss returns the original error unchanged.

## L4 / host-port-pool changes

N/A - neither touched.

## Test plan

- Root-caused from the live `cluster-mixed-benchmark-with-obs` run: node logs showed `snapshot push: failed ... containerd push: get <snap>: image "<snap>": not found` and `reconcile sweep scanned=1 succeeded=0 failed=1`, while `python` snapshot **pulls** from AOCR succeeded (registry healthy).
- New unit test `TestPushSourceCandidatesLatestFallback` (5 cases): tagless→`:latest` fallback, already-tagged / versioned / digest passthrough, and the registry `host:port`-with-tagless-repo trap.
- `go test ./internal/runtime/containerd/` green (full package, ~42s); `gofmt` clean; `go build ./cmd/... ./internal/... ./pkg/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)