### PR TITLE
fix(service): reconcile re-inspects a container before reaping its row (UC-20)

### DIFF
--- a/internal/service/reconcile_destroy_test.go
+++ b/internal/service/reconcile_destroy_test.go
@@ -645,3 +645,25 @@ func TestReconcileReInspectsBeforeReap(t *testing.T) {
 		}
 	})
 }
+
+// TestReconcileGoneContainerConfirmedFallsThrough covers the guard's
+// fall-through-to-reap paths that the Reconcile-level test can't reach: a nil
+// row, and a sandbox whose runtime driver isn't registered (Inspect can't be
+// attempted). Both must report "confirmed gone" so a row is never pinned
+// forever by a nil entry or a missing driver.
+func TestReconcileGoneContainerConfirmedFallsThrough(t *testing.T) {
+	svc := &Service{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	ctx := context.Background()
+
+	if !svc.reconcileGoneContainerConfirmed(ctx, nil) {
+		t.Fatal("nil sandbox must be treated as confirmed gone")
+	}
+
+	// Engine=containerd with no containerd driver registered → runtimeForSandbox
+	// returns ErrContainerEngineNotRegistered, so there is no runtime to
+	// re-Inspect with; the guard must fall through to the reap.
+	orphan := &models.Sandbox{ID: "sb-nodriver", Runtime: models.RuntimeDocker, Engine: models.ContainerEngineContainerd}
+	if !svc.reconcileGoneContainerConfirmed(ctx, orphan) {
+		t.Fatal("sandbox with an unregistered runtime driver must be treated as confirmed gone")
+	}
+}

--- a/internal/service/reconcile_destroy_test.go
+++ b/internal/service/reconcile_destroy_test.go
@@ -25,7 +25,11 @@ import (
 // if reached, so a future refactor that starts calling them in reconcile fails
 // the test instead of silently passing.
 type fakeReconcileRuntime struct {
-	managed               map[string]*models.SandboxRuntimeState
+	managed map[string]*models.SandboxRuntimeState
+	// inspect backs the reconcile guard's targeted re-Inspect (a container the
+	// bulk ListManaged snapshot missed). Keyed by runtime ref; a ref absent
+	// here returns a not-found error, i.e. "container is durably gone".
+	inspect               map[string]*models.SandboxRuntimeState
 	removeImageHits       atomic.Int32
 	networkBlockAllCalls  []string
 	allowPushAllowedPorts bool
@@ -62,8 +66,11 @@ func (f *fakeReconcileRuntime) Destroy(context.Context, *models.Sandbox) error {
 func (f *fakeReconcileRuntime) Resize(context.Context, string, models.ResizeSandboxRequest) error {
 	panic("unexpected Resize on reconcile destroyed path")
 }
-func (f *fakeReconcileRuntime) Inspect(context.Context, string) (*models.SandboxRuntimeState, error) {
-	panic("unexpected Inspect on reconcile destroyed path")
+func (f *fakeReconcileRuntime) Inspect(_ context.Context, ref string) (*models.SandboxRuntimeState, error) {
+	if st, ok := f.inspect[ref]; ok {
+		return st, nil
+	}
+	return nil, errors.New("container not found")
 }
 func (f *fakeReconcileRuntime) Ping(context.Context) error {
 	panic("unexpected Ping on reconcile destroyed path")
@@ -241,6 +248,8 @@ func TestReconcileDestroyedRowFreesHostPort(t *testing.T) {
 	)
 
 	// Seed: a started sandbox with one TCP exposure holding host_port=22500.
+	// rt.managed is empty and rt.inspect has no entry, so the reconcile guard's
+	// re-Inspect returns "container not found" → durably gone → reaped.
 	now := time.Now().UTC()
 	if err := st.Create(ctx, &models.Sandbox{
 		ID:           sandboxID,
@@ -542,4 +551,97 @@ func TestDieEventDoesNotDeleteRow(t *testing.T) {
 	if rt.removeImageHits.Load() != 0 {
 		t.Fatalf("die must not GC image, got %d hits", rt.removeImageHits.Load())
 	}
+}
+
+// TestReconcileReInspectsBeforeReap is the UC-20 regression. The reconcile
+// "container gone" branch reaps a row (and, in cluster mode, its FSM placement)
+// when the sandbox ID is absent from the bulk ListManaged snapshot. That
+// snapshot is one racy read per tick whose per-container Inspect silently skips
+// a container it can't read at that instant (mid-adopt/mid-start). Pre-fix the
+// reap fired on that single miss, deleting a healthy sandbox's row and surfacing
+// as an intermittent cross-node snapshot 404. Post-fix a targeted re-Inspect
+// that still resolves the container spares the row; a genuinely-gone container
+// (Inspect error / empty identity) is still reaped.
+func TestReconcileReInspectsBeforeReap(t *testing.T) {
+	newSvc := func(rt *fakeReconcileRuntime) (*Service, *store.Store) {
+		dbPath := filepath.Join(t.TempDir(), "state.db")
+		st, err := store.Open(dbPath)
+		if err != nil {
+			t.Fatalf("store.Open: %v", err)
+		}
+		t.Cleanup(func() { _ = st.Close() })
+		mgr, err := mounts.New(slog.New(slog.NewTextHandler(io.Discard, nil)), mounts.Config{
+			RootDir:     filepath.Join(t.TempDir(), "mounts"),
+			CredDir:     filepath.Join(t.TempDir(), "cred"),
+			WaitTimeout: time.Second,
+		})
+		if err != nil {
+			t.Fatalf("mounts.New: %v", err)
+		}
+		t.Cleanup(mgr.Close)
+		svc := &Service{
+			cfg:    config.Config{ImageBuildGCEnabled: true},
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+			store:  st,
+			docker: rt,
+			caddy: caddy.New(config.Config{
+				EnableCaddy:       false,
+				HTTPClientTimeout: time.Second,
+			}),
+			mounts: mgr,
+		}
+		return svc, st
+	}
+
+	seed := func(st *store.Store, id string) {
+		now := time.Now().UTC()
+		if err := st.Create(context.Background(), &models.Sandbox{
+			ID:           id,
+			Image:        "ubuntu:22.04",
+			Status:       models.SandboxStatusStarted,
+			ContainerID:  "ctr-" + id,
+			ContainerIP:  "10.0.0.5",
+			Runtime:      models.RuntimeDocker,
+			CreatedAt:    now,
+			UpdatedAt:    now,
+			LastActiveAt: now,
+		}); err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+
+	ctx := context.Background()
+
+	// Bulk snapshot missed it, but a targeted re-Inspect resolves the container
+	// (non-empty runtime identity) — the exact UC-20 race. Must NOT be reaped.
+	t.Run("re-inspect resolves container -> spared", func(t *testing.T) {
+		rt := &fakeReconcileRuntime{
+			managed: map[string]*models.SandboxRuntimeState{},
+			inspect: map[string]*models.SandboxRuntimeState{
+				"ctr-sb-settling": {SandboxID: "sb-settling", ContainerID: "ctr-sb-settling", Status: models.SandboxStatusStarted},
+			},
+		}
+		svc, st := newSvc(rt)
+		seed(st, "sb-settling")
+		if err := svc.Reconcile(ctx); err != nil {
+			t.Fatalf("Reconcile: %v", err)
+		}
+		if _, err := st.Get(ctx, "sb-settling"); err != nil {
+			t.Fatalf("sandbox with a re-inspectable container was reaped on a stale bulk snapshot: %v", err)
+		}
+	})
+
+	// Absent from ListManaged AND re-Inspect returns not-found: durably gone,
+	// cleanup must still run so orphan rows don't accumulate.
+	t.Run("re-inspect not-found -> reaped", func(t *testing.T) {
+		rt := &fakeReconcileRuntime{managed: map[string]*models.SandboxRuntimeState{}}
+		svc, st := newSvc(rt)
+		seed(st, "sb-dead")
+		if err := svc.Reconcile(ctx); err != nil {
+			t.Fatalf("Reconcile: %v", err)
+		}
+		if _, err := st.Get(ctx, "sb-dead"); !errors.Is(err, store.ErrNotFound) {
+			t.Fatalf("durably-gone sandbox should be reaped, got err=%v", err)
+		}
+	})
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -3729,6 +3729,33 @@ func (s *Service) ReplayReservations(ctx context.Context) {
 	s.logger.Info("capacity reservations replayed", "count", replayed)
 }
 
+// reconcileGoneContainerConfirmed reports whether a sandbox absent from the
+// bulk ListManaged snapshot is DURABLY gone and safe to reap (which deletes the
+// store row and, in cluster mode, the FSM placement). ListManaged is one racy
+// read per tick whose per-container Inspect silently skips a container it can't
+// read at that instant (mid-adopt/mid-start — see the `if err != nil` continue
+// in the containerd driver's ListManaged). Reaping on that single miss drops a
+// healthy sandbox's row and its cluster placement, which surfaced as an
+// intermittent cross-node snapshot 404 (UC-20). So re-verify with a direct,
+// targeted Inspect before destroying: a container the driver can still resolve
+// (non-empty runtime identity, no error) is NOT gone — the bulk snapshot was
+// stale — so spare it and let the next steady-state pass adopt it. A missing
+// driver, an Inspect error, or an empty identity all fall through to the reap,
+// so a genuinely-dead container is still cleaned up on this pass.
+func (s *Service) reconcileGoneContainerConfirmed(ctx context.Context, sandbox *models.Sandbox) bool {
+	if sandbox == nil {
+		return true
+	}
+	rt, err := s.runtimeForSandbox(sandbox)
+	if err != nil {
+		return true
+	}
+	if st, err := rt.Inspect(ctx, s.runtimeRef(sandbox)); err == nil && st != nil && st.ContainerID != "" {
+		return false
+	}
+	return true
+}
+
 func (s *Service) Reconcile(ctx context.Context) error {
 	// Topology heartbeat: surface a cluster that has crossed the
 	// 10-ingress-node sharding threshold without operator opt-in to
@@ -3854,6 +3881,18 @@ func (s *Service) Reconcile(ctx context.Context) error {
 						_ = s.deleteExposedPortRoute(ctx, sandbox, port)
 					}
 				}
+				continue
+			}
+			// The bulk ListManaged snapshot missed this row, but that is one racy
+			// read per tick — its per-container Inspect silently skips a
+			// container it can't read at that instant (mid-adopt/mid-start).
+			// Re-verify with a targeted Inspect before the destructive teardown
+			// below, which deletes the row AND the FSM placement
+			// (deleteSelfOwnedClusterPlacement): reaping a container that is
+			// actually still there turns a transient miss into permanent loss and
+			// an intermittent cross-node snapshot 404 on a healthy sandbox
+			// (UC-20). Confirmed-gone (error / no such container) still reaps.
+			if !s.reconcileGoneContainerConfirmed(ctx, sandbox) {
 				continue
 			}
 			// Container is gone (manual `docker rm`, OOM kill, host reboot,


### PR DESCRIPTION
## What

Reconcile's "container gone" branch (`internal/service/service.go`) deletes the sandbox **store row and its cluster FSM placement** whenever a sandbox ID is absent from a single bulk `ListManaged()` snapshot. That snapshot is one racy read per tick — the containerd driver's `ListManaged` silently skips a container whose per-item `Inspect` errors at that instant (mid-adopt / mid-start; `lifecycle.go` does `if err != nil { continue }`). A create that is merely still settling is then indistinguishable from a durably-dead container, so a **healthy** sandbox gets reaped.

Observed live (UC-20, cluster-mixed-benchmark-with-obs): node A creates+owns `sb-…` (POST 201), its own 5-min reconcile tick logs `audit reconcile destroyed` ~180ms later, and the follow-up snapshot — routed by the domain LB to node B — returns **404** because A already deleted the row + placement.

```mermaid
flowchart TD
    C[create returns 201 on owner node A] --> R[reconcile tick: bulk ListManaged]
    R --> M{sb.ID in snapshot?}
    M -- yes --> OK[steady-state update]
    M -- no --> G{"BEFORE: reap immediately<br/>AFTER: re-Inspect the container"}
    G -- "AFTER: driver resolves it (alive)" --> SP[spare row; next pass adopts]
    G -- "gone (error / empty identity)" --> D[reap: delete row + FSM placement]
```

## Fix

`reconcileGoneContainerConfirmed` re-Inspects the specific container before the destructive teardown. A container the driver still resolves (no error, non-empty runtime identity) proves the bulk snapshot was stale → spare the row. A genuinely gone container (Inspect error / empty identity) still reaps, so orphan-row cleanup and host_port freeing are unchanged.

## pr-review.md call-outs

- **Idempotency (§1):** Unchanged and strengthened. Reconcile stays idempotent; the guard only makes it *more* conservative (re-verify before delete). No new host-port-pool walk, no new resource allocation.
- **Sandbox boot-path latency (§2):** **No impact.** The change is entirely inside `Reconcile`, a background 5-min sweep. `CreateSandbox` and its callees are untouched. First-call case: N/A.
- **Failure-path consistency (§4):** Reduces spurious deletes. On the spare path the branch just `continue`s — no partial caddy/store writes. This directly addresses the "reconcile as routine cleanup" hazard by *not* leaning on a single racy signal to destroy state.
- **TCP host-port pool & L4 (§5):** Not touched. The reap path (which cascades exposed_ports and frees `host_port`) still runs for genuinely-gone containers; `TestReconcileDestroyedRowFreesHostPort` and `TestDestroyEventFreesHostPort` still pass.
- **Cluster-mode correctness (§6):** The reap calls `deleteSelfOwnedClusterPlacement`; the guard makes placement deletion fire **only after** a targeted Inspect confirms the container is gone — strictly **fewer** spurious FSM placement deletions. No split-brain / replay implications (this only makes *local* reap more conservative; it never writes to the FSM). **Single-node unaffected:** `runtimeForSandbox` + `Inspect` behave the same, and the Noop cluster's `deleteSelfOwnedClusterPlacement` is already a no-op.

## Test plan

- New regression `TestReconcileReInspectsBeforeReap` (`internal/service/reconcile_destroy_test.go`): re-inspectable container → spared; not-found → reaped. **Verified fails without the guard** (reaped on a stale snapshot) and passes with it.
- `go test ./internal/service/...` green (42s); `go vet` + `go build ./...` + `gofmt` clean.

## Known limitation

This closes the mechanism where the bulk `ListManaged` transiently missed a container that was actually alive. If the deeper trigger is a genuine container *removal* ~180ms post-create (the ordering evidence is consistent with that too), re-Inspect also fails and the row still (correctly) reaps — UC-20 would not fully close and the true culprit would remain. Distinguishing needs an instrumented live run (log every containerd container-delete with its caller); tracked separately, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)