### PR TITLE
fix(itest): make cluster-mixed-benchmark-with-obs reliable (staging race + hyperparam retry)

### DIFF
--- a/integration-tests/lib/common.sh
+++ b/integration-tests/lib/common.sh
@@ -220,6 +220,17 @@ stage_wasm_modules() {
   local ip tgt i alias ref file
   for ip in "${ips[@]}"; do
     tgt="ubuntu@${ip}"
+    # Block until THIS node's user-data finished before touching its sandboxd.
+    # The domain branch only waits on DNS/TLS/health, which proves the SEED
+    # answers (Caddy fronts the API) — a joiner can still be mid-bootstrap here.
+    # install.sh writes+enables the sandboxd unit late, so a restart that races
+    # it fails "Unit sandboxd.service not found" and aborts the whole scenario
+    # as inconclusive. cloud-init status --wait is idempotent and returns at
+    # once on an already-finished box, so this only costs time on the real race.
+    if ! wait_for_cloud_init "$tgt"; then
+      echo "stage_wasm: ${tgt} cloud-init did not finish" >&2
+      return 1
+    fi
     if ! ssh "${SSH_OPTS[@]}" "$tgt" "sudo mkdir -p '${modules_dir}'"; then
       echo "stage_wasm: mkdir ${modules_dir} on ${tgt} failed" >&2
       return 1

--- a/integration-tests/suite/sims/workloads.go
+++ b/integration-tests/suite/sims/workloads.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/aerol-ai/microvm/integration-tests/suite/harness"
+	"github.com/aerol-ai/microvm/sdk/go/pkg/microvm"
 	sdktypes "github.com/aerol-ai/microvm/sdk/go/pkg/types"
 )
 
@@ -73,11 +74,28 @@ func runHyperparamFarm(ctx *RunContext) Result {
 		go func() {
 			defer wg.Done()
 			acc := fmt.Sprintf("0.%d42", i+5)
-			sb, err := ctx.Client.SDK().Create(context.Background(), sdktypes.CreateSandboxOptions{
-				Name:             harness.UniqueName(ctx.Scenario, ctx.T) + fmt.Sprintf("-train-%d", i),
-				Image:            "alpine:3.20",
-				ContainerCommand: []string{"sh", "-c", "sleep 1; echo accuracy=" + acc},
-			})
+			// A 3-wide concurrent create burst can momentarily exceed a node's
+			// pending-reservation budget on this small benchmark cluster: the
+			// warm pools already hold most of the per-node CPU-budget slots, so
+			// one trainer can lose the race for the last slot even though
+			// capacity frees the instant an in-flight create resolves. Real
+			// hyperparameter fan-out retries these transient admission
+			// rejections — without it a single one flakes the whole farm. Stagger
+			// the retry (grows with attempt) so the trainers don't re-collide on
+			// the same freed slot. Non-transient errors fail fast.
+			var sb *microvm.Sandbox
+			var err error
+			for attempt := 0; attempt < 4; attempt++ {
+				sb, err = ctx.Client.SDK().Create(context.Background(), sdktypes.CreateSandboxOptions{
+					Name:             harness.UniqueName(ctx.Scenario, ctx.T) + fmt.Sprintf("-train-%d", i),
+					Image:            "alpine:3.20",
+					ContainerCommand: []string{"sh", "-c", "sleep 1; echo accuracy=" + acc},
+				})
+				if err == nil || !isTransientCapacity(err) {
+					break
+				}
+				time.Sleep(time.Duration(attempt+1) * 2 * time.Second)
+			}
 			if err != nil {
 				ch <- outcome{err: err}
 				return
@@ -231,4 +249,21 @@ PY`
 
 func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
+}
+
+// isTransientCapacity reports whether a create error is a transient cluster
+// admission rejection — a concurrent burst momentarily exceeding a node's
+// pending-reservation budget — that clears with a brief backoff, as opposed to
+// a hard/permanent failure. Matched on the message because the SDK surfaces the
+// server's admission-control error as a plain error string. Kept narrow so a
+// real bug (bad image, auth, malformed request) still fails the sim fast.
+func isTransientCapacity(err error) bool {
+	if err == nil {
+		return false
+	}
+	m := strings.ToLower(err.Error())
+	return strings.Contains(m, "target capacity exceeded") ||
+		strings.Contains(m, "pending reservations") ||
+		strings.Contains(m, "no worker placement target") ||
+		strings.Contains(m, "cannot fit sandbox")
 }


### PR DESCRIPTION
## What

Two independent reliability fixes for the `cluster-mixed-benchmark-with-obs` integration scenario, both surfaced and then **proven green on real AWS** during v0.7.21 release verification.

### 1. `stage_wasm` waits for each node's cloud-init before restarting sandboxd
`internal/../lib/common.sh` — The domain branch only waits on DNS/TLS/health, which proves the **seed** answers (Caddy fronts the API); a **joiner** could still be mid-bootstrap when `stage_wasm_modules` reached it. `install.sh` writes+enables the `sandboxd` unit late in cloud-init, so a racing `systemctl restart sandboxd` failed `Unit sandboxd.service not found` and aborted the whole scenario as *inconclusive* (observed: node2's unit not yet installed at staging time). Now each node gates on its own idempotent `cloud-init status --wait` before staging touches its sandboxd.

### 2. `hyperparam-farm` sim retries transient capacity rejections
`integration-tests/suite/sims/workloads.go` — The sim fans out **3 concurrent** trainer creates with no retry, so a single transient admission rejection (`target capacity exceeded after pending reservations`) failed the whole sim (COMP-01). On the small benchmark cluster the warm pools hold most of each node's CPU-budget slots, so a 3-wide burst can lose the race for the last slot even though capacity frees the instant an in-flight create resolves — exactly what real fan-out clients retry. Now retries Create up to 4× with staggered backoff, **only** on transient capacity/placement errors (`isTransientCapacity`); non-transient errors still fail fast. Mirrors the retry `temporal-workflow` already has.

## Verification (real AWS, 3× t3.large + obs)
- Staging cleared cleanly on all 3 nodes across two consecutive runs (no "unit not found").
- `hyperparam-farm`: ❌ → ✅ (`3 parallel trainers returned accuracy`).
- Release fixes stayed green throughout: UC-21 snapshot ✅, benchmark 6 runtimes ×10 **0 failures**, SLESS-01 ✅.
- All clusters torn down clean (0 leaked instances).

## Scope / risk
- **Integration-test harness only** — no server, SDK, or shipped-artifact changes. `make test` unaffected.
- Compiles clean under `-tags=integration` (`go build`/`go vet`).

## Follow-up (separate, not in this PR)
The proving run also surfaced a **real cluster-mode reconcile race** (UC-20): node owns a freshly-created sandbox, then its own reconcile loop destroys it ~200ms later, and a cross-node snapshot call 404s. That's `internal/cluster/` fragile-area work (reconcile/owner-watcher/placement) needing a dedicated investigation + regression test + cluster-correctness call-out — **not** addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)